### PR TITLE
refactor: seed shared owner module exports

### DIFF
--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -9,7 +9,7 @@
  * 3. Token valid for 1 hour
  */
 
-import type { InstallationRepository } from "@open-inspect/shared";
+import type { InstallationRepository } from "@open-inspect/shared/types/repository-catalog";
 import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import type { CacheStore } from "@open-inspect/shared/cache-store";
 import { z } from "zod";

--- a/packages/control-plane/src/auth/user/admission-policy.ts
+++ b/packages/control-plane/src/auth/user/admission-policy.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { SignInProvider } from "@open-inspect/shared";
+import type { SignInProvider } from "@open-inspect/shared/sign-in-provider";
 import { DEFAULT_PROVIDER_REQUEST_TIMEOUT_MS } from "./providers/constants";
 import type { VerifiedProviderIdentity } from "./providers/types";
 

--- a/packages/control-plane/src/auth/user/providers/types.ts
+++ b/packages/control-plane/src/auth/user/providers/types.ts
@@ -1,4 +1,4 @@
-import type { SignInProvider } from "@open-inspect/shared";
+import type { SignInProvider } from "@open-inspect/shared/sign-in-provider";
 
 export interface VerifiedProviderIdentity<P extends SignInProvider = SignInProvider> {
   readonly provider: P;

--- a/packages/control-plane/src/auth/user/runtime.ts
+++ b/packages/control-plane/src/auth/user/runtime.ts
@@ -4,7 +4,7 @@ import {
   parseAdmissionBoolean,
   type AdmissionPolicyConfig,
 } from "./admission-policy";
-import { SIGN_IN_PROVIDERS, type SignInProvider } from "@open-inspect/shared";
+import { SIGN_IN_PROVIDERS, type SignInProvider } from "@open-inspect/shared/sign-in-provider";
 import { createUserAuth, type UserAuthConfig } from "./better-auth";
 import { GitHubProviderIdentityResolver } from "./providers/github-identity";
 import { GitHubSignInProfileResolver } from "./providers/github-profile";

--- a/packages/control-plane/src/automation/session-target.ts
+++ b/packages/control-plane/src/automation/session-target.ts
@@ -1,4 +1,4 @@
-import type { RepositoryRef } from "@open-inspect/shared";
+import type { RepositoryRef } from "@open-inspect/shared/types/repositories";
 import type { AutomationRunRow } from "../db/automation-store";
 import type { Env } from "../types";
 import type { Logger } from "../logger";

--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -4,8 +4,8 @@ import type {
   AnalyticsBreakdownResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
-  SpawnSource,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
+import type { SpawnSource } from "@open-inspect/shared";
 import type { SqlDatabase } from "./sql-database";
 
 /** Spawn sources that represent direct human-initiated sessions. */

--- a/packages/control-plane/src/db/image-build-finalization.ts
+++ b/packages/control-plane/src/db/image-build-finalization.ts
@@ -2,7 +2,7 @@ import type {
   ImageBuildScopeKind,
   ImageBuildStatus,
   RepositoryShaEntry,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/image-builds";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
 import type { ImageBuildCallbackBuild, ImageBuildProvider } from "../image-builds/model";
 import type { SqlDatabase } from "./sql-database";

--- a/packages/control-plane/src/db/pull-request-analytics-store.ts
+++ b/packages/control-plane/src/db/pull-request-analytics-store.ts
@@ -10,7 +10,8 @@
  * landing concurrently.
  */
 
-import type { AnalyticsPullRequestsResponse, SpawnSource } from "@open-inspect/shared";
+import type { AnalyticsPullRequestsResponse } from "@open-inspect/shared/types/analytics";
+import type { SpawnSource } from "@open-inspect/shared";
 import type { SqlDatabase, SqlResult } from "./sql-database";
 
 /** `now` anchors the open-inventory age computation. */

--- a/packages/control-plane/src/image-builds/provenance.ts
+++ b/packages/control-plane/src/image-builds/provenance.ts
@@ -1,4 +1,4 @@
-import type { RepositoryShaEntry } from "@open-inspect/shared";
+import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
 
 type RepositoryIdentity = Pick<RepositoryShaEntry, "repoOwner" | "repoName">;
 

--- a/packages/control-plane/src/image-builds/rebuild-policy.test.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { evaluateImageBuildRebuildPolicy } from "./rebuild-policy";
 
 const unit = {

--- a/packages/control-plane/src/image-builds/rebuild-policy.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.ts
@@ -1,4 +1,4 @@
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   parseRuntimeVersionNumber,

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -3,7 +3,7 @@ import {
   ANALYTICS_DAYS,
   type AnalyticsBreakdownBy,
   type AnalyticsDays,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
 import { type AnalyticsFilters, AnalyticsStore, HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
 import {
   type PullRequestAnalyticsFilters,

--- a/packages/control-plane/src/routes/session-diffs.ts
+++ b/packages/control-plane/src/routes/session-diffs.ts
@@ -4,7 +4,7 @@ import {
   SESSION_DIFF_MAX_BUNDLE_BYTES,
   sessionDiffFailureSchema,
   sessionDiffUploadSchema,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-diffs";
 import { SessionInternalPaths } from "../session/contracts";
 import { error, parsePattern, type Route } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -9,11 +9,9 @@
 
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
-import {
-  clientMessageSchema,
-  sandboxEventSchema,
-  type SessionAttachmentReference,
-} from "@open-inspect/shared";
+import { clientMessageSchema } from "@open-inspect/shared/types/websocket";
+import { sandboxEventSchema } from "@open-inspect/shared";
+import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { DEFAULT_MODEL } from "@open-inspect/shared/models";

--- a/packages/control-plane/src/session/messenger.ts
+++ b/packages/control-plane/src/session/messenger.ts
@@ -4,7 +4,7 @@
  * delivery to the sandbox socket.
  */
 
-import type { ServerMessage } from "@open-inspect/shared";
+import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 import type { SandboxCommand } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
 

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,4 +1,5 @@
-import { generateBranchName, toDisplayStatus } from "@open-inspect/shared";
+import { generateBranchName } from "@open-inspect/shared/git";
+import { toDisplayStatus } from "@open-inspect/shared";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -4,8 +4,8 @@ import type {
   AnalyticsBreakdownResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
-  SpawnSource,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
+import type { SpawnSource } from "@open-inspect/shared";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
 import { serviceFetch } from "./helpers";

--- a/packages/control-plane/test/integration/pull-request-analytics.test.ts
+++ b/packages/control-plane/test/integration/pull-request-analytics.test.ts
@@ -7,7 +7,8 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
-import type { AnalyticsPullRequestsResponse, SpawnSource } from "@open-inspect/shared";
+import type { AnalyticsPullRequestsResponse } from "@open-inspect/shared/types/analytics";
+import type { SpawnSource } from "@open-inspect/shared";
 import { SessionIndexStore } from "../../src/db/session-index";
 import {
   SessionPullRequestStore,

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -10,7 +10,7 @@ import type { Env } from "./types";
 import type { Logger } from "./logger";
 import { createLogger, parseLogLevel } from "./logger";
 import { verifyWebhookSignature } from "./verify";
-import { normalizeGitHubEvent } from "@open-inspect/shared";
+import { normalizeGitHubEvent } from "@open-inspect/shared/triggers";
 import { signedControlPlaneFetch } from "./internal-auth";
 import {
   issueCommentPayloadSchema,

--- a/packages/linear-bot/src/completion/extractor.ts
+++ b/packages/linear-bot/src/completion/extractor.ts
@@ -8,7 +8,7 @@
 
 import type { Env } from "../types";
 import type { AgentResponse } from "@open-inspect/shared";
-import { extractAgentResponse as sharedExtract } from "@open-inspect/shared";
+import { extractAgentResponse as sharedExtract } from "@open-inspect/shared/completion/extractor";
 import { resolveOutboundCredential } from "@open-inspect/shared/service-auth";
 import { createLogger } from "../logger";
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,6 +61,62 @@
     "./types/integrations": {
       "import": "./dist/types/integrations.js",
       "types": "./dist/types/integrations.d.ts"
+    },
+    "./sign-in-provider": {
+      "import": "./dist/sign-in-provider.js",
+      "types": "./dist/sign-in-provider.d.ts"
+    },
+    "./git": {
+      "import": "./dist/git.js",
+      "types": "./dist/git.d.ts"
+    },
+    "./cron": {
+      "import": "./dist/cron.js",
+      "types": "./dist/cron.d.ts"
+    },
+    "./triggers": {
+      "import": "./dist/triggers/index.js",
+      "types": "./dist/triggers/index.d.ts"
+    },
+    "./slack": {
+      "import": "./dist/slack/index.js",
+      "types": "./dist/slack/index.d.ts"
+    },
+    "./completion/extractor": {
+      "import": "./dist/completion/extractor.js",
+      "types": "./dist/completion/extractor.d.ts"
+    },
+    "./types/repositories": {
+      "import": "./dist/types/repositories.js",
+      "types": "./dist/types/repositories.d.ts"
+    },
+    "./types/repository-catalog": {
+      "import": "./dist/types/repository-catalog.js",
+      "types": "./dist/types/repository-catalog.d.ts"
+    },
+    "./types/automations": {
+      "import": "./dist/types/automations.js",
+      "types": "./dist/types/automations.d.ts"
+    },
+    "./types/websocket": {
+      "import": "./dist/types/websocket.js",
+      "types": "./dist/types/websocket.d.ts"
+    },
+    "./types/server-messages": {
+      "import": "./dist/types/server-messages.js",
+      "types": "./dist/types/server-messages.d.ts"
+    },
+    "./types/session-attachments": {
+      "import": "./dist/types/session-attachments.js",
+      "types": "./dist/types/session-attachments.d.ts"
+    },
+    "./types/session-diffs": {
+      "import": "./dist/types/session-diffs.js",
+      "types": "./dist/types/session-diffs.d.ts"
+    },
+    "./types/analytics": {
+      "import": "./dist/types/analytics.js",
+      "types": "./dist/types/analytics.d.ts"
     }
   },
   "scripts": {

--- a/packages/slack-bot/src/app-home/modals.ts
+++ b/packages/slack-bot/src/app-home/modals.ts
@@ -1,4 +1,4 @@
-import { openView } from "@open-inspect/shared";
+import { openView } from "@open-inspect/shared/slack";
 import {
   BRANCH_INPUT_ACTION_ID,
   BRANCH_INPUT_BLOCK_ID,

--- a/packages/slack-bot/src/completion/extractor.ts
+++ b/packages/slack-bot/src/completion/extractor.ts
@@ -7,7 +7,7 @@
 
 import type { Env } from "../types";
 import type { AgentResponse } from "@open-inspect/shared";
-import { extractAgentResponse as sharedExtract } from "@open-inspect/shared";
+import { extractAgentResponse as sharedExtract } from "@open-inspect/shared/completion/extractor";
 import { resolveOutboundCredential } from "@open-inspect/shared/service-auth";
 import { createLogger } from "../logger";
 

--- a/packages/web/src/app/(app)/analytics/page.test.tsx
+++ b/packages/web/src/app/(app)/analytics/page.test.tsx
@@ -9,7 +9,7 @@ import type {
   AnalyticsBreakdownResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
 import AnalyticsPage from "./page";
 
 expect.extend(matchers);

--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { AnalyticsDays } from "@open-inspect/shared";
+import type { AnalyticsDays } from "@open-inspect/shared/types/analytics";
 import { AnalyticsPullRequestCards } from "@/components/analytics/pull-request-cards";
 import { AnalyticsPullRequestChart } from "@/components/analytics/pull-request-chart";
 import { AnalyticsPullRequestRepoTable } from "@/components/analytics/pull-request-repo-table";

--- a/packages/web/src/components/analytics/pull-request-cards.tsx
+++ b/packages/web/src/components/analytics/pull-request-cards.tsx
@@ -1,4 +1,7 @@
-import type { AnalyticsDays, AnalyticsPullRequestsResponse } from "@open-inspect/shared";
+import type {
+  AnalyticsDays,
+  AnalyticsPullRequestsResponse,
+} from "@open-inspect/shared/types/analytics";
 import { SummaryCard } from "@/components/analytics/summary-cards";
 import {
   formatAnalyticsCount,

--- a/packages/web/src/components/analytics/pull-request-chart.tsx
+++ b/packages/web/src/components/analytics/pull-request-chart.tsx
@@ -8,7 +8,7 @@ import {
   YAxis,
 } from "recharts";
 import { useId } from "react";
-import type { AnalyticsPullRequestTimeseriesPoint } from "@open-inspect/shared";
+import type { AnalyticsPullRequestTimeseriesPoint } from "@open-inspect/shared/types/analytics";
 import { Badge } from "@/components/ui/badge";
 import {
   formatAnalyticsCount,

--- a/packages/web/src/components/analytics/pull-request-repo-table.tsx
+++ b/packages/web/src/components/analytics/pull-request-repo-table.tsx
@@ -1,4 +1,4 @@
-import type { AnalyticsPullRequestRepoEntry } from "@open-inspect/shared";
+import type { AnalyticsPullRequestRepoEntry } from "@open-inspect/shared/types/analytics";
 import {
   formatAnalyticsCount,
   formatAnalyticsLongDuration,

--- a/packages/web/src/components/analytics/repo-bar-chart.tsx
+++ b/packages/web/src/components/analytics/repo-bar-chart.tsx
@@ -1,6 +1,6 @@
 import type { TooltipContentProps } from "recharts";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import type { AnalyticsBreakdownResponse } from "@open-inspect/shared";
+import type { AnalyticsBreakdownResponse } from "@open-inspect/shared/types/analytics";
 import { formatAnalyticsCount } from "@/lib/analytics";
 import { formatSessionCost } from "@/lib/session-cost";
 

--- a/packages/web/src/components/analytics/summary-cards.tsx
+++ b/packages/web/src/components/analytics/summary-cards.tsx
@@ -1,4 +1,4 @@
-import type { AnalyticsDays, AnalyticsSummaryResponse } from "@open-inspect/shared";
+import type { AnalyticsDays, AnalyticsSummaryResponse } from "@open-inspect/shared/types/analytics";
 import { formatSessionCost } from "@/lib/session-cost";
 import { formatAnalyticsCount } from "@/lib/analytics";
 

--- a/packages/web/src/components/analytics/timeseries-chart.tsx
+++ b/packages/web/src/components/analytics/timeseries-chart.tsx
@@ -8,7 +8,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { AnalyticsTimeseriesResponse } from "@open-inspect/shared";
+import type { AnalyticsTimeseriesResponse } from "@open-inspect/shared/types/analytics";
 import { Badge } from "@/components/ui/badge";
 import {
   buildTimeseriesChartData,

--- a/packages/web/src/components/analytics/user-table.tsx
+++ b/packages/web/src/components/analytics/user-table.tsx
@@ -1,4 +1,7 @@
-import type { AnalyticsBreakdownEntry, AnalyticsBreakdownResponse } from "@open-inspect/shared";
+import type {
+  AnalyticsBreakdownEntry,
+  AnalyticsBreakdownResponse,
+} from "@open-inspect/shared/types/analytics";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ChevronDownIcon, ChevronUpIcon } from "@/components/ui/icons";

--- a/packages/web/src/components/automations/automation-status-badge.tsx
+++ b/packages/web/src/components/automations/automation-status-badge.tsx
@@ -1,4 +1,4 @@
-import type { Automation } from "@open-inspect/shared";
+import type { Automation } from "@open-inspect/shared/types/automations";
 import { Badge } from "@/components/ui/badge";
 
 export function AutomationStatusBadge({ automation }: { automation: Automation }) {

--- a/packages/web/src/components/automations/cron-picker.tsx
+++ b/packages/web/src/components/automations/cron-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { isValidCron, nextCronOccurrence, describeCron } from "@open-inspect/shared";
+import { isValidCron, nextCronOccurrence, describeCron } from "@open-inspect/shared/cron";
 import { RadioCard } from "@/components/ui/form-controls";
 import { Input } from "@/components/ui/input";
 import {

--- a/packages/web/src/components/sign-in-provider-buttons.tsx
+++ b/packages/web/src/components/sign-in-provider-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SignInProvider } from "@open-inspect/shared";
+import type { SignInProvider } from "@open-inspect/shared/sign-in-provider";
 import { useState } from "react";
 import { signIn } from "@/lib/auth-session";
 import { Button } from "@/components/ui/button";

--- a/packages/web/src/hooks/use-analytics.ts
+++ b/packages/web/src/hooks/use-analytics.ts
@@ -6,7 +6,7 @@ import type {
   AnalyticsPullRequestsResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
 import { ANALYTICS_REFRESH_INTERVAL_MS } from "@/lib/analytics";
 
 export function useAnalyticsDashboard(days: AnalyticsDays) {

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -4,7 +4,7 @@ import type {
   AnalyticsPullRequestFunnel,
   AnalyticsPullRequestsResponse,
   AnalyticsTimeseriesResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/analytics";
 
 export const ANALYTICS_REFRESH_INTERVAL_MS = 30_000;
 export const ANALYTICS_DAYS: AnalyticsDays[] = [7, 14, 30, 90];

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -2,7 +2,7 @@
 
 import useSWR, { mutate } from "swr";
 import { z } from "zod";
-import type { SignInProvider } from "@open-inspect/shared";
+import type { SignInProvider } from "@open-inspect/shared/sign-in-provider";
 import {
   browserAuthSessionResponseSchema,
   type BrowserAuthSessionUser,

--- a/packages/web/src/lib/sign-in-providers.ts
+++ b/packages/web/src/lib/sign-in-providers.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
-import { parseEnabledSignInProviders, type SignInProvider } from "@open-inspect/shared";
+import {
+  parseEnabledSignInProviders,
+  type SignInProvider,
+} from "@open-inspect/shared/sign-in-provider";
 import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 import { dispatchWebServiceRequest } from "./control-plane-service";
 import { createLogger } from "./logger";


### PR DESCRIPTION
## Summary
- Add the 14 requested one-to-one `@open-inspect/shared` export paths, using emitted `.js` and `.d.ts` targets.
- Migrate isolated owner consumers for `sign-in-provider`, `types/analytics`, remaining `types/image-builds`, and `completion/extractor`.
- Migrate all ready symbols in the ten assigned seed files, preserving deferred root imports and runtime/type-only semantics.

## Owner Paths
Created and consumed:
- `./sign-in-provider` -> `./dist/sign-in-provider.js` / `./dist/sign-in-provider.d.ts`
- `./git` -> `./dist/git.js` / `./dist/git.d.ts`
- `./cron` -> `./dist/cron.js` / `./dist/cron.d.ts`
- `./triggers` -> `./dist/triggers/index.js` / `./dist/triggers/index.d.ts`
- `./slack` -> `./dist/slack/index.js` / `./dist/slack/index.d.ts`
- `./completion/extractor` -> `./dist/completion/extractor.js` / `./dist/completion/extractor.d.ts`
- `./types/repositories` -> `./dist/types/repositories.js` / `./dist/types/repositories.d.ts`
- `./types/repository-catalog` -> `./dist/types/repository-catalog.js` / `./dist/types/repository-catalog.d.ts`
- `./types/automations` -> `./dist/types/automations.js` / `./dist/types/automations.d.ts`
- `./types/websocket` -> `./dist/types/websocket.js` / `./dist/types/websocket.d.ts`
- `./types/server-messages` -> `./dist/types/server-messages.js` / `./dist/types/server-messages.d.ts`
- `./types/session-attachments` -> `./dist/types/session-attachments.js` / `./dist/types/session-attachments.d.ts`
- `./types/session-diffs` -> `./dist/types/session-diffs.js` / `./dist/types/session-diffs.d.ts`
- `./types/analytics` -> `./dist/types/analytics.js` / `./dist/types/analytics.d.ts`

The existing `./types/integrations` and `./types/image-builds` mappings are unchanged. The package root and compatibility exports remain unchanged.

## Inventory Evidence
- Changed files: 34 production, 4 tests, plus `packages/shared/package.json`.
- AST-aware assigned owner import inventory, production: direct owner imports `15 -> 50`; package-root imports containing assigned owner symbols `112 -> 78`.
- AST-aware assigned owner import inventory, tests: direct owner imports `2 -> 6`; package-root imports containing assigned owner symbols `17 -> 13`.
- Isolated owner root imports are zero after migration: sign-in provider, analytics, image-build types, and completion extractor.
- No assigned symbol remains at the root in the completed isolated-owner scope. Remaining root imports are intentionally deferred owner families or mixed imports retaining deferred symbols, including `SpawnSource`, `AgentResponse`, artifacts, statuses, sandbox events, session APIs, and other compatibility surfaces.
- Direct paths expose only names already present on the historical package-root surface; no facade or source declaration was added.

## Architecture
- Shared implementation modules continue using relative imports to concrete owners.
- Application packages depend on shared only; no new compile-time or runtime cycle was introduced.
- Shared module-boundary tests report no runtime SCC and no compile-time SCC.

## Validation
- `npm ci` passed on Node `v22.22.2`.
- `npm run build -w @open-inspect/shared` passed.
- `npm run typecheck` passed.
- `git diff --check` passed.
- Scoped ESLint over all affected package source/test trees passed.
- `npm test -w @open-inspect/shared`: 38 files, 525 tests passed.
- `npm test -w @open-inspect/control-plane`: 146 files, 2,197 tests passed.
- `npm run test:integration -w @open-inspect/control-plane`: 59 files, 677 tests passed.
- `npm test -w @open-inspect/github-bot`: 7 files, 130 tests passed.
- `npm test -w @open-inspect/slack-bot`: 31 files, 388 tests passed.
- `npm test -w @open-inspect/linear-bot`: 14 files, 202 tests passed.
- Changed web analytics test: 1 file, 3 tests passed.
- Web auth-boundary test: 1 file, 7 tests passed with a 30-second timeout.
- Control-plane production build passed.
- GitHub-bot, Slack-bot, and Linear-bot production builds passed.
- The web production build still fails at prerendering `/automations/new` with the existing `TypeError: Cannot read properties of null (reading 'useContext')`; compilation and TypeScript completed first.
- Required full `npm run format:check` remains blocked only by the pre-existing `.opencode/package.json` formatting warning.
- Required full `npm run lint` remains blocked only by 45 pre-existing errors under `.opencode/`; affected package lint passes.
- The initial web workspace test run had one pre-existing 5-second timeout in `src/lib/client-auth-boundary-eslint.test.ts`; rerunning that test with a 30-second timeout passed.

## Exclusions
- No behavior, schema, serialized shape, defaults, validation, public root API, source declarations, wrappers, facades, contracts, lint ratchets, ESM rewrite, dependency, or lockfile changes.
- Deferred owner migration remains for later batches; this PR intentionally does not claim repository-wide root-import completion.


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c4db9334db6270468b7e64185d0f0667)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Organized shared functionality into dedicated, clearer modules across authentication, analytics, automation, session handling, Git integrations, and messaging.
  - Improved internal module resolution and type loading without changing user-facing behavior.

- **Chores**
  - Expanded shared package access points for commonly used utilities and data types.
  - No visible feature changes or workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->