### PR TITLE
feat(slack): let channel-trigger automations decline to reply

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -258,6 +258,14 @@ finishes, the agent's final response is posted as a reply in that message's thre
 any pull requests it opened and to the full web session — and the reaction is cleared. A failed run
 posts a short failure notice in the thread instead.
 
+A run can also **decline to reply**: if the agent's entire final message is `NO_REPLY` (or empty),
+nothing is posted and only the reaction is cleared. Because every reply in a watched thread wakes
+the automation (see below), an automation that watches a busy channel will otherwise answer messages
+that need nothing from it. Mention the sentinel in the automation's instructions — for example _"if
+the message needs nothing from you, reply with exactly `NO_REPLY` and nothing else"_ — since the
+agent will answer everything it is woken for unless told otherwise. A run that opened a pull request
+or produced other artifacts always posts.
+
 Every reply in a thread **continues the same session** — during the run and after it finishes — for
 up to 7 days after the thread's first trigger, exactly like replying in an `@mention` thread. The
 reply is enqueued as a follow-up turn on that session (re-spawning it from a snapshot if it had gone

--- a/docs/integrations/SLACK.md
+++ b/docs/integrations/SLACK.md
@@ -325,6 +325,15 @@ condition to filter by content. See
 - When the run finishes, the agent's final response is posted into the triggering message's thread
   (with links to any pull requests and the full session), and the reaction is cleared. A failed run
   posts a short failure notice instead.
+- A run can **decline to reply**. If the agent's entire final message is `NO_REPLY` (or empty),
+  nothing is posted and only the 👀 reaction is cleared. This lets an automation that watches a busy
+  channel stay quiet on messages that turn out to need nothing from it — chatter between people, or
+  a follow-up addressed to someone else — instead of posting its reasoning about why it has nothing
+  to say. It applies to thread follow-ups as much as to the first trigger, which is where it matters
+  most: every reply in the thread wakes the automation. Tell the agent about the sentinel in the
+  automation's instructions; without an explicit instruction it will answer every message it is
+  woken for. A run that opened a pull request or produced other artifacts always posts, and
+  interactive `@mention` sessions never decline — a person is waiting on a visible answer there.
 - Every reply in a thread continues the same session — during the run and after it finishes — for up
   to 7 days after the thread's first trigger, like replying in an `@mention` thread. The reply is
   routed to that session as a follow-up prompt (re-spawned from a snapshot if it had gone idle),

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -2307,6 +2307,9 @@ describe("SchedulerDO", () => {
         reactionMessageTs: "1700000000.000200",
         // Label reads the steered run's snapshot.
         repoFullName: "acme/web-app",
+        // Marks the turn as automation-owned even though it completes through
+        // the interactive callback route.
+        automationId: "auto-slack",
       });
 
       // A steer is not a new trigger and not a skip.

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -1361,6 +1361,9 @@ export class SchedulerDO extends DurableObject<Env> {
       repoFullName: formatRunRepositoryLabel(run),
       model: automation.model,
       reasoningEffort: automation.reasoning_effort ?? undefined,
+      // Marks the turn as automation-owned: a follow-up completes through the
+      // interactive callback, which would otherwise treat it as a user request.
+      automationId: automation.id,
     };
 
     try {

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -30,6 +30,13 @@ export const slackCallbackContextSchema = z.object({
   model: z.string(),
   reasoningEffort: z.string().optional(),
   reactionMessageTs: z.string().optional(),
+  /**
+   * Set when the session belongs to an automation rather than an interactive
+   * request. A thread follow-up completes through the same callback as an
+   * `@mention` turn, so the route alone cannot tell the two apart, and only the
+   * control plane knows which automation (if any) owns the thread.
+   */
+  automationId: z.string().optional(),
 });
 
 export type SlackCallbackContext = z.infer<typeof slackCallbackContextSchema>;

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -404,6 +404,32 @@ describe("POST /callbacks/complete", () => {
     expect(queued).not.toHaveProperty("extraTopLevel");
   });
 
+  it("queues an automation-sourced job when the context carries an automation id", async () => {
+    const env = makeEnv();
+    const payload = await signPayload(
+      completeCallbackData({
+        context: {
+          source: "slack",
+          channel: "C123",
+          threadTs: "111.222",
+          repoFullName: "acme/app",
+          model: "anthropic/claude-haiku-4-5",
+          automationId: "automation-1",
+        },
+      })
+    );
+
+    const { response } = await postCallback("/callbacks/complete", payload, env);
+
+    expect(response.status).toBe(200);
+    // A thread follow-up on an automation completes through this interactive
+    // route; without the marker it would be ineligible to decline a reply.
+    expect(env.SLACK_COMPLETION_QUEUE.send).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "automation" }),
+      { contentType: "json" }
+    );
+  });
+
   it("returns 503 when enqueue fails", async () => {
     const env = makeEnv({
       SLACK_COMPLETION_QUEUE: {

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -25,6 +25,8 @@ const slackCallbackContextSchema = z.looseObject({
   model: z.string(),
   reasoningEffort: z.string().optional(),
   reactionMessageTs: z.string().optional(),
+  /** Present when the control plane owns this thread as an automation. */
+  automationId: z.string().optional(),
 });
 
 const completionCallbackSchema = z.looseObject({
@@ -214,7 +216,11 @@ callbacksRouter.post("/complete", async (c) => {
   return enqueueCompletion(
     c,
     createSlackCompletionJob({
-      source: "session",
+      // A Slack thread follow-up completes through this route whether it
+      // continues an interactive @mention or an automation's thread. Only the
+      // latter may decline to reply, so trust the control plane's marker rather
+      // than the route.
+      source: valid.context.automationId ? "automation" : "session",
       sessionId: valid.sessionId,
       messageId: valid.messageId,
       success: valid.success,

--- a/packages/slack-bot/src/completion/delivery.test.ts
+++ b/packages/slack-bot/src/completion/delivery.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { processSlackCompletion } from "./delivery";
+import { processSlackCompletion, shouldDeclineReply } from "./delivery";
 import { extractAgentResponse } from "./extractor";
 import { deliverMediaArtifacts } from "./media-upload";
 import type { SlackCompletionJob } from "./job";
+import type { AgentResponse } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type * as ExtractorModule from "./extractor";
 import type * as MediaUploadModule from "./media-upload";
@@ -60,6 +61,17 @@ function successfulAgentResponse() {
     artifacts: [],
     mediaArtifacts: [{ id: "image-1", type: "screenshot" as const }],
     success: true,
+  };
+}
+
+function declinedAgentResponse(overrides: Partial<AgentResponse> = {}): AgentResponse {
+  return {
+    textContent: "NO_REPLY",
+    toolCalls: [],
+    artifacts: [],
+    mediaArtifacts: [],
+    success: true,
+    ...overrides,
   };
 }
 
@@ -152,5 +164,77 @@ describe("processSlackCompletion", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("reactions.remove");
+  });
+
+  it("posts nothing but still clears the reaction when an automation declines", async () => {
+    vi.mocked(extractAgentResponse).mockResolvedValue(declinedAgentResponse());
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
+
+    await processSlackCompletion(job({ source: "automation" }), makeEnv());
+
+    expect(deliverMediaArtifacts).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("reactions.remove");
+  });
+
+  it("posts the interactive fallback when a session produces the sentinel", async () => {
+    vi.mocked(extractAgentResponse).mockResolvedValue(declinedAgentResponse());
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({ ok: true, channel: "C123", ts: "333.444" }))
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+
+    await processSlackCompletion(job({ source: "session" }), makeEnv());
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("chat.postMessage");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("reactions.remove");
+  });
+});
+
+describe("shouldDeclineReply", () => {
+  const automation = { source: "automation", success: true } as const;
+
+  it("accepts the sentinel regardless of case or a trailing period", () => {
+    for (const textContent of ["NO_REPLY", "no_reply", "No_Reply.", "  NO_REPLY  "]) {
+      expect(shouldDeclineReply(automation, declinedAgentResponse({ textContent }))).toBe(true);
+    }
+  });
+
+  it("accepts an empty final message", () => {
+    expect(shouldDeclineReply(automation, declinedAgentResponse({ textContent: "   " }))).toBe(
+      true
+    );
+  });
+
+  it("rejects a sentinel that is part of a real answer", () => {
+    const response = declinedAgentResponse({
+      textContent: "NO_REPLY is the sentinel you asked about.",
+    });
+    expect(shouldDeclineReply(automation, response)).toBe(false);
+  });
+
+  it("rejects interactive sessions so a waiting user always sees something", () => {
+    expect(shouldDeclineReply({ source: "session", success: true }, declinedAgentResponse())).toBe(
+      false
+    );
+  });
+
+  it("rejects failed runs so the operator sees the error", () => {
+    expect(
+      shouldDeclineReply({ source: "automation", success: false }, declinedAgentResponse())
+    ).toBe(false);
+    expect(shouldDeclineReply(automation, declinedAgentResponse({ success: false }))).toBe(false);
+  });
+
+  it("rejects runs that produced artifacts outside Slack", () => {
+    const withPr = declinedAgentResponse({
+      artifacts: [{ type: "pr", url: "https://github.com/acme/app/pull/1", label: "PR #1" }],
+    });
+    expect(shouldDeclineReply(automation, withPr)).toBe(false);
+
+    const withMedia = declinedAgentResponse({
+      mediaArtifacts: [{ id: "image-1", type: "screenshot" }],
+    });
+    expect(shouldDeclineReply(automation, withMedia)).toBe(false);
   });
 });

--- a/packages/slack-bot/src/completion/delivery.ts
+++ b/packages/slack-bot/src/completion/delivery.ts
@@ -1,5 +1,5 @@
 import { postBlocks, postMessage, removeReaction } from "@open-inspect/shared/slack";
-import type { Env } from "../types";
+import type { AgentResponse, Env } from "../types";
 import { createLogger } from "../logger";
 import { extractAgentResponse } from "./extractor";
 import { buildCompletionBlocks, truncateError } from "./blocks";
@@ -7,6 +7,45 @@ import { deliverMediaArtifacts } from "./media-upload";
 import type { SlackCompletionJob } from "./job";
 
 const log = createLogger("completion-delivery");
+
+/**
+ * Sentinel an agent emits as its entire final message to decline replying in
+ * Slack. Recognized only for automation-sourced completions — see
+ * {@link shouldDeclineReply}.
+ */
+export const NO_REPLY_SENTINEL = "NO_REPLY";
+
+/** Tolerates the trailing period a model tends to add to a bare sentinel. */
+const NO_REPLY_PATTERN = new RegExp(`^${NO_REPLY_SENTINEL}\\.?$`, "i");
+
+/**
+ * Whether a finished run has declined to say anything in Slack.
+ *
+ * Channel-trigger automations fire on ambient messages, so "this needed nothing
+ * from me" is a legitimate outcome — the message turned out to be chatter
+ * between humans, or a follow-up addressed to someone else. With no way to
+ * express that, the run's reasoning about why it should stay quiet gets posted
+ * as a reply, and a triage automation becomes the noise it was meant to triage.
+ *
+ * Only automation-sourced completions may decline. An interactive session has a
+ * user waiting on a visible answer, so it always posts, falling back to
+ * "_Agent completed._" when the agent produced no text.
+ *
+ * A run that produced artifacts always posts too: work that landed outside
+ * Slack needs a pointer to it regardless of what the agent wrote.
+ */
+export function shouldDeclineReply(
+  job: Pick<SlackCompletionJob, "source" | "success">,
+  response: AgentResponse
+): boolean {
+  if (job.source !== "automation") return false;
+  if (!job.success || !response.success) return false;
+  if (response.artifacts.length > 0) return false;
+  if ((response.mediaArtifacts ?? []).length > 0) return false;
+
+  const text = response.textContent.trim();
+  return text === "" || NO_REPLY_PATTERN.test(text);
+}
 
 export async function processSlackCompletion(job: SlackCompletionJob, env: Env): Promise<void> {
   const startTime = Date.now();
@@ -56,6 +95,18 @@ export async function processSlackCompletion(job: SlackCompletionJob, env: Env):
             ],
           },
         ],
+      });
+      return;
+    }
+
+    if (shouldDeclineReply(job, agentResponse)) {
+      log.info("callback.complete", {
+        ...base,
+        outcome: "success",
+        declined: true,
+        agent_success: job.success,
+        tool_call_count: agentResponse.toolCalls.length,
+        duration_ms: Date.now() - startTime,
       });
       return;
     }


### PR DESCRIPTION
## Summary

A Slack channel-trigger automation fires on ambient messages, so a run's honest outcome is often that nothing was needed — the message turned out to be chatter between people, or a follow-up addressed to someone else.

Completion delivery had no way to express that. `processSlackCompletion` always posts the agent's final text, falling back to `_Agent completed._` when there is none, so an agent instructed to stay quiet posts its *reasoning about staying quiet* instead. In practice a triage automation on a busy channel becomes the noise it was meant to triage: every reply in a watched thread steers the session (by design — conditions gate new runs, not replies), and every steer produces another post.

This adds a declined-reply path: for automation-sourced completions, a final message of `NO_REPLY` (or an empty one) posts nothing and only clears the 👀 reaction.

### Identifying an automation turn

A thread follow-up completes through `/callbacks/complete`, the same route as an interactive `@mention` turn, which hardcodes `source: "session"`. Gating on the route alone would let only an automation's *first* run decline while every follow-up kept posting — and follow-ups are the bulk of the noise.

Only the control plane knows which automation owns a thread, so `steerSession` now stamps `automationId` onto the Slack callback context and the route derives the job source from it. The field is optional and additive; an interactive session never carries one.

### Scoping, so nothing silently disappears

- **Interactive sessions never decline.** An `@mention` has a person waiting on a visible answer, so the `_Agent completed._` fallback stays exactly as it is.
- **Failed runs never decline** — the operator still sees the error.
- **Runs that produced artifacts never decline.** Work that landed outside Slack needs a pointer to it regardless of what the agent wrote.

Opt-in by nature: an agent only emits the sentinel if the automation's instructions tell it to, so existing automations are unaffected.

## Test plan

- [x] `npm test -w @open-inspect/slack-bot` (397), `npm test -w @open-inspect/control-plane` (2197), `npm test -w @open-inspect/shared` (525)
- [x] `npm run typecheck`, `npm run lint:fix`
- [x] New unit tests for `shouldDeclineReply`: sentinel casing/trailing period, empty text, sentinel embedded in a real answer (rejected), interactive source, failed run, artifacts and media artifacts
- [x] New delivery tests: an automation that declines posts nothing but still clears the reaction; a session emitting the same text posts the ordinary completion
- [x] New callback-route test: a `/callbacks/complete` payload carrying `automationId` queues an automation-sourced job
- [x] Extended the existing steer test to assert the context marker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automations can suppress Slack replies by returning `NO_REPLY` or an empty successful response.
  * Processing reactions are cleared when a reply is suppressed.
  * Runs that produce artifacts, fail, or occur in interactive sessions continue to post responses.
  * Slack thread follow-ups now preserve automation context for consistent handling.

* **Documentation**
  * Updated Slack automation documentation to describe reply suppression and exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->