### PR TITLE
refactor: migrate automation imports to shared owners

### DIFF
--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -2,19 +2,18 @@
  * Automation CRUD routes.
  */
 
+import { isValidCron, nextCronOccurrence, cronIntervalMinutes } from "@open-inspect/shared/cron";
 import {
-  isValidCron,
-  nextCronOccurrence,
-  cronIntervalMinutes,
   validateConditions,
   conditionRegistry,
-  listChannels,
   TRIGGER_TYPE_TO_SOURCE,
-  type CreateAutomationRequest,
-  type UpdateAutomationRequest,
-  type AutomationTriggerType,
-  type TriggerConfig,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/triggers";
+import type { AutomationTriggerType, TriggerConfig } from "@open-inspect/shared/triggers";
+import type {
+  CreateAutomationRequest,
+  UpdateAutomationRequest,
+} from "@open-inspect/shared/types/automations";
+import { listChannels } from "@open-inspect/shared/slack";
 import {
   getValidModelOrDefault,
   isValidModel,
@@ -37,7 +36,7 @@ import { createLogger } from "../logger";
 import {
   automationRepositoriesInputSchema,
   MAX_AUTOMATION_REPOSITORIES,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/automations";
 import { isEnvironmentId } from "@open-inspect/shared/types/environments";
 import {
   type Route,

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -11,15 +11,14 @@
 import { DurableObject } from "cloudflare:workers";
 import {
   automationEventSchema,
-  nextCronOccurrence,
   matchesConditions,
   conditionRegistry,
-  type AutomationCallbackContext,
-  type AutomationInvocationSource,
   type SlackAutomationEvent,
-  type SlackCallbackContext,
   type TriggerConfig,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/triggers";
+import { nextCronOccurrence } from "@open-inspect/shared/cron";
+import type { AutomationInvocationSource } from "@open-inspect/shared/types/automations";
+import type { AutomationCallbackContext, SlackCallbackContext } from "@open-inspect/shared";
 import { computeHmacHex } from "@open-inspect/shared/auth";
 import { z } from "zod";
 import { callbackSigningSecret } from "../auth/service/callback-signing";

--- a/packages/control-plane/src/webhooks/pull-request-lifecycle.test.ts
+++ b/packages/control-plane/src/webhooks/pull-request-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GitHubAutomationEvent } from "@open-inspect/shared";
+import type { GitHubAutomationEvent } from "@open-inspect/shared/triggers";
 import type { SessionPullRequestRecord } from "../db/session-pull-request-store";
 import {
   processPullRequestLifecycleEvent,

--- a/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
+++ b/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
@@ -13,13 +13,13 @@
  * dropped as not-ours.
  */
 
-import {
-  extractSessionIdFromBranch,
-  prArtifactBelongsToRepo,
-  type GitHubAutomationEvent,
-  type GitHubPullRequestEventFacts,
-  type PullRequestStatus,
-} from "@open-inspect/shared";
+import { extractSessionIdFromBranch } from "@open-inspect/shared/git";
+import { prArtifactBelongsToRepo } from "@open-inspect/shared/types/repositories";
+import type {
+  GitHubAutomationEvent,
+  GitHubPullRequestEventFacts,
+} from "@open-inspect/shared/triggers";
+import type { PullRequestStatus } from "@open-inspect/shared";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,

--- a/packages/slack-bot/src/channel-trigger.ts
+++ b/packages/slack-bot/src/channel-trigger.ts
@@ -12,7 +12,7 @@ import {
   normalizeSlackEvent,
   type SlackAutomationEvent,
   type SlackChannelMeta,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/triggers";
 import type { Env } from "./types";
 import { isChannelTriggerCandidate } from "./dm-utils";
 import { getWatchedChannels } from "./classifier/repos";

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, use } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { describeCron } from "@open-inspect/shared";
+import { describeCron } from "@open-inspect/shared/cron";
 import { getReasoningConfig } from "@open-inspect/shared/models";
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { useAutomation, useAutomationInvocations } from "@/hooks/use-automations";

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ReactNode } from "react";
-import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared";
+import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared/types/automations";
 import { DEFAULT_MODEL } from "@open-inspect/shared/models";
 import { AutomationForm, type AutomationFormValues } from "./automation-form";
 import { CronPicker } from "./cron-picker";

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { isValidCron } from "@open-inspect/shared/cron";
 import {
-  isValidCron,
   triggerSources,
-  MAX_AUTOMATION_REPOSITORIES,
   TRIGGER_TYPE_TO_SOURCE,
-  type AutomationRepositoryInput,
   type AutomationTriggerType,
   type AutomationEventSource,
   type TriggerCondition,
   type TriggerConfig,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/triggers";
+import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared/types/automations";
+import type { AutomationRepositoryInput } from "@open-inspect/shared/types/automations";
 import {
   DEFAULT_MODEL,
   getReasoningConfig,

--- a/packages/web/src/components/automations/automation-target-selection.ts
+++ b/packages/web/src/components/automations/automation-target-selection.ts
@@ -1,8 +1,8 @@
 import {
   formatRepositoryFullName,
   parseRepositoryFullName,
-  type AutomationRepositoryInput,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/repositories";
+import type { AutomationRepositoryInput } from "@open-inspect/shared/types/automations";
 import type { SessionTarget } from "@/lib/session-target";
 
 /**

--- a/packages/web/src/components/automations/automations-list.test.tsx
+++ b/packages/web/src/components/automations/automations-list.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ComponentProps } from "react";
-import type { Automation } from "@open-inspect/shared";
+import type { Automation } from "@open-inspect/shared/types/automations";
 import { AutomationsList } from "./automations-list";
 
 expect.extend(matchers);

--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { describeCron, GITHUB_WEBHOOK_EVENT_CATALOG } from "@open-inspect/shared";
-import type { Automation } from "@open-inspect/shared";
+import { describeCron } from "@open-inspect/shared/cron";
+import { GITHUB_WEBHOOK_EVENT_CATALOG } from "@open-inspect/shared/triggers";
+import type { Automation } from "@open-inspect/shared/types/automations";
 import { AutomationStatusBadge } from "@/components/automations/automation-status-badge";
 import { Button } from "@/components/ui/button";
 import { FolderIcon, BoxIcon, ClockIcon, BoltIcon } from "@/components/ui/icons";

--- a/packages/web/src/components/automations/condition-builder.test.tsx
+++ b/packages/web/src/components/automations/condition-builder.test.tsx
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import type { TriggerCondition } from "@open-inspect/shared";
+import type { TriggerCondition } from "@open-inspect/shared/triggers";
 import { ConditionBuilder } from "./condition-builder";
 
 type ChannelListing = { id: string; name: string; isPrivate: boolean; isMember: boolean };

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { TriggerCondition, AutomationEventSource, JsonPathFilter } from "@open-inspect/shared";
-import { conditionRegistry } from "@open-inspect/shared";
+import type {
+  TriggerCondition,
+  AutomationEventSource,
+  JsonPathFilter,
+} from "@open-inspect/shared/triggers";
+import { conditionRegistry } from "@open-inspect/shared/triggers";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";

--- a/packages/web/src/components/automations/condition-summary.test.tsx
+++ b/packages/web/src/components/automations/condition-summary.test.tsx
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import type { TriggerCondition } from "@open-inspect/shared";
+import type { TriggerCondition } from "@open-inspect/shared/triggers";
 import { ConditionSummary } from "./condition-summary";
 
 type ChannelListing = { id: string; name: string; isPrivate: boolean; isMember: boolean };

--- a/packages/web/src/components/automations/condition-summary.tsx
+++ b/packages/web/src/components/automations/condition-summary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { TriggerCondition } from "@open-inspect/shared";
+import type { TriggerCondition } from "@open-inspect/shared/triggers";
 import { useSlackChannels } from "@/hooks/use-slack-channels";
 
 /**

--- a/packages/web/src/components/automations/run-history.test.tsx
+++ b/packages/web/src/components/automations/run-history.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ComponentProps } from "react";
-import type { AutomationInvocation, AutomationRun } from "@open-inspect/shared";
+import type { AutomationInvocation, AutomationRun } from "@open-inspect/shared/types/automations";
 import { RunHistory } from "./run-history";
 
 expect.extend(matchers);

--- a/packages/web/src/components/automations/run-history.tsx
+++ b/packages/web/src/components/automations/run-history.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import type { AutomationInvocation, AutomationRun } from "@open-inspect/shared";
+import type { AutomationInvocation, AutomationRun } from "@open-inspect/shared/types/automations";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ChevronDownIcon, ChevronRightIcon } from "@/components/ui/icons";

--- a/packages/web/src/components/automations/template-gallery.tsx
+++ b/packages/web/src/components/automations/template-gallery.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { AutomationTriggerType } from "@open-inspect/shared";
+import type { AutomationTriggerType } from "@open-inspect/shared/triggers";
 import {
   automationTemplates,
   getVisibleCategories,

--- a/packages/web/src/components/automations/trigger-type-selector.tsx
+++ b/packages/web/src/components/automations/trigger-type-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AutomationTriggerType } from "@open-inspect/shared";
+import type { AutomationTriggerType } from "@open-inspect/shared/triggers";
 
 interface TriggerOption {
   type: AutomationTriggerType;

--- a/packages/web/src/components/automations/use-automation-targets.ts
+++ b/packages/web/src/components/automations/use-automation-targets.ts
@@ -1,11 +1,9 @@
 "use client";
 
 import { useCallback, useMemo, useEffect, useState } from "react";
-import {
-  MAX_AUTOMATION_REPOSITORIES,
-  parseRepositoryFullName,
-  type AutomationRepositoryInput,
-} from "@open-inspect/shared";
+import { parseRepositoryFullName } from "@open-inspect/shared/types/repositories";
+import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared/types/automations";
+import type { AutomationRepositoryInput } from "@open-inspect/shared/types/automations";
 import {
   type AutomationSessionTarget,
   type SelectionMode,

--- a/packages/web/src/hooks/use-automations.ts
+++ b/packages/web/src/hooks/use-automations.ts
@@ -4,7 +4,7 @@ import type {
   Automation,
   ListAutomationsResponse,
   ListAutomationInvocationsResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/automations";
 
 export function useAutomations() {
   const { data: session } = useAuthSession();

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect } from "vitest";
+import { isValidCron, cronIntervalMinutes } from "@open-inspect/shared/cron";
 import {
   triggerSources,
-  isValidCron,
-  cronIntervalMinutes,
   validateConditions,
   conditionRegistry,
   TRIGGER_TYPE_TO_SOURCE,
   type AutomationTriggerType,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/triggers";
 import { DEFAULT_MODEL, isValidModel, isValidReasoningEffort } from "@open-inspect/shared/models";
 import {
   automationTemplates,

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -6,7 +6,7 @@
  * repo-required-at-creation invariant is untouched.
  */
 
-import type { AutomationTriggerType } from "@open-inspect/shared";
+import type { AutomationTriggerType } from "@open-inspect/shared/triggers";
 import type { AutomationFormValues } from "@/components/automations/automation-form";
 
 export type TemplateCategory =


### PR DESCRIPTION
## Summary
- Migrate assigned automation, scheduler, PR lifecycle, Slack channel-trigger, and web automation consumers from the shared package root to existing owner paths.
- Preserve root compatibility exports and all value/type/export-type semantics; no shared source or package metadata changed.

## Exact paths
- `packages/control-plane/src/routes/automations.ts`
- `packages/control-plane/src/scheduler/durable-object.ts`
- `packages/control-plane/src/webhooks/pull-request-lifecycle.ts`
- `packages/control-plane/src/webhooks/pull-request-lifecycle.test.ts`
- `packages/slack-bot/src/channel-trigger.ts`
- `packages/slack-bot/src/channel-trigger.test.ts`
- `packages/web/src/app/(app)/automations/[id]/page.tsx`
- `packages/web/src/components/automations/automation-form.tsx`
- `packages/web/src/components/automations/automation-form.test.tsx`
- `packages/web/src/components/automations/automation-target-selection.ts`
- `packages/web/src/components/automations/automations-list.tsx`
- `packages/web/src/components/automations/automations-list.test.tsx`
- `packages/web/src/components/automations/condition-builder.tsx`
- `packages/web/src/components/automations/condition-builder.test.tsx`
- `packages/web/src/components/automations/condition-summary.tsx`
- `packages/web/src/components/automations/condition-summary.test.tsx`
- `packages/web/src/components/automations/run-history.tsx`
- `packages/web/src/components/automations/run-history.test.tsx`
- `packages/web/src/components/automations/template-gallery.tsx`
- `packages/web/src/components/automations/trigger-type-selector.tsx`
- `packages/web/src/components/automations/use-automation-targets.ts`
- `packages/web/src/hooks/use-automations.ts`
- `packages/web/src/lib/automation-templates.ts`
- `packages/web/src/lib/automation-templates.test.ts`

## Evidence
- 16 production files and 8 existing test files migrated; 24 files changed.
- Assigned AST root consumers: production 16 -> 2, tests 8 -> 1. The retained roots are only deferred `AutomationCallbackContext`, `PullRequestStatus`, and the Slack test namespace mock for unrelated root consumers.
- Assigned direct owner consumers after migration: production `cron=6`, `triggers=11`, `types/automations=9`, `git=1`, `slack=2`, `types/repositories=3`; tests `cron=1`, `triggers=4`, `types/automations=3`, `slack=1`.
- Historical root compatibility remains unchanged. Built owner declarations expose no names beyond the historical root.
- Dependency direction remains `@open-inspect/shared <- application packages`; shared boundary checks report no runtime or compile-time SCC/cycle.

## Validation
- Node `v22.22.2`; `npm ci` completed.
- Shared tests: 38 files, 525 tests passed.
- Control-plane tests: 146 files, 2,197 tests passed.
- Slack-bot tests: 31 files, 388 tests passed.
- Web tests: 111 files, 852 tests passed.
- Shared module-boundary test: 1 file, 4 tests passed.
- Typechecks passed for control-plane, Slack-bot, and web; shared and all workspace typechecks passed.
- Builds passed for shared, control-plane, Slack-bot, GitHub-bot, and Linear-bot.
- `diff --check`, focused Prettier, and focused ESLint passed.

## Deferred and exclusions
- Root-only `types/artifacts`, `types/sessions`, `types/session-api`, `types/statuses`, `types/sandbox-events`, `readBodyCapped`, and `escapeRegExp` were not moved.
- General resource/settings files, Session protocol files, Batch A seed files, and unsupported/behavior-requiring owners are outside this batch.
- Full-repo format check remains blocked by pre-existing `.opencode/package.json` formatting; full-repo lint remains blocked by 45 pre-existing `.opencode` errors.
- Control-plane integration is blocked by an unrelated existing Modal `404 invalid function call` in `test/integration/websocket-client.test.ts`; no CI or runtime behavior was changed.
- Web production build compiles and typechecks but hits the unrelated existing prerender `useContext` failure on `/automations/new`.

Never merge this PR automatically; it is ready for review.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bc4f05e5351f094dca20214a941c44df)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized shared automation, trigger, scheduling, repository, and integration references.
  * No changes to automation workflows, forms, scheduling, webhooks, Slack behavior, or other end-user functionality.

* **Tests**
  * Updated automation-related tests to use the reorganized shared references while preserving existing coverage and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->