### PR TITLE
feat: pass reasoning effort to child sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,16 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        working-directory: .
+        run: npm ci
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -327,6 +337,10 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+      - name: Run sandbox tool tests
+        working-directory: .
+        run: npm test -w @open-inspect/sandbox-runtime
 
   test-python:
     name: Test (Python - modal-infra)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3523,6 +3523,10 @@
       "resolved": "packages/opencomputer-infra",
       "link": true
     },
+    "node_modules/@open-inspect/sandbox-runtime": {
+      "resolved": "packages/sandbox-runtime",
+      "link": true
+    },
     "node_modules/@open-inspect/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -16424,6 +16428,13 @@
         "@opencomputer/sdk": "^0.9.1",
         "esbuild": "^0.28.1",
         "typescript": "^5.7.2"
+      }
+    },
+    "packages/sandbox-runtime": {
+      "name": "@open-inspect/sandbox-runtime",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.1.13"
       }
     },
     "packages/shared": {

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -104,6 +104,110 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     expect(state.status).toBe("active");
   });
 
+  it("inherits the parent's reasoning effort when omitted", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      reasoningEffort: "high",
+    });
+
+    const response = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+      body: JSON.stringify({ title: "Inherited effort", prompt: "Use the parent effort" }),
+    });
+
+    expect(response.status).toBe(201);
+    const { sessionId } = await response.json<{ sessionId: string }>();
+    expect((await store.get(sessionId))?.reasoningEffort).toBe("high");
+
+    const childStub = env.SESSION.get(env.SESSION.idFromName(sessionId));
+    const [session] = await queryDO<{ reasoning_effort: string | null }>(
+      childStub,
+      "SELECT reasoning_effort FROM session"
+    );
+    expect(session.reasoning_effort).toBe("high");
+  });
+
+  it("persists an explicit reasoning effort override", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      reasoningEffort: "low",
+    });
+
+    const response = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+      body: JSON.stringify({
+        title: "Overridden effort",
+        prompt: "Use the explicit effort",
+        reasoningEffort: "high",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const { sessionId } = await response.json<{ sessionId: string }>();
+    expect((await store.get(sessionId))?.reasoningEffort).toBe("high");
+  });
+
+  it("keeps incompatible reasoning effort compatibility semantics", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "high",
+    });
+
+    const response = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+      body: JSON.stringify({
+        title: "Incompatible effort",
+        prompt: "Keep the existing fallback",
+        reasoningEffort: "xhigh",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const { sessionId } = await response.json<{ sessionId: string }>();
+    expect((await store.get(sessionId))?.reasoningEffort).toBeNull();
+  });
+
+  it("inherits an overridden effort through a grandchild", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      reasoningEffort: "low",
+    });
+
+    const childResponse = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+      body: JSON.stringify({
+        title: "Child effort",
+        prompt: "Spawn a grandchild",
+        reasoningEffort: "high",
+      }),
+    });
+    expect(childResponse.status).toBe(201);
+    const { sessionId: childId } = await childResponse.json<{ sessionId: string }>();
+    const childStub = env.SESSION.get(env.SESSION.idFromName(childId));
+    const childToken = `child-sb-tok-${Date.now()}`;
+    await seedSandboxAuth(childStub, {
+      authToken: childToken,
+      sandboxId: `child-sb-${Date.now()}`,
+    });
+
+    const grandchildResponse = await SELF.fetch(`https://test.local/sessions/${childId}/children`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${childToken}` },
+      body: JSON.stringify({ title: "Grandchild effort", prompt: "Use inherited effort" }),
+    });
+    expect(grandchildResponse.status).toBe(201);
+    const { sessionId: grandchildId } = await grandchildResponse.json<{ sessionId: string }>();
+    expect((await store.get(grandchildId))?.reasoningEffort).toBe("high");
+
+    const grandchildStub = env.SESSION.get(env.SESSION.idFromName(grandchildId));
+    const [session] = await queryDO<{ reasoning_effort: string | null }>(
+      grandchildStub,
+      "SELECT reasoning_effort FROM session"
+    );
+    expect(session.reasoning_effort).toBe("high");
+  });
+
   it("persists environment provenance for spawned children", async () => {
     const { parentName, sandboxToken, store } = await setupParent({
       repoId: 12345,

--- a/packages/sandbox-runtime/package.json
+++ b/packages/sandbox-runtime/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@open-inspect/sandbox-runtime",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.1.13"
+  },
+  "scripts": {
+    "test": "node --test tests/*.test.mjs"
+  }
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child-config.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child-config.js
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const spawnChildArgs = {
+  reasoning: z
+    .string()
+    .optional()
+    .describe(
+      "Overrides the child's reasoning effort. Defaults to the parent's effort when omitted."
+    ),
+};
+
+export function buildChildSpawnBody(args) {
+  const body = { title: args.title, prompt: args.prompt };
+  if (args.model) {
+    body.model = args.model;
+  }
+  if (args.reasoning) {
+    body.reasoningEffort = args.reasoning;
+  }
+  return body;
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -7,6 +7,9 @@
 import { tool } from "@opencode-ai/plugin";
 import { z } from "zod";
 import { bridgeFetch, extractError } from "./_bridge-client.js";
+import { buildChildSpawnBody, spawnChildArgs } from "./spawn-child-config.js";
+
+export { buildChildSpawnBody } from "./spawn-child-config.js";
 
 export default tool({
   name: "spawn-child",
@@ -25,13 +28,11 @@ export default tool({
       .describe(
         "Override the LLM model for the child. Must use 'provider/model' format (e.g. 'anthropic/claude-sonnet-4-6', 'openai/gpt-5.4'). Defaults to the parent's model."
       ),
+    ...spawnChildArgs,
   },
   async execute(args) {
     try {
-      const body = { title: args.title, prompt: args.prompt };
-      if (args.model) {
-        body.model = args.model;
-      }
+      const body = buildChildSpawnBody(args);
 
       const response = await bridgeFetch("/children", {
         method: "POST",

--- a/packages/sandbox-runtime/tests/spawn-child.test.mjs
+++ b/packages/sandbox-runtime/tests/spawn-child.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildChildSpawnBody,
+  spawnChildArgs,
+} from "../src/sandbox_runtime/tools/spawn-child-config.js";
+
+test("spawn-child exposes an optional reasoning argument", () => {
+  const result = spawnChildArgs.reasoning.safeParse("high");
+
+  assert.equal(result.success, true);
+  assert.match(spawnChildArgs.reasoning.description, /overrides.*parent/i);
+  assert.match(spawnChildArgs.reasoning.description, /defaults to.*parent/i);
+});
+
+test("buildChildSpawnBody serializes reasoningEffort when supplied", () => {
+  assert.deepEqual(
+    buildChildSpawnBody({ title: "Investigate", prompt: "Find the bug", reasoning: "high" }),
+    {
+      title: "Investigate",
+      prompt: "Find the bug",
+      reasoningEffort: "high",
+    }
+  );
+});
+
+test("buildChildSpawnBody omits reasoningEffort for parent inheritance", () => {
+  assert.deepEqual(buildChildSpawnBody({ title: "Investigate", prompt: "Find the bug" }), {
+    title: "Investigate",
+    prompt: "Find the bug",
+  });
+});


### PR DESCRIPTION
## Summary
- Add an optional `reasoning` argument to the sandbox `spawn-child` tool.
- Serialize it as `reasoningEffort` only when explicitly supplied, preserving parent inheritance when omitted.
- Add D1/ Durable Object integration coverage for inheritance, overrides, compatibility fallback, and grandchild inheritance.
- Wire sandbox tool tests into the workspace and CI.

## Verification
- `npm test -w @open-inspect/sandbox-runtime` (11 passed)
- `npm test -w @open-inspect/control-plane -- --run src/routes/session-children.test.ts` (1 passed)
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/spawn-children.test.ts` (17 passed)
- `npm run build -w @open-inspect/shared` passed
- `npm run typecheck` passed
- Changed-file Prettier and `git diff --check` passed
- Full lint remains blocked by pre-existing `.opencode` environment-global errors

Three independent review passes were completed; findings were fixed and affected checks rerun.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bd201600e84479a28eb93d6d56969ab5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child sessions can now inherit or override the parent session’s reasoning effort.
  * Incompatible model and reasoning combinations fall back safely.
  * Child-spawn requests support an optional reasoning setting.

* **Bug Fixes**
  * Improved propagation of reasoning settings through nested child sessions.

* **Tests**
  * Added coverage for inheritance, overrides, validation, serialization, and nested sessions.
  * CI now runs both Python and Node.js test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->