### PR TITLE
Pass reasoning settings to child sessions

### DIFF
--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -87,16 +87,102 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({});
   });
 
-  async function makeRequest(env: Record<string, unknown>): Promise<Response> {
+  async function makeRequest(
+    env: Record<string, unknown>,
+    body: Record<string, unknown> = { title: "Child task", prompt: "Do the thing" }
+  ): Promise<Response> {
     return handleRequest(
       await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
         method: "POST",
-        body: JSON.stringify({ title: "Child task", prompt: "Do the thing" }),
+        body: JSON.stringify(body),
         service: "linear-bot",
       }),
       env as never
     );
   }
+
+  function makeSuccessfulEnv(context: TestSpawnContext) {
+    const parentStub: DurableObjectStub = {
+      fetch: vi.fn(async () => Response.json(context)),
+    } as never;
+    const childStub: DurableObjectStub = {
+      fetch: vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        if (path === SessionInternalPaths.init) return Response.json({ status: "ok" });
+        if (path === SessionInternalPaths.prompt) {
+          return Response.json({ messageId: "msg-1", status: "queued" });
+        }
+        return Response.json({ error: "unexpected" }, { status: 404 });
+      }),
+    } as never;
+    return {
+      childStub,
+      env: {
+        ...TEST_SERVICE_SECRETS,
+        SCM_PROVIDER: "github",
+        DB: {},
+        SESSION: {
+          idFromName: (name: string) => name,
+          get: (id: string) => (id === parentId ? parentStub : childStub),
+        },
+      },
+    };
+  }
+
+  async function getInitBody(childStub: DurableObjectStub) {
+    const initRequest = vi.mocked(childStub.fetch).mock.calls.find((call) => {
+      const request = call[0] as Request;
+      return new URL(request.url).pathname === SessionInternalPaths.init;
+    })?.[0] as Request;
+    return initRequest.json<{ reasoningEffort: string | null }>();
+  }
+
+  it("inherits the parent's reasoning effort when omitted", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    const { env, childStub } = makeSuccessfulEnv({ ...spawnContext, reasoningEffort: "high" });
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(201);
+    await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: "high" });
+  });
+
+  it("uses an explicit child reasoning effort override", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    const { env, childStub } = makeSuccessfulEnv({ ...spawnContext, reasoningEffort: "high" });
+
+    const response = await makeRequest(env, {
+      title: "Child task",
+      prompt: "Do the thing",
+      reasoningEffort: "low",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: "low" });
+  });
+
+  it("clears an explicit reasoning effort incompatible with the resolved model", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    const { env, childStub } = makeSuccessfulEnv({ ...spawnContext, reasoningEffort: "high" });
+
+    const response = await makeRequest(env, {
+      title: "Child task",
+      prompt: "Do the thing",
+      reasoningEffort: "xhigh",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: null });
+  });
 
   it("returns 201 when child prompt enqueue succeeds", async () => {
     const store = makeStore("canonical-user-123");

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -198,6 +198,56 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     expect(session.environment_id).toBe("env_parent");
   });
 
+  it("persists inherited reasoning effort for children and grandchildren", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({ reasoningEffort: "high" });
+
+    const childRes = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({ title: "Child", prompt: "Spawn another child" }),
+    });
+    expect(childRes.status).toBe(201);
+    const child = await childRes.json<{ sessionId: string }>();
+    expect((await store.get(child.sessionId))?.reasoningEffort).toBe("high");
+
+    const childStub = env.SESSION.get(env.SESSION.idFromName(child.sessionId));
+    const [childSession] = await queryDO<{ reasoning_effort: string | null }>(
+      childStub,
+      "SELECT reasoning_effort FROM session"
+    );
+    expect(childSession.reasoning_effort).toBe("high");
+
+    const childSandboxToken = `child-sb-tok-${Date.now()}`;
+    await seedSandboxAuth(childStub, {
+      authToken: childSandboxToken,
+      sandboxId: `child-sb-${Date.now()}`,
+    });
+    const grandchildRes = await SELF.fetch(
+      `https://test.local/sessions/${child.sessionId}/children`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${childSandboxToken}`,
+        },
+        body: JSON.stringify({ title: "Grandchild", prompt: "Verify inherited reasoning" }),
+      }
+    );
+    expect(grandchildRes.status).toBe(201);
+    const grandchild = await grandchildRes.json<{ sessionId: string }>();
+    expect((await store.get(grandchild.sessionId))?.reasoningEffort).toBe("high");
+
+    const grandchildStub = env.SESSION.get(env.SESSION.idFromName(grandchild.sessionId));
+    const [grandchildSession] = await queryDO<{ reasoning_effort: string | null }>(
+      grandchildStub,
+      "SELECT reasoning_effort FROM session"
+    );
+    expect(grandchildSession.reasoning_effort).toBe("high");
+  });
+
   it("rejects a disabled model override for grandchildren", async () => {
     const { parentName, sandboxToken } = await setupParent();
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -25,12 +25,21 @@ export default tool({
       .describe(
         "Override the LLM model for the child. Must use 'provider/model' format (e.g. 'anthropic/claude-sonnet-4-6', 'openai/gpt-5.4'). Defaults to the parent's model."
       ),
+    reasoning: z
+      .string()
+      .optional()
+      .describe(
+        "Overrides the reasoning effort for the child. Defaults to the parent's reasoning effort."
+      ),
   },
   async execute(args) {
     try {
       const body = { title: args.title, prompt: args.prompt };
       if (args.model) {
         body.model = args.model;
+      }
+      if (args.reasoning !== undefined) {
+        body.reasoningEffort = args.reasoning;
       }
 
       const response = await bridgeFetch("/children", {

--- a/packages/sandbox-runtime/tests/test_spawn_child_tool.py
+++ b/packages/sandbox-runtime/tests/test_spawn_child_tool.py
@@ -1,0 +1,117 @@
+"""Tests for the agent-facing spawn-child tool."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+NODE_BINARY = shutil.which("node")
+SPAWN_CHILD_TOOL = (
+    Path(__file__).resolve().parents[1] / "src" / "sandbox_runtime" / "tools" / "spawn-child.js"
+)
+TOOL_SUBPROCESS_TIMEOUT_SECONDS = 10
+
+pytestmark = pytest.mark.skipif(NODE_BINARY is None, reason="node is required")
+
+
+def _tool_module(tmp_path: Path) -> Path:
+    module = tmp_path / "spawn-child.js"
+    shutil.copyfile(SPAWN_CHILD_TOOL, module)
+    (tmp_path / "package.json").write_text('{"type":"module"}')
+
+    plugin_package = tmp_path / "node_modules" / "@opencode-ai" / "plugin"
+    plugin_package.mkdir(parents=True)
+    (plugin_package / "package.json").write_text('{"type":"module","exports":"./index.js"}')
+    (plugin_package / "index.js").write_text("export const tool = (config) => config;")
+
+    zod_package = tmp_path / "node_modules" / "zod"
+    zod_package.mkdir(parents=True)
+    (zod_package / "package.json").write_text('{"type":"module","exports":"./index.js"}')
+    (zod_package / "index.js").write_text(
+        "const schema = {"
+        " describe(description) { this.description = description; return this; },"
+        " optional() { this.isOptional = true; return this; }"
+        "};"
+        "export const z = { string() { return Object.create(schema); } };"
+    )
+
+    (tmp_path / "_bridge-client.js").write_text(
+        "export async function bridgeFetch(path, options) {"
+        " globalThis.capturedRequest = { path, options };"
+        " return new Response(JSON.stringify({ sessionId: 'child-1' }), {"
+        "   status: 201, headers: { 'Content-Type': 'application/json' }"
+        " });"
+        "}"
+        "export async function extractError(response) { return response.text(); }"
+    )
+    return module
+
+
+def _run_tool(tmp_path: Path, args: dict[str, str] | None = None) -> dict[str, Any]:
+    script = """
+      const tool = (await import(process.argv[1])).default;
+      if (process.argv[2]) {
+        await tool.execute(JSON.parse(process.argv[2]));
+      }
+      process.stdout.write(JSON.stringify({
+        reasoningSchema: tool.args.reasoning,
+        request: globalThis.capturedRequest,
+      }));
+    """
+    result = subprocess.run(
+        [
+            NODE_BINARY,
+            "--input-type=module",
+            "-e",
+            script,
+            _tool_module(tmp_path).as_uri(),
+            json.dumps(args) if args is not None else "",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=TOOL_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    return json.loads(result.stdout)
+
+
+def test_schema_exposes_optional_reasoning_override(tmp_path: Path) -> None:
+    result = _run_tool(tmp_path)
+
+    assert result["reasoningSchema"]["isOptional"] is True
+    assert "overrides" in result["reasoningSchema"]["description"].lower()
+    assert "parent" in result["reasoningSchema"]["description"].lower()
+
+
+def test_serializes_reasoning_as_reasoning_effort(tmp_path: Path) -> None:
+    result = _run_tool(
+        tmp_path,
+        {"title": "Child task", "prompt": "Do the thing", "reasoning": "high"},
+    )
+
+    assert json.loads(result["request"]["options"]["body"]) == {
+        "title": "Child task",
+        "prompt": "Do the thing",
+        "reasoningEffort": "high",
+    }
+
+
+def test_serializes_empty_reasoning_for_backend_compatibility_handling(tmp_path: Path) -> None:
+    result = _run_tool(
+        tmp_path,
+        {"title": "Child task", "prompt": "Do the thing", "reasoning": ""},
+    )
+
+    assert json.loads(result["request"]["options"]["body"])["reasoningEffort"] == ""
+
+
+def test_omits_reasoning_effort_to_inherit_parent_setting(tmp_path: Path) -> None:
+    result = _run_tool(tmp_path, {"title": "Child task", "prompt": "Do the thing"})
+
+    assert json.loads(result["request"]["options"]["body"]) == {
+        "title": "Child task",
+        "prompt": "Do the thing",
+    }


### PR DESCRIPTION
## Summary
- expose an optional agent-facing `reasoning` argument on the sandbox-runtime `spawn-child` tool
- serialize supplied values as `reasoningEffort` while preserving omission for parent inheritance
- add control-plane regressions for inherited, overridden, and incompatible efforts
- verify D1 and Durable Object persistence through child and grandchild spawning

## Testing
- `uv run --extra dev pytest tests/test_spawn_child_tool.py -v` (4 passed)
- `npm test -w @open-inspect/control-plane -- --run src/router.spawn-child.test.ts` (15 passed)
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/spawn-children.test.ts` (14 passed)
- `npm run typecheck`
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev ruff format --check src tests`
- targeted Prettier and ESLint checks
- `git diff --check`

## Review passes
- pass 1: rejected a suggestion to change incompatible-effort handling because the requirement explicitly preserves existing semantics
- pass 2: fixed supplied empty-string reasoning being mistaken for omission; added regression coverage and reran affected checks
- pass 3: no functional or coverage deviations; ensured the temporary generated `uv.lock` was excluded

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/734cec1fce5332923124d1a8507979d2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional reasoning setting when spawning child sessions.
  * Child sessions inherit the parent’s reasoning setting by default.
  * Explicit child settings override inherited values, while incompatible values can be cleared.

* **Bug Fixes**
  * Ensured reasoning settings remain consistent across child and grandchild sessions, including persisted session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->