### PR TITLE
refactor: complete ready shared imports

### DIFF
--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -442,7 +442,7 @@ export async function getCachedInstallationTokenWithExpiry(
 }
 
 // Re-export from shared for backward compatibility
-export type { InstallationRepository } from "@open-inspect/shared";
+export type { InstallationRepository } from "@open-inspect/shared/types/repository-catalog";
 
 /**
  * List all repositories accessible to the GitHub App installation.

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -9,7 +9,7 @@
  * named handler.
  */
 
-import type { AutomationEventSource } from "@open-inspect/shared";
+import type { AutomationEventSource } from "@open-inspect/shared/triggers";
 import { requireEventPoster } from "../auth/identity-enforcement";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";

--- a/packages/control-plane/src/webhooks/automation-webhook.ts
+++ b/packages/control-plane/src/webhooks/automation-webhook.ts
@@ -2,7 +2,7 @@
  * Generic automation webhook route — per-automation inbound HTTP endpoint.
  */
 
-import { normalizeWebhookEvent } from "@open-inspect/shared";
+import { normalizeWebhookEvent } from "@open-inspect/shared/triggers";
 import { AutomationStore } from "../db/automation-store";
 import { verifyWebhookApiKey } from "../auth/webhook-key";
 import type { Route, RequestContext } from "../routes/shared";

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -6,7 +6,7 @@
  * background and is additive: its failure never affects automation matching.
  */
 
-import { automationEventSchema } from "@open-inspect/shared";
+import { automationEventSchema } from "@open-inspect/shared/triggers";
 import { SessionIndexStore } from "../db/session-index";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { createLogger, parseLogLevel } from "../logger";

--- a/packages/control-plane/test/integration/automations-slack-route.test.ts
+++ b/packages/control-plane/test/integration/automations-slack-route.test.ts
@@ -4,7 +4,7 @@ import { AutomationStore, type AutomationRow } from "../../src/db/automation-sto
 import { SlackChannelStore } from "../../src/db/slack-channel-store";
 import { cleanD1Tables } from "./cleanup";
 import { serviceFetch } from "./helpers";
-import type { TriggerConfig } from "@open-inspect/shared";
+import type { TriggerConfig } from "@open-inspect/shared/triggers";
 
 function makeSlackAutomation(overrides?: Partial<AutomationRow>): AutomationRow {
   const now = Date.now();

--- a/packages/control-plane/test/integration/scheduler-events.test.ts
+++ b/packages/control-plane/test/integration/scheduler-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
-import type { SentryAutomationEvent, WebhookAutomationEvent } from "@open-inspect/shared";
+import type { SentryAutomationEvent, WebhookAutomationEvent } from "@open-inspect/shared/triggers";
 import { cleanD1Tables } from "./cleanup";
 import { makeRunRow, seedRun, fetchRuns } from "./run-helpers";
 

--- a/packages/control-plane/test/integration/scheduler-slack-events.test.ts
+++ b/packages/control-plane/test/integration/scheduler-slack-events.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
 import { SlackChannelStore } from "../../src/db/slack-channel-store";
-import type { SlackAutomationEvent } from "@open-inspect/shared";
+import type { SlackAutomationEvent } from "@open-inspect/shared/triggers";
 import { cleanD1Tables } from "./cleanup";
 import { makeRunRow, seedRun, fetchRuns } from "./run-helpers";
 

--- a/packages/web/src/components/session-changes-panel.test.tsx
+++ b/packages/web/src/components/session-changes-panel.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SessionDiffState } from "@open-inspect/shared";
+import type { SessionDiffState } from "@open-inspect/shared/types/session-diffs";
 
 vi.mock("next/dynamic", () => ({
   default: () => () => <div data-testid="diff-renderer" />,


### PR DESCRIPTION
## Summary
- Migrate the remaining assigned ready imports to their concrete shared owners.
- Preserve the package-root compatibility exports and all import type/runtime semantics.
- No shared implementation, package exports, schemas, behavior, or lockfiles changed.

## Owner paths
- `InstallationRepository` -> `@open-inspect/shared/types/repository-catalog`
- `AutomationEventSource` -> `@open-inspect/shared/triggers`
- `normalizeWebhookEvent` -> `@open-inspect/shared/triggers`
- `automationEventSchema` -> `@open-inspect/shared/triggers`
- `TriggerConfig` -> `@open-inspect/shared/triggers`
- `SentryAutomationEvent` -> `@open-inspect/shared/triggers`
- `WebhookAutomationEvent` -> `@open-inspect/shared/triggers`
- `SlackAutomationEvent` -> `@open-inspect/shared/triggers`
- `SessionDiffState` -> `@open-inspect/shared/types/session-diffs`

## Inventory
AST-aware current-head counts, production/tests separately, across tracked TypeScript files:

| Category | Before root | After root | Before direct-owner | After direct-owner |
| --- | ---: | ---: | ---: | ---: |
| Production | 6 | 2 | 19 | 23 |
| Tests | 5 | 0 | 1 | 6 |

All assigned ready symbols have zero root imports/re-exports in their assigned files. The retained production root consumers are outside assigned scope: `AutomationEventSource` in `packages/control-plane/src/auth/identity-enforcement.ts` and `TriggerConfig` in `packages/control-plane/src/db/automation-store.ts`. There are no mixed root imports in the assigned files; deferred symbols remain unchanged. This is not a repository-wide completion claim.

Direct owner export checks found no names outside the historical root surface: triggers `46`, repository catalog `12`, session diffs `39`, each with `0` outside-root exports.

## Architecture and validation
- Shared source has no imports from `@open-inspect/shared`.
- Package graph remains one-way from application packages to `@open-inspect/shared`; SCCs are all single-package components with no new cycle.
- `npm ci` on Node `v22.22.2`: passed.
- `npm run build -w @open-inspect/shared`: passed.
- `npm run typecheck`: passed.
- `git diff --check`: passed.
- `npm test -w @open-inspect/shared`: `38/38` files, `525/525` tests passed.
- `npm test -w @open-inspect/control-plane`: `146/146` files, `2197/2197` tests passed.
- `npm run test:integration -w @open-inspect/control-plane`: `58/59` files, `676/677` tests passed; the existing `websocket-client` test timed out while Modal returned `404 modal-http: invalid function call`.
- `npm run build -w @open-inspect/control-plane`: passed.
- `npm test -w @open-inspect/web`: `111/111` files, `852/852` tests passed.
- `npm run build -w @open-inspect/web`: compilation/typecheck passed, but existing prerendering of `/automations/new` failed with `Cannot read properties of null (reading 'useContext')`.
- `npm run format:check`: blocked by pre-existing `.opencode/package.json` formatting.
- `npm run lint`: blocked by 45 pre-existing `.opencode` environment/unused-variable errors; affected workspace lint passes.
- Scoped Prettier, control-plane lint, and web lint: passed.

## Scope exclusions
No changes to `packages/shared/package.json`, package-root compatibility exports, owner modules, public APIs, behavior, dependencies, lockfiles, ratchets, allowlists, indexes, facades, or unrelated cleanup. No merge performed.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c4a229115a8d4691d9f0bc317763158e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type and schema references to use more specific shared modules.
  * No changes to application behavior or public functionality.

* **Tests**
  * Aligned integration and component tests with the updated shared module references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->