### PR TITLE
Complete automation trigger imports

### DIFF
--- a/packages/control-plane/src/auth/identity-enforcement.ts
+++ b/packages/control-plane/src/auth/identity-enforcement.ts
@@ -9,7 +9,8 @@
  * can run the steps out of order or skip one.
  */
 
-import type { AutomationEventSource, SpawnSource } from "@open-inspect/shared";
+import type { AutomationEventSource } from "@open-inspect/shared/triggers";
+import type { SpawnSource } from "@open-inspect/shared";
 import type { ServiceName } from "@open-inspect/shared/service-auth";
 import { createLogger } from "./../logger";
 import { CALLBACK_DESTINATIONS } from "./service/callback-signing";

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -13,8 +13,8 @@ import type {
   AutomationRepository,
   AutomationRun,
   AutomationRunStatus,
-  TriggerConfig,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/automations";
+import type { TriggerConfig } from "@open-inspect/shared/triggers";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
 
 // ─── Internal row types ──────────────────────────────────────────────────────

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -3,7 +3,7 @@
  * HMAC signature using the automation's stored (encrypted) client secret.
  */
 
-import { verifySentrySignature, normalizeSentryEvent } from "@open-inspect/shared";
+import { verifySentrySignature, normalizeSentryEvent } from "@open-inspect/shared/triggers";
 import { AutomationStore } from "../db/automation-store";
 import { decryptSentrySecret } from "../auth/webhook-key";
 import type { Route, RequestContext } from "../routes/shared";


### PR DESCRIPTION
## Summary
- Migrate automation and trigger consumers to their existing direct shared owner paths.
- Preserve the package root, compatibility exports, export map, aliases, and type/value semantics.

## Scope
Changed exactly:
- `packages/control-plane/src/auth/identity-enforcement.ts`
  - `AutomationEventSource` -> `@open-inspect/shared/triggers`
- `packages/control-plane/src/db/automation-store.ts`
  - automation models -> `@open-inspect/shared/types/automations`
  - `TriggerConfig` -> `@open-inspect/shared/triggers`
- `packages/control-plane/src/webhooks/sentry.ts`
  - `verifySentrySignature`, `normalizeSentryEvent` -> `@open-inspect/shared/triggers`

Production changed count: 3 files, 11 root symbol imports migrated.
Test changed count: 0 files, 0 root symbol imports migrated.

## Inventory evidence
AST-aware current-head inventory before edits:
- Root consumers of these owner surfaces: 11 production, 0 tests.
- Direct-owner consumers: 31 production, 10 tests.

After edits:
- Root consumers: 0 production, 0 tests.
- Direct-owner consumers: 42 production, 10 tests.
- Completed assigned symbols remaining at root: 0.

The assigned symbols remain owned by their existing modules. Direct owner exports are a subset of the historical package-root surface; the root compatibility exports and `packages/shared/package.json` export map are unchanged.

## Boundaries and dependency safety
- No behavior, schema, defaults, API, identity, source moves, wrappers, facades, new indexes, dependencies, lockfiles, or unrelated cleanup.
- Deferred/root-only symbols remain unchanged: `types/artifacts.ts`, `types/sessions.ts`, `types/session-api.ts`, `types/statuses.ts`, `types/sandbox-events.ts`, `readBodyCapped`, and `escapeRegExp`.
- No retained root candidates exist for the two assigned owner surfaces. Other root imports are outside this batch and remain for their existing owners/deferred work.
- Shared module-boundary tests passed: no compile-time or runtime SCC/cycle was introduced; shared remains below application packages in the dependency direction.

## Validation
Passed:
- `npm ci` on Node 22
- `npm run build -w @open-inspect/shared`
- `npm run typecheck` (all workspaces)
- `npm test -w @open-inspect/shared`: 38 files, 525 tests
- shared module-boundary/cycle test: 1 file, 4 tests
- `npm test -w @open-inspect/control-plane`: 146 files, 2,200 tests
- explicit `npm run build -w @open-inspect/control-plane`
- changed-file Prettier and ESLint checks
- `git diff --check`

Repository-wide checks with pre-existing unrelated failures:
- `npm run format:check` is blocked by `.opencode/package.json`.
- `npm run lint` reports 45 existing errors in `.opencode/` tooling files.
- Control-plane integration: 58 files passed, 677 tests passed; 1 existing `websocket-client.test.ts` test timed out after mocked Modal API `404 modal-http: invalid function call` (the same failure reproduced on the rerun).

No shared or control-plane source failure was caused by this import-only change.
