### PR TITLE
fix: keep runtime OpenCode files outside checkouts

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -119,7 +119,7 @@ base_image = (
         f"npm install -g @opencode-ai/plugin@{OPENCODE_VERSION} zod",
     )
     # Pre-build OpenCode plugin deps into a staging directory.
-    # At boot, _install_tools() copies these into .opencode/ so that
+    # At boot, _install_tools() copies these into the external runtime config so that
     # OpenCode's Npm.install() finds package-lock.json in sync and skips
     # the slow arborist reify() call (2-22s) that would otherwise block
     # the first prompt and exceed the bridge's HTTP timeout.
@@ -133,7 +133,7 @@ base_image = (
     .run_commands(
         "mkdir -p /app/opencode-deps",
         # Pin staged plugin to OPENCODE_VERSION so the pre-staged tree copied
-        # into .opencode/ at boot matches the globally installed plugin (#567).
+        # into the runtime config at boot matches the globally installed plugin (#567).
         f'echo \'{{"name":"opencode-tools","type":"module",'
         f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
         " > /app/opencode-deps/package.json",

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -5,6 +5,10 @@
 BIN_INSTALL_DIR_ENV_VAR = "OPENINSPECT_BIN_INSTALL_DIR"
 DEFAULT_BIN_INSTALL_DIR = "/usr/local/bin"
 
+# Runtime-owned OpenCode configuration. Keeping this outside /workspace prevents
+# repository linters and formatters from discovering generated tools and skills.
+OPENCODE_RUNTIME_ROOT = "/tmp/open-inspect-opencode"
+
 # Default service ports. The control plane may override the externally-exposed
 # ones per session via the *_ENV_VAR env vars below; the entrypoint and ttyd
 # proxy fall back to these defaults. TTYD_PORT is localhost-only and fixed — it

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -34,6 +34,7 @@ from .constants import (
     DEFAULT_BIN_INSTALL_DIR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
     IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR,
+    OPENCODE_RUNTIME_ROOT,
     REPO_MANIFEST_FILE_PATH,
     TTYD_PORT,
     TTYD_PROXY_PORT,
@@ -42,7 +43,6 @@ from .constants import (
     TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from .diff_baseline import resolve_session_diff_baselines
-from .git_excludes import install_runtime_git_excludes
 from .log_config import configure_logging, get_logger
 from .repo_config import RepoConfigError, RepoEntry, dump_repo_manifest, parse_repositories
 from .repo_image_callback import RepoImageBuildCallback
@@ -616,8 +616,8 @@ class SandboxSupervisor:
         OpenCode discovers config relative to its cwd — /workspace for
         multi-repo sessions — so per-repo custom tools/skills/commands would
         never load. Files are copied in position order, last write wins with a
-        warning naming both members; the system tools installed afterwards
-        still override on filename collision (same as single-repo today).
+        warning naming both members. Runtime-owned assets are loaded separately
+        from the external config directory after project config.
         """
         if not self.is_multi_repo:
             return
@@ -625,16 +625,10 @@ class SandboxSupervisor:
         dest_root = self.workspace_path / ".opencode"
         # The merged tree is generated state: rebuild it from scratch so
         # entries removed from a member (or a removed member) don't survive
-        # snapshot/repo-image boots. System tools and staged deps are
-        # re-installed after assembly on every boot. node_modules is spared:
-        # assembly never writes into it (member node_modules are skipped), so
-        # it's purely image-managed — deleting it would force
-        # _stage_opencode_deps to re-copy the whole module tree on every
-        # snapshot restore instead of taking its skip-if-present fast path.
+        # snapshot/repo-image boots. Runtime tools and dependencies live in a
+        # separate external config directory and are never assembled here.
         if dest_root.is_dir():
             for child in dest_root.iterdir():
-                if child.name == "node_modules":
-                    continue
                 if child.is_dir() and not child.is_symlink():
                     shutil.rmtree(child, ignore_errors=True)
                 else:
@@ -781,11 +775,31 @@ class SandboxSupervisor:
             for path in self._stage_opencode_deps(Path("/app/opencode-deps"), opencode_dir)
         )
         self.log.info(
-            "opencode.repo_deps_staged",
+            "opencode.runtime_deps_staged",
             dir=str(opencode_dir),
             duration_ms=round((time.monotonic() - staged_at) * 1000),
         )
         return installed
+
+    @staticmethod
+    def _reset_runtime_opencode_config(runtime_root: Path) -> None:
+        """Rebuild runtime-owned config while retaining the staged module cache."""
+        if runtime_root.is_symlink() or (runtime_root.exists() and not runtime_root.is_dir()):
+            runtime_root.unlink()
+        runtime_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        config_dir = runtime_root / ".opencode"
+        if config_dir.is_symlink() or (config_dir.exists() and not config_dir.is_dir()):
+            config_dir.unlink()
+        elif config_dir.is_dir():
+            for child in config_dir.iterdir():
+                if child.name == "node_modules" and child.is_dir() and not child.is_symlink():
+                    continue
+                if child.is_dir() and not child.is_symlink():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink(missing_ok=True)
+        config_dir.mkdir(mode=0o700, exist_ok=True)
 
     @staticmethod
     def _stage_opencode_deps(deps_cache: Path, dest_dir: Path) -> set[str]:
@@ -818,14 +832,7 @@ class SandboxSupervisor:
 
     @staticmethod
     def _resolve_opencode_global_config_dir() -> Path:
-        """Resolve OpenCode's global config directory the way OpenCode does.
-
-        OpenCode (via xdg-basedir) uses OPENCODE_CONFIG_DIR when set, otherwise
-        $XDG_CONFIG_HOME/opencode, otherwise ~/.config/opencode.
-        """
-        override = os.environ.get("OPENCODE_CONFIG_DIR")
-        if override:
-            return Path(override)
+        """Resolve OpenCode's XDG global config directory."""
         xdg = os.environ.get("XDG_CONFIG_HOME")
         base = Path(xdg) if xdg else Path.home() / ".config"
         return base / "opencode"
@@ -835,7 +842,7 @@ class SandboxSupervisor:
 
         OpenCode bootstraps every directory in its config search path and forks
         ``npm install @opencode-ai/plugin`` for each. The global config dir is created empty and
-        is never seeded by _install_tools (which only covers the repo's .opencode/), so with a
+        is never seeded by _install_tools (which only covers the runtime config), so with a
         plugin configured the first POST /session would block on an arborist reify() of it.
 
         The image bakes this tree into the global dir at build time (base.py), so this is
@@ -865,21 +872,20 @@ class SandboxSupervisor:
             duration_ms=round((time.monotonic() - seeded_at) * 1000),
         )
 
-    def _prepare_opencode_filesystem(self, workdir: Path) -> set[str]:
+    def _prepare_opencode_filesystem(self, runtime_root: Path) -> None:
         """Stage OpenCode's filesystem assets (tools, deps, skills, bin) before launch.
 
         The global seed is best-effort (degrades to a slower reify); the rest fail fast.
         """
-        installed: set[str] = set()
         self._assemble_workspace_opencode()
-        installed.update(self._install_tools(workdir))
+        self._reset_runtime_opencode_config(runtime_root)
+        self._install_tools(runtime_root)
         try:
             self._seed_global_opencode_deps()
         except Exception as e:
             self.log.warn("opencode.global_deps_seed_failed", exc=e)
-        installed.update(self._install_skills(workdir))
+        self._install_skills(runtime_root)
         self._install_bin_scripts()
-        return installed
 
     def _install_bin_scripts(self) -> None:
         """Install standalone CLI scripts into the sandbox bin directory.
@@ -1268,26 +1274,23 @@ class SandboxSupervisor:
         # for multi-repo (every member visible) and repo-less sessions.
         workdir = self._opencode_workdir()
 
-        installed_runtime_paths = self._prepare_opencode_filesystem(workdir)
+        runtime_root = Path(OPENCODE_RUNTIME_ROOT)
+        self._prepare_opencode_filesystem(runtime_root)
 
         # Deploy codex auth proxy plugin if OpenAI OAuth is configured
-        opencode_dir = workdir / ".opencode"
+        opencode_dir = runtime_root / ".opencode"
         plugin_source = Path("/app/sandbox_runtime/plugins/codex-auth-plugin.js")
         if plugin_source.exists() and os.environ.get("OPENAI_OAUTH_REFRESH_TOKEN"):
             plugin_dir = opencode_dir / "plugins"
             plugin_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(plugin_source, plugin_dir / "codex-auth-plugin.js")
-            installed_runtime_paths.add(".opencode/plugins/codex-auth-plugin.js")
             self.log.info("openai_oauth.plugin_deployed")
-
-        if installed_runtime_paths and (workdir / ".git").exists():
-            try:
-                install_runtime_git_excludes(workdir, installed_runtime_paths)
-            except Exception as error:
-                self.log.warn("opencode.git_excludes_failed", exc=error)
 
         env = {
             **os.environ,
+            # OpenCode scans this after project config, so runtime assets stay
+            # available without writing generated files into the checkout.
+            "OPENCODE_CONFIG_DIR": str(opencode_dir),
             "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_config),
             # Disable OpenCode's question tool in headless mode. The tool blocks
             # on a Promise waiting for user input via the HTTP API, but the bridge

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -97,8 +97,8 @@ class TestCodexAuthPluginSetup:
         assert data["openai"]["refresh"] == "managed-by-control-plane"
         assert data["openai"]["accountId"] == "acct_xyz"
 
-    async def test_start_opencode_copies_js_plugin(self, tmp_path):
-        """start_opencode() should deploy the precompiled JS plugin into .opencode/plugins."""
+    async def test_start_opencode_copies_js_plugin_outside_checkout(self, tmp_path):
+        """start_opencode() should deploy the JS plugin into runtime-owned config."""
         sup = _make_supervisor()
         sup.workspace_path = tmp_path / "workspace"
         sup.workspace_path.mkdir()
@@ -108,6 +108,7 @@ class TestCodexAuthPluginSetup:
         plugin_source = tmp_path / "app" / "sandbox_runtime" / "plugins" / "codex-auth-plugin.js"
         plugin_source.parent.mkdir(parents=True)
         plugin_source.write_text("export const CodexAuthProxy = async () => ({});")
+        runtime_root = tmp_path / "runtime"
 
         fake_proc = MagicMock()
         fake_proc.stdout = None
@@ -115,14 +116,21 @@ class TestCodexAuthPluginSetup:
         original_path = Path
 
         with (
-            patch.dict("os.environ", {"OPENAI_OAUTH_REFRESH_TOKEN": "rt_real_secret"}, clear=False),
+            patch.dict(
+                "os.environ",
+                {
+                    "OPENAI_OAUTH_REFRESH_TOKEN": "rt_real_secret",
+                    "OPENCODE_CONFIG_DIR": "/user/supplied",
+                },
+                clear=False,
+            ),
+            patch("sandbox_runtime.entrypoint.OPENCODE_RUNTIME_ROOT", str(runtime_root)),
             patch("sandbox_runtime.entrypoint.Path") as mock_path,
             patch("sandbox_runtime.entrypoint.shutil.copy") as mock_copy,
-            patch("sandbox_runtime.entrypoint.install_runtime_git_excludes") as mock_excludes,
             patch(
                 "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
                 AsyncMock(return_value=fake_proc),
-            ),
+            ) as mock_exec,
             patch(
                 "sandbox_runtime.entrypoint.asyncio.create_task",
                 side_effect=lambda coro: coro.close(),
@@ -134,18 +142,17 @@ class TestCodexAuthPluginSetup:
                 else original_path(p)
             )
             sup._setup_openai_oauth = MagicMock()
-            sup._install_tools = MagicMock()
-            sup._install_skills = MagicMock()
-            sup._install_bin_scripts = MagicMock()
+            sup._prepare_opencode_filesystem = MagicMock()
             sup._wait_for_health = AsyncMock()
 
             await sup.start_opencode()
 
         mock_copy.assert_called_once_with(
             plugin_source,
-            sup.workspace_path / ".opencode" / "plugins" / "codex-auth-plugin.js",
+            runtime_root / ".opencode" / "plugins" / "codex-auth-plugin.js",
         )
-        mock_excludes.assert_called_once_with(
-            sup.workspace_path,
-            {".opencode/plugins/codex-auth-plugin.js"},
+        sup._prepare_opencode_filesystem.assert_called_once_with(runtime_root)
+        assert not (sup.workspace_path / ".opencode").exists()
+        assert mock_exec.await_args.kwargs["env"]["OPENCODE_CONFIG_DIR"] == str(
+            runtime_root / ".opencode"
         )

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -412,10 +412,8 @@ class TestOpencodeAssembly:
         assert not stale_manifest.exists()
         assert (tmp_path / ".opencode" / "command" / "deploy.md").read_text() == "current"
 
-    def test_rebuild_preserves_staged_node_modules(self, tmp_path):
-        """The image-managed module tree survives the clean rebuild so
-        snapshot restores keep _stage_opencode_deps' skip-if-present fast
-        path instead of re-copying it every boot."""
+    def test_rebuild_removes_runtime_node_modules(self, tmp_path):
+        """The assembled project tree must not retain old runtime dependencies."""
         sup = _make_supervisor(tmp_path)
         staged = tmp_path / ".opencode" / "node_modules" / "@opencode-ai" / "plugin"
         staged.mkdir(parents=True)
@@ -426,7 +424,7 @@ class TestOpencodeAssembly:
 
         sup._assemble_workspace_opencode()
 
-        assert (staged / "index.js").read_text() == "plugin"
+        assert not staged.exists()
         assert not stale.exists()
 
     def test_skips_node_modules(self, tmp_path):

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -3,7 +3,7 @@
 import json
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from sandbox_runtime.entrypoint import SandboxSupervisor
 
@@ -329,6 +329,99 @@ class TestInstallTools:
         assert (tool_dest / "spawn-child.js").exists()
 
 
+class TestPrepareOpencodeFilesystem:
+    def test_installs_runtime_assets_outside_checkout_and_reconciles_stale_files(self, tmp_path):
+        sup = _make_supervisor()
+        checkout = tmp_path / "checkout"
+        project_config = checkout / ".opencode"
+        project_config.mkdir(parents=True)
+        project_tool = project_config / "tool" / "project.js"
+        project_tool.parent.mkdir()
+        project_tool.write_text("project tool")
+
+        runtime_root = tmp_path / "runtime"
+        runtime_config = runtime_root / ".opencode"
+        stale_tool = runtime_config / "tool" / "stale.js"
+        stale_tool.parent.mkdir(parents=True)
+        stale_tool.write_text("stale")
+        stale_plugin = runtime_config / "plugins" / "codex-auth-plugin.js"
+        stale_plugin.parent.mkdir()
+        stale_plugin.write_text("stale plugin")
+        cached_module = runtime_config / "node_modules" / "cached" / "index.js"
+        cached_module.parent.mkdir(parents=True)
+        cached_module.write_text("cached")
+
+        tools_dir = tmp_path / "app" / "tools"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "spawn-child.js").write_text("runtime tool")
+        skills_dir = tmp_path / "app" / "skills" / "record-video"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("runtime skill")
+
+        sup._assemble_workspace_opencode = MagicMock()
+        sup._seed_global_opencode_deps = MagicMock()
+        sup._install_bin_scripts = MagicMock()
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy",
+            tools=tools_dir,
+            skills=skills_dir.parent,
+        ):
+            sup._prepare_opencode_filesystem(runtime_root)
+
+        assert not stale_tool.exists()
+        assert not stale_plugin.exists()
+        assert cached_module.read_text() == "cached"
+        assert (runtime_config / "tool" / "spawn-child.js").read_text() == "runtime tool"
+        assert (
+            runtime_config / "skills" / "record-video" / "SKILL.md"
+        ).read_text() == "runtime skill"
+        assert project_tool.read_text() == "project tool"
+        sup._assemble_workspace_opencode.assert_called_once_with()
+
+    def test_replaces_symlinked_runtime_config_without_touching_target(self, tmp_path):
+        target = tmp_path / "checkout" / ".opencode"
+        target.mkdir(parents=True)
+        project_file = target / "project.json"
+        project_file.write_text("project config")
+        runtime_root = tmp_path / "runtime"
+        runtime_root.mkdir()
+        (runtime_root / ".opencode").symlink_to(target, target_is_directory=True)
+
+        SandboxSupervisor._reset_runtime_opencode_config(runtime_root)
+
+        assert project_file.read_text() == "project config"
+        assert not (runtime_root / ".opencode").is_symlink()
+        assert (runtime_root / ".opencode").is_dir()
+
+    def test_replaces_symlinked_runtime_root_without_touching_target(self, tmp_path):
+        target = tmp_path / "checkout"
+        target.mkdir()
+        project_file = target / "project.json"
+        project_file.write_text("project config")
+        runtime_root = tmp_path / "runtime"
+        runtime_root.symlink_to(target, target_is_directory=True)
+
+        SandboxSupervisor._reset_runtime_opencode_config(runtime_root)
+
+        assert project_file.read_text() == "project config"
+        assert not runtime_root.is_symlink()
+        assert (runtime_root / ".opencode").is_dir()
+
+    def test_removes_symlinked_module_cache_without_touching_target(self, tmp_path):
+        target = tmp_path / "modules"
+        target.mkdir()
+        cached_file = target / "index.js"
+        cached_file.write_text("external cache")
+        runtime_config = tmp_path / "runtime" / ".opencode"
+        runtime_config.mkdir(parents=True)
+        (runtime_config / "node_modules").symlink_to(target, target_is_directory=True)
+
+        SandboxSupervisor._reset_runtime_opencode_config(tmp_path / "runtime")
+
+        assert cached_file.read_text() == "external cache"
+        assert not (runtime_config / "node_modules").exists()
+
+
 class TestInstallBinScripts:
     """Cases for _install_bin_scripts() standalone CLI installation."""
 
@@ -520,11 +613,13 @@ def _make_opencode_deps_staging(tmp_path: Path) -> Path:
 class TestResolveGlobalConfigDir:
     """Cases for _resolve_opencode_global_config_dir() — OpenCode's xdg-basedir resolution."""
 
-    def test_uses_opencode_config_dir_override(self, tmp_path, monkeypatch):
-        """OPENCODE_CONFIG_DIR wins over XDG_CONFIG_HOME and is used verbatim."""
+    def test_ignores_opencode_config_dir_override(self, tmp_path, monkeypatch):
+        """OPENCODE_CONFIG_DIR is an additional directory, not the XDG global directory."""
         monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path / "custom"))
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-        assert SandboxSupervisor._resolve_opencode_global_config_dir() == tmp_path / "custom"
+        assert (
+            SandboxSupervisor._resolve_opencode_global_config_dir() == tmp_path / "xdg" / "opencode"
+        )
 
     def test_uses_xdg_config_home(self, tmp_path, monkeypatch):
         """Without the override, $XDG_CONFIG_HOME/opencode is used."""


### PR DESCRIPTION
## Summary
- install Open-Inspect tools, skills, OAuth plugin, and staged dependencies in a runtime-owned config directory under `/tmp` instead of repository `.opencode`
- force that directory through `OPENCODE_CONFIG_DIR` only for the OpenCode subprocess while preserving project config discovery
- reconcile stale runtime assets safely across restarts, including symlink hardening, while retaining a valid dependency cache
- keep multi-repository assembly project-only and correct XDG global dependency seeding semantics
- stop adding new checkout-local Git exclusions for runtime assets

## Testing
- `PYTHONPATH=src .venv/bin/pytest tests/test_tool_installation.py tests/test_codex_auth_plugin_setup.py tests/test_multi_repo_workspace.py::TestOpencodeAssembly -q` (`39 passed`)
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
- Modal `ruff check` and `ruff format --check` for `src/images/base.py`
- `npm run lint -- --ignore-pattern '.opencode/**'` (excludes this session's pre-existing legacy runtime assets)
- `git diff --check`

## Notes
- Legacy runtime migration is intentionally out of scope.
- A broader sandbox-runtime run reached 198 passing tests before an unrelated normal-mode test detected this workspace as a repo-image boot from its existing image SHA.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ac418bae19720a36748edae66601071c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenCode runtime files are now isolated from the workspace checkout.
  * Runtime configuration is rebuilt on launch, removing stale files and safely replacing linked paths.
  * OpenCode now consistently uses the intended global configuration directory.
  * Runtime dependencies and plugins are installed in a dedicated temporary location.
* **Tests**
  * Added coverage for runtime cleanup, installation, plugin placement, and multi-repository behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->