### PR TITLE
feat: add Grok 4.5 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ Choose the AI model that fits your task, with per-session reasoning effort contr
 | ---------------- | ----------------------------------------------------------------- |
 | Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
 | OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                      |
-| xAI / SuperGrok  | Grok Build 0.1 (opt-in)                                           |
+| xAI / SuperGrok  | Grok models (opt-in)                                              |
 | OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)     |
 | Z.AI Coding Plan | GLM 5.2 (opt-in)                                                  |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
-Grok Build works with an eligible SuperGrok subscription through control-plane-managed OAuth. See
+Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See
 **[docs/AVAILABLE_MODELS.md](docs/AVAILABLE_MODELS.md)** for the full model list and
 **[docs/OPENAI_MODELS.md](docs/OPENAI_MODELS.md)** or **[docs/GROK_MODELS.md](docs/GROK_MODELS.md)**
 for subscription setup instructions.

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -43,7 +43,7 @@ Grok models require a SuperGrok OAuth refresh token and are disabled by default.
 | Model ID             | Display name   | Description                                     | Reasoning efforts | Default effort |
 | -------------------- | -------------- | ----------------------------------------------- | ----------------- | -------------- |
 | `xai/grok-4.5`       | Grok 4.5       | Latest Grok for chat, coding, and agentic tools | low, medium, high | high           |
-| `xai/grok-build-0.1` | Grok Build 0.1 | Coding model for SuperGrok subscribers          | low, medium, high | high           |
+| `xai/grok-build-0.1` | Grok Build 0.1 | Coding model for SuperGrok subscribers          | Not configurable  | N/A            |
 
 ## OpenCode Zen
 

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -40,9 +40,10 @@ setup instructions.
 Grok models require a SuperGrok OAuth refresh token and are disabled by default. See
 [Using Grok with a SuperGrok Subscription](GROK_MODELS.md) for setup and rollout instructions.
 
-| Model ID             | Display name   | Description                            | Reasoning efforts | Default effort |
-| -------------------- | -------------- | -------------------------------------- | ----------------- | -------------- |
-| `xai/grok-build-0.1` | Grok Build 0.1 | Coding model for SuperGrok subscribers | low, medium, high | high           |
+| Model ID             | Display name   | Description                                     | Reasoning efforts | Default effort |
+| -------------------- | -------------- | ----------------------------------------------- | ----------------- | -------------- |
+| `xai/grok-4.5`       | Grok 4.5       | Latest Grok for chat, coding, and agentic tools | low, medium, high | high           |
+| `xai/grok-build-0.1` | Grok Build 0.1 | Coding model for SuperGrok subscribers          | low, medium, high | high           |
 
 ## OpenCode Zen
 

--- a/docs/GROK_MODELS.md
+++ b/docs/GROK_MODELS.md
@@ -1,17 +1,18 @@
 # Using Grok with a SuperGrok Subscription
 
-Open-Inspect supports xAI's Grok coding model through a SuperGrok subscription. The control plane
-manages the durable OAuth refresh token and gives each sandbox only a short-lived access token.
+Open-Inspect supports xAI's Grok models through a SuperGrok subscription. The control plane manages
+the durable OAuth refresh token and gives each sandbox only a short-lived access token.
 
 > **Note**: SuperGrok availability and model entitlement are controlled by xAI. Confirm that the
-> account you authenticate can use `grok-build-0.1` before rolling the model out broadly.
+> account you authenticate can use the selected model before rolling it out broadly.
 
 ---
 
-## Supported Model
+## Supported Models
 
 | Model ID             | Display name   | Reasoning efforts | Default effort |
 | -------------------- | -------------- | ----------------- | -------------- |
+| `xai/grok-4.5`       | Grok 4.5       | low, medium, high | high           |
 | `xai/grok-build-0.1` | Grok Build 0.1 | low, medium, high | high           |
 
 The **xAI / SuperGrok** group is disabled by default. An administrator must enable it under
@@ -65,9 +66,9 @@ only, then fall back to global. A secondary repository cannot become the token r
 ### Step 3: Enable and Select Grok
 
 1. Open **Settings > Models**.
-2. Enable **Grok Build 0.1** under **xAI / SuperGrok**.
+2. Enable **Grok 4.5** or **Grok Build 0.1** under **xAI / SuperGrok**.
 3. Create a new session or restart an existing sandbox.
-4. Select **Grok Build 0.1** and the desired reasoning effort.
+4. Select the enabled Grok model and the desired reasoning effort.
 
 ---
 
@@ -98,7 +99,7 @@ plugin merely because the control plane was deployed.
 
 Before production rollout, run a staging session with an eligible SuperGrok account and verify:
 
-- `grok-build-0.1` is available to the account.
+- The selected Grok model is available to the account.
 - A prompt succeeds at each enabled reasoning effort.
 - A second prompt reuses or refreshes the brokered access token.
 - A new sandbox can authenticate after token refresh without replacing the stored secret manually.
@@ -110,8 +111,8 @@ Before production rollout, run a staging session with an eligible SuperGrok acco
 
 ### Grok does not appear in the model selector
 
-Enable **Grok Build 0.1** under **Settings > Models**. The xAI group is opt-in and is not part of
-the default enabled model set.
+Enable **Grok 4.5** or **Grok Build 0.1** under **Settings > Models**. The xAI group is opt-in and
+is not part of the default enabled model set.
 
 ### `XAI_OAUTH_REFRESH_TOKEN not configured`
 
@@ -124,7 +125,7 @@ sandbox after changing secrets.
 The refresh token was revoked, expired, or already rotated elsewhere. Repeat the local OpenCode
 login and replace `XAI_OAUTH_REFRESH_TOKEN` in the same secret scope.
 
-### `Model not found: xai/grok-build-0.1`
+### `Model not found: xai/grok-4.5` or `xai/grok-build-0.1`
 
 Rebuild the sandbox image so it includes the xAI auth proxy plugin and confirm the deployment uses
 OpenCode 1.17.18 or newer.
@@ -132,4 +133,4 @@ OpenCode 1.17.18 or newer.
 ### xAI rejects the model or account
 
 Confirm that the authenticated account has an eligible SuperGrok subscription and that xAI currently
-lists `grok-build-0.1` for that account. Entitlement failures cannot be corrected by Open-Inspect.
+lists the selected model for that account. Entitlement failures cannot be corrected by Open-Inspect.

--- a/docs/GROK_MODELS.md
+++ b/docs/GROK_MODELS.md
@@ -13,7 +13,9 @@ the durable OAuth refresh token and gives each sandbox only a short-lived access
 | Model ID             | Display name   | Reasoning efforts | Default effort |
 | -------------------- | -------------- | ----------------- | -------------- |
 | `xai/grok-4.5`       | Grok 4.5       | low, medium, high | high           |
-| `xai/grok-build-0.1` | Grok Build 0.1 | low, medium, high | high           |
+| `xai/grok-build-0.1` | Grok Build 0.1 | Not configurable  | N/A            |
+
+Grok Build performs reasoning internally but does not accept a configurable reasoning effort.
 
 The **xAI / SuperGrok** group is disabled by default. An administrator must enable it under
 **Settings > Models** before it appears in session and integration model selectors.

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -428,6 +428,26 @@ describe("SessionMessageQueue", () => {
     expect(h.broadcast).toHaveBeenCalledWith({ type: "processing_status", isProcessing: true });
   });
 
+  it("drops a persisted reasoning effort that the session model does not support", async () => {
+    const h = buildQueue();
+    const sandboxWs = { readyState: 1 } as WebSocket;
+    h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+    h.repository.getSession.mockReturnValue(
+      createSession({ model: "xai/grok-build-0.1", reasoning_effort: "high" })
+    );
+    h.wsManager.getSandboxSocket.mockReturnValue(sandboxWs);
+
+    await h.queue.processMessageQueue();
+
+    expect(h.wsManager.send).toHaveBeenCalledWith(
+      sandboxWs,
+      expect.objectContaining({
+        model: "xai/grok-build-0.1",
+        reasoningEffort: undefined,
+      })
+    );
+  });
+
   it("falls back atomically when GitHub author mapping is incomplete", async () => {
     const h = buildQueue();
     const sandboxWs = { readyState: 1 } as WebSocket;

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -215,10 +215,12 @@ export class SessionMessageQueue {
     const gitIdentity = resolveParticipantGitIdentity(author, this.scmProvider);
     const session = this.repository.getSession();
     const resolvedModel = getValidModelOrDefault(message.model || session?.model);
-    const resolvedEffort =
+    const requestedEffort =
       message.reasoning_effort ??
       session?.reasoning_effort ??
       getDefaultReasoningEffort(resolvedModel);
+    const resolvedEffort =
+      validateReasoningEffort(resolvedModel, requestedEffort ?? undefined, this.log) ?? undefined;
 
     const command: SandboxCommand = {
       type: "prompt",

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
@@ -103,11 +103,7 @@ export const XaiAuthProxy = async () => ({
           cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
           limit: { context: 256000, output: 256000 },
           release_date: "2026-04-16",
-          variants: {
-            low: { reasoningEffort: "low" },
-            medium: { reasoningEffort: "medium" },
-            high: { reasoningEffort: "high" },
-          },
+          variants: {},
         },
       };
     },

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -292,7 +292,7 @@ class TestBuildPromptRequestBody:
     def test_with_xai_reasoning_effort(self, bridge: AgentBridge):
         body = bridge._ensure_prompt_stream()._build_prompt_request_body(
             "Hello",
-            "xai/grok-build-0.1",
+            "xai/grok-4.5",
             reasoning_effort="high",
         )
 

--- a/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
+++ b/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
@@ -113,6 +113,7 @@ def test_xai_plugin_uses_broker_without_refresh_token_environment():
     assert 'provider: "xai"' in plugin
     assert "/xai-token-refresh" in plugin
     assert "XAI_OAUTH_REFRESH_TOKEN" not in plugin
+    assert "reasoningEffort" not in plugin
 
 
 async def test_start_opencode_deploys_xai_plugin_from_marker(tmp_path):

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -243,7 +243,7 @@ describe("model utilities", () => {
     expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.6-terra")).toBe(true);
     expect(supportsReasoning("xai/grok-4.5")).toBe(true);
-    expect(supportsReasoning("xai/grok-build-0.1")).toBe(true);
+    expect(supportsReasoning("xai/grok-build-0.1")).toBe(false);
     expect(supportsReasoning("deepseek/deepseek-v4-flash")).toBe(false);
     expect(supportsReasoning("invalid")).toBe(false);
 
@@ -256,7 +256,7 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
     expect(getDefaultReasoningEffort("openai/gpt-5.6-luna")).toBeUndefined();
     expect(getDefaultReasoningEffort("xai/grok-4.5")).toBe("high");
-    expect(getDefaultReasoningEffort("xai/grok-build-0.1")).toBe("high");
+    expect(getDefaultReasoningEffort("xai/grok-build-0.1")).toBeUndefined();
     expect(getDefaultReasoningEffort("deepseek/deepseek-v4-pro")).toBeUndefined();
   });
 
@@ -293,10 +293,7 @@ describe("model utilities", () => {
       efforts: ["low", "medium", "high"],
       default: "high",
     });
-    expect(getReasoningConfig("xai/grok-build-0.1")).toEqual({
-      efforts: ["low", "medium", "high"],
-      default: "high",
-    });
+    expect(getReasoningConfig("xai/grok-build-0.1")).toBeUndefined();
     expect(getReasoningConfig("deepseek/deepseek-v4-flash")).toBeUndefined();
   });
 
@@ -314,7 +311,7 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-4.5", "medium")).toBe(true);
     expect(isValidReasoningEffort("xai/grok-4.5", "xhigh")).toBe(false);
-    expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(true);
+    expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("deepseek/deepseek-v4-pro", "high")).toBe(false);
     expect(isValidReasoningEffort("invalid", "high")).toBe(false);

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -242,7 +242,6 @@ describe("model utilities", () => {
     expect(supportsReasoning("claude-opus-4-8")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.6-terra")).toBe(true);
-    expect(supportsReasoning("xai/grok-4.5")).toBe(true);
     expect(supportsReasoning("xai/grok-build-0.1")).toBe(false);
     expect(supportsReasoning("deepseek/deepseek-v4-flash")).toBe(false);
     expect(supportsReasoning("invalid")).toBe(false);
@@ -255,7 +254,6 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
     expect(getDefaultReasoningEffort("openai/gpt-5.6-luna")).toBeUndefined();
-    expect(getDefaultReasoningEffort("xai/grok-4.5")).toBe("high");
     expect(getDefaultReasoningEffort("xai/grok-build-0.1")).toBeUndefined();
     expect(getDefaultReasoningEffort("deepseek/deepseek-v4-pro")).toBeUndefined();
   });
@@ -289,10 +287,6 @@ describe("model utilities", () => {
       efforts: ["low", "medium", "high", "xhigh"],
       default: "high",
     });
-    expect(getReasoningConfig("xai/grok-4.5")).toEqual({
-      efforts: ["low", "medium", "high"],
-      default: "high",
-    });
     expect(getReasoningConfig("xai/grok-build-0.1")).toBeUndefined();
     expect(getReasoningConfig("deepseek/deepseek-v4-flash")).toBeUndefined();
   });
@@ -309,8 +303,6 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
-    expect(isValidReasoningEffort("xai/grok-4.5", "medium")).toBe(true);
-    expect(isValidReasoningEffort("xai/grok-4.5", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("deepseek/deepseek-v4-pro", "high")).toBe(false);

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -40,7 +40,7 @@ const OPENAI_MODELS = [
   "openai/gpt-5.3-codex-spark",
 ] as const;
 
-const XAI_MODELS = ["xai/grok-build-0.1"] as const;
+const XAI_MODELS = ["xai/grok-4.5", "xai/grok-build-0.1"] as const;
 
 const ZEN_MODELS = [
   "opencode/kimi-k2.5",
@@ -242,6 +242,7 @@ describe("model utilities", () => {
     expect(supportsReasoning("claude-opus-4-8")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.6-terra")).toBe(true);
+    expect(supportsReasoning("xai/grok-4.5")).toBe(true);
     expect(supportsReasoning("xai/grok-build-0.1")).toBe(true);
     expect(supportsReasoning("deepseek/deepseek-v4-flash")).toBe(false);
     expect(supportsReasoning("invalid")).toBe(false);
@@ -254,6 +255,7 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
     expect(getDefaultReasoningEffort("openai/gpt-5.6-luna")).toBeUndefined();
+    expect(getDefaultReasoningEffort("xai/grok-4.5")).toBe("high");
     expect(getDefaultReasoningEffort("xai/grok-build-0.1")).toBe("high");
     expect(getDefaultReasoningEffort("deepseek/deepseek-v4-pro")).toBeUndefined();
   });
@@ -287,6 +289,10 @@ describe("model utilities", () => {
       efforts: ["low", "medium", "high", "xhigh"],
       default: "high",
     });
+    expect(getReasoningConfig("xai/grok-4.5")).toEqual({
+      efforts: ["low", "medium", "high"],
+      default: "high",
+    });
     expect(getReasoningConfig("xai/grok-build-0.1")).toEqual({
       efforts: ["low", "medium", "high"],
       default: "high",
@@ -306,6 +312,8 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
+    expect(isValidReasoningEffort("xai/grok-4.5", "medium")).toBe(true);
+    expect(isValidReasoningEffort("xai/grok-4.5", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(true);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("deepseek/deepseek-v4-pro", "high")).toBe(false);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -193,6 +193,12 @@ export const MODEL_CATALOG = [
     enabledByDefault: false,
     models: [
       {
+        id: "xai/grok-4.5",
+        name: "Grok 4.5",
+        description: "Latest Grok for chat, coding, and agentic tools",
+        reasoning: { efforts: ["low", "medium", "high"], default: "high" },
+      },
+      {
         id: "xai/grok-build-0.1",
         name: "Grok Build 0.1",
         description: "Coding model for SuperGrok subscribers",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -202,7 +202,6 @@ export const MODEL_CATALOG = [
         id: "xai/grok-build-0.1",
         name: "Grok Build 0.1",
         description: "Coding model for SuperGrok subscribers",
-        reasoning: { efforts: ["low", "medium", "high"], default: "high" },
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add `xai/grok-4.5` to the opt-in xAI / SuperGrok model catalog
- expose Grok 4.5 low, medium, and high reasoning efforts, with high as the default
- remove invalid reasoning-effort controls from `grok-build-0.1`, which reasons internally but does not accept `reasoningEffort`
- strip stale persisted efforts at prompt dispatch so existing Grok Build sessions no longer send the rejected parameter
- update shared, sandbox-runtime, control-plane, and documentation coverage

## Upstream verification

Confirmed against OpenCode and its model metadata:

- Grok 4.5 uses provider model ID `grok-4.5` and supports low, medium, and high effort variants.
- Grok Build declares reasoning capability with an empty `reasoning_options` list, meaning reasoning is built in but its effort is not configurable.
- The existing xAI auth proxy preserves OpenCode models and injects Grok Build with an explicitly empty variant map.

## Verification

- `npm test -w @open-inspect/shared` (525 tests passed)
- `npm test -w @open-inspect/control-plane -- src/session/message-queue.test.ts` (28 tests passed)
- targeted sandbox-runtime tests (29 tests passed)
- Ruff check and format check on changed Python tests
- `npm run typecheck`
- Prettier check on changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `xai/grok-4.5` with low, medium, and high reasoning options.
  * Set high reasoning as the default; the model remains disabled by default.

* **Bug Fixes**
  * Prevented unsupported reasoning settings from being sent to incompatible models.
  * Updated Grok Build 0.1 to no longer expose reasoning options.

* **Documentation**
  * Updated model availability, setup, rollout verification, troubleshooting, entitlement, and authentication guidance for Grok models.

* **Tests**
  * Added coverage for model support, authentication, queue processing, and reasoning configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->