### PR TITLE
feat: add Luna max reasoning support

### DIFF
--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -39,7 +39,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v54-opencode-1-17-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v55-opencode-1-18-11");
   });
 
   it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
@@ -49,7 +49,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     await client.runRuntimeForeground("sb-1", 60);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v54-opencode-1-17-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v55-opencode-1-18-11");
   });
 });
 

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -192,7 +192,7 @@ const RUNTIME_HOSTS_BOOTSTRAP =
 // runtime reports an empty version and the build-complete callback is rejected
 // (runtime-version floor check). Keep in sync with the value baked in
 // packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
-const OPENCOMPUTER_SANDBOX_VERSION = "v54-opencode-1-17-18";
+const OPENCOMPUTER_SANDBOX_VERSION = "v55-opencode-1-18-11";
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -6,7 +6,7 @@
 
 export const VERCEL_PYTHON_BIN = "/usr/bin/python3.12";
 export const DEFAULT_VERCEL_RUNTIME = "node24";
-export const VERCEL_SANDBOX_VERSION = "v54-opencode-1-17-18";
+export const VERCEL_SANDBOX_VERSION = "v55-opencode-1-18-11";
 export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 
@@ -16,7 +16,7 @@ export function buildVercelBootstrapScript(params: { runtimeExtractDir?: string 
   return `
 set -euo pipefail
 
-OPENCODE_VERSION="1.17.18"
+OPENCODE_VERSION="1.18.11"
 CODE_SERVER_VERSION="4.109.5"
 AGENT_BROWSER_VERSION="0.21.2"
 TTYD_VERSION="1.7.7"

--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -10,11 +10,11 @@ from daytona import CreateSnapshotParams, Daytona, Image
 #
 # OpenCode restored `/event` stream context in 1.14.50 and fixed the remaining
 # eager-subscription race in 1.15.5. Keep the CLI and plugin on the same pin.
-OPENCODE_VERSION = "1.17.18"
+OPENCODE_VERSION = "1.18.11"
 CODE_SERVER_VERSION = "4.109.5"
 AGENT_BROWSER_VERSION = "0.21.2"
 # Bump when changing image contents to invalidate the Daytona snapshot.
-SANDBOX_VERSION = "daytona-v3-opencode-1-17-18"
+SANDBOX_VERSION = "daytona-v4-opencode-1-18-11"
 
 
 def build_base_image(repo_root: Path) -> Image:

--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -14,7 +14,7 @@
 FROM python:3.12-slim-bookworm
 
 # Pinned toolchain versions (keep in sync with daytona-infra/src/toolchain.py).
-ARG OPENCODE_VERSION=1.17.18
+ARG OPENCODE_VERSION=1.18.11
 ARG CODE_SERVER_VERSION=4.109.5
 ARG AGENT_BROWSER_VERSION=0.21.2
 

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -24,7 +24,7 @@ SANDBOX_RUNTIME_DIR = Path(sandbox_runtime.__file__).parent
 #
 # OpenCode restored `/event` stream context in 1.14.50 and fixed the remaining
 # eager-subscription race in 1.15.5. Keep the CLI and plugin on the same pin.
-OPENCODE_VERSION = "1.17.18"
+OPENCODE_VERSION = "1.18.11"
 
 # code-server version to install (pinned for reproducible images)
 CODE_SERVER_VERSION = "4.109.5"
@@ -37,8 +37,8 @@ TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
-# v55: rename child session tools
-CACHE_BUSTER = "v55-child-session-tools"
+# v56: upgrade OpenCode for GPT 5.6 Luna max reasoning
+CACHE_BUSTER = "v56-opencode-1-18-11"
 
 # Base image with all development tools
 base_image = (

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { Image, Snapshots } from "@opencomputer/sdk/node";
 
-const OPENCODE_VERSION = "1.17.18";
+const OPENCODE_VERSION = "1.18.11";
 const CODE_SERVER_VERSION = "4.109.5";
 const PYTHON_VERSION = "3.12";
 const AGENT_BROWSER_VERSION = "0.21.2";
@@ -240,7 +240,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "v54-opencode-1-17-18",
+      SANDBOX_VERSION: "v55-opencode-1-18-11",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -509,7 +509,7 @@ def _make_opencode_deps_staging(tmp_path: Path) -> Path:
     """Build a fake /app/opencode-deps staging tree (plugin-only, in sync)."""
     deps_cache = tmp_path / "opencode-deps"
     deps_cache.mkdir()
-    (deps_cache / "package.json").write_text('{"dependencies": {"@opencode-ai/plugin": "1.17.18"}}')
+    (deps_cache / "package.json").write_text('{"dependencies": {"@opencode-ai/plugin": "1.18.11"}}')
     (deps_cache / "package-lock.json").write_text('{"lockfileVersion": 3}')
     plugin = deps_cache / "node_modules" / "@opencode-ai" / "plugin"
     plugin.mkdir(parents=True)

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -283,6 +283,10 @@ describe("model utilities", () => {
       efforts: ["none", "low", "medium", "high", "xhigh"],
       default: undefined,
     });
+    expect(getReasoningConfig("openai/gpt-5.6-luna")).toEqual({
+      efforts: ["none", "low", "medium", "high", "xhigh", "max"],
+      default: undefined,
+    });
     expect(getReasoningConfig("openai/gpt-5.3-codex")).toEqual({
       efforts: ["low", "medium", "high", "xhigh"],
       default: "high",
@@ -302,6 +306,7 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
+    expect(isValidReasoningEffort("openai/gpt-5.6-luna", "max")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "xhigh")).toBe(false);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -10,7 +10,7 @@
  *
  * - "none": No reasoning (OpenAI only)
  * - "low"/"medium"/"high"/"xhigh": Progressive reasoning depth
- * - "max": Maximum reasoning budget (Anthropic extended thinking)
+ * - "max": Maximum reasoning effort for models that support it
  */
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -158,7 +158,7 @@ export const MODEL_CATALOG = [
         name: "GPT 5.6 Luna",
         description: "Fast, cost-efficient high-volume workloads",
         reasoning: {
-          efforts: ["none", "low", "medium", "high", "xhigh"],
+          efforts: ["none", "low", "medium", "high", "xhigh", "max"],
           default: undefined,
         },
       },


### PR DESCRIPTION
## Summary

- upgrade OpenCode CLI and plugin pins from `1.17.18` to `1.18.11` across Modal, Daytona, E2B, OpenComputer, and Vercel sandboxes
- invalidate sandbox images and snapshots so the upgraded runtime is rebuilt everywhere
- expose the `max` reasoning effort for `openai/gpt-5.6-luna` in the shared model catalog
- update model validation and sandbox-version tests

## Testing

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (525 tests)
- `npm run typecheck -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/sandbox/opencomputer-rest-client.test.ts`
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/vercel` (43 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/opencomputer-infra`
- `npm run build -w @open-inspect/opencomputer-infra`
- `uv run --extra dev pytest tests/test_tool_installation.py -q` (25 tests)
- verified `opencode-ai@1.18.11` and `@opencode-ai/plugin@1.18.11` are published on npm

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/055b8182448fa80432bb5e1a82dee11a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `max` reasoning effort for `openai/gpt-5.6-luna`.
  - Updated model guidance to describe `max` as the highest reasoning level.

- **Updates**
  - Upgraded the OpenCode runtime and plugin environment to version 1.18.11 across supported sandbox environments.
  - Refreshed sandbox builds and runtime identifiers to use the updated environment version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->