### PR TITLE
fix: return xAI token when cache write fails

### DIFF
--- a/packages/control-plane/src/session/xai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/xai-token-refresh-service.test.ts
@@ -217,7 +217,7 @@ describe("XaiTokenRefreshService", () => {
     expect(state.refresh).toHaveBeenCalledTimes(1);
   });
 
-  it("fails when a rotated token cannot be persisted", async () => {
+  it("returns a refreshed token when rotated tokens cannot be persisted", async () => {
     state.repo.set(123, { XAI_OAUTH_REFRESH_TOKEN: "refresh-old" });
     state.refresh.mockResolvedValue({
       access_token: "access-new",
@@ -225,11 +225,22 @@ describe("XaiTokenRefreshService", () => {
       expires_in: 3600,
     });
     state.failWrites = true;
+    const log = logger();
+    const refreshService = new XaiTokenRefreshService(
+      {} as SqlDatabase,
+      "key",
+      async () => 123,
+      log
+    );
 
-    await expect(service().refresh(session())).resolves.toEqual({
-      ok: false,
-      status: 502,
-      error: "xAI token refresh failed",
+    await expect(refreshService.refresh(session())).resolves.toEqual({
+      ok: true,
+      accessToken: "access-new",
+      expiresIn: 3600,
     });
+    expect(log.error).toHaveBeenCalledWith(
+      "xAI token refreshed but failed to persist rotated tokens",
+      { source: "repo", error: "write failed" }
+    );
   });
 });

--- a/packages/control-plane/src/session/xai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/xai-token-refresh-service.ts
@@ -148,8 +148,15 @@ export class XaiTokenRefreshService {
       XAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
       XAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + expiresIn * 1000),
     };
-    await this.writeSecrets(state.source, secrets);
-    this.log.info("xAI tokens rotated and cached", { source: state.source.kind });
+    try {
+      await this.writeSecrets(state.source, secrets);
+      this.log.info("xAI tokens rotated and cached", { source: state.source.kind });
+    } catch (error) {
+      this.log.error("xAI token refreshed but failed to persist rotated tokens", {
+        source: state.source.kind,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return { ok: true, accessToken: tokens.access_token, expiresIn };
   }
 


### PR DESCRIPTION
## Summary
- return a successfully refreshed xAI access token even when persisting the rotated credentials fails
- log persistence failures separately from upstream xAI refresh failures
- add regression coverage for the cache-write failure path

## Rationale
The upstream refresh has already produced a usable short-lived access token before the secrets write occurs. Returning `502` on a persistence failure unnecessarily prevents the current SuperGrok session from using that token and incorrectly reports the operation as an xAI refresh failure.

Persistence is still attempted so rotated refresh tokens and access-token caching continue to work normally, while failures remain observable through error logging.

## Validation
- `npm test -w @open-inspect/control-plane -- src/session/xai-token-refresh-service.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ea442b0937193813d52eca009bbe8baf)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token refreshes now succeed even when saving rotated credentials fails.
  * Refreshed access tokens and their expiration details remain available instead of returning an error.
  * Persistence failures are logged for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->