### PR TITLE
Complete shared owner import adoption

### DIFF
--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -1,12 +1,14 @@
 import {
-  buildAgentResponseFromEvents,
-  getArtifactLabelFromArtifact,
   type ArtifactInfo,
   type ChildSessionDetail,
   type ChildSessionFinalResponse,
   type ChildSessionTrajectory,
   type EventResponse,
 } from "@open-inspect/shared";
+import {
+  buildAgentResponseFromEvents,
+  getArtifactLabelFromArtifact,
+} from "@open-inspect/shared/completion/extractor";
 import {
   encodeEventTimelineCursor,
   parseEventTimelineCursor,

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -14,7 +14,6 @@ import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job"
 
 export type {
   ArtifactType,
-  ClientMessage,
   CreateSessionRequest,
   CreateSessionResponse,
   EventResponse,
@@ -25,16 +24,19 @@ export type {
   MessageStatus,
   ParticipantRole,
   ParticipantPresence,
-  SessionAttachmentReference,
-  ResolvedSessionAttachment,
   SpawnSource,
   SandboxEvent,
   SandboxStatus,
-  ServerMessage,
-  SessionRepositoryState,
   SessionState,
   SessionStatus,
 } from "@open-inspect/shared";
+export type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
+export type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+export type {
+  SessionAttachmentReference,
+  ResolvedSessionAttachment,
+} from "@open-inspect/shared/types/session-attachments";
+export type { ClientMessage } from "@open-inspect/shared/types/websocket";
 
 // Environment bindings
 export interface Env {

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -79,7 +79,7 @@ export type {
   RepoMetadata,
   ControlPlaneRepo,
   ControlPlaneReposResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/repository-catalog";
 export type {
   Environment,
   ListEnvironmentsResponse,
@@ -140,7 +140,8 @@ export interface ToolCallCallback {
 
 // ─── Classification Types ────────────────────────────────────────────────────
 
-export type { ClassificationResult, ConfidenceLevel } from "@open-inspect/shared";
+export type { ConfidenceLevel } from "@open-inspect/shared";
+export type { ClassificationResult } from "@open-inspect/shared/types/repository-catalog";
 
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- import `buildAgentResponseFromEvents` and `getArtifactLabelFromArtifact` from `@open-inspect/shared/completion/extractor`
- re-export `SessionRepositoryState` from `@open-inspect/shared/types/repositories`, `ClientMessage` from `@open-inspect/shared/types/websocket`, `ServerMessage` from `@open-inspect/shared/types/server-messages`, and `SessionAttachmentReference` / `ResolvedSessionAttachment` from `@open-inspect/shared/types/session-attachments`
- re-export `RepoConfig`, `RepoMetadata`, `ControlPlaneRepo`, `ControlPlaneReposResponse`, and `ClassificationResult` from `@open-inspect/shared/types/repository-catalog`

This is a behavior-neutral import/re-export cleanup across 3 production files and 0 test files. Type-only semantics are preserved.

## Dependency impact

- named references to the shared root in these files: 50 -> 38 (-12)
- shared-root declarations in these files: 9 -> 8 (-1)
- shared-root consumer file count: unchanged, because these files still use symbols whose ownership is deferred
- all 27 existing direct owner paths were audited; no consumer still imports or re-exports one of their owned symbols from the shared root
- root compatibility exports remain intact
- deferred symbols remain at `@open-inspect/shared`

No source movement, new facade, tests, lint/root-import ratchet, ESM/NodeNext work, schema changes, or serialized-shape changes are included.

## Validation

- `npm run build -w @open-inspect/shared`
- typecheck: shared, control-plane, linear-bot
- lint: shared, control-plane, linear-bot
- production builds: control-plane, linear-bot
- shared tests: 38 files, 525 tests
- control-plane unit tests: 149 files, 2,230 tests
- control-plane integration tests: 59 files, 680 tests
- linear-bot tests: 14 files, 202 tests
- total: 260 files, 3,637 tests
- Prettier and `git diff --check`
- static owner-path audit

## Self-review

Architecture review found the package dependency direction unchanged, direct imports aligned with existing source owners, root compatibility preserved, and no cycle or API-stability risk. Simplicity review found the three-file diff already minimal, with no extra abstraction or removable code.

## Rollback

Revert this PR; root compatibility remains available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized shared type exports into dedicated modules.
  * Improved separation between runtime and type-only imports.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->