### PR TITLE
Refactor image build planning plumbing

### DIFF
--- a/packages/control-plane/src/image-builds/opencomputer-adapter.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.ts
@@ -74,9 +74,7 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
     // build teardown (the sandbox is gone by the time the image is deleted, so
     // there is no attachment left to delete it through).
     await this.deleteBuildSandbox(
-      input.buildId,
       input.providerSessionId,
-      input.correlation,
       {
         deleteSecretStore: false,
       },
@@ -88,9 +86,7 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
     // A failed build produced no checkpoint, so nothing references its store —
     // delete it with the sandbox.
     await this.deleteBuildSandbox(
-      input.buildId,
       input.providerSessionId,
-      input.correlation,
       {
         deleteSecretStore: true,
       },
@@ -107,14 +103,10 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
   }
 
   private async deleteBuildSandbox(
-    buildId: string,
     providerSessionId: string,
-    correlation: FinalizeImageBuildInput["correlation"],
     options: { deleteSecretStore: boolean },
     signal?: AbortSignal
   ): Promise<void> {
-    void buildId;
-    void correlation;
     await this.provider.deleteSandbox(
       providerSessionId,
       {

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -11,14 +11,13 @@ import {
   IMAGE_BUILD_CALLBACK_TOKEN_TTL_MS,
 } from "./callback-auth";
 import type { ImageBuildProvider, ImageBuildScope } from "./model";
-import { getImageBuildCloneAuthMode } from "./provider-policy";
 import {
   loadScopeBuildSecrets,
   resolveScopeSandboxSettings,
   resolveScopeTarget,
   type ResolvedImageBuildTarget,
 } from "./scope";
-import type { ImageBuildCloneAuth, PlannedImageBuild } from "./types";
+import type { ImageBuildCloneAuth, ImageBuildPlan } from "./types";
 
 const logger = createLogger("image-builds:planner");
 const MS_PER_SECOND = 1000;
@@ -73,10 +72,9 @@ export class ImageBuildPlanner {
     correlation: CorrelationContext;
     target: ResolvedImageBuildTarget;
     callbackAuth: PlannedCallbackAuth;
-  }): Promise<PlannedImageBuild> {
+  }): Promise<ImageBuildPlan> {
     const { repositories, repositoriesFingerprint } = params.target;
     const primary = repositories[0];
-    const callbackAuth = params.callbackAuth;
 
     const [sandboxSettings, userEnvVars, cloneAuth] = await Promise.all([
       resolveScopeSandboxSettings(this.db, params.scope, primary),
@@ -101,24 +99,15 @@ export class ImageBuildPlanner {
       },
     };
 
-    const registration = { tokenHash: callbackAuth.tokenHash, expiresAt: callbackAuth.expiresAt };
-
     return {
-      plan: {
-        ...basePlan,
-        provider: this.provider,
-        callbackToken: callbackAuth.token,
-        cloneAuth,
-      },
-      callbackAuth: registration,
+      ...basePlan,
+      provider: this.provider,
+      callbackToken: params.callbackAuth.token,
+      cloneAuth,
     };
   }
 
   private async resolveCloneAuth(scope: ImageBuildScope): Promise<ImageBuildCloneAuth> {
-    if (getImageBuildCloneAuthMode(this.provider) !== "credential_helper") {
-      return { type: "unavailable" };
-    }
-
     try {
       const provider = createSourceControlProviderFromEnv(this.env);
       const auth = await provider.generateCredentialHelperAuth();

--- a/packages/control-plane/src/image-builds/provider-policy.ts
+++ b/packages/control-plane/src/image-builds/provider-policy.ts
@@ -9,14 +9,11 @@ import type { ImageBuildProvider } from "./model";
  * from provider-neutral lifecycle terms instead of open-coded provider checks.
  */
 
-/** How the provider's build sandbox authenticates its git clones. */
-export type ImageBuildCloneAuthMode = "credential_helper" | "none";
-
-const IMAGE_BUILD_CLONE_AUTH_MODES = {
-  modal: "credential_helper",
-  vercel: "credential_helper",
-  opencomputer: "credential_helper",
-} satisfies Record<ImageBuildProvider, ImageBuildCloneAuthMode>;
+const IMAGE_BUILD_PROVIDERS = {
+  modal: true,
+  vercel: true,
+  opencomputer: true,
+} satisfies Record<ImageBuildProvider, true>;
 
 export function getImageBuildsUnsupportedMessage(env: Env): string | null {
   if (resolveImageBuildProvider(env.SANDBOX_PROVIDER)) {
@@ -31,18 +28,6 @@ export function resolveImageBuildProvider(value: string | undefined): ImageBuild
   return isImageBuildProvider(provider) ? provider : null;
 }
 
-export function getImageBuildProvider(env: Env): ImageBuildProvider {
-  const provider = resolveImageBuildProvider(env.SANDBOX_PROVIDER);
-  if (!provider) {
-    throw new Error(`Image builds are not supported for SANDBOX_PROVIDER=${env.SANDBOX_PROVIDER}`);
-  }
-  return provider;
-}
-
-export function getImageBuildCloneAuthMode(provider: ImageBuildProvider): ImageBuildCloneAuthMode {
-  return IMAGE_BUILD_CLONE_AUTH_MODES[provider];
-}
-
 function isImageBuildProvider(provider: SandboxBackendName): provider is ImageBuildProvider {
-  return provider in IMAGE_BUILD_CLONE_AUTH_MODES;
+  return provider in IMAGE_BUILD_PROVIDERS;
 }

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -57,12 +57,6 @@ export interface ImageBuildPlan extends BaseImageBuildPlan {
   cloneAuth: ImageBuildCloneAuth;
 }
 
-export interface PlannedImageBuild {
-  plan: ImageBuildPlan;
-  /** Registration side of the callback token every build authenticates with. */
-  callbackAuth: { tokenHash: string; expiresAt: number };
-}
-
 /** Lets provider-session adapters bind the provider sandbox id before the runtime launches. */
 export interface ImageBuildStartCallbacks {
   bindProviderSession(providerSessionId: string): Promise<void>;

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -15,7 +15,7 @@ import { IMAGE_BUILD_CLEANUP_ATTEMPT_MS } from "./reaper";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
 import type { ImageBuildFinalizationQueue } from "./finalization-job";
-import type { PlannedImageBuild } from "./types";
+import type { ImageBuildPlan } from "./types";
 import { ImageBuildWorkflow } from "./workflow";
 
 const ENV_SCOPE: ImageBuildScope = { kind: "environment", id: "env_1" };
@@ -79,42 +79,36 @@ function createAdapter() {
   };
 }
 
-function plannedBuild(overrides: Record<string, unknown> = {}): PlannedImageBuild {
+function plannedBuild(overrides: Record<string, unknown> = {}): ImageBuildPlan {
   return {
-    plan: {
-      buildId: "imgb-env_1-1-abcd",
-      scope: ENV_SCOPE,
-      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-      repositoriesFingerprint: "fp-1",
-      callbackUrl: "https://worker.test/image-builds/build-complete",
-      failureCallbackUrl: "https://worker.test/image-builds/build-failed",
-      buildTimeoutMs: 1800_000,
-      correlation: { trace_id: "t", request_id: "r" },
-      provider: "modal",
-      callbackToken: MODAL_CALLBACK_TOKEN,
-      cloneAuth: { type: "unavailable" },
-      ...overrides,
-    },
-    callbackAuth: { tokenHash: "hash-modal", expiresAt: 9_999_999_999_999 },
+    buildId: "imgb-env_1-1-abcd",
+    scope: ENV_SCOPE,
+    repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+    repositoriesFingerprint: "fp-1",
+    callbackUrl: "https://worker.test/image-builds/build-complete",
+    failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+    buildTimeoutMs: 1800_000,
+    correlation: { trace_id: "t", request_id: "r" },
+    provider: "modal",
+    callbackToken: MODAL_CALLBACK_TOKEN,
+    cloneAuth: { type: "unavailable" },
+    ...overrides,
   };
 }
 
-function vercelPlannedBuild(): PlannedImageBuild {
+function vercelPlannedBuild(): ImageBuildPlan {
   return {
-    plan: {
-      buildId: "imgb-env_1-1-abcd",
-      scope: ENV_SCOPE,
-      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-      repositoriesFingerprint: "fp-1",
-      callbackUrl: "https://worker.test/image-builds/build-complete",
-      failureCallbackUrl: "https://worker.test/image-builds/build-failed",
-      buildTimeoutMs: 1800_000,
-      correlation: { trace_id: "t", request_id: "r" },
-      provider: "vercel",
-      callbackToken: "callback-token",
-      cloneAuth: { type: "unavailable" },
-    },
-    callbackAuth: { tokenHash: "hash-1", expiresAt: 9_999_999_999_999 },
+    buildId: "imgb-env_1-1-abcd",
+    scope: ENV_SCOPE,
+    repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+    repositoriesFingerprint: "fp-1",
+    callbackUrl: "https://worker.test/image-builds/build-complete",
+    failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+    buildTimeoutMs: 1800_000,
+    correlation: { trace_id: "t", request_id: "r" },
+    provider: "vercel",
+    callbackToken: "callback-token",
+    cloneAuth: { type: "unavailable" },
   };
 }
 

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -193,7 +193,19 @@ export class ImageBuildWorkflow {
     // Validate provider configuration before any database work. This keeps a
     // bad deployment from accumulating failed rows and preserves the most
     // actionable configuration error when multiple bindings are absent.
-    const adapter = this.createAdapterForOperation(provider, "trigger_build", ctx, "start");
+    let adapter: ImageBuildAdapter;
+    try {
+      adapter = this.adapterFactory.create(provider, "start");
+    } catch (e) {
+      logger.error("image_build.adapter_config_error", {
+        operation: "trigger_build",
+        provider,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new ImageBuildProviderUnconfiguredError("Image build provider is not configured", e);
+    }
     if (!this.finalizationQueue) {
       throw new ImageBuildWorkflowUnavailableError("Image build finalization Queue not configured");
     }
@@ -269,7 +281,7 @@ export class ImageBuildWorkflow {
         return { type: "already_building", buildId: winner.id };
       }
 
-      const planned = await planner.planBuild({
+      const plan = await planner.planBuild({
         buildId,
         scope,
         callbackUrl,
@@ -280,7 +292,7 @@ export class ImageBuildWorkflow {
       });
 
       startAdapter = adapter;
-      await adapter.startBuild(planned.plan, {
+      await adapter.startBuild(plan, {
         bindProviderSession: async (providerSessionId) => {
           providerSessionIdForCleanup = providerSessionId;
           const bound = await this.store.bindProviderSession(buildId, provider, providerSessionId);
@@ -294,7 +306,7 @@ export class ImageBuildWorkflow {
         build_id: buildId,
         scope_kind: scope.kind,
         scope_id: scope.id,
-        repositories_fingerprint: planned.plan.repositoriesFingerprint,
+        repositories_fingerprint: plan.repositoriesFingerprint,
         request_id: ctx.request_id,
         trace_id: ctx.trace_id,
       });
@@ -558,39 +570,6 @@ export class ImageBuildWorkflow {
       trace_id: params.ctx.trace_id,
     });
     return new ImageBuildCallbackAuthRejectedError("Unauthorized");
-  }
-
-  private createAdapterForOperation(
-    provider: ImageBuildProvider,
-    operation: string,
-    ctx: ImageBuildWorkflowContext,
-    adapterOperation: "start" | "existing_session" = "existing_session"
-  ): ImageBuildAdapter {
-    return this.createAdapterGuarded(provider, operation, ctx, () =>
-      this.adapterFactory.create(provider, adapterOperation)
-    );
-  }
-
-  private createAdapterGuarded<TAdapter>(
-    provider: ImageBuildProvider,
-    operation: string,
-    ctx: ImageBuildWorkflowContext,
-    create: () => TAdapter,
-    buildId?: string
-  ): TAdapter {
-    try {
-      return create();
-    } catch (e) {
-      logger.error("image_build.adapter_config_error", {
-        operation,
-        build_id: buildId,
-        provider,
-        error: errorMessage(e),
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-      throw new ImageBuildProviderUnconfiguredError("Image build provider is not configured", e);
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

- return `ImageBuildPlan` directly from the planner instead of wrapping it with duplicate callback registration data
- remove unused provider clone-auth policy and provider lookup exports
- inline the one-call adapter construction guard and drop unused OpenComputer cleanup parameters
- update workflow fixtures to match the narrower planner contract

## Why

The unified image-build rollout left behind abstractions for states and callers that no longer exist. Removing them keeps the provider-neutral lifecycle intact while reducing indirection and preventing the dead callback registration copy from drifting from the row registered by the workflow.

## Impact

No runtime behavior changes. Callback registration still occurs before secrets are loaded, adapter construction still fails closed before database writes, and clone-token failures still produce `unavailable` auth.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/image-builds` (130 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- Prettier and ESLint on all changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified image build planning and workflow execution.
  * Streamlined provider configuration and authentication handling.
  * Improved error reporting when an image build provider is not configured.
  * Simplified sandbox cleanup processing.
* **Tests**
  * Updated image build workflow tests to reflect the streamlined build plan structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->