### PR TITLE
Remove legacy image build callback contracts

### DIFF
--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -178,13 +178,11 @@ shared one-hour limit.
 
 Modal follows the same lifecycle as the other providers: the control plane creates a dormant
 sandbox, records its id, starts the runtime, and snapshots it only after the callback has been
-durably accepted. New builds no longer invoke the long-running Modal `build_image` function; the
-legacy function and cron remain deployed only until the final cleanup step in the rollout.
+durably accepted. The retired long-running Modal `build_image` function and Modal-side rebuild cron
+have been removed; rebuild evaluation now runs only in the provider-neutral control-plane scheduler.
 
 Terraform deploys the Modal app before the control-plane Worker so a one-shot upgrade cannot expose
-the new Worker until Modal's provider-session endpoints are available. The repository history keeps
-that cutover reviewable as three changes: add the compatible Modal endpoints, switch the Worker to
-Queue finalization, then remove the legacy Modal builder.
+the Worker until Modal's provider-session endpoints are available.
 
 ### What Happens When You Start a Session
 

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -9,8 +9,8 @@ This package provides the data plane for Open-Inspect:
 - **Sandboxes**: Isolated development environments running OpenCode
 - **Images**: Pre-built container images with all development tools
 - **Snapshots**: Filesystem snapshots for fast startup and session persistence
-- **Scheduler**: Cron-based rebuilds of prebuilt scope images — repositories and environments alike
-  (every 30 minutes)
+- **Image builds**: Short-lived provider sessions that the control plane creates, starts, snapshots,
+  and terminates
 
 ## Architecture
 

--- a/packages/shared/src/types/image-builds.ts
+++ b/packages/shared/src/types/image-builds.ts
@@ -3,9 +3,8 @@
  *
  * An image build bakes a provider image for a *scope* — either a single
  * repository or an environment (an ordered repository set). These types
- * mirror the D1 `image_builds` table and the Modal worker callback payloads;
- * they are consumed by the control plane, the web BFF, and (by comment
- * convention) the Python data plane.
+ * mirror the D1 `image_builds` table and the repository provenance reported by
+ * the sandbox runtime. They are consumed by the control plane and web BFF.
  */
 
 /** Mirrors the `image_builds.status` column. */
@@ -38,8 +37,7 @@ export interface RepositoryShaEntry {
  * scopes. `repositories_fingerprint` identifies the scope's repository set
  * as of the build — rows whose fingerprint differs from the scope's current
  * one are stale. `repository_shas` is the JSON-encoded `RepositoryShaEntry[]`
- * column value — `JSON.parse` before use; `ImageBuildCompleteCallback`
- * carries the same data already parsed. `provider` values come from the
+ * column value — `JSON.parse` before use. `provider` values come from the
  * control plane's provider union (deploy configuration, not part of this
  * contract).
  */
@@ -55,28 +53,4 @@ export interface ImageBuildRecordView {
   build_duration_seconds: number | null;
   error_message: string | null;
   created_at: number;
-}
-
-/**
- * Success callback POSTed by the Modal build worker
- * (`image_builder.py`) to `/image-builds/build-complete`.
- *
- * `repository_shas` arrives as a parsed array here and is stored
- * JSON-encoded (see `ImageBuildRecordView.repository_shas`).
- */
-export interface ImageBuildCompleteCallback {
-  build_id: string;
-  provider_image_id: string;
-  repository_shas: RepositoryShaEntry[];
-  runtime_version: string;
-  build_duration_seconds: number;
-}
-
-/**
- * Failure callback POSTed by the Modal build worker
- * (`image_builder.py`) to `/image-builds/build-failed`.
- */
-export interface ImageBuildFailedCallback {
-  build_id: string;
-  error: string;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -248,8 +248,6 @@ export type {
   ImageBuildScopeKind,
   RepositoryShaEntry,
   ImageBuildRecordView,
-  ImageBuildCompleteCallback,
-  ImageBuildFailedCallback,
 } from "./image-builds";
 
 export { ANALYTICS_DAYS, ANALYTICS_BREAKDOWN_BY } from "./analytics";


### PR DESCRIPTION
## Summary

- remove the unused shared callback interfaces for the retired Modal image builder
- stop re-exporting callback shapes that no longer match the live provider-session lifecycle
- update the image prebuild guide to reflect removal of the Modal builder and rebuild cron
- correct the Modal package overview so scheduling ownership matches the control plane

## Why

The old success type required `provider_image_id`, but current runtimes report a bound `provider_session_id` and the control plane creates the image artifact during queued finalization. Keeping the old exported types and rollout text made the removed architecture look current.

## Impact

This removes two unused TypeScript type exports only; there is no runtime change. Current D1 record and repository provenance contracts remain exported.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck` across all workspaces
- `npm test -w @open-inspect/shared` (525 tests)
- Prettier and ESLint on changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Image rebuild evaluation is now handled through a centralized, provider-neutral scheduler.
  * Image builds use short-lived provider sessions, improving lifecycle management and reducing reliance on long-running processes.
* **Documentation**
  * Updated image prebuild and infrastructure documentation to reflect the current rebuild workflow and deployment ordering.
  * Clarified image-build records and sandbox runtime provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->