### PR TITLE
fix: use async Modal snapshot interfaces

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -448,7 +448,7 @@ class SandboxManager:
             tunnel_urls=extra_tunnel_urls,
         )
 
-    def take_snapshot(
+    async def take_snapshot(
         self,
         handle: SandboxHandle,
     ) -> str:
@@ -475,9 +475,7 @@ class SandboxManager:
         start_time = time.time()
         snapshot_id = f"snap-{handle.sandbox_id}-{int(time.time() * 1000)}"
 
-        # Use Modal's native snapshot_filesystem() API
-        # This returns an Image directly (not async)
-        image = handle.modal_sandbox.snapshot_filesystem(
+        image = await handle.modal_sandbox.snapshot_filesystem.aio(
             timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
         )
 
@@ -510,7 +508,7 @@ class SandboxManager:
             SandboxHandle if found, None otherwise
         """
         try:
-            modal_sandbox = modal.Sandbox.from_id(sandbox_id)
+            modal_sandbox = await modal.Sandbox.from_id.aio(sandbox_id)
             return SandboxHandle(
                 sandbox_id=sandbox_id,
                 modal_sandbox=modal_sandbox,

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -320,8 +320,7 @@ async def api_snapshot_sandbox(
         if not handle:
             raise HTTPException(status_code=404, detail=f"Sandbox not found: {sandbox_id}")
 
-        # Take filesystem snapshot using Modal's native API (sync method)
-        image_id = manager.take_snapshot(handle)
+        image_id = await manager.take_snapshot(handle)
 
         return {
             "success": True,

--- a/packages/modal-infra/tests/test_snapshot_timeout.py
+++ b/packages/modal-infra/tests/test_snapshot_timeout.py
@@ -1,7 +1,9 @@
 """Tests for Modal filesystem snapshot timeout configuration."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from sandbox_runtime.types import SandboxStatus
 from src.sandbox.manager import (
@@ -11,10 +13,17 @@ from src.sandbox.manager import (
 )
 
 
-def test_take_snapshot_passes_explicit_timeout():
+def _async_method(return_value=None):
+    method = MagicMock()
+    method.aio = AsyncMock(return_value=return_value)
+    return method
+
+
+@pytest.mark.asyncio
+async def test_take_snapshot_passes_explicit_timeout():
     """Session snapshots should not rely on Modal's short default timeout."""
     image = SimpleNamespace(object_id="im-session")
-    snapshot_filesystem = MagicMock(return_value=image)
+    snapshot_filesystem = _async_method(image)
     handle = SandboxHandle(
         sandbox_id="sandbox-1",
         modal_sandbox=SimpleNamespace(snapshot_filesystem=snapshot_filesystem),
@@ -22,7 +31,22 @@ def test_take_snapshot_passes_explicit_timeout():
         created_at=0,
     )
 
-    image_id = SandboxManager().take_snapshot(handle)
+    image_id = await SandboxManager().take_snapshot(handle)
 
     assert image_id == "im-session"
-    snapshot_filesystem.assert_called_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+    snapshot_filesystem.assert_not_called()
+    snapshot_filesystem.aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_get_sandbox_by_id_awaits_async_lookup(monkeypatch):
+    modal_sandbox = SimpleNamespace()
+    from_id = _async_method(modal_sandbox)
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", from_id)
+
+    handle = await SandboxManager().get_sandbox_by_id("sandbox-1")
+
+    assert handle is not None
+    assert handle.modal_sandbox is modal_sandbox
+    from_id.assert_not_called()
+    from_id.aio.assert_awaited_once_with("sandbox-1")

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -382,7 +382,7 @@ async def test_generic_snapshot_reason_cannot_select_build_identity_rules(monkey
     handle = SimpleNamespace()
     manager = SimpleNamespace(
         get_sandbox_by_id=AsyncMock(return_value=handle),
-        take_snapshot=MagicMock(return_value="im-session-1"),
+        take_snapshot=AsyncMock(return_value="im-session-1"),
     )
     monkeypatch.setattr("src.sandbox.manager.SandboxManager", lambda: manager)
 
@@ -396,3 +396,4 @@ async def test_generic_snapshot_reason_cannot_select_build_identity_rules(monkey
 
     assert result["data"]["image_id"] == "im-session-1"
     manager.get_sandbox_by_id.assert_awaited_once_with("modal-session-1")
+    manager.take_snapshot.assert_awaited_once_with(handle)


### PR DESCRIPTION
## Summary

- replace blocking `modal.Sandbox.from_id()` with the awaited Modal async interface
- make session snapshot creation async and await `snapshot_filesystem.aio()`
- update the snapshot API endpoint and add regression coverage that ensures blocking methods are not called

## Validation

- `uv run --frozen pytest tests/ -v` (164 passed)
- `uv run --frozen ruff check src/sandbox/manager.py src/web_api.py tests/test_snapshot_timeout.py tests/test_web_api_build_sandbox.py`
- `uv run --frozen ruff format --check src/sandbox/manager.py src/web_api.py tests/test_snapshot_timeout.py tests/test_web_api_build_sandbox.py`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8d0c38cc53926e86938878c3a3831e92)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox snapshot and lookup operations by using asynchronous processing.
  - Web API snapshot requests now correctly wait for sandbox operations to complete.

- **Tests**
  - Expanded coverage for asynchronous snapshot handling, timeout propagation, sandbox lookup, and API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->