### PR TITLE
Use repository catalog confidence imports

### DIFF
--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -140,8 +140,10 @@ export interface ToolCallCallback {
 
 // ─── Classification Types ────────────────────────────────────────────────────
 
-export type { ConfidenceLevel } from "@open-inspect/shared";
-export type { ClassificationResult } from "@open-inspect/shared/types/repository-catalog";
+export type {
+  ClassificationResult,
+  ConfidenceLevel,
+} from "@open-inspect/shared/types/repository-catalog";
 
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -13,7 +13,7 @@ import { buildEnvironmentDescriptions } from "./environments";
 import { loadTargetCatalog, type TargetCatalog } from "./catalog";
 import { matchTargetId, resolveChannelTargets, resolveRoutingRuleTargets } from "./routing";
 import { escapeMrkdwnText } from "@open-inspect/shared/slack";
-import type { ConfidenceLevel } from "@open-inspect/shared";
+import type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
 import { targetId, targetLabel, targetValue, type SlackSessionTarget } from "../targets";
 import { createLogger } from "../logger";
 

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -62,7 +62,7 @@ export interface ThreadContext {
   previousMessages?: string[];
 }
 
-import type { ConfidenceLevel } from "@open-inspect/shared";
+import type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
 // targets.ts is a pure leaf (types + policy functions, no I/O), so the types
 // barrel can depend on it without a cycle.
 import type { SlackSessionTarget } from "../targets";
@@ -81,7 +81,7 @@ export interface ClassificationResult {
   needsClarification: boolean;
 }
 
-export type { ConfidenceLevel } from "@open-inspect/shared";
+export type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
 export type { Environment } from "@open-inspect/shared/types/environments";
 export type { SlackSessionTarget } from "../targets";
 


### PR DESCRIPTION
## Summary

- move all remaining `ConfidenceLevel` imports and re-exports from the shared root to `@open-inspect/shared/types/repository-catalog`
- consolidate the adjacent Linear repository-catalog type re-exports
- preserve the shared root compatibility export

## Scope

This is a type-only import-path migration across three bot files. It adds no package path, source module, behavior change, test, or import ratchet.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm test -w @open-inspect/linear-bot` (14 files, 202 tests)
- `npm test -w @open-inspect/slack-bot` (31 files, 397 tests)
- `npm run lint -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/slack-bot`
- targeted Prettier and diff checks
- verified no `ConfidenceLevel` import or re-export remains on the shared root

## Architecture review

The change replaces broad facade references with the existing source owner. All edges remain type-only, package direction is unchanged, and no runtime dependency or cycle is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal references to classification types across bot integrations.
  * No user-facing behavior or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->