### PR TITLE
docs: add SuperGrok subscription changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## August 1, 2026
+
+**Grok models with your SuperGrok subscription.** Use Grok 4.5 or Grok Build 0.1 through managed xAI
+OAuth, with opt-in model controls and reasoning-effort settings for Grok 4.5. Refresh credentials
+stay encrypted in the control plane while sandboxes receive only short-lived access tokens.
+
 ## July 31, 2026
 
 **Automatic prebuild refresh.** Repository and environment images now rebuild automatically when


### PR DESCRIPTION
## Summary

- add an August 1 changelog entry for SuperGrok subscription support
- highlight Grok 4.5 and Grok Build 0.1 availability
- note opt-in controls and control-plane-managed OAuth security

## Verification

- `npx prettier --check CHANGELOG.md`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/767efca7b757e8feee31256b0c33a623)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for managed xAI OAuth access to Grok 4.5 and Grok Build 0.1.
  * Documented opt-in model controls, reasoning settings, encrypted credential refresh, and short-lived sandbox tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->