### PR TITLE
Fix stale sandbox status after WebSocket reconnect

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1064,6 +1064,7 @@ export class SessionDO extends DurableObject<Env> {
         // IMPORTANT: Must await to ensure alarm is scheduled before returning
         const now = Date.now();
         this.updateLastActivity(now);
+        this.repository.updateSandboxHeartbeat(now);
         await this.scheduleInactivityCheck();
 
         log.info("ws.connect", {

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { runInDurableObject } from "cloudflare:test";
+import type { SessionDO } from "../../src/session/durable-object";
 import {
   collectMessages,
   initNamedSession,
@@ -140,6 +142,55 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
       reconnectedWs!.close();
     }
   );
+
+  it("refreshes heartbeat on reconnect before an old disconnect alarm runs", async () => {
+    const name = `ws-sandbox-reconnect-heartbeat-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "ready",
+    });
+
+    const { ws: firstWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(firstWs).not.toBeNull();
+    firstWs!.accept();
+
+    const closed = new Promise<void>((resolve) => {
+      firstWs!.addEventListener("close", () => resolve());
+    });
+    firstWs!.close(1001, "Going away");
+    await closed;
+
+    const oldHeartbeat = Date.now() - 10 * 60 * 1000;
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec("UPDATE sandbox SET last_heartbeat = ?", oldHeartbeat);
+    });
+
+    const { ws: reconnectedWs, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(response.status).toBe(101);
+    expect(reconnectedWs).not.toBeNull();
+    reconnectedWs!.accept();
+
+    const sandboxAfterReconnect = await queryDO<{ last_heartbeat: number; status: string }>(
+      stub,
+      "SELECT last_heartbeat, status FROM sandbox"
+    );
+    expect(sandboxAfterReconnect[0].last_heartbeat).toBeGreaterThan(oldHeartbeat);
+
+    await runInDurableObject(stub, (instance: SessionDO) => instance.alarm());
+
+    const sandboxAfterAlarm = await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox");
+    expect(sandboxAfterAlarm[0].status).toBe("ready");
+
+    reconnectedWs!.close();
+  });
 
   it("failed sandbox can reconnect and self-heal to ready", async () => {
     const name = `ws-sandbox-selfheal-${Date.now()}`;


### PR DESCRIPTION
## Summary
- refresh the persisted sandbox heartbeat when an authenticated sandbox WebSocket is accepted
- use the same connection timestamp for heartbeat and activity liveness
- add an integration regression covering an old heartbeat, disconnect watchdog, successful reconnect, and subsequent alarm evaluation

## Why
A disconnect alarm scheduled for an earlier sandbox WebSocket could run after a replacement connection was accepted. Because reconnect updated status and activity but not `last_heartbeat`, alarm handling could immediately classify the live replacement connection as stale before its first periodic runtime heartbeat.

## Verification
- `npm run test:integration -w @open-inspect/control-plane -- websocket-sandbox.test.ts` (11 passed)
- `npm test -w @open-inspect/control-plane` (151 files, 2,255 tests passed)
- `npm run typecheck -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/session/durable-object.ts packages/control-plane/test/integration/websocket-sandbox.test.ts`
- `npx prettier --check packages/control-plane/src/session/durable-object.ts packages/control-plane/test/integration/websocket-sandbox.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/07e075c0ca61ba84a121449c1eee441e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox session reconnection handling by refreshing heartbeat activity before disconnect monitoring runs.
  * Prevented active, ready sandboxes from being incorrectly marked disconnected after reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->