### PR TITLE
fix: distinguish subtasks from child sessions

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-child",
   description:
-    "Spawn a child coding session in a separate sandbox. Invoke only when the user's current request explicitly asks for a 'child session' or 'child sessions'; otherwise work directly. Never infer permission or suggest using one. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a child ID; check status only when its result is needed.",
+    "Spawn a child coding session in a separate sandbox. Invoke only when the user's current request explicitly asks for a 'child session' or 'child sessions'. Do not treat 'sub-agent', 'subagent', 'sub-task', or 'subtask' as requests for child sessions; those terms refer to in-process task delegation. Otherwise work directly. Never infer permission or suggest using a child session. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a child ID; check status only when its result is needed.",
   args: {
     title: z.string().describe("Short title describing the child session (shown in the UI)."),
     prompt: z

--- a/packages/sandbox-runtime/tests/test_spawn_child_tool.py
+++ b/packages/sandbox-runtime/tests/test_spawn_child_tool.py
@@ -57,6 +57,7 @@ def _run_tool(tmp_path: Path, args: dict[str, str] | None = None) -> dict[str, A
         await tool.execute(JSON.parse(process.argv[2]));
       }
       process.stdout.write(JSON.stringify({
+        description: tool.description,
         reasoningSchema: tool.args.reasoning,
         request: globalThis.capturedRequest,
       }));
@@ -84,6 +85,15 @@ def test_schema_exposes_optional_reasoning_override(tmp_path: Path) -> None:
     assert result["reasoningSchema"]["isOptional"] is True
     assert "overrides" in result["reasoningSchema"]["description"].lower()
     assert "parent" in result["reasoningSchema"]["description"].lower()
+
+
+def test_description_distinguishes_subtasks_from_child_sessions(tmp_path: Path) -> None:
+    description = _run_tool(tmp_path)["description"].lower()
+
+    assert "explicitly asks for a 'child session'" in description
+    assert "do not treat 'sub-agent'" in description
+    assert "'sub-task'" in description
+    assert "in-process task delegation" in description
 
 
 def test_serializes_reasoning_as_reasoning_effort(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- restrict `spawn-child` guidance to explicit child-session requests
- clarify that `sub-agent` and `sub-task` wording means in-process task delegation
- add regression coverage for the tool description

## Testing
- `uvx --with httpx --with websockets --with pydantic --with 'PyJWT[crypto]' --from pytest pytest tests/test_spawn_child_tool.py -v` (5 passed)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/36c107564433cc2afcc5cbe16b6697bc)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the child-session tool description to distinguish explicit child sessions from sub-agents, sub-tasks, and in-process delegation.

* **Tests**
  * Added coverage to verify the updated terminology and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->