### PR TITLE
Fix folding for delayed child task events

### DIFF
--- a/docs/plans/task-activity-nesting.md
+++ b/docs/plans/task-activity-nesting.md
@@ -54,8 +54,9 @@ All fields are optional so historical events continue to parse and render unchan
    and `isSubtask` at prompt completion so they remain visible inline rather than being dropped.
 5. Re-emit a same-status Task snapshot when correlation metadata first appears, making relationship
    discovery observable even when an earlier snapshot had no metadata.
-6. Clear the active child-to-Task relation when the Task terminates so a later resume cannot inherit
-   stale ownership.
+6. Clear the active child-to-Task relation when the Task terminates, but retain the completed owner
+   for delayed child events. Replace that completed owner when a later resume begins so new activity
+   cannot inherit stale ownership.
 
 ## Control-Plane Persistence
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/child_activity.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/child_activity.py
@@ -76,6 +76,8 @@ class ChildActivityCorrelator:
     def authorize_or_queue_message(
         self, child_session_id: str, message_id: str
     ) -> MessageDisposition:
+        if message_id in self._message_task_call_ids:
+            return MessageDisposition.AUTHORIZED
         task_call_id = self.task_for_activity(child_session_id)
         if task_call_id:
             self._message_task_call_ids[message_id] = task_call_id

--- a/packages/sandbox-runtime/src/sandbox_runtime/child_activity.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/child_activity.py
@@ -40,7 +40,7 @@ class ChildActivityCorrelator:
     _session_task_call_ids: dict[str, str] = field(default_factory=dict)
     _task_call_session_ids: dict[str, str] = field(default_factory=dict)
     _message_task_call_ids: dict[str, str] = field(default_factory=dict)
-    _closed_session_ids: set[str] = field(default_factory=set)
+    _closed_session_task_call_ids: dict[str, str] = field(default_factory=dict)
     _pending: list[PendingChildActivity] = field(default_factory=list)
     _drop_logged: bool = False
 
@@ -56,10 +56,16 @@ class ChildActivityCorrelator:
         is_new = self.track(child_session_id)
         self._session_task_call_ids[child_session_id] = task_call_id
         self._task_call_session_ids[task_call_id] = child_session_id
+        self._closed_session_task_call_ids.pop(child_session_id, None)
         return is_new
 
     def active_task(self, child_session_id: str) -> str | None:
         return self._session_task_call_ids.get(child_session_id)
+
+    def task_for_activity(self, child_session_id: str) -> str | None:
+        return self.active_task(child_session_id) or self._closed_session_task_call_ids.get(
+            child_session_id
+        )
 
     def child_for_task(self, task_call_id: str) -> str | None:
         return self._task_call_session_ids.get(task_call_id)
@@ -70,7 +76,7 @@ class ChildActivityCorrelator:
     def authorize_or_queue_message(
         self, child_session_id: str, message_id: str
     ) -> MessageDisposition:
-        task_call_id = self.active_task(child_session_id)
+        task_call_id = self.task_for_activity(child_session_id)
         if task_call_id:
             self._message_task_call_ids[message_id] = task_call_id
             return MessageDisposition.AUTHORIZED
@@ -85,7 +91,7 @@ class ChildActivityCorrelator:
             PendingChildMessage(
                 child_session_id,
                 message_id,
-                child_session_id not in self._closed_session_ids,
+                child_session_id not in self._closed_session_task_call_ids,
             )
         )
         return MessageDisposition.QUEUED
@@ -97,7 +103,7 @@ class ChildActivityCorrelator:
             PendingChildError(
                 child_session_id,
                 error,
-                child_session_id not in self._closed_session_ids,
+                child_session_id not in self._closed_session_task_call_ids,
             )
         )
         return True
@@ -129,7 +135,7 @@ class ChildActivityCorrelator:
         child_session_id = self.child_for_task(task_call_id)
         if child_session_id and self.active_task(child_session_id) == task_call_id:
             del self._session_task_call_ids[child_session_id]
-            self._closed_session_ids.add(child_session_id)
+            self._closed_session_task_call_ids[child_session_id] = task_call_id
 
     def should_log_drop(self) -> bool:
         if self._drop_logged:

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -541,7 +541,7 @@ class OpenCodePromptStream:
             )
             # Stream does not end — the parent continues after a sub-task error
             normalized_error = error_msg or "Sub-task error"
-            task_call_id = state.child_activity.active_task(error_session_id)
+            task_call_id = state.child_activity.task_for_activity(error_session_id)
             if not task_call_id:
                 if not state.child_activity.queue_error(error_session_id, normalized_error):
                     self._log_pending_child_drop(state)

--- a/packages/sandbox-runtime/tests/test_child_activity.py
+++ b/packages/sandbox-runtime/tests/test_child_activity.py
@@ -45,6 +45,10 @@ def test_resume_replaces_completed_task_for_new_messages_without_changing_old_ow
         correlator.authorize_or_queue_message("child-1", "resumed-message")
         is MessageDisposition.AUTHORIZED
     )
+    assert (
+        correlator.authorize_or_queue_message("child-1", "late-message")
+        is MessageDisposition.AUTHORIZED
+    )
     assert correlator.task_for_message("late-message") == "task-1"
     assert correlator.task_for_message("resumed-message") == "task-2"
 

--- a/packages/sandbox-runtime/tests/test_child_activity.py
+++ b/packages/sandbox-runtime/tests/test_child_activity.py
@@ -21,6 +21,34 @@ def test_correlates_messages_and_preserves_ownership_after_close():
     assert correlator.task_for_message("message-1") == "task-1"
 
 
+def test_correlates_message_first_seen_after_close_to_completed_task():
+    correlator = ChildActivityCorrelator()
+    correlator.associate("child-1", "task-1")
+    correlator.close("task-1")
+
+    assert (
+        correlator.authorize_or_queue_message("child-1", "late-message")
+        is MessageDisposition.AUTHORIZED
+    )
+    assert correlator.task_for_message("late-message") == "task-1"
+
+
+def test_resume_replaces_completed_task_for_new_messages_without_changing_old_ownership():
+    correlator = ChildActivityCorrelator()
+    correlator.associate("child-1", "task-1")
+    correlator.close("task-1")
+    correlator.authorize_or_queue_message("child-1", "late-message")
+
+    correlator.associate("child-1", "task-2")
+
+    assert (
+        correlator.authorize_or_queue_message("child-1", "resumed-message")
+        is MessageDisposition.AUTHORIZED
+    )
+    assert correlator.task_for_message("late-message") == "task-1"
+    assert correlator.task_for_message("resumed-message") == "task-2"
+
+
 def test_ambiguous_activity_is_not_reassigned_to_a_resumed_task():
     correlator = ChildActivityCorrelator()
     correlator.associate("child-1", "task-1")

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -527,6 +527,35 @@ class TestApplySseEventDispositions:
                 },
             ),
         )
+        repeated_message = stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "late-child-msg",
+                        "role": "assistant",
+                        "sessionID": CHILD_SESSION_ID,
+                    }
+                },
+            ),
+        )
+        final_part = stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "tool",
+                        "sessionID": CHILD_SESSION_ID,
+                        "messageID": "late-child-msg",
+                        "tool": "Bash",
+                        "callID": "final-call",
+                        "state": {"status": "completed", "input": {"command": "git status"}},
+                    }
+                },
+            ),
+        )
         orphaned = stream._flush_unassociated_child_activity(state)
 
         assert completed_task.events[0]["childSessionId"] == CHILD_SESSION_ID
@@ -557,6 +586,8 @@ class TestApplySseEventDispositions:
                 "childSessionId": CHILD_SESSION_ID,
             }
         ]
+        assert repeated_message.events == []
+        assert final_part.events[0]["taskCallId"] == "closed-task"
         assert orphaned == []
 
     def test_other_session_events_are_filtered_out(self):

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -367,6 +367,18 @@ class TestApplySseEventDispositions:
             }
         ]
 
+    def test_child_session_error_after_completion_keeps_completed_task_ownership(self):
+        state = make_state()
+        state.child_activity.associate(CHILD_SESSION_ID, "task-call-1")
+        state.child_activity.close("task-call-1")
+
+        step = make_stream()._apply_sse_event(
+            state,
+            sse("session.error", {"sessionID": CHILD_SESSION_ID, "error": {}}),
+        )
+
+        assert step.events[0]["taskCallId"] == "task-call-1"
+
     def test_uncorrelated_child_error_is_flushed_at_parent_idle(self):
         state = make_state()
         state.child_activity.track(CHILD_SESSION_ID)
@@ -447,15 +459,29 @@ class TestApplySseEventDispositions:
 
         assert late_part.events[0]["taskCallId"] == "task-call"
 
-    def test_late_child_message_is_not_reassigned_to_resumed_task(self):
+    def test_child_message_after_completion_keeps_completed_task_ownership(self):
         state = make_state()
         state.allowed_assistant_msg_ids.add("parent-msg")
-        state.child_activity.track(CHILD_SESSION_ID)
-        state.child_activity.associate(CHILD_SESSION_ID, "closed-task")
-        state.child_activity.close("closed-task")
         stream = make_stream()
 
-        stream._apply_sse_event(
+        completed_task = stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "tool",
+                        "sessionID": PARENT_SESSION_ID,
+                        "messageID": "parent-msg",
+                        "tool": "task",
+                        "callID": "closed-task",
+                        "metadata": {"sessionId": CHILD_SESSION_ID},
+                        "state": {"status": "completed", "input": {"prompt": "review"}},
+                    }
+                },
+            ),
+        )
+        late_message = stream._apply_sse_event(
             state,
             sse(
                 "message.updated",
@@ -468,7 +494,7 @@ class TestApplySseEventDispositions:
                 },
             ),
         )
-        stream._apply_sse_event(
+        late_part = stream._apply_sse_event(
             state,
             sse(
                 "message.part.updated",
@@ -503,6 +529,22 @@ class TestApplySseEventDispositions:
         )
         orphaned = stream._flush_unassociated_child_activity(state)
 
+        assert completed_task.events[0]["childSessionId"] == CHILD_SESSION_ID
+        assert late_message.events == []
+        assert late_part.events == [
+            {
+                "type": "tool_call",
+                "tool": "Read",
+                "args": {"filePath": "README.md"},
+                "callId": "late-call",
+                "status": "completed",
+                "output": "",
+                "messageId": "cp-msg-1",
+                "isSubtask": True,
+                "childSessionId": CHILD_SESSION_ID,
+                "taskCallId": "closed-task",
+            }
+        ]
         assert resumed_task.events == [
             {
                 "type": "tool_call",
@@ -515,8 +557,7 @@ class TestApplySseEventDispositions:
                 "childSessionId": CHILD_SESSION_ID,
             }
         ]
-        assert orphaned[0]["childSessionId"] == CHILD_SESSION_ID
-        assert "taskCallId" not in orphaned[0]
+        assert orphaned == []
 
     def test_other_session_events_are_filtered_out(self):
         step = make_stream()._apply_sse_event(


### PR DESCRIPTION
## Summary

- retain the most recently completed Task owner separately from the active child-session association
- correlate child messages and errors that arrive after the Task completion snapshot with that completed Task
- replace completed ownership when a resumed Task starts, while preserving message-level ownership already assigned to the prior invocation
- add regression coverage for completion-before-child-message ordering, resumed Tasks, and delayed child errors
- update the task activity nesting design notes with the corrected lifecycle

## Root cause

The runtime deleted the child-session-to-Task association as soon as it observed a completed Task snapshot. When OpenCode delivered the child `message.updated` afterward, subsequent child tool events had `isSubtask` and `childSessionId` but no `taskCallId`. The web timeline correctly left those unowned events at the top level instead of folding them beneath the Task.

## Validation

- `39 passed` across child activity, prompt stream, and subtask streaming tests
- Ruff lint passed
- Ruff format check passed
- MyPy passed for the changed runtime modules
- `git diff --check` passed

The complete sandbox-runtime suite was also attempted, but unrelated supervisor tests inherit sandbox-level OAuth and snapshot-restore environment variables and fail their isolation assumptions; all tests reached for the changed correlation and streaming paths passed.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d7888a973ad5b26056f49be3f40b26e8)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved task ownership for messages and errors received after a child session closes.
  * Ensured resumed tasks correctly receive new activity without changing ownership of earlier events.
  * Prevented late child activity from becoming unassociated or incorrectly linked to a newer task.
  * Improved handling of delayed child-session errors and tool events.

* **Tests**
  * Added coverage for late messages, resumed tasks, and post-completion child-session errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->