### PR TITLE
Support current Sentry issue webhooks

### DIFF
--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -6,12 +6,14 @@
 import { verifySentrySignature, normalizeSentryEvent } from "@open-inspect/shared/triggers";
 import { AutomationStore } from "../db/automation-store";
 import { decryptSentrySecret } from "../auth/webhook-key";
+import { createLogger } from "../logger";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
 import type { Env } from "../types";
 
 /** Maximum Sentry webhook payload size (256KB — Sentry payloads with stack traces can be large). */
 const MAX_PAYLOAD_SIZE = 256 * 1024;
+const logger = createLogger("sentry-webhook");
 
 async function handleSentryWebhook(
   request: Request,
@@ -73,8 +75,19 @@ async function handleSentryWebhook(
     return error("Invalid JSON", 400);
   }
 
-  const event = normalizeSentryEvent(payload, automationId);
+  const sentryResource = request.headers.get("sentry-hook-resource");
+  const event = normalizeSentryEvent(payload, automationId, sentryResource);
   if (!event) {
+    logger.warn("Sentry webhook skipped during normalization", {
+      event: "sentry.webhook_skipped",
+      reason: "unsupported_or_invalid_payload",
+      automation_id: automationId,
+      configured_event_type: automation.event_type,
+      sentry_resource: sentryResource,
+      sentry_action: typeof payload.action === "string" ? payload.action : null,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
     return json({ ok: true, skipped: true });
   }
 

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -76,20 +76,26 @@ async function handleSentryWebhook(
   }
 
   const sentryResource = request.headers.get("sentry-hook-resource");
-  const event = normalizeSentryEvent(payload, automationId, sentryResource);
-  if (!event) {
-    logger.warn("Sentry webhook skipped during normalization", {
+  const normalization = normalizeSentryEvent(payload, automationId, sentryResource);
+  if (normalization.status === "skipped") {
+    const logData = {
       event: "sentry.webhook_skipped",
-      reason: "unsupported_or_invalid_payload",
+      reason: normalization.reason,
       automation_id: automationId,
       configured_event_type: automation.event_type,
       sentry_resource: sentryResource,
       sentry_action: typeof payload.action === "string" ? payload.action : null,
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
-    });
+    };
+    if (normalization.reason === "unsupported_action") {
+      logger.info("Sentry webhook action is not configured for automation", logData);
+    } else {
+      logger.warn("Sentry webhook skipped during normalization", logData);
+    }
     return json({ ok: true, skipped: true });
   }
+  const event = normalization.event;
 
   // 4. Forward to SchedulerDO
   if (!env.SCHEDULER) {

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -20,6 +20,10 @@ function classifySentryAction(action: unknown): "created" | "critical" | "other"
   return typeof action === "string" ? "other" : "missing";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 async function handleSentryWebhook(
   request: Request,
   env: Env,
@@ -73,12 +77,13 @@ async function handleSentryWebhook(
   }
 
   // 3. Parse and normalize
-  let payload: Record<string, unknown>;
+  let parsedPayload: unknown;
   try {
-    payload = JSON.parse(body) as Record<string, unknown>;
+    parsedPayload = JSON.parse(body) as unknown;
   } catch {
     return error("Invalid JSON", 400);
   }
+  const payload = isRecord(parsedPayload) ? parsedPayload : {};
 
   const sentryResource = request.headers.get("sentry-hook-resource");
   const normalization = normalizeSentryEvent(payload, automationId, sentryResource);

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -15,6 +15,11 @@ import type { Env } from "../types";
 const MAX_PAYLOAD_SIZE = 256 * 1024;
 const logger = createLogger("sentry-webhook");
 
+function classifySentryAction(action: unknown): "created" | "critical" | "other" | "missing" {
+  if (action === "created" || action === "critical") return action;
+  return typeof action === "string" ? "other" : "missing";
+}
+
 async function handleSentryWebhook(
   request: Request,
   env: Env,
@@ -84,7 +89,7 @@ async function handleSentryWebhook(
       automation_id: automationId,
       configured_event_type: automation.event_type,
       sentry_resource: sentryResource,
-      sentry_action: typeof payload.action === "string" ? payload.action : null,
+      sentry_action: classifySentryAction(payload.action),
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     };

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -235,6 +235,25 @@ describe("POST /webhooks/sentry/:id", () => {
     expect(result.skipped).toBe(true);
   });
 
+  it("returns a skipped response for a signed non-object JSON payload", async () => {
+    const automation = await createSentryAutomation();
+    const body = "null";
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Sentry-Hook-Resource": "issue",
+        "sentry-hook-signature": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, skipped: true });
+  });
+
   it("logs why an authenticated Sentry webhook was skipped", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const automation = await createSentryAutomation();

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -119,6 +119,22 @@ const sentryIssueCreatedPayload = {
   actor: { type: "application", id: "sentry", name: "Sentry" },
 };
 
+const sentryMetricWarningPayload = {
+  action: "warning",
+  data: {
+    metric_alert: {
+      id: 456,
+      title: "Error rate > 3%",
+      alert_rule: { id: 789, name: "Elevated error rate" },
+      date_started: "2026-08-03T20:00:00Z",
+      current_trigger: { label: "warning" },
+    },
+    description_text: "Error rate exceeded 3%",
+    description_title: "Metric Alert",
+    web_url: "https://sentry.io/alerts/456/",
+  },
+};
+
 // ─── Sentry webhook tests (per-automation) ───────────────────────────────────
 
 describe("POST /webhooks/sentry/:id", () => {
@@ -255,7 +271,7 @@ describe("POST /webhooks/sentry/:id", () => {
           service: "control-plane",
           component: "sentry-webhook",
           event: "sentry.webhook_skipped",
-          reason: "unsupported_or_invalid_payload",
+          reason: "invalid_shape",
           automation_id: automation.id,
           configured_event_type: "issue.created",
           sentry_resource: "issue",
@@ -266,6 +282,49 @@ describe("POST /webhooks/sentry/:id", () => {
       );
       expect(JSON.stringify(logEntries)).not.toContain("must-not-be-logged");
     } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not warn for an intentionally ignored metric alert action", async () => {
+    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const automation = await createSentryAutomation({ event_type: "metric_alert.critical" });
+    const body = JSON.stringify(sentryMetricWarningPayload);
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    try {
+      const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Sentry-Hook-Resource": "metric_alert",
+          "sentry-hook-signature": signature,
+        },
+        body,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true, skipped: true });
+
+      const infoEntries = infoSpy.mock.calls.flatMap(([line]) => {
+        if (typeof line !== "string") return [];
+        try {
+          return [JSON.parse(line) as Record<string, unknown>];
+        } catch {
+          return [];
+        }
+      });
+      expect(infoEntries).toContainEqual(
+        expect.objectContaining({
+          event: "sentry.webhook_skipped",
+          reason: "unsupported_action",
+          sentry_resource: "metric_alert",
+        })
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      infoSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { SELF, env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
 import { hashApiKey } from "../../src/auth/webhook-key";
 import { encryptToken } from "../../src/auth/crypto";
 import { cleanD1Tables } from "./cleanup";
+import { fetchRuns } from "./run-helpers";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -97,10 +98,55 @@ const sentryIssuePayload = {
   actor: { type: "application", id: 1, name: "Sentry" },
 };
 
+const sentryIssueCreatedPayload = {
+  action: "created",
+  installation: { uuid: "installation-1" },
+  data: {
+    issue: {
+      id: "67890",
+      shortId: "TEST-2",
+      title: "TypeError: Cannot read properties of undefined",
+      culprit: "src/App.tsx in BrokenCheckout",
+      level: "error",
+      status: "unresolved",
+      project: { id: "2", slug: "test-project", name: "Test" },
+      count: "1",
+      firstSeen: "2026-08-03T20:00:00Z",
+      lastSeen: "2026-08-03T20:00:00Z",
+      web_url: "https://sentry.io/issues/67890/",
+    },
+  },
+  actor: { type: "application", id: "sentry", name: "Sentry" },
+};
+
 // ─── Sentry webhook tests (per-automation) ───────────────────────────────────
 
 describe("POST /webhooks/sentry/:id", () => {
   beforeEach(cleanD1Tables);
+
+  it("creates an automation run for a current Sentry issue.created webhook", async () => {
+    const automation = await createSentryAutomation();
+    const body = JSON.stringify(sentryIssueCreatedPayload);
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Sentry-Hook-Resource": "issue",
+        "sentry-hook-signature": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json<{ ok: boolean; skipped?: boolean }>();
+    expect(result.ok).toBe(true);
+    expect(result.skipped).not.toBe(true);
+
+    const runs = await fetchRuns(automation.id);
+    expect(runs).toHaveLength(1);
+  });
 
   it("accepts valid signature (does not return 401)", async () => {
     const automation = await createSentryAutomation();
@@ -111,6 +157,7 @@ describe("POST /webhooks/sentry/:id", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "Sentry-Hook-Resource": "event_alert",
         "sentry-hook-signature": signature,
       },
       body,
@@ -170,6 +217,57 @@ describe("POST /webhooks/sentry/:id", () => {
     const result = await response.json<{ ok: boolean; skipped: boolean }>();
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
+  });
+
+  it("logs why an authenticated Sentry webhook was skipped", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const automation = await createSentryAutomation();
+    const unsupportedPayload = {
+      action: "unknown",
+      data: { issue: { id: "12345", privateContext: "must-not-be-logged" } },
+    };
+    const body = JSON.stringify(unsupportedPayload);
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    try {
+      const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Sentry-Hook-Resource": "issue",
+          "sentry-hook-signature": signature,
+        },
+        body,
+      });
+
+      expect(response.status).toBe(200);
+      const logEntries = warnSpy.mock.calls.flatMap(([line]) => {
+        if (typeof line !== "string") return [];
+        try {
+          return [JSON.parse(line) as Record<string, unknown>];
+        } catch {
+          return [];
+        }
+      });
+      expect(logEntries).toContainEqual(
+        expect.objectContaining({
+          level: "warn",
+          service: "control-plane",
+          component: "sentry-webhook",
+          event: "sentry.webhook_skipped",
+          reason: "unsupported_or_invalid_payload",
+          automation_id: automation.id,
+          configured_event_type: "issue.created",
+          sentry_resource: "issue",
+          sentry_action: "unknown",
+          request_id: expect.any(String),
+          trace_id: expect.any(String),
+        })
+      );
+      expect(JSON.stringify(logEntries)).not.toContain("must-not-be-logged");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("returns 404 for non-sentry automation", async () => {

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -239,7 +239,7 @@ describe("POST /webhooks/sentry/:id", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const automation = await createSentryAutomation();
     const unsupportedPayload = {
-      action: "unknown",
+      action: "must-not-be-logged",
       data: { issue: { id: "12345", privateContext: "must-not-be-logged" } },
     };
     const body = JSON.stringify(unsupportedPayload);
@@ -275,7 +275,7 @@ describe("POST /webhooks/sentry/:id", () => {
           automation_id: automation.id,
           configured_event_type: "issue.created",
           sentry_resource: "issue",
-          sentry_action: "unknown",
+          sentry_action: "other",
           request_id: expect.any(String),
           trace_id: expect.any(String),
         })

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -299,7 +299,7 @@ describe("POST /webhooks/sentry/:id", () => {
           trace_id: expect.any(String),
         })
       );
-      expect(JSON.stringify(logEntries)).not.toContain("must-not-be-logged");
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("must-not-be-logged");
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -42,7 +42,14 @@ export {
   sentryConditions,
   normalizeSentryEvent,
   buildSentryContextBlock,
+  buildSentryIssueWebhookContextBlock,
+  buildSentryMetricContextBlock,
   verifySentrySignature,
+} from "./sentry";
+export type {
+  SentryIssueAlertPayload,
+  SentryIssueWebhookPayload,
+  SentryMetricAlertPayload,
 } from "./sentry";
 
 // Webhook source module

--- a/packages/shared/src/triggers/sentry/context.ts
+++ b/packages/shared/src/triggers/sentry/context.ts
@@ -2,14 +2,17 @@
  * Build context blocks for Sentry automation events.
  */
 
+import type {
+  SentryIssueAlertPayload,
+  SentryIssueWebhookPayload,
+  SentryMetricAlertPayload,
+} from "./payloads";
+
 const MAX_STACK_FRAMES = 5;
 
-export function buildSentryContextBlock(payload: Record<string, unknown>): string {
-  const data = payload.data as Record<string, unknown>;
-  const event = data.event as Record<string, unknown>;
-  const issue = data.issue as Record<string, unknown>;
-  const project = issue.project as Record<string, unknown>;
-  const metadata = event.metadata as Record<string, unknown>;
+export function buildSentryContextBlock(payload: SentryIssueAlertPayload): string {
+  const { event, issue } = payload.data;
+  const { metadata } = event;
 
   const title =
     metadata.type && metadata.value ? `${metadata.type}: ${metadata.value}` : String(issue.title);
@@ -18,7 +21,7 @@ export function buildSentryContextBlock(payload: Record<string, unknown>): strin
     "This automation was triggered by a new Sentry error.",
     "",
     `Error: ${title}`,
-    `Project: ${project.slug}`,
+    `Project: ${issue.project.slug}`,
     `Level: ${issue.level}`,
     `Issue: ${issue.shortId}`,
     `First seen: ${issue.firstSeen}`,
@@ -27,14 +30,9 @@ export function buildSentryContextBlock(payload: Record<string, unknown>): strin
   ];
 
   // Stack trace
-  const exception = event.exception as { values?: Array<Record<string, unknown>> } | undefined;
+  const exception = event.exception;
   if (exception?.values?.length) {
-    const lastException = exception.values[exception.values.length - 1];
-    const stacktrace = lastException.stacktrace as
-      | {
-          frames?: Array<Record<string, unknown>>;
-        }
-      | undefined;
+    const stacktrace = exception.values.at(-1)?.stacktrace;
 
     if (stacktrace?.frames?.length) {
       // Frames are bottom-to-top in Sentry; reverse for most recent first
@@ -53,11 +51,45 @@ export function buildSentryContextBlock(payload: Record<string, unknown>): strin
   }
 
   // Tags
-  const tags = event.tags as Array<{ key: string; value: string }> | undefined;
+  const tags = event.tags;
   if (tags?.length) {
     lines.push("");
     lines.push(`Tags: ${tags.map((t) => `${t.key}=${t.value}`).join(", ")}`);
   }
 
+  return lines.join("\n");
+}
+
+export function buildSentryIssueWebhookContextBlock(payload: SentryIssueWebhookPayload): string {
+  const issue = payload.data.issue;
+  const lines = [
+    "This automation was triggered by a new Sentry issue.",
+    "",
+    `Error: ${issue.title}`,
+    `Project: ${issue.project.slug}`,
+    `Level: ${issue.level}`,
+    `Issue: ${issue.shortId}`,
+  ];
+
+  if (issue.firstSeen) lines.push(`First seen: ${issue.firstSeen}`);
+  if (issue.count !== undefined) lines.push(`Events: ${issue.count}`);
+  if (issue.culprit) lines.push(`Culprit: ${issue.culprit}`);
+  if (issue.web_url) lines.push(`URL: ${issue.web_url}`);
+
+  return lines.join("\n");
+}
+
+export function buildSentryMetricContextBlock(payload: SentryMetricAlertPayload): string {
+  const alert = payload.data.metric_alert;
+  const lines = [
+    "This automation was triggered by a Sentry metric alert.",
+    "",
+    `Alert: ${alert.title}`,
+    `Trigger: ${alert.current_trigger.label}`,
+    `Started: ${alert.date_started}`,
+    `URL: ${payload.data.web_url}`,
+    "",
+    `Description: ${payload.data.description_text}`,
+  ];
   return lines.join("\n");
 }

--- a/packages/shared/src/triggers/sentry/index.ts
+++ b/packages/shared/src/triggers/sentry/index.ts
@@ -5,9 +5,18 @@
 import type { TriggerSourceDefinition } from "../types";
 
 export type { SentryAutomationEvent } from "../types";
+export type {
+  SentryIssueAlertPayload,
+  SentryIssueWebhookPayload,
+  SentryMetricAlertPayload,
+} from "./payloads";
 export { conditions as sentryConditions } from "./conditions";
 export { normalizeSentryEvent } from "./normalizer";
-export { buildSentryContextBlock } from "./context";
+export {
+  buildSentryContextBlock,
+  buildSentryIssueWebhookContextBlock,
+  buildSentryMetricContextBlock,
+} from "./context";
 export { verifySentrySignature } from "./signature";
 
 export const sentrySource: TriggerSourceDefinition = {

--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -83,38 +83,52 @@ const issueWebhookPayload = {
   actor: { type: "application", id: "sentry", name: "Sentry" },
 };
 
+function expectNormalized(result: ReturnType<typeof normalizeSentryEvent>) {
+  expect(result.status).toBe("normalized");
+  if (result.status !== "normalized") {
+    throw new Error(`Expected normalized event, received ${result.reason}`);
+  }
+  return result.event;
+}
+
 describe("normalizeSentryEvent", () => {
   it("normalizes a current Sentry issue.created webhook", () => {
-    const event = normalizeSentryEvent(issueWebhookPayload, undefined, "issue");
+    const event = expectNormalized(normalizeSentryEvent(issueWebhookPayload, undefined, "issue"));
 
-    expect(event).not.toBeNull();
-    expect(event!.eventType).toBe("issue.created");
-    expect(event!.triggerKey).toBe("sentry_issue:67890");
-    expect(event!.concurrencyKey).toBe("sentry_issue:67890");
-    expect(event!.sentryProject).toBe("sentry-demo");
-    expect(event!.sentryLevel).toBe("error");
-    expect(event!.culpritFile).toBeUndefined();
-    expect(event!.contextBlock).toContain("TypeError");
-    expect(event!.contextBlock).toContain("FRONTEND-XYZ");
+    expect(event.eventType).toBe("issue.created");
+    expect(event.triggerKey).toBe("sentry_issue:67890");
+    expect(event.concurrencyKey).toBe("sentry_issue:67890");
+    expect(event.sentryProject).toBe("sentry-demo");
+    expect(event.sentryLevel).toBe("error");
+    expect(event.culpritFile).toBeUndefined();
+    expect(event.contextBlock).toContain("TypeError");
+    expect(event.contextBlock).toContain("FRONTEND-XYZ");
   });
 
   it("uses the Sentry resource header to discriminate issue and alert payloads", () => {
-    expect(normalizeSentryEvent(issueWebhookPayload, undefined, "event_alert")).toBeNull();
-    expect(normalizeSentryEvent(issueAlertPayload, undefined, "issue")).toBeNull();
+    expect(normalizeSentryEvent(issueWebhookPayload, undefined, "event_alert")).toEqual({
+      status: "skipped",
+      reason: "invalid_shape",
+    });
+    expect(normalizeSentryEvent(issueAlertPayload, undefined, "issue")).toEqual({
+      status: "skipped",
+      reason: "unsupported_action",
+    });
   });
 
   it("normalizes an issue alert payload", () => {
-    const event = normalizeSentryEvent(issueAlertPayload, undefined, "event_alert");
-    expect(event).not.toBeNull();
-    expect(event!.source).toBe("sentry");
-    expect(event!.eventType).toBe("issue.created");
-    expect(event!.triggerKey).toBe("sentry_issue:12345");
-    expect(event!.concurrencyKey).toBe("sentry_issue:12345");
-    expect(event!.sentryProject).toBe("acme-backend");
-    expect(event!.sentryLevel).toBe("error");
-    expect(event!.culpritFile).toBe("src/handlers/auth.ts");
-    expect(event!.contextBlock).toContain("TypeError");
-    expect(event!.contextBlock).toContain("acme-backend");
+    const event = expectNormalized(
+      normalizeSentryEvent(issueAlertPayload, undefined, "event_alert")
+    );
+    expect(event.source).toBe("sentry");
+    expect(event.eventType).toBe("issue.created");
+    expect(event.triggerKey).toBe("sentry_issue:12345");
+    expect(event.concurrencyKey).toBe("sentry_issue:12345");
+    expect(event.sentryProject).toBe("acme-backend");
+    expect(event.sentryLevel).toBe("error");
+    expect(event.culpritFile).toBe("src/handlers/auth.ts");
+    expect(event.contextBlock).toContain("TypeError");
+    expect(event.contextBlock).toContain("acme-backend");
   });
 
   it("normalizes a regression payload", () => {
@@ -122,10 +136,9 @@ describe("normalizeSentryEvent", () => {
       ...issueAlertPayload,
       action: "regression",
     };
-    const event = normalizeSentryEvent(regressionPayload);
-    expect(event).not.toBeNull();
-    expect(event!.eventType).toBe("issue.regression");
-    expect(event!.triggerKey).toContain("sentry_regression:");
+    const event = expectNormalized(normalizeSentryEvent(regressionPayload));
+    expect(event.eventType).toBe("issue.regression");
+    expect(event.triggerKey).toContain("sentry_regression:");
   });
 
   it("normalizes a metric alert payload", () => {
@@ -144,14 +157,13 @@ describe("normalizeSentryEvent", () => {
         web_url: "https://sentry.io/alerts/456/",
       },
     };
-    const event = normalizeSentryEvent(metricPayload, undefined, "metric_alert");
-    expect(event).not.toBeNull();
-    expect(event!.eventType).toBe("metric_alert.critical");
-    expect(event!.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");
-    expect(event!.concurrencyKey).toBe("sentry_metric:789");
+    const event = expectNormalized(normalizeSentryEvent(metricPayload, undefined, "metric_alert"));
+    expect(event.eventType).toBe("metric_alert.critical");
+    expect(event.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");
+    expect(event.concurrencyKey).toBe("sentry_metric:789");
   });
 
-  it("returns null for non-critical metric alerts", () => {
+  it("returns unsupported_action for non-critical metric alerts", () => {
     const warningPayload = {
       action: "warning",
       data: {
@@ -167,15 +179,31 @@ describe("normalizeSentryEvent", () => {
         web_url: "https://sentry.io/alerts/456/",
       },
     };
-    expect(normalizeSentryEvent(warningPayload)).toBeNull();
+    expect(normalizeSentryEvent(warningPayload)).toEqual({
+      status: "skipped",
+      reason: "unsupported_action",
+    });
   });
 
-  it("returns null for unrecognized payload shapes", () => {
-    expect(normalizeSentryEvent({ action: "unknown" })).toBeNull();
-    expect(normalizeSentryEvent({})).toBeNull();
+  it("returns invalid_shape for unrecognized payload shapes", () => {
+    expect(normalizeSentryEvent({ action: "unknown" })).toEqual({
+      status: "skipped",
+      reason: "invalid_shape",
+    });
+    expect(normalizeSentryEvent({})).toEqual({
+      status: "skipped",
+      reason: "invalid_shape",
+    });
   });
 
-  it("returns null for an issue alert missing consumed issue fields", () => {
+  it("returns unknown_resource for unsupported resource headers", () => {
+    expect(normalizeSentryEvent(issueWebhookPayload, undefined, "installation")).toEqual({
+      status: "skipped",
+      reason: "unknown_resource",
+    });
+  });
+
+  it("returns invalid_shape for an issue alert missing consumed issue fields", () => {
     const malformed = {
       action: "triggered",
       data: {
@@ -186,10 +214,13 @@ describe("normalizeSentryEvent", () => {
       },
       actor: { type: "application", id: 1, name: "Sentry" },
     };
-    expect(normalizeSentryEvent(malformed)).toBeNull();
+    expect(normalizeSentryEvent(malformed)).toEqual({
+      status: "skipped",
+      reason: "invalid_shape",
+    });
   });
 
-  it("returns null for a metric alert missing trigger-key fields", () => {
+  it("returns invalid_shape for a metric alert missing trigger-key fields", () => {
     const malformed = {
       action: "critical",
       data: {
@@ -204,6 +235,9 @@ describe("normalizeSentryEvent", () => {
         web_url: "https://sentry.io/alerts/456/",
       },
     };
-    expect(normalizeSentryEvent(malformed)).toBeNull();
+    expect(normalizeSentryEvent(malformed)).toEqual({
+      status: "skipped",
+      reason: "invalid_shape",
+    });
   });
 });

--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -62,9 +62,49 @@ const issueAlertPayload = {
   actor: { type: "application", id: 1, name: "Sentry" },
 };
 
+const issueWebhookPayload = {
+  action: "created",
+  installation: { uuid: "installation-1" },
+  data: {
+    issue: {
+      id: "67890",
+      shortId: "FRONTEND-XYZ",
+      title: "TypeError: Cannot read properties of undefined",
+      culprit: "src/App.tsx in BrokenCheckout",
+      level: "error",
+      status: "unresolved",
+      project: { id: "2", slug: "sentry-demo", name: "Sentry Demo" },
+      count: "1",
+      firstSeen: "2026-08-03T20:00:00Z",
+      lastSeen: "2026-08-03T20:00:00Z",
+      web_url: "https://sentry.io/issues/67890/",
+    },
+  },
+  actor: { type: "application", id: "sentry", name: "Sentry" },
+};
+
 describe("normalizeSentryEvent", () => {
+  it("normalizes a current Sentry issue.created webhook", () => {
+    const event = normalizeSentryEvent(issueWebhookPayload, undefined, "issue");
+
+    expect(event).not.toBeNull();
+    expect(event!.eventType).toBe("issue.created");
+    expect(event!.triggerKey).toBe("sentry_issue:67890");
+    expect(event!.concurrencyKey).toBe("sentry_issue:67890");
+    expect(event!.sentryProject).toBe("sentry-demo");
+    expect(event!.sentryLevel).toBe("error");
+    expect(event!.culpritFile).toBeUndefined();
+    expect(event!.contextBlock).toContain("TypeError");
+    expect(event!.contextBlock).toContain("FRONTEND-XYZ");
+  });
+
+  it("uses the Sentry resource header to discriminate issue and alert payloads", () => {
+    expect(normalizeSentryEvent(issueWebhookPayload, undefined, "event_alert")).toBeNull();
+    expect(normalizeSentryEvent(issueAlertPayload, undefined, "issue")).toBeNull();
+  });
+
   it("normalizes an issue alert payload", () => {
-    const event = normalizeSentryEvent(issueAlertPayload);
+    const event = normalizeSentryEvent(issueAlertPayload, undefined, "event_alert");
     expect(event).not.toBeNull();
     expect(event!.source).toBe("sentry");
     expect(event!.eventType).toBe("issue.created");
@@ -104,7 +144,7 @@ describe("normalizeSentryEvent", () => {
         web_url: "https://sentry.io/alerts/456/",
       },
     };
-    const event = normalizeSentryEvent(metricPayload);
+    const event = normalizeSentryEvent(metricPayload, undefined, "metric_alert");
     expect(event).not.toBeNull();
     expect(event!.eventType).toBe("metric_alert.critical");
     expect(event!.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -10,10 +10,27 @@ import { buildSentryContextBlock } from "./context";
 // ─── Schemas ────────────────────────────────────────────────────────────────
 // Each schema is the single source of truth for one Sentry webhook shape: it
 // produces the static payload type via `z.infer` and validates at runtime via
-// `safeParse`. Only the fields consumed for trigger/concurrency keys and `meta`
-// are modeled. A successful parse guarantees the structural fields that
-// `buildSentryContextBlock` dereferences off the raw payload (`data.event`,
-// `data.event.metadata`, `data.issue`, `data.issue.project`).
+// `safeParse`. Only fields consumed by normalization and context builders are
+// modeled.
+
+const sentryIssueWebhookSchema = z.object({
+  action: z.literal("created"),
+  data: z.object({
+    issue: z.object({
+      id: z.string(),
+      shortId: z.string(),
+      title: z.string(),
+      culprit: z.string().nullish(),
+      level: z.string(),
+      count: z.union([z.string(), z.number()]).optional(),
+      firstSeen: z.string().nullish(),
+      project: z.object({
+        slug: z.string(),
+      }),
+      web_url: z.string().optional(),
+    }),
+  }),
+});
 
 const sentryIssueAlertSchema = z.object({
   action: z.string(),
@@ -58,14 +75,40 @@ const sentryMetricAlertSchema = z.object({
 });
 
 type SentryMetricAlertPayload = z.infer<typeof sentryMetricAlertSchema>;
+type SentryIssueWebhookPayload = z.infer<typeof sentryIssueWebhookSchema>;
 
 export function normalizeSentryEvent(
   payload: Record<string, unknown>,
-  automationId?: string
+  automationId?: string,
+  sentryHookResource?: string | null
 ): SentryAutomationEvent | null {
-  // Issue alert (event_alert action or issue action)
+  if (!sentryHookResource || sentryHookResource === "issue") {
+    const issueWebhookResult = sentryIssueWebhookSchema.safeParse(payload);
+    if (issueWebhookResult.success) {
+      const issue = issueWebhookResult.data.data.issue;
+      return {
+        source: "sentry",
+        automationId: automationId ?? "",
+        eventType: "issue.created",
+        triggerKey: `sentry_issue:${issue.id}`,
+        concurrencyKey: `sentry_issue:${issue.id}`,
+        sentryProject: issue.project.slug,
+        sentryLevel: issue.level,
+        contextBlock: buildSentryIssueWebhookContextBlock(issueWebhookResult.data),
+        meta: {
+          issueId: issue.id,
+          shortId: issue.shortId,
+          issueUrl: issue.web_url,
+        },
+      };
+    }
+
+    if (sentryHookResource === "issue") return null;
+  }
+
+  // Legacy issue alert (`event_alert` resource)
   const issueResult = sentryIssueAlertSchema.safeParse(payload);
-  if (issueResult.success) {
+  if ((!sentryHookResource || sentryHookResource === "event_alert") && issueResult.success) {
     const { action, data } = issueResult.data;
     const issue = data.issue;
     const isRegression = action === "regression" || issue.status === "regressed";
@@ -95,7 +138,7 @@ export function normalizeSentryEvent(
 
   // Metric alert
   const metricResult = sentryMetricAlertSchema.safeParse(payload);
-  if (metricResult.success) {
+  if ((!sentryHookResource || sentryHookResource === "metric_alert") && metricResult.success) {
     const p = metricResult.data;
     if (p.action !== "critical") return null;
 
@@ -120,6 +163,25 @@ export function normalizeSentryEvent(
   }
 
   return null;
+}
+
+function buildSentryIssueWebhookContextBlock(p: SentryIssueWebhookPayload): string {
+  const issue = p.data.issue;
+  const lines = [
+    "This automation was triggered by a new Sentry issue.",
+    "",
+    `Error: ${issue.title}`,
+    `Project: ${issue.project.slug}`,
+    `Level: ${issue.level}`,
+    `Issue: ${issue.shortId}`,
+  ];
+
+  if (issue.firstSeen) lines.push(`First seen: ${issue.firstSeen}`);
+  if (issue.count !== undefined) lines.push(`Events: ${issue.count}`);
+  if (issue.culprit) lines.push(`Culprit: ${issue.culprit}`);
+  if (issue.web_url) lines.push(`URL: ${issue.web_url}`);
+
+  return lines.join("\n");
 }
 
 function buildSentryMetricContextBlock(p: SentryMetricAlertPayload): string {

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -14,7 +14,7 @@ import { buildSentryContextBlock } from "./context";
 // modeled.
 
 const sentryIssueWebhookSchema = z.object({
-  action: z.literal("created"),
+  action: z.string(),
   data: z.object({
     issue: z.object({
       id: z.string(),
@@ -77,92 +77,142 @@ const sentryMetricAlertSchema = z.object({
 type SentryMetricAlertPayload = z.infer<typeof sentryMetricAlertSchema>;
 type SentryIssueWebhookPayload = z.infer<typeof sentryIssueWebhookSchema>;
 
+export type SentryNormalizationResult =
+  | { status: "normalized"; event: SentryAutomationEvent }
+  | {
+      status: "skipped";
+      reason: "unsupported_action" | "unknown_resource" | "invalid_shape";
+    };
+
 export function normalizeSentryEvent(
   payload: Record<string, unknown>,
   automationId?: string,
   sentryHookResource?: string | null
-): SentryAutomationEvent | null {
+): SentryNormalizationResult {
+  if (
+    sentryHookResource &&
+    !["issue", "event_alert", "metric_alert"].includes(sentryHookResource)
+  ) {
+    return { status: "skipped", reason: "unknown_resource" };
+  }
+
+  let unsupportedIssueAction = false;
   if (!sentryHookResource || sentryHookResource === "issue") {
     const issueWebhookResult = sentryIssueWebhookSchema.safeParse(payload);
     if (issueWebhookResult.success) {
-      const issue = issueWebhookResult.data.data.issue;
+      if (issueWebhookResult.data.action !== "created") {
+        if (sentryHookResource === "issue") {
+          return { status: "skipped", reason: "unsupported_action" };
+        }
+        unsupportedIssueAction = true;
+      } else {
+        const issue = issueWebhookResult.data.data.issue;
+        return {
+          status: "normalized",
+          event: {
+            source: "sentry",
+            automationId: automationId ?? "",
+            eventType: "issue.created",
+            triggerKey: `sentry_issue:${issue.id}`,
+            concurrencyKey: `sentry_issue:${issue.id}`,
+            sentryProject: issue.project.slug,
+            sentryLevel: issue.level,
+            contextBlock: buildSentryIssueWebhookContextBlock(issueWebhookResult.data),
+            meta: {
+              issueId: issue.id,
+              shortId: issue.shortId,
+              issueUrl: issue.web_url,
+            },
+          },
+        };
+      }
+    }
+
+    if (sentryHookResource === "issue") {
+      return { status: "skipped", reason: "invalid_shape" };
+    }
+  }
+
+  // Legacy issue alert (`event_alert` resource)
+  if (!sentryHookResource || sentryHookResource === "event_alert") {
+    const issueResult = sentryIssueAlertSchema.safeParse(payload);
+    if (issueResult.success) {
+      const { action, data } = issueResult.data;
+      const issue = data.issue;
+      const isRegression = action === "regression" || issue.status === "regressed";
+      const eventType = isRegression ? "issue.regression" : "issue.created";
+      const triggerKey = isRegression
+        ? `sentry_regression:${issue.id}:${issue.lastSeen}`
+        : `sentry_issue:${issue.id}`;
+      const concurrencyKey = `sentry_issue:${issue.id}`;
+
       return {
-        source: "sentry",
-        automationId: automationId ?? "",
-        eventType: "issue.created",
-        triggerKey: `sentry_issue:${issue.id}`,
-        concurrencyKey: `sentry_issue:${issue.id}`,
-        sentryProject: issue.project.slug,
-        sentryLevel: issue.level,
-        contextBlock: buildSentryIssueWebhookContextBlock(issueWebhookResult.data),
-        meta: {
-          issueId: issue.id,
-          shortId: issue.shortId,
-          issueUrl: issue.web_url,
+        status: "normalized",
+        event: {
+          source: "sentry",
+          automationId: automationId ?? "",
+          eventType,
+          triggerKey,
+          concurrencyKey,
+          sentryProject: issue.project.slug,
+          sentryLevel: issue.level,
+          culpritFile: data.event.metadata.filename,
+          contextBlock: buildSentryContextBlock(payload),
+          meta: {
+            issueId: issue.id,
+            shortId: issue.shortId,
+            triggeredRule: data.triggered_rule,
+          },
         },
       };
     }
 
-    if (sentryHookResource === "issue") return null;
-  }
-
-  // Legacy issue alert (`event_alert` resource)
-  const issueResult = sentryIssueAlertSchema.safeParse(payload);
-  if ((!sentryHookResource || sentryHookResource === "event_alert") && issueResult.success) {
-    const { action, data } = issueResult.data;
-    const issue = data.issue;
-    const isRegression = action === "regression" || issue.status === "regressed";
-    const eventType = isRegression ? "issue.regression" : "issue.created";
-    const triggerKey = isRegression
-      ? `sentry_regression:${issue.id}:${issue.lastSeen}`
-      : `sentry_issue:${issue.id}`;
-    const concurrencyKey = `sentry_issue:${issue.id}`;
-
-    return {
-      source: "sentry",
-      automationId: automationId ?? "",
-      eventType,
-      triggerKey,
-      concurrencyKey,
-      sentryProject: issue.project.slug,
-      sentryLevel: issue.level,
-      culpritFile: data.event.metadata.filename,
-      contextBlock: buildSentryContextBlock(payload),
-      meta: {
-        issueId: issue.id,
-        shortId: issue.shortId,
-        triggeredRule: data.triggered_rule,
-      },
-    };
+    if (sentryHookResource === "event_alert") {
+      return { status: "skipped", reason: "invalid_shape" };
+    }
   }
 
   // Metric alert
-  const metricResult = sentryMetricAlertSchema.safeParse(payload);
-  if ((!sentryHookResource || sentryHookResource === "metric_alert") && metricResult.success) {
-    const p = metricResult.data;
-    if (p.action !== "critical") return null;
+  if (!sentryHookResource || sentryHookResource === "metric_alert") {
+    const metricResult = sentryMetricAlertSchema.safeParse(payload);
+    if (metricResult.success) {
+      const p = metricResult.data;
+      if (p.action !== "critical") {
+        return { status: "skipped", reason: "unsupported_action" };
+      }
 
-    const alert = p.data.metric_alert;
-    const triggerKey = `sentry_metric:${alert.alert_rule.id}:${alert.date_started}`;
-    const concurrencyKey = `sentry_metric:${alert.alert_rule.id}`;
+      const alert = p.data.metric_alert;
+      const triggerKey = `sentry_metric:${alert.alert_rule.id}:${alert.date_started}`;
+      const concurrencyKey = `sentry_metric:${alert.alert_rule.id}`;
 
-    return {
-      source: "sentry",
-      automationId: automationId ?? "",
-      eventType: "metric_alert.critical",
-      triggerKey,
-      concurrencyKey,
-      sentryProject: "",
-      sentryLevel: "critical",
-      contextBlock: buildSentryMetricContextBlock(p),
-      meta: {
-        alertRuleId: alert.alert_rule.id,
-        alertTitle: alert.title,
-      },
-    };
+      return {
+        status: "normalized",
+        event: {
+          source: "sentry",
+          automationId: automationId ?? "",
+          eventType: "metric_alert.critical",
+          triggerKey,
+          concurrencyKey,
+          sentryProject: "",
+          sentryLevel: "critical",
+          contextBlock: buildSentryMetricContextBlock(p),
+          meta: {
+            alertRuleId: alert.alert_rule.id,
+            alertTitle: alert.title,
+          },
+        },
+      };
+    }
+
+    if (sentryHookResource === "metric_alert") {
+      return { status: "skipped", reason: "invalid_shape" };
+    }
   }
 
-  return null;
+  return {
+    status: "skipped",
+    reason: unsupportedIssueAction ? "unsupported_action" : "invalid_shape",
+  };
 }
 
 function buildSentryIssueWebhookContextBlock(p: SentryIssueWebhookPayload): string {

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -2,80 +2,17 @@
  * Normalize Sentry webhook payloads into SentryAutomationEvent.
  */
 
-import { z } from "zod";
-
 import type { SentryAutomationEvent } from "../types";
-import { buildSentryContextBlock } from "./context";
-
-// ─── Schemas ────────────────────────────────────────────────────────────────
-// Each schema is the single source of truth for one Sentry webhook shape: it
-// produces the static payload type via `z.infer` and validates at runtime via
-// `safeParse`. Only fields consumed by normalization and context builders are
-// modeled.
-
-const sentryIssueWebhookSchema = z.object({
-  action: z.string(),
-  data: z.object({
-    issue: z.object({
-      id: z.string(),
-      shortId: z.string(),
-      title: z.string(),
-      culprit: z.string().nullish(),
-      level: z.string(),
-      count: z.union([z.string(), z.number()]).optional(),
-      firstSeen: z.string().nullish(),
-      project: z.object({
-        slug: z.string(),
-      }),
-      web_url: z.string().optional(),
-    }),
-  }),
-});
-
-const sentryIssueAlertSchema = z.object({
-  action: z.string(),
-  data: z.object({
-    event: z.object({
-      metadata: z.object({
-        filename: z.string().optional(),
-      }),
-    }),
-    issue: z.object({
-      id: z.string(),
-      shortId: z.string(),
-      level: z.string(),
-      status: z.string(),
-      lastSeen: z.string(),
-      project: z.object({
-        slug: z.string(),
-      }),
-    }),
-    triggered_rule: z.string(),
-  }),
-});
-
-const sentryMetricAlertSchema = z.object({
-  action: z.string(),
-  data: z.object({
-    metric_alert: z.object({
-      id: z.number(),
-      title: z.string(),
-      date_started: z.string(),
-      alert_rule: z.object({
-        id: z.number(),
-      }),
-      current_trigger: z.object({
-        label: z.string(),
-      }),
-    }),
-    web_url: z.string(),
-    description_text: z.string(),
-    description_title: z.string(),
-  }),
-});
-
-type SentryMetricAlertPayload = z.infer<typeof sentryMetricAlertSchema>;
-type SentryIssueWebhookPayload = z.infer<typeof sentryIssueWebhookSchema>;
+import {
+  buildSentryContextBlock,
+  buildSentryIssueWebhookContextBlock,
+  buildSentryMetricContextBlock,
+} from "./context";
+import {
+  sentryIssueAlertSchema,
+  sentryIssueWebhookSchema,
+  sentryMetricAlertSchema,
+} from "./payloads";
 
 export type SentryNormalizationResult =
   | { status: "normalized"; event: SentryAutomationEvent }
@@ -157,7 +94,7 @@ export function normalizeSentryEvent(
           sentryProject: issue.project.slug,
           sentryLevel: issue.level,
           culpritFile: data.event.metadata.filename,
-          contextBlock: buildSentryContextBlock(payload),
+          contextBlock: buildSentryContextBlock(issueResult.data),
           meta: {
             issueId: issue.id,
             shortId: issue.shortId,
@@ -213,38 +150,4 @@ export function normalizeSentryEvent(
     status: "skipped",
     reason: unsupportedIssueAction ? "unsupported_action" : "invalid_shape",
   };
-}
-
-function buildSentryIssueWebhookContextBlock(p: SentryIssueWebhookPayload): string {
-  const issue = p.data.issue;
-  const lines = [
-    "This automation was triggered by a new Sentry issue.",
-    "",
-    `Error: ${issue.title}`,
-    `Project: ${issue.project.slug}`,
-    `Level: ${issue.level}`,
-    `Issue: ${issue.shortId}`,
-  ];
-
-  if (issue.firstSeen) lines.push(`First seen: ${issue.firstSeen}`);
-  if (issue.count !== undefined) lines.push(`Events: ${issue.count}`);
-  if (issue.culprit) lines.push(`Culprit: ${issue.culprit}`);
-  if (issue.web_url) lines.push(`URL: ${issue.web_url}`);
-
-  return lines.join("\n");
-}
-
-function buildSentryMetricContextBlock(p: SentryMetricAlertPayload): string {
-  const alert = p.data.metric_alert;
-  const lines = [
-    "This automation was triggered by a Sentry metric alert.",
-    "",
-    `Alert: ${alert.title}`,
-    `Trigger: ${alert.current_trigger.label}`,
-    `Started: ${alert.date_started}`,
-    `URL: ${p.data.web_url}`,
-    "",
-    `Description: ${p.data.description_text}`,
-  ];
-  return lines.join("\n");
 }

--- a/packages/shared/src/triggers/sentry/payloads.ts
+++ b/packages/shared/src/triggers/sentry/payloads.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const sentryIssueWebhookSchema = z.object({
+  action: z.string(),
+  data: z.object({
+    issue: z.object({
+      id: z.string(),
+      shortId: z.string(),
+      title: z.string(),
+      culprit: z.string().nullish(),
+      level: z.string(),
+      count: z.union([z.string(), z.number()]).optional(),
+      firstSeen: z.string().nullish(),
+      project: z.object({
+        slug: z.string(),
+      }),
+      web_url: z.string().optional(),
+    }),
+  }),
+});
+
+export const sentryIssueAlertSchema = z.object({
+  action: z.string(),
+  data: z.object({
+    event: z.object({
+      metadata: z.object({
+        type: z.string().optional(),
+        value: z.string().optional(),
+        filename: z.string().optional(),
+      }),
+      exception: z
+        .object({
+          values: z.array(
+            z.object({
+              stacktrace: z
+                .object({
+                  frames: z.array(
+                    z.object({
+                      filename: z.string().optional(),
+                      abs_path: z.string().optional(),
+                      function: z.string().optional(),
+                      lineno: z.number().optional(),
+                    })
+                  ),
+                })
+                .optional(),
+            })
+          ),
+        })
+        .optional(),
+      tags: z.array(z.object({ key: z.string(), value: z.string() })).optional(),
+    }),
+    issue: z.object({
+      id: z.string(),
+      shortId: z.string(),
+      title: z.string().optional(),
+      culprit: z.string().nullish(),
+      level: z.string(),
+      count: z.union([z.string(), z.number()]).optional(),
+      firstSeen: z.string().nullish(),
+      status: z.string(),
+      lastSeen: z.string(),
+      project: z.object({
+        slug: z.string(),
+      }),
+    }),
+    triggered_rule: z.string(),
+  }),
+});
+
+export const sentryMetricAlertSchema = z.object({
+  action: z.string(),
+  data: z.object({
+    metric_alert: z.object({
+      id: z.number(),
+      title: z.string(),
+      date_started: z.string(),
+      alert_rule: z.object({
+        id: z.number(),
+      }),
+      current_trigger: z.object({
+        label: z.string(),
+      }),
+    }),
+    web_url: z.string(),
+    description_text: z.string(),
+    description_title: z.string(),
+  }),
+});
+
+export type SentryIssueWebhookPayload = z.infer<typeof sentryIssueWebhookSchema>;
+export type SentryIssueAlertPayload = z.infer<typeof sentryIssueAlertSchema>;
+export type SentryMetricAlertPayload = z.infer<typeof sentryMetricAlertSchema>;


### PR DESCRIPTION
## Summary

- normalize current Sentry issue.created custom-integration webhooks separately from legacy event alerts
- route normalization using the Sentry-Hook-Resource header while preserving legacy event_alert and metric_alert behavior
- emit a structured sentry.webhook_skipped warning with safe diagnostic metadata when normalization rejects a signed delivery
- add unit and integration coverage proving issue.created deliveries create automation runs and skipped payload contents are not logged

## Root cause

The webhook handler acknowledged unsupported payloads with HTTP 200 and skipped=true. Its only issue schema required alert-only data.event and data.triggered_rule fields, so current issue.created deliveries were rejected before SchedulerDO and no invocation, run, or session was created.

## Impact

Current Sentry issue.created webhooks now reach SchedulerDO and launch their configured automation. Future normalization skips are visible in Worker logs through the sentry.webhook_skipped event without logging webhook payloads or secrets.

## Validation

- shared unit tests: 531 passed
- control-plane unit tests: 2,254 passed
- focused webhook integration tests: 16 passed
- full control-plane integration suite passed
- shared and control-plane typechecks passed
- ESLint, Prettier, and git diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for current Sentry `issue.created` webhooks, including issue details and context in automation runs.
  - Sentry webhook types are now identified using resource headers, supporting issue, event-alert, and metric-alert payloads.

- **Bug Fixes**
  - Improved handling of unsupported or invalid Sentry payloads so they are safely skipped.
  - Preserved compatibility with legacy Sentry event-alert and metric-alert integrations.
  - Improved webhook processing diagnostics while avoiding sensitive payload data in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->