### PR TITLE
Normalize Sentry metric alert identifiers

### DIFF
--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -141,14 +141,17 @@ describe("normalizeSentryEvent", () => {
     expect(event.triggerKey).toContain("sentry_regression:");
   });
 
-  it("normalizes a metric alert payload", () => {
+  it.each([
+    ["string", "456", "789"],
+    ["numeric", 456, 789],
+  ])("normalizes a metric alert payload with %s identifiers", (_type, metricId, alertRuleId) => {
     const metricPayload = {
       action: "critical",
       data: {
         metric_alert: {
-          id: 456,
+          id: metricId,
           title: "Error rate > 5%",
-          alert_rule: { id: 789, name: "High error rate" },
+          alert_rule: { id: alertRuleId, name: "High error rate" },
           date_started: "2026-03-23T14:30:00Z",
           current_trigger: { label: "critical" },
         },
@@ -161,6 +164,7 @@ describe("normalizeSentryEvent", () => {
     expect(event.eventType).toBe("metric_alert.critical");
     expect(event.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");
     expect(event.concurrencyKey).toBe("sentry_metric:789");
+    expect(event.meta.alertRuleId).toBe("789");
   });
 
   it("returns unsupported_action for non-critical metric alerts", () => {

--- a/packages/shared/src/triggers/sentry/payloads.ts
+++ b/packages/shared/src/triggers/sentry/payloads.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const sentryIdentifierSchema = z.union([z.string(), z.number()]).transform(String);
+
 export const sentryIssueWebhookSchema = z.object({
   action: z.string(),
   data: z.object({
@@ -72,11 +74,11 @@ export const sentryMetricAlertSchema = z.object({
   action: z.string(),
   data: z.object({
     metric_alert: z.object({
-      id: z.number(),
+      id: sentryIdentifierSchema,
       title: z.string(),
       date_started: z.string(),
       alert_rule: z.object({
-        id: z.number(),
+        id: sentryIdentifierSchema,
       }),
       current_trigger: z.object({
         label: z.string(),


### PR DESCRIPTION
## Summary

- accept string and numeric identifiers in Sentry metric alert webhooks
- normalize both metric alert and alert rule identifiers to strings at the schema boundary
- verify trigger, concurrency, and metadata keys use the canonical parsed alert rule identifier

## Context

Follow-up to #1264. Sentry's documented metric alert payload represents both `metric_alert.id` and `metric_alert.alert_rule.id` as strings, while the merged schema only accepted numbers.

Documentation: https://docs.sentry.io/organization/integrations/integration-platform/webhooks/metric-alerts/

## Validation

- `npm test -w @open-inspect/shared` (39 files, 533 tests)
- `npm run typecheck -w @open-inspect/shared`
- `npm run build -w @open-inspect/shared`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/webhooks.test.ts` (18 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run format:check`
- focused ESLint and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry metric alert handling for identifiers provided as either text or numbers.
  * Standardized alert rule identifiers to consistent string values in normalized metadata.
* **Tests**
  * Expanded coverage to verify normalization across both supported identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->