### PR TITLE
Persist session sidebar owner filter

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -11,6 +11,7 @@ import {
   CURRENT_USER_CREATED_BY,
   SIDEBAR_SESSIONS_KEY,
 } from "@/lib/session-list";
+import { SESSION_CREATOR_FILTER_STORAGE_KEY } from "@/hooks/use-sidebar-sessions";
 
 expect.extend(matchers);
 
@@ -62,6 +63,8 @@ vi.mock("@/hooks/use-environments", () => ({
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  localStorage.clear();
   vi.useRealTimers();
   mockUseIsMobile.mockReturnValue(false);
   mockPush.mockReset();
@@ -488,7 +491,102 @@ describe("SessionSidebar", () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(mineKey);
     });
+    expect(localStorage.getItem(SESSION_CREATOR_FILTER_STORAGE_KEY)).toBe("mine");
     expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+  });
+
+  it("restores the saved creator filter after a refresh", async () => {
+    const mineKey = buildSessionsPageKey({
+      excludeStatus: "archived",
+      excludeAutomationLineage: true,
+      createdBy: [CURRENT_USER_CREATED_BY],
+    });
+    localStorage.setItem(SESSION_CREATOR_FILTER_STORAGE_KEY, "mine");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === mineKey) {
+        return jsonResponse({
+          sessions: [createSession(2, { title: "Saved mine session" })],
+          hasMore: false,
+        });
+      }
+      throw new Error(`Unexpected fetch for ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fetcher: async (url: string) => (await fetch(url)).json(),
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Saved mine session")).toBeInTheDocument();
+    expect(screen.getByText("Mine").closest("button")).toHaveAttribute("data-state", "on");
+    expect(fetchMock).toHaveBeenCalledWith(mineKey);
+    expect(fetchMock).not.toHaveBeenCalledWith(SIDEBAR_SESSIONS_KEY);
+  });
+
+  it("ignores an invalid saved creator filter", async () => {
+    localStorage.setItem(SESSION_CREATOR_FILTER_STORAGE_KEY, "invalid");
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    expect(screen.getByText("All").closest("button")).toHaveAttribute("data-state", "on");
+  });
+
+  it("keeps the creator filter usable when storage is unavailable", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("Storage unavailable");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage unavailable");
+    });
+    const mineKey = buildSessionsPageKey({
+      excludeStatus: "archived",
+      excludeAutomationLineage: true,
+      createdBy: [CURRENT_USER_CREATED_BY],
+    });
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: {
+            [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false },
+            [mineKey]: {
+              sessions: [createSession(2, { title: "Mine without storage" })],
+              hasMore: false,
+            },
+          },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Mine"));
+    expect(await screen.findByText("Mine without storage")).toBeInTheDocument();
+    expect(screen.getByText("Mine").closest("button")).toHaveAttribute("data-state", "on");
   });
 
   it("shows the environment name on cards for environment-launched sessions", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -85,6 +85,7 @@ export function SessionSidebar({
     loadingMore,
     sessionsError,
     sessionCreatorFilter,
+    isSessionCreatorFilterHydrated,
     setSessionCreatorFilter,
     scrollContainerRef,
     maybeLoadMoreSessions,
@@ -179,7 +180,7 @@ export function SessionSidebar({
       <div className="px-3 py-2">
         <ToggleGroup
           type="single"
-          value={sessionCreatorFilter}
+          value={isSessionCreatorFilterHydrated ? sessionCreatorFilter : ""}
           onValueChange={(value) => {
             if (value === "all" || value === "mine") {
               setSessionCreatorFilter(value);

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -85,7 +85,6 @@ export function SessionSidebar({
     loadingMore,
     sessionsError,
     sessionCreatorFilter,
-    isSessionCreatorFilterHydrated,
     setSessionCreatorFilter,
     scrollContainerRef,
     maybeLoadMoreSessions,
@@ -180,7 +179,7 @@ export function SessionSidebar({
       <div className="px-3 py-2">
         <ToggleGroup
           type="single"
-          value={isSessionCreatorFilterHydrated ? sessionCreatorFilter : ""}
+          value={sessionCreatorFilter ?? ""}
           onValueChange={(value) => {
             if (value === "all" || value === "mine") {
               setSessionCreatorFilter(value);

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -25,6 +25,7 @@ import {
 } from "@/lib/session-read-state";
 
 const VISIBLE_SESSION_LIST_POLL_MS = 30_000;
+export const SESSION_CREATOR_FILTER_STORAGE_KEY = "open-inspect-sidebar-session-creator-filter";
 
 export type SessionItem = Session;
 
@@ -33,12 +34,36 @@ type SessionCreatorFilter = "all" | "mine";
 export function useSidebarSessions(currentSessionId: string | null) {
   const { data: authSession } = useAuthSession();
   const router = useRouter();
-  const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
+  const [sessionCreatorFilter, setSessionCreatorFilterState] =
+    useState<SessionCreatorFilter>("all");
+  const [isSessionCreatorFilterHydrated, setIsSessionCreatorFilterHydrated] = useState(false);
   const [extraPageRequest, setExtraPageRequest] = useState({
     key: null as string | null,
     count: 0,
   });
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    try {
+      const storedFilter = localStorage.getItem(SESSION_CREATOR_FILTER_STORAGE_KEY);
+      if (storedFilter === "all" || storedFilter === "mine") {
+        setSessionCreatorFilterState(storedFilter);
+      }
+    } catch {
+      // Storage is optional; the default remains usable in restricted browsers.
+    } finally {
+      setIsSessionCreatorFilterHydrated(true);
+    }
+  }, []);
+
+  const setSessionCreatorFilter = useCallback((value: SessionCreatorFilter) => {
+    setSessionCreatorFilterState(value);
+    try {
+      localStorage.setItem(SESSION_CREATOR_FILTER_STORAGE_KEY, value);
+    } catch {
+      // Continue with the in-memory preference when storage is unavailable.
+    }
+  }, []);
 
   const sidebarSessionListOptions = useMemo(
     () => ({
@@ -54,10 +79,10 @@ export function useSidebarSessions(currentSessionId: string | null) {
   );
 
   const sidebarSessionsKey = useMemo(() => {
-    if (!authSession) return null;
+    if (!authSession || !isSessionCreatorFilterHydrated) return null;
 
     return buildSessionsPageKey(sidebarSessionListOptions);
-  }, [authSession, sidebarSessionListOptions]);
+  }, [authSession, isSessionCreatorFilterHydrated, sidebarSessionListOptions]);
   const {
     data: firstPage,
     error: sessionsError,
@@ -105,7 +130,7 @@ export function useSidebarSessions(currentSessionId: string | null) {
     refreshWhenHidden: false,
     revalidateAll: true,
   });
-  const loading = sessionsLoading;
+  const loading = !isSessionCreatorFilterHydrated || sessionsLoading;
   const loadingMore = isValidating && extraPages?.[size - 1] === undefined;
   const hasMorePages = extraPages?.at(-1)?.hasMore ?? firstPage?.hasMore ?? false;
 
@@ -276,6 +301,7 @@ export function useSidebarSessions(currentSessionId: string | null) {
     loadingMore,
     sessionsError,
     sessionCreatorFilter,
+    isSessionCreatorFilterHydrated,
     setSessionCreatorFilter,
     scrollContainerRef,
     maybeLoadMoreSessions,

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -35,8 +35,7 @@ export function useSidebarSessions(currentSessionId: string | null) {
   const { data: authSession } = useAuthSession();
   const router = useRouter();
   const [sessionCreatorFilter, setSessionCreatorFilterState] =
-    useState<SessionCreatorFilter>("all");
-  const [isSessionCreatorFilterHydrated, setIsSessionCreatorFilterHydrated] = useState(false);
+    useState<SessionCreatorFilter | null>(null);
   const [extraPageRequest, setExtraPageRequest] = useState({
     key: null as string | null,
     count: 0,
@@ -44,15 +43,16 @@ export function useSidebarSessions(currentSessionId: string | null) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let initialFilter: SessionCreatorFilter = "all";
     try {
       const storedFilter = localStorage.getItem(SESSION_CREATOR_FILTER_STORAGE_KEY);
       if (storedFilter === "all" || storedFilter === "mine") {
-        setSessionCreatorFilterState(storedFilter);
+        initialFilter = storedFilter;
       }
     } catch {
       // Storage is optional; the default remains usable in restricted browsers.
     } finally {
-      setIsSessionCreatorFilterHydrated(true);
+      setSessionCreatorFilterState(initialFilter);
     }
   }, []);
 
@@ -79,10 +79,10 @@ export function useSidebarSessions(currentSessionId: string | null) {
   );
 
   const sidebarSessionsKey = useMemo(() => {
-    if (!authSession || !isSessionCreatorFilterHydrated) return null;
+    if (!authSession || sessionCreatorFilter === null) return null;
 
     return buildSessionsPageKey(sidebarSessionListOptions);
-  }, [authSession, isSessionCreatorFilterHydrated, sidebarSessionListOptions]);
+  }, [authSession, sessionCreatorFilter, sidebarSessionListOptions]);
   const {
     data: firstPage,
     error: sessionsError,
@@ -130,7 +130,7 @@ export function useSidebarSessions(currentSessionId: string | null) {
     refreshWhenHidden: false,
     revalidateAll: true,
   });
-  const loading = !isSessionCreatorFilterHydrated || sessionsLoading;
+  const loading = sessionCreatorFilter === null || sessionsLoading;
   const loadingMore = isValidating && extraPages?.[size - 1] === undefined;
   const hasMorePages = extraPages?.at(-1)?.hasMore ?? firstPage?.hasMore ?? false;
 
@@ -301,7 +301,6 @@ export function useSidebarSessions(currentSessionId: string | null) {
     loadingMore,
     sessionsError,
     sessionCreatorFilter,
-    isSessionCreatorFilterHydrated,
     setSessionCreatorFilter,
     scrollContainerRef,
     maybeLoadMoreSessions,


### PR DESCRIPTION
## Summary
- persist the session sidebar `All`/`Mine` owner filter in local storage
- hydrate the saved preference before enabling session fetching to avoid an incorrect initial request or selection
- keep the sidebar in a loading state during preference hydration and degrade safely when storage is unavailable
- add coverage for persistence, refresh restoration, invalid values, and unavailable storage

## Testing
- `npm test -w @open-inspect/web -- --run src/components/session-sidebar.test.tsx`
- `npm test -w @open-inspect/web -- --run src/lib/client-auth-boundary-eslint.test.ts`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `git diff --check`

The full web suite passed 878/879 tests; the remaining client-auth boundary test exceeded its 5-second timeout under full-suite load and passed when rerun in isolation.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/88733b8ca9717598e792a0a6b5367cca)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent session creator filter with “All” and “Mine” options.
  * Restores the selected filter when returning to or refreshing the app.
  * Safely defaults to showing all sessions when saved preferences are invalid or unavailable.

* **Bug Fixes**
  * Prevented the sidebar from displaying an incorrect filter before preferences finish loading.
  * Kept session filtering functional when browser storage access fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->