### PR TITLE
Keep the cold-cache repos refresh alive when the client disconnects

### DIFF
--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -2,10 +2,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import { reposRoutes } from "./repos";
+import type * as SharedRoutes from "./shared";
 import type { RequestContext } from "./shared";
 
-const { mockCacheDelete, mockLogger, mockUpsert } = vi.hoisted(() => ({
+const {
+  mockCacheDelete,
+  mockCacheGet,
+  mockCachePut,
+  mockGetBatch,
+  mockListRepositories,
+  mockLogger,
+  mockUpsert,
+} = vi.hoisted(() => ({
   mockCacheDelete: vi.fn(),
+  mockCacheGet: vi.fn(),
+  mockCachePut: vi.fn(),
+  mockGetBatch: vi.fn(),
+  mockListRepositories: vi.fn(),
   mockLogger: {
     debug: vi.fn(),
     info: vi.fn(),
@@ -17,12 +30,16 @@ const { mockCacheDelete, mockLogger, mockUpsert } = vi.hoisted(() => ({
 
 vi.mock("../db/repo-metadata", () => ({
   RepoMetadataStore: vi.fn().mockImplementation(function () {
-    return { upsert: mockUpsert };
+    return { upsert: mockUpsert, getBatch: mockGetBatch };
   }),
 }));
 
 vi.mock("@open-inspect/shared/cache-store", () => ({
-  createKvCacheStore: vi.fn(() => ({ delete: mockCacheDelete })),
+  createKvCacheStore: vi.fn(() => ({
+    delete: mockCacheDelete,
+    get: mockCacheGet,
+    put: mockCachePut,
+  })),
 }));
 
 vi.mock("../logger", () => ({
@@ -44,6 +61,26 @@ function createContext(): RequestContext {
   };
 }
 
+vi.mock("./shared", async () => {
+  const actual = await vi.importActual<typeof SharedRoutes>("./shared");
+  return {
+    ...actual,
+    createRouteSourceControlProvider: vi.fn(() => ({
+      listRepositories: mockListRepositories,
+    })),
+  };
+});
+
+function getListHandler() {
+  const route = reposRoutes.find(
+    (candidate) => candidate.method === "GET" && candidate.pattern.test("/repos")
+  );
+  if (!route) throw new Error("No repository list route found");
+  const match = "/repos".match(route.pattern);
+  if (!match) throw new Error("List route did not match /repos");
+  return { handler: route.handler, match };
+}
+
 function getUpdateHandler(path: string) {
   const route = reposRoutes.find((candidate) => candidate.method === "PUT");
   if (!route) throw new Error("No repository metadata update route found");
@@ -51,6 +88,55 @@ function getUpdateHandler(path: string) {
   if (!match) throw new Error(`Update route did not match ${path}`);
   return { handler: route.handler, match };
 }
+
+describe("repository list route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCacheGet.mockResolvedValue(null);
+    mockCachePut.mockResolvedValue(undefined);
+    mockGetBatch.mockResolvedValue(new Map());
+    mockListRepositories.mockResolvedValue([
+      {
+        id: 1,
+        owner: "acme",
+        name: "widgets",
+        fullName: "acme/widgets",
+        description: null,
+        private: true,
+        archived: false,
+        defaultBranch: "main",
+      },
+    ]);
+  });
+
+  it("keeps the cold-cache refresh alive when the client disconnects", async () => {
+    // A cold cache is populated synchronously. The web proxy aborts at
+    // CONTROL_PLANE_FETCH_TIMEOUT_MS, which cancels the worker — so unless the
+    // refresh is registered with waitUntil, the KV write never lands and every
+    // later request repeats the same slow path against an empty cache.
+    const waitUntil = vi.fn();
+    const { handler, match } = getListHandler();
+    const ctx = createContext();
+
+    const response = await handler(
+      new Request("https://test.local/repos"),
+      { REPOS_CACHE: {} as KVNamespace } as Env,
+      match,
+      {
+        ...ctx,
+        executionCtx: {
+          waitUntil,
+          passThroughOnException: vi.fn(),
+        } as unknown as ExecutionContext,
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCachePut).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await expect(waitUntil.mock.calls[0][0]).resolves.not.toThrow();
+  });
+});
 
 describe("repository metadata routes", () => {
   beforeEach(() => {

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -39,17 +39,29 @@ interface CachedReposList {
   freshUntil?: number;
 }
 
+type ReposRefreshResult =
+  | { ok: true; repos: EnrichedRepository[]; cachedAt: string }
+  | { ok: false; reason: "not_configured" | "fetch_failed" };
+
+/** Times the SCM call when a request context is available; identity otherwise. */
+type ScmApiTimer = <T>(fn: () => Promise<T>) => Promise<T>;
+
 /**
  * Fetch repos via the source control provider, enrich with D1 metadata, and write to KV cache.
  * Runs either in the foreground (cache miss) or background (stale-while-revalidate).
  */
-async function refreshReposCache(env: Env, db: SqlDatabase, traceId?: string): Promise<void> {
+async function refreshReposCache(
+  env: Env,
+  db: SqlDatabase,
+  traceId?: string,
+  timeScmApi: ScmApiTimer = (fn) => fn()
+): Promise<ReposRefreshResult> {
   const provider = createRouteSourceControlProvider(env);
   const cacheStore = createKvCacheStore(env.REPOS_CACHE);
 
   let repos: InstallationRepository[];
   try {
-    repos = await provider.listRepositories();
+    repos = await timeScmApi(() => provider.listRepositories());
 
     logger.info("Repo fetch completed", {
       trace_id: traceId,
@@ -60,13 +72,13 @@ async function refreshReposCache(env: Env, db: SqlDatabase, traceId?: string): P
       logger.warn("SCM provider not configured, skipping repo refresh", {
         trace_id: traceId,
       });
-      return;
+      return { ok: false, reason: "not_configured" };
     }
     logger.error("Failed to list installation repositories (background refresh)", {
       trace_id: traceId,
       error: e instanceof Error ? e : String(e),
     });
-    return;
+    return { ok: false, reason: "fetch_failed" };
   }
 
   const metadataStore = new RepoMetadataStore(db);
@@ -107,6 +119,8 @@ async function refreshReposCache(env: Env, db: SqlDatabase, traceId?: string): P
       error: e instanceof Error ? e : String(e),
     });
   }
+
+  return { ok: true, repos: enrichedRepos, cachedAt };
 }
 
 /**
@@ -157,64 +171,29 @@ async function handleListRepos(
     });
   }
 
-  // No cache at all — must fetch synchronously
-  const provider = createRouteSourceControlProvider(env);
+  // No cache at all — populate synchronously. The refresh is also registered
+  // with waitUntil so it outlives this response: a caller that gives up first
+  // (the web proxy aborts at CONTROL_PLANE_FETCH_TIMEOUT_MS) would otherwise
+  // cancel the Worker before the KV write, leaving the cache empty so the next
+  // request repeats the same slow path — a miss that can never self-heal,
+  // because the stale-while-revalidate branch above needs an entry to exist.
+  const refresh = refreshReposCache(env, ctx.db, ctx.trace_id, (fn) =>
+    ctx.metrics.time("scm_api", fn)
+  );
+  ctx.executionCtx?.waitUntil(refresh);
 
-  let repos: InstallationRepository[];
-  try {
-    repos = await ctx.metrics.time("scm_api", () => provider.listRepositories());
-  } catch (e) {
-    if (e instanceof SourceControlProviderError && e.errorType === "permanent" && !e.httpStatus) {
+  const result = await refresh;
+  if (!result.ok) {
+    if (result.reason === "not_configured") {
       return error("SCM provider not configured", 500);
     }
-    logger.error("Failed to list installation repositories", {
-      error: e instanceof Error ? e : String(e),
-    });
     return error("Failed to fetch repositories", 500);
   }
 
-  logger.info("Repo fetch completed", {
-    trace_id: ctx.trace_id,
-    total_repos: repos.length,
-  });
-
-  const metadataStore = new RepoMetadataStore(ctx.db);
-  let metadataMap: Map<string, RepoMetadata>;
-  try {
-    metadataMap = await metadataStore.getBatch(
-      repos.map((r) => ({ owner: r.owner, name: r.name }))
-    );
-  } catch (e) {
-    logger.warn("Failed to fetch repo metadata batch", {
-      error: e instanceof Error ? e : String(e),
-    });
-    metadataMap = new Map();
-  }
-
-  const enrichedRepos: EnrichedRepository[] = repos.map((repo) => {
-    const key = `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}`;
-    const metadata = metadataMap.get(key);
-    return metadata ? { ...repo, metadata } : repo;
-  });
-
-  const cachedAt = new Date().toISOString();
-  const freshUntil = Date.now() + REPOS_CACHE_FRESH_MS;
-  try {
-    await ctx.metrics.time("kv_write", () =>
-      cacheStore.put(
-        REPOS_CACHE_KEY,
-        JSON.stringify({ repos: enrichedRepos, cachedAt, freshUntil }),
-        { expirationTtl: REPOS_CACHE_KV_TTL_SECONDS }
-      )
-    );
-  } catch (e) {
-    logger.warn("Failed to cache repos list", { error: e instanceof Error ? e : String(e) });
-  }
-
   return json({
-    repos: enrichedRepos,
+    repos: result.repos,
     cached: false,
-    cachedAt,
+    cachedAt: result.cachedAt,
   });
 }
 


### PR DESCRIPTION
## Summary

- On a cache miss, `GET /repos` fetches from the SCM provider, enriches from D1, and writes KV inline with the response. If the caller gives up before that finishes, the Worker is cancelled before the KV write — so the cache stays empty and the next request repeats the same slow path.
- The stale-while-revalidate branch can't rescue it, because that path requires an existing entry. Once the KV entry expires (`REPOS_CACHE_KV_TTL_SECONDS`, 1h), a deployment whose repo listing is slower than the caller's timeout gets stuck: every request races the timeout and none ever repopulates the cache, so the repository picker never loads.
- The web app makes this reachable by default: `packages/web/src/lib/control-plane-transport.ts` aborts control-plane requests at `CONTROL_PLANE_FETCH_TIMEOUT_MS` (15s) via `AbortSignal.timeout`.
- Fix: register the refresh with `waitUntil` so it outlives the response, and reuse `refreshReposCache` for the miss path instead of duplicating the fetch/enrich/write logic in the handler.

We hit this on a deployment with ~100 repositories, where the listing plus metadata batch exceeded 15s. Symptom was `GET /repos` repeatedly ending in `canceled` at ~15.0s while every other route stayed sub-200ms, with the KV key absent throughout.

## Notes

`refreshReposCache` now returns a small result type so the miss path can distinguish "provider not configured" (500 `SCM provider not configured`) from a fetch failure (500 `Failed to fetch repositories`), preserving the previous responses. It takes an optional timer so the miss path keeps recording the `scm_api` metric; the background path passes nothing and behaves as before.

This makes the miss path resilient rather than fast — the first request can still exceed a caller's timeout. It no longer poisons every subsequent one, since the write now lands and the next request is served from cache.

## Test plan

- [x] `npm test -w @open-inspect/control-plane` (2255 tests pass)
- [x] `npm run typecheck -w @open-inspect/control-plane`
- [x] New test in `src/routes/repos.test.ts` asserts the miss path registers the refresh with `waitUntil` and still writes the cache — it fails on `main` (`waitUntil` called 0 times) and passes with this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository listing reliability when cached data is unavailable.
  * Repository information now refreshes successfully in the background, including when a connection closes early.
  * Added clearer handling for refresh failures so users receive more meaningful errors.
  * Improved timing visibility for source-control requests, supporting better monitoring of repository loading performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->