### PR TITLE
test: stabilize Sentry scheduler event integration

### DIFF
--- a/packages/control-plane/test/integration/scheduler-events.test.ts
+++ b/packages/control-plane/test/integration/scheduler-events.test.ts
@@ -111,21 +111,27 @@ describe("SchedulerDO /internal/event (integration)", () => {
           next_run_at: null,
         })
       );
+      // Keep this matching test independent of SessionDO and sandbox startup.
+      // A deleted environment still produces one child, which fails locally
+      // during target resolution after the invocation is persisted.
+      await env.DB.batch(store.bindReplaceEnvironments(automationId, ["env-deleted"], Date.now()));
 
       const event = makeSentryEvent(automationId);
       const res = await sendEvent(event);
 
       expect(res.status).toBe(200);
-      const body = await res.json<{ triggered: number; skipped: number }>();
-      // Session creation will fail in test env, but the run is still created.
-      // triggered may be 0 if session creation fails, but the row exists.
-      expect(body.triggered + body.skipped).toBeLessThanOrEqual(1);
+      const body = await res.json<{ triggered: number; skipped: number; steered: number }>();
+      expect(body).toEqual({ triggered: 0, skipped: 0, steered: 0 });
 
       const runs = await fetchRuns(automationId);
-      expect(runs.length).toBeGreaterThanOrEqual(1);
+      expect(runs).toHaveLength(1);
 
       const run = runs[0]!;
-      expect(run.automation_id).toBe(automationId);
+      expect(run).toMatchObject({
+        automation_id: automationId,
+        environment_id: "env-deleted",
+        status: "failed",
+      });
       // Firing keys live on the invocation, not the child run.
       expect(run.invocation_id).not.toBeNull();
       const invocation = await store.getInvocationById(run.invocation_id!);
@@ -134,6 +140,8 @@ describe("SchedulerDO /internal/event (integration)", () => {
         trigger_key: event.triggerKey,
         concurrency_key: event.concurrencyKey,
       });
+      const { total } = await store.listInvocations(automationId, { limit: 10, offset: 0 });
+      expect(total).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- prevent the Sentry event-matching integration test from starting a real SessionDO and sandbox warm-up
- use a deleted environment target to preserve the real one-child invocation path while forcing deterministic local target-resolution failure
- tighten assertions to require exactly one invocation and one failed child

## Validation
- `npm run test:integration -- --run test/integration/scheduler-events.test.ts -t "triggers a matching sentry automation as an invocation of 1"`
- `npm run test:integration -- --run test/integration/scheduler-events.test.ts`
- `npm run typecheck`
- `npx prettier --check test/integration/scheduler-events.test.ts`
- full `npm run test:integration`: scheduler tests passed; the run failed only on the existing `websocket-client.test.ts` 5-second timeout while the test Modal endpoint returned 404 (`697 passed`, `1 failed`)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/39206cedf3e7a45c7cedfc7778117c66)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for events associated with deleted environments.
  * Added validation that these events produce no counted results while recording exactly one failed run and one automation invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->