### PR TITLE
Clarify shared session schema ownership

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -100,8 +100,6 @@ export type {
   SessionParticipant,
   Session,
   SessionMessage,
-  SessionState,
-  ParticipantPresence,
   PullRequestSummary,
   SessionReadState,
   SessionReadAction,
@@ -125,7 +123,7 @@ export {
 } from "./sessions";
 
 export { serverMessageSchema } from "./server-messages";
-export type { ServerMessage } from "./server-messages";
+export type { ServerMessage, SessionState, ParticipantPresence } from "./server-messages";
 
 export {
   SESSION_DIFF_VERSION,

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -1,12 +1,51 @@
 import { z } from "zod";
 import { sessionArtifactSchema } from "./artifacts";
+import { sessionRepositoryStateSchema } from "./repositories";
 import { sandboxEventSchema, tolerantSandboxEventsSchema } from "./sandbox-events";
-import {
-  participantPresenceSchema,
-  sandboxStatusSchema,
-  sessionStateSchema,
-  sessionStatusSchema,
-} from "./sessions";
+import { sandboxStatusSchema, sessionStatusSchema } from "./sessions";
+
+const sessionStateSchema = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  repoOwner: z.string().nullable(),
+  repoName: z.string().nullable(),
+  baseBranch: z.string().nullable(),
+  branchName: z.string().nullable(),
+  status: sessionStatusSchema,
+  sandboxStatus: sandboxStatusSchema,
+  messageCount: z.number(),
+  createdAt: z.number(),
+  model: z.string().optional(),
+  reasoningEffort: z.string().optional(),
+  isProcessing: z.boolean().optional(),
+  parentSessionId: z.string().nullable().optional(),
+  totalCost: z.number().optional(),
+  codeServerUrl: z.string().nullable().optional(),
+  codeServerPassword: z.string().nullable().optional(),
+  tunnelUrls: z.record(z.string(), z.string()).nullable().optional(),
+  ttydUrl: z.string().nullable().optional(),
+  ttydToken: z.string().nullable().optional(),
+  sandboxDashboardUrl: z.string().nullable().optional(),
+  /**
+   * Ordered repository list; [0] = primary. Optional so pre-feature servers
+   * and producers stay valid — consumers default to [] (absent means a
+   * scalar-era session; synthesize from repoOwner/repoName when rendering).
+   */
+  repositories: z.array(sessionRepositoryStateSchema).optional(),
+  // Environment provenance (design §7.6). environmentName resolves live —
+  // null when the environment was deleted after launch.
+  environmentId: z.string().nullable().optional(),
+  environmentName: z.string().nullable().optional(),
+});
+
+const participantPresenceSchema = z.object({
+  participantId: z.string(),
+  userId: z.string(),
+  name: z.string(),
+  avatar: z.string().optional(),
+  status: z.enum(["active", "idle", "away"]),
+  lastSeen: z.number(),
+});
 
 const participantSummarySchema = z.object({
   participantId: z.string(),

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -37,6 +37,7 @@ const sessionStateSchema = z.object({
   environmentId: z.string().nullable().optional(),
   environmentName: z.string().nullable().optional(),
 });
+export type SessionState = z.infer<typeof sessionStateSchema>;
 
 const participantPresenceSchema = z.object({
   participantId: z.string(),
@@ -46,6 +47,7 @@ const participantPresenceSchema = z.object({
   status: z.enum(["active", "idle", "away"]),
   lastSeen: z.number(),
 });
+export type ParticipantPresence = z.infer<typeof participantPresenceSchema>;
 
 const participantSummarySchema = z.object({
   participantId: z.string(),

--- a/packages/shared/src/types/sessions.ts
+++ b/packages/shared/src/types/sessions.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { ResolvedSessionAttachment } from "./session-attachments";
-import type { SessionListRepository, SessionRepositoryState } from "./repositories";
+import type { SessionListRepository } from "./repositories";
 
 export const sessionStatusSchema = z.enum([
   "created",
@@ -173,52 +173,6 @@ export interface SessionMessage {
   createdAt: number;
   startedAt: number | null;
   completedAt: number | null;
-}
-
-export interface SessionState {
-  id: string;
-  title: string | null;
-  repoOwner: string | null;
-  repoName: string | null;
-  baseBranch: string | null;
-  branchName: string | null;
-  status: SessionStatus;
-  sandboxStatus: SandboxStatus;
-  messageCount: number;
-  createdAt: number;
-  model?: string;
-  reasoningEffort?: string;
-  isProcessing?: boolean;
-  parentSessionId?: string | null;
-  totalCost?: number;
-  codeServerUrl?: string | null;
-  codeServerPassword?: string | null;
-  tunnelUrls?: Record<string, string> | null;
-  ttydUrl?: string | null;
-  ttydToken?: string | null;
-  sandboxDashboardUrl?: string | null;
-  /**
-   * Ordered repository list; [0] = primary. Absent on scalar-era producers —
-   * consumers default to [] / synthesize from repoOwner/repoName.
-   */
-  repositories?: SessionRepositoryState[];
-  /**
-   * The environment this session was launched from (provenance), or null for
-   * repo-launched/ad-hoc sessions. `environmentName` is resolved live and is
-   * null when the environment has since been deleted (design §7.6) — the UI
-   * renders "environment deleted" in that case.
-   */
-  environmentId?: string | null;
-  environmentName?: string | null;
-}
-
-export interface ParticipantPresence {
-  participantId: string;
-  userId: string;
-  name: string;
-  avatar?: string;
-  status: "active" | "idle" | "away";
-  lastSeen: number;
 }
 
 export const sessionParticipantProfileSchema = z.object({

--- a/packages/shared/src/types/sessions.ts
+++ b/packages/shared/src/types/sessions.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 import type { ResolvedSessionAttachment } from "./session-attachments";
-import {
-  sessionRepositoryStateSchema,
-  type SessionListRepository,
-  type SessionRepositoryState,
-} from "./repositories";
+import type { SessionListRepository, SessionRepositoryState } from "./repositories";
 
 export const sessionStatusSchema = z.enum([
   "created",
@@ -65,15 +61,6 @@ export type SpawnSource =
   | "github-bot"
   | "linear-bot"
   | "slack-bot";
-
-export const spawnSourceSchema = z.enum([
-  "user",
-  "agent",
-  "automation",
-  "github-bot",
-  "linear-bot",
-  "slack-bot",
-]);
 
 export interface SessionParticipant {
   id: string;
@@ -249,48 +236,3 @@ export const sessionParticipantProfilesResponseSchema = z.object({
 export type SessionParticipantProfilesResponse = z.infer<
   typeof sessionParticipantProfilesResponseSchema
 >;
-
-/** Internal runtime schema used by the server-message protocol. */
-export const sessionStateSchema = z.object({
-  id: z.string(),
-  title: z.string().nullable(),
-  repoOwner: z.string().nullable(),
-  repoName: z.string().nullable(),
-  baseBranch: z.string().nullable(),
-  branchName: z.string().nullable(),
-  status: sessionStatusSchema,
-  sandboxStatus: sandboxStatusSchema,
-  messageCount: z.number(),
-  createdAt: z.number(),
-  model: z.string().optional(),
-  reasoningEffort: z.string().optional(),
-  isProcessing: z.boolean().optional(),
-  parentSessionId: z.string().nullable().optional(),
-  totalCost: z.number().optional(),
-  codeServerUrl: z.string().nullable().optional(),
-  codeServerPassword: z.string().nullable().optional(),
-  tunnelUrls: z.record(z.string(), z.string()).nullable().optional(),
-  ttydUrl: z.string().nullable().optional(),
-  ttydToken: z.string().nullable().optional(),
-  sandboxDashboardUrl: z.string().nullable().optional(),
-  /**
-   * Ordered repository list; [0] = primary. Optional so pre-feature servers
-   * and producers stay valid — consumers default to [] (absent means a
-   * scalar-era session; synthesize from repoOwner/repoName when rendering).
-   */
-  repositories: z.array(sessionRepositoryStateSchema).optional(),
-  // Environment provenance (design §7.6). environmentName resolves live —
-  // null when the environment was deleted after launch.
-  environmentId: z.string().nullable().optional(),
-  environmentName: z.string().nullable().optional(),
-});
-
-/** Internal runtime schema used by the server-message protocol. */
-export const participantPresenceSchema = z.object({
-  participantId: z.string(),
-  userId: z.string(),
-  name: z.string(),
-  avatar: z.string().optional(),
-  status: z.enum(["active", "idle", "away"]),
-  lastSeen: z.number(),
-});


### PR DESCRIPTION
## Summary

- move the private `SessionState` and participant-presence validators into `server-messages.ts`, the only module that consumes them
- remove the unused and unsupported `spawnSourceSchema`
- keep `sandboxStatusSchema` beside `SandboxStatus` as the canonical session-owned validator

## Scope

This is an ownership-only change. It adds no package path, migrates no application consumer, changes no historical root export, and changes no serialized value or validation behavior. Package exposure and consumer adoption remain a separate follow-up.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (39 files, 533 tests)
- `npm run lint -w @open-inspect/shared`
- `npm run typecheck` (all workspaces)
- targeted Prettier and diff checks
- structural comparison confirms both moved validators are unchanged
- export audit confirms all 23 historical root names remain; the only additional source export is the intentionally retained `sandboxStatusSchema`
- shared module-boundary tests confirm no runtime or compile-time cycle

## Architecture review

The runtime validators now live privately with `serverMessageSchema`, while the stable session types and canonical sandbox-status validator remain in `sessions.ts`. The move removes a runtime dependency from `sessions.ts`, adds no new module, and preserves package direction and public compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session updates now include repository information, including the ordered repository list when available.
  * Session state reports environment details, including environment ID and name.
  * Server updates provide consistent session and participant presence information.

* **Improvements**
  * Session notifications offer richer context for monitoring active sessions, processing status, costs, tooling, repositories, and environment provenance.
  * Session and participant presence data are now presented consistently across server updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->