### PR TITLE
refactor: remove unreachable registry-snapshot create path

### DIFF
--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -121,7 +121,6 @@ export interface CreateSandboxRequest {
   repoName: string | null;
   controlPlaneUrl: string;
   sandboxAuthToken: string;
-  snapshotId?: string;
   opencodeSessionId?: string;
   provider?: string;
   model?: string;
@@ -341,7 +340,6 @@ export class ModalClient {
           repo_name: request.repoName,
           control_plane_url: request.controlPlaneUrl,
           sandbox_auth_token: request.sandboxAuthToken,
-          snapshot_id: request.snapshotId || null,
           opencode_session_id: request.opencodeSessionId || null,
           provider: request.provider || "anthropic",
           model: request.model || "claude-sonnet-4-6",

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -79,12 +79,10 @@ class SandboxConfig:
     repo_owner: str | None
     repo_name: str | None
     sandbox_id: str | None = None  # Expected sandbox ID from control plane
-    snapshot_id: str | None = None
     session_config: SessionConfig | None = None
     control_plane_url: str = ""
     sandbox_auth_token: str = ""
     timeout_seconds: int = DEFAULT_SANDBOX_TIMEOUT_SECONDS
-    fallback_clone_token: str | None = None  # VCS token for legacy snapshot fallback paths
     user_env_vars: dict[str, str] | None = None  # User-provided env vars (repo secrets)
     repo_image_id: str | None = None  # Pre-built repo image ID from provider
     repo_image_sha: str | None = None  # Git SHA the repo image was built from
@@ -304,8 +302,9 @@ class SandboxManager:
         """
         Create a new sandbox for a session.
 
-        If a snapshot_id is provided, restores from that snapshot.
-        Otherwise, creates from the latest image for the repo.
+        Creates from the pre-built repo image when one is provided,
+        otherwise from the base image. Snapshot restores go through
+        restore_sandbox, not this path.
 
         Args:
             config: Sandbox configuration including repo info and session config
@@ -345,13 +344,8 @@ class SandboxManager:
 
         # Host scoping (VCS_HOST / VCS_CLONE_USERNAME) is injected even without a
         # repository so GitLab/Bitbucket deployments don't fall back to github.com
-        # credential-helper behavior; clone tokens stay repository-gated.
-        fallback_clone_token = config.fallback_clone_token if has_repository else None
-        inject_vcs_env_vars(
-            env_vars,
-            clone_token=fallback_clone_token,
-            include_github_cli_aliases=bool(fallback_clone_token),
-        )
+        # credential-helper behavior; fresh creates never carry a clone token.
+        inject_vcs_env_vars(env_vars, clone_token=None)
 
         code_server_password: str | None = None
         if config.code_server_enabled:
@@ -368,10 +362,8 @@ class SandboxManager:
         if config.session_config:
             env_vars["SESSION_CONFIG"] = config.session_config.model_dump_json()
 
-        # Determine image to use (priority: session snapshot > repo image > base image)
-        if config.snapshot_id:
-            image = modal.Image.from_registry(f"open-inspect-snapshot:{config.snapshot_id}")
-        elif config.repo_image_id:
+        # Determine image to use (priority: repo image > base image)
+        if config.repo_image_id:
             image = modal.Image.from_id(config.repo_image_id)
             env_vars["FROM_REPO_IMAGE"] = "true"
             env_vars["REPO_IMAGE_SHA"] = config.repo_image_sha or ""
@@ -440,7 +432,6 @@ class SandboxManager:
             modal_sandbox=sandbox,
             status=SandboxStatus.WARMING,
             created_at=time.time(),
-            snapshot_id=config.snapshot_id,
             modal_object_id=modal_object_id,
             code_server_url=code_server_url,
             code_server_password=code_server_password,

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -134,7 +134,7 @@ def _session_config_from_create_request(
 
 @app.function(
     image=function_image,
-    secrets=[github_app_secrets, internal_api_secret],
+    secrets=[internal_api_secret],
 )
 @fastapi_endpoint(method="POST")
 async def api_create_sandbox(
@@ -158,7 +158,6 @@ async def api_create_sandbox(
         "repo_name": "...",
         "control_plane_url": "...",
         "sandbox_auth_token": "...",
-        "snapshot_id": null,
         "provider": "anthropic",
         "model": "claude-sonnet-4-6"
     }
@@ -181,14 +180,10 @@ async def api_create_sandbox(
 
         manager = SandboxManager()
 
-        snapshot_id = request.get("snapshot_id")
         repo_image_id = request.get("repo_image_id") or None
         repo_owner, repo_name = _normalize_optional_repository_context(
             request.get("repo_owner"),
             request.get("repo_name"),
-        )
-        fallback_clone_token = (
-            resolve_clone_token() if snapshot_id and repo_owner and repo_name else None
         )
 
         session_config = _session_config_from_create_request(
@@ -199,11 +194,9 @@ async def api_create_sandbox(
             repo_owner=repo_owner,
             repo_name=repo_name,
             sandbox_id=request.get("sandbox_id"),  # Use control-plane-provided ID for auth
-            snapshot_id=snapshot_id,
             session_config=session_config,
             control_plane_url=control_plane_url,
             sandbox_auth_token=request.get("sandbox_auth_token"),
-            fallback_clone_token=fallback_clone_token,
             user_env_vars=request.get("user_env_vars") or None,
             repo_image_id=repo_image_id,
             repo_image_sha=request.get("repo_image_sha") or None,

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -394,8 +394,7 @@ def _fake_sandbox_create(captured):
 
 
 # Note: fresh and repo-image sandboxes never receive SCM tokens in the
-# environment. Callers only set fallback_clone_token for snapshot paths that
-# still need VCS_CLONE_TOKEN for legacy entrypoints.
+# environment; created sandboxes rely on brokered credentials only.
 
 
 @pytest.mark.asyncio
@@ -516,59 +515,6 @@ async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, toke
     assert "VCS_CLONE_TOKEN" not in env
     assert env.get("GITHUB_TOKEN") != "ghs_repo_image_token"
     assert env.get("GITHUB_APP_TOKEN") != "ghs_repo_image_token"
-    assert "OI_GITHUB_TOKEN_IS_FALLBACK" not in env
-
-
-@pytest.mark.asyncio
-async def test_session_snapshot_boot_preserves_clone_token(monkeypatch):
-    """A session-snapshot boot keeps the legacy fallback token."""
-    captured = {}
-
-    monkeypatch.setattr("src.sandbox.manager.modal.Image.from_registry", lambda *a, **kw: object())
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
-    monkeypatch.delenv("SCM_PROVIDER", raising=False)
-
-    manager = SandboxManager()
-    config = SandboxConfig(
-        repo_owner="acme",
-        repo_name="repo",
-        fallback_clone_token="ghs_snapshot_token",
-        snapshot_id="snap-1",
-    )
-    await manager.create_sandbox(config)
-
-    env = captured["env"]
-    assert env["VCS_CLONE_TOKEN"] == "ghs_snapshot_token"
-    assert env["OI_GITHUB_TOKEN_IS_FALLBACK"] == "1"
-
-
-@pytest.mark.asyncio
-async def test_no_repo_session_snapshot_boot_omits_clone_token(monkeypatch):
-    """A no-repository snapshot boot gets host scoping but no VCS credentials."""
-    captured = {}
-
-    monkeypatch.setattr("src.sandbox.manager.modal.Image.from_registry", lambda *a, **kw: object())
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
-    monkeypatch.delenv("SCM_PROVIDER", raising=False)
-
-    manager = SandboxManager()
-    config = SandboxConfig(
-        repo_owner=None,
-        repo_name=None,
-        fallback_clone_token="ghs_snapshot_token",
-        snapshot_id="snap-1",
-    )
-    await manager.create_sandbox(config)
-
-    env = captured["env"]
-    assert "REPOSITORY_MODE" not in env
-    assert env["REPO_OWNER"] == ""
-    assert env["REPO_NAME"] == ""
-    assert env["VCS_HOST"] == "github.com"
-    assert env["VCS_CLONE_USERNAME"] == "x-access-token"
-    assert "VCS_CLONE_TOKEN" not in env
-    assert "GITHUB_TOKEN" not in env
-    assert "GITHUB_APP_TOKEN" not in env
     assert "OI_GITHUB_TOKEN_IS_FALLBACK" not in env
 
 

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -95,7 +95,6 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkey
 
     assert result["success"] is True
     assert calls == []
-    assert captured["config"].fallback_clone_token is None
 
 
 @pytest.mark.asyncio
@@ -182,38 +181,6 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_repo_image_boot(m
 
     assert result["success"] is True
     assert calls == []
-    assert captured["config"].fallback_clone_token is None
-
-
-@pytest.mark.asyncio
-async def test_create_sandbox_resolves_clone_token_for_snapshot_boot(monkeypatch):
-    """Session snapshot boots still receive a legacy fallback token."""
-    captured = {}
-    calls = []
-
-    _patch_auth(monkeypatch)
-    _patch_manager(monkeypatch, captured)
-
-    def resolve_clone_token() -> str:
-        calls.append(True)
-        return "ghs_snapshot"
-
-    monkeypatch.setattr(web_api, "resolve_clone_token", resolve_clone_token)
-
-    result = await _call_create_sandbox(
-        {
-            "session_id": "sess-1",
-            "repo_owner": "acme",
-            "repo_name": "repo",
-            "control_plane_url": "https://control-plane.example",
-            "sandbox_auth_token": "sandbox-token",
-            "snapshot_id": "snap-1",
-        }
-    )
-
-    assert result["success"] is True
-    assert calls == [True]
-    assert captured["config"].fallback_clone_token == "ghs_snapshot"
 
 
 @pytest.mark.asyncio
@@ -223,7 +190,6 @@ async def test_create_sandbox_threads_missing_repo_fields(monkeypatch):
 
     _patch_auth(monkeypatch)
     _patch_manager(monkeypatch, captured)
-    monkeypatch.setattr(web_api, "resolve_clone_token", lambda: "unused")
 
     result = await _call_create_sandbox(
         {
@@ -240,31 +206,6 @@ async def test_create_sandbox_threads_missing_repo_fields(monkeypatch):
     assert config.repo_name is None
     assert config.session_config.repo_owner is None
     assert config.session_config.repo_name is None
-    assert config.fallback_clone_token is None
-
-
-@pytest.mark.asyncio
-async def test_create_sandbox_snapshot_without_repo_does_not_resolve_clone_token(monkeypatch):
-    """No-repository snapshot boots must not mint a repository clone token."""
-    captured = {}
-    calls = []
-
-    _patch_auth(monkeypatch)
-    _patch_manager(monkeypatch, captured)
-    monkeypatch.setattr(web_api, "resolve_clone_token", lambda: calls.append(True) or "ghs_token")
-
-    result = await _call_create_sandbox(
-        {
-            "session_id": "sess-1",
-            "control_plane_url": "https://control-plane.example",
-            "sandbox_auth_token": "sandbox-token",
-            "snapshot_id": "snap-1",
-        }
-    )
-
-    assert result["success"] is True
-    assert calls == []
-    assert captured["config"].fallback_clone_token is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up cleanup from the image-build standardization arc (#1178–#1249). The regular create-sandbox path still carried a `snapshot_id` branch that built `modal.Image.from_registry("open-inspect-snapshot:<id>")` — a registry image scheme that has never existed anywhere in the repo. Real snapshot restores go through `api_restore_sandbox` → `modal.Image.from_id`. No control-plane caller ever set `snapshotId` on the create request, so the branch — and the `fallback_clone_token` wiring that existed solely to feed it — was unreachable (and would have crashed on `from_registry` if ever hit).

- `web_api.py`: drop `snapshot_id`/`fallback_clone_token` from `api_create_sandbox`; remove the now-unused `github_app_secrets` binding from that endpoint (`resolve_clone_token` was its only consumer there — the restore endpoint keeps its binding, which is legitimately live)
- `manager.py`: drop `SandboxConfig.snapshot_id`/`fallback_clone_token`, the `from_registry` image branch, and the dead clone-token wiring. `include_github_cli_aliases` is preserved — the restore path uses it with a real token; the removed call site always passed `False`, so `inject_vcs_env_vars(env_vars, clone_token=None)` is behaviorally identical
- `client.ts`: drop `snapshotId` from the Modal create request type and body (no producer existed)
- tests: delete the four tests pinning the dead snapshot-boot behavior; keep the guards asserting create never resolves a clone token

Pure dead-code removal: +9/−140, no runtime behavior change.

## Validation

- modal-infra: 170 tests passed (4 deleted with the dead path); `ruff check` and `ruff format --check` clean
- control plane: 2,255 unit tests passed; typecheck clean on both tsconfigs; shared build clean
- Prettier + ESLint clean on changed TS
- Independently thermo-reviewed (Opus): no findings; verified `has_repository` still live for sandbox naming, and that dropping `github_app_secrets` from create is safe because `SCM_PROVIDER`/`ALLOWED_CONTROL_PLANE_HOSTS` live in `internal_api_secret`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified sandbox creation now starts from a repository image or base image.
  - Snapshot restoration is handled separately after sandbox creation.
  - Fresh and repository-based sandboxes use brokered credentials automatically.

- **Improvements**
  - Sandbox creation no longer requires a GitHub App secret.
  - Removed legacy snapshot and clone-token configuration from the creation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->