### PR TITLE
refactor: remove pre-cutover Modal launch-protocol shims

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -498,8 +498,6 @@ describe("ModalClient", () => {
     await client.startImageBuildSandbox({
       buildId: "imgb-1",
       providerSessionId: "modal-session-1",
-      callbackUrl: "https://cp.test/image-builds/build-complete",
-      failureCallbackUrl: "https://cp.test/image-builds/build-failed",
       callbackToken: "cb-token-1",
     });
 
@@ -511,8 +509,6 @@ describe("ModalClient", () => {
     expect(body).toEqual({
       build_id: "imgb-1",
       provider_session_id: "modal-session-1",
-      callback_url: "https://cp.test/image-builds/build-complete",
-      failure_callback_url: "https://cp.test/image-builds/build-failed",
       callback_token: "cb-token-1",
     });
   });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -224,8 +224,6 @@ export interface CreateImageBuildSandboxResponse {
 export interface StartImageBuildSandboxRequest {
   buildId: string;
   providerSessionId: string;
-  callbackUrl: string;
-  failureCallbackUrl: string;
   callbackToken: string;
 }
 
@@ -669,8 +667,6 @@ export class ModalClient {
       {
         build_id: request.buildId,
         provider_session_id: request.providerSessionId,
-        callback_url: request.callbackUrl,
-        failure_callback_url: request.failureCallbackUrl,
         callback_token: request.callbackToken,
       },
       correlation

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -542,8 +542,6 @@ describe("ModalSandboxProvider", () => {
         {
           buildId: "build-123",
           providerSessionId: "modal-session-123",
-          callbackUrl: "https://worker.test/image-builds/build-complete",
-          failureCallbackUrl: "https://worker.test/image-builds/build-failed",
           callbackToken: "callback-token",
           correlation,
         },

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -43,8 +43,6 @@ interface CreateModalImageBuildConfig {
 interface StartModalImageBuildConfig {
   buildId: string;
   providerSessionId: string;
-  callbackUrl: string;
-  failureCallbackUrl: string;
   callbackToken: string;
   correlation?: CorrelationContext;
 }
@@ -338,8 +336,6 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
     await this.startImageBuildSandbox({
       buildId: config.buildId,
       providerSessionId: created.providerSessionId,
-      callbackUrl: config.callbackUrl,
-      failureCallbackUrl: config.failureCallbackUrl,
       callbackToken: config.callbackToken,
       correlation: config.correlation,
     });

--- a/packages/modal-infra/src/sandbox/build_session.py
+++ b/packages/modal-infra/src/sandbox/build_session.py
@@ -5,7 +5,6 @@ import time
 from typing import cast
 
 import modal
-from modal.stream_type import StreamType
 
 from sandbox_runtime.constants import IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR
 from sandbox_runtime.log_config import get_logger
@@ -49,8 +48,8 @@ class ModalBuildSessionService:
         scope_kind: str,
         scope_id: str,
         repositories: list[dict],
-        callback_url: str | None = None,
-        failure_callback_url: str | None = None,
+        callback_url: str,
+        failure_callback_url: str,
         clone_token: str = "",
         clone_host: str | None = None,
         clone_username: str | None = None,
@@ -60,9 +59,6 @@ class ModalBuildSessionService:
     ) -> str:
         start_time = time.time()
         primary = repositories[0]
-        if bool(callback_url) != bool(failure_callback_url):
-            raise ValueError("callback URLs must be provided together")
-        gated_launch = bool(callback_url and failure_callback_url)
         env_vars = dict(user_env_vars or {})
         for name in (
             BUILD_ID_ENV,
@@ -87,18 +83,11 @@ class ModalBuildSessionService:
                     }
                 ),
                 IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR: str(build_execution_timeout_seconds),
+                BUILD_ID_ENV: build_id,
+                CALLBACK_URL_ENV: callback_url,
+                FAILURE_CALLBACK_URL_ENV: failure_callback_url,
             }
         )
-        if gated_launch:
-            assert callback_url is not None
-            assert failure_callback_url is not None
-            env_vars.update(
-                {
-                    BUILD_ID_ENV: build_id,
-                    CALLBACK_URL_ENV: callback_url,
-                    FAILURE_CALLBACK_URL_ENV: failure_callback_url,
-                }
-            )
         inject_vcs_env_vars(
             env_vars,
             clone_token or None,
@@ -106,19 +95,14 @@ class ModalBuildSessionService:
             clone_username=clone_username,
         )
 
-        command = (
-            ("python", "-m", "sandbox_runtime.entrypoint", MODAL_IMAGE_BUILD_START_ARGUMENT)
-            if gated_launch
-            else ("python", "-c", "import signal; signal.pause()")
-        )
+        command = ("python", "-m", "sandbox_runtime.entrypoint", MODAL_IMAGE_BUILD_START_ARGUMENT)
         tags = {
             "openinspect_kind": "image-build",
             "openinspect_build_id": build_id,
             "openinspect_scope_kind": scope_kind,
             "openinspect_scope_id": scope_id,
+            LAUNCH_PROTOCOL_TAG: MODAL_IMAGE_BUILD_START_PROTOCOL,
         }
-        if gated_launch:
-            tags[LAUNCH_PROTOCOL_TAG] = MODAL_IMAGE_BUILD_START_PROTOCOL
 
         sandbox = await modal.Sandbox.create.aio(
             *command,
@@ -146,38 +130,19 @@ class ModalBuildSessionService:
         *,
         build_id: str,
         provider_session_id: str,
-        callback_url: str,
-        failure_callback_url: str,
         callback_token: str,
     ) -> None:
         sandbox, tags = await self._resolve(build_id, provider_session_id)
         launch_protocol = tags.get(LAUNCH_PROTOCOL_TAG)
-        if launch_protocol == MODAL_IMAGE_BUILD_START_PROTOCOL:
-            sandbox.stdin.write(callback_token + "\n")
-            await sandbox.stdin.drain.aio()
-        elif launch_protocol is None:
-            await sandbox.exec.aio(
-                "python",
-                "-m",
-                "sandbox_runtime.entrypoint",
-                workdir="/workspace",
-                env={
-                    BUILD_ID_ENV: build_id,
-                    CALLBACK_URL_ENV: callback_url,
-                    FAILURE_CALLBACK_URL_ENV: failure_callback_url,
-                    CALLBACK_TOKEN_ENV: callback_token,
-                    PROVIDER_SESSION_ID_ENV: provider_session_id,
-                },
-                stdout=StreamType.DEVNULL,
-                stderr=StreamType.DEVNULL,
-            )
-        else:
+        if launch_protocol != MODAL_IMAGE_BUILD_START_PROTOCOL:
             raise ValueError(f"unsupported image-build launch protocol: {launch_protocol}")
+        sandbox.stdin.write(callback_token + "\n")
+        await sandbox.stdin.drain.aio()
         log.info(
             "sandbox.start_build",
             build_id=build_id,
             modal_object_id=provider_session_id,
-            launch_protocol=launch_protocol or "legacy-exec",
+            launch_protocol=launch_protocol,
         )
 
     async def terminate(

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -607,20 +607,10 @@ async def api_create_build_sandbox(
         )
         clone_host = _optional_string(request, "clone_host")
         clone_username = _optional_string(request, "clone_username")
-        callback_url = _optional_string(request, "callback_url")
-        failure_callback_url = _optional_string(request, "failure_callback_url")
-        if bool(callback_url) != bool(failure_callback_url):
-            raise HTTPException(
-                status_code=400,
-                detail="callback_url and failure_callback_url must be provided together",
-            )
-        if (
-            callback_url
-            and failure_callback_url
-            and (
-                not validate_control_plane_url(callback_url)
-                or not validate_control_plane_url(failure_callback_url)
-            )
+        callback_url = _required_string(request, "callback_url")
+        failure_callback_url = _required_string(request, "failure_callback_url")
+        if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
+            failure_callback_url
         ):
             raise HTTPException(
                 status_code=400, detail="callback URLs must target the control plane"
@@ -687,22 +677,11 @@ async def api_start_build_sandbox(
     try:
         from .sandbox.build_session import ModalBuildSessionService
 
-        callback_url = _required_string(request, "callback_url")
-        failure_callback_url = _required_string(request, "failure_callback_url")
-        if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
-            failure_callback_url
-        ):
-            raise HTTPException(
-                status_code=400, detail="callback URLs must target the control plane"
-            )
-
         build_id = _required_string(request, "build_id")
         provider_session_id = _required_string(request, "provider_session_id")
         await ModalBuildSessionService().start(
             build_id=build_id,
             provider_session_id=provider_session_id,
-            callback_url=callback_url,
-            failure_callback_url=failure_callback_url,
             callback_token=_required_string(request, "callback_token"),
         )
         return {"success": True, "data": {"started": True}}

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -118,44 +118,6 @@ async def test_create_build_sandbox_runs_gated_entrypoint_and_scrubs_callback_en
 
 
 @pytest.mark.asyncio
-async def test_create_build_sandbox_without_callback_context_uses_legacy_placeholder(monkeypatch):
-    sandbox = SimpleNamespace(object_id="modal-session-1")
-    create = _async_method(sandbox)
-    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.create", create)
-
-    await ModalBuildSessionService().create(
-        build_id="build-1",
-        scope_kind="repo",
-        scope_id="acme/repo",
-        repositories=[{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
-    )
-
-    args = create.aio.await_args.args
-    kwargs = create.aio.await_args.kwargs
-    assert args == ("python", "-c", "import signal; signal.pause()")
-    assert "openinspect_launch_protocol" not in kwargs["tags"]
-    assert "OI_REPO_IMAGE_CALLBACK_URL" not in kwargs["env"]
-    assert "OI_REPO_IMAGE_FAILURE_CALLBACK_URL" not in kwargs["env"]
-
-
-@pytest.mark.asyncio
-async def test_create_build_sandbox_rejects_unpaired_callback_urls(monkeypatch):
-    create = _async_method(SimpleNamespace(object_id="modal-session-1"))
-    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.create", create)
-
-    with pytest.raises(ValueError, match="callback URLs must be provided together"):
-        await ModalBuildSessionService().create(
-            build_id="build-1",
-            scope_kind="repo",
-            scope_id="acme/repo",
-            repositories=[{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
-            callback_url="https://cp.test/image-builds/build-complete",
-        )
-
-    create.aio.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_start_build_sandbox_writes_only_callback_token_to_gated_entrypoint(monkeypatch):
     stdin = SimpleNamespace(write=MagicMock(), drain=_async_method())
     sandbox = SimpleNamespace(
@@ -174,8 +136,6 @@ async def test_start_build_sandbox_writes_only_callback_token_to_gated_entrypoin
     await ModalBuildSessionService().start(
         build_id="build-1",
         provider_session_id="modal-session-1",
-        callback_url="https://cp.test/image-builds/build-complete",
-        failure_callback_url="https://cp.test/image-builds/build-failed",
         callback_token="a" * 64,
     )
 
@@ -187,51 +147,19 @@ async def test_start_build_sandbox_writes_only_callback_token_to_gated_entrypoin
 
 
 @pytest.mark.asyncio
-async def test_start_build_sandbox_uses_legacy_exec_for_untagged_sandbox(monkeypatch):
-    sandbox = SimpleNamespace(
-        get_tags=_async_method(
-            {
-                "openinspect_kind": "image-build",
-                "openinspect_build_id": "build-1",
-            }
-        ),
-        exec=_async_method(),
-    )
-    _mock_sandbox_lookup(monkeypatch, sandbox)
-
-    await ModalBuildSessionService().start(
-        build_id="build-1",
-        provider_session_id="modal-session-1",
-        callback_url="https://cp.test/image-builds/build-complete",
-        failure_callback_url="https://cp.test/image-builds/build-failed",
-        callback_token="callback-token",
-    )
-
-    assert sandbox.exec.aio.await_args.args == (
-        "python",
-        "-m",
-        "sandbox_runtime.entrypoint",
-    )
-    assert sandbox.exec.aio.await_args.kwargs["env"] == {
-        "OI_REPO_IMAGE_BUILD_ID": "build-1",
-        "OI_REPO_IMAGE_CALLBACK_URL": "https://cp.test/image-builds/build-complete",
-        "OI_REPO_IMAGE_FAILURE_CALLBACK_URL": "https://cp.test/image-builds/build-failed",
-        "OI_REPO_IMAGE_CALLBACK_TOKEN": "callback-token",
-        "OI_REPO_IMAGE_PROVIDER_SESSION_ID": "modal-session-1",
-    }
-
-
-@pytest.mark.asyncio
-async def test_start_build_sandbox_rejects_unknown_launch_protocol_without_delivery(monkeypatch):
+@pytest.mark.parametrize("launch_protocol", ["stdin-v2", None])
+async def test_start_build_sandbox_rejects_unsupported_launch_protocol_without_delivery(
+    monkeypatch, launch_protocol
+):
     stdin = SimpleNamespace(write=MagicMock(), drain=_async_method())
+    tags = {
+        "openinspect_kind": "image-build",
+        "openinspect_build_id": "build-1",
+    }
+    if launch_protocol is not None:
+        tags["openinspect_launch_protocol"] = launch_protocol
     sandbox = SimpleNamespace(
-        get_tags=_async_method(
-            {
-                "openinspect_kind": "image-build",
-                "openinspect_build_id": "build-1",
-                "openinspect_launch_protocol": "stdin-v2",
-            }
-        ),
+        get_tags=_async_method(tags),
         stdin=stdin,
         exec=_async_method(),
     )
@@ -241,8 +169,6 @@ async def test_start_build_sandbox_rejects_unknown_launch_protocol_without_deliv
         await ModalBuildSessionService().start(
             build_id="build-1",
             provider_session_id="modal-session-1",
-            callback_url="https://cp.test/image-builds/build-complete",
-            failure_callback_url="https://cp.test/image-builds/build-failed",
             callback_token="callback-token",
         )
 
@@ -268,8 +194,6 @@ async def test_start_build_sandbox_refuses_mismatched_tags(monkeypatch):
         await ModalBuildSessionService().start(
             build_id="build-1",
             provider_session_id="modal-session-1",
-            callback_url="https://cp.test/image-builds/build-complete",
-            failure_callback_url="https://cp.test/image-builds/build-failed",
             callback_token="callback-token",
         )
 

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -9,6 +9,10 @@ from src import web_api
 from src.sandbox.build_session import DEFAULT_BUILD_TIMEOUT_SECONDS
 
 REPOSITORIES = [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}]
+CALLBACK_CONTEXT = {
+    "callback_url": "https://cp.test/image-builds/build-complete",
+    "failure_callback_url": "https://cp.test/image-builds/build-failed",
+}
 
 
 def _patch_dependencies(monkeypatch: pytest.MonkeyPatch):
@@ -99,6 +103,7 @@ async def test_create_build_sandbox_adds_finalization_grace_to_default_timeout(m
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
         },
     )
 
@@ -111,7 +116,23 @@ async def test_create_build_sandbox_adds_finalization_grace_to_default_timeout(m
 
 
 @pytest.mark.asyncio
-async def test_create_build_sandbox_rejects_partial_callback_context(monkeypatch):
+@pytest.mark.parametrize(
+    ("payload_callbacks", "missing_field"),
+    [
+        ({}, "callback_url"),
+        (
+            {"callback_url": "https://worker.test/image-builds/build-complete"},
+            "failure_callback_url",
+        ),
+        (
+            {"failure_callback_url": "https://worker.test/image-builds/build-failed"},
+            "callback_url",
+        ),
+    ],
+)
+async def test_create_build_sandbox_rejects_missing_callback_urls(
+    monkeypatch, payload_callbacks, missing_field
+):
     service = _patch_dependencies(monkeypatch)
 
     with pytest.raises(web_api.HTTPException) as exc:
@@ -122,12 +143,12 @@ async def test_create_build_sandbox_rejects_partial_callback_context(monkeypatch
                 "scope_id": "acme/repo",
                 "build_id": "imgb-1",
                 "repositories": REPOSITORIES,
-                "callback_url": "https://worker.test/image-builds/build-complete",
+                **payload_callbacks,
             },
         )
 
     assert exc.value.status_code == 400
-    assert exc.value.detail == "callback_url and failure_callback_url must be provided together"
+    assert exc.value.detail == f"{missing_field} is required"
     service.create.assert_not_awaited()
 
 
@@ -147,6 +168,7 @@ async def test_create_rejects_non_string_clone_fields(monkeypatch, field, value)
         "scope_id": "acme/repo",
         "build_id": "imgb-1",
         "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        **CALLBACK_CONTEXT,
         field: value,
     }
 
@@ -171,6 +193,7 @@ async def test_create_logs_http_outcome(monkeypatch):
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+            **CALLBACK_CONTEXT,
         },
     )
 
@@ -205,6 +228,7 @@ async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
                 "scope_id": "acme/repo",
                 "build_id": "imgb-1",
                 "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+                **CALLBACK_CONTEXT,
                 field: "1800",
             },
         )
@@ -224,6 +248,7 @@ async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+            **CALLBACK_CONTEXT,
             "build_timeout_seconds": 99999,
         },
     )
@@ -254,6 +279,7 @@ async def test_create_rejects_case_insensitive_repository_path_collisions(monkey
                         "branch": "develop",
                     },
                 ],
+                **CALLBACK_CONTEXT,
             },
         )
 
@@ -263,7 +289,7 @@ async def test_create_rejects_case_insensitive_repository_path_collisions(monkey
 
 
 @pytest.mark.asyncio
-async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
+async def test_start_passes_bound_identity_and_callback_token(monkeypatch):
     service = _patch_dependencies(monkeypatch)
 
     result = await _call(
@@ -271,8 +297,6 @@ async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
         {
             "build_id": "imgb-1",
             "provider_session_id": "modal-session-1",
-            "callback_url": "https://cp.test/image-builds/build-complete",
-            "failure_callback_url": "https://cp.test/image-builds/build-failed",
             "callback_token": "callback-token",
         },
     )
@@ -281,16 +305,13 @@ async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
     service.start.assert_awaited_once_with(
         build_id="imgb-1",
         provider_session_id="modal-session-1",
-        callback_url="https://cp.test/image-builds/build-complete",
-        failure_callback_url="https://cp.test/image-builds/build-failed",
         callback_token="callback-token",
     )
 
 
 @pytest.mark.asyncio
-async def test_start_logs_callback_validation_failure(monkeypatch):
+async def test_start_logs_missing_callback_token_validation_failure(monkeypatch):
     service = _patch_dependencies(monkeypatch)
-    monkeypatch.setattr(web_api, "validate_control_plane_url", lambda _url: False)
     info = MagicMock()
     monkeypatch.setattr(web_api.log, "info", info)
 
@@ -300,9 +321,6 @@ async def test_start_logs_callback_validation_failure(monkeypatch):
             {
                 "build_id": "imgb-1",
                 "provider_session_id": "modal-session-1",
-                "callback_url": "https://attacker.test/complete",
-                "failure_callback_url": "https://attacker.test/failed",
-                "callback_token": "callback-token",
             },
         )
 


### PR DESCRIPTION
## Summary

Removes the transitional launch-protocol compatibility left from the Modal image-build cutover (#1178/#1249). The shims existed so builds created by pre-cutover deploys could finish; build sandboxes live ≤70 minutes, so none can still exist, and the false arms were already unreachable from the only caller — the control plane always sends both callback URLs (`ImageBuildPlan.callbackUrl` is a required `string`).

- `api_create_build_sandbox`: `callback_url`/`failure_callback_url` switch from optional-with-pairing-check to required; duplicate pairing `ValueError` in `build_session.create()` deleted
- `build_session.create()`: `gated_launch` flag and the `("python", "-c", "import signal; signal.pause()")` dormant-placeholder command deleted — the gated stdin-token entrypoint is now the only launch path; callback env vars and the `stdin-token-v1` tag are always set
- `build_session.start()`: the legacy-exec branch (env-var token re-injection via `sandbox.exec`, logged as `legacy-exec`) deleted; any sandbox not tagged `stdin-token-v1` (including untagged) now raises the existing unsupported-protocol error — the version gate stays
- Completing the cascade: `start()`'s `callback_url`/`failure_callback_url` parameters fed only the deleted legacy-exec block, so they're removed from `start()`, `api_start_build_sandbox` (which was returning 400 for fields the implementation ignored), and the control-plane start request (`StartImageBuildSandboxRequest`, `StartModalImageBuildConfig`). The create path keeps them — that's where they're real.

Vercel/OpenComputer are unaffected: their env-var token delivery (`CALLBACK_TOKEN_ENV`) lives in `repo_image_callback.py` and is untouched.

## Validation

- modal-infra: 174 tests passed; ruff check + format clean
- control plane: 2,255 unit tests passed; typecheck clean on both tsconfigs; shared build clean; prettier + ESLint clean on changed files
- Test coverage preserved: missing-callback-URL create → 400 (parametrized, each field alone and both), untagged/unknown-protocol start → error with no token delivery (parametrized, adds the untagged case), start-endpoint 400 logging reasserted against the missing-token path
- Independently thermo-reviewed (Opus): one finding (dead `start()` URL params still required by the endpoint), fixed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build sandbox startup now uses a callback token for secure session coordination.
  * Build sandbox creation requires valid callback URLs.
* **Bug Fixes**
  * Removed legacy callback URL handling during sandbox startup.
  * Unsupported launch protocols are now rejected without starting a process.
* **Tests**
  * Expanded validation for missing callback information and unsupported launch protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->