### PR TITLE
refactor: require completion fields at image-build callback boundary

### DIFF
--- a/packages/control-plane/src/image-builds/errors.ts
+++ b/packages/control-plane/src/image-builds/errors.ts
@@ -11,7 +11,6 @@ export type ImageBuildErrorCode =
   | "workflow_unavailable"
   | "provider_unconfigured"
   | "trigger_failed"
-  | "invalid_callback"
   | "callback_auth_rejected"
   | "callback_auth_unavailable"
   | "completion_not_accepted"
@@ -55,10 +54,6 @@ export class ImageBuildTriggerFailedError extends ImageBuildError {
   constructor(message = "Failed to trigger build", cause?: unknown) {
     super(message, cause);
   }
-}
-
-export class ImageBuildInvalidCallbackError extends ImageBuildError {
-  readonly code = "invalid_callback";
 }
 
 export class ImageBuildCallbackAuthRejectedError extends ImageBuildError {

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -16,8 +16,8 @@ export interface ImageBuildFinalizationQueue {
 }
 
 type FinalizationOutcome =
-  | { outcome: "success"; completion: CompleteImageBuildCallback & { providerSessionId: string } }
-  | { outcome: "failure"; failure: FailImageBuildCallback & { providerSessionId: string } };
+  | { outcome: "success"; completion: CompleteImageBuildCallback }
+  | { outcome: "failure"; failure: FailImageBuildCallback };
 
 /**
  * Creates a deterministic command whose hash binds the accepted callback
@@ -34,7 +34,7 @@ export async function createImageBuildFinalizationJob(
           providerSessionId: result.completion.providerSessionId,
           outcome: result.outcome,
           repositoryShas: result.completion.repositoryShas
-            ?.map((repository) => ({
+            .map((repository) => ({
               repoOwner: repository.repoOwner.toLowerCase(),
               repoName: repository.repoName.toLowerCase(),
               baseSha: repository.baseSha,

--- a/packages/control-plane/src/image-builds/provenance.ts
+++ b/packages/control-plane/src/image-builds/provenance.ts
@@ -1,4 +1,5 @@
 import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
+import { z } from "zod";
 
 type RepositoryIdentity = Pick<RepositoryShaEntry, "repoOwner" | "repoName">;
 
@@ -7,27 +8,24 @@ export function repositoryIdentityKey(repository: RepositoryIdentity): string {
   return `${repository.repoOwner.toLowerCase()}/${repository.repoName.toLowerCase()}`;
 }
 
+/**
+ * Canonical schema for one repository provenance entry — the single
+ * cross-language shape produced by the runtime ({repoOwner, repoName,
+ * baseSha}, all non-empty). Callback bodies and persisted rows both validate
+ * against this; unknown keys are dropped by projection.
+ */
+export const repositoryShaEntrySchema = z.object({
+  repoOwner: z.string().min(1),
+  repoName: z.string().min(1),
+  baseSha: z.string().min(1),
+});
+
+const repositoryShasSchema = z.array(repositoryShaEntrySchema);
+
 /** Decode the repository SHA document used by callbacks and persisted build rows. */
 export function decodeRepositoryShas(value: unknown): RepositoryShaEntry[] | null {
-  if (!Array.isArray(value)) return null;
-
-  const repositories: RepositoryShaEntry[] = [];
-  for (const entry of value) {
-    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
-    const { repoOwner, repoName, baseSha } = entry as Record<string, unknown>;
-    if (
-      typeof repoOwner !== "string" ||
-      repoOwner.length === 0 ||
-      typeof repoName !== "string" ||
-      repoName.length === 0 ||
-      typeof baseSha !== "string" ||
-      baseSha.length === 0
-    ) {
-      return null;
-    }
-    repositories.push({ repoOwner, repoName, baseSha });
-  }
-  return repositories;
+  const parsed = repositoryShasSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
 /** Parse and decode a D1 JSON provenance column without leaking exceptions. */

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -65,20 +65,20 @@ export interface ImageBuildStartCallbacks {
 /**
  * Wire form of the build-complete callback after route-level parsing.
  * repository_shas and runtime_version are reported by the build itself —
- * registration fails closed when either is missing or unparseable, because an
- * unversioned image must never pass the floor check.
+ * the route fails closed (400) when either is missing or unparseable, because
+ * an unversioned image must never pass the floor check.
  */
 export interface CompleteImageBuildCallback {
   buildId: string;
-  providerSessionId?: string;
-  repositoryShas?: RepositoryShaEntry[];
-  runtimeVersion?: string;
-  buildDurationMs?: number;
+  providerSessionId: string;
+  repositoryShas: RepositoryShaEntry[];
+  runtimeVersion: string;
+  buildDurationMs: number;
 }
 
 export interface FailImageBuildCallback {
   buildId: string;
-  providerSessionId?: string;
+  providerSessionId: string;
   errorMessage: string;
 }
 

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -5,7 +5,6 @@ import {
   ImageBuildCallbackAuthRejectedError,
   ImageBuildCompletionNotAcceptedError,
   ImageBuildFailureNotAcceptedError,
-  ImageBuildInvalidCallbackError,
   ImageBuildScopeNotFoundError,
   ImageBuildTriggerFailedError,
   ImageBuildWorkflowUnavailableError,
@@ -160,6 +159,7 @@ const ctx = { trace_id: "t", request_id: "r" };
 function validCompletion(overrides: Record<string, unknown> = {}) {
   return {
     buildId: "imgb-env_1-1-abcd",
+    providerSessionId: "vercel-session-1",
     repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v56-managed-provider-runtime",
     buildDurationMs: 12_500,
@@ -644,48 +644,14 @@ describe("ImageBuildWorkflow", () => {
       ).rejects.toBeInstanceOf(ImageBuildCompletionNotAcceptedError);
     });
 
-    it("does not consume the token for an authenticated malformed completion", async () => {
-      const store = sessionBuildStore();
-      const { workflow } = createWorkflow({ store });
-
-      await expect(
-        workflow.acceptBuildComplete({
-          completion: validCompletion({
-            providerSessionId: "vercel-session-1",
-            runtimeVersion: undefined,
-          }),
-          callbackToken: "callback-token",
-          context: ctx,
-        })
-      ).rejects.toBeInstanceOf(ImageBuildInvalidCallbackError);
-
-      expect(store.authorizeCompletionCallback).toHaveBeenCalled();
-    });
-
-    it("requires provider_session_id on provider-session completions", async () => {
-      const { workflow } = createWorkflow({ store: sessionBuildStore() });
-
-      await expect(
-        workflow.acceptBuildComplete({
-          completion: validCompletion(),
-          callbackToken: "callback-token",
-          context: ctx,
-        })
-      ).rejects.toBeInstanceOf(ImageBuildInvalidCallbackError);
-    });
-
-    it("authenticates the token before validating the completion payload", async () => {
+    it("rejects completions whose callback token fails authentication", async () => {
       const store = sessionBuildStore();
       store.authorizeCompletionCallback.mockResolvedValue(null);
       const { workflow } = createWorkflow({ store });
 
-      // Malformed payload (no session id, no runtime version) + bad token:
-      // the caller must see the auth failure, not a validation error.
       await expect(
         workflow.acceptBuildComplete({
-          completion: validCompletion({
-            runtimeVersion: undefined,
-          }),
+          completion: validCompletion(),
           callbackToken: "stale-token",
           context: ctx,
         })
@@ -812,7 +778,7 @@ describe("ImageBuildWorkflow", () => {
       ).rejects.toBeInstanceOf(ImageBuildFailureNotAcceptedError);
     });
 
-    it("authenticates the token before requiring provider_session_id on failures", async () => {
+    it("rejects failures whose callback token fails authentication", async () => {
       const store = sessionBuildStore();
       store.authorizeCompletionCallback.mockResolvedValue(null);
       const { workflow } = createWorkflow({ store });
@@ -821,6 +787,7 @@ describe("ImageBuildWorkflow", () => {
         workflow.acceptBuildFailed({
           failure: {
             buildId: "imgb-env_1-1-abcd",
+            providerSessionId: "vercel-session-1",
             errorMessage: "boom",
           },
           callbackToken: "stale-token",

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -13,7 +13,6 @@ import {
   ImageBuildCallbackAuthUnavailableError,
   ImageBuildCompletionNotAcceptedError,
   ImageBuildFailureNotAcceptedError,
-  ImageBuildInvalidCallbackError,
   ImageBuildPlanningError,
   ImageBuildProviderUnconfiguredError,
   ImageBuildScopeNotFoundError,
@@ -21,7 +20,7 @@ import {
   ImageBuildWorkflowUnavailableError,
 } from "./errors";
 import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
-import { parseRuntimeVersionNumber, type ImageBuildProvider, type ImageBuildScope } from "./model";
+import type { ImageBuildProvider, ImageBuildScope } from "./model";
 import {
   ImageBuildPlanner,
   type PlannedCallbackAuth,
@@ -30,7 +29,6 @@ import {
 import { ImageBuildReaper } from "./reaper";
 import { resolveImageBuildProvider } from "./provider-policy";
 import { createImageBuildAdapterFactory, type ImageBuildAdapterFactory } from "./provider-factory";
-import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
 import type {
   ImageBuildAdapter,
   CompleteImageBuildCallback,
@@ -57,14 +55,6 @@ export interface AcceptBuildFailedCommand {
   failure: FailImageBuildCallback;
   callbackToken?: string | null;
   context: ImageBuildWorkflowContext;
-}
-
-/** Runtime-reported metadata persisted before Queue finalization. */
-interface ValidatedBuildCompletion {
-  buildId: string;
-  repositoryShas: RepositoryShaEntry[];
-  runtimeVersion: string;
-  buildDurationMs: number;
 }
 
 /**
@@ -362,31 +352,26 @@ export class ImageBuildWorkflow {
     command: AcceptBuildCompleteCommand
   ): Promise<ImageBuildWorkflowResult> {
     const { completion, context: ctx } = command;
-    const providerSessionId = completion.providerSessionId ?? "";
     const authenticated = await this.authorizeCompletionCallback(
       completion.buildId,
-      providerSessionId,
+      completion.providerSessionId,
       command.callbackToken,
       ctx
     );
-    const validated = this.validateCompletion(completion);
-    if (!providerSessionId) {
-      throw new ImageBuildInvalidCallbackError("provider_session_id is required");
-    }
     const job = await createImageBuildFinalizationJob({
       outcome: "success",
-      completion: { ...completion, ...validated, providerSessionId },
+      completion,
     });
 
     const acceptance = await this.store.finalization.acceptSuccessfulCompletion({
       buildId: authenticated.build.id,
       provider: authenticated.build.provider,
-      providerSessionId,
+      providerSessionId: completion.providerSessionId,
       tokenHash: authenticated.tokenHash,
       completionHash: job.completionHash,
-      repositoryShas: validated.repositoryShas,
-      runtimeVersion: validated.runtimeVersion,
-      buildDurationMs: validated.buildDurationMs,
+      repositoryShas: completion.repositoryShas,
+      runtimeVersion: completion.runtimeVersion,
+      buildDurationMs: completion.buildDurationMs,
       now: Date.now(),
     });
     if (acceptance === "rejected") {
@@ -397,12 +382,12 @@ export class ImageBuildWorkflow {
     }
 
     logger.info("image_build.build_complete_received", {
-      build_id: validated.buildId,
+      build_id: completion.buildId,
       scope_kind: authenticated.build.scope.kind,
       scope_id: authenticated.build.scope.id,
       provider: authenticated.build.provider,
-      provider_session_id: providerSessionId,
-      runtime_version: validated.runtimeVersion,
+      provider_session_id: completion.providerSessionId,
+      runtime_version: completion.runtimeVersion,
       replayed: acceptance === "replayed",
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
@@ -416,24 +401,20 @@ export class ImageBuildWorkflow {
    */
   async acceptBuildFailed(command: AcceptBuildFailedCommand): Promise<ImageBuildWorkflowResult> {
     const { failure, context: ctx } = command;
-    const providerSessionId = failure.providerSessionId ?? "";
     const authenticated = await this.authorizeCompletionCallback(
       failure.buildId,
-      providerSessionId,
+      failure.providerSessionId,
       command.callbackToken,
       ctx
     );
-    if (!providerSessionId) {
-      throw new ImageBuildInvalidCallbackError("provider_session_id is required");
-    }
     const job = await createImageBuildFinalizationJob({
       outcome: "failure",
-      failure: { ...failure, providerSessionId },
+      failure,
     });
     const acceptance = await this.store.finalization.acceptFailedCompletion({
       buildId: failure.buildId,
       provider: authenticated.build.provider,
-      providerSessionId,
+      providerSessionId: failure.providerSessionId,
       tokenHash: authenticated.tokenHash,
       completionHash: job.completionHash,
       errorMessage: failure.errorMessage,
@@ -450,7 +431,7 @@ export class ImageBuildWorkflow {
       scope_id: authenticated.build.scope.id,
       provider: authenticated.build.provider,
       error_message: failure.errorMessage,
-      provider_session_id: providerSessionId,
+      provider_session_id: failure.providerSessionId,
       replayed: acceptance === "replayed",
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
@@ -464,38 +445,6 @@ export class ImageBuildWorkflow {
     ctx: ImageBuildWorkflowContext
   ): Promise<{ deletedFailed: number; reapedFailed: number; reapedSuperseded: number }> {
     return this.reaper.cleanupImages(failedMaxAgeMs, ctx);
-  }
-
-  private validateCompletion(completion: CompleteImageBuildCallback): ValidatedBuildCompletion {
-    if (!completion.repositoryShas || completion.repositoryShas.length === 0) {
-      throw new ImageBuildInvalidCallbackError("repository_shas is required");
-    }
-    if (
-      typeof completion.runtimeVersion !== "string" ||
-      parseRuntimeVersionNumber(completion.runtimeVersion) === null
-    ) {
-      // Fail closed: an unversioned image must never be registered, or it
-      // could pass spawn selection's floor check.
-      throw new ImageBuildInvalidCallbackError(
-        "runtime_version is required and must start with v<number>"
-      );
-    }
-    if (
-      typeof completion.buildDurationMs !== "number" ||
-      !Number.isFinite(completion.buildDurationMs) ||
-      completion.buildDurationMs < 0
-    ) {
-      throw new ImageBuildInvalidCallbackError(
-        "build_duration_seconds must be a non-negative finite number"
-      );
-    }
-
-    return {
-      buildId: completion.buildId,
-      repositoryShas: completion.repositoryShas,
-      runtimeVersion: completion.runtimeVersion,
-      buildDurationMs: completion.buildDurationMs,
-    };
   }
 
   private async authorizeCompletionCallback(

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -21,6 +21,7 @@ import {
   type ImageBuildScope,
 } from "../image-builds/model";
 import { getImageBuildsUnsupportedMessage } from "../image-builds/provider-policy";
+import { repositoryShaEntrySchema } from "../image-builds/provenance";
 import { scheduleImageBuildOnSave } from "../image-builds/save-hooks";
 import {
   listEnabledScopes,
@@ -50,12 +51,6 @@ const logger = createLogger("router:image-builds");
 const MS_PER_SECOND = 1000;
 const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
 
-const repositoryShaEntrySchema = z.object({
-  repoOwner: z.string().min(1),
-  repoName: z.string().min(1),
-  baseSha: z.string().min(1),
-});
-
 /**
  * Build-complete callback body. Every field is required: all providers bind a
  * provider session before the runtime launches, and the runtime always
@@ -69,7 +64,15 @@ const buildCompleteBodySchema = z.object({
   runtime_version: z.string().refine((value) => parseRuntimeVersionNumber(value) !== null, {
     message: "must start with v<number>",
   }),
-  build_duration_seconds: z.number().nonnegative(),
+  // The converted milliseconds must stay finite: Infinity would be
+  // canonicalized to null by JSON.stringify inside the completion hash and
+  // the persisted row.
+  build_duration_seconds: z
+    .number()
+    .nonnegative()
+    .refine((value) => Number.isFinite(value * MS_PER_SECOND), {
+      message: "must convert to finite milliseconds",
+    }),
 });
 
 const buildFailedBodySchema = z.object({

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -8,18 +8,19 @@
  * - Enabled-scope and status queries
  */
 
-import type {
-  ImageBuildRecordView,
-  RepositoryShaEntry,
-} from "@open-inspect/shared/types/image-builds";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
+import { z } from "zod";
 import { ImageBuildStore } from "../db/image-builds";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import { createLogger } from "../logger";
 import { getImageBuildCallbackBearerToken } from "../image-builds/callback-auth";
 import { ImageBuildError } from "../image-builds/errors";
-import { repoImageBuildScope, type ImageBuildScope } from "../image-builds/model";
+import {
+  parseRuntimeVersionNumber,
+  repoImageBuildScope,
+  type ImageBuildScope,
+} from "../image-builds/model";
 import { getImageBuildsUnsupportedMessage } from "../image-builds/provider-policy";
-import { decodeRepositoryShas } from "../image-builds/provenance";
 import { scheduleImageBuildOnSave } from "../image-builds/save-hooks";
 import {
   listEnabledScopes,
@@ -49,19 +50,36 @@ const logger = createLogger("router:image-builds");
 const MS_PER_SECOND = 1000;
 const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
 
-interface ImageBuildCompleteBody {
-  build_id?: unknown;
-  provider_session_id?: unknown;
-  repository_shas?: unknown;
-  runtime_version?: unknown;
-  build_duration_seconds?: unknown;
-}
+const repositoryShaEntrySchema = z.object({
+  repoOwner: z.string().min(1),
+  repoName: z.string().min(1),
+  baseSha: z.string().min(1),
+});
 
-interface ImageBuildFailedBody {
-  build_id?: unknown;
-  provider_session_id?: unknown;
-  error?: unknown;
-}
+/**
+ * Build-complete callback body. Every field is required: all providers bind a
+ * provider session before the runtime launches, and the runtime always
+ * reports repository_shas and runtime_version — an unversioned image must
+ * never be registered, or it could pass spawn selection's floor check.
+ */
+const buildCompleteBodySchema = z.object({
+  build_id: z.string().min(1),
+  provider_session_id: z.string().min(1),
+  repository_shas: z.array(repositoryShaEntrySchema).min(1),
+  runtime_version: z.string().refine((value) => parseRuntimeVersionNumber(value) !== null, {
+    message: "must start with v<number>",
+  }),
+  build_duration_seconds: z.number().nonnegative(),
+});
+
+const buildFailedBodySchema = z.object({
+  build_id: z.string().min(1),
+  provider_session_id: z.string().min(1),
+  // Deliberately tolerant: a malformed error report must never 400 the one
+  // callback that moves a wedged build out of `building` — anything that is
+  // not a non-empty string falls back to "Unknown error" at the handler.
+  error: z.unknown().optional(),
+});
 
 function requireImageBuilds(env: Env): Response | null {
   const message = getImageBuildsUnsupportedMessage(env);
@@ -94,8 +112,6 @@ function imageBuildErrorToResponse(errorValue: unknown): Response {
   switch (errorValue.code) {
     case "scope_not_found":
       return error(errorValue.message, 404);
-    case "invalid_callback":
-      return error(errorValue.message, 400);
     case "callback_auth_rejected":
       return error(errorValue.message, 401);
     case "completion_not_accepted":
@@ -115,7 +131,12 @@ function imageBuildErrorToResponse(errorValue: unknown): Response {
   }
 }
 
-async function parseCallbackBody<T>(request: Request): Promise<T | Response> {
+/**
+ * Read and JSON-parse a size-bounded callback body. Schema validation is the
+ * caller's — this only guards transport-level failure modes (oversized or
+ * non-JSON payloads).
+ */
+async function readCallbackBody(request: Request): Promise<{ body: unknown } | Response> {
   const contentLength = Number.parseInt(request.headers.get("content-length") ?? "", 10);
   if (Number.isFinite(contentLength) && contentLength > MAX_CALLBACK_BODY_BYTES) {
     return error("Payload too large", 413);
@@ -134,80 +155,26 @@ async function parseCallbackBody<T>(request: Request): Promise<T | Response> {
   }
 
   try {
-    const parsed: unknown = JSON.parse(bodyText);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return error("Invalid JSON body", 400);
-    }
-    return parsed as T;
+    return { body: JSON.parse(bodyText) };
   } catch {
     return error("Invalid JSON body", 400);
   }
 }
 
-function requireStringField(value: unknown, field: string): string | Response {
-  return typeof value === "string" && value.length > 0 ? value : error(`${field} is required`, 400);
-}
-
-function optionalStringField(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.length > 0 ? value : fallback;
-}
-
 /**
- * Parse the repository_shas document ([{repoOwner, repoName, baseSha}], the
- * single cross-language shape produced by the runtime). Malformed entries are
- * a 400 — deeper requirements (non-empty) are the workflow's fail-close.
+ * Parse a callback body against its schema. Missing or invalid fields are a
+ * 400 before auth — field presence leaks nothing about any build row.
  */
-function parseRepositoryShas(value: unknown): RepositoryShaEntry[] | undefined | Response {
-  if (value === undefined) return undefined;
-  if (!Array.isArray(value)) return error("repository_shas must be an array", 400);
-  return (
-    decodeRepositoryShas(value) ??
-    error("repository_shas entries require repoOwner, repoName, and baseSha", 400)
-  );
-}
+function parseCallbackBody<Schema extends z.ZodType>(
+  schema: Schema,
+  body: unknown
+): z.infer<Schema> | Response {
+  const parsed = schema.safeParse(body);
+  if (parsed.success) return parsed.data;
 
-function buildCompleteCommand(body: ImageBuildCompleteBody): CompleteImageBuildCallback | Response {
-  const buildId = requireStringField(body.build_id, "build_id");
-  if (buildId instanceof Response) return buildId;
-
-  let buildDurationMs: number | undefined;
-  if (body.build_duration_seconds !== undefined) {
-    if (typeof body.build_duration_seconds !== "number") {
-      return error("build_duration_seconds must be a number", 400);
-    }
-    buildDurationMs = body.build_duration_seconds * MS_PER_SECOND;
-  }
-
-  const repositoryShas = parseRepositoryShas(body.repository_shas);
-  if (repositoryShas instanceof Response) return repositoryShas;
-
-  return {
-    buildId,
-    providerSessionId:
-      typeof body.provider_session_id === "string" && body.provider_session_id.length > 0
-        ? body.provider_session_id
-        : undefined,
-    repositoryShas,
-    runtimeVersion:
-      typeof body.runtime_version === "string" && body.runtime_version.length > 0
-        ? body.runtime_version
-        : undefined,
-    buildDurationMs,
-  };
-}
-
-function buildFailedCommand(body: ImageBuildFailedBody): FailImageBuildCallback | Response {
-  const buildId = requireStringField(body.build_id, "build_id");
-  if (buildId instanceof Response) return buildId;
-
-  return {
-    buildId,
-    providerSessionId:
-      typeof body.provider_session_id === "string" && body.provider_session_id.length > 0
-        ? body.provider_session_id
-        : undefined,
-    errorMessage: optionalStringField(body.error, "Unknown error"),
-  };
+  const issue = parsed.error.issues[0];
+  const path = issue.path.join(".");
+  return error(path ? `${path}: ${issue.message}` : issue.message, 400);
 }
 
 /**
@@ -220,11 +187,19 @@ async function handleBuildComplete(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parseCallbackBody<ImageBuildCompleteBody>(request);
+  const body = await readCallbackBody(request);
   if (body instanceof Response) return body;
 
-  const completion = buildCompleteCommand(body);
-  if (completion instanceof Response) return completion;
+  const parsed = parseCallbackBody(buildCompleteBodySchema, body.body);
+  if (parsed instanceof Response) return parsed;
+
+  const completion: CompleteImageBuildCallback = {
+    buildId: parsed.build_id,
+    providerSessionId: parsed.provider_session_id,
+    repositoryShas: parsed.repository_shas,
+    runtimeVersion: parsed.runtime_version,
+    buildDurationMs: parsed.build_duration_seconds * MS_PER_SECOND,
+  };
 
   try {
     const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildComplete({
@@ -248,11 +223,18 @@ async function handleBuildFailed(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parseCallbackBody<ImageBuildFailedBody>(request);
+  const body = await readCallbackBody(request);
   if (body instanceof Response) return body;
 
-  const failure = buildFailedCommand(body);
-  if (failure instanceof Response) return failure;
+  const parsed = parseCallbackBody(buildFailedBodySchema, body.body);
+  if (parsed instanceof Response) return parsed;
+
+  const failure: FailImageBuildCallback = {
+    buildId: parsed.build_id,
+    providerSessionId: parsed.provider_session_id,
+    errorMessage:
+      typeof parsed.error === "string" && parsed.error.length > 0 ? parsed.error : "Unknown error",
+  };
 
   try {
     const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildFailed({

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -843,13 +843,17 @@ describe("Image builds", () => {
     });
 
     it.each([
+      ["missing provider_session_id", { provider_session_id: undefined }],
       ["missing runtime_version", { runtime_version: undefined }],
       ["unparseable runtime_version", { runtime_version: "53-no-prefix" }],
       ["missing repository_shas", { repository_shas: undefined }],
+      ["empty repository_shas", { repository_shas: [] }],
       [
         "repository_shas entry without baseSha",
         { repository_shas: [{ repoOwner: "a", repoName: "b" }] },
       ],
+      ["missing build_duration_seconds", { build_duration_seconds: undefined }],
+      ["negative build_duration_seconds", { build_duration_seconds: -1 }],
     ])("fails registration closed on %s", async (_label, overrides) => {
       const environmentId = await seedEnvironment();
       await registerBuild(environmentId, "cb-invalid");
@@ -869,6 +873,40 @@ describe("Image builds", () => {
 
       expect(response.status).toBe(400);
       expect((await getRow("cb-invalid"))?.status).toBe("building");
+    });
+
+    it("rejects a malformed callback body before authentication", async () => {
+      // No token at all: field presence is checked first (400, not 401) —
+      // required-ness lives at the route boundary and leaks nothing.
+      const response = await SELF.fetch(`${BASE}/image-builds/build-complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          build_id: "cb-preauth",
+          repository_shas: REPOSITORY_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 1,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects a build-failed callback without provider_session_id", async () => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-failed-no-session");
+
+      const response = await SELF.fetch(`${BASE}/image-builds/build-failed`, {
+        method: "POST",
+        headers: tokenHeaders(MODAL_BUILD_TOKEN),
+        body: JSON.stringify({
+          build_id: "cb-failed-no-session",
+          error: "setup.failed: boom",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect((await getRow("cb-failed-no-session"))?.status).toBe("building");
     });
 
     it("POST /image-builds/build-failed marks the build failed", async () => {

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -854,6 +854,9 @@ describe("Image builds", () => {
       ],
       ["missing build_duration_seconds", { build_duration_seconds: undefined }],
       ["negative build_duration_seconds", { build_duration_seconds: -1 }],
+      // Finite seconds whose ×1000 conversion overflows to Infinity, which
+      // JSON.stringify would canonicalize to null downstream.
+      ["overflowing build_duration_seconds", { build_duration_seconds: 1e308 }],
     ])("fails registration closed on %s", async (_label, overrides) => {
       const environmentId = await seedEnvironment();
       await registerBuild(environmentId, "cb-invalid");

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -70,7 +70,6 @@ class RepositoryBootResult:
     """State produced by repository synchronization and hook execution."""
 
     git_sync_success: bool
-    head_sha: str
     repository_shas: list[dict[str, str]]
     setup_success: bool | None
     start_success: bool | None
@@ -1984,7 +1983,6 @@ class SandboxSupervisor:
         self._write_workspace_manifest()
         return RepositoryBootResult(
             git_sync_success=git_sync_success,
-            head_sha=head_sha,
             repository_shas=repository_shas,
             setup_success=setup_success,
             start_success=start_success,
@@ -2087,7 +2085,6 @@ class SandboxSupervisor:
                 if repo_image_callback:
                     reported = await self._run_until_shutdown(
                         repo_image_callback.report_success(
-                            base_sha=boot_result.head_sha,
                             build_duration_seconds=time.time() - startup_start,
                             repository_shas=boot_result.repository_shas,
                             runtime_version=runtime_version,

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
@@ -24,6 +24,16 @@ CALLBACK_TOKEN_ENV = "OI_REPO_IMAGE_CALLBACK_TOKEN"
 PROVIDER_SESSION_ID_ENV = "OI_REPO_IMAGE_PROVIDER_SESSION_ID"
 
 
+class RepoImageCallbackMisconfigured(Exception):
+    """Some but not all build-callback environment variables are set.
+
+    Raised instead of returning None so a build-mode sandbox aborts with a
+    nonzero exit rather than running the build with completion reporting
+    silently disabled (which would leave the control-plane row wedged in
+    `building` until the provider-side timeout reaper fires).
+    """
+
+
 @dataclass(frozen=True)
 class RepoImageBuildCallback:
     """Authenticated callback reporter for image build mode."""
@@ -39,31 +49,37 @@ class RepoImageBuildCallback:
 
     @classmethod
     def from_env(cls, logger: StructuredLogger | None = None) -> RepoImageBuildCallback | None:
-        """Create a callback reporter from build-mode environment variables."""
+        """Create a callback reporter from build-mode environment variables.
+
+        Returns None when no callback variable is set at all (not an
+        image-build callback context). Raises RepoImageCallbackMisconfigured
+        when only some are set: the control plane rejects callbacks missing
+        any field, so a partially configured build must abort at boot instead
+        of running with reporting silently disabled.
+        """
         build_id = os.environ.get(BUILD_ID_ENV, "")
         callback_url = os.environ.get(CALLBACK_URL_ENV, "")
         failure_callback_url = os.environ.get(FAILURE_CALLBACK_URL_ENV, "")
         token = os.environ.get(CALLBACK_TOKEN_ENV, "")
         provider_session_id = os.environ.get(PROVIDER_SESSION_ID_ENV, "")
 
-        if not build_id and not callback_url and not token:
+        values = (
+            (BUILD_ID_ENV, build_id),
+            (CALLBACK_URL_ENV, callback_url),
+            (FAILURE_CALLBACK_URL_ENV, failure_callback_url),
+            (CALLBACK_TOKEN_ENV, token),
+            (PROVIDER_SESSION_ID_ENV, provider_session_id),
+        )
+        if not any(value for _name, value in values):
             return None
 
         log = logger or get_logger("repo_image_callback")
-        missing = [
-            name
-            for name, value in (
-                (BUILD_ID_ENV, build_id),
-                (CALLBACK_URL_ENV, callback_url),
-                (FAILURE_CALLBACK_URL_ENV, failure_callback_url),
-                (CALLBACK_TOKEN_ENV, token),
-                (PROVIDER_SESSION_ID_ENV, provider_session_id),
-            )
-            if not value
-        ]
+        missing = [name for name, value in values if not value]
         if missing:
             log.error("repo_image.callback_misconfigured", missing=missing)
-            return None
+            raise RepoImageCallbackMisconfigured(
+                f"partial build-callback configuration; missing: {', '.join(missing)}"
+            )
 
         return cls(
             build_id=build_id,

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
@@ -44,6 +44,7 @@ class RepoImageBuildCallback:
         callback_url = os.environ.get(CALLBACK_URL_ENV, "")
         failure_callback_url = os.environ.get(FAILURE_CALLBACK_URL_ENV, "")
         token = os.environ.get(CALLBACK_TOKEN_ENV, "")
+        provider_session_id = os.environ.get(PROVIDER_SESSION_ID_ENV, "")
 
         if not build_id and not callback_url and not token:
             return None
@@ -56,6 +57,7 @@ class RepoImageBuildCallback:
                 (CALLBACK_URL_ENV, callback_url),
                 (FAILURE_CALLBACK_URL_ENV, failure_callback_url),
                 (CALLBACK_TOKEN_ENV, token),
+                (PROVIDER_SESSION_ID_ENV, provider_session_id),
             )
             if not value
         ]
@@ -68,36 +70,31 @@ class RepoImageBuildCallback:
             callback_url=callback_url,
             failure_callback_url=failure_callback_url,
             token=token,
-            provider_session_id=os.environ.get(PROVIDER_SESSION_ID_ENV, ""),
+            provider_session_id=provider_session_id,
             logger=log,
         )
 
     async def report_success(
         self,
         *,
-        base_sha: str,
         build_duration_seconds: float,
-        repository_shas: list[dict[str, str]] | None = None,
-        runtime_version: str = "",
+        repository_shas: list[dict[str, str]],
+        runtime_version: str,
     ) -> bool:
         """Report a successful image build.
 
-        repository_shas ([{repoOwner, repoName, baseSha}]) and runtime_version are
-        required by environment-image registration (design §7.3) and ignored
-        by the repo-image callback route.
+        repository_shas ([{repoOwner, repoName, baseSha}]) and runtime_version
+        are required by image registration (design §7.3) — the control plane
+        rejects a completion missing either. provider_session_id is always
+        sent: every provider sets it unconditionally at spawn.
         """
         payload: dict[str, Any] = {
             "build_id": self.build_id,
-            "base_sha": base_sha,
             "build_duration_seconds": round(build_duration_seconds, 3),
+            "repository_shas": repository_shas,
+            "runtime_version": runtime_version,
+            "provider_session_id": self.provider_session_id,
         }
-        if repository_shas:
-            payload["repository_shas"] = repository_shas
-        if runtime_version:
-            payload["runtime_version"] = runtime_version
-        if self.provider_session_id:
-            payload["provider_session_id"] = self.provider_session_id
-
         return await self._post_with_retry(self.callback_url, payload)
 
     async def report_failure(self, error: str) -> bool:
@@ -105,9 +102,8 @@ class RepoImageBuildCallback:
         payload = {
             "build_id": self.build_id,
             "error": error[-ERROR_MESSAGE_MAX_CHARS:],
+            "provider_session_id": self.provider_session_id,
         }
-        if self.provider_session_id:
-            payload["provider_session_id"] = self.provider_session_id
         return await self._post_with_retry(self.failure_callback_url, payload)
 
     async def _post_with_retry(self, url: str, payload: dict[str, Any]) -> bool:

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
@@ -70,7 +70,11 @@ class RepoImageBuildCallback:
             (CALLBACK_TOKEN_ENV, token),
             (PROVIDER_SESSION_ID_ENV, provider_session_id),
         )
-        if not any(value for _name, value in values):
+        # Configuration is detected by variable PRESENCE, not truthiness: a
+        # present-but-empty variable is a misconfigured build context, and the
+        # empty-value check below must reject it rather than silently
+        # disabling completion reporting.
+        if not any(name in os.environ for name, _value in values):
             return None
 
         log = logger or get_logger("repo_image_callback")

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -396,6 +396,43 @@ class TestImageBuildMode:
         callback.report_failure.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_partial_callback_configuration_aborts_build(self, build_env, monkeypatch):
+        """Partial callback env aborts the build instead of silently disabling reporting."""
+        from sandbox_runtime.repo_image_callback import (
+            BUILD_ID_ENV,
+            CALLBACK_TOKEN_ENV,
+            CALLBACK_URL_ENV,
+            FAILURE_CALLBACK_URL_ENV,
+            PROVIDER_SESSION_ID_ENV,
+            RepoImageCallbackMisconfigured,
+        )
+
+        supervisor = _make_supervisor(build_env)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
+        supervisor.run_setup_script = AsyncMock(return_value=True)
+        supervisor.shutdown = AsyncMock()
+
+        partial_env = {
+            **build_env,
+            BUILD_ID_ENV: "build-1",
+            CALLBACK_URL_ENV: "https://cp.test/image-builds/build-complete",
+            FAILURE_CALLBACK_URL_ENV: "https://cp.test/image-builds/build-failed",
+            CALLBACK_TOKEN_ENV: "callback-token",
+        }
+        monkeypatch.delenv(PROVIDER_SESSION_ID_ENV, raising=False)
+
+        # The raise propagates out of run() (a nonzero exit for the build
+        # process) — a completed build must never sit waiting on a shutdown
+        # signal with no way to report completion.
+        with (
+            patch.dict(os.environ, partial_env, clear=False),
+            pytest.raises(RepoImageCallbackMisconfigured),
+        ):
+            await supervisor.run()
+
+        supervisor.sync_repositories.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reports_failure_callback_from_build_mode(self, build_env):
         """Build mode should report failures itself when callback metadata is configured."""
         supervisor = _make_supervisor(build_env)

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -368,7 +368,6 @@ class TestImageBuildMode:
             await supervisor.run()
 
         callback.report_success.assert_awaited_once_with(
-            base_sha="abc123def456",
             build_duration_seconds=ANY,
             repository_shas=[
                 {"repoOwner": "acme", "repoName": "my-repo", "baseSha": "abc123def456"}

--- a/packages/sandbox-runtime/tests/test_modal_image_build_start.py
+++ b/packages/sandbox-runtime/tests/test_modal_image_build_start.py
@@ -164,7 +164,7 @@ async def test_modal_entrypoint_runs_supervisor_with_memory_only_callback_token(
     async def finish_build(supervisor, _expected_tunnel_ports):
         observed_supervisor["value"] = supervisor
         observed_hook_env.update(supervisor._hook_env())
-        return entrypoint.RepositoryBootResult(True, "abc123", [], True, None)
+        return entrypoint.RepositoryBootResult(True, [], True, None)
 
     monkeypatch.setattr(entrypoint.SandboxSupervisor, "_run_image_build_execution", finish_build)
 

--- a/packages/sandbox-runtime/tests/test_repo_image_callback.py
+++ b/packages/sandbox-runtime/tests/test_repo_image_callback.py
@@ -26,6 +26,17 @@ def test_from_env_returns_none_when_unconfigured(monkeypatch):
     assert RepoImageBuildCallback.from_env() is None
 
 
+def test_from_env_rejects_present_but_empty_configuration(monkeypatch):
+    monkeypatch.setenv(CALLBACK_URL_ENV, "")
+    monkeypatch.delenv(BUILD_ID_ENV, raising=False)
+    monkeypatch.delenv(FAILURE_CALLBACK_URL_ENV, raising=False)
+    monkeypatch.delenv(CALLBACK_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(PROVIDER_SESSION_ID_ENV, raising=False)
+
+    with pytest.raises(RepoImageCallbackMisconfigured):
+        RepoImageBuildCallback.from_env()
+
+
 def test_from_env_rejects_partial_configuration(monkeypatch):
     logger = MagicMock()
     monkeypatch.setenv(BUILD_ID_ENV, "build-1")

--- a/packages/sandbox-runtime/tests/test_repo_image_callback.py
+++ b/packages/sandbox-runtime/tests/test_repo_image_callback.py
@@ -10,6 +10,7 @@ from sandbox_runtime.repo_image_callback import (
     CALLBACK_URL_ENV,
     CALLBACK_USER_AGENT,
     FAILURE_CALLBACK_URL_ENV,
+    PROVIDER_SESSION_ID_ENV,
     RepoImageBuildCallback,
 )
 
@@ -19,6 +20,7 @@ def test_from_env_returns_none_when_unconfigured(monkeypatch):
     monkeypatch.delenv(CALLBACK_URL_ENV, raising=False)
     monkeypatch.delenv(FAILURE_CALLBACK_URL_ENV, raising=False)
     monkeypatch.delenv(CALLBACK_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(PROVIDER_SESSION_ID_ENV, raising=False)
 
     assert RepoImageBuildCallback.from_env() is None
 
@@ -29,6 +31,7 @@ def test_from_env_rejects_partial_configuration(monkeypatch):
     monkeypatch.delenv(CALLBACK_URL_ENV, raising=False)
     monkeypatch.setenv(FAILURE_CALLBACK_URL_ENV, "https://cp.test/repo-images/build-failed")
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
+    monkeypatch.setenv(PROVIDER_SESSION_ID_ENV, "vercel-session-1")
 
     assert RepoImageBuildCallback.from_env(logger) is None
     logger.error.assert_called_once()
@@ -40,6 +43,22 @@ def test_from_env_rejects_missing_failure_callback_url(monkeypatch):
     monkeypatch.setenv(CALLBACK_URL_ENV, "https://cp.test/repo-images/build-complete")
     monkeypatch.delenv(FAILURE_CALLBACK_URL_ENV, raising=False)
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
+    monkeypatch.setenv(PROVIDER_SESSION_ID_ENV, "vercel-session-1")
+
+    assert RepoImageBuildCallback.from_env(logger) is None
+    logger.error.assert_called_once()
+
+
+def test_from_env_rejects_missing_provider_session_id(monkeypatch):
+    # Every provider sets the session id unconditionally at spawn; the control
+    # plane rejects callbacks without it, so fail fast at boot instead of
+    # 400-and-retrying silently.
+    logger = MagicMock()
+    monkeypatch.setenv(BUILD_ID_ENV, "build-1")
+    monkeypatch.setenv(CALLBACK_URL_ENV, "https://cp.test/repo-images/build-complete")
+    monkeypatch.setenv(FAILURE_CALLBACK_URL_ENV, "https://cp.test/repo-images/build-failed")
+    monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
+    monkeypatch.delenv(PROVIDER_SESSION_ID_ENV, raising=False)
 
     assert RepoImageBuildCallback.from_env(logger) is None
     logger.error.assert_called_once()
@@ -50,11 +69,13 @@ def test_from_env_reads_both_callback_urls(monkeypatch):
     monkeypatch.setenv(CALLBACK_URL_ENV, "https://cp.test/repo-images/build-complete")
     monkeypatch.setenv(FAILURE_CALLBACK_URL_ENV, "https://cp.test/repo-images/build-failed")
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
+    monkeypatch.setenv(PROVIDER_SESSION_ID_ENV, "vercel-session-1")
 
     reporter = RepoImageBuildCallback.from_env()
     assert reporter is not None
     assert reporter.callback_url == "https://cp.test/repo-images/build-complete"
     assert reporter.failure_callback_url == "https://cp.test/repo-images/build-failed"
+    assert reporter.provider_session_id == "vercel-session-1"
 
 
 @pytest.mark.asyncio
@@ -76,7 +97,11 @@ async def test_report_success_posts_authenticated_payload(monkeypatch):
         logger=MagicMock(),
     )
 
-    assert await reporter.report_success(base_sha="abc123", build_duration_seconds=12.3456)
+    assert await reporter.report_success(
+        build_duration_seconds=12.3456,
+        repository_shas=[{"repoOwner": "acme", "repoName": "web", "baseSha": "abc123"}],
+        runtime_version="v99-test",
+    )
 
     assert len(requests) == 1
     request = requests[0]
@@ -86,8 +111,9 @@ async def test_report_success_posts_authenticated_payload(monkeypatch):
     assert request.headers["content-type"] == "application/json"
     assert json.loads(request.content) == {
         "build_id": "build-1",
-        "base_sha": "abc123",
         "build_duration_seconds": 12.346,
+        "repository_shas": [{"repoOwner": "acme", "repoName": "web", "baseSha": "abc123"}],
+        "runtime_version": "v99-test",
         "provider_session_id": "vercel-session-1",
     }
 
@@ -141,7 +167,11 @@ async def test_retries_transient_callback_failures(monkeypatch):
         logger=MagicMock(),
     )
 
-    assert await reporter.report_success(base_sha="", build_duration_seconds=1.0)
+    assert await reporter.report_success(
+        build_duration_seconds=1.0,
+        repository_shas=[{"repoOwner": "acme", "repoName": "web", "baseSha": "abc123"}],
+        runtime_version="v99-test",
+    )
     assert len(requests) == 2
     sleep.assert_awaited_once_with(2)
 

--- a/packages/sandbox-runtime/tests/test_repo_image_callback.py
+++ b/packages/sandbox-runtime/tests/test_repo_image_callback.py
@@ -12,6 +12,7 @@ from sandbox_runtime.repo_image_callback import (
     FAILURE_CALLBACK_URL_ENV,
     PROVIDER_SESSION_ID_ENV,
     RepoImageBuildCallback,
+    RepoImageCallbackMisconfigured,
 )
 
 
@@ -33,7 +34,8 @@ def test_from_env_rejects_partial_configuration(monkeypatch):
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
     monkeypatch.setenv(PROVIDER_SESSION_ID_ENV, "vercel-session-1")
 
-    assert RepoImageBuildCallback.from_env(logger) is None
+    with pytest.raises(RepoImageCallbackMisconfigured):
+        RepoImageBuildCallback.from_env(logger)
     logger.error.assert_called_once()
 
 
@@ -45,7 +47,8 @@ def test_from_env_rejects_missing_failure_callback_url(monkeypatch):
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
     monkeypatch.setenv(PROVIDER_SESSION_ID_ENV, "vercel-session-1")
 
-    assert RepoImageBuildCallback.from_env(logger) is None
+    with pytest.raises(RepoImageCallbackMisconfigured):
+        RepoImageBuildCallback.from_env(logger)
     logger.error.assert_called_once()
 
 
@@ -60,7 +63,9 @@ def test_from_env_rejects_missing_provider_session_id(monkeypatch):
     monkeypatch.setenv(CALLBACK_TOKEN_ENV, "callback-token")
     monkeypatch.delenv(PROVIDER_SESSION_ID_ENV, raising=False)
 
-    assert RepoImageBuildCallback.from_env(logger) is None
+    with pytest.raises(RepoImageCallbackMisconfigured) as excinfo:
+        RepoImageBuildCallback.from_env(logger)
+    assert PROVIDER_SESSION_ID_ENV in str(excinfo.value)
     logger.error.assert_called_once()
 
 
@@ -164,6 +169,7 @@ async def test_retries_transient_callback_failures(monkeypatch):
         callback_url="https://cp.test/repo-images/build-complete",
         failure_callback_url="https://cp.test/repo-images/build-failed",
         token="callback-token",
+        provider_session_id="vercel-session-1",
         logger=MagicMock(),
     )
 


### PR DESCRIPTION
## Summary

Removes the optional-then-required callback-contract fossil left by the staged image-build cutover (#1178/#1246). Every provider now always binds a provider session and the sandbox runtime always sends the completion fields, but the wire types still marked them optional and required-ness was re-imposed at runtime in two later layers.

- `CompleteImageBuildCallback`: `providerSessionId`, `repositoryShas`, `runtimeVersion`, `buildDurationMs` now required; `providerSessionId` required on `FailImageBuildCallback`
- Route parsing: the hand-rolled `parseCallbackBody`/`requireStringField`/`parseRepositoryShas` stack is replaced by two zod schemas (house style per `finalization-job.ts`). Semantic checks from `validateCompletion` moved into the schemas: nonempty `repository_shas` with per-entry nonempty strings, `runtime_version` refined via `parseRuntimeVersionNumber`, non-negative duration. The 16KB size guard and 413/400 paths are unchanged. The failure `error` field keeps its old tolerance (`z.unknown()` + coerce-to-"Unknown error") — never 400 the callback that un-wedges a `building` row
- Workflow: deleted `validateCompletion`, both post-auth `provider_session_id is required` throws, and the `?? ""` coercions; with the last throw sites gone, the entire `invalid_callback` error lane (`ImageBuildInvalidCallbackError`, the union member, the 400 mapping arm) is deleted too
- Sandbox runtime: `report_success` drops `base_sha` (no CP route reads it; `RepositoryBootResult.head_sha` became write-only and is dropped as well); `provider_session_id` sent unconditionally on success and failure; `from_env` now fails fast at boot if `OI_REPO_IMAGE_PROVIDER_SESSION_ID` is missing instead of posting an empty value into a 400+retry loop; stale docstring referencing the removed repo-image callback route rewritten

**Deliberate ordering change:** malformed bodies now 400 *before* auth (previously auth-then-validate was pinned by a unit test). The schema is static, so the response leaks nothing per-build, and it is strictly safer for token consumption — a malformed body never reaches `authorizeCompletionCallback`. The new order is pinned by an integration test (400-not-401 with no token), and the 401 tests all use fully-valid payloads so auth coverage is preserved.

`completionHash` inputs are unchanged (verified identical object shape), so no replay-hash drift for in-flight builds. All providers set the session-id env var unconditionally at spawn (Vercel `buildImageCallbackEnv`, OpenComputer `startRuntime`, Modal via `MODAL_SANDBOX_ID` which hard-fails launch when missing).

Net: 12 files, +190/−237.

## Validation

- control plane: 2,253 unit + 704 integration tests passed; typecheck clean on both tsconfigs; shared build clean
- sandbox-runtime: 709 tests passed (adds the missing-env fail-fast test)
- prettier + ESLint clean on changed TS; ruff check + format clean on changed Python
- Independently thermo-reviewed (Opus): four findings (orphaned `invalid_callback` lane, write-only `head_sha`, docstring-vs-code fail-fast gap, incidental `error`-field tightening) — all fixed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image build callbacks now require provider session IDs and complete metadata, including repository SHAs, runtime version, and build duration.
  - Callback payloads are validated before processing, with clearer handling for malformed failure details.
  - Partially configured callback settings are detected and reported before builds begin.

- **Bug Fixes**
  - Unauthenticated or invalid callbacks are rejected before they can affect build state.
  - Repository SHA reporting is now consistent across successful image builds.
  - Removed legacy base commit SHA reporting and obsolete callback error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->