### PR TITLE
refactor: unify the image-build provider trigger contract

### DIFF
--- a/packages/control-plane/src/image-builds/modal-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.test.ts
@@ -8,7 +8,7 @@ import type { ImageBuildFinalizationAttemptError } from "./finalization-error";
 
 function createProvider(): ModalImageBuildProvider {
   return {
-    triggerEnvironmentImageBuild: vi.fn(async () => undefined),
+    triggerImageBuild: vi.fn(async () => undefined),
     terminateImageBuildSandbox: vi.fn(async () => undefined),
     snapshotImageBuildSandbox: vi.fn(async () => ({ success: true, imageId: "modal-image-1" })),
     deleteProviderImage: vi.fn(async () => undefined),
@@ -49,7 +49,7 @@ describe("ModalImageBuildAdapter", () => {
 
     await adapter.startBuild(plan, { bindProviderSession });
 
-    expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
+    expect(provider.triggerImageBuild).toHaveBeenCalledWith({
       scopeKind: "repo",
       scopeId: "acme/repo",
       buildId: "build-1",
@@ -74,7 +74,7 @@ describe("ModalImageBuildAdapter", () => {
   it("leaves post-bind start-failure cleanup to the workflow", async () => {
     const provider = createProvider();
     const bindProviderSession = vi.fn(async () => undefined);
-    vi.mocked(provider.triggerEnvironmentImageBuild).mockImplementation(async (config) => {
+    vi.mocked(provider.triggerImageBuild).mockImplementation(async (config) => {
       await config.onProviderSessionCreated("modal-session-1");
       throw new Error("launch failed");
     });

--- a/packages/control-plane/src/image-builds/modal-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.test.ts
@@ -8,10 +8,7 @@ import type { ImageBuildFinalizationAttemptError } from "./finalization-error";
 
 function createProvider(): ModalImageBuildProvider {
   return {
-    triggerEnvironmentImageBuild: vi.fn(async () => ({
-      buildId: "build-1",
-      status: "building",
-    })),
+    triggerEnvironmentImageBuild: vi.fn(async () => undefined),
     terminateImageBuildSandbox: vi.fn(async () => undefined),
     snapshotImageBuildSandbox: vi.fn(async () => ({ success: true, imageId: "modal-image-1" })),
     deleteProviderImage: vi.fn(async () => undefined),
@@ -61,7 +58,7 @@ describe("ModalImageBuildAdapter", () => {
       cloneHost: "gitlab.com",
       cloneUsername: "oauth2",
       buildExecutionTimeoutSeconds: 1800,
-      providerSessionTimeoutMs: 2_400_000,
+      providerSessionTimeoutSeconds: 2400,
       userEnvVars: { FOO: "bar" },
       callbackUrl: "https://worker.test/image-builds/build-complete",
       failureCallbackUrl: "https://worker.test/image-builds/build-failed",

--- a/packages/control-plane/src/image-builds/modal-adapter.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.ts
@@ -10,7 +10,7 @@ import type {
   ImageBuildStartCallbacks,
 } from "./types";
 import { ImageBuildFinalizationAttemptError } from "./finalization-error";
-import { resolveImageBuildProviderSessionTimeoutMs } from "./timeouts";
+import { resolveImageBuildProviderSessionTimeoutSeconds } from "./timeouts";
 
 /**
  * Modal provider-session image build adapter.
@@ -30,7 +30,9 @@ export class ModalImageBuildAdapter implements ImageBuildAdapter {
         plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.username : undefined,
       userEnvVars: plan.userEnvVars,
       buildExecutionTimeoutSeconds: Math.ceil(plan.buildTimeoutMs / 1000),
-      providerSessionTimeoutMs: resolveImageBuildProviderSessionTimeoutMs(plan.buildTimeoutMs),
+      providerSessionTimeoutSeconds: resolveImageBuildProviderSessionTimeoutSeconds(
+        plan.buildTimeoutMs
+      ),
       callbackUrl: plan.callbackUrl,
       failureCallbackUrl: plan.failureCallbackUrl,
       callbackToken: plan.callbackToken,

--- a/packages/control-plane/src/image-builds/modal-adapter.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.ts
@@ -19,7 +19,7 @@ export class ModalImageBuildAdapter implements ImageBuildAdapter {
   constructor(private readonly provider: ModalImageBuildProvider) {}
 
   async startBuild(plan: ImageBuildPlan, callbacks: ImageBuildStartCallbacks): Promise<void> {
-    await this.provider.triggerEnvironmentImageBuild({
+    await this.provider.triggerImageBuild({
       scopeKind: plan.scope.kind,
       scopeId: plan.scope.id,
       buildId: plan.buildId,

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -5,7 +5,7 @@ import type { ImageBuildPlan } from "./types";
 
 function createProvider(): OpenComputerSandboxProvider {
   return {
-    triggerEnvironmentImageBuild: vi.fn(async () => undefined),
+    triggerImageBuild: vi.fn(async () => undefined),
     takeSnapshot: vi.fn(async () => ({ success: true, imageId: "oc-checkpoint-1" })),
     deleteSandbox: vi.fn(async () => ({ success: true })),
     deleteProviderImage: vi.fn(async () => undefined),
@@ -45,7 +45,7 @@ describe("OpenComputerImageBuildAdapter", () => {
 
     await adapter.startBuild(createPlan(), { bindProviderSession });
 
-    expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
+    expect(provider.triggerImageBuild).toHaveBeenCalledWith({
       scopeKind: "repo",
       scopeId: "acme/repo",
       buildId: "build-1",

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -46,7 +46,8 @@ describe("OpenComputerImageBuildAdapter", () => {
     await adapter.startBuild(createPlan(), { bindProviderSession });
 
     expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
-      environmentId: "acme/repo",
+      scopeKind: "repo",
+      scopeId: "acme/repo",
       buildId: "build-1",
       repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
       callbackUrl: "https://worker.test/image-builds/build-complete",
@@ -57,6 +58,10 @@ describe("OpenComputerImageBuildAdapter", () => {
       providerSessionTimeoutSeconds: 2401,
       userEnvVars: { FOO: "bar" },
       onProviderSessionCreated: bindProviderSession,
+      correlation: {
+        request_id: "request-1",
+        trace_id: "trace-1",
+      },
     });
   });
 

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.ts
@@ -21,7 +21,7 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
   constructor(private readonly provider: OpenComputerSandboxProvider) {}
 
   async startBuild(plan: ImageBuildPlan, callbacks: ImageBuildStartCallbacks): Promise<void> {
-    await this.provider.triggerEnvironmentImageBuild({
+    await this.provider.triggerImageBuild({
       scopeKind: plan.scope.kind,
       scopeId: plan.scope.id,
       repositories: plan.repositories,

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.ts
@@ -22,9 +22,8 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
 
   async startBuild(plan: ImageBuildPlan, callbacks: ImageBuildStartCallbacks): Promise<void> {
     await this.provider.triggerEnvironmentImageBuild({
-      // The provider build API is keyed by environmentId (used only for
-      // sandbox naming/labels); scope.id fills it for every scope kind.
-      environmentId: plan.scope.id,
+      scopeKind: plan.scope.kind,
+      scopeId: plan.scope.id,
       repositories: plan.repositories,
       buildId: plan.buildId,
       callbackUrl: plan.callbackUrl,
@@ -37,6 +36,7 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter {
         plan.buildTimeoutMs
       ),
       onProviderSessionCreated: callbacks.bindProviderSession,
+      correlation: plan.correlation,
     });
   }
 

--- a/packages/control-plane/src/image-builds/timeouts.ts
+++ b/packages/control-plane/src/image-builds/timeouts.ts
@@ -13,15 +13,11 @@ export const MAX_IMAGE_BUILD_PROVIDER_SESSION_TIMEOUT_MS =
   MAX_BUILD_TIMEOUT_SECONDS * MS_PER_SECOND + IMAGE_BUILD_FINALIZATION_GRACE_MS;
 
 /**
+ * Provider-session budget in the whole seconds expected by provider APIs.
  * Provider sessions must outlive the user-configured build-execution budget:
  * after setup reports success, the Queue consumer still needs time to receive
  * the callback and create the provider artifact.
  */
-export function resolveImageBuildProviderSessionTimeoutMs(buildTimeoutMs: number): number {
-  return buildTimeoutMs + IMAGE_BUILD_FINALIZATION_GRACE_MS;
-}
-
-/** Provider-session budget in the whole seconds expected by provider APIs. */
 export function resolveImageBuildProviderSessionTimeoutSeconds(buildTimeoutMs: number): number {
-  return Math.ceil(resolveImageBuildProviderSessionTimeoutMs(buildTimeoutMs) / MS_PER_SECOND);
+  return Math.ceil((buildTimeoutMs + IMAGE_BUILD_FINALIZATION_GRACE_MS) / MS_PER_SECOND);
 }

--- a/packages/control-plane/src/image-builds/vercel-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.test.ts
@@ -46,7 +46,8 @@ describe("VercelImageBuildAdapter", () => {
     await adapter.startBuild(createPlan(), { bindProviderSession });
 
     expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
-      environmentId: "acme/repo",
+      scopeKind: "repo",
+      scopeId: "acme/repo",
       buildId: "build-1",
       repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
       callbackUrl: "https://worker.test/image-builds/build-complete",

--- a/packages/control-plane/src/image-builds/vercel-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.test.ts
@@ -5,7 +5,7 @@ import type { ImageBuildPlan } from "./types";
 
 function createProvider(): VercelSandboxProvider {
   return {
-    triggerEnvironmentImageBuild: vi.fn(async () => undefined),
+    triggerImageBuild: vi.fn(async () => undefined),
     takeSnapshot: vi.fn(async () => ({ success: true, imageId: "vercel-snapshot-1" })),
     stopSandbox: vi.fn(async () => ({ success: true })),
     deleteProviderImage: vi.fn(async () => undefined),
@@ -45,7 +45,7 @@ describe("VercelImageBuildAdapter", () => {
 
     await adapter.startBuild(createPlan(), { bindProviderSession });
 
-    expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
+    expect(provider.triggerImageBuild).toHaveBeenCalledWith({
       scopeKind: "repo",
       scopeId: "acme/repo",
       buildId: "build-1",
@@ -80,7 +80,7 @@ describe("VercelImageBuildAdapter", () => {
         bindProviderSession: vi.fn(),
       });
 
-      expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith(
+      expect(provider.triggerImageBuild).toHaveBeenCalledWith(
         expect.objectContaining({
           buildExecutionTimeoutSeconds: expectedExecutionMinutes * 60,
           providerSessionTimeoutSeconds: expectedSessionMinutes * 60,

--- a/packages/control-plane/src/image-builds/vercel-adapter.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.ts
@@ -31,7 +31,7 @@ export class VercelImageBuildAdapter implements ImageBuildAdapter {
       plan.buildTimeoutMs,
       VERCEL_MAX_SANDBOX_TIMEOUT_MS - IMAGE_BUILD_FINALIZATION_GRACE_MS
     );
-    await this.provider.triggerEnvironmentImageBuild({
+    await this.provider.triggerImageBuild({
       scopeKind: plan.scope.kind,
       scopeId: plan.scope.id,
       repositories: plan.repositories,

--- a/packages/control-plane/src/image-builds/vercel-adapter.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.ts
@@ -32,9 +32,8 @@ export class VercelImageBuildAdapter implements ImageBuildAdapter {
       VERCEL_MAX_SANDBOX_TIMEOUT_MS - IMAGE_BUILD_FINALIZATION_GRACE_MS
     );
     await this.provider.triggerEnvironmentImageBuild({
-      // The provider build API is keyed by environmentId (used only for
-      // sandbox naming/labels); scope.id fills it for every scope kind.
-      environmentId: plan.scope.id,
+      scopeKind: plan.scope.kind,
+      scopeId: plan.scope.id,
       repositories: plan.repositories,
       buildId: plan.buildId,
       callbackUrl: plan.callbackUrl,

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -306,7 +306,8 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
     expect(vercelProvider.triggerEnvironmentImageBuild).toHaveBeenCalledTimes(1);
     expect(vercelProvider.triggerEnvironmentImageBuild).toHaveBeenCalledWith(
       expect.objectContaining({
-        environmentId: "acme/repo",
+        scopeKind: "repo",
+        scopeId: "acme/repo",
         repositories: REPO_REPOSITORIES,
         cloneToken: "clone-token",
       })
@@ -330,7 +331,8 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
     expect(openComputerProvider.triggerEnvironmentImageBuild).toHaveBeenCalledTimes(1);
     expect(openComputerProvider.triggerEnvironmentImageBuild).toHaveBeenCalledWith(
       expect.objectContaining({
-        environmentId: "acme/repo",
+        scopeKind: "repo",
+        scopeId: "acme/repo",
         repositories: REPO_REPOSITORIES,
         cloneToken: "clone-token",
       })

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -35,11 +35,11 @@ const modalClient = vi.hoisted(() => ({
 }));
 
 const vercelProvider = vi.hoisted(() => ({
-  triggerEnvironmentImageBuild: vi.fn(),
+  triggerImageBuild: vi.fn(),
 }));
 
 const openComputerProvider = vi.hoisted(() => ({
-  triggerEnvironmentImageBuild: vi.fn(),
+  triggerImageBuild: vi.fn(),
 }));
 
 const integrationSettings = vi.hoisted(() => ({
@@ -238,8 +238,8 @@ beforeEach(() => {
   });
   modalClient.startImageBuildSandbox.mockResolvedValue(undefined);
   modalClient.terminateImageBuildSandbox.mockResolvedValue(undefined);
-  vercelProvider.triggerEnvironmentImageBuild.mockResolvedValue(undefined);
-  openComputerProvider.triggerEnvironmentImageBuild.mockResolvedValue(undefined);
+  vercelProvider.triggerImageBuild.mockResolvedValue(undefined);
+  openComputerProvider.triggerImageBuild.mockResolvedValue(undefined);
   integrationSettings.resolveSandboxSettings.mockResolvedValue({});
   scmProvider.generateCredentialHelperAuth.mockResolvedValue({
     username: "x-access-token",
@@ -303,8 +303,8 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
     const response = await callTrigger(createVercelEnv());
 
     expect(response.status).toBe(200);
-    expect(vercelProvider.triggerEnvironmentImageBuild).toHaveBeenCalledTimes(1);
-    expect(vercelProvider.triggerEnvironmentImageBuild).toHaveBeenCalledWith(
+    expect(vercelProvider.triggerImageBuild).toHaveBeenCalledTimes(1);
+    expect(vercelProvider.triggerImageBuild).toHaveBeenCalledWith(
       expect.objectContaining({
         scopeKind: "repo",
         scopeId: "acme/repo",
@@ -328,8 +328,8 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
 
     expect(response.status).toBe(200);
     expect(scmProvider.generateCredentialHelperAuth).toHaveBeenCalled();
-    expect(openComputerProvider.triggerEnvironmentImageBuild).toHaveBeenCalledTimes(1);
-    expect(openComputerProvider.triggerEnvironmentImageBuild).toHaveBeenCalledWith(
+    expect(openComputerProvider.triggerImageBuild).toHaveBeenCalledTimes(1);
+    expect(openComputerProvider.triggerImageBuild).toHaveBeenCalledWith(
       expect.objectContaining({
         scopeKind: "repo",
         scopeId: "acme/repo",

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -214,7 +214,7 @@ export interface CreateImageBuildSandboxRequest {
   userEnvVars?: Record<string, string>;
   buildExecutionTimeoutSeconds: number;
   /** Provider-session lifetime, including deferred Queue finalization headroom. */
-  providerSessionTimeoutSeconds?: number;
+  providerSessionTimeoutSeconds: number;
 }
 
 export interface CreateImageBuildSandboxResponse {
@@ -619,7 +619,7 @@ export class ModalClient {
           failure_callback_url: request.failureCallbackUrl,
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
-          build_timeout_seconds: request.providerSessionTimeoutSeconds ?? null,
+          build_timeout_seconds: request.providerSessionTimeoutSeconds,
         }),
       });
 

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -5,12 +5,40 @@
  * enabling unit testing and future provider support.
  */
 
+import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import type { CorrelationContext } from "../logger";
 import type { McpServerConfig } from "@open-inspect/shared/types/integrations";
 
 /** Default sandbox lifetime in seconds (2 hours). */
 export const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200;
+
+/**
+ * Provider-neutral configuration for triggering an image build inside a
+ * provider session. Every supported provider follows the same
+ * create-bind-launch contract: create the build sandbox, bind its provider
+ * session id via `onProviderSessionCreated`, then launch the build runtime.
+ * Providers that need extra fields extend this type (see
+ * ModalImageBuildTriggerConfig).
+ */
+export interface ImageBuildProviderTriggerConfig {
+  buildId: string;
+  scopeKind: ImageBuildScopeKind;
+  /** Build scope id; used only for sandbox naming/labels. */
+  scopeId: string;
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  callbackUrl: string;
+  failureCallbackUrl: string;
+  callbackToken: string;
+  userEnvVars?: Record<string, string>;
+  cloneToken?: string;
+  buildExecutionTimeoutSeconds: number;
+  /** Provider-session lifetime in seconds, including deferred finalization headroom. */
+  providerSessionTimeoutSeconds?: number;
+  onProviderSessionCreated: (providerSessionId: string) => Promise<void>;
+  correlation?: CorrelationContext;
+}
 
 /**
  * Capabilities supported by a sandbox provider.

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -34,10 +34,15 @@ export interface ImageBuildProviderTriggerConfig {
   userEnvVars?: Record<string, string>;
   cloneToken?: string;
   buildExecutionTimeoutSeconds: number;
-  /** Provider-session lifetime in seconds, including deferred finalization headroom. */
-  providerSessionTimeoutSeconds?: number;
+  /**
+   * Provider-session lifetime in seconds, including deferred finalization
+   * headroom. Always resolved by the adapter layer
+   * (resolveImageBuildProviderSessionTimeoutSeconds) — providers apply it
+   * verbatim instead of choosing their own default.
+   */
+  providerSessionTimeoutSeconds: number;
   onProviderSessionCreated: (providerSessionId: string) => Promise<void>;
-  correlation?: CorrelationContext;
+  correlation: CorrelationContext;
 }
 
 /**

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -505,7 +505,7 @@ describe("ModalSandboxProvider", () => {
       const correlation = { request_id: "request-1", trace_id: "trace-1" };
       const onProviderSessionCreated = vi.fn(async () => undefined);
 
-      await provider.triggerEnvironmentImageBuild({
+      await provider.triggerImageBuild({
         buildId: "build-123",
         scopeKind: "repo",
         scopeId: "acme/repo",

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -505,7 +505,7 @@ describe("ModalSandboxProvider", () => {
       const correlation = { request_id: "request-1", trace_id: "trace-1" };
       const onProviderSessionCreated = vi.fn(async () => undefined);
 
-      const result = await provider.triggerEnvironmentImageBuild({
+      await provider.triggerEnvironmentImageBuild({
         buildId: "build-123",
         scopeKind: "repo",
         scopeId: "acme/repo",
@@ -513,7 +513,7 @@ describe("ModalSandboxProvider", () => {
         cloneToken: "clone-token",
         userEnvVars: { FOO: "bar" },
         buildExecutionTimeoutSeconds: 1800,
-        providerSessionTimeoutMs: 2_400_000,
+        providerSessionTimeoutSeconds: 2400,
         callbackUrl: "https://worker.test/image-builds/build-complete",
         failureCallbackUrl: "https://worker.test/image-builds/build-failed",
         callbackToken: "callback-token",
@@ -521,7 +521,6 @@ describe("ModalSandboxProvider", () => {
         correlation,
       });
 
-      expect(result).toEqual({ buildId: "build-123", status: "building" });
       expect(client.createImageBuildSandbox).toHaveBeenCalledWith(
         {
           scopeKind: "repo",

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -53,7 +53,7 @@ export interface SnapshotModalImageBuildConfig {
 }
 
 export interface ModalImageBuildProvider {
-  triggerEnvironmentImageBuild(config: ModalImageBuildTriggerConfig): Promise<void>;
+  triggerImageBuild(config: ModalImageBuildTriggerConfig): Promise<void>;
   terminateImageBuildSandbox(config: TerminateModalImageBuildConfig): Promise<void>;
   snapshotImageBuildSandbox(config: SnapshotModalImageBuildConfig): Promise<SnapshotResult>;
   deleteProviderImage(
@@ -303,7 +303,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
     }
   }
 
-  async triggerEnvironmentImageBuild(config: ModalImageBuildTriggerConfig): Promise<void> {
+  async triggerImageBuild(config: ModalImageBuildTriggerConfig): Promise<void> {
     const created = await this.createImageBuildSandbox(config);
     await config.onProviderSessionCreated(created.providerSessionId);
     await this.startImageBuildSandbox({

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -5,13 +5,13 @@
  * enabling unit testing and future provider abstraction.
  */
 
-import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
 import { ModalApiError } from "../client";
 import type { ModalClient } from "../client";
 import type { CorrelationContext } from "../../logger";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
   SandboxProviderError,
+  type ImageBuildProviderTriggerConfig,
   type SandboxProvider,
   type SandboxProviderCapabilities,
   type CreateSandboxConfig,
@@ -22,24 +22,6 @@ import {
   type SnapshotResult,
 } from "../provider";
 
-const MS_PER_SECOND = 1000;
-
-interface CreateModalImageBuildConfig {
-  buildId: string;
-  scopeKind: ImageBuildScopeKind;
-  scopeId: string;
-  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
-  cloneToken?: string;
-  cloneHost?: string;
-  cloneUsername?: string;
-  callbackUrl: string;
-  failureCallbackUrl: string;
-  userEnvVars?: Record<string, string>;
-  buildExecutionTimeoutSeconds: number;
-  providerSessionTimeoutMs?: number;
-  correlation?: CorrelationContext;
-}
-
 interface StartModalImageBuildConfig {
   buildId: string;
   providerSessionId: string;
@@ -49,14 +31,10 @@ interface StartModalImageBuildConfig {
   correlation?: CorrelationContext;
 }
 
-export interface TriggerModalEnvironmentImageBuildConfig extends CreateModalImageBuildConfig {
-  callbackToken: string;
-  onProviderSessionCreated: (providerSessionId: string) => Promise<void>;
-}
-
-export interface TriggerModalEnvironmentImageBuildResult {
-  buildId: string;
-  status: string;
+/** Modal extends the shared trigger contract with explicit SCM clone identity. */
+export interface ModalImageBuildTriggerConfig extends ImageBuildProviderTriggerConfig {
+  cloneHost?: string;
+  cloneUsername?: string;
 }
 
 export interface TerminateModalImageBuildConfig {
@@ -75,9 +53,7 @@ export interface SnapshotModalImageBuildConfig {
 }
 
 export interface ModalImageBuildProvider {
-  triggerEnvironmentImageBuild(
-    config: TriggerModalEnvironmentImageBuildConfig
-  ): Promise<TriggerModalEnvironmentImageBuildResult>;
+  triggerEnvironmentImageBuild(config: ModalImageBuildTriggerConfig): Promise<void>;
   terminateImageBuildSandbox(config: TerminateModalImageBuildConfig): Promise<void>;
   snapshotImageBuildSandbox(config: SnapshotModalImageBuildConfig): Promise<SnapshotResult>;
   deleteProviderImage(
@@ -294,7 +270,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   }
 
   private async createImageBuildSandbox(
-    config: CreateModalImageBuildConfig
+    config: ModalImageBuildTriggerConfig
   ): Promise<{ providerSessionId: string }> {
     try {
       return await this.client.createImageBuildSandbox(
@@ -310,10 +286,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
           failureCallbackUrl: config.failureCallbackUrl,
           userEnvVars: config.userEnvVars,
           buildExecutionTimeoutSeconds: config.buildExecutionTimeoutSeconds,
-          providerSessionTimeoutSeconds:
-            config.providerSessionTimeoutMs === undefined
-              ? undefined
-              : Math.ceil(config.providerSessionTimeoutMs / MS_PER_SECOND),
+          providerSessionTimeoutSeconds: config.providerSessionTimeoutSeconds,
         },
         config.correlation
       );
@@ -330,9 +303,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
     }
   }
 
-  async triggerEnvironmentImageBuild(
-    config: TriggerModalEnvironmentImageBuildConfig
-  ): Promise<TriggerModalEnvironmentImageBuildResult> {
+  async triggerEnvironmentImageBuild(config: ModalImageBuildTriggerConfig): Promise<void> {
     const created = await this.createImageBuildSandbox(config);
     await config.onProviderSessionCreated(created.providerSessionId);
     await this.startImageBuildSandbox({
@@ -343,8 +314,6 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
       callbackToken: config.callbackToken,
       correlation: config.correlation,
     });
-
-    return { buildId: config.buildId, status: "building" };
   }
 
   async terminateImageBuildSandbox(config: TerminateModalImageBuildConfig): Promise<void> {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -337,7 +337,8 @@ describe("OpenComputerSandboxProvider", () => {
 
     await provider.triggerEnvironmentImageBuild({
       buildId: "build-bb",
-      environmentId: "env_flagship",
+      scopeKind: "environment",
+      scopeId: "env_flagship",
       repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "main" }],
       callbackUrl: "https://control.example/image-builds/build-complete",
       failureCallbackUrl: "https://control.example/image-builds/build-failed",
@@ -665,7 +666,8 @@ describe("OpenComputerSandboxProvider", () => {
 
     await provider.triggerEnvironmentImageBuild({
       buildId: "build-1",
-      environmentId: "env_flagship",
+      scopeKind: "environment",
+      scopeId: "env_flagship",
       repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "main" }],
       callbackUrl: "https://control.example/image-builds/build-complete",
       failureCallbackUrl: "https://control.example/image-builds/build-failed",
@@ -734,7 +736,8 @@ describe("OpenComputerSandboxProvider", () => {
 
     await provider.triggerEnvironmentImageBuild({
       buildId: "envimg-1",
-      environmentId: "env_flagship",
+      scopeKind: "environment",
+      scopeId: "env_flagship",
       repositories: [
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
@@ -791,12 +794,14 @@ describe("OpenComputerSandboxProvider", () => {
     await expect(
       provider.triggerEnvironmentImageBuild({
         buildId: "build-1",
-        environmentId: "env_flagship",
+        scopeKind: "environment",
+        scopeId: "env_flagship",
         repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "main" }],
         callbackUrl: "https://control.example/image-builds/build-complete",
         failureCallbackUrl: "https://control.example/image-builds/build-failed",
         callbackToken: "callback-token",
         buildExecutionTimeoutSeconds: 1800,
+        onProviderSessionCreated: vi.fn(async () => undefined),
       })
     ).rejects.toThrow("Failed to trigger OpenComputer environment image build");
 

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -335,7 +335,7 @@ describe("OpenComputerSandboxProvider", () => {
       codeServerPasswordSecret: "secret",
     });
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       buildId: "build-bb",
       scopeKind: "environment",
       scopeId: "env_flagship",
@@ -666,7 +666,7 @@ describe("OpenComputerSandboxProvider", () => {
       llmEnvVars: { ANTHROPIC_API_KEY: "sk-provider" },
     });
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       buildId: "build-1",
       scopeKind: "environment",
       scopeId: "env_flagship",
@@ -738,7 +738,7 @@ describe("OpenComputerSandboxProvider", () => {
       codeServerPasswordSecret: "secret",
     });
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       buildId: "envimg-1",
       scopeKind: "environment",
       scopeId: "env_flagship",
@@ -798,7 +798,7 @@ describe("OpenComputerSandboxProvider", () => {
     });
 
     await expect(
-      provider.triggerEnvironmentImageBuild({
+      provider.triggerImageBuild({
         buildId: "build-1",
         scopeKind: "environment",
         scopeId: "env_flagship",

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -344,9 +344,11 @@ describe("OpenComputerSandboxProvider", () => {
       failureCallbackUrl: "https://control.example/image-builds/build-failed",
       callbackToken: "callback-token",
       buildExecutionTimeoutSeconds: 1800,
+      providerSessionTimeoutSeconds: 2400,
       cloneToken: "clone-token",
       userEnvVars: {},
       onProviderSessionCreated: vi.fn(async () => undefined),
+      correlation: { trace_id: "trace-1", request_id: "request-1" },
     });
 
     expect(client.createSandbox).toHaveBeenCalledWith(
@@ -681,7 +683,9 @@ describe("OpenComputerSandboxProvider", () => {
         OI_REPO_IMAGE_CALLBACK_SECRET: "legacy-user-controlled",
         OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS: "99999",
       },
+      providerSessionTimeoutSeconds: 2400,
       onProviderSessionCreated,
+      correlation: { trace_id: "trace-1", request_id: "request-1" },
     });
 
     expect(client.createSandbox).toHaveBeenCalledWith(
@@ -746,8 +750,10 @@ describe("OpenComputerSandboxProvider", () => {
       failureCallbackUrl: "https://control.example/environment-images/build-failed",
       callbackToken: "callback-token",
       buildExecutionTimeoutSeconds: 1800,
+      providerSessionTimeoutSeconds: 2400,
       cloneToken: "clone-token",
       onProviderSessionCreated,
+      correlation: { trace_id: "trace-1", request_id: "request-1" },
     });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
@@ -801,7 +807,9 @@ describe("OpenComputerSandboxProvider", () => {
         failureCallbackUrl: "https://control.example/image-builds/build-failed",
         callbackToken: "callback-token",
         buildExecutionTimeoutSeconds: 1800,
+        providerSessionTimeoutSeconds: 2400,
         onProviderSessionCreated: vi.fn(async () => undefined),
+        correlation: { trace_id: "trace-1", request_id: "request-1" },
       })
     ).rejects.toThrow("Failed to trigger OpenComputer environment image build");
 

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -38,6 +38,7 @@ import {
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
+  type ImageBuildProviderTriggerConfig,
   type ResumeConfig,
   type ResumeResult,
   type RestoreConfig,
@@ -64,27 +65,6 @@ const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_CALLBACK_SECRET",
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
 ] as const;
-
-export interface TriggerOpenComputerEnvironmentImageBuildConfig {
-  buildId: string;
-  environmentId: string;
-  /** Repositories in position order ([0] = primary), cloned at their base branches. */
-  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
-  callbackUrl: string;
-  failureCallbackUrl: string;
-  callbackToken: string;
-  userEnvVars?: Record<string, string>;
-  cloneToken?: string;
-  buildExecutionTimeoutSeconds: number;
-  /** Provider-session lifetime, including deferred finalization headroom. */
-  providerSessionTimeoutSeconds?: number;
-  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
-}
-
-export interface TriggerOpenComputerEnvironmentImageBuildResult {
-  buildId: string;
-  status: string;
-}
 
 export interface OpenComputerProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -377,9 +357,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
    * SESSION_CONFIG carries the repository list so the list-native runtime
    * clones and sets up every repository.
    */
-  async triggerEnvironmentImageBuild(
-    config: TriggerOpenComputerEnvironmentImageBuildConfig
-  ): Promise<TriggerOpenComputerEnvironmentImageBuildResult> {
+  async triggerEnvironmentImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
     const template = this.requireTemplate();
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;
@@ -389,11 +367,11 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         throw new Error("environment build requires at least one repository");
       }
 
-      const sandboxName = `build-env-${config.environmentId}-${Date.now()}`;
+      const sandboxName = `build-env-${config.scopeId}-${Date.now()}`;
       const environment = this.buildBuildEnvironment({
         userEnvVars: config.userEnvVars,
         cloneToken: config.cloneToken,
-        sandboxId: `build-env-${config.environmentId}`,
+        sandboxId: `build-env-${config.scopeId}`,
         repoOwner: primary.repoOwner,
         repoName: primary.repoName,
         sessionConfig: {
@@ -416,27 +394,25 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
           openinspect_provider: "opencomputer",
           openinspect_kind: "environment-image-build",
           openinspect_build_id: config.buildId,
-          openinspect_environment: config.environmentId,
+          openinspect_environment: config.scopeId,
         },
         timeoutSeconds: config.providerSessionTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
         secretStore: secretStore?.name,
       });
       providerObjectId = sandbox.id;
 
-      if (config.onProviderSessionCreated) {
-        await config.onProviderSessionCreated(sandbox.id);
-      }
+      await config.onProviderSessionCreated(sandbox.id);
 
       await this.client.startRuntime(sandbox.id, {
         [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sandbox.id,
       });
       log.info("opencomputer.environment_image_build_triggered", {
         build_id: config.buildId,
-        environment_id: config.environmentId,
+        scope_kind: config.scopeKind,
+        scope_id: config.scopeId,
         sandbox_id: sandbox.id,
+        ...config.correlation,
       });
-
-      return { buildId: config.buildId, status: "building" };
     } catch (error) {
       if (providerObjectId) {
         await this.cleanupSandboxAfterFailedCreate(providerObjectId, config.buildId);

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -354,7 +354,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
    * SESSION_CONFIG carries the repository list so the list-native runtime
    * clones and sets up every repository.
    */
-  async triggerEnvironmentImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
+  async triggerImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
     const template = this.requireTemplate();
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -6,10 +6,7 @@
  * to OpenComputer rather than being driven by OpenInspect's lifecycle manager.
  */
 
-import {
-  DEFAULT_BUILD_TIMEOUT_SECONDS,
-  type SandboxSettings,
-} from "@open-inspect/shared/types/integrations";
+import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
 import { createLogger } from "../../logger";
 import type { SourceControlProviderName } from "../../source-control";
@@ -396,7 +393,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
           openinspect_build_id: config.buildId,
           openinspect_environment: config.scopeId,
         },
-        timeoutSeconds: config.providerSessionTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
+        timeoutSeconds: config.providerSessionTimeoutSeconds,
         secretStore: secretStore?.name,
       });
       providerObjectId = sandbox.id;
@@ -406,12 +403,16 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       await this.client.startRuntime(sandbox.id, {
         [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sandbox.id,
       });
+      // The OpenComputer REST client takes no correlation argument, so the
+      // trace cannot be forwarded downstream yet — it is recorded on this
+      // trigger log line only. Spread first so the explicit fields (notably
+      // sandbox_id, the new build sandbox) win over correlation's.
       log.info("opencomputer.environment_image_build_triggered", {
+        ...config.correlation,
         build_id: config.buildId,
         scope_kind: config.scopeKind,
         scope_id: config.scopeId,
         sandbox_id: sandbox.id,
-        ...config.correlation,
       });
     } catch (error) {
       if (providerObjectId) {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -128,12 +128,14 @@ const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
 function environmentBuildConfig() {
   return {
     buildId: "envimg-1",
-    environmentId: "env_flagship",
+    scopeKind: "environment" as const,
+    scopeId: "env_flagship",
     repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
     callbackUrl: "https://control-plane.test/image-builds/build-complete",
     failureCallbackUrl: "https://control-plane.test/image-builds/build-failed",
     callbackToken: "callback-token",
     buildExecutionTimeoutSeconds: 1800,
+    onProviderSessionCreated: async () => undefined,
   };
 }
 
@@ -587,7 +589,7 @@ describe("VercelSandboxProvider", () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    const result = await provider.triggerEnvironmentImageBuild({
+    await provider.triggerEnvironmentImageBuild({
       ...environmentBuildConfig(),
       userEnvVars: {
         USER_SECRET: "value",
@@ -642,7 +644,6 @@ describe("VercelSandboxProvider", () => {
       }),
       undefined
     );
-    expect(result).toEqual({ buildId: "envimg-1", status: "building" });
   });
 
   it("reports a compatible authoritative runtime version for image builds", () => {
@@ -657,9 +658,10 @@ describe("VercelSandboxProvider", () => {
     const onProviderSessionCreated = vi.fn(async () => undefined);
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    const result = await provider.triggerEnvironmentImageBuild({
+    await provider.triggerEnvironmentImageBuild({
       buildId: "envimg-1",
-      environmentId: "env_flagship",
+      scopeKind: "environment",
+      scopeId: "env_flagship",
       repositories: [
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
@@ -713,7 +715,6 @@ describe("VercelSandboxProvider", () => {
       }),
       undefined
     );
-    expect(result).toEqual({ buildId: "envimg-1", status: "building" });
   });
 
   it("honors an explicit build timeout below the Vercel limit for image builds", async () => {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -135,7 +135,9 @@ function environmentBuildConfig() {
     failureCallbackUrl: "https://control-plane.test/image-builds/build-failed",
     callbackToken: "callback-token",
     buildExecutionTimeoutSeconds: 1800,
+    providerSessionTimeoutSeconds: 2400,
     onProviderSessionCreated: async () => undefined,
+    correlation: { trace_id: "trace-1", request_id: "request-1" },
   };
 }
 
@@ -605,7 +607,7 @@ describe("VercelSandboxProvider", () => {
     expect(createCall).toEqual(
       expect.objectContaining({
         runtime: "node24",
-        timeoutMs: 1800 * 1000,
+        timeoutMs: 2400 * 1000,
         sourceSnapshotId: "base-snapshot-1",
       })
     );
@@ -642,7 +644,7 @@ describe("VercelSandboxProvider", () => {
             "https://control-plane.test/image-builds/build-failed",
         },
       }),
-      undefined
+      { trace_id: "trace-1", request_id: "request-1" }
     );
   });
 
@@ -670,8 +672,10 @@ describe("VercelSandboxProvider", () => {
       failureCallbackUrl: "https://control-plane.test/environment-images/build-failed",
       callbackToken: "callback-token",
       buildExecutionTimeoutSeconds: 1800,
+      providerSessionTimeoutSeconds: 2400,
       cloneToken: "clone-token",
       onProviderSessionCreated,
+      correlation: { trace_id: "trace-1", request_id: "request-1" },
     });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
@@ -713,7 +717,7 @@ describe("VercelSandboxProvider", () => {
             "https://control-plane.test/environment-images/build-failed",
         },
       }),
-      undefined
+      { trace_id: "trace-1", request_id: "request-1" }
     );
   });
 

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -591,7 +591,7 @@ describe("VercelSandboxProvider", () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       ...environmentBuildConfig(),
       userEnvVars: {
         USER_SECRET: "value",
@@ -660,7 +660,7 @@ describe("VercelSandboxProvider", () => {
     const onProviderSessionCreated = vi.fn(async () => undefined);
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       buildId: "envimg-1",
       scopeKind: "environment",
       scopeId: "env_flagship",
@@ -725,7 +725,7 @@ describe("VercelSandboxProvider", () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       ...environmentBuildConfig(),
       providerSessionTimeoutSeconds: 40 * 60,
     });
@@ -737,7 +737,7 @@ describe("VercelSandboxProvider", () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, providerConfig);
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       ...environmentBuildConfig(),
       providerSessionTimeoutSeconds: 70 * 60,
     });
@@ -767,7 +767,7 @@ describe("VercelSandboxProvider", () => {
     const provider = new VercelSandboxProvider(client, providerConfig);
     const onProviderSessionCreated = vi.fn(async () => undefined);
 
-    await provider.triggerEnvironmentImageBuild({
+    await provider.triggerImageBuild({
       ...environmentBuildConfig(),
       onProviderSessionCreated,
     });

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -2,10 +2,7 @@
  * Vercel Sandbox provider implementation.
  */
 
-import {
-  DEFAULT_BUILD_TIMEOUT_SECONDS,
-  type SandboxSettings,
-} from "@open-inspect/shared/types/integrations";
+import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
@@ -295,9 +292,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         {
           name: sandboxName,
           runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
-          timeoutMs: resolveVercelTimeoutMs(
-            config.providerSessionTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS
-          ),
+          timeoutMs: resolveVercelTimeoutMs(config.providerSessionTimeoutSeconds),
           env,
           tags: {
             openinspect_framework: "open-inspect",
@@ -318,7 +313,10 @@ export class VercelSandboxProvider implements SandboxProvider {
         config.correlation
       );
 
+      // Spread correlation first so the explicit fields (notably session_id,
+      // the new provider session) win over correlation's.
       log.info("vercel.environment_image_build_triggered", {
+        ...config.correlation,
         build_id: config.buildId,
         scope_kind: config.scopeKind,
         scope_id: config.scopeId,

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -8,7 +8,6 @@ import {
 } from "@open-inspect/shared/types/integrations";
 import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
-import type { CorrelationContext } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
 import {
   applyScmCloneEnv,
@@ -25,6 +24,7 @@ import {
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
+  type ImageBuildProviderTriggerConfig,
   type RestoreConfig,
   type RestoreResult,
   type SandboxProvider,
@@ -87,28 +87,6 @@ export interface VercelProviderConfig {
   apiBaseUrl?: string;
   token: string;
   teamId?: string;
-}
-
-export interface TriggerVercelEnvironmentImageBuildConfig {
-  buildId: string;
-  environmentId: string;
-  /** Repositories in position order ([0] = primary), cloned at their base branches. */
-  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
-  callbackUrl: string;
-  failureCallbackUrl: string;
-  callbackToken: string;
-  userEnvVars?: Record<string, string>;
-  cloneToken?: string;
-  buildExecutionTimeoutSeconds: number;
-  /** Provider-session lifetime, including deferred finalization headroom. */
-  providerSessionTimeoutSeconds?: number;
-  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
-  correlation?: CorrelationContext;
-}
-
-export interface TriggerVercelEnvironmentImageBuildResult {
-  buildId: string;
-  status: string;
 }
 
 export class VercelSandboxProvider implements SandboxProvider {
@@ -287,9 +265,7 @@ export class VercelSandboxProvider implements SandboxProvider {
    * SESSION_CONFIG carries the repository list so the list-native runtime
    * clones and sets up every repository.
    */
-  async triggerEnvironmentImageBuild(
-    config: TriggerVercelEnvironmentImageBuildConfig
-  ): Promise<TriggerVercelEnvironmentImageBuildResult> {
+  async triggerEnvironmentImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
     try {
       const baseSnapshotId = await this.resolveBaseSnapshotId(config.correlation);
       if (!baseSnapshotId) {
@@ -303,11 +279,11 @@ export class VercelSandboxProvider implements SandboxProvider {
         throw new Error("environment build requires at least one repository");
       }
 
-      const sandboxName = `build-env-${config.environmentId}-${Date.now()}`;
+      const sandboxName = `build-env-${config.scopeId}-${Date.now()}`;
       const env = this.buildBuildEnvVars({
         userEnvVars: config.userEnvVars,
         cloneToken: config.cloneToken,
-        sandboxId: `build-env-${config.environmentId}`,
+        sandboxId: `build-env-${config.scopeId}`,
         repoOwner: primary.repoOwner,
         repoName: primary.repoName,
         sessionConfig: {
@@ -327,16 +303,14 @@ export class VercelSandboxProvider implements SandboxProvider {
             openinspect_framework: "open-inspect",
             openinspect_kind: "environment-image-build",
             openinspect_build_id: config.buildId,
-            openinspect_environment: config.environmentId,
+            openinspect_environment: config.scopeId,
           },
           sourceSnapshotId: baseSnapshotId,
         },
         config.correlation
       );
 
-      if (config.onProviderSessionCreated) {
-        await config.onProviderSessionCreated(created.session.id);
-      }
+      await config.onProviderSessionCreated(created.session.id);
 
       const command = await this.launchEntrypoint(
         created.session.id,
@@ -346,13 +320,12 @@ export class VercelSandboxProvider implements SandboxProvider {
 
       log.info("vercel.environment_image_build_triggered", {
         build_id: config.buildId,
-        environment_id: config.environmentId,
+        scope_kind: config.scopeKind,
+        scope_id: config.scopeId,
         session_id: created.session.id,
         command_id: command.commandId,
         sandbox_name: sandboxName,
       });
-
-      return { buildId: config.buildId, status: "building" };
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to trigger Vercel environment image build", error);

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -262,7 +262,7 @@ export class VercelSandboxProvider implements SandboxProvider {
    * SESSION_CONFIG carries the repository list so the list-native runtime
    * clones and sets up every repository.
    */
-  async triggerEnvironmentImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
+  async triggerImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
     try {
       const baseSnapshotId = await this.resolveBaseSnapshotId(config.correlation);
       if (!baseSnapshotId) {


### PR DESCRIPTION
## Summary

Stack 1/3 of the image-build standardization follow-ups. Now that all providers share the temporary-provider-session build lifecycle (#1178/#1204/#1207), the three per-provider trigger contracts were near-identical with accidental skew. This PR makes them one contract.

- New shared `ImageBuildProviderTriggerConfig` in `sandbox/provider.ts` (import direction verified: `image-builds → sandbox`, no cycle): `scopeKind` + `scopeId`, `providerSessionTimeoutSeconds` (**seconds everywhere** — Modal previously took ms and converted back to seconds internally; `resolveImageBuildProviderSessionTimeoutMs` lost its last consumer and is deleted), `correlation`, and `onProviderSessionCreated` — all **required** (the only caller, the adapter layer, always supplied them; three scattered `?? DEFAULT_BUILD_TIMEOUT_SECONDS` fallbacks are deleted so the adapter's resolver is the single owner of the session budget)
- The three `Trigger*EnvironmentImageBuildResult` types are deleted — every adapter awaited and discarded them; `triggerEnvironmentImageBuild` returns `Promise<void>`
- The `environmentId` misnomer is gone (it only ever carried `scope.id` for sandbox naming/labels; the apologetic comments go with it). Trigger log fields are now `scope_kind`/`scope_id`, and both OC/Vercel trigger logs spread `...config.correlation` (flat, first-position, matching package log conventions)
- Modal-only `cloneHost`/`cloneUsername` live in a `ModalImageBuildTriggerConfig` extension

Per-provider subtleties preserved verbatim (independently verified): Modal's 429 → `definitely_not_created` mapping, OpenComputer's secret-store retention split, Vercel's `VERCEL_MAX_SANDBOX_TIMEOUT_MS` cap.

## Stack

1. **This PR** — trigger-contract unification
2. (next) build-env assembly consolidation — based on this branch
3. (last) seconds standardization + wire-key rename — based on 2

Merge in order. Expect trivial rebases against the independent cleanup PRs #1281–#1284 where files overlap.

## Validation

- control plane: 2,255 unit + 698 integration tests passed; typecheck clean (both tsconfigs); shared build + prettier + ESLint clean
- Thermo-reviewed (Opus) as part of a 3-branch stack review: two in-scope findings on this branch (correlation-log asymmetry, dead optionality on the unified contract) — both fixed here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized image-build triggering across providers with shared build scope, timeout, callback, and correlation details.
  - Added clearer build-scope metadata for sandbox creation, labeling, and logging.

- **Bug Fixes**
  - Corrected provider session timeout handling to use seconds consistently.
  - Improved provider-session creation and build-trigger reliability.
  - Simplified build triggering to complete without returning an intermediate status result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->