### PR TITLE
refactor: consolidate image-build sandbox env assembly

### DIFF
--- a/packages/control-plane/src/db/image-build-finalization.ts
+++ b/packages/control-plane/src/db/image-build-finalization.ts
@@ -7,8 +7,6 @@ import { timingSafeEqual } from "@open-inspect/shared/auth";
 import type { ImageBuildCallbackBuild, ImageBuildProvider } from "../image-builds/model";
 import type { SqlDatabase } from "./sql-database";
 
-const MS_PER_SECOND = 1000;
-
 interface CallbackTokenRow {
   id: string;
   scope_kind: ImageBuildScopeKind;
@@ -62,7 +60,7 @@ export class ImageBuildFinalizationStore {
     completionHash: string;
     repositoryShas: RepositoryShaEntry[];
     runtimeVersion: string;
-    buildDurationMs: number;
+    buildDurationSeconds: number;
     now: number;
   }): Promise<ImageBuildCompletionAcceptance> {
     const result = await this.db
@@ -82,7 +80,7 @@ export class ImageBuildFinalizationStore {
         params.completionHash,
         JSON.stringify(params.repositoryShas),
         params.runtimeVersion,
-        params.buildDurationMs / MS_PER_SECOND,
+        params.buildDurationSeconds,
         params.now,
         params.buildId,
         params.provider,

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -13,8 +13,6 @@ import type {
 import { ImageBuildFinalizationStore } from "./image-build-finalization";
 import type { SqlDatabase } from "./sql-database";
 
-const MS_PER_SECOND = 1000;
-
 /** D1 caps bound parameters per statement; IN-list queries chunk below it. */
 const MAX_SCOPE_IDS_PER_QUERY = 50;
 
@@ -292,7 +290,7 @@ export class ImageBuildStore {
     providerImageId: string,
     repositoryShas: RepositoryShaEntry[],
     runtimeVersion: string,
-    buildDurationMs: number,
+    buildDurationSeconds: number,
     finalizationLeaseToken?: string
   ): Promise<MarkImageBuildReadyResult> {
     const build = await this.db
@@ -337,7 +335,7 @@ export class ImageBuildStore {
         providerImageId,
         JSON.stringify(repositoryShas),
         runtimeVersion,
-        buildDurationMs / MS_PER_SECOND,
+        buildDurationSeconds,
         buildId,
         provider,
         ...(finalizationLeaseToken ? [finalizationLeaseToken] : []),
@@ -359,7 +357,7 @@ export class ImageBuildStore {
           providerSessionId: build.provider_session_id,
           repositoryShas,
           runtimeVersion,
-          buildDurationMs,
+          buildDurationSeconds,
           scopeKind: build.scope_kind,
           scopeId: build.scope_id,
           createdAt: build.created_at,
@@ -426,7 +424,7 @@ export class ImageBuildStore {
     providerSessionId: string | null;
     repositoryShas: RepositoryShaEntry[];
     runtimeVersion: string;
-    buildDurationMs: number;
+    buildDurationSeconds: number;
     scopeKind: ImageBuildScopeKind;
     scopeId: string;
     createdAt: number;
@@ -458,7 +456,7 @@ export class ImageBuildStore {
         params.providerImageId,
         JSON.stringify(params.repositoryShas),
         params.runtimeVersion,
-        params.buildDurationMs / MS_PER_SECOND,
+        params.buildDurationSeconds,
         params.buildId,
         params.provider,
         ...(params.finalizationLeaseToken ? [params.finalizationLeaseToken] : []),

--- a/packages/control-plane/src/image-builds/finalization-job.test.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.test.ts
@@ -14,7 +14,7 @@ describe("image build finalization jobs", () => {
         { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
       ],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
     };
 
     const first = await createImageBuildFinalizationJob({ outcome: "success", completion });
@@ -34,6 +34,32 @@ describe("image build finalization jobs", () => {
     expect(JSON.stringify(first)).not.toContain("abc123");
   });
 
+  it("keeps the frozen hash canonicalization stable across refactors", async () => {
+    // Golden value computed from the pre-seconds-refactor canonical document
+    // ({... buildDurationMs: 12500}). The completion hash is a persisted
+    // idempotency contract: a deploy-straddling callback retry must hash
+    // identically before and after a refactor. If this fails, the hash
+    // schema changed — that requires an explicit version migration, not a
+    // fixture update.
+    const job = await createImageBuildFinalizationJob({
+      outcome: "success",
+      completion: {
+        buildId: "build-1",
+        providerSessionId: "session-1",
+        repositoryShas: [
+          { repoOwner: "Acme", repoName: "Web", baseSha: "abc123" },
+          { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
+        ],
+        runtimeVersion: "v53-runtime",
+        buildDurationSeconds: 12.5,
+      },
+    });
+
+    expect(job.completionHash).toBe(
+      "a38995471a349e98e513c04a4a8806b3275e2dcbbff53523ab50aee0d0644df9"
+    );
+  });
+
   it("treats repository SHA order as irrelevant to completion identity", async () => {
     const completion = {
       buildId: "build-1",
@@ -43,7 +69,7 @@ describe("image build finalization jobs", () => {
         { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
       ],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
     };
 
     const ordered = await createImageBuildFinalizationJob({ outcome: "success", completion });

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -46,7 +46,12 @@ export async function createImageBuildFinalizationJob(
                 left.baseSha.localeCompare(right.baseSha)
             ),
           runtimeVersion: result.completion.runtimeVersion,
-          buildDurationMs: result.completion.buildDurationMs,
+          // Frozen hash canonicalization: this document is a persisted
+          // idempotency contract, not a mirror of the domain types. The
+          // member keeps its original name and millisecond value so the same
+          // wire callback hashes identically across deploys and refactors —
+          // change it only with an explicit hash-schema version bump.
+          buildDurationMs: result.completion.buildDurationSeconds * 1000,
         }
       : {
           buildId,

--- a/packages/control-plane/src/image-builds/finalizer.test.ts
+++ b/packages/control-plane/src/image-builds/finalizer.test.ts
@@ -257,7 +257,7 @@ describe("ImageBuildFinalizer", () => {
       "image-1",
       expect.any(Array),
       "v53-runtime",
-      12_500,
+      12.5,
       expect.any(String)
     );
   });

--- a/packages/control-plane/src/image-builds/finalizer.ts
+++ b/packages/control-plane/src/image-builds/finalizer.ts
@@ -209,7 +209,7 @@ export class ImageBuildFinalizer {
       providerImageId,
       repositoryShas,
       build.runtime_version,
-      (build.build_duration_seconds ?? 0) * 1000,
+      build.build_duration_seconds ?? 0,
       leaseToken
     );
     if (ready.type === "not_accepting_completion") {

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -73,7 +73,8 @@ export interface CompleteImageBuildCallback {
   providerSessionId: string;
   repositoryShas: RepositoryShaEntry[];
   runtimeVersion: string;
-  buildDurationMs: number;
+  /** Wire seconds passed through unconverted — the D1 column is also seconds. */
+  buildDurationSeconds: number;
 }
 
 export interface FailImageBuildCallback {

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -162,7 +162,7 @@ function validCompletion(overrides: Record<string, unknown> = {}) {
     providerSessionId: "vercel-session-1",
     repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v56-managed-provider-runtime",
-    buildDurationMs: 12_500,
+    buildDurationSeconds: 12.5,
     ...overrides,
   };
 }

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -371,7 +371,7 @@ export class ImageBuildWorkflow {
       completionHash: job.completionHash,
       repositoryShas: completion.repositoryShas,
       runtimeVersion: completion.runtimeVersion,
-      buildDurationMs: completion.buildDurationMs,
+      buildDurationSeconds: completion.buildDurationSeconds,
       now: Date.now(),
     });
     if (acceptance === "rejected") {

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -48,7 +48,6 @@ import {
 } from "./shared";
 
 const logger = createLogger("router:image-builds");
-const MS_PER_SECOND = 1000;
 const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
 
 /**
@@ -64,15 +63,11 @@ const buildCompleteBodySchema = z.object({
   runtime_version: z.string().refine((value) => parseRuntimeVersionNumber(value) !== null, {
     message: "must start with v<number>",
   }),
-  // The converted milliseconds must stay finite: Infinity would be
-  // canonicalized to null by JSON.stringify inside the completion hash and
-  // the persisted row.
-  build_duration_seconds: z
-    .number()
-    .nonnegative()
-    .refine((value) => Number.isFinite(value * MS_PER_SECOND), {
-      message: "must convert to finite milliseconds",
-    }),
+  // Must stay finite: Infinity would be canonicalized to null by
+  // JSON.stringify inside the completion hash and the persisted row. Capped
+  // at MAX_SAFE_INTEGER so an absurd duration cannot lose integer precision
+  // in the persisted row or the completion-hash canonicalization.
+  build_duration_seconds: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER),
 });
 
 const buildFailedBodySchema = z.object({
@@ -201,7 +196,7 @@ async function handleBuildComplete(
     providerSessionId: parsed.provider_session_id,
     repositoryShas: parsed.repository_shas,
     runtimeVersion: parsed.runtime_version,
-    buildDurationMs: parsed.build_duration_seconds * MS_PER_SECOND,
+    buildDurationSeconds: parsed.build_duration_seconds,
   };
 
   try {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -481,6 +481,7 @@ describe("ModalClient", () => {
       callback_url: "https://worker.test/image-builds/build-complete",
       failure_callback_url: "https://worker.test/image-builds/build-failed",
       build_execution_timeout_seconds: 1800,
+      provider_session_timeout_seconds: 2400,
       build_timeout_seconds: 2400,
     });
     expect(result).toEqual({ providerSessionId: "modal-session-1" });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -615,6 +615,11 @@ export class ModalClient {
           failure_callback_url: request.failureCallbackUrl,
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
+          provider_session_timeout_seconds: request.providerSessionTimeoutSeconds,
+          // Transitional duplicate under the pre-rename key: the control plane
+          // and Modal deploy the same commit via independent pipelines, so an
+          // older Modal may still read only build_timeout_seconds during the
+          // skew window. Drop once both planes are known to be past the rename.
           build_timeout_seconds: request.providerSessionTimeoutSeconds,
         }),
       });

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -46,6 +46,31 @@ export interface ImageBuildProviderTriggerConfig {
 }
 
 /**
+ * Naming and provider-object labels shared by the image-build trigger paths.
+ * `sandboxId` is the stable logical id the runtime sees as `SANDBOX_ID`;
+ * `sandboxName` is the per-attempt provider-object name (unique per trigger);
+ * `labels` identify the build sandbox on the provider (tags on Vercel,
+ * labels on OpenComputer). Providers with extra label conventions spread and
+ * extend `labels`.
+ */
+export function imageBuildSandboxIdentity(config: ImageBuildProviderTriggerConfig): {
+  sandboxId: string;
+  sandboxName: string;
+  labels: Record<string, string>;
+} {
+  return {
+    sandboxId: `build-env-${config.scopeId}`,
+    sandboxName: `build-env-${config.scopeId}-${Date.now()}`,
+    labels: {
+      openinspect_framework: "open-inspect",
+      openinspect_kind: "environment-image-build",
+      openinspect_build_id: config.buildId,
+      openinspect_environment: config.scopeId,
+    },
+  };
+}
+
+/**
  * Capabilities supported by a sandbox provider.
  * Providers can support different feature sets.
  */

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -46,31 +46,6 @@ export interface ImageBuildProviderTriggerConfig {
 }
 
 /**
- * Naming and provider-object labels shared by the image-build trigger paths.
- * `sandboxId` is the stable logical id the runtime sees as `SANDBOX_ID`;
- * `sandboxName` is the per-attempt provider-object name (unique per trigger);
- * `labels` identify the build sandbox on the provider (tags on Vercel,
- * labels on OpenComputer). Providers with extra label conventions spread and
- * extend `labels`.
- */
-export function imageBuildSandboxIdentity(config: ImageBuildProviderTriggerConfig): {
-  sandboxId: string;
-  sandboxName: string;
-  labels: Record<string, string>;
-} {
-  return {
-    sandboxId: `build-env-${config.scopeId}`,
-    sandboxName: `build-env-${config.scopeId}-${Date.now()}`,
-    labels: {
-      openinspect_framework: "open-inspect",
-      openinspect_kind: "environment-image-build",
-      openinspect_build_id: config.buildId,
-      openinspect_environment: config.scopeId,
-    },
-  };
-}
-
-/**
  * Capabilities supported by a sandbox provider.
  * Providers can support different feature sets.
  */

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -26,13 +26,13 @@ import {
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
   IMAGE_BUILD_MODE_ENV_VAR,
+  imageBuildSandboxIdentity,
   REPO_IMAGE_CALLBACK_ENV_KEYS,
   RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
   VCS_CLONE_TOKEN_ENV_VAR,
 } from "../sandbox-env";
 import {
-  imageBuildSandboxIdentity,
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
@@ -348,7 +348,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;
     try {
-      const identity = imageBuildSandboxIdentity(config);
+      const identity = imageBuildSandboxIdentity(config, Date.now());
       const environment = this.buildBuildEnvironment(config, identity.sandboxId);
       secretStore = await this.createSecretStoreFor(config.buildId, environment.secretEnvVars);
       const sandbox = await this.client.createSandbox({

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -21,13 +21,14 @@ import {
   type OpenComputerSecretStoreResponse,
 } from "../opencomputer-rest-client";
 import {
+  buildImageBuildCallbackEnv,
   buildImageBuildEnvVars,
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
   IMAGE_BUILD_MODE_ENV_VAR,
   imageBuildSandboxIdentity,
-  REPO_IMAGE_CALLBACK_ENV_KEYS,
+  REPO_IMAGE_CALLBACK_ENV,
   RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
   VCS_CLONE_TOKEN_ENV_VAR,
@@ -367,7 +368,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       await config.onProviderSessionCreated(sandbox.id);
 
       await this.client.startRuntime(sandbox.id, {
-        [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sandbox.id,
+        [REPO_IMAGE_CALLBACK_ENV.providerSessionId]: sandbox.id,
       });
       // The OpenComputer REST client takes no correlation argument, so the
       // trace cannot be forwarded downstream yet — it is recorded on this
@@ -484,13 +485,18 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       baseEnvVars,
     });
 
-    Object.assign(envVars, {
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[1]]: config.buildId,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[2]]: config.callbackUrl,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[3]]: config.callbackToken,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[4]]: config.failureCallbackUrl,
-      [IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY]: String(config.buildExecutionTimeoutSeconds),
-    });
+    Object.assign(
+      envVars,
+      // No providerSessionId: the sandbox does not exist yet at create time;
+      // OpenComputer delivers the id separately at startRuntime.
+      buildImageBuildCallbackEnv({
+        buildId: config.buildId,
+        callbackUrl: config.callbackUrl,
+        failureCallbackUrl: config.failureCallbackUrl,
+        token: config.callbackToken,
+      }),
+      { [IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY]: String(config.buildExecutionTimeoutSeconds) }
+    );
 
     return { envVars, secretEnvVars };
   }

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -21,17 +21,18 @@ import {
   type OpenComputerSecretStoreResponse,
 } from "../opencomputer-rest-client";
 import {
-  applyScmCloneEnv,
+  buildImageBuildEnvVars,
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
   IMAGE_BUILD_MODE_ENV_VAR,
+  REPO_IMAGE_CALLBACK_ENV_KEYS,
+  RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
-  SESSION_CONFIG_ENV_VAR,
-  toRepositoryConfigPayload,
   VCS_CLONE_TOKEN_ENV_VAR,
 } from "../sandbox-env";
 import {
+  imageBuildSandboxIdentity,
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
@@ -50,18 +51,6 @@ import {
 
 const log = createLogger("opencomputer-provider");
 const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
-const REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
-  "OI_REPO_IMAGE_BUILD_ID",
-  "OI_REPO_IMAGE_CALLBACK_URL",
-  "OI_REPO_IMAGE_CALLBACK_TOKEN",
-  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
-] as const;
-const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
-  "OI_REPO_IMAGE_CALLBACK_SECRET",
-  IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
-] as const;
 
 export interface OpenComputerProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -359,39 +348,16 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;
     try {
-      const primary = config.repositories[0];
-      if (!primary) {
-        throw new Error("environment build requires at least one repository");
-      }
-
-      const sandboxName = `build-env-${config.scopeId}-${Date.now()}`;
-      const environment = this.buildBuildEnvironment({
-        userEnvVars: config.userEnvVars,
-        cloneToken: config.cloneToken,
-        sandboxId: `build-env-${config.scopeId}`,
-        repoOwner: primary.repoOwner,
-        repoName: primary.repoName,
-        sessionConfig: {
-          branch: primary.baseBranch,
-          repositories: config.repositories.map(toRepositoryConfigPayload),
-        },
-        buildId: config.buildId,
-        callbackUrl: config.callbackUrl,
-        failureCallbackUrl: config.failureCallbackUrl,
-        callbackToken: config.callbackToken,
-        buildExecutionTimeoutSeconds: config.buildExecutionTimeoutSeconds,
-      });
+      const identity = imageBuildSandboxIdentity(config);
+      const environment = this.buildBuildEnvironment(config, identity.sandboxId);
       secretStore = await this.createSecretStoreFor(config.buildId, environment.secretEnvVars);
       const sandbox = await this.client.createSandbox({
-        name: sandboxName,
+        name: identity.sandboxName,
         template,
         env: environment.envVars,
         labels: {
-          openinspect_framework: "open-inspect",
           openinspect_provider: "opencomputer",
-          openinspect_kind: "environment-image-build",
-          openinspect_build_id: config.buildId,
-          openinspect_environment: config.scopeId,
+          ...identity.labels,
         },
         timeoutSeconds: config.providerSessionTimeoutSeconds,
         secretStore: secretStore?.name,
@@ -496,32 +462,29 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     return { envVars, secretEnvVars };
   }
 
-  /** Build-sandbox env for both repo- and environment-image builds; the caller owns identity + SESSION_CONFIG shape. */
-  private buildBuildEnvironment(config: {
-    userEnvVars?: Record<string, string>;
-    cloneToken?: string;
-    sandboxId: string;
-    repoOwner: string;
-    repoName: string;
-    sessionConfig: Record<string, unknown>;
-    buildId: string;
-    callbackUrl: string;
-    failureCallbackUrl: string;
-    callbackToken: string;
-    buildExecutionTimeoutSeconds: number;
-  }): PreparedOpenComputerEnvironment {
-    const environment = this.prepareEnvironment(config.userEnvVars, {
+  /**
+   * Shared build-sandbox env assembly plus OpenComputer's callback overlay
+   * and secret-store split. Unlike Vercel (which delivers callback env at
+   * entrypoint launch), OpenComputer bakes the callback contract into the
+   * sandbox env at create time; only the provider session id is delivered at
+   * startRuntime.
+   */
+  private buildBuildEnvironment(
+    config: ImageBuildProviderTriggerConfig,
+    sandboxId: string
+  ): PreparedOpenComputerEnvironment {
+    const { envVars: baseEnvVars, secretEnvVars } = this.prepareEnvironment(config.userEnvVars, {
       scrubReservedRepoImageEnv: true,
     });
-    const { envVars } = environment;
+    const envVars = buildImageBuildEnvVars({
+      sandboxId,
+      repositories: config.repositories,
+      scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
+      cloneToken: config.cloneToken,
+      baseEnvVars,
+    });
 
     Object.assign(envVars, {
-      PYTHONUNBUFFERED: "1",
-      SANDBOX_ID: config.sandboxId,
-      REPO_OWNER: config.repoOwner,
-      REPO_NAME: config.repoName,
-      [IMAGE_BUILD_MODE_ENV_VAR]: "true",
-      [SESSION_CONFIG_ENV_VAR]: JSON.stringify(config.sessionConfig),
       [REPO_IMAGE_CALLBACK_ENV_KEYS[1]]: config.buildId,
       [REPO_IMAGE_CALLBACK_ENV_KEYS[2]]: config.callbackUrl,
       [REPO_IMAGE_CALLBACK_ENV_KEYS[3]]: config.callbackToken,
@@ -529,9 +492,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       [IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY]: String(config.buildExecutionTimeoutSeconds),
     });
 
-    applyScmCloneEnv(envVars, scmCloneIdentity(this.providerConfig.scmProvider), config.cloneToken);
-
-    return environment;
+    return { envVars, secretEnvVars };
   }
 
   private prepareEnvironment(

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -7,12 +7,12 @@ import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
 import {
+  buildImageBuildCallbackEnv,
   buildImageBuildEnvVars,
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
   imageBuildSandboxIdentity,
-  REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
 } from "../../sandbox-env";
 import {
@@ -544,11 +544,13 @@ export class VercelSandboxProvider implements SandboxProvider {
     sessionId: string
   ): Record<string, string> {
     return {
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sessionId,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[1]]: config.buildId,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[2]]: config.callbackUrl,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[3]]: config.callbackToken,
-      [REPO_IMAGE_CALLBACK_ENV_KEYS[4]]: config.failureCallbackUrl,
+      ...buildImageBuildCallbackEnv({
+        buildId: config.buildId,
+        callbackUrl: config.callbackUrl,
+        failureCallbackUrl: config.failureCallbackUrl,
+        token: config.callbackToken,
+        providerSessionId: sessionId,
+      }),
       [IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY]: String(config.buildExecutionTimeoutSeconds),
     };
   }

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -11,12 +11,12 @@ import {
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
+  imageBuildSandboxIdentity,
   REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
 } from "../../sandbox-env";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
-  imageBuildSandboxIdentity,
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
@@ -258,7 +258,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         );
       }
 
-      const identity = imageBuildSandboxIdentity(config);
+      const identity = imageBuildSandboxIdentity(config, Date.now());
       const env = this.buildBuildEnvVars(config, identity.sandboxId);
       const created = await this.client.createSandbox(
         {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -7,17 +7,16 @@ import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
 import {
-  applyScmCloneEnv,
+  buildImageBuildEnvVars,
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
-  IMAGE_BUILD_MODE_ENV_VAR,
+  REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
-  SESSION_CONFIG_ENV_VAR,
-  toRepositoryConfigPayload,
 } from "../../sandbox-env";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+  imageBuildSandboxIdentity,
   SandboxProviderError,
   type CreateSandboxConfig,
   type CreateSandboxResult,
@@ -56,18 +55,6 @@ const VERCEL_MEMORY_MIB_PER_VCPU = 2048;
 const VERCEL_SUPPORTED_VCPUS: readonly VercelVcpus[] = [1, 2, 4, 8];
 const VERCEL_MAX_VCPUS = VERCEL_SUPPORTED_VCPUS[VERCEL_SUPPORTED_VCPUS.length - 1];
 const VERCEL_TUNNEL_ENV_WRITE_TIMEOUT_MS = 30_000;
-const REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
-  "OI_REPO_IMAGE_BUILD_ID",
-  "OI_REPO_IMAGE_CALLBACK_URL",
-  "OI_REPO_IMAGE_CALLBACK_TOKEN",
-  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
-] as const;
-const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
-  "OI_REPO_IMAGE_CALLBACK_SECRET",
-  IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
-] as const;
 
 function resolveVercelTimeoutMs(timeoutSeconds?: number): number {
   const requestedMs = (timeoutSeconds ?? DEFAULT_SANDBOX_TIMEOUT_SECONDS) * 1000;
@@ -271,35 +258,15 @@ export class VercelSandboxProvider implements SandboxProvider {
         );
       }
 
-      const primary = config.repositories[0];
-      if (!primary) {
-        throw new Error("environment build requires at least one repository");
-      }
-
-      const sandboxName = `build-env-${config.scopeId}-${Date.now()}`;
-      const env = this.buildBuildEnvVars({
-        userEnvVars: config.userEnvVars,
-        cloneToken: config.cloneToken,
-        sandboxId: `build-env-${config.scopeId}`,
-        repoOwner: primary.repoOwner,
-        repoName: primary.repoName,
-        sessionConfig: {
-          branch: primary.baseBranch,
-          repositories: config.repositories.map(toRepositoryConfigPayload),
-        },
-      });
+      const identity = imageBuildSandboxIdentity(config);
+      const env = this.buildBuildEnvVars(config, identity.sandboxId);
       const created = await this.client.createSandbox(
         {
-          name: sandboxName,
+          name: identity.sandboxName,
           runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
           timeoutMs: resolveVercelTimeoutMs(config.providerSessionTimeoutSeconds),
           env,
-          tags: {
-            openinspect_framework: "open-inspect",
-            openinspect_kind: "environment-image-build",
-            openinspect_build_id: config.buildId,
-            openinspect_environment: config.scopeId,
-          },
+          tags: identity.labels,
           sourceSnapshotId: baseSnapshotId,
         },
         config.correlation
@@ -322,7 +289,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         scope_id: config.scopeId,
         session_id: created.session.id,
         command_id: command.commandId,
-        sandbox_name: sandboxName,
+        sandbox_name: identity.sandboxName,
       });
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
@@ -383,30 +350,21 @@ export class VercelSandboxProvider implements SandboxProvider {
     return envVars;
   }
 
-  /** Build-sandbox env for both repo- and environment-image builds; the caller owns identity + SESSION_CONFIG shape. */
-  private buildBuildEnvVars(config: {
-    userEnvVars?: Record<string, string>;
-    cloneToken?: string;
-    sandboxId: string;
-    repoOwner: string;
-    repoName: string;
-    sessionConfig: Record<string, unknown>;
-  }): Record<string, string> {
-    const envVars: Record<string, string> = { ...(config.userEnvVars ?? {}) };
-    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
-      delete envVars[key];
-    }
-
-    Object.assign(envVars, this.buildPlatformEnvVars(), {
-      SANDBOX_ID: config.sandboxId,
-      SANDBOX_VERSION: VERCEL_SANDBOX_VERSION,
-      REPO_OWNER: config.repoOwner,
-      REPO_NAME: config.repoName,
-      [IMAGE_BUILD_MODE_ENV_VAR]: "true",
-      [SESSION_CONFIG_ENV_VAR]: JSON.stringify(config.sessionConfig),
+  /** Shared build-sandbox env assembly plus Vercel's platform overlay. */
+  private buildBuildEnvVars(
+    config: ImageBuildProviderTriggerConfig,
+    sandboxId: string
+  ): Record<string, string> {
+    const envVars = buildImageBuildEnvVars({
+      sandboxId,
+      repositories: config.repositories,
+      scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
+      cloneToken: config.cloneToken,
+      baseEnvVars: config.userEnvVars,
     });
-
-    applyScmCloneEnv(envVars, scmCloneIdentity(this.providerConfig.scmProvider), config.cloneToken);
+    Object.assign(envVars, this.buildPlatformEnvVars(), {
+      SANDBOX_VERSION: VERCEL_SANDBOX_VERSION,
+    });
     return envVars;
   }
 

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -1,10 +1,15 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import {
   applyScmCloneEnv,
+  buildImageBuildCallbackEnv,
   buildImageBuildEnvVars,
   buildSandboxEnvVars,
   buildSessionConfig,
+  IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
+  IMAGE_BUILD_MODE_ENV_VAR,
   imageBuildSandboxIdentity,
+  REPO_IMAGE_CALLBACK_ENV,
   RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
 } from "./sandbox-env";
@@ -369,5 +374,80 @@ describe("imageBuildSandboxIdentity", () => {
 
   it("is deterministic for a fixed timestamp", () => {
     expect(imageBuildSandboxIdentity(config, 99)).toEqual(imageBuildSandboxIdentity(config, 99));
+  });
+});
+
+describe("buildImageBuildCallbackEnv", () => {
+  const values = {
+    buildId: "build-1",
+    callbackUrl: "https://cp.test/image-builds/build-complete",
+    failureCallbackUrl: "https://cp.test/image-builds/build-failed",
+    token: "callback-token",
+  };
+
+  it("assembles the full callback env record from semantic values", () => {
+    expect(buildImageBuildCallbackEnv({ ...values, providerSessionId: "session-9" })).toEqual({
+      OI_REPO_IMAGE_BUILD_ID: "build-1",
+      OI_REPO_IMAGE_CALLBACK_URL: "https://cp.test/image-builds/build-complete",
+      OI_REPO_IMAGE_FAILURE_CALLBACK_URL: "https://cp.test/image-builds/build-failed",
+      OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
+      OI_REPO_IMAGE_PROVIDER_SESSION_ID: "session-9",
+    });
+  });
+
+  it("omits the provider session id key when the id is not yet known", () => {
+    expect(buildImageBuildCallbackEnv(values)).toEqual({
+      OI_REPO_IMAGE_BUILD_ID: "build-1",
+      OI_REPO_IMAGE_CALLBACK_URL: "https://cp.test/image-builds/build-complete",
+      OI_REPO_IMAGE_FAILURE_CALLBACK_URL: "https://cp.test/image-builds/build-failed",
+      OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
+    });
+  });
+});
+
+describe("cross-plane env-key contract manifest", () => {
+  // Single source of the cross-plane contract; the Python halves (runtime
+  // constants, Modal's RESERVED_USER_ENV_KEYS) are pinned to the same file in
+  // packages/modal-infra/tests/test_build_sandbox_lifecycle.py. Tests-only
+  // consumption: the runtime constants stay as code.
+  const manifest = JSON.parse(
+    readFileSync(
+      new URL(
+        "../../../sandbox-runtime/src/sandbox_runtime/image_build_callback_env.json",
+        import.meta.url
+      ),
+      "utf8"
+    )
+  ) as {
+    callback_env: Record<string, string>;
+    build_mode_env_var: string;
+    execution_timeout_env_var: string;
+    reserved_only_control_plane: string[];
+    reserved_only_modal: string[];
+  };
+
+  it("pins REPO_IMAGE_CALLBACK_ENV to the manifest by value", () => {
+    expect(REPO_IMAGE_CALLBACK_ENV).toEqual({
+      buildId: manifest.callback_env.build_id,
+      callbackUrl: manifest.callback_env.callback_url,
+      failureCallbackUrl: manifest.callback_env.failure_callback_url,
+      token: manifest.callback_env.token,
+      providerSessionId: manifest.callback_env.provider_session_id,
+    });
+  });
+
+  it("pins the build-mode marker and execution-timeout key to the manifest", () => {
+    expect(IMAGE_BUILD_MODE_ENV_VAR).toBe(manifest.build_mode_env_var);
+    expect(IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY).toBe(manifest.execution_timeout_env_var);
+  });
+
+  it("pins the reserved scrub list to the callback keys plus the control-plane-only extras", () => {
+    expect([...RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS].sort()).toEqual(
+      [...Object.values(manifest.callback_env), ...manifest.reserved_only_control_plane].sort()
+    );
+    // The Modal-only reserved key is scrubbed on the Python side, never here.
+    for (const key of manifest.reserved_only_modal) {
+      expect(RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS).not.toContain(key);
+    }
   });
 });

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from "vitest";
 import {
   applyScmCloneEnv,
+  buildImageBuildEnvVars,
   buildSandboxEnvVars,
   buildSessionConfig,
+  imageBuildSandboxIdentity,
+  RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS,
   scmCloneIdentity,
 } from "./sandbox-env";
-import { DEFAULT_SANDBOX_TIMEOUT_SECONDS, type CreateSandboxConfig } from "./provider";
+import {
+  DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+  type CreateSandboxConfig,
+  type ImageBuildProviderTriggerConfig,
+} from "./provider";
 
 const baseInput = {
   sessionId: "session-123",
@@ -251,5 +258,116 @@ describe("buildSandboxEnvVars", () => {
     expect(envVars.LLM_KEY).toBe("sk-provider");
     expect(envVars.SANDBOX_ID).toBe("sandbox-456");
     expect(envVars).not.toHaveProperty("IGNORED");
+  });
+});
+
+describe("buildImageBuildEnvVars", () => {
+  const repositories = [
+    { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+    { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+  ];
+
+  it("assembles the full build-mode env on top of user vars", () => {
+    const envVars = buildImageBuildEnvVars({
+      sandboxId: "build-env-env_flagship",
+      repositories,
+      scmIdentity: scmCloneIdentity("github"),
+      cloneToken: "clone-token",
+      baseEnvVars: { USER_SECRET: "value" },
+    });
+
+    expect(envVars).toEqual({
+      USER_SECRET: "value",
+      PYTHONUNBUFFERED: "1",
+      SANDBOX_ID: "build-env-env_flagship",
+      REPO_OWNER: "acme",
+      REPO_NAME: "web",
+      IMAGE_BUILD_MODE: "true",
+      SESSION_CONFIG: expect.any(String),
+      VCS_HOST: "github.com",
+      VCS_CLONE_USERNAME: "x-access-token",
+      VCS_CLONE_TOKEN: "clone-token",
+    });
+  });
+
+  it("serializes a repositories-bearing SESSION_CONFIG anchored to the primary branch", () => {
+    const envVars = buildImageBuildEnvVars({
+      sandboxId: "build-env-env_flagship",
+      repositories,
+      scmIdentity: scmCloneIdentity("github"),
+    });
+
+    expect(JSON.parse(envVars.SESSION_CONFIG)).toEqual({
+      branch: "main",
+      repositories: [
+        { repo_owner: "acme", repo_name: "web", branch: "main" },
+        { repo_owner: "acme", repo_name: "api", branch: "develop" },
+      ],
+    });
+  });
+
+  it("scrubs every reserved callback key from the user layer", () => {
+    const baseEnvVars: Record<string, string> = { SAFE: "kept" };
+    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+      baseEnvVars[key] = "user-controlled";
+    }
+
+    const envVars = buildImageBuildEnvVars({
+      sandboxId: "build-env-env_flagship",
+      repositories,
+      scmIdentity: scmCloneIdentity("github"),
+      baseEnvVars,
+    });
+
+    expect(envVars.SAFE).toBe("kept");
+    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+      expect(envVars).not.toHaveProperty(key);
+    }
+  });
+
+  it("throws when the repository list is empty", () => {
+    expect(() =>
+      buildImageBuildEnvVars({
+        sandboxId: "build-env-env_flagship",
+        repositories: [],
+        scmIdentity: scmCloneIdentity("github"),
+      })
+    ).toThrow("image build requires at least one repository");
+  });
+});
+
+describe("imageBuildSandboxIdentity", () => {
+  const config: ImageBuildProviderTriggerConfig = {
+    buildId: "build-1",
+    scopeKind: "repo",
+    scopeId: "acme/web",
+    repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+    callbackUrl: "https://cp.test/image-builds/build-complete",
+    failureCallbackUrl: "https://cp.test/image-builds/build-failed",
+    callbackToken: "callback-token",
+    buildExecutionTimeoutSeconds: 1800,
+    providerSessionTimeoutSeconds: 2400,
+    onProviderSessionCreated: async () => undefined,
+    correlation: { trace_id: "trace-1", request_id: "request-1" },
+  };
+
+  it("derives a stable sandbox id, a per-attempt name, and scope-carrying labels", () => {
+    expect(imageBuildSandboxIdentity(config, 1234)).toEqual({
+      sandboxId: "build-env-acme/web",
+      sandboxName: "build-env-acme/web-1234",
+      labels: {
+        openinspect_framework: "open-inspect",
+        openinspect_kind: "environment-image-build",
+        openinspect_build_id: "build-1",
+        openinspect_scope_kind: "repo",
+        openinspect_scope_id: "acme/web",
+        // Legacy label preserved for existing operator queries.
+        openinspect_environment: "acme/web",
+      },
+    });
+  });
+
+  it("is deterministic for a fixed timestamp", () => {
+    expect(imageBuildSandboxIdentity(config, 99)).toEqual(imageBuildSandboxIdentity(config, 99));
   });
 });

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -105,20 +105,54 @@ export const IMAGE_BUILD_MODE_ENV_VAR = "IMAGE_BUILD_MODE";
 export const IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY = "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS";
 
 /**
- * Env keys of the image-build callback contract, mirrored from the runtime
- * constants in `sandbox_runtime/repo_image_callback.py` (pinned by a contract
- * test in `packages/modal-infra/tests/test_build_sandbox_lifecycle.py`).
- * Position is load-bearing where providers index into this list:
- * [0] provider session id, [1] build id, [2] callback URL, [3] callback
- * token, [4] failure callback URL.
+ * Env vars of the image-build callback contract, keyed by semantic name and
+ * mirrored from the runtime constants in
+ * `sandbox_runtime/repo_image_callback.py`. Both language sides are pinned by
+ * value to the shared manifest
+ * `packages/sandbox-runtime/src/sandbox_runtime/image_build_callback_env.json`
+ * (TS: `sandbox-env.test.ts`; Python:
+ * `packages/modal-infra/tests/test_build_sandbox_lifecycle.py`).
  */
-export const REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
-  "OI_REPO_IMAGE_BUILD_ID",
-  "OI_REPO_IMAGE_CALLBACK_URL",
-  "OI_REPO_IMAGE_CALLBACK_TOKEN",
-  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
-] as const;
+export const REPO_IMAGE_CALLBACK_ENV = {
+  buildId: "OI_REPO_IMAGE_BUILD_ID",
+  callbackUrl: "OI_REPO_IMAGE_CALLBACK_URL",
+  failureCallbackUrl: "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
+  token: "OI_REPO_IMAGE_CALLBACK_TOKEN",
+  providerSessionId: "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
+} as const;
+
+/** Values of the image-build callback contract, delivered as env vars. */
+export interface ImageBuildCallbackEnvValues {
+  buildId: string;
+  callbackUrl: string;
+  failureCallbackUrl: string;
+  token: string;
+  /**
+   * Omitted from the returned map when absent: OpenComputer bakes the
+   * callback env at create time, before the provider session id exists, and
+   * delivers the id separately at runtime start.
+   */
+  providerSessionId?: string;
+}
+
+/**
+ * Assemble the callback-contract env map from semantic values, so provider
+ * call sites never pair names with values by hand (or by list position).
+ */
+export function buildImageBuildCallbackEnv(
+  values: ImageBuildCallbackEnvValues
+): Record<string, string> {
+  const envVars: Record<string, string> = {
+    [REPO_IMAGE_CALLBACK_ENV.buildId]: values.buildId,
+    [REPO_IMAGE_CALLBACK_ENV.callbackUrl]: values.callbackUrl,
+    [REPO_IMAGE_CALLBACK_ENV.failureCallbackUrl]: values.failureCallbackUrl,
+    [REPO_IMAGE_CALLBACK_ENV.token]: values.token,
+  };
+  if (values.providerSessionId !== undefined) {
+    envVars[REPO_IMAGE_CALLBACK_ENV.providerSessionId] = values.providerSessionId;
+  }
+  return envVars;
+}
 
 /**
  * Keys scrubbed from user env vars before a build sandbox launches, so a
@@ -126,11 +160,11 @@ export const REPO_IMAGE_CALLBACK_ENV_KEYS = [
  * the legacy `OI_REPO_IMAGE_CALLBACK_SECRET` from the pre-token contract —
  * still reserved so stale user secrets can't reintroduce it.
  */
-export const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
+export const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS: readonly string[] = [
+  ...Object.values(REPO_IMAGE_CALLBACK_ENV),
   "OI_REPO_IMAGE_CALLBACK_SECRET",
   IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
-] as const;
+];
 /** One-shot clone token used only by image-build sandboxes. */
 export const VCS_CLONE_TOKEN_ENV_VAR = "VCS_CLONE_TOKEN";
 

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -102,6 +102,34 @@ export const SESSION_CONFIG_ENV_VAR = "SESSION_CONFIG";
 /** Build-mode marker checked as `=== "true"` by the runtime entrypoint. */
 export const IMAGE_BUILD_MODE_ENV_VAR = "IMAGE_BUILD_MODE";
 export const IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY = "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS";
+
+/**
+ * Env keys of the image-build callback contract, mirrored from the runtime
+ * constants in `sandbox_runtime/repo_image_callback.py` (pinned by a contract
+ * test in `packages/modal-infra/tests/test_build_sandbox_lifecycle.py`).
+ * Position is load-bearing where providers index into this list:
+ * [0] provider session id, [1] build id, [2] callback URL, [3] callback
+ * token, [4] failure callback URL.
+ */
+export const REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
+  "OI_REPO_IMAGE_BUILD_ID",
+  "OI_REPO_IMAGE_CALLBACK_URL",
+  "OI_REPO_IMAGE_CALLBACK_TOKEN",
+  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
+] as const;
+
+/**
+ * Keys scrubbed from user env vars before a build sandbox launches, so a
+ * user-defined secret can never hijack the build callback contract. Includes
+ * the legacy `OI_REPO_IMAGE_CALLBACK_SECRET` from the pre-token contract —
+ * still reserved so stale user secrets can't reintroduce it.
+ */
+export const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
+  "OI_REPO_IMAGE_CALLBACK_SECRET",
+  IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
+] as const;
 /** One-shot clone token used only by image-build sandboxes. */
 export const VCS_CLONE_TOKEN_ENV_VAR = "VCS_CLONE_TOKEN";
 
@@ -232,5 +260,64 @@ export function buildSandboxEnvVars(
   // survives — OpenComputer deliberately preserves one on prebuilt-image
   // boots (see its provider tests).
 
+  return envVars;
+}
+
+/** Provider-specific inputs to {@link buildImageBuildEnvVars}. */
+export interface ImageBuildEnvVarsOptions {
+  /** Logical sandbox id (`build-env-<scopeId>`), surfaced as `SANDBOX_ID`. */
+  sandboxId: string;
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
+  repositories: SessionRepositoryInfo[];
+  /** Resolved clone identity — {@link scmCloneIdentity} of the configured SCM provider. */
+  scmIdentity: ScmCloneIdentity;
+  /** One-shot clone token delivered as `VCS_CLONE_TOKEN`. */
+  cloneToken?: string;
+  /**
+   * User env vars (repo secrets), or a provider-composed base layer
+   * (OpenComputer layers provider LLM credentials underneath user secrets).
+   * Reserved image-build keys are scrubbed from this layer so user-defined
+   * secrets can never hijack the build callback contract.
+   */
+  baseEnvVars?: Record<string, string>;
+}
+
+/**
+ * Build the env map for an image-build sandbox — the build-mode sibling of
+ * {@link buildSandboxEnvVars}, shared by the Vercel and OpenComputer
+ * providers (which used to hand-roll byte-identical copies) and mirrored by
+ * Modal's Python `ModalBuildSessionService.create` in
+ * `packages/modal-infra/src/sandbox/build_session.py`.
+ *
+ * Build sandboxes never receive the session-auth system vars: the runtime
+ * boots in image-build mode (`IMAGE_BUILD_MODE=true`) and reports back over
+ * the callback contract instead. Provider-specific additions (platform
+ * paths, callback env timing) are layered on by the caller after this
+ * returns.
+ */
+export function buildImageBuildEnvVars(options: ImageBuildEnvVarsOptions): Record<string, string> {
+  const primary = options.repositories[0];
+  if (!primary) {
+    throw new Error("environment build requires at least one repository");
+  }
+
+  const envVars: Record<string, string> = { ...(options.baseEnvVars ?? {}) };
+  for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+    delete envVars[key];
+  }
+
+  Object.assign(envVars, {
+    PYTHONUNBUFFERED: "1",
+    SANDBOX_ID: options.sandboxId,
+    REPO_OWNER: primary.repoOwner,
+    REPO_NAME: primary.repoName,
+    [IMAGE_BUILD_MODE_ENV_VAR]: "true",
+    [SESSION_CONFIG_ENV_VAR]: JSON.stringify({
+      branch: primary.baseBranch,
+      repositories: options.repositories.map(toRepositoryConfigPayload),
+    }),
+  });
+
+  applyScmCloneEnv(envVars, options.scmIdentity, options.cloneToken);
   return envVars;
 }

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -4,6 +4,7 @@ import type { SourceControlProviderName } from "../source-control";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
   type CreateSandboxConfig,
+  type ImageBuildProviderTriggerConfig,
   type RestoreConfig,
   type SessionRepositoryInfo,
 } from "./provider";
@@ -263,6 +264,46 @@ export function buildSandboxEnvVars(
   return envVars;
 }
 
+/**
+ * Naming and provider-object labels shared by the image-build trigger paths.
+ * `sandboxId` is the stable logical id the runtime sees as `SANDBOX_ID`;
+ * `sandboxName` is the per-attempt provider-object name — pass the trigger
+ * timestamp (`Date.now()`) as `now` so the impure input is visible at the
+ * call site and one config yields one name per trigger attempt;
+ * `labels` identify the build sandbox on the provider (tags on Vercel,
+ * labels on OpenComputer). Providers with extra label conventions spread and
+ * extend `labels`.
+ *
+ * The `build-env-` prefix is deliberately scope-agnostic legacy: it predates
+ * scoped builds and is kept verbatim so repo-scoped builds keep the same
+ * `SANDBOX_ID`/name shape operators already query for.
+ */
+export function imageBuildSandboxIdentity(
+  config: ImageBuildProviderTriggerConfig,
+  now: number
+): {
+  sandboxId: string;
+  sandboxName: string;
+  labels: Record<string, string>;
+} {
+  return {
+    sandboxId: `build-env-${config.scopeId}`,
+    sandboxName: `build-env-${config.scopeId}-${now}`,
+    labels: {
+      openinspect_framework: "open-inspect",
+      openinspect_kind: "environment-image-build",
+      openinspect_build_id: config.buildId,
+      // Canonical scope labels, mirroring Modal's Python tags in
+      // packages/modal-infra/src/sandbox/build_session.py.
+      openinspect_scope_kind: config.scopeKind,
+      openinspect_scope_id: config.scopeId,
+      // Legacy label kept alongside the scope pair so existing operator
+      // label queries keep matching; builds are no longer environment-only.
+      openinspect_environment: config.scopeId,
+    },
+  };
+}
+
 /** Provider-specific inputs to {@link buildImageBuildEnvVars}. */
 export interface ImageBuildEnvVarsOptions {
   /** Logical sandbox id (`build-env-<scopeId>`), surfaced as `SANDBOX_ID`. */
@@ -298,7 +339,7 @@ export interface ImageBuildEnvVarsOptions {
 export function buildImageBuildEnvVars(options: ImageBuildEnvVarsOptions): Record<string, string> {
   const primary = options.repositories[0];
   if (!primary) {
-    throw new Error("environment build requires at least one repository");
+    throw new Error("image build requires at least one repository");
   }
 
   const envVars: Record<string, string> = { ...(options.baseEnvVars ?? {}) };

--- a/packages/control-plane/test/integration/image-build-finalization-queue.test.ts
+++ b/packages/control-plane/test/integration/image-build-finalization-queue.test.ts
@@ -30,7 +30,7 @@ async function seedAcceptedBuild(buildId: string): Promise<ImageBuildStore> {
     completionHash: COMPLETION_HASH,
     repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v53-runtime",
-    buildDurationMs: 1_000,
+    buildDurationSeconds: 1,
     now,
   });
   return store;

--- a/packages/control-plane/test/integration/image-build-finalization-store.test.ts
+++ b/packages/control-plane/test/integration/image-build-finalization-store.test.ts
@@ -55,7 +55,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     };
 
@@ -116,7 +116,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1_000,
+      buildDurationSeconds: 1,
       now,
     });
 
@@ -152,7 +152,7 @@ describe("ImageBuildStore finalization state", () => {
         completionHash: `completion-${index + 1}`,
         repositoryShas: [],
         runtimeVersion: "v53-runtime",
-        buildDurationMs: 1_000,
+        buildDurationSeconds: 1,
         now: callbackTime,
       });
     }
@@ -320,7 +320,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     });
     await store.supersedeActiveImages(environmentScope(environmentId));
@@ -456,7 +456,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     });
 
@@ -516,7 +516,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1,
+      buildDurationSeconds: 1,
       now,
     });
 

--- a/packages/control-plane/test/integration/image-build-scheduler.test.ts
+++ b/packages/control-plane/test/integration/image-build-scheduler.test.ts
@@ -50,7 +50,7 @@ describe("image build scheduler integration", () => {
       completionHash,
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1_000,
+      buildDurationSeconds: 1,
       now: callbackTime,
     });
     await env.DB.prepare("UPDATE image_builds SET created_at = 1 WHERE id = ?")
@@ -113,7 +113,7 @@ describe("image build scheduler integration", () => {
         completionHash,
         repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
         runtimeVersion: "v53-runtime",
-        buildDurationMs: 1_000,
+        buildDurationSeconds: 1,
         now: index + 1,
       });
     }

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -164,7 +164,7 @@ describe("Image builds", () => {
         "im-new",
         REPOSITORY_SHAS,
         RUNTIME_VERSION,
-        12_500
+        12.5
       );
 
       expect(result.type).toBe("marked_ready");
@@ -211,7 +211,7 @@ describe("Image builds", () => {
         "im-late",
         REPOSITORY_SHAS,
         RUNTIME_VERSION,
-        10_000
+        10
       );
 
       expect(result.type).toBe("superseded_by_newer_ready");
@@ -854,8 +854,8 @@ describe("Image builds", () => {
       ],
       ["missing build_duration_seconds", { build_duration_seconds: undefined }],
       ["negative build_duration_seconds", { build_duration_seconds: -1 }],
-      // Finite seconds whose ×1000 conversion overflows to Infinity, which
-      // JSON.stringify would canonicalize to null downstream.
+      // Finite but beyond MAX_SAFE_INTEGER seconds — would lose integer
+      // precision in the persisted row and hash canonicalization.
       ["overflowing build_duration_seconds", { build_duration_seconds: 1e308 }],
     ])("fails registration closed on %s", async (_label, overrides) => {
       const environmentId = await seedEnvironment();

--- a/packages/modal-infra/src/sandbox/build_session.py
+++ b/packages/modal-infra/src/sandbox/build_session.py
@@ -33,6 +33,20 @@ DEFAULT_BUILD_TIMEOUT_SECONDS = 1800
 MAX_BUILD_TIMEOUT_SECONDS = 3600
 LAUNCH_PROTOCOL_TAG = "openinspect_launch_protocol"
 
+# Keys scrubbed from user env vars before a build sandbox launches — the
+# Python sibling of the control plane's RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS
+# (packages/control-plane/src/sandbox/sandbox-env.ts). The intended divergence
+# between the two sets is pinned by a contract test in
+# tests/test_build_sandbox_lifecycle.py.
+RESERVED_USER_ENV_KEYS = (
+    BUILD_ID_ENV,
+    CALLBACK_URL_ENV,
+    FAILURE_CALLBACK_URL_ENV,
+    CALLBACK_TOKEN_ENV,
+    PROVIDER_SESSION_ID_ENV,
+    MODAL_SANDBOX_ID_ENV,
+)
+
 
 class BuildSessionNotFoundError(LookupError):
     """The requested provider session is absent or bound to another build."""
@@ -60,14 +74,7 @@ class ModalBuildSessionService:
         start_time = time.time()
         primary = repositories[0]
         env_vars = dict(user_env_vars or {})
-        for name in (
-            BUILD_ID_ENV,
-            CALLBACK_URL_ENV,
-            FAILURE_CALLBACK_URL_ENV,
-            CALLBACK_TOKEN_ENV,
-            PROVIDER_SESSION_ID_ENV,
-            MODAL_SANDBOX_ID_ENV,
-        ):
+        for name in RESERVED_USER_ENV_KEYS:
             env_vars.pop(name, None)
         env_vars.update(
             {

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -590,9 +590,15 @@ async def api_create_build_sandbox(
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
-        timeout_seconds = _validated_timeout_seconds(
+        # legacy_field: transitional dual-read for the build_timeout_seconds ->
+        # provider_session_timeout_seconds rename. The control plane and Modal
+        # deploy the same commit via independent pipelines, so an older control
+        # plane may still send only the legacy key during the skew window.
+        # Drop the alias once both planes are known to be past the rename.
+        provider_session_timeout_seconds = _validated_timeout_seconds(
             request,
-            "build_timeout_seconds",
+            "provider_session_timeout_seconds",
+            legacy_field="build_timeout_seconds",
             default_seconds=(
                 DEFAULT_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
             ),
@@ -621,7 +627,7 @@ async def api_create_build_sandbox(
             clone_username=clone_username,
             user_env_vars=request.get("user_env_vars") or None,
             build_execution_timeout_seconds=build_execution_timeout_seconds,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=provider_session_timeout_seconds,
         )
         return {
             "success": True,
@@ -801,8 +807,12 @@ def _validated_timeout_seconds(
     *,
     default_seconds: int,
     max_seconds: int,
+    legacy_field: str | None = None,
 ) -> int:
     value = request.get(field)
+    if value is None and legacy_field is not None:
+        field = legacy_field
+        value = request.get(field)
     if value is None:
         return default_seconds
     if not isinstance(value, int) or isinstance(value, bool):

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -25,6 +25,7 @@ from src.sandbox.build_session import (
     ModalBuildSessionService,
 )
 from src.sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+from src.web_api import IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
 
 
 def _async_method(return_value=None):
@@ -55,6 +56,43 @@ def test_build_timeout_limits_match_shared_contract(constant_name, python_value)
 
     assert match is not None, f"missing numeric shared constant: {constant_name}"
     assert python_value == int(match.group(1))
+
+
+def test_finalization_grace_matches_control_plane_contract():
+    """Pin IMAGE_BUILD_FINALIZATION_GRACE_SECONDS to the control-plane grace window.
+
+    web_api.py mirrors IMAGE_BUILD_FINALIZATION_GRACE_MS from the control
+    plane's image-builds/timeouts.ts; both planes must reserve the same
+    finalization headroom on top of the build-execution budget.
+    """
+    ts_source = (
+        Path(__file__).resolve().parents[2]
+        / "control-plane"
+        / "src"
+        / "image-builds"
+        / "timeouts.ts"
+    ).read_text()
+    match = re.search(
+        r"export\s+const\s+IMAGE_BUILD_FINALIZATION_GRACE_MS\s*=\s*([^;]+);",
+        ts_source,
+    )
+    assert match is not None, "missing TS constant: IMAGE_BUILD_FINALIZATION_GRACE_MS"
+
+    ms_per_second_match = re.search(r"const\s+MS_PER_SECOND\s*=\s*(\d+)\s*;", ts_source)
+    assert ms_per_second_match is not None, "missing TS constant: MS_PER_SECOND"
+    ms_per_second = int(ms_per_second_match.group(1))
+
+    ts_grace_ms = 1
+    for factor in (part.strip() for part in match.group(1).split("*")):
+        if factor == "MS_PER_SECOND":
+            ts_grace_ms *= ms_per_second
+        else:
+            assert factor.isdigit(), (
+                "could not evaluate IMAGE_BUILD_FINALIZATION_GRACE_MS: expected a "
+                f"product of integer literals and MS_PER_SECOND, got factor {factor!r}"
+            )
+            ts_grace_ms *= int(factor)
+    assert ts_grace_ms == IMAGE_BUILD_FINALIZATION_GRACE_SECONDS * ms_per_second
 
 
 def _load_callback_env_manifest() -> dict:

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -57,106 +57,65 @@ def test_build_timeout_limits_match_shared_contract(constant_name, python_value)
     assert python_value == int(match.group(1))
 
 
-def _read_control_plane_sandbox_env_source() -> str:
-    return (
-        Path(__file__).resolve().parents[2] / "control-plane" / "src" / "sandbox" / "sandbox-env.ts"
-    ).read_text()
+def _load_callback_env_manifest() -> dict:
+    """Language-neutral manifest of the cross-plane image-build env-key contract.
 
-
-def test_image_build_callback_env_keys_match_control_plane_contract():
-    """Pin the TS REPO_IMAGE_CALLBACK_ENV_KEYS list (order included) to the runtime constants.
-
-    The control plane assembles build-sandbox env in TypeScript
-    (buildImageBuildEnvVars) while Modal's ModalBuildSessionService.create
-    mirrors it in Python; both must agree on the callback env key names.
+    The same file is pinned by value on the TypeScript side
+    (packages/control-plane/src/sandbox/sandbox-env.test.ts), so neither plane
+    can drift without failing its own test suite. Tests-only consumption: the
+    runtime constants stay as code.
     """
-    ts_source = _read_control_plane_sandbox_env_source()
-    match = re.search(
-        r"export\s+const\s+REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
-        ts_source,
-        re.DOTALL,
+    manifest_path = (
+        Path(__file__).resolve().parents[2]
+        / "sandbox-runtime"
+        / "src"
+        / "sandbox_runtime"
+        / "image_build_callback_env.json"
     )
-
-    assert match is not None, "missing TS constant: REPO_IMAGE_CALLBACK_ENV_KEYS"
-    ts_keys = re.findall(r'"([^"]+)"', match.group(1))
-    assert ts_keys == [
-        PROVIDER_SESSION_ID_ENV,
-        BUILD_ID_ENV,
-        CALLBACK_URL_ENV,
-        CALLBACK_TOKEN_ENV,
-        FAILURE_CALLBACK_URL_ENV,
-    ]
+    return json.loads(manifest_path.read_text())
 
 
-def test_reserved_callback_env_scrub_sets_align_across_languages():
+def test_runtime_callback_env_constants_match_manifest():
+    """Pin the runtime callback env-var constants to the shared manifest by value."""
+    manifest = _load_callback_env_manifest()
+
+    assert manifest["callback_env"] == {
+        "build_id": BUILD_ID_ENV,
+        "callback_url": CALLBACK_URL_ENV,
+        "failure_callback_url": FAILURE_CALLBACK_URL_ENV,
+        "token": CALLBACK_TOKEN_ENV,
+        "provider_session_id": PROVIDER_SESSION_ID_ENV,
+    }
+    assert manifest["execution_timeout_env_var"] == IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR
+    # The runtime entrypoint reads the build-mode marker as a literal
+    # (os.environ.get("IMAGE_BUILD_MODE") == "true" in entrypoint.py).
+    assert manifest["build_mode_env_var"] == "IMAGE_BUILD_MODE"
+
+
+def test_reserved_user_env_scrub_matches_manifest():
     """Pin the reserved-key scrub — the hijack-prevention half of the contract.
 
-    The TS RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS list (buildImageBuildEnvVars)
-    and Python's RESERVED_USER_ENV_KEYS (ModalBuildSessionService.create) both
-    scrub user env vars before a build sandbox launches. They intentionally
-    diverge at the edges; this test pins the shared core and the exact
-    divergence so neither side can silently drop a scrubbed key.
+    Modal's RESERVED_USER_ENV_KEYS (ModalBuildSessionService.create) and the
+    control plane's RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS both scrub user env
+    vars before a build sandbox launches. They intentionally diverge at the
+    edges; each side pins its own half against the manifest so neither can
+    silently drop a scrubbed key. Intended divergence:
+    - the legacy pre-token secret key and the execution-timeout key are
+      scrubbed only in TS (the timeout scrub is safe on Modal only because
+      create() unconditionally re-sets the key after the scrub — asserted in
+      test_create_build_sandbox_runs_gated_entrypoint_and_scrubs_callback_env);
+    - the Modal stdin-launch sandbox-id key is scrubbed only in Python
+      (meaningless off-Modal).
     """
-    ts_source = _read_control_plane_sandbox_env_source()
-    match = re.search(
-        r"export\s+const\s+RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
-        ts_source,
-        re.DOTALL,
-    )
-    assert match is not None, "missing TS constant: RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS"
-    body = match.group(1)
-    ts_reserved = set(re.findall(r'"([^"]+)"', body))
-    # Resolve the two identifier references in the TS array literal.
-    assert "...REPO_IMAGE_CALLBACK_ENV_KEYS" in body
-    callback_keys = re.search(
-        r"export\s+const\s+REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
-        ts_source,
-        re.DOTALL,
-    )
-    assert callback_keys is not None
-    ts_reserved.update(re.findall(r'"([^"]+)"', callback_keys.group(1)))
-    assert "IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY" in body
-    ts_reserved.add(IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR)
-
+    manifest = _load_callback_env_manifest()
+    callback_env_values = set(manifest["callback_env"].values())
     python_reserved = set(RESERVED_USER_ENV_KEYS)
-    shared_callback_keys = {
-        PROVIDER_SESSION_ID_ENV,
-        BUILD_ID_ENV,
-        CALLBACK_URL_ENV,
-        CALLBACK_TOKEN_ENV,
-        FAILURE_CALLBACK_URL_ENV,
-    }
-    assert shared_callback_keys <= ts_reserved
-    assert shared_callback_keys <= python_reserved
-    # Intended divergence, pinned:
-    # - the legacy pre-token secret key is scrubbed only in TS (never read by
-    #   the Modal runtime);
-    # - the execution-timeout key is scrubbed only in TS — safe on Modal only
-    #   because create() unconditionally re-sets it after the scrub (asserted
-    #   in test_create_build_sandbox_runs_gated_entrypoint_and_scrubs_callback_env);
-    # - the Modal stdin-launch sandbox-id key is scrubbed only in Python
-    #   (meaningless off-Modal).
-    assert ts_reserved - python_reserved == {
-        "OI_REPO_IMAGE_CALLBACK_SECRET",
-        IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR,
-    }
-    assert python_reserved - ts_reserved == {MODAL_SANDBOX_ID_ENV}
 
-
-@pytest.mark.parametrize(
-    ("constant_name", "python_value"),
-    [
-        ("IMAGE_BUILD_MODE_ENV_VAR", "IMAGE_BUILD_MODE"),
-        ("IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY", IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR),
-    ],
-)
-def test_image_build_env_var_names_match_control_plane_contract(constant_name, python_value):
-    """Keep the build-mode marker and execution-timeout key aligned across languages."""
-    ts_source = _read_control_plane_sandbox_env_source()
-    match = re.search(rf'export\s+const\s+{constant_name}\s*=\s*"([^"]+)"\s*;', ts_source)
-
-    assert match is not None, f"missing string TS constant: {constant_name}"
-    assert match.group(1) == python_value
+    assert python_reserved == callback_env_values | set(manifest["reserved_only_modal"])
+    assert set(manifest["reserved_only_modal"]) == {MODAL_SANDBOX_ID_ENV}
+    # The TS-only extras never enter the Python scrub set.
+    assert set(manifest["reserved_only_control_plane"]) & python_reserved == set()
+    assert IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR in manifest["reserved_only_control_plane"]
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -8,6 +8,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from sandbox_runtime.constants import IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR
+from sandbox_runtime.repo_image_callback import (
+    BUILD_ID_ENV,
+    CALLBACK_TOKEN_ENV,
+    CALLBACK_URL_ENV,
+    FAILURE_CALLBACK_URL_ENV,
+    PROVIDER_SESSION_ID_ENV,
+)
 from src.sandbox.build_session import (
     DEFAULT_BUILD_TIMEOUT_SECONDS,
     MAX_BUILD_TIMEOUT_SECONDS,
@@ -45,6 +53,53 @@ def test_build_timeout_limits_match_shared_contract(constant_name, python_value)
 
     assert match is not None, f"missing numeric shared constant: {constant_name}"
     assert python_value == int(match.group(1))
+
+
+def _read_control_plane_sandbox_env_source() -> str:
+    return (
+        Path(__file__).resolve().parents[2] / "control-plane" / "src" / "sandbox" / "sandbox-env.ts"
+    ).read_text()
+
+
+def test_image_build_callback_env_keys_match_control_plane_contract():
+    """Pin the TS REPO_IMAGE_CALLBACK_ENV_KEYS list (order included) to the runtime constants.
+
+    The control plane assembles build-sandbox env in TypeScript
+    (buildImageBuildEnvVars) while Modal's ModalBuildSessionService.create
+    mirrors it in Python; both must agree on the callback env key names.
+    """
+    ts_source = _read_control_plane_sandbox_env_source()
+    match = re.search(
+        r"export\s+const\s+REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
+        ts_source,
+        re.DOTALL,
+    )
+
+    assert match is not None, "missing TS constant: REPO_IMAGE_CALLBACK_ENV_KEYS"
+    ts_keys = re.findall(r'"([^"]+)"', match.group(1))
+    assert ts_keys == [
+        PROVIDER_SESSION_ID_ENV,
+        BUILD_ID_ENV,
+        CALLBACK_URL_ENV,
+        CALLBACK_TOKEN_ENV,
+        FAILURE_CALLBACK_URL_ENV,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "python_value"),
+    [
+        ("IMAGE_BUILD_MODE_ENV_VAR", "IMAGE_BUILD_MODE"),
+        ("IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY", IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR),
+    ],
+)
+def test_image_build_env_var_names_match_control_plane_contract(constant_name, python_value):
+    """Keep the build-mode marker and execution-timeout key aligned across languages."""
+    ts_source = _read_control_plane_sandbox_env_source()
+    match = re.search(rf'export\s+const\s+{constant_name}\s*=\s*"([^"]+)"\s*;', ts_source)
+
+    assert match is not None, f"missing string TS constant: {constant_name}"
+    assert match.group(1) == python_value
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from sandbox_runtime.constants import IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR
+from sandbox_runtime.modal_image_build_start import MODAL_SANDBOX_ID_ENV
 from sandbox_runtime.repo_image_callback import (
     BUILD_ID_ENV,
     CALLBACK_TOKEN_ENV,
@@ -19,6 +20,7 @@ from sandbox_runtime.repo_image_callback import (
 from src.sandbox.build_session import (
     DEFAULT_BUILD_TIMEOUT_SECONDS,
     MAX_BUILD_TIMEOUT_SECONDS,
+    RESERVED_USER_ENV_KEYS,
     BuildSessionNotFoundError,
     ModalBuildSessionService,
 )
@@ -84,6 +86,61 @@ def test_image_build_callback_env_keys_match_control_plane_contract():
         CALLBACK_TOKEN_ENV,
         FAILURE_CALLBACK_URL_ENV,
     ]
+
+
+def test_reserved_callback_env_scrub_sets_align_across_languages():
+    """Pin the reserved-key scrub — the hijack-prevention half of the contract.
+
+    The TS RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS list (buildImageBuildEnvVars)
+    and Python's RESERVED_USER_ENV_KEYS (ModalBuildSessionService.create) both
+    scrub user env vars before a build sandbox launches. They intentionally
+    diverge at the edges; this test pins the shared core and the exact
+    divergence so neither side can silently drop a scrubbed key.
+    """
+    ts_source = _read_control_plane_sandbox_env_source()
+    match = re.search(
+        r"export\s+const\s+RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
+        ts_source,
+        re.DOTALL,
+    )
+    assert match is not None, "missing TS constant: RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS"
+    body = match.group(1)
+    ts_reserved = set(re.findall(r'"([^"]+)"', body))
+    # Resolve the two identifier references in the TS array literal.
+    assert "...REPO_IMAGE_CALLBACK_ENV_KEYS" in body
+    callback_keys = re.search(
+        r"export\s+const\s+REPO_IMAGE_CALLBACK_ENV_KEYS\s*=\s*\[(.*?)\]\s*as\s+const",
+        ts_source,
+        re.DOTALL,
+    )
+    assert callback_keys is not None
+    ts_reserved.update(re.findall(r'"([^"]+)"', callback_keys.group(1)))
+    assert "IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY" in body
+    ts_reserved.add(IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR)
+
+    python_reserved = set(RESERVED_USER_ENV_KEYS)
+    shared_callback_keys = {
+        PROVIDER_SESSION_ID_ENV,
+        BUILD_ID_ENV,
+        CALLBACK_URL_ENV,
+        CALLBACK_TOKEN_ENV,
+        FAILURE_CALLBACK_URL_ENV,
+    }
+    assert shared_callback_keys <= ts_reserved
+    assert shared_callback_keys <= python_reserved
+    # Intended divergence, pinned:
+    # - the legacy pre-token secret key is scrubbed only in TS (never read by
+    #   the Modal runtime);
+    # - the execution-timeout key is scrubbed only in TS — safe on Modal only
+    #   because create() unconditionally re-sets it after the scrub (asserted
+    #   in test_create_build_sandbox_runs_gated_entrypoint_and_scrubs_callback_env);
+    # - the Modal stdin-launch sandbox-id key is scrubbed only in Python
+    #   (meaningless off-Modal).
+    assert ts_reserved - python_reserved == {
+        "OI_REPO_IMAGE_CALLBACK_SECRET",
+        IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR,
+    }
+    assert python_reserved - ts_reserved == {MODAL_SANDBOX_ID_ENV}
 
 
 @pytest.mark.parametrize(

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -68,7 +68,7 @@ async def test_create_build_sandbox_forwards_callback_context_and_returns_provid
             "callback_url": "https://worker.test/image-builds/build-complete",
             "failure_callback_url": "https://worker.test/image-builds/build-failed",
             "user_env_vars": {"FOO": "bar"},
-            "build_timeout_seconds": 2400,
+            "provider_session_timeout_seconds": 2400,
         },
     )
 
@@ -215,7 +215,7 @@ async def test_create_logs_http_outcome(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "field",
-    ["build_execution_timeout_seconds", "build_timeout_seconds"],
+    ["build_execution_timeout_seconds", "provider_session_timeout_seconds"],
 )
 async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
     service = _patch_dependencies(monkeypatch)
@@ -238,6 +238,46 @@ async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
 
 
 @pytest.mark.asyncio
+async def test_create_reads_legacy_build_timeout_key_during_rename_skew(monkeypatch):
+    """An older control plane sends build_timeout_seconds; honor it until both planes rename."""
+    service = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
+            "build_timeout_seconds": 4200,
+        },
+    )
+
+    assert service.create.await_args.kwargs["timeout_seconds"] == 4200
+
+
+@pytest.mark.asyncio
+async def test_create_prefers_renamed_provider_session_timeout_key_over_legacy(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
+            "provider_session_timeout_seconds": 2400,
+            "build_timeout_seconds": 4200,
+        },
+    )
+
+    assert service.create.await_args.kwargs["timeout_seconds"] == 2400
+
+
+@pytest.mark.asyncio
 async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
     service = _patch_dependencies(monkeypatch)
 
@@ -249,7 +289,7 @@ async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
             "build_id": "imgb-1",
             "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
             **CALLBACK_CONTEXT,
-            "build_timeout_seconds": 99999,
+            "provider_session_timeout_seconds": 99999,
         },
     )
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/image_build_callback_env.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/image_build_callback_env.json
@@ -1,0 +1,17 @@
+{
+  "description": "Single source of the cross-plane image-build env-key contract. Consumed by value-pinning tests on both sides: control-plane TS constants in packages/control-plane/src/sandbox/sandbox-env.ts (tested in sandbox-env.test.ts) and the sandbox-runtime / Modal Python constants (tested in packages/modal-infra/tests/test_build_sandbox_lifecycle.py). Production code on both sides keeps its own constants; only tests read this file.",
+  "callback_env": {
+    "build_id": "OI_REPO_IMAGE_BUILD_ID",
+    "callback_url": "OI_REPO_IMAGE_CALLBACK_URL",
+    "failure_callback_url": "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
+    "token": "OI_REPO_IMAGE_CALLBACK_TOKEN",
+    "provider_session_id": "OI_REPO_IMAGE_PROVIDER_SESSION_ID"
+  },
+  "build_mode_env_var": "IMAGE_BUILD_MODE",
+  "execution_timeout_env_var": "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS",
+  "reserved_only_control_plane": [
+    "OI_REPO_IMAGE_CALLBACK_SECRET",
+    "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS"
+  ],
+  "reserved_only_modal": ["MODAL_SANDBOX_ID"]
+}


### PR DESCRIPTION
## Summary

Stack 2/3 (based on #1286 — merge that first). The standardization re-introduced exactly the per-provider env duplication `buildSandboxEnvVars` was created to kill: byte-identical callback-key constants and near-identical build-env bodies in the Vercel and OpenComputer providers, plus a third copy in Modal's Python.

- `REPO_IMAGE_CALLBACK_ENV_KEYS` + `RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS` hoisted into `sandbox-env.ts` (which already owns `IMAGE_BUILD_MODE_ENV_VAR`). The legacy `OI_REPO_IMAGE_CALLBACK_SECRET` reserved entry is deliberately kept — dropping it is a separate decision
- New `buildImageBuildEnvVars(config)` sibling of `buildSandboxEnvVars`, called by both TS providers. It owns the common core (reserved-key scrub, `SANDBOX_ID`/`IMAGE_BUILD_MODE`/`SESSION_CONFIG`, clone env); callback keys and the execution-timeout key stay caller-side because delivery timing genuinely differs (Vercel at entrypoint launch, OC at create time) — behavior-preserving by design. Directly unit-tested, including the reserved-key hijack-prevention scrub
- New `imageBuildSandboxIdentity(config, now)` consolidates the duplicated sandbox naming + `openinspect_*` labels (explicit timestamp param keeps the impurity visible); labels now also carry `openinspect_scope_kind`/`openinspect_scope_id` alongside the legacy `openinspect_environment` key, mirroring Modal's Python tags
- Modal's Python copy can't share code, so it's pinned instead: `RESERVED_USER_ENV_KEYS` hoisted to a module constant in `build_session.py` (no behavior change) and two new cross-language contract tests regex-read the TS source — callback key names (order-sensitive) and the reserved-scrub sets, with the intended TS/Python divergence asserted and commented (`MODAL_SANDBOX_ID` Python-only; secret + timeout key TS-only, safe because Modal re-sets the timeout post-scrub)

## Validation

- control plane: 2,261 unit + 698 integration tests passed; typecheck clean; prettier + ESLint clean
- modal-infra: 178 tests passed; ruff clean
- Thermo-reviewed (Opus): six in-scope findings (scope-kind labels, missing unit tests, timestamp impurity, helper placement, guard-message wording, reserved-set contract gap) — all fixed here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized image-build sandbox identity, callback settings, build mode, timeouts, and repository metadata.
  * Added shared environment handling across supported sandbox providers.
  * Added safeguards to remove reserved environment variables before build-specific values are applied.
  * Added support for provider session timeouts, with compatibility for the previous timeout setting.

* **Bug Fixes**
  * Improved validation for missing repositories and build completion durations.
  * Build durations are now consistently handled and stored in seconds.

* **Tests**
  * Expanded coverage for environment construction, identity generation, validation, timeout compatibility, and completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->