### PR TITLE
refactor: standardize build duration on seconds and rename session-timeout wire key

### DIFF
--- a/packages/control-plane/src/db/image-build-finalization.ts
+++ b/packages/control-plane/src/db/image-build-finalization.ts
@@ -7,8 +7,6 @@ import { timingSafeEqual } from "@open-inspect/shared/auth";
 import type { ImageBuildCallbackBuild, ImageBuildProvider } from "../image-builds/model";
 import type { SqlDatabase } from "./sql-database";
 
-const MS_PER_SECOND = 1000;
-
 interface CallbackTokenRow {
   id: string;
   scope_kind: ImageBuildScopeKind;
@@ -62,7 +60,7 @@ export class ImageBuildFinalizationStore {
     completionHash: string;
     repositoryShas: RepositoryShaEntry[];
     runtimeVersion: string;
-    buildDurationMs: number;
+    buildDurationSeconds: number;
     now: number;
   }): Promise<ImageBuildCompletionAcceptance> {
     const result = await this.db
@@ -82,7 +80,7 @@ export class ImageBuildFinalizationStore {
         params.completionHash,
         JSON.stringify(params.repositoryShas),
         params.runtimeVersion,
-        params.buildDurationMs / MS_PER_SECOND,
+        params.buildDurationSeconds,
         params.now,
         params.buildId,
         params.provider,

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -13,8 +13,6 @@ import type {
 import { ImageBuildFinalizationStore } from "./image-build-finalization";
 import type { SqlDatabase } from "./sql-database";
 
-const MS_PER_SECOND = 1000;
-
 /** D1 caps bound parameters per statement; IN-list queries chunk below it. */
 const MAX_SCOPE_IDS_PER_QUERY = 50;
 
@@ -292,7 +290,7 @@ export class ImageBuildStore {
     providerImageId: string,
     repositoryShas: RepositoryShaEntry[],
     runtimeVersion: string,
-    buildDurationMs: number,
+    buildDurationSeconds: number,
     finalizationLeaseToken?: string
   ): Promise<MarkImageBuildReadyResult> {
     const build = await this.db
@@ -337,7 +335,7 @@ export class ImageBuildStore {
         providerImageId,
         JSON.stringify(repositoryShas),
         runtimeVersion,
-        buildDurationMs / MS_PER_SECOND,
+        buildDurationSeconds,
         buildId,
         provider,
         ...(finalizationLeaseToken ? [finalizationLeaseToken] : []),
@@ -359,7 +357,7 @@ export class ImageBuildStore {
           providerSessionId: build.provider_session_id,
           repositoryShas,
           runtimeVersion,
-          buildDurationMs,
+          buildDurationSeconds,
           scopeKind: build.scope_kind,
           scopeId: build.scope_id,
           createdAt: build.created_at,
@@ -426,7 +424,7 @@ export class ImageBuildStore {
     providerSessionId: string | null;
     repositoryShas: RepositoryShaEntry[];
     runtimeVersion: string;
-    buildDurationMs: number;
+    buildDurationSeconds: number;
     scopeKind: ImageBuildScopeKind;
     scopeId: string;
     createdAt: number;
@@ -458,7 +456,7 @@ export class ImageBuildStore {
         params.providerImageId,
         JSON.stringify(params.repositoryShas),
         params.runtimeVersion,
-        params.buildDurationMs / MS_PER_SECOND,
+        params.buildDurationSeconds,
         params.buildId,
         params.provider,
         ...(params.finalizationLeaseToken ? [params.finalizationLeaseToken] : []),

--- a/packages/control-plane/src/image-builds/finalization-job.test.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.test.ts
@@ -34,6 +34,32 @@ describe("image build finalization jobs", () => {
     expect(JSON.stringify(first)).not.toContain("abc123");
   });
 
+  it("keeps the frozen hash canonicalization stable across refactors", async () => {
+    // Golden value computed from the pre-seconds-refactor canonical document
+    // ({... buildDurationMs: 12500}). The completion hash is a persisted
+    // idempotency contract: a deploy-straddling callback retry must hash
+    // identically before and after a refactor. If this fails, the hash
+    // schema changed — that requires an explicit version migration, not a
+    // fixture update.
+    const job = await createImageBuildFinalizationJob({
+      outcome: "success",
+      completion: {
+        buildId: "build-1",
+        providerSessionId: "session-1",
+        repositoryShas: [
+          { repoOwner: "Acme", repoName: "Web", baseSha: "abc123" },
+          { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
+        ],
+        runtimeVersion: "v53-runtime",
+        buildDurationSeconds: 12.5,
+      },
+    });
+
+    expect(job.completionHash).toBe(
+      "a38995471a349e98e513c04a4a8806b3275e2dcbbff53523ab50aee0d0644df9"
+    );
+  });
+
   it("treats repository SHA order as irrelevant to completion identity", async () => {
     const completion = {
       buildId: "build-1",

--- a/packages/control-plane/src/image-builds/finalization-job.test.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.test.ts
@@ -14,7 +14,7 @@ describe("image build finalization jobs", () => {
         { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
       ],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
     };
 
     const first = await createImageBuildFinalizationJob({ outcome: "success", completion });
@@ -43,7 +43,7 @@ describe("image build finalization jobs", () => {
         { repoOwner: "Acme", repoName: "Api", baseSha: "def456" },
       ],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
     };
 
     const ordered = await createImageBuildFinalizationJob({ outcome: "success", completion });

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -46,7 +46,12 @@ export async function createImageBuildFinalizationJob(
                 left.baseSha.localeCompare(right.baseSha)
             ),
           runtimeVersion: result.completion.runtimeVersion,
-          buildDurationSeconds: result.completion.buildDurationSeconds,
+          // Frozen hash canonicalization: this document is a persisted
+          // idempotency contract, not a mirror of the domain types. The
+          // member keeps its original name and millisecond value so the same
+          // wire callback hashes identically across deploys and refactors —
+          // change it only with an explicit hash-schema version bump.
+          buildDurationMs: result.completion.buildDurationSeconds * 1000,
         }
       : {
           buildId,

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -46,7 +46,7 @@ export async function createImageBuildFinalizationJob(
                 left.baseSha.localeCompare(right.baseSha)
             ),
           runtimeVersion: result.completion.runtimeVersion,
-          buildDurationMs: result.completion.buildDurationMs,
+          buildDurationSeconds: result.completion.buildDurationSeconds,
         }
       : {
           buildId,

--- a/packages/control-plane/src/image-builds/finalizer.test.ts
+++ b/packages/control-plane/src/image-builds/finalizer.test.ts
@@ -257,7 +257,7 @@ describe("ImageBuildFinalizer", () => {
       "image-1",
       expect.any(Array),
       "v53-runtime",
-      12_500,
+      12.5,
       expect.any(String)
     );
   });

--- a/packages/control-plane/src/image-builds/finalizer.ts
+++ b/packages/control-plane/src/image-builds/finalizer.ts
@@ -209,7 +209,7 @@ export class ImageBuildFinalizer {
       providerImageId,
       repositoryShas,
       build.runtime_version,
-      (build.build_duration_seconds ?? 0) * 1000,
+      build.build_duration_seconds ?? 0,
       leaseToken
     );
     if (ready.type === "not_accepting_completion") {

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -73,7 +73,8 @@ export interface CompleteImageBuildCallback {
   providerSessionId: string;
   repositoryShas: RepositoryShaEntry[];
   runtimeVersion: string;
-  buildDurationMs: number;
+  /** Wire seconds passed through unconverted — the D1 column is also seconds. */
+  buildDurationSeconds: number;
 }
 
 export interface FailImageBuildCallback {

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -162,7 +162,7 @@ function validCompletion(overrides: Record<string, unknown> = {}) {
     providerSessionId: "vercel-session-1",
     repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v56-managed-provider-runtime",
-    buildDurationMs: 12_500,
+    buildDurationSeconds: 12.5,
     ...overrides,
   };
 }

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -371,7 +371,7 @@ export class ImageBuildWorkflow {
       completionHash: job.completionHash,
       repositoryShas: completion.repositoryShas,
       runtimeVersion: completion.runtimeVersion,
-      buildDurationMs: completion.buildDurationMs,
+      buildDurationSeconds: completion.buildDurationSeconds,
       now: Date.now(),
     });
     if (acceptance === "rejected") {

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -48,7 +48,6 @@ import {
 } from "./shared";
 
 const logger = createLogger("router:image-builds");
-const MS_PER_SECOND = 1000;
 const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
 
 /**
@@ -64,15 +63,11 @@ const buildCompleteBodySchema = z.object({
   runtime_version: z.string().refine((value) => parseRuntimeVersionNumber(value) !== null, {
     message: "must start with v<number>",
   }),
-  // The converted milliseconds must stay finite: Infinity would be
-  // canonicalized to null by JSON.stringify inside the completion hash and
-  // the persisted row.
-  build_duration_seconds: z
-    .number()
-    .nonnegative()
-    .refine((value) => Number.isFinite(value * MS_PER_SECOND), {
-      message: "must convert to finite milliseconds",
-    }),
+  // Must stay finite: Infinity would be canonicalized to null by
+  // JSON.stringify inside the completion hash and the persisted row. Capped
+  // at MAX_SAFE_INTEGER so an absurd duration cannot lose integer precision
+  // in the persisted row or the completion-hash canonicalization.
+  build_duration_seconds: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER),
 });
 
 const buildFailedBodySchema = z.object({
@@ -201,7 +196,7 @@ async function handleBuildComplete(
     providerSessionId: parsed.provider_session_id,
     repositoryShas: parsed.repository_shas,
     runtimeVersion: parsed.runtime_version,
-    buildDurationMs: parsed.build_duration_seconds * MS_PER_SECOND,
+    buildDurationSeconds: parsed.build_duration_seconds,
   };
 
   try {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -482,6 +482,7 @@ describe("ModalClient", () => {
       failure_callback_url: "https://worker.test/image-builds/build-failed",
       build_execution_timeout_seconds: 1800,
       provider_session_timeout_seconds: 2400,
+      build_timeout_seconds: 2400,
     });
     expect(result).toEqual({ providerSessionId: "modal-session-1" });
   });

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -481,7 +481,7 @@ describe("ModalClient", () => {
       callback_url: "https://worker.test/image-builds/build-complete",
       failure_callback_url: "https://worker.test/image-builds/build-failed",
       build_execution_timeout_seconds: 1800,
-      build_timeout_seconds: 2400,
+      provider_session_timeout_seconds: 2400,
     });
     expect(result).toEqual({ providerSessionId: "modal-session-1" });
   });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -615,7 +615,7 @@ export class ModalClient {
           failure_callback_url: request.failureCallbackUrl,
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
-          build_timeout_seconds: request.providerSessionTimeoutSeconds,
+          provider_session_timeout_seconds: request.providerSessionTimeoutSeconds,
         }),
       });
 

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -616,6 +616,11 @@ export class ModalClient {
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
           provider_session_timeout_seconds: request.providerSessionTimeoutSeconds,
+          // Transitional duplicate under the pre-rename key: the control plane
+          // and Modal deploy the same commit via independent pipelines, so an
+          // older Modal may still read only build_timeout_seconds during the
+          // skew window. Drop once both planes are known to be past the rename.
+          build_timeout_seconds: request.providerSessionTimeoutSeconds,
         }),
       });
 

--- a/packages/control-plane/test/integration/image-build-finalization-queue.test.ts
+++ b/packages/control-plane/test/integration/image-build-finalization-queue.test.ts
@@ -30,7 +30,7 @@ async function seedAcceptedBuild(buildId: string): Promise<ImageBuildStore> {
     completionHash: COMPLETION_HASH,
     repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v53-runtime",
-    buildDurationMs: 1_000,
+    buildDurationSeconds: 1,
     now,
   });
   return store;

--- a/packages/control-plane/test/integration/image-build-finalization-store.test.ts
+++ b/packages/control-plane/test/integration/image-build-finalization-store.test.ts
@@ -55,7 +55,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     };
 
@@ -116,7 +116,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1_000,
+      buildDurationSeconds: 1,
       now,
     });
 
@@ -152,7 +152,7 @@ describe("ImageBuildStore finalization state", () => {
         completionHash: `completion-${index + 1}`,
         repositoryShas: [],
         runtimeVersion: "v53-runtime",
-        buildDurationMs: 1_000,
+        buildDurationSeconds: 1,
         now: callbackTime,
       });
     }
@@ -320,7 +320,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     });
     await store.supersedeActiveImages(environmentScope(environmentId));
@@ -456,7 +456,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 12_500,
+      buildDurationSeconds: 12.5,
       now,
     });
 
@@ -516,7 +516,7 @@ describe("ImageBuildStore finalization state", () => {
       completionHash: "completion-hash",
       repositoryShas: [],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1,
+      buildDurationSeconds: 1,
       now,
     });
 

--- a/packages/control-plane/test/integration/image-build-scheduler.test.ts
+++ b/packages/control-plane/test/integration/image-build-scheduler.test.ts
@@ -50,7 +50,7 @@ describe("image build scheduler integration", () => {
       completionHash,
       repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
       runtimeVersion: "v53-runtime",
-      buildDurationMs: 1_000,
+      buildDurationSeconds: 1,
       now: callbackTime,
     });
     await env.DB.prepare("UPDATE image_builds SET created_at = 1 WHERE id = ?")
@@ -113,7 +113,7 @@ describe("image build scheduler integration", () => {
         completionHash,
         repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
         runtimeVersion: "v53-runtime",
-        buildDurationMs: 1_000,
+        buildDurationSeconds: 1,
         now: index + 1,
       });
     }

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -164,7 +164,7 @@ describe("Image builds", () => {
         "im-new",
         REPOSITORY_SHAS,
         RUNTIME_VERSION,
-        12_500
+        12.5
       );
 
       expect(result.type).toBe("marked_ready");
@@ -211,7 +211,7 @@ describe("Image builds", () => {
         "im-late",
         REPOSITORY_SHAS,
         RUNTIME_VERSION,
-        10_000
+        10
       );
 
       expect(result.type).toBe("superseded_by_newer_ready");
@@ -854,8 +854,8 @@ describe("Image builds", () => {
       ],
       ["missing build_duration_seconds", { build_duration_seconds: undefined }],
       ["negative build_duration_seconds", { build_duration_seconds: -1 }],
-      // Finite seconds whose ×1000 conversion overflows to Infinity, which
-      // JSON.stringify would canonicalize to null downstream.
+      // Finite but beyond MAX_SAFE_INTEGER seconds — would lose integer
+      // precision in the persisted row and hash canonicalization.
       ["overflowing build_duration_seconds", { build_duration_seconds: 1e308 }],
     ])("fails registration closed on %s", async (_label, overrides) => {
       const environmentId = await seedEnvironment();

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -590,9 +590,9 @@ async def api_create_build_sandbox(
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
-        timeout_seconds = _validated_timeout_seconds(
+        provider_session_timeout_seconds = _validated_timeout_seconds(
             request,
-            "build_timeout_seconds",
+            "provider_session_timeout_seconds",
             default_seconds=(
                 DEFAULT_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
             ),
@@ -621,7 +621,7 @@ async def api_create_build_sandbox(
             clone_username=clone_username,
             user_env_vars=request.get("user_env_vars") or None,
             build_execution_timeout_seconds=build_execution_timeout_seconds,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=provider_session_timeout_seconds,
         )
         return {
             "success": True,

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -590,9 +590,15 @@ async def api_create_build_sandbox(
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
+        # legacy_field: transitional dual-read for the build_timeout_seconds ->
+        # provider_session_timeout_seconds rename. The control plane and Modal
+        # deploy the same commit via independent pipelines, so an older control
+        # plane may still send only the legacy key during the skew window.
+        # Drop the alias once both planes are known to be past the rename.
         provider_session_timeout_seconds = _validated_timeout_seconds(
             request,
             "provider_session_timeout_seconds",
+            legacy_field="build_timeout_seconds",
             default_seconds=(
                 DEFAULT_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
             ),
@@ -801,8 +807,12 @@ def _validated_timeout_seconds(
     *,
     default_seconds: int,
     max_seconds: int,
+    legacy_field: str | None = None,
 ) -> int:
     value = request.get(field)
+    if value is None and legacy_field is not None:
+        field = legacy_field
+        value = request.get(field)
     if value is None:
         return default_seconds
     if not isinstance(value, int) or isinstance(value, bool):

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -25,6 +25,7 @@ from src.sandbox.build_session import (
     ModalBuildSessionService,
 )
 from src.sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+from src.web_api import IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
 
 
 def _async_method(return_value=None):
@@ -55,6 +56,31 @@ def test_build_timeout_limits_match_shared_contract(constant_name, python_value)
 
     assert match is not None, f"missing numeric shared constant: {constant_name}"
     assert python_value == int(match.group(1))
+
+
+def test_finalization_grace_matches_control_plane_contract():
+    """Pin IMAGE_BUILD_FINALIZATION_GRACE_SECONDS to the control-plane grace window.
+
+    web_api.py mirrors IMAGE_BUILD_FINALIZATION_GRACE_MS from the control
+    plane's image-builds/timeouts.ts; both planes must reserve the same
+    finalization headroom on top of the build-execution budget.
+    """
+    ts_source = (
+        Path(__file__).resolve().parents[2]
+        / "control-plane"
+        / "src"
+        / "image-builds"
+        / "timeouts.ts"
+    ).read_text()
+    match = re.search(
+        r"export\s+const\s+IMAGE_BUILD_FINALIZATION_GRACE_MS\s*=\s*"
+        r"(\d+)\s*\*\s*(\d+)\s*\*\s*MS_PER_SECOND\s*;",
+        ts_source,
+    )
+
+    assert match is not None, "missing TS constant: IMAGE_BUILD_FINALIZATION_GRACE_MS"
+    ts_grace_seconds = int(match.group(1)) * int(match.group(2))
+    assert ts_grace_seconds == IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
 
 
 def _load_callback_env_manifest() -> dict:

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -73,14 +73,26 @@ def test_finalization_grace_matches_control_plane_contract():
         / "timeouts.ts"
     ).read_text()
     match = re.search(
-        r"export\s+const\s+IMAGE_BUILD_FINALIZATION_GRACE_MS\s*=\s*"
-        r"(\d+)\s*\*\s*(\d+)\s*\*\s*MS_PER_SECOND\s*;",
+        r"export\s+const\s+IMAGE_BUILD_FINALIZATION_GRACE_MS\s*=\s*([^;]+);",
         ts_source,
     )
-
     assert match is not None, "missing TS constant: IMAGE_BUILD_FINALIZATION_GRACE_MS"
-    ts_grace_seconds = int(match.group(1)) * int(match.group(2))
-    assert ts_grace_seconds == IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
+
+    ms_per_second_match = re.search(r"const\s+MS_PER_SECOND\s*=\s*(\d+)\s*;", ts_source)
+    assert ms_per_second_match is not None, "missing TS constant: MS_PER_SECOND"
+    ms_per_second = int(ms_per_second_match.group(1))
+
+    ts_grace_ms = 1
+    for factor in (part.strip() for part in match.group(1).split("*")):
+        if factor == "MS_PER_SECOND":
+            ts_grace_ms *= ms_per_second
+        else:
+            assert factor.isdigit(), (
+                "could not evaluate IMAGE_BUILD_FINALIZATION_GRACE_MS: expected a "
+                f"product of integer literals and MS_PER_SECOND, got factor {factor!r}"
+            )
+            ts_grace_ms *= int(factor)
+    assert ts_grace_ms == IMAGE_BUILD_FINALIZATION_GRACE_SECONDS * ms_per_second
 
 
 def _load_callback_env_manifest() -> dict:

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -238,6 +238,46 @@ async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
 
 
 @pytest.mark.asyncio
+async def test_create_reads_legacy_build_timeout_key_during_rename_skew(monkeypatch):
+    """An older control plane sends build_timeout_seconds; honor it until both planes rename."""
+    service = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
+            "build_timeout_seconds": 4200,
+        },
+    )
+
+    assert service.create.await_args.kwargs["timeout_seconds"] == 4200
+
+
+@pytest.mark.asyncio
+async def test_create_prefers_renamed_provider_session_timeout_key_over_legacy(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
+            "provider_session_timeout_seconds": 2400,
+            "build_timeout_seconds": 4200,
+        },
+    )
+
+    assert service.create.await_args.kwargs["timeout_seconds"] == 2400
+
+
+@pytest.mark.asyncio
 async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
     service = _patch_dependencies(monkeypatch)
 

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -68,7 +68,7 @@ async def test_create_build_sandbox_forwards_callback_context_and_returns_provid
             "callback_url": "https://worker.test/image-builds/build-complete",
             "failure_callback_url": "https://worker.test/image-builds/build-failed",
             "user_env_vars": {"FOO": "bar"},
-            "build_timeout_seconds": 2400,
+            "provider_session_timeout_seconds": 2400,
         },
     )
 
@@ -215,7 +215,7 @@ async def test_create_logs_http_outcome(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "field",
-    ["build_execution_timeout_seconds", "build_timeout_seconds"],
+    ["build_execution_timeout_seconds", "provider_session_timeout_seconds"],
 )
 async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
     service = _patch_dependencies(monkeypatch)
@@ -249,7 +249,7 @@ async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
             "build_id": "imgb-1",
             "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
             **CALLBACK_CONTEXT,
-            "build_timeout_seconds": 99999,
+            "provider_session_timeout_seconds": 99999,
         },
     )
 


### PR DESCRIPTION
## Summary

Stack 3/3 (based on #1287; merge #1286 → #1287 → this). Kills the seconds↔milliseconds ping-pong and the misleading Modal wire key.

- **Seconds end to end for build duration**: the wire field and the D1 column were both already seconds, but the value crossed the s↔ms boundary four times in between (route parse ×1000 → store ÷1000 → finalizer ×1000 → store ÷1000). Internal types now carry `buildDurationSeconds`; all four conversions are deleted. Wire field names unchanged. In-flight D1 rows are safe across the deploy (the column value is identical either way), and the completion-hash canonicalization is **frozen at its legacy shape** (`buildDurationMs: seconds * 1000`, pinned by a golden-hash test) — the hash document is a persisted idempotency contract, so deploy-straddling retries keep their idempotent replayed response with no degradation
- **Wire-key rename**: Modal's `build_timeout_seconds` actually carried the provider-*session* timeout (`build_execution_timeout_seconds` is the build budget). Renamed to `provider_session_timeout_seconds` with a deliberate one-release skew shim in both directions — the CP dual-writes both keys and `web_api.py` dual-reads with a legacy fallback (commented for removal once both planes are past the rename). Grep-verified `client.ts` is the endpoint's only caller
- **Grace-constant pin**: `IMAGE_BUILD_FINALIZATION_GRACE_SECONDS` (Modal) silently mirrored `IMAGE_BUILD_FINALIZATION_GRACE_MS` (control plane) with no contract test, unlike the build-timeout constants. A new cross-language test evaluates the TS expression (tolerant of formulation changes — `600 * MS_PER_SECOND` and a plain literal both pass) and asserts equality

**Conflict note**: the minimal route-parse change here overlaps the zod rewrite in #1284; whichever merges second takes a small rebase re-expressing "no unit conversion at parse" in the schema.

**Follow-up** (intentionally not in this PR): drop the dual-read/dual-write shim after both planes deploy past the rename.

## Validation

- control plane: 2,261 unit + 698 integration tests passed; typecheck clean; prettier + ESLint clean
- modal-infra: 181 tests passed; ruff clean
- Sanity greps at tip: zero `buildDurationMs`/`providerSessionTimeoutMs`; `build_timeout_seconds` only in the shim + its tests
- Thermo-reviewed (Opus): two in-scope findings (rename skew window, brittle contract-test regex) — both fixed here
