### PR TITLE
fix(slack): bound the repo catalog fetch on the mention path

### DIFF
--- a/packages/slack-bot/src/classifier/control-plane.ts
+++ b/packages/slack-bot/src/classifier/control-plane.ts
@@ -27,12 +27,16 @@ export const KV_CACHE_TTL_SECONDS = 300;
 export async function controlPlaneFetch(
   env: Env,
   path: string,
-  traceId?: string
+  traceId?: string,
+  timeoutMs?: number
 ): Promise<Response> {
   return signedControlPlaneFetch(
     env,
     { method: "GET", url: `https://internal${path}`, traceId },
-    { headers: { Accept: "application/json" } }
+    {
+      headers: { Accept: "application/json" },
+      ...(timeoutMs === undefined ? {} : { signal: AbortSignal.timeout(timeoutMs) }),
+    }
   );
 }
 

--- a/packages/slack-bot/src/classifier/repos.test.ts
+++ b/packages/slack-bot/src/classifier/repos.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import { clearLocalCache, getAvailableRepos, getRoutingRules, getWatchedChannels } from "./repos";
+import {
+  clearLocalCache,
+  getAvailableRepos,
+  getRoutingRules,
+  getWatchedChannels,
+  REPOS_FETCH_TIMEOUT_MS,
+} from "./repos";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -189,6 +195,53 @@ describe("getAvailableRepos", () => {
 
     await expect(getAvailableRepos(env, "trace-2")).resolves.toEqual(cachedRepos);
     expect(env.SLACK_KV.get).toHaveBeenCalledWith("repos:cache", "json");
+  });
+
+  it("bounds the catalog fetch and serves the KV fallback when it times out", async () => {
+    // The mention handler runs inside waitUntil. An unbounded fetch here eats the
+    // background budget, and the platform cancels the remaining work after the
+    // ack has posted but before a session exists — the request then vanishes
+    // with neither a session nor an error.
+    const cachedRepos = [
+      {
+        id: "acme/web",
+        owner: "acme",
+        name: "web",
+        fullName: "acme/web",
+        displayName: "web",
+        description: "Cached repo",
+        defaultBranch: "main",
+        private: false,
+      },
+    ];
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const env = {
+      SLACK_KV: {
+        get: vi.fn().mockResolvedValue(cachedRepos),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      },
+      CONTROL_PLANE: {
+        fetch: vi
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" })
+          ),
+      },
+      SERVICE_AUTH_SECRET: "test-secret",
+    } as unknown as Env;
+
+    const repos = await getAvailableRepos(env, "trace-timeout");
+
+    expect(repos).toEqual(cachedRepos);
+    expect(env.SLACK_KV.get).toHaveBeenCalledWith("repos:cache", "json");
+    // The bound is what makes the abort happen at all; without it the fetch runs
+    // until the platform kills the whole invocation.
+    expect(timeoutSpy).toHaveBeenCalledWith(REPOS_FETCH_TIMEOUT_MS);
+    const init = vi.mocked(env.CONTROL_PLANE.fetch).mock.calls[0]?.[1] as RequestInit | undefined;
+    // Identity, not just shape: attaching some other signal would pass an
+    // instanceof check while leaving the fetch effectively unbounded.
+    expect(init?.signal).toBe(timeoutSpy.mock.results[0]?.value);
   });
 
   it("falls back when the control-plane repository response is malformed", async () => {

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -37,6 +37,20 @@ const log = createLogger("repos");
 const FALLBACK_REPOS: RepoConfig[] = [];
 
 /**
+ * Bound on the catalog fetch, because it sits on the critical path of every
+ * mention and those handlers run inside `waitUntil`. A cold control-plane cache
+ * can make `GET /repos` take tens of seconds; left unbounded it consumes the
+ * whole background-task budget and the platform cancels the remaining work
+ * mid-flight — after the "Working on..." ack has posted but before a session
+ * exists, so the request disappears with neither a session nor an error.
+ *
+ * Giving up early costs a possibly-stale catalog from the KV fallback, which is
+ * a far better outcome than dropping the request. A warm fetch takes well under
+ * a second, so this only trips when something is genuinely wrong.
+ */
+export const REPOS_FETCH_TIMEOUT_MS = 5_000;
+
+/**
  * Local in-memory cache for repos.
  */
 let localCache: {
@@ -96,7 +110,7 @@ export async function getAvailableRepos(env: Env, traceId?: string): Promise<Rep
 
   const startTime = Date.now();
   try {
-    const response = await controlPlaneFetch(env, "/repos", traceId);
+    const response = await controlPlaneFetch(env, "/repos", traceId, REPOS_FETCH_TIMEOUT_MS);
 
     if (!response.ok) {
       log.error("control_plane.fetch_repos", {


### PR DESCRIPTION
## Summary

A Slack mention whose repo-catalog fetch was slow **disappeared**. The `Working on *X*...` ack posted, and then nothing: no session, no error, no reply. The user re-mentioned the bot 15 minutes later and it worked, so it read as flakiness rather than a bug.

The mention handler runs inside `waitUntil`, and `getAvailableRepos` called `GET /repos` with no bound. On a cold control-plane cache that request can take tens of seconds, at which point it has consumed the whole background-task budget and the platform cancels the remainder of the handler. The cancellation lands *after* the ack and *before* session creation, which is the worst possible window:

- no session exists, so nothing can complete;
- the ack is already posted, so the thread shows work in progress forever;
- `startSessionAndSendPrompt`'s own failure branches — which do post "Sorry, I couldn't create a session" — never run.

Production trace:

```
12:07:08.123  app_mention received
12:07:32.950  control_plane.fetch_repos  outcome=success  repo_count=318  duration_ms=24390
12:07:37.315  (ack posted)
12:07:38.108  WARN waitUntil() tasks did not complete within the allowed time
              after invocation end and have been cancelled
```

The retry against a warm cache: `duration_ms=592`.

## Fix

Bound the fetch at `REPOS_FETCH_TIMEOUT_MS` (5s). `getAvailableRepos` already falls back to the bot's own KV copy of the catalog on any error, so a timeout costs a possibly-stale catalog instead of the entire request. A warm fetch is well under a second, so the bound only trips when something is genuinely wrong.

`controlPlaneFetch` gains an optional `timeoutMs`; callers that don't pass one are unchanged.

## Why a bound rather than making the fetch fast

This pairs with #1273. That change made the control plane's cache refresh survive the *caller* disconnecting, which is exactly what now happens: the bot gives up at 5s, the refresh completes in the background, and the next mention is served from a warm cache. Before both changes an aborted miss left KV empty, so cold could persist indefinitely.

## Known gap, deliberately not in this PR

The ack is still posted before the session exists, so any *other* way the handler dies leaves the same dangling "Working on..." message. Two ways to close that — post the ack only after session creation, or update it on failure — but the first trades away ~1s of feedback on the happy path and the second can't help when the isolate is killed outright. That's a UX call worth making separately from this root-cause fix; happy to follow up whichever way you prefer.

## Test plan

- [x] `npm test -w @open-inspect/slack-bot` (407), `-w @open-inspect/shared` (545), `-w @open-inspect/control-plane` (2311)
- [x] `npm run typecheck`, `npm run lint` clean
- [x] New test in `src/classifier/repos.test.ts`: a fetch that rejects with `TimeoutError` returns the KV-cached catalog, and the request is asserted to carry an `AbortSignal` created with `REPOS_FETCH_TIMEOUT_MS`. It asserts the bound via a spy rather than waiting on real time, so it runs in single-digit milliseconds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository catalog requests now time out after five seconds, preventing indefinitely stalled requests.
  * Existing cached repository data continues to be used when requests time out or fail.

* **Tests**
  * Added coverage confirming timeout behavior and cached-data fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->