### PR TITLE
fix: persist canonical user identity issuers

### DIFF
--- a/packages/control-plane/src/auth/user/providers/github-identity.ts
+++ b/packages/control-plane/src/auth/user/providers/github-identity.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
+import { SIGN_IN_PROVIDER_ISSUERS } from "@open-inspect/shared/sign-in-provider";
 import { createLogger, type Logger } from "../../../logger";
 import { DEFAULT_PROVIDER_REQUEST_TIMEOUT_MS } from "./constants";
 import { assertCanonicalIssuer, OAuthProviderError, type VerifiedProviderIdentity } from "./types";
 
-const GITHUB_ISSUER = "https://github.com";
 const GITHUB_API_URL = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_EMAILS_PER_PAGE = 100;
@@ -50,7 +50,7 @@ export class GitHubProviderIdentityResolver {
     private readonly config: GitHubProviderIdentityResolverConfig,
     dependencies: GitHubProviderIdentityResolverDependencies = {}
   ) {
-    assertCanonicalIssuer(config.issuer, GITHUB_ISSUER);
+    assertCanonicalIssuer(config.issuer, SIGN_IN_PROVIDER_ISSUERS.github);
     this.fetchImpl = dependencies.fetch ?? globalThis.fetch.bind(globalThis);
     this.requestTimeoutMs = dependencies.requestTimeoutMs ?? DEFAULT_PROVIDER_REQUEST_TIMEOUT_MS;
     this.logger = dependencies.logger ?? createLogger("github-provider-identity");
@@ -67,7 +67,7 @@ export class GitHubProviderIdentityResolver {
     ];
     return {
       provider: "github",
-      issuer: GITHUB_ISSUER,
+      issuer: SIGN_IN_PROVIDER_ISSUERS.github,
       subject: String(user.id),
       login: user.login,
       displayName: user.name ?? user.login,

--- a/packages/control-plane/src/auth/user/providers/google-profile.ts
+++ b/packages/control-plane/src/auth/user/providers/google-profile.ts
@@ -1,13 +1,12 @@
 import { verifyGoogleIdToken } from "better-auth/social-providers";
+import { SIGN_IN_PROVIDER_ISSUERS } from "@open-inspect/shared/sign-in-provider";
 import { z } from "zod";
 import type { AdmissionPolicy, GoogleAdmissionEvidence } from "../admission-policy";
 import type { ProviderProfile, ProviderTokens } from "../provider-profile";
 import { OAuthProviderError } from "./types";
 
-const GOOGLE_ISSUER = "https://accounts.google.com";
-
 const googleClaimsSchema = z.object({
-  iss: z.union([z.literal(GOOGLE_ISSUER), z.literal("accounts.google.com")]),
+  iss: z.union([z.literal(SIGN_IN_PROVIDER_ISSUERS.google), z.literal("accounts.google.com")]),
   sub: z.string().min(1),
   email: z.email(),
   email_verified: z.literal(true),
@@ -54,7 +53,7 @@ export class GoogleSignInProfileResolver {
     const signIn: GoogleAdmissionEvidence = {
       identity: {
         provider: "google",
-        issuer: GOOGLE_ISSUER,
+        issuer: SIGN_IN_PROVIDER_ISSUERS.google,
         subject: parsedClaims.data.sub,
         ...(parsedClaims.data.name ? { displayName: parsedClaims.data.name } : {}),
         ...(parsedClaims.data.picture ? { avatarUrl: parsedClaims.data.picture } : {}),

--- a/packages/control-plane/src/auth/user/runtime.ts
+++ b/packages/control-plane/src/auth/user/runtime.ts
@@ -4,7 +4,11 @@ import {
   parseAdmissionBoolean,
   type AdmissionPolicyConfig,
 } from "./admission-policy";
-import { SIGN_IN_PROVIDERS, type SignInProvider } from "@open-inspect/shared/sign-in-provider";
+import {
+  SIGN_IN_PROVIDERS,
+  SIGN_IN_PROVIDER_ISSUERS,
+  type SignInProvider,
+} from "@open-inspect/shared/sign-in-provider";
 import { createUserAuth, type UserAuthConfig } from "./better-auth";
 import { GitHubProviderIdentityResolver } from "./providers/github-identity";
 import { GitHubSignInProfileResolver } from "./providers/github-profile";
@@ -12,7 +16,6 @@ import { GoogleSignInProfileResolver } from "./providers/google-profile";
 import { D1CanonicalUserProjection } from "../../db/canonical-user-projection";
 import type { Env } from "../../types";
 
-const GITHUB_ISSUER = "https://github.com";
 const MINIMUM_SECRET_LENGTH = 32;
 
 export class UserAuthConfigurationError extends Error {
@@ -149,7 +152,7 @@ function createGitHubAuthConfig(
 
   const profile = new GitHubSignInProfileResolver({
     identityResolver: new GitHubProviderIdentityResolver({
-      issuer: GITHUB_ISSUER,
+      issuer: SIGN_IN_PROVIDER_ISSUERS.github,
       userAgent: `${appName} Control Plane`,
     }),
     admissionPolicy,

--- a/packages/control-plane/src/db/user-identity-issuer-migration.test.ts
+++ b/packages/control-plane/src/db/user-identity-issuer-migration.test.ts
@@ -1,0 +1,72 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const MIGRATIONS_DIRECTORY = fileURLToPath(
+  new URL("../../../../terraform/d1/migrations/", import.meta.url)
+);
+const ISSUER_BACKFILL_MIGRATION = "0056_backfill_user_identity_issuers.sql";
+
+function applyMigrationsBeforeIssuerBackfill(db: DatabaseSync): void {
+  const migrationFiles = readdirSync(MIGRATIONS_DIRECTORY)
+    .filter((file) => /^\d{4}_.+\.sql$/.test(file) && file < ISSUER_BACKFILL_MIGRATION)
+    .sort();
+
+  for (const migrationFile of migrationFiles) {
+    db.exec(readFileSync(`${MIGRATIONS_DIRECTORY}/${migrationFile}`, "utf8"));
+  }
+}
+
+describe("user identity issuer backfill migration", () => {
+  it("updates only null issuers for sign-in providers", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec("PRAGMA foreign_keys = ON");
+      applyMigrationsBeforeIssuerBackfill(db);
+      db.exec(`
+        INSERT INTO users (
+          id, display_name, email, avatar_url, created_at, updated_at
+        ) VALUES (
+          'canonical-user', 'Canonical User', NULL, NULL, 1785000000000, 1785000001000
+        );
+
+        INSERT INTO user_identities (
+          id, user_id, provider, provider_user_id, provider_issuer, created_at
+        ) VALUES
+          ('github-null', 'canonical-user', 'github', 'github-null', NULL, 1785000000000),
+          ('google-null', 'canonical-user', 'google', 'google-null', NULL, 1785000000000),
+          ('slack-null', 'canonical-user', 'slack', 'slack-null', NULL, 1785000000000),
+          ('linear-null', 'canonical-user', 'linear', 'linear-null', NULL, 1785000000000),
+          (
+            'github-existing',
+            'canonical-user',
+            'github',
+            'github-existing',
+            'https://github.example.com',
+            1785000000000
+          );
+      `);
+
+      db.exec(readFileSync(`${MIGRATIONS_DIRECTORY}/${ISSUER_BACKFILL_MIGRATION}`, "utf8"));
+
+      expect(
+        db
+          .prepare(
+            `SELECT id, provider_issuer
+             FROM user_identities
+             ORDER BY id`
+          )
+          .all()
+      ).toEqual([
+        { id: "github-existing", provider_issuer: "https://github.example.com" },
+        { id: "github-null", provider_issuer: "https://github.com" },
+        { id: "google-null", provider_issuer: "https://accounts.google.com" },
+        { id: "linear-null", provider_issuer: null },
+        { id: "slack-null", provider_issuer: null },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/control-plane/src/db/user-store.ts
+++ b/packages/control-plane/src/db/user-store.ts
@@ -1,3 +1,4 @@
+import { getSignInProviderIssuer } from "@open-inspect/shared/sign-in-provider";
 import { generateId } from "../auth/crypto";
 import { isUniqueConstraintError } from "./errors";
 import type { SqlDatabase } from "./sql-database";
@@ -36,6 +37,7 @@ export interface UserIdentity {
   providerUserId: string;
   providerLogin: string | null;
   providerEmail: string | null;
+  providerIssuer: string | null;
   createdAt: number;
 }
 
@@ -77,6 +79,7 @@ interface UserIdentityRow {
   provider_user_id: string;
   provider_login: string | null;
   provider_email: string | null;
+  provider_issuer: string | null;
   created_at: number;
 }
 
@@ -101,6 +104,7 @@ function toUserIdentity(row: UserIdentityRow): UserIdentity {
     providerUserId: row.provider_user_id,
     providerLogin: row.provider_login,
     providerEmail: row.provider_email,
+    providerIssuer: row.provider_issuer,
     createdAt: row.created_at,
   };
 }
@@ -206,10 +210,11 @@ export class UserStore {
     const id = generateId();
     const now = Date.now();
     const email = identity.providerEmail?.toLowerCase() ?? null;
+    const issuer = getSignInProviderIssuer(identity.provider);
 
     await this.db
       .prepare(
-        "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, provider_issuer, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
       )
       .bind(
         id,
@@ -218,6 +223,7 @@ export class UserStore {
         identity.providerUserId,
         identity.providerLogin ?? null,
         email,
+        issuer,
         now
       )
       .run();
@@ -229,6 +235,7 @@ export class UserStore {
       providerUserId: identity.providerUserId,
       providerLogin: identity.providerLogin ?? null,
       providerEmail: email,
+      providerIssuer: issuer,
       createdAt: now,
     };
   }
@@ -357,6 +364,7 @@ export class UserStore {
     const now = Date.now();
     const displayName = identity.displayName ?? null;
     const avatarUrl = identity.avatarUrl ?? null;
+    const issuer = getSignInProviderIssuer(identity.provider);
 
     await this.db.batch([
       this.db
@@ -366,7 +374,7 @@ export class UserStore {
         .bind(userId, displayName, normalizedEmail, avatarUrl, now, now),
       this.db
         .prepare(
-          "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+          "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, provider_issuer, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(
           identityId,
@@ -375,6 +383,7 @@ export class UserStore {
           identity.providerUserId,
           identity.providerLogin ?? null,
           normalizedEmail,
+          issuer,
           now
         ),
     ]);

--- a/packages/control-plane/test/integration/user-store.test.ts
+++ b/packages/control-plane/test/integration/user-store.test.ts
@@ -3,6 +3,13 @@ import { env } from "cloudflare:test";
 import { UserStore } from "../../src/db/user-store";
 import { cleanD1Tables } from "./cleanup";
 
+const providerIssuers = [
+  ["github", "https://github.com"],
+  ["google", "https://accounts.google.com"],
+  ["slack", null],
+  ["linear", null],
+] as const;
+
 describe("UserStore", () => {
   let store: UserStore;
 
@@ -14,6 +21,16 @@ describe("UserStore", () => {
   // ── resolveOrCreateUser ─────────────────────────────────────────
 
   describe("resolveOrCreateUser", () => {
+    it.each(providerIssuers)("stores the canonical issuer for %s", async (provider, issuer) => {
+      await store.resolveOrCreateUser({
+        provider,
+        providerUserId: `${provider}-subject`,
+      });
+
+      const identity = await store.getIdentity(provider, `${provider}-subject`);
+      expect(identity?.providerIssuer).toBe(issuer);
+    });
+
     it("creates a new user with no email", async () => {
       const result = await store.resolveOrCreateUser({
         provider: "github",
@@ -249,6 +266,23 @@ describe("UserStore", () => {
         cnt: number;
       }>();
       expect(allUsers!.cnt).toBe(1);
+    });
+  });
+
+  // ── createIdentity ──────────────────────────────────────────────
+
+  describe("createIdentity", () => {
+    it.each(providerIssuers)("stores the canonical issuer for %s", async (provider, issuer) => {
+      const user = await store.createUser({ displayName: "Alice" });
+
+      await store.createIdentity({
+        userId: user.id,
+        provider,
+        providerUserId: `${provider}-subject`,
+      });
+
+      const identity = await store.getIdentity(provider, `${provider}-subject`);
+      expect(identity?.providerIssuer).toBe(issuer);
     });
   });
 

--- a/packages/shared/src/sign-in-provider.test.ts
+++ b/packages/shared/src/sign-in-provider.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { getSignInProviderIssuer, parseEnabledSignInProviders } from "./sign-in-provider";
+import {
+  getSignInProviderIssuer,
+  isSignInProvider,
+  parseEnabledSignInProviders,
+} from "./sign-in-provider";
+
+describe("isSignInProvider", () => {
+  it.each(["github", "google"])("recognizes %s", (provider) => {
+    expect(isSignInProvider(provider)).toBe(true);
+  });
+
+  it.each(["slack", "linear"])("rejects %s", (provider) => {
+    expect(isSignInProvider(provider)).toBe(false);
+  });
+});
 
 describe("getSignInProviderIssuer", () => {
   it.each([

--- a/packages/shared/src/sign-in-provider.test.ts
+++ b/packages/shared/src/sign-in-provider.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { parseEnabledSignInProviders } from "./sign-in-provider";
+import { getSignInProviderIssuer, parseEnabledSignInProviders } from "./sign-in-provider";
+
+describe("getSignInProviderIssuer", () => {
+  it.each([
+    ["github", "https://github.com"],
+    ["google", "https://accounts.google.com"],
+    ["slack", null],
+    ["linear", null],
+  ])("maps %s to its canonical issuer", (provider, expectedIssuer) => {
+    expect(getSignInProviderIssuer(provider)).toBe(expectedIssuer);
+  });
+});
 
 describe("parseEnabledSignInProviders", () => {
   it("accepts the compiled providers in canonical order", () => {

--- a/packages/shared/src/sign-in-provider.ts
+++ b/packages/shared/src/sign-in-provider.ts
@@ -10,8 +10,12 @@ export const SIGN_IN_PROVIDER_ISSUERS = {
   google: "https://accounts.google.com",
 } as const satisfies Readonly<Record<SignInProvider, string>>;
 
+export function isSignInProvider(provider: string): provider is SignInProvider {
+  return SIGN_IN_PROVIDERS.some((candidate) => candidate === provider);
+}
+
 export function getSignInProviderIssuer(provider: string): string | null {
-  if (provider === "github" || provider === "google") {
+  if (isSignInProvider(provider)) {
     return SIGN_IN_PROVIDER_ISSUERS[provider];
   }
   return null;

--- a/packages/shared/src/sign-in-provider.ts
+++ b/packages/shared/src/sign-in-provider.ts
@@ -5,6 +5,18 @@ export const SIGN_IN_PROVIDERS = ["github", "google"] as const;
 
 export type SignInProvider = (typeof SIGN_IN_PROVIDERS)[number];
 
+export const SIGN_IN_PROVIDER_ISSUERS = {
+  github: "https://github.com",
+  google: "https://accounts.google.com",
+} as const satisfies Readonly<Record<SignInProvider, string>>;
+
+export function getSignInProviderIssuer(provider: string): string | null {
+  if (provider === "github" || provider === "google") {
+    return SIGN_IN_PROVIDER_ISSUERS[provider];
+  }
+  return null;
+}
+
 export interface EnabledSignInProviders {
   readonly providers: readonly SignInProvider[];
 }

--- a/terraform/d1/migrations/0056_backfill_user_identity_issuers.sql
+++ b/terraform/d1/migrations/0056_backfill_user_identity_issuers.sql
@@ -1,0 +1,9 @@
+-- Converge sign-in identities created after provider_issuer was introduced.
+UPDATE user_identities
+SET provider_issuer = IIF(
+  provider = 'github',
+  'https://github.com',
+  'https://accounts.google.com'
+)
+WHERE provider_issuer IS NULL
+  AND provider IN ('github', 'google');


### PR DESCRIPTION
## Summary
- define the canonical GitHub and Google issuer mapping in `@open-inspect/shared`
- persist `provider_issuer` from both `UserStore` identity insertion paths while leaving Slack and Linear issuers null
- expose the stored issuer through `UserIdentity` and reuse the shared constants in sign-in provider code
- add D1 migration `0056` to backfill GitHub and Google identities created with null issuers
- cover both identity creation paths for all four providers

## Verification
- `npm run build -w @open-inspect/shared`
- `npm run build -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/shared -- --run src/sign-in-provider.test.ts`
- `npm test -w @open-inspect/control-plane` (153 files, 2,311 tests)
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/user-store.test.ts` (24 tests)
- isolated reruns of `websocket-client.test.ts` and `session-diffs.test.ts` passed after load-related timeouts in the full parallel integration run
- ESLint, Prettier, and `git diff --check`

Closes COL-27.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/4b4921ea11a733b1f6939800648b76a3)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added canonical issuer tracking for user identities across supported sign-in providers.
  * Improved GitHub and Google sign-in validation consistency.
  * Existing GitHub and Google identities are automatically populated with provider issuer information.

* **Reliability**
  * Added validation to ensure issuer data is consistently mapped and persisted across sign-in providers.
  * Added safeguards to preserve existing issuer values and leave unsupported provider records unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->