### PR TITLE
feat(slack): support OpenAI target classification

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -204,6 +204,7 @@ jobs:
           TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          TF_VAR_slack_classification_model: "${{ secrets.SLACK_CLASSIFICATION_MODEL || 'anthropic/claude-haiku-4-5' }}"
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
@@ -359,6 +360,7 @@ jobs:
           TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          TF_VAR_slack_classification_model: "${{ secrets.SLACK_CLASSIFICATION_MODEL || 'anthropic/claude-haiku-4-5' }}"
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -98,6 +98,11 @@ jobs:
         run: terraform validate -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
 
+      - name: Terraform Tests
+        id: test
+        run: terraform test -filter=tests/auth_provider_configuration.tftest.hcl
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
       - name: Post Validation Results
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
@@ -115,6 +120,7 @@ jobs:
             | Format | ${{ steps.fmt.outcome == 'success' && '✅' || '⚠️' }} |
             | Init | ${{ steps.init.outcome == 'success' && '✅' || '❌' }} |
             | Validate | ${{ steps.validate.outcome == 'success' && '✅' || '❌' }} |
+            | Tests | ${{ steps.test.outcome == 'success' && '✅' || '❌' }} |
             ${planNote}
 
             *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -547,6 +547,9 @@ google_client_secret = ""
 enable_slack_bot     = false
 slack_bot_token      = ""
 slack_signing_secret = ""
+# Deployment-wide classifier (Anthropic preserves the default; OpenAI requires
+# the global managed ChatGPT OAuth credential described in OPENAI_MODELS.md).
+slack_classification_model = "anthropic/claude-haiku-4-5"
 
 # GitHub Bot (set enable_github_bot = true to deploy the webhook worker)
 enable_github_bot      = false
@@ -755,6 +758,20 @@ In Slack, for each channel where you want the bot to respond:
 
 The bot only responds to @mentions in channels it has been invited to.
 
+### Optional: OpenAI Slack target classification
+
+Slack target classification runs before a repository or environment is known, so its OpenAI
+credential must be available globally. Roll out the option in this order:
+
+1. Deploy with the default `slack_classification_model = "anthropic/claude-haiku-4-5"` (the existing
+   behavior).
+2. Add `OPENAI_OAUTH_REFRESH_TOKEN` to **Settings → Secrets → All Repositories (Global)**. This uses
+   the managed ChatGPT OAuth transport; repository and environment tokens cannot be used for this
+   pre-target call, and no `OPENAI_API_KEY` is required. See [Using OpenAI Models](OPENAI_MODELS.md)
+   for how to obtain the refresh token.
+3. Set `slack_classification_model = "openai/gpt-5.6-luna"` in `terraform.tfvars` and run
+   `terraform apply`.
+
 ---
 
 ## Step 7c: Complete GitHub Bot Setup (If Using GitHub Bot)
@@ -961,6 +978,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `ENABLE_SLACK_BOT`               | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
 | `SLACK_BOT_TOKEN`                | Slack bot token (required if enabled)                                                       |
 | `SLACK_SIGNING_SECRET`           | Slack signing secret (required if enabled)                                                  |
+| `SLACK_CLASSIFICATION_MODEL`     | Optional classifier: `anthropic/claude-haiku-4-5` (default) or `openai/gpt-5.6-luna`        |
 | `ENABLE_LINEAR_BOT`              | `true` to deploy Linear bot, `false` to skip (default: `false`)                             |
 | `LINEAR_CLIENT_ID`               | Linear OAuth application client ID (required if Linear enabled)                             |
 | `LINEAR_CLIENT_SECRET`           | Linear OAuth application client secret (required if Linear enabled)                         |

--- a/docs/OPENAI_MODELS.md
+++ b/docs/OPENAI_MODELS.md
@@ -1,7 +1,7 @@
 # Using OpenAI Models
 
 Open-Inspect supports OpenAI Codex models in addition to Anthropic Claude models. This guide covers
-how to configure your deployment to use them.
+the managed ChatGPT OAuth transport used by sessions and by optional Slack target classification.
 
 > **Note**: This setup process is temporary and will be streamlined in a future release.
 
@@ -12,12 +12,13 @@ how to configure your deployment to use them.
 For the full model list, including Claude Fable 5 and other Anthropic models, see
 [Available Models](AVAILABLE_MODELS.md).
 
-| Model               | Description               |
-| ------------------- | ------------------------- |
-| GPT 5.4             | Flagship model            |
-| GPT 5.5             | Latest flagship model     |
-| GPT 5.3 Codex       | Latest codex variant      |
-| GPT 5.3 Codex Spark | Lightweight Codex variant |
+| Model               | Description                                |
+| ------------------- | ------------------------------------------ |
+| GPT 5.4             | Flagship model                             |
+| GPT 5.5             | Latest flagship model                      |
+| GPT 5.6 Luna        | Fast, cost-efficient high-volume workloads |
+| GPT 5.3 Codex       | Latest codex variant                       |
+| GPT 5.3 Codex Spark | Lightweight Codex variant                  |
 
 OpenAI models support reasoning effort levels: none, low, medium, high, and extra high (default:
 high for Codex models).
@@ -42,19 +43,26 @@ required tokens.
    ```bash
    cat ~/.local/share/opencode/auth.json
    ```
-6. From the `openai` section, copy the values for:
-   - `refresh` — the refresh token
-   - `accountId` — your ChatGPT account ID
+6. From the `openai` section, copy the `refresh` value (the refresh token). The `accountId` value is
+   optional; the managed transport learns and rotates it from the OAuth response when needed.
 
 ### Step 2: Add Secrets to Your Deployment
 
-1. Go to your Open-Inspect web app's **Settings** page
-2. Add the following repository secrets:
+1. Go to your Open-Inspect web app's **Settings** page.
+2. For normal sessions, credentials may be stored as global, repository, or environment secrets; the
+   selected session target determines which scope is read.
+3. For Slack target classification, the target is not known yet. Add the refresh token to the
+   **global** scope — repository and environment tokens cannot be used for this pre-target call.
+4. Add the following secrets:
 
-   | Secret Name                  | Value                           |
-   | ---------------------------- | ------------------------------- |
-   | `OPENAI_OAUTH_REFRESH_TOKEN` | The `refresh` token from Step 1 |
-   | `OPENAI_OAUTH_ACCOUNT_ID`    | The `accountId` from Step 1     |
+   | Secret Name                  | Value                                                              |
+   | ---------------------------- | ------------------------------------------------------------------ |
+   | `OPENAI_OAUTH_REFRESH_TOKEN` | The `refresh` token from Step 1 (global for Slack classification)  |
+   | `OPENAI_OAUTH_ACCOUNT_ID`    | Optional ChatGPT account ID; the managed transport can populate it |
+
+Open-Inspect uses the existing managed ChatGPT OAuth transport; it does not use an `OPENAI_API_KEY`
+for these flows. The refresh token remains in the control plane, which brokers short-lived access to
+the model.
 
 ### Step 3: Select an OpenAI Model
 
@@ -70,7 +78,22 @@ sandbox needs to make an OpenAI API call, it requests a short-lived access token
 plane, which handles token refresh and rotation automatically. Only the temporary access token is
 present inside the sandbox.
 
-Credentials are scoped per repository, so different repos can use different OpenAI accounts.
+Credentials can be scoped globally, per repository, or per environment, so different targets can use
+different OpenAI accounts.
+
+### Slack target-classification rollout
+
+Slack classification is deployment-wide because it runs before a repository or environment is known.
+Roll it out in three stages:
+
+1. Deploy the classification support. Terraform keeps Anthropic as the default with
+   `slack_classification_model = "anthropic/claude-haiku-4-5"`, so existing deployments are
+   unchanged.
+2. Configure `OPENAI_OAUTH_REFRESH_TOKEN` in **global** secrets using the steps above. Do not put
+   the pre-target credential only on a repository or environment, and do not add an
+   `OPENAI_API_KEY`.
+3. Switch the deployment to `slack_classification_model = "openai/gpt-5.6-luna"` and run
+   `terraform apply`. Verify a Slack request that resolves to a repository or environment.
 
 ---
 
@@ -83,9 +106,15 @@ Open-Inspect.
 
 ### Session fails to start with an OpenAI model
 
-Verify that both `OPENAI_OAUTH_REFRESH_TOKEN` and `OPENAI_OAUTH_ACCOUNT_ID` are set in your
-repository secrets (Settings page). The refresh token may have expired — repeat Step 1 to obtain
-fresh credentials.
+Verify that `OPENAI_OAUTH_REFRESH_TOKEN` is set in your session target's secrets (or global
+secrets). `OPENAI_OAUTH_ACCOUNT_ID` may be omitted when the managed transport can derive it. The
+refresh token may have expired — repeat Step 1 to obtain fresh credentials.
+
+### Slack classification cannot reach OpenAI
+
+Verify that `OPENAI_OAUTH_REFRESH_TOKEN` is present in **global** secrets. Slack classification runs
+before the target repository or environment is known, so repository and environment secrets are not
+available. This flow uses managed ChatGPT OAuth and never `OPENAI_API_KEY`.
 
 ### "Token refresh failed" errors
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -63,14 +63,17 @@ repository, re-import it or update the environment secret directly.
 
 ### When to use global secrets
 
-Use global secrets for keys that every session needs regardless of which repository it runs against.
-The most common example:
+Use global secrets for keys that every session needs regardless of which repository it runs against,
+and for operations that run before a target is known (such as Slack target classification). The most
+common examples:
 
-| Key                 | Description                                                                                                                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ANTHROPIC_API_KEY` | Required for Claude models when using the **Daytona** or **Vercel** sandbox provider (Modal injects this automatically via its own secrets mechanism) |
-| `DEEPSEEK_API_KEY`  | Required for DeepSeek models with any sandbox provider                                                                                                |
-| `ZHIPU_API_KEY`     | Required for Z.AI Coding Plan GLM models with any sandbox provider                                                                                    |
+| Key                          | Description                                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`          | Required for Claude models when using the **Daytona** or **Vercel** sandbox provider (Modal injects this automatically via its own secrets mechanism) |
+| `DEEPSEEK_API_KEY`           | Required for DeepSeek models with any sandbox provider                                                                                                |
+| `ZHIPU_API_KEY`              | Required for Z.AI Coding Plan GLM models with any sandbox provider                                                                                    |
+| `OPENAI_OAUTH_REFRESH_TOKEN` | Managed ChatGPT OAuth; **global** scope is required for Slack target classification because its repository/environment target is not known yet        |
+| `OPENAI_OAUTH_ACCOUNT_ID`    | Optional ChatGPT account ID for managed OAuth; it can be populated after the first refresh                                                            |
 
 > **Daytona and Vercel sandbox users**: If you plan to use Claude models, you must add
 > `ANTHROPIC_API_KEY` as a global secret after deploying. Without it, Claude sessions will fail with
@@ -152,6 +155,12 @@ Managed OpenAI and xAI OAuth credentials are exceptions to generic environment i
 refresh and cached access tokens stay in the control plane; the sandbox receives only a non-secret
 provider marker and requests short-lived access through its session-authenticated broker.
 
+OpenAI Slack target classification uses this same managed ChatGPT OAuth transport. Store
+`OPENAI_OAUTH_REFRESH_TOKEN` in **global** secrets before switching the deployment's
+`slack_classification_model` to `openai/gpt-5.6-luna`: classification runs before a repository or
+environment is known, so repository and environment tokens cannot be used. No `OPENAI_API_KEY` is
+needed.
+
 ### Secrets and prebuilt images
 
 Image builds (repository images and environment images) run your `.openinspect/setup.sh` with the
@@ -171,17 +180,17 @@ from it, even after you rotate the secret. Two guidelines:
 
 ## Common Examples
 
-| Key                          | Scope  | Purpose                                                      |
-| ---------------------------- | ------ | ------------------------------------------------------------ |
-| `ANTHROPIC_API_KEY`          | Global | Claude API access (required for Daytona or Vercel sandboxes) |
-| `DEEPSEEK_API_KEY`           | Global | DeepSeek API access                                          |
-| `ZHIPU_API_KEY`              | Global | Z.AI Coding Plan GLM access                                  |
-| `OPENAI_OAUTH_REFRESH_TOKEN` | Repo   | OpenAI Codex access ([setup guide](OPENAI_MODELS.md))        |
-| `OPENAI_OAUTH_ACCOUNT_ID`    | Repo   | OpenAI Codex access ([setup guide](OPENAI_MODELS.md))        |
-| `XAI_OAUTH_REFRESH_TOKEN`    | Any    | SuperGrok access ([setup guide](GROK_MODELS.md))             |
-| `DATABASE_URL`               | Repo   | Database connection string                                   |
-| `AWS_ACCESS_KEY_ID`          | Repo   | AWS credentials for a specific project                       |
-| `STRIPE_SECRET_KEY`          | Repo   | Stripe API key for a specific project                        |
+| Key                          | Scope                                                                                         | Purpose                                                      |
+| ---------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `ANTHROPIC_API_KEY`          | Global                                                                                        | Claude API access (required for Daytona or Vercel sandboxes) |
+| `DEEPSEEK_API_KEY`           | Global                                                                                        | DeepSeek API access                                          |
+| `ZHIPU_API_KEY`              | Global                                                                                        | Z.AI Coding Plan GLM access                                  |
+| `OPENAI_OAUTH_REFRESH_TOKEN` | Global for Slack classification; repo/environment also supported for target-specific sessions | OpenAI Codex access ([setup guide](OPENAI_MODELS.md))        |
+| `OPENAI_OAUTH_ACCOUNT_ID`    | Same scope as its refresh token; optional                                                     | OpenAI Codex account ID ([setup guide](OPENAI_MODELS.md))    |
+| `XAI_OAUTH_REFRESH_TOKEN`    | Any                                                                                           | SuperGrok access ([setup guide](GROK_MODELS.md))             |
+| `DATABASE_URL`               | Repo                                                                                          | Database connection string                                   |
+| `AWS_ACCESS_KEY_ID`          | Repo                                                                                          | AWS credentials for a specific project                       |
+| `STRIPE_SECRET_KEY`          | Repo                                                                                          | Stripe API key for a specific project                        |
 
 ---
 
@@ -189,9 +198,10 @@ from it, even after you rotate the secret. Two guidelines:
 
 ### "Model not found" errors
 
-If you see "Model not found" errors, add the API key for your selected model provider as a global
+If you see "Model not found" errors, add the credential for your selected model provider as a global
 secret in Settings. For Claude on Daytona or Vercel, add `ANTHROPIC_API_KEY`. For DeepSeek, add
-`DEEPSEEK_API_KEY`. For Z.AI Coding Plan, add `ZHIPU_API_KEY`. For SuperGrok, follow the
+`DEEPSEEK_API_KEY`. For Z.AI Coding Plan, add `ZHIPU_API_KEY`. For OpenAI Slack classification, add
+`OPENAI_OAUTH_REFRESH_TOKEN` globally; do not add `OPENAI_API_KEY`. For SuperGrok, follow the
 [managed OAuth setup guide](GROK_MODELS.md) instead of injecting the refresh token into a sandbox.
 
 ### Secret not appearing in sandbox

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -41,6 +41,7 @@ import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
 import { sessionRoutes } from "./routes/sessions";
 import { handleSlackNotify } from "./routes/slack-notify";
+import { classifierRoutes } from "./routes/classifier";
 import { webhookRoutes } from "./webhooks";
 
 const logger = createLogger("router");
@@ -171,6 +172,7 @@ function isWebServiceAuthRoute(method: string, path: string): boolean {
 export function isScmAgnosticRoute(method: string, path: string): boolean {
   return (
     isWebServiceAuthRoute(method, path) ||
+    path === "/internal/classifier/infer" ||
     /^\/scm-settings(?:\/.*)?$/.test(path) ||
     /^\/analytics\/(summary|timeseries|breakdown|pull-requests)$/.test(path) ||
     (method === "PATCH" && /^\/sessions\/[^/]+\/read-state$/.test(path)) ||
@@ -327,6 +329,7 @@ const routes: Route[] = [
 
   ...browserAuthRoutes,
   ...signInProviderRoutes,
+  ...classifierRoutes,
 
   // Session management
   ...sessionRoutes,

--- a/packages/control-plane/src/routes/classifier.test.ts
+++ b/packages/control-plane/src/routes/classifier.test.ts
@@ -406,9 +406,9 @@ describe("POST /internal/classifier/infer", () => {
     expect(responseText).not.toContain("upstream secret details");
   });
 
-  it("times out a never-ending upstream stream and cancels its reader", async () => {
+  it("times out when the upstream stream and reader cancellation never finish", async () => {
     vi.useFakeTimers();
-    const cancel = vi.fn();
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
     vi.mocked(fetch).mockResolvedValueOnce(openStreamResponse(undefined, cancel));
 
     try {

--- a/packages/control-plane/src/routes/classifier.test.ts
+++ b/packages/control-plane/src/routes/classifier.test.ts
@@ -1,0 +1,230 @@
+import { CLASSIFIER_PROMPT_MAX_CHARS, CLASSIFY_TARGET_TOOL_NAME } from "@open-inspect/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as OpenAITokenRefreshModule from "../session/openai-token-refresh-service";
+import { handleRequest } from "../router";
+import { signedServiceRequest, TEST_SERVICE_SECRETS } from "../router.test-support";
+
+const brokerState = vi.hoisted(() => ({
+  refreshGlobal: vi.fn(),
+}));
+
+vi.mock("../session/openai-token-refresh-service", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenAITokenRefreshModule>();
+  return {
+    ...actual,
+    OpenAITokenBroker: class {
+      refreshGlobal = brokerState.refreshGlobal;
+    },
+  };
+});
+
+const env = {
+  ...TEST_SERVICE_SECRETS,
+  REPO_SECRETS_ENCRYPTION_KEY: "encryption-key",
+  SCM_PROVIDER: "github",
+  DB: {
+    prepare: vi.fn(),
+    batch: vi.fn(),
+  },
+};
+
+const decision = {
+  targetId: "acme/api",
+  confidence: "high",
+  reasoning: "The request names the API.",
+  alternatives: [],
+};
+
+function upstreamFunctionCall(argumentsValue = JSON.stringify(decision)): Response {
+  return Response.json({
+    output: [
+      {
+        type: "function_call",
+        name: CLASSIFY_TARGET_TOOL_NAME,
+        arguments: argumentsValue,
+      },
+    ],
+  });
+}
+
+async function classifierRequest(
+  body: unknown,
+  service: "slack-bot" | "github-bot" = "slack-bot"
+): Promise<Response> {
+  const serialized = JSON.stringify(body);
+  return handleRequest(
+    await signedServiceRequest("https://internal/internal/classifier/infer", {
+      method: "POST",
+      body: serialized,
+      service,
+    }),
+    env as never
+  );
+}
+
+describe("POST /internal/classifier/infer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    brokerState.refreshGlobal.mockResolvedValue({
+      ok: true,
+      accessToken: "secret-access-token",
+      expiresIn: 1800,
+      accountId: "account-123",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(upstreamFunctionCall()));
+  });
+
+  it("rejects requests without service authentication", async () => {
+    const response = await handleRequest(
+      new Request("https://internal/internal/classifier/infer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "openai/gpt-5.6-luna", prompt: "route this" }),
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(401);
+    expect(brokerState.refreshGlobal).not.toHaveBeenCalled();
+  });
+
+  it("allows only the slack-bot service principal", async () => {
+    const response = await classifierRequest(
+      { model: "openai/gpt-5.6-luna", prompt: "route this" },
+      "github-bot"
+    );
+
+    expect(response.status).toBe(403);
+    expect(brokerState.refreshGlobal).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing prompt", { model: "openai/gpt-5.6-luna" }],
+    ["empty prompt", { model: "openai/gpt-5.6-luna", prompt: "" }],
+    ["unknown field", { model: "openai/gpt-5.6-luna", prompt: "route", extra: true }],
+    [
+      "oversized prompt",
+      { model: "openai/gpt-5.6-luna", prompt: "x".repeat(CLASSIFIER_PROMPT_MAX_CHARS + 1) },
+    ],
+  ])("rejects invalid input: %s", async (_name, body) => {
+    const response = await classifierRequest(body);
+
+    expect(response.status).toBe(400);
+    expect(brokerState.refreshGlobal).not.toHaveBeenCalled();
+  });
+
+  it("rejects classifier models other than OpenAI Luna", async () => {
+    const response = await classifierRequest({
+      model: "anthropic/claude-haiku-4-5",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Unsupported classifier model" });
+  });
+
+  it("returns 503 without configured global OAuth", async () => {
+    brokerState.refreshGlobal.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: "OPENAI_OAUTH_REFRESH_TOKEN not configured",
+    });
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "OpenAI OAuth is not configured" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends the forced strict function request to the Codex Responses endpoint", async () => {
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this request",
+    });
+
+    expect(response.status).toBe(200);
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(init?.method).toBe("POST");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer secret-access-token");
+    expect(headers.get("ChatGPT-Account-Id")).toBe("account-123");
+    expect(headers.get("originator")).toBe("opencode");
+    expect(headers.get("session_id")).toBeTruthy();
+    expect(headers.get("Content-Type")).toBe("application/json");
+    const upstreamBody = JSON.parse(String(init?.body));
+    expect(upstreamBody).toMatchObject({
+      model: "gpt-5.6-luna",
+      input: "route this request",
+      tool_choice: { type: "function", name: CLASSIFY_TARGET_TOOL_NAME },
+      parallel_tool_calls: false,
+      store: false,
+      stream: false,
+    });
+    expect(upstreamBody.tools).toEqual([
+      expect.objectContaining({
+        type: "function",
+        name: CLASSIFY_TARGET_TOOL_NAME,
+        strict: true,
+        parameters: expect.objectContaining({ additionalProperties: false }),
+      }),
+    ]);
+    await expect(response.json()).resolves.toEqual({ decision });
+  });
+
+  it("omits the account header when the token has no account id", async () => {
+    brokerState.refreshGlobal.mockResolvedValue({
+      ok: true,
+      accessToken: "secret-access-token",
+      expiresIn: 1800,
+    });
+
+    await classifierRequest({ model: "openai/gpt-5.6-luna", prompt: "route this" });
+
+    const headers = new Headers(vi.mocked(fetch).mock.calls[0][1]?.headers);
+    expect(headers.has("ChatGPT-Account-Id")).toBe(false);
+  });
+
+  it.each([
+    ["refusal", Response.json({ output: [{ type: "message", status: "completed" }] })],
+    ["malformed JSON arguments", upstreamFunctionCall("not-json")],
+    [
+      "invalid decision",
+      upstreamFunctionCall(JSON.stringify({ ...decision, confidence: "certain" })),
+    ],
+    ["non-JSON response", new Response("not-json")],
+  ])("returns 502 for %s", async (_name, upstreamResponse) => {
+    vi.mocked(fetch).mockResolvedValueOnce(upstreamResponse);
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Classifier returned an invalid response",
+    });
+  });
+
+  it("maps non-OK upstream responses without returning their body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("upstream secret details", { status: 429 })
+    );
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(502);
+    const responseText = await response.text();
+    expect(responseText).toBe(JSON.stringify({ error: "Classifier upstream unavailable" }));
+    expect(responseText).not.toContain("secret-access-token");
+    expect(responseText).not.toContain("upstream secret details");
+  });
+});

--- a/packages/control-plane/src/routes/classifier.test.ts
+++ b/packages/control-plane/src/routes/classifier.test.ts
@@ -35,15 +35,44 @@ const decision = {
   alternatives: [],
 };
 
-function upstreamFunctionCall(argumentsValue = JSON.stringify(decision)): Response {
-  return Response.json({
-    output: [
-      {
-        type: "function_call",
-        name: CLASSIFY_TARGET_TOOL_NAME,
-        arguments: argumentsValue,
-      },
-    ],
+function functionCall(argumentsValue = JSON.stringify(decision)) {
+  return {
+    type: "function_call",
+    call_id: "call-classify",
+    namespace: "functions",
+    name: CLASSIFY_TARGET_TOOL_NAME,
+    arguments: argumentsValue,
+  };
+}
+
+function sseEvent(event: Record<string, unknown>): string {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function fragmentedSseResponse(...events: Array<Record<string, unknown>>): Response {
+  const body = events.map(sseEvent).join("");
+  const encoder = new TextEncoder();
+  const chunkSizes = [1, 2, 7, 3, 19, 5, 11];
+  let offset = 0;
+  let chunkIndex = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      while (offset < body.length) {
+        const size = chunkSizes[chunkIndex % chunkSizes.length];
+        controller.enqueue(encoder.encode(body.slice(offset, offset + size)));
+        offset += size;
+        chunkIndex += 1;
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+}
+
+function completedFunctionCall(argumentsValue = JSON.stringify(decision)): Response {
+  return fragmentedSseResponse({
+    type: "response.completed",
+    response: { id: "resp-classify", output: [functionCall(argumentsValue)] },
   });
 }
 
@@ -71,7 +100,7 @@ describe("POST /internal/classifier/infer", () => {
       expiresIn: 1800,
       accountId: "account-123",
     });
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(upstreamFunctionCall()));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(completedFunctionCall()));
   });
 
   it("rejects requests without service authentication", async () => {
@@ -153,26 +182,126 @@ describe("POST /internal/classifier/infer", () => {
     const headers = new Headers(init?.headers);
     expect(headers.get("authorization")).toBe("Bearer secret-access-token");
     expect(headers.get("ChatGPT-Account-Id")).toBe("account-123");
-    expect(headers.get("originator")).toBe("opencode");
+    expect(headers.get("originator")).toBe("codex_cli_rs");
     expect(headers.get("session_id")).toBeTruthy();
+    expect(headers.get("Accept")).toBe("text/event-stream");
     expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
     const upstreamBody = JSON.parse(String(init?.body));
     expect(upstreamBody).toMatchObject({
       model: "gpt-5.6-luna",
-      input: "route this request",
-      tool_choice: { type: "function", name: CLASSIFY_TARGET_TOOL_NAME },
+      tool_choice: "required",
       parallel_tool_calls: false,
+      reasoning: { context: "all_turns" },
       store: false,
-      stream: false,
+      stream: true,
     });
-    expect(upstreamBody.tools).toEqual([
-      expect.objectContaining({
-        type: "function",
-        name: CLASSIFY_TARGET_TOOL_NAME,
-        strict: true,
-        parameters: expect.objectContaining({ additionalProperties: false }),
-      }),
+    expect(upstreamBody).not.toHaveProperty("tools");
+    expect(upstreamBody.input).toEqual([
+      {
+        type: "additional_tools",
+        role: "developer",
+        tools: [
+          {
+            type: "namespace",
+            name: "functions",
+            description: "",
+            tools: [
+              expect.objectContaining({
+                type: "function",
+                name: CLASSIFY_TARGET_TOOL_NAME,
+                strict: true,
+                parameters: expect.objectContaining({ additionalProperties: false }),
+              }),
+            ],
+          },
+        ],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "route this request" }],
+      },
     ]);
+    await expect(response.json()).resolves.toEqual({ decision });
+  });
+
+  it("uses output_item.done when response.completed has no output", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      fragmentedSseResponse(
+        { type: "response.created", response: { id: "resp-classify" } },
+        { type: "response.output_item.done", item: functionCall() },
+        { type: "response.completed", response: { id: "resp-classify", output: [] } }
+      )
+    );
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ decision });
+  });
+
+  it("rejects malformed authoritative output instead of using completed fallback", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      fragmentedSseResponse(
+        {
+          type: "response.output_item.done",
+          item: functionCall("not-json"),
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp-classify", output: [functionCall()] },
+        }
+      )
+    );
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Classifier returned an invalid response",
+    });
+  });
+
+  it("falls back to streamed function-call arguments", async () => {
+    const argumentsValue = JSON.stringify(decision);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      fragmentedSseResponse(
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc-classify",
+            name: CLASSIFY_TARGET_TOOL_NAME,
+            arguments: "",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "fc-classify",
+          delta: argumentsValue.slice(0, 17),
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: "fc-classify",
+          arguments: argumentsValue,
+        },
+        { type: "response.completed", response: { id: "resp-classify" } }
+      )
+    );
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ decision });
   });
 
@@ -190,13 +319,45 @@ describe("POST /internal/classifier/infer", () => {
   });
 
   it.each([
-    ["refusal", Response.json({ output: [{ type: "message", status: "completed" }] })],
-    ["malformed JSON arguments", upstreamFunctionCall("not-json")],
+    [
+      "missing tool call",
+      fragmentedSseResponse({
+        type: "response.completed",
+        response: { id: "resp-classify", output: [] },
+      }),
+    ],
+    ["malformed JSON arguments", completedFunctionCall("not-json")],
     [
       "invalid decision",
-      upstreamFunctionCall(JSON.stringify({ ...decision, confidence: "certain" })),
+      completedFunctionCall(JSON.stringify({ ...decision, confidence: "certain" })),
     ],
-    ["non-JSON response", new Response("not-json")],
+    [
+      "function call from another namespace",
+      fragmentedSseResponse(
+        {
+          type: "response.output_item.done",
+          item: { ...functionCall(), namespace: "other" },
+        },
+        { type: "response.completed", response: { id: "resp-classify" } }
+      ),
+    ],
+    [
+      "completed fallback from another namespace",
+      fragmentedSseResponse({
+        type: "response.completed",
+        response: {
+          id: "resp-classify",
+          output: [{ ...functionCall(), namespace: "other" }],
+        },
+      }),
+    ],
+    ["malformed SSE", new Response("event: response.completed\ndata: {not-json}\n\n")],
+    [
+      "oversized SSE event",
+      new Response(`data: ${"x".repeat(70 * 1024)}\n\n`, {
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    ],
   ])("returns 502 for %s", async (_name, upstreamResponse) => {
     vi.mocked(fetch).mockResolvedValueOnce(upstreamResponse);
 
@@ -209,6 +370,39 @@ describe("POST /internal/classifier/infer", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Classifier returned an invalid response",
     });
+  });
+
+  it.each(["response.failed", "error"])("sanitizes %s events", async (type) => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      fragmentedSseResponse({ type, error: { message: "upstream secret details" } })
+    );
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(502);
+    const responseText = await response.text();
+    expect(responseText).toBe(JSON.stringify({ error: "Classifier upstream unavailable" }));
+    expect(responseText).not.toContain("upstream secret details");
+  });
+
+  it("maps broker authorization failure to 502 for the authenticated caller", async () => {
+    brokerState.refreshGlobal.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      error: "refresh token rejected",
+    });
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "OpenAI OAuth unavailable" });
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("maps non-OK upstream responses without returning their body", async () => {

--- a/packages/control-plane/src/routes/classifier.test.ts
+++ b/packages/control-plane/src/routes/classifier.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type * as OpenAITokenRefreshModule from "../session/openai-token-refresh-service";
 import { handleRequest } from "../router";
 import { signedServiceRequest, TEST_SERVICE_SECRETS } from "../router.test-support";
+import { CLASSIFIER_UPSTREAM_TIMEOUT_MS } from "./classifier";
 
 const brokerState = vi.hoisted(() => ({
   refreshGlobal: vi.fn(),
@@ -74,6 +75,22 @@ function completedFunctionCall(argumentsValue = JSON.stringify(decision)): Respo
     type: "response.completed",
     response: { id: "resp-classify", output: [functionCall(argumentsValue)] },
   });
+}
+
+function openStreamResponse(
+  initialBody: string | undefined,
+  cancel: () => void | Promise<void>
+): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (initialBody !== undefined) controller.enqueue(encoder.encode(initialBody));
+      },
+      cancel,
+    }),
+    { headers: { "Content-Type": "text/event-stream" } }
+  );
 }
 
 async function classifierRequest(
@@ -179,6 +196,7 @@ describe("POST /internal/classifier/infer", () => {
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
     expect(init?.method).toBe("POST");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
     const headers = new Headers(init?.headers);
     expect(headers.get("authorization")).toBe("Bearer secret-access-token");
     expect(headers.get("ChatGPT-Account-Id")).toBe("account-123");
@@ -386,6 +404,75 @@ describe("POST /internal/classifier/infer", () => {
     const responseText = await response.text();
     expect(responseText).toBe(JSON.stringify({ error: "Classifier upstream unavailable" }));
     expect(responseText).not.toContain("upstream secret details");
+  });
+
+  it("times out a never-ending upstream stream and cancels its reader", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    vi.mocked(fetch).mockResolvedValueOnce(openStreamResponse(undefined, cancel));
+
+    try {
+      const responsePromise = classifierRequest({
+        model: "openai/gpt-5.6-luna",
+        prompt: "route this",
+      });
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(CLASSIFIER_UPSTREAM_TIMEOUT_MS);
+
+      const response = await responsePromise;
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toEqual({
+        error: "Classifier upstream unavailable",
+      });
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out even when the fetch implementation ignores abort", async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch).mockImplementationOnce(() => new Promise<Response>(() => undefined));
+
+    try {
+      const responsePromise = classifierRequest({
+        model: "openai/gpt-5.6-luna",
+        prompt: "route this",
+      });
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(CLASSIFIER_UPSTREAM_TIMEOUT_MS);
+
+      const response = await responsePromise;
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toEqual({
+        error: "Classifier upstream unavailable",
+      });
+      expect(vi.mocked(fetch).mock.calls[0][1]?.signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores reader cancellation failures and releases the lock", async () => {
+    const cancel = vi.fn().mockRejectedValue(new Error("cancel failed with secret details"));
+    const upstream = openStreamResponse(
+      sseEvent({
+        type: "response.completed",
+        response: { id: "resp-classify", output: [functionCall()] },
+      }),
+      cancel
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(upstream);
+
+    const response = await classifierRequest({
+      model: "openai/gpt-5.6-luna",
+      prompt: "route this",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ decision });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(upstream.body?.locked).toBe(false);
   });
 
   it("maps broker authorization failure to 502 for the authenticated caller", async () => {

--- a/packages/control-plane/src/routes/classifier.ts
+++ b/packages/control-plane/src/routes/classifier.ts
@@ -239,7 +239,7 @@ async function parseClassifierStream(
       ? { kind: "failed" }
       : { kind: "invalid" };
   } finally {
-    await reader.cancel().catch(() => undefined);
+    void reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
 

--- a/packages/control-plane/src/routes/classifier.ts
+++ b/packages/control-plane/src/routes/classifier.ts
@@ -20,30 +20,199 @@ const logger = createLogger("router:classifier");
 const CLASSIFIER_MODEL = "openai/gpt-5.6-luna";
 const OPENAI_MODEL = "gpt-5.6-luna";
 const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
+const MAX_SSE_BYTES = 1024 * 1024;
+const MAX_SSE_EVENT_BYTES = 64 * 1024;
+const MAX_SSE_EVENTS = 1_000;
+const MAX_TOOL_ARGUMENT_BYTES = 32 * 1024;
 
 function extractDecision(body: unknown): unknown {
   if (typeof body !== "object" || body === null || !("output" in body)) return null;
   const output = body.output;
   if (!Array.isArray(output)) return null;
 
-  const functionCall = output.find(
-    (item): item is { type: "function_call"; name: string; arguments: string } =>
-      typeof item === "object" &&
-      item !== null &&
-      "type" in item &&
-      item.type === "function_call" &&
-      "name" in item &&
-      item.name === CLASSIFY_TARGET_TOOL_NAME &&
-      "arguments" in item &&
-      typeof item.arguments === "string"
-  );
-  if (!functionCall) return null;
+  return output.map(parseFunctionCallItem).find((decision) => decision !== null) ?? null;
+}
 
+type PendingFunctionCall = {
+  namespace?: string;
+  name?: string;
+  arguments: string;
+};
+
+type ClassifierStreamResult =
+  | { kind: "completed"; decision: unknown }
+  | { kind: "failed" }
+  | { kind: "invalid" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function functionCallFromItem(value: unknown): PendingFunctionCall | null {
+  if (
+    !isRecord(value) ||
+    value.type !== "function_call" ||
+    (value.namespace !== undefined && value.namespace !== "functions") ||
+    value.name !== CLASSIFY_TARGET_TOOL_NAME ||
+    typeof value.arguments !== "string"
+  ) {
+    return null;
+  }
+  return {
+    namespace: typeof value.namespace === "string" ? value.namespace : undefined,
+    name: value.name,
+    arguments: value.arguments,
+  };
+}
+
+function parseFunctionArguments(call: PendingFunctionCall | null): unknown {
+  if (
+    !call ||
+    (call.namespace !== undefined && call.namespace !== "functions") ||
+    call.name !== CLASSIFY_TARGET_TOOL_NAME
+  ) {
+    return null;
+  }
+  if (new TextEncoder().encode(call.arguments).byteLength > MAX_TOOL_ARGUMENT_BYTES) return null;
   try {
-    return JSON.parse(functionCall.arguments);
+    return JSON.parse(call.arguments);
   } catch {
     return null;
   }
+}
+
+function parseFunctionCallItem(value: unknown): unknown {
+  return parseFunctionArguments(functionCallFromItem(value));
+}
+
+async function parseClassifierStream(response: Response): Promise<ClassifierStreamResult> {
+  if (!response.body) return { kind: "invalid" };
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const pendingCalls = new Map<string, PendingFunctionCall>();
+  let completedOutputDecision: unknown = null;
+  let outputItemDecision: unknown = null;
+  let lineBuffer = "";
+  let eventData = "";
+  let totalBytes = 0;
+  let eventCount = 0;
+
+  const processEvent = (): "continue" | "completed" | "failed" | "invalid" => {
+    if (!eventData) return "continue";
+    eventCount += 1;
+    if (eventCount > MAX_SSE_EVENTS || encoder.encode(eventData).byteLength > MAX_SSE_EVENT_BYTES) {
+      return "invalid";
+    }
+
+    let event: unknown;
+    try {
+      event = JSON.parse(eventData);
+    } catch {
+      return "invalid";
+    }
+    if (!isRecord(event) || typeof event.type !== "string") return "invalid";
+
+    if (event.type === "error" || event.type === "response.failed") return "failed";
+
+    if (event.type === "response.output_item.added" && isRecord(event.item)) {
+      const id = typeof event.item.id === "string" ? event.item.id : null;
+      if (id && event.item.type === "function_call") {
+        pendingCalls.set(id, {
+          namespace: typeof event.item.namespace === "string" ? event.item.namespace : undefined,
+          name: typeof event.item.name === "string" ? event.item.name : undefined,
+          arguments: typeof event.item.arguments === "string" ? event.item.arguments : "",
+        });
+      }
+      return "continue";
+    }
+
+    if (event.type === "response.function_call_arguments.delta") {
+      const itemId = typeof event.item_id === "string" ? event.item_id : null;
+      if (!itemId || typeof event.delta !== "string") return "invalid";
+      const call = pendingCalls.get(itemId) ?? { arguments: "" };
+      call.arguments += event.delta;
+      if (encoder.encode(call.arguments).byteLength > MAX_TOOL_ARGUMENT_BYTES) return "invalid";
+      pendingCalls.set(itemId, call);
+      return "continue";
+    }
+
+    if (event.type === "response.function_call_arguments.done") {
+      const itemId = typeof event.item_id === "string" ? event.item_id : null;
+      if (!itemId || typeof event.arguments !== "string") return "invalid";
+      const call = pendingCalls.get(itemId) ?? { arguments: "" };
+      call.arguments = event.arguments;
+      if (typeof event.namespace === "string") call.namespace = event.namespace;
+      if (typeof event.name === "string") call.name = event.name;
+      if (encoder.encode(call.arguments).byteLength > MAX_TOOL_ARGUMENT_BYTES) return "invalid";
+      pendingCalls.set(itemId, call);
+      return "continue";
+    }
+
+    if (event.type === "response.output_item.done") {
+      if (!isRecord(event.item) || event.item.type !== "function_call") return "continue";
+      outputItemDecision = parseFunctionCallItem(event.item);
+      if (outputItemDecision === null) return "invalid";
+      return "continue";
+    }
+
+    if (event.type === "response.completed") {
+      completedOutputDecision = extractDecision(event.response);
+      return "completed";
+    }
+
+    return "continue";
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_SSE_BYTES) return { kind: "invalid" };
+      lineBuffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = lineBuffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        let line = lineBuffer.slice(0, newlineIndex);
+        lineBuffer = lineBuffer.slice(newlineIndex + 1);
+        if (line.endsWith("\r")) line = line.slice(0, -1);
+
+        if (line === "") {
+          const result = processEvent();
+          eventData = "";
+          if (result === "failed") return { kind: "failed" };
+          if (result === "invalid") return { kind: "invalid" };
+          if (result === "completed") {
+            const streamedDecision =
+              outputItemDecision ??
+              [...pendingCalls.values()]
+                .map(parseFunctionArguments)
+                .find((candidate) => candidate !== null) ??
+              completedOutputDecision;
+            return { kind: "completed", decision: streamedDecision };
+          }
+        } else if (line.startsWith("data:")) {
+          const data = line.slice(5).replace(/^ /, "");
+          eventData += eventData ? `\n${data}` : data;
+          if (encoder.encode(eventData).byteLength > MAX_SSE_EVENT_BYTES) {
+            return { kind: "invalid" };
+          }
+        }
+        newlineIndex = lineBuffer.indexOf("\n");
+      }
+      if (encoder.encode(lineBuffer).byteLength > MAX_SSE_EVENT_BYTES) {
+        return { kind: "invalid" };
+      }
+    }
+  } catch {
+    return { kind: "invalid" };
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { kind: "invalid" };
 }
 
 export async function handleClassifierInference(
@@ -72,18 +241,19 @@ export async function handleClassifierInference(
   const broker = new OpenAITokenBroker(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY, logger);
   const tokenResult = await broker.refreshGlobal();
   if (!tokenResult.ok) {
-    const status = tokenResult.status === 404 ? 503 : tokenResult.status;
     return error(
       tokenResult.status === 404 ? "OpenAI OAuth is not configured" : "OpenAI OAuth unavailable",
-      status
+      tokenResult.status === 404 ? 503 : 502
     );
   }
 
   const headers = new Headers({
     authorization: `Bearer ${tokenResult.accessToken}`,
+    Accept: "text/event-stream",
     "Content-Type": "application/json",
-    originator: "opencode",
+    originator: "codex_cli_rs",
     session_id: ctx.trace_id,
+    "x-openai-internal-codex-responses-lite": "true",
   });
   if (tokenResult.accountId) headers.set("ChatGPT-Account-Id", tokenResult.accountId);
 
@@ -94,20 +264,38 @@ export async function handleClassifierInference(
       headers,
       body: JSON.stringify({
         model: OPENAI_MODEL,
-        input: parsedRequest.data.prompt,
-        tools: [
+        input: [
           {
-            type: "function",
-            name: CLASSIFY_TARGET_TOOL_NAME,
-            description: "Select the best target for the Slack request.",
-            parameters: targetClassificationJsonSchema,
-            strict: true,
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              {
+                type: "namespace",
+                name: "functions",
+                description: "",
+                tools: [
+                  {
+                    type: "function",
+                    name: CLASSIFY_TARGET_TOOL_NAME,
+                    description: "Select the best target for the Slack request.",
+                    parameters: targetClassificationJsonSchema,
+                    strict: true,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: parsedRequest.data.prompt }],
           },
         ],
-        tool_choice: { type: "function", name: CLASSIFY_TARGET_TOOL_NAME },
+        tool_choice: "required",
         parallel_tool_calls: false,
+        reasoning: { context: "all_turns" },
         store: false,
-        stream: false,
+        stream: true,
       }),
     });
   } catch {
@@ -129,14 +317,13 @@ export async function handleClassifierInference(
     return error("Classifier upstream unavailable", 502);
   }
 
-  let upstreamBody: unknown;
-  try {
-    upstreamBody = await upstream.json();
-  } catch {
+  const streamResult = await parseClassifierStream(upstream);
+  if (streamResult.kind === "failed") return error("Classifier upstream unavailable", 502);
+  if (streamResult.kind === "invalid") {
     return error("Classifier returned an invalid response", 502);
   }
 
-  const decision = targetClassificationDecisionSchema.safeParse(extractDecision(upstreamBody));
+  const decision = targetClassificationDecisionSchema.safeParse(streamResult.decision);
   if (!decision.success) return error("Classifier returned an invalid response", 502);
 
   return json({ decision: decision.data });

--- a/packages/control-plane/src/routes/classifier.ts
+++ b/packages/control-plane/src/routes/classifier.ts
@@ -1,0 +1,151 @@
+import {
+  CLASSIFY_TARGET_TOOL_NAME,
+  classifierInferenceRequestSchema,
+  targetClassificationDecisionSchema,
+  targetClassificationJsonSchema,
+} from "@open-inspect/shared";
+import { createLogger } from "../logger";
+import { OpenAITokenBroker } from "../session/openai-token-refresh-service";
+import type { Env } from "../types";
+import {
+  error,
+  json,
+  parseJsonBody,
+  parsePattern,
+  type RequestContext,
+  type Route,
+} from "./shared";
+
+const logger = createLogger("router:classifier");
+const CLASSIFIER_MODEL = "openai/gpt-5.6-luna";
+const OPENAI_MODEL = "gpt-5.6-luna";
+const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
+
+function extractDecision(body: unknown): unknown {
+  if (typeof body !== "object" || body === null || !("output" in body)) return null;
+  const output = body.output;
+  if (!Array.isArray(output)) return null;
+
+  const functionCall = output.find(
+    (item): item is { type: "function_call"; name: string; arguments: string } =>
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      item.type === "function_call" &&
+      "name" in item &&
+      item.name === CLASSIFY_TARGET_TOOL_NAME &&
+      "arguments" in item &&
+      typeof item.arguments === "string"
+  );
+  if (!functionCall) return null;
+
+  try {
+    return JSON.parse(functionCall.arguments);
+  } catch {
+    return null;
+  }
+}
+
+export async function handleClassifierInference(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  if (ctx.principal?.kind !== "service" || ctx.principal.service !== "slack-bot") {
+    return error("Forbidden", 403);
+  }
+
+  const rawBody = await parseJsonBody<unknown>(request);
+  if (rawBody instanceof Response) return rawBody;
+
+  const parsedRequest = classifierInferenceRequestSchema.safeParse(rawBody);
+  if (!parsedRequest.success) return error("Invalid classifier inference request", 400);
+  if (parsedRequest.data.model !== CLASSIFIER_MODEL) {
+    return error("Unsupported classifier model", 400);
+  }
+
+  if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
+    return error("OpenAI OAuth is not configured", 503);
+  }
+
+  const broker = new OpenAITokenBroker(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY, logger);
+  const tokenResult = await broker.refreshGlobal();
+  if (!tokenResult.ok) {
+    const status = tokenResult.status === 404 ? 503 : tokenResult.status;
+    return error(
+      tokenResult.status === 404 ? "OpenAI OAuth is not configured" : "OpenAI OAuth unavailable",
+      status
+    );
+  }
+
+  const headers = new Headers({
+    authorization: `Bearer ${tokenResult.accessToken}`,
+    "Content-Type": "application/json",
+    originator: "opencode",
+    session_id: ctx.trace_id,
+  });
+  if (tokenResult.accountId) headers.set("ChatGPT-Account-Id", tokenResult.accountId);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(CODEX_RESPONSES_ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        input: parsedRequest.data.prompt,
+        tools: [
+          {
+            type: "function",
+            name: CLASSIFY_TARGET_TOOL_NAME,
+            description: "Select the best target for the Slack request.",
+            parameters: targetClassificationJsonSchema,
+            strict: true,
+          },
+        ],
+        tool_choice: { type: "function", name: CLASSIFY_TARGET_TOOL_NAME },
+        parallel_tool_calls: false,
+        store: false,
+        stream: false,
+      }),
+    });
+  } catch {
+    logger.error("Classifier upstream request failed", {
+      event: "classifier.upstream_failed",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Classifier upstream unavailable", 502);
+  }
+
+  if (!upstream.ok) {
+    logger.warn("Classifier upstream returned an error", {
+      event: "classifier.upstream_error",
+      upstream_status: upstream.status,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Classifier upstream unavailable", 502);
+  }
+
+  let upstreamBody: unknown;
+  try {
+    upstreamBody = await upstream.json();
+  } catch {
+    return error("Classifier returned an invalid response", 502);
+  }
+
+  const decision = targetClassificationDecisionSchema.safeParse(extractDecision(upstreamBody));
+  if (!decision.success) return error("Classifier returned an invalid response", 502);
+
+  return json({ decision: decision.data });
+}
+
+export const classifierRoutes: Route[] = [
+  {
+    method: "POST",
+    pattern: parsePattern("/internal/classifier/infer"),
+    handler: handleClassifierInference,
+  },
+];

--- a/packages/control-plane/src/routes/classifier.ts
+++ b/packages/control-plane/src/routes/classifier.ts
@@ -1,5 +1,6 @@
 import {
   CLASSIFY_TARGET_TOOL_NAME,
+  OPENAI_CLASSIFICATION_MODEL_ID,
   classifierInferenceRequestSchema,
   targetClassificationDecisionSchema,
   targetClassificationJsonSchema,
@@ -17,9 +18,9 @@ import {
 } from "./shared";
 
 const logger = createLogger("router:classifier");
-const CLASSIFIER_MODEL = "openai/gpt-5.6-luna";
 const OPENAI_MODEL = "gpt-5.6-luna";
 const CODEX_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
+export const CLASSIFIER_UPSTREAM_TIMEOUT_MS = 30_000;
 const MAX_SSE_BYTES = 1024 * 1024;
 const MAX_SSE_EVENT_BYTES = 64 * 1024;
 const MAX_SSE_EVENTS = 1_000;
@@ -43,6 +44,30 @@ type ClassifierStreamResult =
   | { kind: "completed"; decision: unknown }
   | { kind: "failed" }
   | { kind: "invalid" };
+
+class ClassifierUpstreamAbortError extends Error {}
+
+function waitForUpstream<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new ClassifierUpstreamAbortError());
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new ClassifierUpstreamAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (caught: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(caught);
+      }
+    );
+  });
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -85,7 +110,10 @@ function parseFunctionCallItem(value: unknown): unknown {
   return parseFunctionArguments(functionCallFromItem(value));
 }
 
-async function parseClassifierStream(response: Response): Promise<ClassifierStreamResult> {
+async function parseClassifierStream(
+  response: Response,
+  signal: AbortSignal
+): Promise<ClassifierStreamResult> {
   if (!response.body) return { kind: "invalid" };
 
   const reader = response.body.getReader();
@@ -167,7 +195,7 @@ async function parseClassifierStream(response: Response): Promise<ClassifierStre
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await waitForUpstream(reader.read(), signal);
       if (done) break;
       totalBytes += value.byteLength;
       if (totalBytes > MAX_SSE_BYTES) return { kind: "invalid" };
@@ -206,9 +234,12 @@ async function parseClassifierStream(response: Response): Promise<ClassifierStre
         return { kind: "invalid" };
       }
     }
-  } catch {
-    return { kind: "invalid" };
+  } catch (caught) {
+    return caught instanceof ClassifierUpstreamAbortError || signal.aborted
+      ? { kind: "failed" }
+      : { kind: "invalid" };
   } finally {
+    await reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
 
@@ -230,7 +261,7 @@ export async function handleClassifierInference(
 
   const parsedRequest = classifierInferenceRequestSchema.safeParse(rawBody);
   if (!parsedRequest.success) return error("Invalid classifier inference request", 400);
-  if (parsedRequest.data.model !== CLASSIFIER_MODEL) {
+  if (parsedRequest.data.model !== OPENAI_CLASSIFICATION_MODEL_ID) {
     return error("Unsupported classifier model", 400);
   }
 
@@ -257,76 +288,86 @@ export async function handleClassifierInference(
   });
   if (tokenResult.accountId) headers.set("ChatGPT-Account-Id", tokenResult.accountId);
 
-  let upstream: Response;
+  const abortController = new AbortController();
+  const upstreamTimeout = setTimeout(() => abortController.abort(), CLASSIFIER_UPSTREAM_TIMEOUT_MS);
   try {
-    upstream = await fetch(CODEX_RESPONSES_ENDPOINT, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        model: OPENAI_MODEL,
-        input: [
-          {
-            type: "additional_tools",
-            role: "developer",
-            tools: [
+    let upstream: Response;
+    try {
+      upstream = await waitForUpstream(
+        fetch(CODEX_RESPONSES_ENDPOINT, {
+          method: "POST",
+          headers,
+          signal: abortController.signal,
+          body: JSON.stringify({
+            model: OPENAI_MODEL,
+            input: [
               {
-                type: "namespace",
-                name: "functions",
-                description: "",
+                type: "additional_tools",
+                role: "developer",
                 tools: [
                   {
-                    type: "function",
-                    name: CLASSIFY_TARGET_TOOL_NAME,
-                    description: "Select the best target for the Slack request.",
-                    parameters: targetClassificationJsonSchema,
-                    strict: true,
+                    type: "namespace",
+                    name: "functions",
+                    description: "",
+                    tools: [
+                      {
+                        type: "function",
+                        name: CLASSIFY_TARGET_TOOL_NAME,
+                        description: "Select the best target for the Slack request.",
+                        parameters: targetClassificationJsonSchema,
+                        strict: true,
+                      },
+                    ],
                   },
                 ],
               },
+              {
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: parsedRequest.data.prompt }],
+              },
             ],
-          },
-          {
-            type: "message",
-            role: "user",
-            content: [{ type: "input_text", text: parsedRequest.data.prompt }],
-          },
-        ],
-        tool_choice: "required",
-        parallel_tool_calls: false,
-        reasoning: { context: "all_turns" },
-        store: false,
-        stream: true,
-      }),
-    });
-  } catch {
-    logger.error("Classifier upstream request failed", {
-      event: "classifier.upstream_failed",
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Classifier upstream unavailable", 502);
+            tool_choice: "required",
+            parallel_tool_calls: false,
+            reasoning: { context: "all_turns" },
+            store: false,
+            stream: true,
+          }),
+        }),
+        abortController.signal
+      );
+    } catch {
+      logger.error("Classifier upstream request failed", {
+        event: "classifier.upstream_failed",
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return error("Classifier upstream unavailable", 502);
+    }
+
+    if (!upstream.ok) {
+      logger.warn("Classifier upstream returned an error", {
+        event: "classifier.upstream_error",
+        upstream_status: upstream.status,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return error("Classifier upstream unavailable", 502);
+    }
+
+    const streamResult = await parseClassifierStream(upstream, abortController.signal);
+    if (streamResult.kind === "failed") return error("Classifier upstream unavailable", 502);
+    if (streamResult.kind === "invalid") {
+      return error("Classifier returned an invalid response", 502);
+    }
+
+    const decision = targetClassificationDecisionSchema.safeParse(streamResult.decision);
+    if (!decision.success) return error("Classifier returned an invalid response", 502);
+
+    return json({ decision: decision.data });
+  } finally {
+    clearTimeout(upstreamTimeout);
   }
-
-  if (!upstream.ok) {
-    logger.warn("Classifier upstream returned an error", {
-      event: "classifier.upstream_error",
-      upstream_status: upstream.status,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Classifier upstream unavailable", 502);
-  }
-
-  const streamResult = await parseClassifierStream(upstream);
-  if (streamResult.kind === "failed") return error("Classifier upstream unavailable", 502);
-  if (streamResult.kind === "invalid") {
-    return error("Classifier returned an invalid response", 502);
-  }
-
-  const decision = targetClassificationDecisionSchema.safeParse(streamResult.decision);
-  if (!decision.success) return error("Classifier returned an invalid response", 502);
-
-  return json({ decision: decision.data });
 }
 
 export const classifierRoutes: Route[] = [

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
 import type { Env } from "../types";
 import type { SessionRow } from "./types";
-import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
+import { OpenAITokenBroker, OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { OpenAITokenRefreshError } from "../auth/openai";
 
 const mockState = vi.hoisted(() => ({
@@ -163,6 +163,96 @@ describe("OpenAITokenRefreshService", () => {
       accountId: "acct_cached",
     });
     expect(mockState.refreshImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns a cached global access token without consulting session scopes", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-cached-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    };
+    mockState.repoSecrets.set(123, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "repo-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+    });
+
+    const result = await new OpenAITokenBroker(
+      {} as Env["DB"],
+      "enc-key",
+      createLogger()
+    ).refreshGlobal();
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "global-cached-access",
+      expiresIn: expect.any(Number),
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and rotates global credentials", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+      account_id: "acct_global",
+    });
+
+    const result = await new OpenAITokenBroker(
+      {} as Env["DB"],
+      "enc-key",
+      createLogger()
+    ).refreshGlobal();
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "global-access-new",
+      expiresIn: 1800,
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledWith("global-refresh-old");
+    expect(mockState.globalWrites).toHaveLength(1);
+    expect(mockState.globalWrites[0]).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-access-new",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    });
+  });
+
+  it("uses a concurrently rotated global access token after refresh gets 401", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      mockState.globalSecrets = {
+        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+        OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+      };
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const promise = new OpenAITokenBroker(
+      {} as Env["DB"],
+      "enc-key",
+      createLogger()
+    ).refreshGlobal();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(promise).resolves.toMatchObject({
+      ok: true,
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
   });
 
   it("returns 404 when refresh token is missing in repo and global secrets", async () => {

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
-import type { Env } from "../types";
 import type { SessionRow } from "./types";
 import { OpenAITokenBroker, OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { OpenAITokenRefreshError } from "../auth/openai";
@@ -18,7 +17,27 @@ const mockState = vi.hoisted(() => ({
   }>,
   globalWrites: [] as Array<Record<string, string>>,
   environmentWrites: [] as Array<{ environmentId: string; secrets: Record<string, string> }>,
+  repoWriteImpl: vi.fn(),
+  globalWriteImpl: vi.fn(),
 }));
+
+const TEST_DB: D1Database = {
+  prepare(_query: string): D1PreparedStatement {
+    throw new Error("Unexpected D1 prepare call");
+  },
+  async batch<T = unknown>(_statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    return [];
+  },
+  async exec(_query: string): Promise<D1ExecResult> {
+    throw new Error("Unexpected D1 exec call");
+  },
+  withSession(): D1DatabaseSession {
+    throw new Error("Unexpected D1 session call");
+  },
+  async dump(): Promise<ArrayBuffer> {
+    return new ArrayBuffer(0);
+  },
+};
 
 vi.mock("../auth/openai", () => {
   class MockOpenAITokenRefreshError extends Error {
@@ -50,6 +69,7 @@ vi.mock("../db/repo-secrets", () => ({
       name: string,
       secrets: Record<string, string>
     ): Promise<void> {
+      await mockState.repoWriteImpl(repoId, owner, name, secrets);
       mockState.repoWrites.push({ repoId, owner, name, secrets });
       const existing = mockState.repoSecrets.get(repoId) ?? {};
       mockState.repoSecrets.set(repoId, { ...existing, ...secrets });
@@ -64,6 +84,7 @@ vi.mock("../db/global-secrets", () => ({
     }
 
     async setSecrets(secrets: Record<string, string>): Promise<void> {
+      await mockState.globalWriteImpl(secrets);
       mockState.globalWrites.push(secrets);
       mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
     }
@@ -132,6 +153,10 @@ describe("OpenAITokenRefreshService", () => {
     mockState.globalWrites = [];
     mockState.environmentWrites = [];
     mockState.refreshImpl.mockReset();
+    mockState.repoWriteImpl.mockReset();
+    mockState.repoWriteImpl.mockResolvedValue(undefined);
+    mockState.globalWriteImpl.mockReset();
+    mockState.globalWriteImpl.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -148,7 +173,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
@@ -178,11 +203,7 @@ describe("OpenAITokenRefreshService", () => {
       OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
     });
 
-    const result = await new OpenAITokenBroker(
-      {} as Env["DB"],
-      "enc-key",
-      createLogger()
-    ).refreshGlobal();
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
 
     expect(result).toEqual({
       ok: true,
@@ -205,11 +226,7 @@ describe("OpenAITokenRefreshService", () => {
       account_id: "acct_global",
     });
 
-    const result = await new OpenAITokenBroker(
-      {} as Env["DB"],
-      "enc-key",
-      createLogger()
-    ).refreshGlobal();
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
 
     expect(result).toEqual({
       ok: true,
@@ -224,6 +241,56 @@ describe("OpenAITokenRefreshService", () => {
       OPENAI_OAUTH_ACCESS_TOKEN: "global-access-new",
       OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
     });
+  });
+
+  it("retries a transient global persistence failure and returns success after saving", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalWriteImpl
+      .mockRejectedValueOnce(new Error("D1 temporarily unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({ ok: true, accessToken: "global-access-new" });
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("returns an actionable failure when rotated global credentials cannot be persisted", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
+    });
+    expect(result.ok).toBe(false);
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.globalWrites).toHaveLength(0);
   });
 
   it("uses a concurrently rotated global access token after refresh gets 401", async () => {
@@ -241,11 +308,7 @@ describe("OpenAITokenRefreshService", () => {
       throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
     });
 
-    const promise = new OpenAITokenBroker(
-      {} as Env["DB"],
-      "enc-key",
-      createLogger()
-    ).refreshGlobal();
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
     await vi.advanceTimersByTimeAsync(500);
 
     await expect(promise).resolves.toMatchObject({
@@ -257,7 +320,7 @@ describe("OpenAITokenRefreshService", () => {
 
   it("returns 404 when refresh token is missing in repo and global secrets", async () => {
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()
@@ -286,7 +349,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
@@ -309,6 +372,40 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_ACCESS_TOKEN).toBe("access-new");
   });
 
+  it("returns an actionable failure when rotated session credentials cannot be persisted", async () => {
+    vi.useFakeTimers();
+    const repoId = 123;
+    mockState.repoSecrets.set(repoId, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "access-new",
+      refresh_token: "refresh-new",
+      expires_in: 1800,
+    });
+    mockState.repoWriteImpl.mockRejectedValue(new Error("storage unavailable"));
+
+    const service = new OpenAITokenRefreshService(
+      TEST_DB,
+      "enc-key",
+      async () => repoId,
+      createLogger()
+    );
+    const promise = service.refresh(createSession());
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
+    });
+    expect(result.ok).toBe(false);
+    expect(mockState.repoWriteImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.repoWrites).toHaveLength(0);
+  });
+
   it("uses cached token after concurrent rotation when refresh gets 401", async () => {
     vi.useFakeTimers();
 
@@ -329,7 +426,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
@@ -367,7 +464,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()
@@ -401,7 +498,7 @@ describe("OpenAITokenRefreshService", () => {
     };
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -11,6 +11,11 @@ import type { Logger } from "../logger";
 import type { SessionRow } from "./types";
 
 const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS = 3;
+const OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS = 100;
+const OPENAI_CONCURRENT_ROTATION_DELAY_MS = 500;
+const OPENAI_TOKEN_PERSIST_FAILURE =
+  "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth";
 
 /**
  * Where a session's OpenAI OAuth tokens are read from and rotated back to. A
@@ -208,28 +213,25 @@ export class OpenAITokenBroker {
     const accountId = extractOpenAIAccountId(tokens);
     const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
 
-    try {
-      const secretsToWrite: Record<string, string> = {
-        OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
-        OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
-        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
-      };
+    const secretsToWrite: Record<string, string> = {
+      OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
+      OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
+    };
 
-      if (accountId) {
-        secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
-      }
-
-      await this.writeSecretsForSource(tokenState.source, secretsToWrite);
-
-      this.log.info("OpenAI tokens rotated and cached", {
-        source: tokenState.source.kind,
-        has_account_id: !!accountId,
-      });
-    } catch (e) {
-      this.log.error("Failed to store rotated OpenAI tokens", {
-        error: e instanceof Error ? e.message : String(e),
-      });
+    if (accountId) {
+      secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
     }
+
+    const persisted = await this.persistRotatedTokens(tokenState.source, secretsToWrite);
+    if (!persisted) {
+      return { ok: false, status: 500, error: OPENAI_TOKEN_PERSIST_FAILURE };
+    }
+
+    this.log.info("OpenAI tokens rotated and cached", {
+      source: tokenState.source.kind,
+      has_account_id: !!accountId,
+    });
 
     return {
       ok: true,
@@ -237,6 +239,36 @@ export class OpenAITokenBroker {
       expiresIn: tokens.expires_in,
       accountId,
     };
+  }
+
+  private async persistRotatedTokens(
+    source: TokenSecretSource,
+    secrets: Record<string, string>
+  ): Promise<boolean> {
+    for (let attempt = 1; attempt <= OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.writeSecretsForSource(source, secrets);
+        return true;
+      } catch (e) {
+        const finalAttempt = attempt === OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS;
+        const context = {
+          source: source.kind,
+          attempt,
+          max_attempts: OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS,
+          error: e instanceof Error ? e.message : String(e),
+        };
+
+        if (finalAttempt) {
+          this.log.error("Failed to store rotated OpenAI tokens", context);
+          return false;
+        }
+
+        this.log.warn("Failed to store rotated OpenAI tokens; retrying", context);
+        await new Promise((resolve) => setTimeout(resolve, OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS));
+      }
+    }
+
+    return false;
   }
 
   private async handleUnauthorizedRefresh(
@@ -247,7 +279,7 @@ export class OpenAITokenBroker {
       source: tokenState.source.kind,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, OPENAI_CONCURRENT_ROTATION_DELAY_MS));
 
     try {
       const reread = await readTokenState();

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -33,17 +33,34 @@ export type OpenAITokenRefreshResult =
   | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
   | { ok: false; status: number; error: string };
 
-export class OpenAITokenRefreshService {
+/** Source-aware broker shared by session-scoped and global OAuth consumers. */
+export class OpenAITokenBroker {
   constructor(
     private readonly db: SqlDatabase,
     private readonly encryptionKey: string,
-    private readonly ensureRepoId: (session: SessionRow) => Promise<number>,
     private readonly log: Logger
   ) {}
 
-  async refresh(session: SessionRow): Promise<OpenAITokenRefreshResult> {
-    const readTokenState = () => this.readTokenState(session);
+  refreshGlobal(): Promise<OpenAITokenRefreshResult> {
+    return this.refreshFrom(() => this.readTokenStateForSources([{ kind: "global" }]));
+  }
 
+  refreshSession(
+    session: SessionRow,
+    ensureRepoId: (session: SessionRow) => Promise<number>
+  ): Promise<OpenAITokenRefreshResult> {
+    return this.refreshFrom(async () => {
+      const source = await this.resolveSessionSecretSource(session, ensureRepoId);
+      const sources = source
+        ? [source, { kind: "global" } as const]
+        : [{ kind: "global" } as const];
+      return this.readTokenStateForSources(sources);
+    });
+  }
+
+  private async refreshFrom(
+    readTokenState: () => Promise<OpenAITokenState | null>
+  ): Promise<OpenAITokenRefreshResult> {
     let tokenState: OpenAITokenState | null;
     try {
       tokenState = await readTokenState();
@@ -114,12 +131,15 @@ export class OpenAITokenRefreshService {
    * environment (global-only). Environment-launched sessions resolve to the
    * environment and never read member repo secrets (§6.4/§7.4).
    */
-  private async resolveSessionSecretSource(session: SessionRow): Promise<TokenSecretSource | null> {
+  private async resolveSessionSecretSource(
+    session: SessionRow,
+    ensureRepoId: (session: SessionRow) => Promise<number>
+  ): Promise<TokenSecretSource | null> {
     if (session.environment_id) {
       return { kind: "environment", environmentId: session.environment_id };
     }
     if (session.repo_owner && session.repo_name) {
-      const repoId = await this.ensureRepoId(session);
+      const repoId = await ensureRepoId(session);
       return {
         kind: "repo",
         repoId,
@@ -168,18 +188,17 @@ export class OpenAITokenRefreshService {
     }
   }
 
-  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    const source = await this.resolveSessionSecretSource(session);
-    if (source) {
+  private async readTokenStateForSources(
+    sources: readonly TokenSecretSource[]
+  ): Promise<OpenAITokenState | null> {
+    for (const source of sources) {
       const secrets = await this.readSecretsForSource(source);
       const state = this.getTokenStateFromSecrets(secrets, source);
       if (state) {
         return state;
       }
     }
-
-    const globalSecrets = await this.readSecretsForSource({ kind: "global" });
-    return this.getTokenStateFromSecrets(globalSecrets, { kind: "global" });
+    return null;
   }
 
   private async attemptRefresh(
@@ -254,5 +273,23 @@ export class OpenAITokenRefreshService {
     }
 
     return { ok: false, status: 401, error: "OpenAI token refresh failed: unauthorized" };
+  }
+}
+
+/** Backwards-compatible session facade used by the Durable Object. */
+export class OpenAITokenRefreshService {
+  private readonly broker: OpenAITokenBroker;
+
+  constructor(
+    db: SqlDatabase,
+    encryptionKey: string,
+    private readonly ensureRepoId: (session: SessionRow) => Promise<number>,
+    log: Logger
+  ) {
+    this.broker = new OpenAITokenBroker(db, encryptionKey, log);
+  }
+
+  refresh(session: SessionRow): Promise<OpenAITokenRefreshResult> {
+    return this.broker.refreshSession(session, this.ensureRepoId);
   }
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -66,6 +66,22 @@ export type {
   ConfidenceLevel,
 } from "./repository-catalog";
 
+export {
+  CLASSIFY_TARGET_TOOL_NAME,
+  CLASSIFIER_PROMPT_MAX_CHARS,
+  classificationModelSchema,
+  targetClassificationDecisionSchema,
+  classifierInferenceRequestSchema,
+  classifierInferenceResponseSchema,
+  targetClassificationJsonSchema,
+} from "./target-classification";
+export type {
+  ClassificationModel,
+  TargetClassificationDecision,
+  ClassifierInferenceRequest,
+  ClassifierInferenceResponse,
+} from "./target-classification";
+
 export { listArtifactsResponseSchema, toDisplayStatus } from "./artifacts";
 export type {
   SessionArtifact,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -69,6 +69,8 @@ export type {
 export {
   CLASSIFY_TARGET_TOOL_NAME,
   CLASSIFIER_PROMPT_MAX_CHARS,
+  ANTHROPIC_CLASSIFICATION_MODEL_ID,
+  OPENAI_CLASSIFICATION_MODEL_ID,
   classificationModelSchema,
   targetClassificationDecisionSchema,
   classifierInferenceRequestSchema,

--- a/packages/shared/src/types/target-classification.test.ts
+++ b/packages/shared/src/types/target-classification.test.ts
@@ -35,7 +35,7 @@ describe("target classification contracts", () => {
     ).toBe(false);
   });
 
-  it("rejects empty strings and emits provider tool constraints", () => {
+  it("rejects whitespace-only decision strings", () => {
     const decision = {
       targetId: "   ",
       confidence: "high",

--- a/packages/shared/src/types/target-classification.test.ts
+++ b/packages/shared/src/types/target-classification.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLASSIFIER_PROMPT_MAX_CHARS,
+  classifierInferenceRequestSchema,
+  classifierInferenceResponseSchema,
+  classificationModelSchema,
+  targetClassificationDecisionSchema,
+  targetClassificationJsonSchema,
+} from "./target-classification";
+
+describe("target classification contracts", () => {
+  it("allows only the supported classifier models", () => {
+    expect(classificationModelSchema.parse("anthropic/claude-haiku-4-5")).toBe(
+      "anthropic/claude-haiku-4-5"
+    );
+    expect(classificationModelSchema.parse("openai/gpt-5.6-luna")).toBe("openai/gpt-5.6-luna");
+    expect(classificationModelSchema.safeParse("openai/gpt-5.6-sol").success).toBe(false);
+  });
+
+  it("validates a strict provider-neutral decision", () => {
+    const decision = {
+      targetId: "acme/web",
+      confidence: "high",
+      reasoning: "The message names the web app.",
+      alternatives: [],
+    };
+
+    expect(targetClassificationDecisionSchema.parse(decision)).toEqual(decision);
+    expect(
+      targetClassificationDecisionSchema.safeParse({ ...decision, unexpected: true }).success
+    ).toBe(false);
+  });
+
+  it("derives a strict provider tool schema from the decision contract", () => {
+    expect(targetClassificationJsonSchema).toMatchObject({
+      type: "object",
+      required: ["targetId", "confidence", "reasoning", "alternatives"],
+      additionalProperties: false,
+      properties: {
+        confidence: { enum: ["high", "medium", "low"] },
+      },
+    });
+    expect(targetClassificationJsonSchema).not.toHaveProperty("$schema");
+    expect(JSON.stringify(targetClassificationJsonSchema)).not.toContain("minLength");
+  });
+
+  it("bounds inference prompts and wraps decisions at the service boundary", () => {
+    expect(
+      classifierInferenceRequestSchema.safeParse({
+        model: "openai/gpt-5.6-luna",
+        prompt: "x".repeat(CLASSIFIER_PROMPT_MAX_CHARS + 1),
+      }).success
+    ).toBe(false);
+
+    expect(
+      classifierInferenceResponseSchema.parse({
+        decision: {
+          targetId: null,
+          confidence: "low",
+          reasoning: "No target is clear.",
+          alternatives: [],
+        },
+      })
+    ).toEqual({
+      decision: {
+        targetId: null,
+        confidence: "low",
+        reasoning: "No target is clear.",
+        alternatives: [],
+      },
+    });
+  });
+});

--- a/packages/shared/src/types/target-classification.test.ts
+++ b/packages/shared/src/types/target-classification.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   CLASSIFIER_PROMPT_MAX_CHARS,
+  ANTHROPIC_CLASSIFICATION_MODEL_ID,
   classifierInferenceRequestSchema,
   classifierInferenceResponseSchema,
   classificationModelSchema,
+  OPENAI_CLASSIFICATION_MODEL_ID,
   targetClassificationDecisionSchema,
   targetClassificationJsonSchema,
 } from "./target-classification";
 
 describe("target classification contracts", () => {
   it("allows only the supported classifier models", () => {
-    expect(classificationModelSchema.parse("anthropic/claude-haiku-4-5")).toBe(
-      "anthropic/claude-haiku-4-5"
+    expect(classificationModelSchema.parse(ANTHROPIC_CLASSIFICATION_MODEL_ID)).toBe(
+      ANTHROPIC_CLASSIFICATION_MODEL_ID
     );
-    expect(classificationModelSchema.parse("openai/gpt-5.6-luna")).toBe("openai/gpt-5.6-luna");
+    expect(classificationModelSchema.parse(OPENAI_CLASSIFICATION_MODEL_ID)).toBe(
+      OPENAI_CLASSIFICATION_MODEL_ID
+    );
     expect(classificationModelSchema.safeParse("openai/gpt-5.6-sol").success).toBe(false);
   });
 
@@ -31,17 +35,33 @@ describe("target classification contracts", () => {
     ).toBe(false);
   });
 
+  it("rejects empty strings and emits provider tool constraints", () => {
+    const decision = {
+      targetId: "   ",
+      confidence: "high",
+      reasoning: "A reason.",
+      alternatives: ["   "],
+    };
+
+    expect(targetClassificationDecisionSchema.safeParse(decision).success).toBe(false);
+    expect(
+      targetClassificationDecisionSchema.safeParse({ ...decision, targetId: null }).success
+    ).toBe(false);
+  });
+
   it("derives a strict provider tool schema from the decision contract", () => {
     expect(targetClassificationJsonSchema).toMatchObject({
       type: "object",
       required: ["targetId", "confidence", "reasoning", "alternatives"],
       additionalProperties: false,
       properties: {
+        targetId: { anyOf: [{ type: "string", minLength: 1 }, { type: "null" }] },
         confidence: { enum: ["high", "medium", "low"] },
+        reasoning: { type: "string", minLength: 1 },
+        alternatives: { type: "array", items: { type: "string", minLength: 1 } },
       },
     });
     expect(targetClassificationJsonSchema).not.toHaveProperty("$schema");
-    expect(JSON.stringify(targetClassificationJsonSchema)).not.toContain("minLength");
   });
 
   it("bounds inference prompts and wraps decisions at the service boundary", () => {

--- a/packages/shared/src/types/target-classification.ts
+++ b/packages/shared/src/types/target-classification.ts
@@ -3,17 +3,17 @@ import { z } from "zod";
 export const CLASSIFY_TARGET_TOOL_NAME = "classify_target";
 export const CLASSIFIER_PROMPT_MAX_CHARS = 128_000;
 
+export const ANTHROPIC_CLASSIFICATION_MODEL_ID = "anthropic/claude-haiku-4-5";
+export const OPENAI_CLASSIFICATION_MODEL_ID = "openai/gpt-5.6-luna";
+
 export const classificationModelSchema = z.enum([
-  "anthropic/claude-haiku-4-5",
-  "openai/gpt-5.6-luna",
+  ANTHROPIC_CLASSIFICATION_MODEL_ID,
+  OPENAI_CLASSIFICATION_MODEL_ID,
 ]);
 
 export type ClassificationModel = z.infer<typeof classificationModelSchema>;
 
-const nonEmptyTrimmedStringSchema = z
-  .string()
-  .trim()
-  .refine((value) => value.length > 0, "Must not be empty");
+const nonEmptyTrimmedStringSchema = z.string().trim().min(1, "Must not be empty");
 
 export const targetClassificationDecisionSchema = z
   .object({

--- a/packages/shared/src/types/target-classification.ts
+++ b/packages/shared/src/types/target-classification.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const CLASSIFY_TARGET_TOOL_NAME = "classify_target";
+export const CLASSIFIER_PROMPT_MAX_CHARS = 128_000;
+
+export const classificationModelSchema = z.enum([
+  "anthropic/claude-haiku-4-5",
+  "openai/gpt-5.6-luna",
+]);
+
+export type ClassificationModel = z.infer<typeof classificationModelSchema>;
+
+const nonEmptyTrimmedStringSchema = z
+  .string()
+  .trim()
+  .refine((value) => value.length > 0, "Must not be empty");
+
+export const targetClassificationDecisionSchema = z
+  .object({
+    targetId: nonEmptyTrimmedStringSchema
+      .nullable()
+      .describe(
+        'A repository "owner/name" or an environment id ("env_…") if confident, otherwise null.'
+      ),
+    confidence: z.enum(["high", "medium", "low"]),
+    reasoning: nonEmptyTrimmedStringSchema.describe(
+      "Brief explanation of the classification decision."
+    ),
+    alternatives: z
+      .array(nonEmptyTrimmedStringSchema)
+      .describe("Alternative target ids when confidence is not high."),
+  })
+  .strict();
+
+export type TargetClassificationDecision = z.infer<typeof targetClassificationDecisionSchema>;
+
+export const classifierInferenceRequestSchema = z
+  .object({
+    model: classificationModelSchema,
+    prompt: z.string().min(1).max(CLASSIFIER_PROMPT_MAX_CHARS),
+  })
+  .strict();
+
+export type ClassifierInferenceRequest = z.infer<typeof classifierInferenceRequestSchema>;
+
+export const classifierInferenceResponseSchema = z
+  .object({ decision: targetClassificationDecisionSchema })
+  .strict();
+
+export type ClassifierInferenceResponse = z.infer<typeof classifierInferenceResponseSchema>;
+
+const { $schema: _metaSchema, ...generatedDecisionJsonSchema } = z.toJSONSchema(
+  targetClassificationDecisionSchema
+);
+
+/** Provider-neutral schema used for forced classifier tool calls. */
+export const targetClassificationJsonSchema: typeof generatedDecisionJsonSchema & {
+  type: "object";
+} = {
+  ...generatedDecisionJsonSchema,
+  type: "object",
+};

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CLASSIFIER_PROMPT_MAX_CHARS } from "@open-inspect/shared";
 import type { Env, Environment, RepoConfig } from "../types";
 
 const {
@@ -195,6 +196,134 @@ describe("RepoClassifier", () => {
     expect(result.needsClarification).toBe(true);
     expect(result.reasoning).toContain("structured model output");
     expect(result.alternatives).toBeUndefined();
+  });
+
+  describe("Anthropic tool-input normalization", () => {
+    it.each([
+      ["blank", { targetId: "   " }],
+      ["missing", {}],
+      ["non-string", { targetId: 42 }],
+    ])("treats %s targetId as null", async (_label, targetFields) => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_normalized_target",
+            name: "classify_target",
+            input: {
+              ...targetFields,
+              confidence: "high",
+              reasoning: "The model could not identify a target.",
+              alternatives: [],
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("an ambiguous request");
+
+      expect(result.target).toBeNull();
+      expect(result.confidence).toBe("high");
+      expect(result.needsClarification).toBe(true);
+    });
+
+    it("trims and lowercases confidence, trims and deduplicates alternatives, and ignores extra keys", async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_normalized_fields",
+            name: "classify_target",
+            input: {
+              targetId: " acme/prod ",
+              confidence: " Medium ",
+              reasoning: "  The message names the production worker.  ",
+              alternatives: [" acme/web ", "acme/web", " acme/prod "],
+              extra: "ignored",
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("work on production");
+
+      expect(classifiedRepoFullName(result)).toBe("acme/prod");
+      expect(result.confidence).toBe("medium");
+      expect(result.reasoning).toBe("The message names the production worker.");
+      expect(result.alternatives).toEqual([{ kind: "repository", repo: TEST_REPOS[1] }]);
+      expect(result.needsClarification).toBe(true);
+    });
+  });
+
+  it("bounds the generated prompt consistently for Anthropic and OpenAI while preserving the message and task", async () => {
+    const oversizedCatalog = "catalog-entry ".repeat(10_000);
+    const context = {
+      channelId: "C123",
+      channelName: "engineering",
+      previousMessages: ["thread-context ".repeat(10_000)],
+    };
+    mockBuildRepoDescriptions.mockReturnValue(oversizedCatalog);
+    mockMessagesCreate.mockResolvedValue({
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_oversized_anthropic",
+          name: "classify_target",
+          input: {
+            targetId: "acme/prod",
+            confidence: "high",
+            reasoning: "The message names prod.",
+            alternatives: [],
+          },
+        },
+      ],
+    });
+
+    const message = "Current user message must remain intact.";
+    const anthropicClassifier = new RepoClassifier(TEST_ENV);
+    await anthropicClassifier.classify(message, context);
+    const anthropicPrompt = mockMessagesCreate.mock.calls[0][0].messages[0].content;
+
+    mockMessagesCreate.mockClear();
+    mockSignedControlPlaneFetch.mockResolvedValue(
+      Response.json({
+        decision: {
+          targetId: "acme/prod",
+          confidence: "high",
+          reasoning: "The message names prod.",
+          alternatives: [],
+        },
+      })
+    );
+    const openAiClassifier = new RepoClassifier({
+      ...TEST_ENV,
+      CLASSIFICATION_MODEL: "openai/gpt-5.6-luna",
+    });
+    await openAiClassifier.classify(message, context);
+    const openAiPrompt = JSON.parse(mockSignedControlPlaneFetch.mock.calls[0][1].body).prompt;
+
+    expect(anthropicPrompt.length).toBeLessThanOrEqual(CLASSIFIER_PROMPT_MAX_CHARS);
+    expect(openAiPrompt.length).toBeLessThanOrEqual(CLASSIFIER_PROMPT_MAX_CHARS);
+    expect(openAiPrompt).toBe(anthropicPrompt);
+    expect(anthropicPrompt).toContain(message);
+    expect(anthropicPrompt).toContain("## Your Task");
+    expect(anthropicPrompt).toContain("[truncated]");
+  });
+
+  it("returns an actionable error when the current message cannot fit intact", async () => {
+    const classifier = new RepoClassifier(TEST_ENV);
+    const result = await classifier.classify("user-message ".repeat(CLASSIFIER_PROMPT_MAX_CHARS));
+
+    expect(result).toMatchObject({
+      target: null,
+      confidence: "low",
+      reasoning: "This Slack message is too long to classify. Please shorten it and try again.",
+      needsClarification: true,
+    });
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+    expect(mockSignedControlPlaneFetch).not.toHaveBeenCalled();
   });
 
   describe("routing rules", () => {

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -7,18 +7,22 @@ const {
   mockBuildRepoDescriptions,
   mockGetRoutingRules,
   mockGetAvailableEnvironments,
+  mockSignedControlPlaneFetch,
+  mockAnthropicConstructor,
 } = vi.hoisted(() => ({
   mockMessagesCreate: vi.fn(),
   mockGetAvailableRepos: vi.fn(),
   mockBuildRepoDescriptions: vi.fn(),
   mockGetRoutingRules: vi.fn(),
   mockGetAvailableEnvironments: vi.fn(),
+  mockSignedControlPlaneFetch: vi.fn(),
+  mockAnthropicConstructor: vi.fn(),
 }));
 
 vi.mock("@anthropic-ai/sdk", () => ({
   // vitest 4 only treats `function`/`class` implementations as constructable;
   // an arrow function here throws "is not a constructor" on `new Anthropic()`.
-  default: vi.fn().mockImplementation(function () {
+  default: mockAnthropicConstructor.mockImplementation(function () {
     return {
       messages: {
         create: mockMessagesCreate,
@@ -39,6 +43,10 @@ vi.mock("./environments", async (importOriginal) => ({
   getAvailableEnvironments: mockGetAvailableEnvironments,
   // Imported by targets.ts (via ../targets); unused in these tests.
   getEnvironmentById: vi.fn(),
+}));
+
+vi.mock("../internal-auth", () => ({
+  signedControlPlaneFetch: mockSignedControlPlaneFetch,
 }));
 
 import { RepoClassifier } from "./index";
@@ -85,7 +93,7 @@ const TEST_ENVIRONMENT: Environment = {
 
 const TEST_ENV = {
   ANTHROPIC_API_KEY: "test-api-key",
-  CLASSIFICATION_MODEL: "claude-haiku-4-5",
+  CLASSIFICATION_MODEL: "anthropic/claude-haiku-4-5",
 } as Env;
 
 /** The classified repo's fullName, or undefined for null/environment targets. */
@@ -102,6 +110,7 @@ describe("RepoClassifier", () => {
     mockGetRoutingRules.mockResolvedValue([]);
     mockGetAvailableEnvironments.mockResolvedValue([]);
     mockBuildRepoDescriptions.mockResolvedValue("- acme/prod\n- acme/web");
+    mockSignedControlPlaneFetch.mockRejectedValue(new Error("unexpected control-plane call"));
   });
 
   it("uses tool output when provider returns valid structured classification", async () => {
@@ -127,8 +136,10 @@ describe("RepoClassifier", () => {
     expect(classifiedRepoFullName(result)).toBe("acme/prod");
     expect(result.confidence).toBe("high");
     expect(result.needsClarification).toBe(false);
+    expect(mockAnthropicConstructor).toHaveBeenCalledOnce();
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
+        model: "claude-haiku-4-5",
         temperature: 0,
         tool_choice: expect.objectContaining({
           type: "tool",
@@ -229,6 +240,7 @@ describe("RepoClassifier", () => {
       expect(classifiedRepoFullName(result)).toBe("acme/web");
       expect(result.needsClarification).toBe(false);
       expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(mockAnthropicConstructor).not.toHaveBeenCalled();
     });
 
     it("skips a rule whose target is not accessible and falls through to the LLM", async () => {
@@ -663,6 +675,111 @@ describe("RepoClassifier", () => {
       const result = await classifier.classify("web app issue");
 
       expect(result.reasoning).toBe("Mentions &lt;!channel&gt; &amp; the web app.");
+    });
+  });
+
+  describe("provider selection", () => {
+    const OPENAI_ENV = {
+      ...TEST_ENV,
+      CLASSIFICATION_MODEL: "openai/gpt-5.6-luna",
+    } as Env;
+
+    const openAiDecision = {
+      targetId: "acme/web",
+      confidence: "high",
+      reasoning: "The message names the web application.",
+      alternatives: [],
+    } as const;
+
+    it("uses the signed control-plane adapter for OpenAI classification", async () => {
+      mockSignedControlPlaneFetch.mockResolvedValue(Response.json({ decision: openAiDecision }));
+
+      const classifier = new RepoClassifier(OPENAI_ENV);
+      const result = await classifier.classify("web app issue", undefined, "trace-openai");
+
+      expect(classifiedRepoFullName(result)).toBe("acme/web");
+      expect(result.needsClarification).toBe(false);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(mockAnthropicConstructor).not.toHaveBeenCalled();
+      expect(mockSignedControlPlaneFetch).toHaveBeenCalledOnce();
+
+      const [calledEnv, request, init] = mockSignedControlPlaneFetch.mock.calls[0];
+      expect(calledEnv).toBe(OPENAI_ENV);
+      expect(request).toMatchObject({
+        method: "POST",
+        url: "https://internal/internal/classifier/infer",
+        traceId: "trace-openai",
+      });
+      expect(JSON.parse(request.body)).toEqual({
+        model: "openai/gpt-5.6-luna",
+        prompt: expect.any(String),
+      });
+      expect(init).toEqual({ headers: { Accept: "application/json" } });
+    });
+
+    it("rejects a non-canonical bare OpenAI model", async () => {
+      const classifier = new RepoClassifier({
+        ...OPENAI_ENV,
+        CLASSIFICATION_MODEL: "gpt-5.6-luna",
+      } as Env);
+      const result = await classifier.classify("web app issue");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(mockSignedControlPlaneFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns clarification when the OpenAI response is malformed", async () => {
+      mockSignedControlPlaneFetch.mockResolvedValue(
+        Response.json({ decision: { targetId: null } })
+      );
+
+      const classifier = new RepoClassifier(OPENAI_ENV);
+      const result = await classifier.classify("web app issue");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+    });
+
+    it("returns clarification when the OpenAI adapter receives a non-OK response", async () => {
+      mockSignedControlPlaneFetch.mockResolvedValue(
+        new Response("upstream failure", { status: 503 })
+      );
+
+      const classifier = new RepoClassifier(OPENAI_ENV);
+      const result = await classifier.classify("web app issue");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+    });
+
+    it("does not call a provider for an unsupported classifier model", async () => {
+      const classifier = new RepoClassifier({
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "openai/gpt-5.6-sol",
+      } as Env);
+      const result = await classifier.classify("web app issue");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(mockSignedControlPlaneFetch).not.toHaveBeenCalled();
+    });
+
+    it("keeps deterministic routing ahead of an unsupported provider", async () => {
+      mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/web" }]);
+
+      const classifier = new RepoClassifier({
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "unsupported/model",
+      } as Env);
+      const result = await classifier.classify("frontend issue");
+
+      expect(classifiedRepoFullName(result)).toBe("acme/web");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(mockSignedControlPlaneFetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -9,6 +9,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import {
   CLASSIFY_TARGET_TOOL_NAME,
+  CLASSIFIER_PROMPT_MAX_CHARS,
   classifierInferenceRequestSchema,
   classifierInferenceResponseSchema,
   classificationModelSchema,
@@ -42,6 +43,64 @@ const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
     "Use targetId as null when uncertain.",
   input_schema: CLASSIFY_TARGET_INPUT_SCHEMA,
 };
+
+const PROMPT_TRUNCATION_MARKER = "[truncated]";
+const PROMPT_TOO_LONG_REASONING =
+  "This Slack message is too long to classify. Please shorten it and try again.";
+const CLASSIFIER_PROMPT_INTRO =
+  "You are a target classifier for a coding agent. Your job is to determine which code repository or environment a Slack message is referring to.";
+const CLASSIFIER_PROMPT_TASK = `## Your Task
+
+Analyze the message and context to determine which repository or environment the user is referring to.
+
+Consider:
+1. Explicit mentions of repository or environment names or aliases
+2. Technical keywords that match repository technologies
+3. File paths or code patterns mentioned
+4. Channel associations (some channels are associated with specific repos)
+5. Context from previous messages in the thread
+
+## Response Format
+
+Return your decision by calling the ${CLASSIFY_TARGET_TOOL_NAME} tool with:
+- targetId: a repository "owner/name", an environment id ("env_…"), or null if unclear
+- confidence: "high" | "medium" | "low"
+- reasoning: brief explanation
+- alternatives: other possible targets when confidence is not high`;
+
+function truncateWithMarker(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= PROMPT_TRUNCATION_MARKER.length) {
+    return PROMPT_TRUNCATION_MARKER.slice(0, Math.max(0, maxChars));
+  }
+  return `${value.slice(0, maxChars - PROMPT_TRUNCATION_MARKER.length)}${PROMPT_TRUNCATION_MARKER}`;
+}
+
+function boundClassificationPrompt(catalogAndContext: string, message: string): string {
+  const userSection = `## User's Message\n${message}`;
+  const fixedPrompt = `${CLASSIFIER_PROMPT_INTRO}\n\n${userSection}\n\n${CLASSIFIER_PROMPT_TASK}`;
+  const catalogBudget = CLASSIFIER_PROMPT_MAX_CHARS - fixedPrompt.length - 2;
+
+  if (catalogBudget >= 0 && catalogAndContext.length <= catalogBudget) {
+    return `${CLASSIFIER_PROMPT_INTRO}\n\n${catalogAndContext}\n\n${userSection}\n\n${CLASSIFIER_PROMPT_TASK}`;
+  }
+
+  // Keep the current user message and task intact whenever the catalog/context
+  // is the part that made the generated prompt exceed the provider limit.
+  if (fixedPrompt.length <= CLASSIFIER_PROMPT_MAX_CHARS && catalogBudget >= 0) {
+    const boundedCatalog = truncateWithMarker(catalogAndContext, Math.max(0, catalogBudget));
+    return `${CLASSIFIER_PROMPT_INTRO}\n\n${boundedCatalog}\n\n${userSection}\n\n${CLASSIFIER_PROMPT_TASK}`;
+  }
+
+  throw new ClassifierPromptTooLongError();
+}
+
+class ClassifierPromptTooLongError extends Error {
+  constructor() {
+    super(PROMPT_TOO_LONG_REASONING);
+    this.name = "ClassifierPromptTooLongError";
+  }
+}
 
 /**
  * Build the classification prompt for the LLM over the target catalog.
@@ -82,34 +141,12 @@ ${context.previousMessages.map((m) => `- ${m}`).join("\n")}`
 }`;
   }
 
-  return `You are a target classifier for a coding agent. Your job is to determine which code repository or environment a Slack message is referring to.
-
-## Available Repositories
+  const catalogAndContext = `## Available Repositories
 ${repoDescriptions}
 ${environmentSection}
-${contextSection}
+${contextSection}`;
 
-## User's Message
-${message}
-
-## Your Task
-
-Analyze the message and context to determine which repository or environment the user is referring to.
-
-Consider:
-1. Explicit mentions of repository or environment names or aliases
-2. Technical keywords that match repository technologies
-3. File paths or code patterns mentioned
-4. Channel associations (some channels are associated with specific repos)
-5. Context from previous messages in the thread
-
-## Response Format
-
-Return your decision by calling the ${CLASSIFY_TARGET_TOOL_NAME} tool with:
-- targetId: a repository "owner/name", an environment id ("env_…"), or null if unclear
-- confidence: "high" | "medium" | "low"
-- reasoning: brief explanation
-- alternatives: other possible targets when confidence is not high`;
+  return boundClassificationPrompt(catalogAndContext, message);
 }
 
 /**
@@ -119,6 +156,35 @@ function resolveClassificationModel(value: unknown): ClassificationModel | null 
   const raw = (typeof value === "string" ? value.trim() : "") || DEFAULT_CLASSIFICATION_MODEL;
   const parsed = classificationModelSchema.safeParse(raw);
   return parsed.success ? parsed.data : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeAnthropicToolInput(raw: unknown): TargetClassificationDecision {
+  if (!isRecord(raw)) {
+    throw new Error("LLM response was not an object");
+  }
+
+  const rawTargetId = raw.targetId;
+  const targetId =
+    typeof rawTargetId === "string" && rawTargetId.trim().length > 0 ? rawTargetId.trim() : null;
+  const normalized = targetClassificationDecisionSchema.safeParse({
+    targetId,
+    confidence:
+      typeof raw.confidence === "string" ? raw.confidence.trim().toLowerCase() : raw.confidence,
+    reasoning: raw.reasoning,
+    alternatives: raw.alternatives,
+  });
+  if (!normalized.success) {
+    throw new Error("Invalid structured tool input in LLM response");
+  }
+
+  return {
+    ...normalized.data,
+    alternatives: [...new Set(normalized.data.alternatives)],
+  };
 }
 
 function extractStructuredResponse(
@@ -133,11 +199,7 @@ function extractStructuredResponse(
     throw new Error("No structured tool_use classification in LLM response");
   }
 
-  const parsed = targetClassificationDecisionSchema.safeParse(toolUseBlock.input);
-  if (!parsed.success) {
-    throw new Error("Invalid structured classification in LLM response");
-  }
-  return parsed.data;
+  return normalizeAnthropicToolInput(toolUseBlock.input);
 }
 
 /**
@@ -426,7 +488,9 @@ export class RepoClassifier {
         target: null,
         confidence: "low",
         reasoning:
-          "Could not classify a target from structured model output. Please pick one below.",
+          e instanceof ClassifierPromptTooLongError
+            ? PROMPT_TOO_LONG_REASONING
+            : "Could not classify a target from structured model output. Please pick one below.",
         // No basis to suggest specific targets on a classification failure;
         // the picker lets the user search the full list.
         alternatives: undefined,

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -10,6 +10,8 @@ import Anthropic from "@anthropic-ai/sdk";
 import {
   CLASSIFY_TARGET_TOOL_NAME,
   CLASSIFIER_PROMPT_MAX_CHARS,
+  ANTHROPIC_CLASSIFICATION_MODEL_ID,
+  OPENAI_CLASSIFICATION_MODEL_ID,
   classifierInferenceRequestSchema,
   classifierInferenceResponseSchema,
   classificationModelSchema,
@@ -29,8 +31,8 @@ import { createLogger } from "../logger";
 import { signedControlPlaneFetch } from "../internal-auth";
 
 const log = createLogger("classifier");
-const DEFAULT_CLASSIFICATION_MODEL: ClassificationModel = "anthropic/claude-haiku-4-5";
-const ANTHROPIC_CLASSIFICATION_MODEL = "claude-haiku-4-5";
+const DEFAULT_CLASSIFICATION_MODEL: ClassificationModel = ANTHROPIC_CLASSIFICATION_MODEL_ID;
+const ANTHROPIC_API_MODEL = "claude-haiku-4-5";
 const CLASSIFIER_INFERENCE_URL = "https://internal/internal/classifier/infer";
 const CLASSIFY_TARGET_INPUT_SCHEMA: Anthropic.Messages.Tool.InputSchema = {
   ...targetClassificationJsonSchema,
@@ -227,7 +229,7 @@ export class RepoClassifier {
 
   private async inferWithAnthropic(prompt: string): Promise<TargetClassificationDecision> {
     const response = await this.getAnthropicClient().messages.create({
-      model: ANTHROPIC_CLASSIFICATION_MODEL,
+      model: ANTHROPIC_API_MODEL,
       max_tokens: 500,
       temperature: 0,
       tools: [CLASSIFY_TARGET_TOOL],
@@ -284,10 +286,10 @@ export class RepoClassifier {
     prompt: string,
     traceId?: string
   ): Promise<TargetClassificationDecision> {
-    if (model === "anthropic/claude-haiku-4-5") {
+    if (model === ANTHROPIC_CLASSIFICATION_MODEL_ID) {
       return this.inferWithAnthropic(prompt);
     }
-    if (model === "openai/gpt-5.6-luna") {
+    if (model === OPENAI_CLASSIFICATION_MODEL_ID) {
       return this.inferWithControlPlane(model, prompt, traceId);
     }
     throw new Error(`Unsupported classifier model: ${model}`);

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -7,51 +7,40 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk";
+import {
+  CLASSIFY_TARGET_TOOL_NAME,
+  classifierInferenceRequestSchema,
+  classifierInferenceResponseSchema,
+  classificationModelSchema,
+  targetClassificationDecisionSchema,
+  targetClassificationJsonSchema,
+  type ClassificationModel,
+  type TargetClassificationDecision,
+} from "@open-inspect/shared";
 import type { Env, ThreadContext, ClassificationResult } from "../types";
 import { buildRepoDescriptions } from "./repos";
 import { buildEnvironmentDescriptions } from "./environments";
 import { loadTargetCatalog, type TargetCatalog } from "./catalog";
 import { matchTargetId, resolveChannelTargets, resolveRoutingRuleTargets } from "./routing";
 import { escapeMrkdwnText } from "@open-inspect/shared/slack";
-import type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
 import { targetId, targetLabel, targetValue, type SlackSessionTarget } from "../targets";
 import { createLogger } from "../logger";
+import { signedControlPlaneFetch } from "../internal-auth";
 
 const log = createLogger("classifier");
-const CLASSIFY_TARGET_TOOL_NAME = "classify_target";
-const CONFIDENCE_LEVELS: ClassificationResult["confidence"][] = ["high", "medium", "low"];
+const DEFAULT_CLASSIFICATION_MODEL: ClassificationModel = "anthropic/claude-haiku-4-5";
+const ANTHROPIC_CLASSIFICATION_MODEL = "claude-haiku-4-5";
+const CLASSIFIER_INFERENCE_URL = "https://internal/internal/classifier/infer";
+const CLASSIFY_TARGET_INPUT_SCHEMA: Anthropic.Messages.Tool.InputSchema = {
+  ...targetClassificationJsonSchema,
+};
 
 const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
   name: CLASSIFY_TARGET_TOOL_NAME,
   description:
     "Classify which repository or environment a Slack message refers to. " +
     "Use targetId as null when uncertain.",
-  input_schema: {
-    type: "object",
-    properties: {
-      targetId: {
-        type: ["string", "null"],
-        description:
-          'A repository "owner/name" or an environment id ("env_…") if confident enough to choose one, otherwise null.',
-      },
-      confidence: {
-        type: "string",
-        enum: CONFIDENCE_LEVELS,
-      },
-      reasoning: {
-        type: "string",
-        description: "Brief explanation of classification decision.",
-      },
-      alternatives: {
-        type: "array",
-        items: { type: "string" },
-        description:
-          "Alternative repository fullNames / environment ids when confidence is not high.",
-      },
-    },
-    required: ["targetId", "confidence", "reasoning", "alternatives"],
-    additionalProperties: false,
-  },
+  input_schema: CLASSIFY_TARGET_INPUT_SCHEMA,
 };
 
 /**
@@ -126,59 +115,15 @@ Return your decision by calling the ${CLASSIFY_TARGET_TOOL_NAME} tool with:
 /**
  * Parse the LLM response into a structured result.
  */
-interface LLMResponse {
-  targetId: string | null;
-  confidence: ConfidenceLevel;
-  reasoning: string;
-  alternatives: string[];
+function resolveClassificationModel(value: unknown): ClassificationModel | null {
+  const raw = (typeof value === "string" ? value.trim() : "") || DEFAULT_CLASSIFICATION_MODEL;
+  const parsed = classificationModelSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }
 
-function normalizeModelResponse(raw: unknown): LLMResponse {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("LLM response was not an object");
-  }
-
-  const input = raw as Record<string, unknown>;
-  const rawTargetId = input.targetId;
-  const targetId =
-    rawTargetId === null
-      ? null
-      : typeof rawTargetId === "string" && rawTargetId.trim().length > 0
-        ? rawTargetId.trim()
-        : null;
-
-  const rawConfidence = typeof input.confidence === "string" ? input.confidence.trim() : "";
-  const confidence = rawConfidence.toLowerCase();
-  if (!CONFIDENCE_LEVELS.includes(confidence as ClassificationResult["confidence"])) {
-    throw new Error(`Invalid confidence value: ${rawConfidence || String(input.confidence)}`);
-  }
-
-  if (typeof input.reasoning !== "string" || input.reasoning.trim().length === 0) {
-    throw new Error("Missing reasoning in LLM response");
-  }
-
-  if (!Array.isArray(input.alternatives)) {
-    throw new Error("Alternatives must be an array");
-  }
-
-  const alternatives = input.alternatives
-    .filter((value): value is string => typeof value === "string")
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-
-  if (alternatives.length !== input.alternatives.length) {
-    throw new Error("Invalid alternatives in LLM response");
-  }
-
-  return {
-    targetId,
-    confidence: confidence as ClassificationResult["confidence"],
-    reasoning: input.reasoning.trim(),
-    alternatives: [...new Set(alternatives)],
-  };
-}
-
-function extractStructuredResponse(response: Anthropic.Messages.Message): LLMResponse {
+function extractStructuredResponse(
+  response: Anthropic.Messages.Message
+): TargetClassificationDecision {
   const toolUseBlock = response.content.find(
     (block): block is Anthropic.Messages.ToolUseBlock =>
       block.type === "tool_use" && block.name === CLASSIFY_TARGET_TOOL_NAME
@@ -188,21 +133,102 @@ function extractStructuredResponse(response: Anthropic.Messages.Message): LLMRes
     throw new Error("No structured tool_use classification in LLM response");
   }
 
-  return normalizeModelResponse(toolUseBlock.input);
+  const parsed = targetClassificationDecisionSchema.safeParse(toolUseBlock.input);
+  if (!parsed.success) {
+    throw new Error("Invalid structured classification in LLM response");
+  }
+  return parsed.data;
 }
 
 /**
  * Repository classifier class.
  */
 export class RepoClassifier {
-  private client: Anthropic;
+  private client: Anthropic | undefined;
   private env: Env;
 
   constructor(env: Env) {
     this.env = env;
-    this.client = new Anthropic({
-      apiKey: env.ANTHROPIC_API_KEY,
+  }
+
+  private getAnthropicClient(): Anthropic {
+    if (!this.client) {
+      if (!this.env.ANTHROPIC_API_KEY) {
+        throw new Error("Anthropic classifier API key is not configured");
+      }
+      this.client = new Anthropic({
+        apiKey: this.env.ANTHROPIC_API_KEY,
+      });
+    }
+    return this.client;
+  }
+
+  private async inferWithAnthropic(prompt: string): Promise<TargetClassificationDecision> {
+    const response = await this.getAnthropicClient().messages.create({
+      model: ANTHROPIC_CLASSIFICATION_MODEL,
+      max_tokens: 500,
+      temperature: 0,
+      tools: [CLASSIFY_TARGET_TOOL],
+      tool_choice: {
+        type: "tool",
+        name: CLASSIFY_TARGET_TOOL_NAME,
+        disable_parallel_tool_use: true,
+      },
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
     });
+
+    return extractStructuredResponse(response);
+  }
+
+  private async inferWithControlPlane(
+    model: ClassificationModel,
+    prompt: string,
+    traceId?: string
+  ): Promise<TargetClassificationDecision> {
+    const request = classifierInferenceRequestSchema.safeParse({ model, prompt });
+    if (!request.success) {
+      throw new Error("Invalid classifier inference request");
+    }
+    const body = JSON.stringify(request.data);
+    const response = await signedControlPlaneFetch(
+      this.env,
+      {
+        method: "POST",
+        url: CLASSIFIER_INFERENCE_URL,
+        body,
+        traceId,
+      },
+      { headers: { Accept: "application/json" } }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Classifier inference request failed with ${response.status}`);
+    }
+
+    const parsed = classifierInferenceResponseSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new Error("Invalid classifier inference response");
+    }
+    return parsed.data.decision;
+  }
+
+  private async infer(
+    model: ClassificationModel,
+    prompt: string,
+    traceId?: string
+  ): Promise<TargetClassificationDecision> {
+    if (model === "anthropic/claude-haiku-4-5") {
+      return this.inferWithAnthropic(prompt);
+    }
+    if (model === "openai/gpt-5.6-luna") {
+      return this.inferWithControlPlane(model, prompt, traceId);
+    }
+    throw new Error(`Unsupported classifier model: ${model}`);
   }
 
   /**
@@ -352,26 +378,13 @@ export class RepoClassifier {
     // Use LLM for classification
     try {
       const prompt = buildClassificationPrompt(message, catalog, context);
-
-      const response = await this.client.messages.create({
-        model: this.env.CLASSIFICATION_MODEL || "claude-haiku-4-5",
-        max_tokens: 500,
-        temperature: 0,
-        tools: [CLASSIFY_TARGET_TOOL],
-        tool_choice: {
-          type: "tool",
-          name: CLASSIFY_TARGET_TOOL_NAME,
-          disable_parallel_tool_use: true,
-        },
-        messages: [
-          {
-            role: "user",
-            content: prompt,
-          },
-        ],
-      });
-
-      const llmResult = extractStructuredResponse(response);
+      const model = resolveClassificationModel(this.env.CLASSIFICATION_MODEL);
+      if (!model) {
+        throw new Error(
+          `Unsupported classifier model: ${this.env.CLASSIFICATION_MODEL || "(unset)"}`
+        );
+      }
+      const llmResult = await this.infer(model, prompt, traceId);
 
       const matchedTarget = llmResult.targetId ? matchTargetId(llmResult.targetId, catalog) : null;
 

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -35,7 +35,7 @@ export interface Env {
   SLACK_BOT_TOKEN: string;
   SLACK_SIGNING_SECRET: string;
   SLACK_APP_TOKEN?: string;
-  ANTHROPIC_API_KEY: string;
+  ANTHROPIC_API_KEY?: string;
   CONTROL_PLANE_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -193,6 +193,9 @@ enable_slack_bot = false
 
 slack_bot_token = ""       # e.g., "xoxb-..."
 slack_signing_secret = ""
+# Deployment-wide target-classification model. Anthropic preserves the default;
+# OpenAI uses the managed ChatGPT OAuth credentials documented in docs/OPENAI_MODELS.md.
+slack_classification_model = "anthropic/claude-haiku-4-5"
 
 # Linear Agent (Optional)
 # Create an OAuth Application at: https://linear.app/settings/api/applications/new

--- a/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
+++ b/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
@@ -191,3 +191,53 @@ run "combined_with_github_only_admission" {
 
   expect_failures = [terraform_data.sign_in_provider_gate]
 }
+
+run "slack_classification_anthropic" {
+  command = plan
+
+  variables {
+    enable_slack_bot        = true
+    enable_service_bindings = false
+    slack_bot_token         = "test-slack-token"
+    slack_signing_secret    = "test-slack-signing-secret"
+  }
+
+  assert {
+    condition = (
+      var.slack_classification_model == "anthropic/claude-haiku-4-5" &&
+      contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
+    )
+    error_message = "Anthropic Slack classification must use the canonical default and bind ANTHROPIC_API_KEY."
+  }
+}
+
+run "slack_classification_openai" {
+  command = plan
+
+  variables {
+    enable_slack_bot           = true
+    enable_service_bindings    = false
+    slack_bot_token            = "test-slack-token"
+    slack_signing_secret       = "test-slack-signing-secret"
+    slack_classification_model = "openai/gpt-5.6-luna"
+  }
+
+  assert {
+    condition = (
+      var.slack_classification_model == "openai/gpt-5.6-luna" &&
+      contains(module.slack_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL") &&
+      !contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
+    )
+    error_message = "OpenAI Slack classification must bind CLASSIFICATION_MODEL without ANTHROPIC_API_KEY."
+  }
+}
+
+run "slack_classification_invalid_model" {
+  command = plan
+
+  variables {
+    slack_classification_model = "openai/gpt-5.6"
+  }
+
+  expect_failures = [var.slack_classification_model]
+}

--- a/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
+++ b/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
@@ -205,10 +205,24 @@ run "slack_classification_anthropic" {
   assert {
     condition = (
       var.slack_classification_model == "anthropic/claude-haiku-4-5" &&
+      module.slack_bot_worker[0].plain_text_binding_values["CLASSIFICATION_MODEL"] == "anthropic/claude-haiku-4-5" &&
       contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
     )
-    error_message = "Anthropic Slack classification must use the canonical default and bind ANTHROPIC_API_KEY."
+    error_message = "Anthropic Slack classification must use the canonical model binding and bind ANTHROPIC_API_KEY."
   }
+}
+
+run "slack_classification_anthropic_missing_key" {
+  command = plan
+
+  variables {
+    enable_slack_bot     = true
+    slack_bot_token      = "test-slack-token"
+    slack_signing_secret = "test-slack-signing-secret"
+    anthropic_api_key    = "  "
+  }
+
+  expect_failures = [var.anthropic_api_key]
 }
 
 run "slack_classification_openai" {
@@ -220,15 +234,16 @@ run "slack_classification_openai" {
     slack_bot_token            = "test-slack-token"
     slack_signing_secret       = "test-slack-signing-secret"
     slack_classification_model = "openai/gpt-5.6-luna"
+    anthropic_api_key          = ""
   }
 
   assert {
     condition = (
       var.slack_classification_model == "openai/gpt-5.6-luna" &&
-      contains(module.slack_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL") &&
+      module.slack_bot_worker[0].plain_text_binding_values["CLASSIFICATION_MODEL"] == "openai/gpt-5.6-luna" &&
       !contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
     )
-    error_message = "OpenAI Slack classification must bind CLASSIFICATION_MODEL without ANTHROPIC_API_KEY."
+    error_message = "OpenAI Slack classification must use the canonical model binding without ANTHROPIC_API_KEY."
   }
 }
 

--- a/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
+++ b/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
@@ -20,7 +20,6 @@ variables {
   github_app_id               = "1"
   github_app_private_key      = "test-private-key"
   github_app_installation_id  = "1"
-  anthropic_api_key           = "test-anthropic-key"
   token_encryption_key        = "test-token-key"
   repo_secrets_encryption_key = "test-repo-key"
   nextauth_secret             = "test-browser-auth-secret-with-32-characters"
@@ -200,6 +199,7 @@ run "slack_classification_anthropic" {
     enable_service_bindings = false
     slack_bot_token         = "test-slack-token"
     slack_signing_secret    = "test-slack-signing-secret"
+    anthropic_api_key       = "test-anthropic-key"
   }
 
   assert {
@@ -219,7 +219,6 @@ run "slack_classification_anthropic_missing_key" {
     enable_slack_bot     = true
     slack_bot_token      = "test-slack-token"
     slack_signing_secret = "test-slack-signing-secret"
-    anthropic_api_key    = "  "
   }
 
   expect_failures = [var.anthropic_api_key]
@@ -234,7 +233,6 @@ run "slack_classification_openai" {
     slack_bot_token            = "test-slack-token"
     slack_signing_secret       = "test-slack-signing-secret"
     slack_classification_model = "openai/gpt-5.6-luna"
-    anthropic_api_key          = ""
   }
 
   assert {

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -309,6 +309,8 @@ variable "anthropic_api_key" {
   description = "Anthropic API key for Claude"
   type        = string
   sensitive   = true
+  default     = ""
+  nullable    = false
 
   validation {
     condition = (

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -309,6 +309,15 @@ variable "anthropic_api_key" {
   description = "Anthropic API key for Claude"
   type        = string
   sensitive   = true
+
+  validation {
+    condition = (
+      !var.enable_slack_bot ||
+      var.slack_classification_model != "anthropic/claude-haiku-4-5" ||
+      trimspace(var.anthropic_api_key) != ""
+    )
+    error_message = "anthropic_api_key must be non-blank when Slack uses Anthropic classification."
+  }
 }
 
 # =============================================================================

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -241,6 +241,20 @@ variable "slack_signing_secret" {
   default     = ""
 }
 
+variable "slack_classification_model" {
+  description = "Deployment-wide model used to classify Slack prompts before a target repository is known. Allowed values: anthropic/claude-haiku-4-5 or openai/gpt-5.6-luna."
+  type        = string
+  default     = "anthropic/claude-haiku-4-5"
+
+  validation {
+    condition = contains([
+      "anthropic/claude-haiku-4-5",
+      "openai/gpt-5.6-luna",
+    ], var.slack_classification_model)
+    error_message = "slack_classification_model must be 'anthropic/claude-haiku-4-5' or 'openai/gpt-5.6-luna'."
+  }
+}
+
 # =============================================================================
 # Linear Agent Credentials
 # =============================================================================

--- a/terraform/environments/production/workers-slack.tf
+++ b/terraform/environments/production/workers-slack.tf
@@ -70,18 +70,22 @@ module "slack_bot_worker" {
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "claude-haiku-4-5" },
-    { name = "CLASSIFICATION_MODEL", value = "claude-haiku-4-5" },
+    { name = "CLASSIFICATION_MODEL", value = var.slack_classification_model },
     # Kill switch for Slack channel-message triggers; the bot only ingests/
     # forwards channel messages when this is exactly "true" (dark by default).
     { name = "SLACK_TRIGGERS_ENABLED", value = var.slack_triggers_enabled ? "true" : "false" },
   ]
 
-  secrets = [
-    { name = "SLACK_BOT_TOKEN", value = var.slack_bot_token },
-    { name = "SLACK_SIGNING_SECRET", value = var.slack_signing_secret },
-    { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
-    { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_slack_bot.result },
-  ]
+  secrets = concat(
+    [
+      { name = "SLACK_BOT_TOKEN", value = var.slack_bot_token },
+      { name = "SLACK_SIGNING_SECRET", value = var.slack_signing_secret },
+      { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_slack_bot.result },
+    ],
+    var.slack_classification_model == "anthropic/claude-haiku-4-5" ? [
+      { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
+    ] : []
+  )
 
   compatibility_date  = "2024-09-23"
   compatibility_flags = ["nodejs_compat"]

--- a/terraform/modules/cloudflare-worker/outputs.tf
+++ b/terraform/modules/cloudflare-worker/outputs.tf
@@ -33,6 +33,11 @@ output "plain_text_binding_names" {
   value       = [for binding in var.plain_text_bindings : binding.name]
 }
 
+output "plain_text_binding_values" {
+  description = "Configured plain-text binding values keyed by binding name."
+  value       = { for binding in var.plain_text_bindings : binding.name => binding.value }
+}
+
 output "secret_binding_names" {
   description = "Names of configured secret bindings; secret values are not exposed."
   value       = nonsensitive([for binding in var.secrets : binding.name])


### PR DESCRIPTION
Closes #1298

## Summary

- add a deployment setting for the Slack target-classification model
- keep Claude Haiku as the default and add GPT-5.6 Luna as an option
- send OpenAI classification through a signed control-plane route
- reuse the existing managed ChatGPT OAuth credentials
- keep OpenAI tokens out of the Slack worker
- add Terraform validation, tests, and setup documentation

## How it works

Slack still runs routing rules, channel associations, and the single-target shortcut before calling a model.

For OpenAI classification, the Slack worker sends the prompt to the control plane using the existing service authentication. The control plane refreshes the global ChatGPT OAuth credential, calls Luna through the Responses-Lite streaming endpoint, validates the tool response, and returns the target decision.

Anthropic continues to run directly from the Slack worker. Its existing response normalization behavior is preserved.

## Reliability

- cap the streaming response, individual events, event count, and tool arguments
- reject malformed or incomplete classifier responses
- apply the same prompt limit to both providers
- trim catalog and thread context before touching the current Slack message
- retry rotated-token persistence and return an error if the new credentials cannot be saved
- keep upstream errors and credentials out of Slack responses

## Configuration

Anthropic remains the default:

```hcl
slack_classification_model = "anthropic/claude-haiku-4-5"
```

To use OpenAI, add `OPENAI_OAUTH_REFRESH_TOKEN` to global secrets and set:

```hcl
slack_classification_model = "openai/gpt-5.6-luna"
```

No `OPENAI_API_KEY` is needed.

## Verification

- `npm test`
- `npm run test:integration -w @open-inspect/control-plane`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `terraform test -filter=tests/auth_provider_configuration.tftest.hcl`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Slack target classification, defaulting to Anthropic Claude Haiku.
  * Added optional OpenAI GPT 5.6 Luna classification through managed ChatGPT OAuth credentials.
  * Added global OAuth credential support with token refresh, caching, retries, and safer failure handling.
  * Improved prompt-size handling, response validation, normalization, and error reporting.

* **Documentation**
  * Updated setup, secrets, deployment, and OpenAI model guidance.

* **Tests**
  * Expanded coverage for classification, authentication, Terraform configuration, OAuth handling, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->