### PR TITLE
Remove static methods from SandboxManager

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -128,13 +128,12 @@ class SandboxManager:
     - Take snapshots for session persistence
     """
 
-    @staticmethod
-    def _generate_code_server_password() -> str:
+    def _generate_code_server_password(self) -> str:
         """Generate a random code-server password."""
         return secrets.token_urlsafe(16)
 
-    @staticmethod
     async def _resolve_tunnels(
+        self,
         sandbox: modal.Sandbox,
         sandbox_id: str,
         ports: list[int],
@@ -171,8 +170,7 @@ class SandboxManager:
                 await asyncio.sleep(backoff * (attempt + 1))
         return resolved
 
-    @staticmethod
-    def _validate_ports(raw: list) -> list[int]:
+    def _validate_ports(self, raw: list) -> list[int]:
         """Validate and sanitize tunnel ports: must be int, 1-65535, max MAX_TUNNEL_PORTS."""
         ports: list[int] = []
         for p in raw:
@@ -182,8 +180,7 @@ class SandboxManager:
                 break
         return ports
 
-    @staticmethod
-    def _resolve_service_ports(settings: dict[str, Any] | None) -> tuple[int, int]:
+    def _resolve_service_ports(self, settings: dict[str, Any] | None) -> tuple[int, int]:
         """Return effective (code_server_port, ttyd_proxy_port) from settings.
 
         Falls back to the CODE_SERVER_PORT / TTYD_PROXY_PORT defaults when unset
@@ -201,8 +198,8 @@ class SandboxManager:
             coerce(s.get("terminalPort"), TTYD_PROXY_PORT),
         )
 
-    @staticmethod
     def _collect_exposed_ports(
+        self,
         code_server_enabled: bool,
         terminal_enabled: bool,
         settings: dict[str, Any] | None,
@@ -220,14 +217,14 @@ class SandboxManager:
             reserved.add(ttyd_proxy_port)
 
         raw_ports = (settings or {}).get("tunnelPorts", [])
-        tunnel_ports = SandboxManager._validate_ports(raw_ports) if raw_ports else []
+        tunnel_ports = self._validate_ports(raw_ports) if raw_ports else []
         # Remove reserved ports from tunnel_ports to avoid duplicates
         tunnel_ports = [p for p in tunnel_ports if p not in reserved]
         exposed.extend(tunnel_ports)
         return exposed, tunnel_ports
 
-    @staticmethod
     async def _resolve_and_setup_tunnels(
+        self,
         sandbox: modal.Sandbox,
         sandbox_id: str,
         code_server_enabled: bool,
@@ -247,7 +244,7 @@ class SandboxManager:
         if not all_ports:
             return None, None, None
 
-        resolved = await SandboxManager._resolve_tunnels(sandbox, sandbox_id, all_ports)
+        resolved = await self._resolve_tunnels(sandbox, sandbox_id, all_ports)
 
         # Only pull a service port out of the resolved map when that service owns
         # it. Otherwise a user's own port (e.g. 8080 with code-server disabled)
@@ -257,12 +254,12 @@ class SandboxManager:
         extra_urls = resolved if resolved else None
 
         if extra_urls:
-            await SandboxManager._write_tunnel_env_file(sandbox, sandbox_id, extra_urls)
+            await self._write_tunnel_env_file(sandbox, sandbox_id, extra_urls)
 
         return code_server_url, ttyd_url, extra_urls
 
-    @staticmethod
     async def _write_tunnel_env_file(
+        self,
         sandbox: modal.Sandbox,
         sandbox_id: str,
         tunnel_urls: dict[int, str],

--- a/packages/modal-infra/tests/test_code_server.py
+++ b/packages/modal-infra/tests/test_code_server.py
@@ -6,18 +6,20 @@ import pytest
 
 from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
 
+manager = SandboxManager()
+
 
 class TestGenerateCodeServerPassword:
     """SandboxManager._generate_code_server_password tests."""
 
     def test_returns_nonempty_password(self):
-        password = SandboxManager._generate_code_server_password()
+        password = manager._generate_code_server_password()
         assert len(password) > 0
 
     def test_generates_unique_passwords(self):
         passwords = set()
         for _ in range(20):
-            passwords.add(SandboxManager._generate_code_server_password())
+            passwords.add(manager._generate_code_server_password())
         assert len(passwords) == 20
 
 
@@ -32,7 +34,7 @@ class TestResolveCodeServerTunnel:
         sandbox = MagicMock()
         sandbox.tunnels.return_value = {CODE_SERVER_PORT: tunnel}
 
-        resolved = await SandboxManager._resolve_tunnels(sandbox, "sb-123", [CODE_SERVER_PORT])
+        resolved = await manager._resolve_tunnels(sandbox, "sb-123", [CODE_SERVER_PORT])
         assert resolved.get(CODE_SERVER_PORT) == "https://tunnel.example.com"
 
     @pytest.mark.asyncio
@@ -41,7 +43,7 @@ class TestResolveCodeServerTunnel:
         sandbox.tunnels.side_effect = Exception("tunnel unavailable")
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            resolved = await SandboxManager._resolve_tunnels(
+            resolved = await manager._resolve_tunnels(
                 sandbox, "sb-123", [CODE_SERVER_PORT], retries=2, backoff=0.0
             )
         assert resolved == {}
@@ -53,7 +55,7 @@ class TestResolveCodeServerTunnel:
         sandbox.tunnels.return_value = {}  # no entry for CODE_SERVER_PORT
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            resolved = await SandboxManager._resolve_tunnels(
+            resolved = await manager._resolve_tunnels(
                 sandbox, "sb-123", [CODE_SERVER_PORT], retries=2, backoff=0.0
             )
         assert resolved == {}
@@ -70,7 +72,7 @@ class TestResolveCodeServerTunnel:
         ]
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            resolved = await SandboxManager._resolve_tunnels(
+            resolved = await manager._resolve_tunnels(
                 sandbox, "sb-123", [CODE_SERVER_PORT], retries=3, backoff=0.0
             )
         assert resolved.get(CODE_SERVER_PORT) == "https://tunnel.example.com"

--- a/packages/modal-infra/tests/test_ttyd.py
+++ b/packages/modal-infra/tests/test_ttyd.py
@@ -12,12 +12,14 @@ from src.sandbox.manager import (
     SandboxManager,
 )
 
+manager = SandboxManager()
+
 
 class TestCollectExposedPortsTerminal:
     """_collect_exposed_ports with terminal_enabled flag."""
 
     def test_terminal_enabled_includes_proxy_port(self):
-        exposed, _extra = SandboxManager._collect_exposed_ports(
+        exposed, _extra = manager._collect_exposed_ports(
             code_server_enabled=False,
             terminal_enabled=True,
             settings=None,
@@ -29,7 +31,7 @@ class TestCollectExposedPortsTerminal:
         assert TTYD_PORT not in exposed
 
     def test_terminal_disabled_excludes_proxy_port(self):
-        exposed, _extra = SandboxManager._collect_exposed_ports(
+        exposed, _extra = manager._collect_exposed_ports(
             code_server_enabled=False,
             terminal_enabled=False,
             settings=None,
@@ -39,7 +41,7 @@ class TestCollectExposedPortsTerminal:
         assert TTYD_PROXY_PORT not in exposed
 
     def test_terminal_and_code_server_both_enabled(self):
-        exposed, _extra = SandboxManager._collect_exposed_ports(
+        exposed, _extra = manager._collect_exposed_ports(
             code_server_enabled=True,
             terminal_enabled=True,
             settings=None,
@@ -52,7 +54,7 @@ class TestCollectExposedPortsTerminal:
     def test_terminal_port_deduped_from_tunnel_ports(self):
         """If user explicitly lists TTYD_PROXY_PORT in tunnelPorts, it should not duplicate."""
         settings = {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}
-        exposed, extra = SandboxManager._collect_exposed_ports(
+        exposed, extra = manager._collect_exposed_ports(
             code_server_enabled=False,
             terminal_enabled=True,
             settings=settings,
@@ -77,7 +79,7 @@ class TestResolveTunnelsTerminal:
         sandbox = MagicMock()
         sandbox.tunnels.return_value = {TTYD_PROXY_PORT: tunnel}
 
-        cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+        cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
             sandbox,
             "sb-123",
             code_server_enabled=False,
@@ -93,7 +95,7 @@ class TestResolveTunnelsTerminal:
     @pytest.mark.asyncio
     async def test_returns_none_when_terminal_disabled(self):
         sandbox = MagicMock()
-        cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+        cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
             sandbox,
             "sb-123",
             code_server_enabled=False,
@@ -119,7 +121,7 @@ class TestResolveTunnelsTerminal:
             TTYD_PROXY_PORT: ttyd_tunnel,
         }
 
-        cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+        cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
             sandbox,
             "sb-123",
             code_server_enabled=True,

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -14,6 +14,8 @@ from sandbox_runtime.constants import (
 )
 from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
 
+manager = SandboxManager()
+
 
 def _mock_sandbox_with_filesystem() -> tuple[MagicMock, AsyncMock]:
     """Return (sandbox, write_text) with sandbox.filesystem.write_text.aio mocked."""
@@ -38,7 +40,7 @@ class TestResolveTunnels:
         sandbox = MagicMock()
         sandbox.tunnels.return_value = {3000: tunnel_3000, 3001: tunnel_3001}
 
-        result = await SandboxManager._resolve_tunnels(sandbox, "sb-1", [3000, 3001])
+        result = await manager._resolve_tunnels(sandbox, "sb-1", [3000, 3001])
         assert result == {
             3000: "https://tunnel-3000.example.com",
             3001: "https://tunnel-3001.example.com",
@@ -53,7 +55,7 @@ class TestResolveTunnels:
         sandbox.tunnels.return_value = {3000: tunnel_3000}
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            result = await SandboxManager._resolve_tunnels(
+            result = await manager._resolve_tunnels(
                 sandbox, "sb-1", [3000, 3001], retries=2, backoff=0.0
             )
         assert result == {3000: "https://tunnel-3000.example.com"}
@@ -64,9 +66,7 @@ class TestResolveTunnels:
         sandbox.tunnels.side_effect = Exception("tunnel unavailable")
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            result = await SandboxManager._resolve_tunnels(
-                sandbox, "sb-1", [3000], retries=3, backoff=0.0
-            )
+            result = await manager._resolve_tunnels(sandbox, "sb-1", [3000], retries=3, backoff=0.0)
         assert result == {}
 
     @pytest.mark.asyncio
@@ -83,7 +83,7 @@ class TestResolveTunnels:
         ]
 
         with patch("src.sandbox.manager.asyncio.sleep", new_callable=AsyncMock):
-            result = await SandboxManager._resolve_tunnels(
+            result = await manager._resolve_tunnels(
                 sandbox, "sb-1", [3000, 3001], retries=3, backoff=0.0
             )
         assert result == {
@@ -99,7 +99,7 @@ class TestResolveAndSetupTunnels:
     @pytest.mark.asyncio
     async def test_returns_none_none_none_for_no_ports(self):
         sandbox = MagicMock()
-        cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+        cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
             sandbox,
             "sb-1",
             False,
@@ -123,7 +123,7 @@ class TestResolveAndSetupTunnels:
             new_callable=AsyncMock,
             return_value=tunnel_urls,
         ):
-            cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+            cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 False,
@@ -152,7 +152,7 @@ class TestResolveAndSetupTunnels:
             new_callable=AsyncMock,
             return_value=resolved,
         ):
-            cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+            cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 True,
@@ -178,7 +178,7 @@ class TestResolveAndSetupTunnels:
             new_callable=AsyncMock,
             return_value=resolved,
         ):
-            cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+            cs_url, ttyd_url, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 False,
@@ -207,7 +207,7 @@ class TestResolveAndSetupTunnels:
             new_callable=AsyncMock,
             return_value=resolved,
         ):
-            cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+            cs_url, _ttyd_url, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 True,
@@ -228,7 +228,7 @@ class TestWriteTunnelEnvFile:
     async def test_writes_dotenv_format_to_expected_path(self):
         sandbox, write_text = _mock_sandbox_with_filesystem()
 
-        await SandboxManager._write_tunnel_env_file(
+        await manager._write_tunnel_env_file(
             sandbox,
             "sb-1",
             {
@@ -253,7 +253,7 @@ class TestWriteTunnelEnvFile:
         write_text.side_effect = Exception("write failed")
 
         with patch("src.sandbox.manager.log") as mock_log:
-            await SandboxManager._write_tunnel_env_file(
+            await manager._write_tunnel_env_file(
                 sandbox, "sb-1", {3000: "https://tunnel-3000.example.com"}
             )
 
@@ -275,7 +275,7 @@ class TestResolveAndSetupTunnelsWritesFile:
             new_callable=AsyncMock,
             return_value=tunnel_urls,
         ):
-            await SandboxManager._resolve_and_setup_tunnels(
+            await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 False,
@@ -300,7 +300,7 @@ class TestResolveAndSetupTunnelsWritesFile:
             new_callable=AsyncMock,
             return_value={},
         ):
-            _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
+            _cs, _ttyd, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 False,
@@ -324,7 +324,7 @@ class TestResolveAndSetupTunnelsWritesFile:
             new_callable=AsyncMock,
             return_value={CODE_SERVER_PORT: "https://cs.example.com"},
         ):
-            await SandboxManager._resolve_and_setup_tunnels(
+            await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 True,
@@ -350,7 +350,7 @@ class TestResolveAndSetupTunnelsWritesFile:
             ),
             patch("src.sandbox.manager.log"),
         ):
-            _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
+            _cs, _ttyd, extra = await manager._resolve_and_setup_tunnels(
                 sandbox,
                 "sb-1",
                 False,
@@ -467,49 +467,49 @@ class TestCollectExposedPorts:
     """SandboxManager._collect_exposed_ports tests."""
 
     def test_no_ports_when_no_settings(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             False, False, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == []
         assert tunnel == []
 
     def test_code_server_only(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             True, False, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [CODE_SERVER_PORT]
         assert tunnel == []
 
     def test_tunnel_ports_only(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             False, False, {"tunnelPorts": [3000, 5173]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [3000, 5173]
         assert tunnel == [3000, 5173]
 
     def test_combined_code_server_and_tunnels(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             True, False, {"tunnelPorts": [3000]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [CODE_SERVER_PORT, 3000]
         assert tunnel == [3000]
 
     def test_terminal_only(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             False, True, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [TTYD_PROXY_PORT]
         assert tunnel == []
 
     def test_deduplicates_ttyd_port_from_tunnels(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             False, True, {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [TTYD_PROXY_PORT, 3000]
         assert tunnel == [3000]
 
     def test_deduplicates_code_server_port_from_tunnels(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             True,
             False,
             {"tunnelPorts": [CODE_SERVER_PORT, 3000]},
@@ -521,14 +521,14 @@ class TestCollectExposedPorts:
 
     def test_custom_code_server_port_frees_default_for_tunnel(self):
         # code-server moved to 8081 → the default 8080 is free as a user tunnel.
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             True, False, {"tunnelPorts": [CODE_SERVER_PORT]}, 8081, TTYD_PROXY_PORT
         )
         assert exposed == [8081, CODE_SERVER_PORT]
         assert tunnel == [CODE_SERVER_PORT]
 
     def test_custom_terminal_port_frees_default_for_tunnel(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(
+        exposed, tunnel = manager._collect_exposed_ports(
             False, True, {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}, CODE_SERVER_PORT, 7000
         )
         assert exposed == [7000, TTYD_PROXY_PORT, 3000]
@@ -539,20 +539,20 @@ class TestValidatePorts:
     """SandboxManager._validate_ports tests."""
 
     def test_accepts_valid_ports(self):
-        assert SandboxManager._validate_ports([80, 3000, 65535]) == [80, 3000, 65535]
+        assert manager._validate_ports([80, 3000, 65535]) == [80, 3000, 65535]
 
     def test_rejects_out_of_range(self):
-        assert SandboxManager._validate_ports([0, -1, 65536, 3000]) == [3000]
+        assert manager._validate_ports([0, -1, 65536, 3000]) == [3000]
 
     def test_rejects_non_integers(self):
-        assert SandboxManager._validate_ports(["3000", 3.5, None, 8080]) == [8080]
+        assert manager._validate_ports(["3000", 3.5, None, 8080]) == [8080]
 
     def test_caps_at_ten(self):
         ports = list(range(1, 20))
-        assert len(SandboxManager._validate_ports(ports)) == 10
+        assert len(manager._validate_ports(ports)) == 10
 
     def test_empty_list(self):
-        assert SandboxManager._validate_ports([]) == []
+        assert manager._validate_ports([]) == []
 
 
 def _patch_sandbox_create(monkeypatch, captured: dict) -> None:
@@ -580,22 +580,25 @@ class TestResolveServicePorts:
     """SandboxManager._resolve_service_ports tests."""
 
     def test_defaults_when_unset(self):
-        assert SandboxManager._resolve_service_ports(None) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
-        assert SandboxManager._resolve_service_ports({}) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        assert manager._resolve_service_ports(None) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        assert manager._resolve_service_ports({}) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
 
     def test_uses_configured_ports(self):
-        assert SandboxManager._resolve_service_ports(
-            {"codeServerPort": 9000, "terminalPort": 9001}
-        ) == (9000, 9001)
+        assert manager._resolve_service_ports({"codeServerPort": 9000, "terminalPort": 9001}) == (
+            9000,
+            9001,
+        )
 
     def test_falls_back_on_invalid(self):
-        assert SandboxManager._resolve_service_ports(
-            {"codeServerPort": 0, "terminalPort": 99999}
-        ) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        assert manager._resolve_service_ports({"codeServerPort": 0, "terminalPort": 99999}) == (
+            CODE_SERVER_PORT,
+            TTYD_PROXY_PORT,
+        )
         # strings and bools are not valid in-range ints
-        assert SandboxManager._resolve_service_ports(
-            {"codeServerPort": "8081", "terminalPort": True}
-        ) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        assert manager._resolve_service_ports({"codeServerPort": "8081", "terminalPort": True}) == (
+            CODE_SERVER_PORT,
+            TTYD_PROXY_PORT,
+        )
 
 
 class TestServicePortEnvVars:


### PR DESCRIPTION
## Summary
- convert all seven `SandboxManager` static helpers into instance methods
- route helper-to-helper calls through the current manager instance
- update code-server, terminal, and tunnel-port tests to exercise bound methods

## Verification
- `uv run --extra dev pytest tests/test_code_server.py tests/test_ttyd.py tests/test_tunnel_ports.py -q` (59 passed)
- `uv run --extra dev ruff check src/sandbox/manager.py tests/test_code_server.py tests/test_ttyd.py tests/test_tunnel_ports.py`
- `uv run --extra dev ruff format --check src/sandbox/manager.py tests/test_code_server.py tests/test_ttyd.py tests/test_tunnel_ports.py`

Linear: COL-28

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/382126bbf0805dd21fb726dfabcce8e4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sandbox management operations to use a shared manager instance.
  * Preserved existing behavior for tunnel setup, port validation, service resolution, and exposed-port handling.

* **Tests**
  * Updated tunnel, terminal, and code-server tests to use the shared manager instance.
  * Existing coverage and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->