### PR TITLE
fix(slack): preserve accessible notify fallback

### DIFF
--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -321,7 +321,7 @@ describe("handleSlackNotify", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("splits a message longer than one section instead of truncating it", async () => {
+  it("splits a long message and lets Slack derive accessible fallback text", async () => {
     seedActiveSession();
     integrationStoreMock.getResolvedConfig.mockResolvedValue({
       enabledRepos: null,
@@ -347,6 +347,7 @@ describe("handleSlackNotify", () => {
     const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body)) as {
       blocks: Array<{ type: string; text?: { text: string } }>;
     };
+    expect(body).not.toHaveProperty("text");
     const sections = body.blocks.filter((b) => b.type === "section");
     expect(sections.length).toBeGreaterThan(1);
     for (const section of sections) {
@@ -397,13 +398,14 @@ describe("handleSlackNotify", () => {
     expect(slackUrl).toContain("chat.postMessage");
     const sentBody = JSON.parse(slackCall[1].body as string) as {
       channel: string;
-      text: string;
+      blocks: Array<{ type: string; text?: { text: string } }>;
     };
     expect(sentBody.channel).toBe("#ops");
-    expect(sentBody.text).not.toContain("<!here>");
-    expect(sentBody.text).not.toContain("<@U999>");
-    expect(sentBody.text).toContain("https://evil");
-    expect(sentBody.text).not.toContain("|github.com>");
+    const sentText = sentBody.blocks.find((block) => block.type === "section")?.text?.text ?? "";
+    expect(sentText).not.toContain("<!here>");
+    expect(sentText).not.toContain("<@U999>");
+    expect(sentText).toContain("https://evil");
+    expect(sentText).not.toContain("|github.com>");
   });
 
   it("returns the success envelope (no events emitted) and logs attribution on success", async () => {

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -5,7 +5,7 @@
 
 import {
   getPermalink,
-  postMessage,
+  postBlocks,
   sanitizeAgentText,
   splitIntoSlackSections,
   SLACK_DENIAL_STATUS,
@@ -125,11 +125,9 @@ export async function handleSlackNotify(
     appName: env.APP_NAME ?? "Open-Inspect",
     webAppUrl: env.WEB_APP_URL,
   });
-  // A section-split message has no single text body; the notification preview
-  // takes the opening section.
-  const post = await postMessage(token, parsed.channel, sections[0] ?? sanitized.text, {
+  // Without top-level text, Slack derives screen-reader text from the blocks.
+  const post = await postBlocks(token, parsed.channel, blocks, {
     thread_ts: parsed.threadTs,
-    blocks,
   });
 
   if (!post.ok) {


### PR DESCRIPTION
## Summary

- let Slack derive accessible fallback text from every notification block
- preserve the full content of section-split agent notifications for screen readers
- align agent notify delivery with the existing completion-delivery accessibility pattern

## Root cause

PR #1291 split long agent notifications into multiple blocks but supplied only the opening section as top-level `text`. Slack screen readers prefer that field over interior blocks, so later sections remained visually available while being omitted from the accessible representation.

This uses the existing `postBlocks` client so Slack derives fallback text from the supported blocks instead.

## Test plan

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/routes/slack-notify.test.ts`
- `npm test -w @open-inspect/control-plane` (2,313 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm exec prettier -- --check packages/control-plane/src/routes/slack-notify.ts packages/control-plane/src/routes/slack-notify.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack notifications for long messages by preserving all content without truncation.
  * Enhanced accessibility by allowing screen readers to derive notification text from message sections.
  * Maintained message sanitization and threaded notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->