### PR TITLE
test: fix Modal timeout fixture callbacks

### DIFF
--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -330,6 +330,7 @@ async def test_create_clamps_build_execution_timeout_independently(monkeypatch):
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
             "build_execution_timeout_seconds": 99999,
             "build_timeout_seconds": 1,
         },


### PR DESCRIPTION
## Summary

- include the existing valid callback URL context in the build execution timeout clamping test
- keep the fix scoped to the stale test fixture; production behavior is unchanged

## Root cause

PR #1255 was validated on August 3 before callback URLs became required for build sandbox creation on August 4. It was merged on August 6 without current-base validation, so the newly added timeout test reached main with an outdated request fixture. The test failed during callback_url validation before exercising either timeout assertion.

Fixes the CI failure in https://github.com/ColeMurray/background-agents/actions/runs/31133401945/job/92727432767.

## Validation

- uv run pytest tests/ -q (177 passed)
- uv run ruff check tests/test_web_api_build_sandbox.py
- uv run ruff format --check tests/test_web_api_build_sandbox.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated build-execution-timeout coverage to include standard callback URL fields in the request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->