### PR TITLE
Clarify shared artifact schema ownership

### DIFF
--- a/packages/shared/src/types/artifacts.ts
+++ b/packages/shared/src/types/artifacts.ts
@@ -1,33 +1,22 @@
 import { z } from "zod";
 
-export type ArtifactType = "pr" | "screenshot" | "video" | "preview" | "branch";
-
 export const artifactTypeSchema = z.enum(["pr", "screenshot", "video", "preview", "branch"]);
-
-export const recordSchema = z.record(z.string(), z.unknown());
+export type ArtifactType = z.infer<typeof artifactTypeSchema>;
 
 // Artifact created by session
-export interface SessionArtifact {
-  id: string;
-  type: ArtifactType;
-  url: string | null;
-  metadata: Record<string, unknown> | null;
-  createdAt: number;
-  /**
-   * Last content change (epoch ms). Optional for rolling deploys — producers
-   * predating PR lifecycle tracking omit it; consumers fall back to createdAt.
-   */
-  updatedAt?: number;
-}
-
 export const sessionArtifactSchema = z.object({
   id: z.string(),
   type: artifactTypeSchema,
   url: z.string().nullable(),
-  metadata: recordSchema.nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
   createdAt: z.number(),
+  /**
+   * Last content change (epoch ms). Optional for rolling deploys — producers
+   * predating PR lifecycle tracking omit it; consumers fall back to createdAt.
+   */
   updatedAt: z.number().optional(),
 });
+export type SessionArtifact = z.infer<typeof sessionArtifactSchema>;
 
 // ─── Pull request lifecycle ───────────────────────────────────────────────────
 

--- a/packages/shared/src/types/sandbox-events.ts
+++ b/packages/shared/src/types/sandbox-events.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { recordSchema } from "./artifacts";
 import { sessionDiffBaselineRepositorySchema } from "./session-diffs";
 import { resolvedSessionAttachmentsSchema } from "./session-attachments";
 
+const recordSchema = z.record(z.string(), z.unknown());
 const gitSyncStatusSchema = z.enum(["pending", "in_progress", "completed", "failed"]);
 export type GitSyncStatus = z.infer<typeof gitSyncStatusSchema>;
 

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { recordSchema, type AgentResponse } from "./artifacts";
+import type { AgentResponse } from "./artifacts";
 import { isValidSandboxTimeoutMs } from "./integrations";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
@@ -222,7 +222,7 @@ export const createMediaArtifactRequestSchema = z.object({
   artifactId: z.string(),
   artifactType: z.string(),
   objectKey: z.string(),
-  metadata: recordSchema.optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type CreateMediaArtifactRequest = z.infer<typeof createMediaArtifactRequestSchema>;


### PR DESCRIPTION
## Summary

- derive `ArtifactType` and `SessionArtifact` from their canonical Zod schemas
- remove the generic exported `recordSchema` helper from the artifact module
- keep identical record validation local to the sandbox-event and media-request owners

## Scope

This is an ownership-only refactor. It preserves the package-root API and serialized behavior, and does not add a package path, migrate consumers, add a facade, add tests, or add import enforcement.

## Architecture

The artifact module retains artifact-specific schemas, including the already-supported `sessionArtifactSchema`. Generic record validation no longer creates a runtime dependency from sandbox events to artifacts. After this change, the artifact module has no unrelated exported helper blocking later direct-path adoption.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (39 files, 553 tests)
- `npm test -w @open-inspect/shared -- src/module-boundaries.test.ts` (4 tests)
- `npm run lint -w @open-inspect/shared`
- `npm run format:check`
- `npm run typecheck` (all workspaces)
- root export and package export files unchanged
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal validation of session artifacts and metadata.
  * Standardized artifact type definitions based on their validation schemas.
  * Preserved existing artifact validation behavior, including optional update timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->