### PR TITLE
cleanup: drop build_timeout_seconds rename-skew shim

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -482,7 +482,6 @@ describe("ModalClient", () => {
       failure_callback_url: "https://worker.test/image-builds/build-failed",
       build_execution_timeout_seconds: 1800,
       provider_session_timeout_seconds: 2400,
-      build_timeout_seconds: 2400,
     });
     expect(result).toEqual({ providerSessionId: "modal-session-1" });
   });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -643,11 +643,6 @@ export class ModalClient {
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
           provider_session_timeout_seconds: request.providerSessionTimeoutSeconds,
-          // Transitional duplicate under the pre-rename key: the control plane
-          // and Modal deploy the same commit via independent pipelines, so an
-          // older Modal may still read only build_timeout_seconds during the
-          // skew window. Drop once both planes are known to be past the rename.
-          build_timeout_seconds: request.providerSessionTimeoutSeconds,
         }),
       });
 

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -590,15 +590,9 @@ async def api_create_build_sandbox(
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
-        # legacy_field: transitional dual-read for the build_timeout_seconds ->
-        # provider_session_timeout_seconds rename. The control plane and Modal
-        # deploy the same commit via independent pipelines, so an older control
-        # plane may still send only the legacy key during the skew window.
-        # Drop the alias once both planes are known to be past the rename.
         provider_session_timeout_seconds = _validated_timeout_seconds(
             request,
             "provider_session_timeout_seconds",
-            legacy_field="build_timeout_seconds",
             default_seconds=(
                 DEFAULT_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
             ),
@@ -807,12 +801,8 @@ def _validated_timeout_seconds(
     *,
     default_seconds: int,
     max_seconds: int,
-    legacy_field: str | None = None,
 ) -> int:
     value = request.get(field)
-    if value is None and legacy_field is not None:
-        field = legacy_field
-        value = request.get(field)
     if value is None:
         return default_seconds
     if not isinstance(value, int) or isinstance(value, bool):

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -261,8 +261,8 @@ async def test_create_rejects_non_integer_build_timeout(monkeypatch, field):
 
 
 @pytest.mark.asyncio
-async def test_create_reads_legacy_build_timeout_key_during_rename_skew(monkeypatch):
-    """An older control plane sends build_timeout_seconds; honor it until both planes rename."""
+async def test_create_ignores_retired_build_timeout_seconds_key(monkeypatch):
+    """The pre-rename build_timeout_seconds key is retired; only the renamed key is read."""
     service = _patch_dependencies(monkeypatch)
 
     await _call(
@@ -277,27 +277,10 @@ async def test_create_reads_legacy_build_timeout_key_during_rename_skew(monkeypa
         },
     )
 
-    assert service.create.await_args.kwargs["timeout_seconds"] == 4200
-
-
-@pytest.mark.asyncio
-async def test_create_prefers_renamed_provider_session_timeout_key_over_legacy(monkeypatch):
-    service = _patch_dependencies(monkeypatch)
-
-    await _call(
-        web_api.api_create_build_sandbox,
-        {
-            "scope_kind": "repo",
-            "scope_id": "acme/repo",
-            "build_id": "imgb-1",
-            "repositories": REPOSITORIES,
-            **CALLBACK_CONTEXT,
-            "provider_session_timeout_seconds": 2400,
-            "build_timeout_seconds": 4200,
-        },
+    assert (
+        service.create.await_args.kwargs["timeout_seconds"]
+        == DEFAULT_BUILD_TIMEOUT_SECONDS + web_api.IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
     )
-
-    assert service.create.await_args.kwargs["timeout_seconds"] == 2400
 
 
 @pytest.mark.asyncio
@@ -330,8 +313,9 @@ async def test_create_clamps_build_execution_timeout_independently(monkeypatch):
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": REPOSITORIES,
+            **CALLBACK_CONTEXT,
             "build_execution_timeout_seconds": 99999,
-            "build_timeout_seconds": 1,
+            "provider_session_timeout_seconds": 1,
         },
     )
 


### PR DESCRIPTION
## Summary

Removes the transitional `build_timeout_seconds` → `provider_session_timeout_seconds` rename-skew shim introduced in #1288, now that the rename is fully deployed on both planes:

- **control plane** (`sandbox/client.ts`): stop dual-writing the legacy `build_timeout_seconds` key alongside `provider_session_timeout_seconds` in the create-build-sandbox payload.
- **Modal** (`web_api.py`): drop the `legacy_field="build_timeout_seconds"` dual-read alias and remove the now-unused `legacy_field` parameter from `_validated_timeout_seconds`.
- Tests: the two rename-skew tests are replaced by a single test pinning that the retired key is now **ignored** (falls back to the default provider-session timeout), so an accidental revival of the old key would be caught.

Both shim sites carried "drop once both planes are past the rename" comments; this is that follow-up. The rename (#1288) has merged, synced to the production fork, and deployed on both pipelines, so the currently-deployed control plane already sends the new key and the currently-deployed Modal prefers it — removal is safe in either deploy-skew direction.

## Also fixes a red test on main

`test_create_clamps_build_execution_timeout_independently` (added in #1255) was failing on `main`: its payload predates #1283 making callback URLs required at create, so the endpoint 400s before reaching the timeout logic. Since this PR rewrites that test's payload anyway (it used the retired key), it also adds the required `**CALLBACK_CONTEXT`.

## Testing

- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane` — 2313 passed
- `npm run test:integration -w @open-inspect/control-plane` — 744 passed
- `uv run --frozen pytest tests/` in `packages/modal-infra` — 176 passed (175 + the repaired one; 1 was failing on main before this PR)
- `ruff check` / `ruff format --check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for the legacy `build_timeout_seconds` field when creating image-build sandboxes.
  * Use `provider_session_timeout_seconds` to configure the provider session timeout.
* **Bug Fixes**
  * Timeout validation, defaults, and limits now consistently use the supported timeout field.
* **Tests**
  * Updated coverage to verify legacy fields are ignored and timeout settings remain independently supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->