### PR TITLE
Move session spawn context into control plane

### DIFF
--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -1,4 +1,4 @@
-import { spawnChildSessionRequestSchema, spawnContextSchema } from "@open-inspect/shared";
+import { spawnChildSessionRequestSchema } from "@open-inspect/shared";
 import {
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
@@ -23,6 +23,7 @@ import {
   resolveCodeServerEnabled,
   resolveSandboxSettings,
 } from "../session/integration-settings-resolution";
+import { spawnContextSchema } from "../session/spawn-context";
 import type { Env } from "../types";
 import { error, json, parsePattern, type Route } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,8 +1,8 @@
-import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionStatus } from "../../../types";
 import { parsePersistedSandboxSettings } from "../../../sandbox/settings";
 import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
+import type { SpawnContext } from "../../spawn-context";
 import type { ArtifactRow, SandboxRow, SessionRow } from "../../types";
 import {
   RECENT_EVENT_FETCH_LIMIT,

--- a/packages/control-plane/src/session/spawn-context.test.ts
+++ b/packages/control-plane/src/session/spawn-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { spawnContextSchema } from "./spawn-context";
+
+describe("spawnContextSchema", () => {
+  it("parses a valid spawn context with nullable fields", () => {
+    const result = spawnContextSchema.safeParse({
+      repoOwner: "open-inspect",
+      repoName: "background-agents",
+      repoId: null,
+      model: "anthropic/claude-sonnet-4-6",
+      reasoningEffort: null,
+      baseBranch: null,
+      sandboxTimeoutMs: 14_400_000,
+      owner: {
+        userId: "user-1",
+        scmUserId: null,
+        scmLogin: null,
+        scmName: null,
+        scmEmail: null,
+        scmAccessTokenEncrypted: null,
+        scmRefreshTokenEncrypted: null,
+        scmTokenExpiresAt: null,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sandboxTimeoutMs).toBe(14_400_000);
+    }
+  });
+
+  it("parses a repo-less spawn context", () => {
+    const result = spawnContextSchema.safeParse({
+      repoOwner: null,
+      repoName: null,
+      repoId: null,
+      model: "anthropic/claude-sonnet-4-6",
+      reasoningEffort: null,
+      baseBranch: null,
+      owner: {
+        userId: "user-1",
+        scmUserId: null,
+        scmLogin: null,
+        scmName: null,
+        scmEmail: null,
+        scmAccessTokenEncrypted: null,
+        scmRefreshTokenEncrypted: null,
+        scmTokenExpiresAt: null,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([-1_000, 1_500, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid snapshotted sandbox timeout %s",
+    (sandboxTimeoutMs) => {
+      const result = spawnContextSchema.safeParse({
+        repoOwner: null,
+        repoName: null,
+        repoId: null,
+        model: "anthropic/claude-sonnet-4-6",
+        reasoningEffort: null,
+        baseBranch: null,
+        sandboxTimeoutMs,
+        owner: {
+          userId: "user-1",
+          scmUserId: null,
+          scmLogin: null,
+          scmName: null,
+          scmEmail: null,
+          scmAccessTokenEncrypted: null,
+          scmRefreshTokenEncrypted: null,
+          scmTokenExpiresAt: null,
+        },
+      });
+
+      expect(result.success).toBe(false);
+    }
+  );
+
+  it("rejects a malformed partial spawn context", () => {
+    const result = spawnContextSchema.safeParse({
+      repoOwner: "open-inspect",
+      repoName: "background-agents",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/control-plane/src/session/spawn-context.ts
+++ b/packages/control-plane/src/session/spawn-context.ts
@@ -1,5 +1,5 @@
+import { isValidSandboxTimeoutMs } from "@open-inspect/shared/types/integrations";
 import { z } from "zod";
-import { isValidSandboxTimeoutMs } from "./integrations";
 
 const sandboxTimeoutMsSchema = z.number().refine(isValidSandboxTimeoutMs);
 

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { env } from "cloudflare:test";
 import { cleanD1Tables } from "./cleanup";
 import { initSession, queryDO, seedEvents } from "./helpers";
-import type { SpawnContext, ChildSessionDetail } from "@open-inspect/shared";
+import type { ChildSessionDetail } from "@open-inspect/shared";
+import type { SpawnContext } from "../../src/session/spawn-context";
 
 const originalFetch = globalThis.fetch;
 

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -19,7 +19,6 @@ import {
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
   cancelChildSessionRequestSchema,
-  spawnContextSchema,
 } from ".";
 
 describe("boundary schemas", () => {
@@ -775,94 +774,6 @@ describe("boundary schemas", () => {
 
     it("rejects a non-boolean cancelNested", () => {
       const result = cancelChildSessionRequestSchema.safeParse({ cancelNested: "yes" });
-
-      expect(result.success).toBe(false);
-    });
-  });
-
-  describe("spawnContextSchema", () => {
-    it("parses a valid spawn context with nullable fields", () => {
-      const result = spawnContextSchema.safeParse({
-        repoOwner: "open-inspect",
-        repoName: "background-agents",
-        repoId: null,
-        model: "anthropic/claude-sonnet-4-6",
-        reasoningEffort: null,
-        baseBranch: null,
-        sandboxTimeoutMs: 14_400_000,
-        owner: {
-          userId: "user-1",
-          scmUserId: null,
-          scmLogin: null,
-          scmName: null,
-          scmEmail: null,
-          scmAccessTokenEncrypted: null,
-          scmRefreshTokenEncrypted: null,
-          scmTokenExpiresAt: null,
-        },
-      });
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.sandboxTimeoutMs).toBe(14_400_000);
-      }
-    });
-
-    it("parses a repo-less spawn context", () => {
-      const result = spawnContextSchema.safeParse({
-        repoOwner: null,
-        repoName: null,
-        repoId: null,
-        model: "anthropic/claude-sonnet-4-6",
-        reasoningEffort: null,
-        baseBranch: null,
-        owner: {
-          userId: "user-1",
-          scmUserId: null,
-          scmLogin: null,
-          scmName: null,
-          scmEmail: null,
-          scmAccessTokenEncrypted: null,
-          scmRefreshTokenEncrypted: null,
-          scmTokenExpiresAt: null,
-        },
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it.each([-1_000, 1_500, Number.MAX_SAFE_INTEGER + 1])(
-      "rejects invalid snapshotted sandbox timeout %s",
-      (sandboxTimeoutMs) => {
-        const result = spawnContextSchema.safeParse({
-          repoOwner: null,
-          repoName: null,
-          repoId: null,
-          model: "anthropic/claude-sonnet-4-6",
-          reasoningEffort: null,
-          baseBranch: null,
-          sandboxTimeoutMs,
-          owner: {
-            userId: "user-1",
-            scmUserId: null,
-            scmLogin: null,
-            scmName: null,
-            scmEmail: null,
-            scmAccessTokenEncrypted: null,
-            scmRefreshTokenEncrypted: null,
-            scmTokenExpiresAt: null,
-          },
-        });
-
-        expect(result.success).toBe(false);
-      }
-    );
-
-    it("rejects a malformed partial spawn context", () => {
-      const result = spawnContextSchema.safeParse({
-        repoOwner: "open-inspect",
-        repoName: "background-agents",
-      });
 
       expect(result.success).toBe(false);
     });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -192,7 +192,6 @@ export {
   spawnChildSessionRequestSchema,
   cancelChildSessionRequestSchema,
 } from "./session-api";
-export { spawnContextSchema } from "./session-spawn-context";
 export type {
   UserPreferences,
   SlackCallbackContext,
@@ -213,7 +212,6 @@ export type {
   ChildSessionTrajectory,
   ChildSessionDetail,
 } from "./session-api";
-export type { SpawnContext } from "./session-spawn-context";
 
 export {
   MAX_ENVIRONMENT_NAME_LENGTH,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -191,8 +191,8 @@ export {
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
   cancelChildSessionRequestSchema,
-  spawnContextSchema,
 } from "./session-api";
+export { spawnContextSchema } from "./session-spawn-context";
 export type {
   UserPreferences,
   SlackCallbackContext,
@@ -209,11 +209,11 @@ export type {
   ListSessionsResponse,
   SpawnChildSessionRequest,
   CancelChildSessionRequest,
-  SpawnContext,
   ChildSessionFinalResponse,
   ChildSessionTrajectory,
   ChildSessionDetail,
 } from "./session-api";
+export type { SpawnContext } from "./session-spawn-context";
 
 export {
   MAX_ENVIRONMENT_NAME_LENGTH,

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type { AgentResponse } from "./artifacts";
-import { isValidSandboxTimeoutMs } from "./integrations";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
 import {
@@ -20,7 +19,6 @@ export interface UserPreferences {
 }
 
 const nonEmptyStringSchema = z.string().trim().min(1);
-const sandboxTimeoutMsSchema = z.number().refine(isValidSandboxTimeoutMs);
 
 export const slackCallbackContextSchema = z.object({
   source: z.literal("slack"),
@@ -265,38 +263,6 @@ export const cancelChildSessionRequestSchema = z.object({
 });
 
 export type CancelChildSessionRequest = z.infer<typeof cancelChildSessionRequestSchema>;
-
-/**
- * Returned by the parent Durable Object's GET /internal/spawn-context.
- *
- * Deliberately scalar in v1: child sessions inherit — and are restricted to —
- * the parent's PRIMARY repository, even for multi-repo parents. The spawn
- * route validates against the scalar mirror. Letting children target another
- * repository requires spawnContext.repositories, a named fast-follow (design
- * §13.13), not a v1 promise.
- */
-export const spawnContextSchema = z.object({
-  repoOwner: z.string().nullable(),
-  repoName: z.string().nullable(),
-  repoId: z.number().nullable(),
-  model: z.string(),
-  reasoningEffort: z.string().nullable(),
-  baseBranch: z.string().nullable(),
-  sandboxTimeoutMs: sandboxTimeoutMsSchema.optional(),
-  owner: z.object({
-    userId: z.string(),
-    canonicalUserId: z.string().nullable().optional(),
-    scmUserId: z.string().nullable(),
-    scmLogin: z.string().nullable(),
-    scmName: z.string().nullable(),
-    scmEmail: z.string().nullable(),
-    scmAccessTokenEncrypted: z.string().nullable(),
-    scmRefreshTokenEncrypted: z.string().nullable(),
-    scmTokenExpiresAt: z.number().nullable(),
-  }),
-});
-
-export type SpawnContext = z.infer<typeof spawnContextSchema>;
 
 /** Returned by the child Durable Object's GET /internal/child-summary. */
 export interface ChildSessionFinalResponse extends AgentResponse {

--- a/packages/shared/src/types/session-spawn-context.ts
+++ b/packages/shared/src/types/session-spawn-context.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { isValidSandboxTimeoutMs } from "./integrations";
+
+const sandboxTimeoutMsSchema = z.number().refine(isValidSandboxTimeoutMs);
+
+/**
+ * Returned by the parent Durable Object's GET /internal/spawn-context.
+ *
+ * Deliberately scalar in v1: child sessions inherit — and are restricted to —
+ * the parent's PRIMARY repository, even for multi-repo parents. The spawn
+ * route validates against the scalar mirror. Letting children target another
+ * repository requires spawnContext.repositories, a named fast-follow (design
+ * §13.13), not a v1 promise.
+ */
+export const spawnContextSchema = z.object({
+  repoOwner: z.string().nullable(),
+  repoName: z.string().nullable(),
+  repoId: z.number().nullable(),
+  model: z.string(),
+  reasoningEffort: z.string().nullable(),
+  baseBranch: z.string().nullable(),
+  sandboxTimeoutMs: sandboxTimeoutMsSchema.optional(),
+  owner: z.object({
+    userId: z.string(),
+    canonicalUserId: z.string().nullable().optional(),
+    scmUserId: z.string().nullable(),
+    scmLogin: z.string().nullable(),
+    scmName: z.string().nullable(),
+    scmEmail: z.string().nullable(),
+    scmAccessTokenEncrypted: z.string().nullable(),
+    scmRefreshTokenEncrypted: z.string().nullable(),
+    scmTokenExpiresAt: z.number().nullable(),
+  }),
+});
+
+export type SpawnContext = z.infer<typeof spawnContextSchema>;


### PR DESCRIPTION
## Summary

- move `spawnContextSchema` and `SpawnContext` out of `@open-inspect/shared` into the control-plane Session owner
- migrate the Durable Object producer, route validator, and integration type reference to the internal module
- relocate the existing schema tests with their owner

## Scope

This is an ownership-only refactor. It preserves the schema fields and serialized behavior, removes the historical root exports that had no cross-package consumers, and does not add a package path, facade, new behavior, or import enforcement.

## Architecture

The parent Durable Object spawn-context response contains encrypted SCM fields and is produced and consumed exclusively inside control-plane. `src/session/spawn-context.ts` now directly owns that internal response schema and inferred type. The broader shared Session HTTP API no longer exposes or depends on it.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (39 files, 547 tests)
- `npm run lint -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane` (155 files, 2,319 tests)
- `npm run test:integration -w @open-inspect/control-plane -- do-internal-routes.test.ts` (17 tests)
- `npm run lint -w @open-inspect/control-plane`
- `npm test -w @open-inspect/shared -- src/module-boundaries.test.ts` (4 tests)
- `npm run format:check`
- `npm run typecheck` (all workspaces)
- `git diff --check`