### PR TITLE
Adopt shared sandbox event imports

### DIFF
--- a/packages/control-plane/src/realtime/events.ts
+++ b/packages/control-plane/src/realtime/events.ts
@@ -2,7 +2,8 @@
  * Real-time event utilities.
  */
 
-import type { SandboxEvent, ServerMessage } from "../types";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { ServerMessage } from "../types";
 
 /**
  * Event categories for filtering.

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -1,4 +1,4 @@
-import { type SandboxEvent } from "@open-inspect/shared";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import {
   SESSION_DIFF_ID_PATTERN,
   sessionDiffFailureSchema,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -10,7 +10,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import { clientMessageSchema } from "@open-inspect/shared/types/websocket";
-import { sandboxEventSchema } from "@open-inspect/shared";
+import { sandboxEventSchema } from "@open-inspect/shared/types/sandbox-events";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -10,7 +10,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import { clientMessageSchema } from "@open-inspect/shared/types/websocket";
-import { sandboxEventSchema } from "@open-inspect/shared/types/sandbox-events";
+import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
@@ -52,7 +52,6 @@ import type {
   Env,
   ClientInfo,
   ServerMessage,
-  SandboxEvent,
   SessionRepositoryState,
   SessionState,
   SandboxStatus,

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -1,10 +1,9 @@
+import type { ClientMessage, ServerMessage } from "../types";
 import type {
-  ClientMessage,
   EventResponse,
   ListEventsResponse,
   SandboxEvent,
-  ServerMessage,
-} from "../types";
+} from "@open-inspect/shared/types/sandbox-events";
 import { encodeEventTimelineCursor, type EventListCursor } from "./event-cursor";
 import type { EventRow } from "./types";
 import type { SessionRepository } from "./repository";

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -3,8 +3,8 @@ import {
   type ChildSessionDetail,
   type ChildSessionFinalResponse,
   type ChildSessionTrajectory,
-  type EventResponse,
 } from "@open-inspect/shared";
+import type { EventResponse } from "@open-inspect/shared/types/sandbox-events";
 import {
   buildAgentResponseFromEvents,
   getArtifactLabelFromArtifact,

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -4,8 +4,8 @@ import {
   type CreateMediaArtifactRequest,
   type SessionArtifact,
 } from "@open-inspect/shared";
-import { sandboxEventSchema } from "@open-inspect/shared/types/sandbox-events";
-import type { ParticipantRole, SandboxEvent } from "../../../types";
+import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { ParticipantRole } from "../../../types";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { XaiTokenRefreshResult } from "../../xai-token-refresh-service";

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -1,10 +1,10 @@
 import type { Logger } from "../../../logger";
 import {
   createMediaArtifactRequestSchema,
-  sandboxEventSchema,
   type CreateMediaArtifactRequest,
   type SessionArtifact,
 } from "@open-inspect/shared";
+import { sandboxEventSchema } from "@open-inspect/shared/types/sandbox-events";
 import type { ParticipantRole, SandboxEvent } from "../../../types";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -11,7 +11,8 @@ import {
   getValidModelOrDefault,
   isValidModel,
 } from "@open-inspect/shared/models";
-import type { ClientInfo, MessageSource, SandboxEvent } from "../types";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { ClientInfo, MessageSource } from "../types";
 import type { SourceControlProviderName } from "../source-control";
 import type { AlarmScheduler, SandboxLifecycle } from "../sandbox/lifecycle/manager";
 import type { ParticipantRow, PromptGitIdentity, SandboxCommand } from "./types";

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -15,7 +15,7 @@ import type {
   SandboxRow,
   SessionRepositoryRow,
 } from "./types";
-import { toolCallIdentityKey } from "@open-inspect/shared";
+import { toolCallIdentityKey } from "@open-inspect/shared/types/sandbox-events";
 import type {
   SessionStatus,
   SandboxStatus,

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -16,16 +16,15 @@ import type {
   SessionRepositoryRow,
 } from "./types";
 import { toolCallIdentityKey } from "@open-inspect/shared/types/sandbox-events";
+import type { GitSyncStatus, SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type {
   SessionStatus,
   SandboxStatus,
-  GitSyncStatus,
   MessageStatus,
   MessageSource,
   ParticipantRole,
   SpawnSource,
   ArtifactType,
-  SandboxEvent,
 } from "../types";
 import {
   eventTimelineCursorFromRow,

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import type { GitPushSpec } from "../source-control";
-import type { SandboxEvent, ServerMessage } from "../types";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { ServerMessage } from "../types";
 import type { CallbackNotificationService } from "./callback-notification-service";
 import type { SessionDiffService } from "./diffs/service";
 import type { SessionRepository } from "./repository";

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -2,7 +2,7 @@ import type { SessionArtifact } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
 import type { Logger } from "../logger";
 import type { GitPushSpec } from "../source-control";
-import type { SandboxEvent } from "../types";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import { assertArtifactType } from "./artifacts";
 import type { SessionRepository } from "./repository";
 import type { CallbackNotificationService } from "./callback-notification-service";

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,6 +1,7 @@
 import type { ArtifactRow } from "../types";
 import type { SessionMessage } from "@open-inspect/shared";
-import type { ArtifactResponse, ListEventsResponse } from "../../types";
+import type { ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
+import type { ArtifactResponse } from "../../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 import type { EnqueuePromptRequest } from "../enqueue-prompt-contract";

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -6,14 +6,13 @@ import type {
   ResolvedSessionAttachment,
   SessionStatus,
   SandboxStatus,
-  GitSyncStatus,
   MessageStatus,
   MessageSource,
   ParticipantRole,
   SpawnSource,
   ArtifactType,
-  EventType,
 } from "../types";
+import type { EventType, GitSyncStatus } from "@open-inspect/shared/types/sandbox-events";
 import type { GitPushSpec } from "../source-control";
 
 // Database row types (match SQLite schema)

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -16,20 +16,22 @@ export type {
   ArtifactType,
   CreateSessionRequest,
   CreateSessionResponse,
-  EventResponse,
-  EventType,
-  GitSyncStatus,
-  ListEventsResponse,
   MessageSource,
   MessageStatus,
   ParticipantRole,
   ParticipantPresence,
   SpawnSource,
-  SandboxEvent,
   SandboxStatus,
   SessionState,
   SessionStatus,
 } from "@open-inspect/shared";
+export type {
+  EventResponse,
+  EventType,
+  GitSyncStatus,
+  ListEventsResponse,
+  SandboxEvent,
+} from "@open-inspect/shared/types/sandbox-events";
 export type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
 export type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 export type {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -25,13 +25,6 @@ export type {
   SessionState,
   SessionStatus,
 } from "@open-inspect/shared";
-export type {
-  EventResponse,
-  EventType,
-  GitSyncStatus,
-  ListEventsResponse,
-  SandboxEvent,
-} from "@open-inspect/shared/types/sandbox-events";
 export type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
 export type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 export type {

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -155,14 +155,13 @@ export type {
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 
 export type {
-  EventResponse,
-  ListEventsResponse,
   ArtifactResponse,
   ListArtifactsResponse,
   ToolCallSummary,
   ArtifactInfo,
   AgentResponse,
 } from "@open-inspect/shared";
+export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
 
 // ─── User Preferences ────────────────────────────────────────────────────────
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -106,6 +106,10 @@
       "import": "./dist/types/server-messages.js",
       "types": "./dist/types/server-messages.d.ts"
     },
+    "./types/sandbox-events": {
+      "import": "./dist/types/sandbox-events.js",
+      "types": "./dist/types/sandbox-events.d.ts"
+    },
     "./types/session-attachments": {
       "import": "./dist/types/session-attachments.js",
       "types": "./dist/types/session-attachments.d.ts"

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -7,12 +7,9 @@ import {
   createSessionRequestSchema,
   callbackContextSchema,
   listArtifactsResponseSchema,
-  listEventsResponseSchema,
   MAX_AUTOMATION_REPOSITORIES,
   normalizeOptionalRepositoryPair,
   RepositoryPairValidationError,
-  sandboxEventSchema,
-  toolCallIdentityKey,
   sendPromptRequestSchema,
   serverMessageSchema,
   sessionParticipantProfilesResponseSchema,
@@ -20,6 +17,11 @@ import {
   spawnChildSessionRequestSchema,
   cancelChildSessionRequestSchema,
 } from ".";
+import {
+  listEventsResponseSchema,
+  sandboxEventSchema,
+  toolCallIdentityKey,
+} from "./sandbox-events";
 
 describe("boundary schemas", () => {
   describe("createSessionRequestSchema", () => {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -87,23 +87,6 @@ export type {
 } from "./artifacts";
 export { sessionArtifactSchema } from "./artifacts";
 
-export {
-  eventResponseSchema,
-  eventTypeSchema,
-  listEventsResponseSchema,
-  sandboxEventSchema,
-  toolCallIdentityKey,
-  toolCallIdentityTuple,
-} from "./sandbox-events";
-export type {
-  AgentEvent,
-  SandboxEvent,
-  EventResponse,
-  ListEventsResponse,
-  GitSyncStatus,
-  EventType,
-} from "./sandbox-events";
-
 export type {
   SessionParticipant,
   Session,

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -10,11 +10,11 @@ import {
   formatRepositoryFullName,
   parseRepositoryFullName,
   prArtifactBelongsToRepo,
-  sandboxEventSchema,
   serverMessageSchema,
   sessionRepositoriesInputSchema,
   toRepositoryRef,
 } from "./index";
+import { sandboxEventSchema } from "./sandbox-events";
 
 describe("repository full names", () => {
   it("round-trips a repository with a nested owner namespace", () => {

--- a/packages/shared/src/types/type-contracts.test.ts
+++ b/packages/shared/src/types/type-contracts.test.ts
@@ -19,17 +19,16 @@ import type {
   CreateSessionRequest,
   ListAutomationsResponse,
   RepositoryInput,
-  SandboxEvent,
   ServerMessage,
   UpdateEnvironmentInput,
   createEnvironmentInputSchema,
   createSessionInputSchema,
   createSessionRequestSchema,
   repositoryInputSchema,
-  sandboxEventSchema,
   serverMessageSchema,
   updateEnvironmentInputSchema,
 } from ".";
+import type { SandboxEvent, sandboxEventSchema } from "./sandbox-events";
 
 it("preserves public Zod input and output relationships", () => {
   expectTypeOf<RepositoryInput>().toEqualTypeOf<z.input<typeof repositoryInputSchema>>();

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -191,8 +191,6 @@ export interface ToolCallCallback {
  * Event response from control-plane events API.
  */
 export type {
-  EventResponse,
-  ListEventsResponse,
   ArtifactResponse,
   ListArtifactsResponse,
   ToolCallSummary,
@@ -200,3 +198,4 @@ export type {
   AgentResponse,
   UserPreferences,
 } from "@open-inspect/shared";
+export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";

--- a/packages/web/src/hooks/use-session-participant-profiles.test.tsx
+++ b/packages/web/src/hooks/use-session-participant-profiles.test.tsx
@@ -2,7 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { ParticipantPresence, SandboxEvent } from "@open-inspect/shared";
+import type { ParticipantPresence } from "@open-inspect/shared";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import { useSessionParticipantProfiles } from "./use-session-participant-profiles";
 
 const swrState = vi.hoisted(() => ({ data: undefined as unknown, mutate: vi.fn() }));

--- a/packages/web/src/hooks/use-session-participant-profiles.ts
+++ b/packages/web/src/hooks/use-session-participant-profiles.ts
@@ -3,9 +3,9 @@
 import {
   sessionParticipantProfilesResponseSchema,
   type ParticipantPresence,
-  type SandboxEvent,
   type SessionParticipantProfile,
 } from "@open-inspect/shared";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import { useEffect, useMemo, useRef } from "react";
 import useSWR from "swr";
 import { resolveParticipantDisplay } from "@/lib/participant-display";

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -1,5 +1,5 @@
 import type { SandboxEvent } from "@/types/session";
-import { toolCallIdentityKey } from "@open-inspect/shared";
+import { toolCallIdentityKey } from "@open-inspect/shared/types/sandbox-events";
 
 export type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 

--- a/packages/web/src/types/session.ts
+++ b/packages/web/src/types/session.ts
@@ -1,9 +1,9 @@
 import type {
   PullRequestDisplayStatus,
-  SandboxEvent as SharedSandboxEvent,
   ScreenshotArtifactMetadata,
   VideoArtifactMetadata,
 } from "@open-inspect/shared";
+import type { SandboxEvent as SharedSandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 
 // Session-related type definitions
 


### PR DESCRIPTION
## Summary

- expose the existing sandbox-event owner at `@open-inspect/shared/types/sandbox-events`
- migrate control-plane, web, Slack, and Linear imports and reexports to that path
- remove the sandbox-event symbols from both the shared root barrel and the control-plane type aggregator once all repository consumers have moved

## Scope

This is a mechanical owner-path adoption. It does not change source declarations, schemas, serialized behavior, or runtime logic, and it does not add a facade, enforcement rule, or import-only tests.

The repository now has zero imports or reexports of sandbox-event symbols from `@open-inspect/shared`. Control-plane consumers also import the sandbox-event owner directly instead of routing through `src/types.ts`. Shared-package tests use the existing relative owner path.

## Validation

- `npm run typecheck`
- `npm run format:check`
- `npm test -w @open-inspect/shared` (547 tests)
- `npm test -w @open-inspect/control-plane` (2,319 tests)
- `npm test -w @open-inspect/web` (894 tests)
- `npm test -w @open-inspect/slack-bot` (407 tests)
- `npm test -w @open-inspect/linear-bot` (211 tests)
- affected package production builds
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Organized sandbox event types and schemas into a dedicated shared module.
  * Updated internal integrations to use the reorganized event type exports.
  * Preserved existing runtime behavior and public functionality.
* **Tests**
  * Updated type and schema contract tests to reflect the reorganized exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->