### PR TITLE
Add SCM pull request label settings

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -756,6 +756,27 @@ describe("IntegrationSettingsStore", () => {
     });
   });
 
+  describe("SCM field-level overrides", () => {
+    it("keeps omitted repository fields inherited when global defaults change", async () => {
+      await store.setGlobal("scm", {
+        defaults: { alwaysUseDraftMode: false, pullRequestLabel: "global" },
+      });
+      await store.setRepoSettings("scm", "acme/widgets", {
+        pullRequestLabel: "repository",
+      });
+
+      await store.setGlobal("scm", {
+        defaults: { alwaysUseDraftMode: true, pullRequestLabel: "new-global" },
+      });
+      const config = await store.getResolvedConfig("scm", "acme/widgets");
+
+      expect(config.settings).toEqual({
+        alwaysUseDraftMode: true,
+        pullRequestLabel: "repository",
+      });
+    });
+  });
+
   describe("validation errors", () => {
     it("rejects invalid model ID", async () => {
       await expect(

--- a/packages/control-plane/src/db/scm-settings.test.ts
+++ b/packages/control-plane/src/db/scm-settings.test.ts
@@ -106,6 +106,21 @@ describe("ScmSettingsStore", () => {
     expect(delegate.setRepoSettings).not.toHaveBeenCalled();
   });
 
+  it("rejects commas in pullRequestLabel and does not write", async () => {
+    await expect(
+      store.setGlobal({ defaults: { pullRequestLabel: "release,agent" } })
+    ).rejects.toThrow("pullRequestLabel must not contain commas");
+    await expect(
+      store.setRepoSettings("acme/web", {
+        alwaysUseDraftMode: false,
+        pullRequestLabel: "release,agent",
+      })
+    ).rejects.toThrow("pullRequestLabel must not contain commas");
+
+    expect(delegate.setGlobal).not.toHaveBeenCalled();
+    expect(delegate.setRepoSettings).not.toHaveBeenCalled();
+  });
+
   it("normalizes an empty label to an inherited or unset value", async () => {
     await store.setGlobal({ defaults: { pullRequestLabel: "   " } });
     await store.setRepoSettings("acme/web", {

--- a/packages/control-plane/src/db/scm-settings.test.ts
+++ b/packages/control-plane/src/db/scm-settings.test.ts
@@ -151,12 +151,10 @@ describe("ScmSettingsStore", () => {
     expect(delegate.setRepoSettings).not.toHaveBeenCalled();
   });
 
-  it("rejects an empty repository override and does not write", async () => {
-    await expect(
-      store.setRepoSettings("acme/web", {} as unknown as ScmRepoSettings)
-    ).rejects.toThrow("alwaysUseDraftMode is required for repository overrides");
+  it("allows an empty repository override so every field inherits", async () => {
+    await store.setRepoSettings("acme/web", {});
 
-    expect(delegate.setRepoSettings).not.toHaveBeenCalled();
+    expect(delegate.setRepoSettings).toHaveBeenCalledWith("scm", "acme/web", {});
   });
 
   it.each([null, false])("rejects provided falsy global defaults: %j", async (defaults) => {

--- a/packages/control-plane/src/db/scm-settings.test.ts
+++ b/packages/control-plane/src/db/scm-settings.test.ts
@@ -43,9 +43,11 @@ describe("ScmSettingsStore", () => {
   });
 
   it("delegates setGlobal to the 'scm' key", async () => {
-    await store.setGlobal({ defaults: { alwaysUseDraftMode: true } });
+    await store.setGlobal({
+      defaults: { alwaysUseDraftMode: true, pullRequestLabel: "  open-inspect  " },
+    });
     expect(delegate.setGlobal).toHaveBeenCalledWith("scm", {
-      defaults: { alwaysUseDraftMode: true },
+      defaults: { alwaysUseDraftMode: true, pullRequestLabel: "open-inspect" },
     });
   });
 
@@ -55,7 +57,10 @@ describe("ScmSettingsStore", () => {
       { repo: "acme/web", settings: { alwaysUseDraftMode: true } },
     ]);
 
-    await store.setRepoSettings("Acme/Web", { alwaysUseDraftMode: true });
+    await store.setRepoSettings("Acme/Web", {
+      alwaysUseDraftMode: true,
+      pullRequestLabel: "  generated  ",
+    });
     const repoSettings = await store.getRepoSettings("acme/web");
     const list = await store.listRepoSettings();
     await store.deleteRepoSettings("acme/web");
@@ -63,6 +68,7 @@ describe("ScmSettingsStore", () => {
 
     expect(delegate.setRepoSettings).toHaveBeenCalledWith("scm", "Acme/Web", {
       alwaysUseDraftMode: true,
+      pullRequestLabel: "generated",
     });
     expect(delegate.getRepoSettings).toHaveBeenCalledWith("scm", "acme/web");
     expect(repoSettings).toEqual({ alwaysUseDraftMode: false });
@@ -81,6 +87,36 @@ describe("ScmSettingsStore", () => {
 
     expect(delegate.setGlobal).not.toHaveBeenCalled();
     expect(delegate.setRepoSettings).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string pullRequestLabel and does not write", async () => {
+    await expect(
+      store.setGlobal({
+        defaults: { pullRequestLabel: 42 as unknown as string },
+      })
+    ).rejects.toThrow("pullRequestLabel must be a string");
+    await expect(
+      store.setRepoSettings("acme/web", {
+        alwaysUseDraftMode: false,
+        pullRequestLabel: true as unknown as string,
+      })
+    ).rejects.toThrow("pullRequestLabel must be a string");
+
+    expect(delegate.setGlobal).not.toHaveBeenCalled();
+    expect(delegate.setRepoSettings).not.toHaveBeenCalled();
+  });
+
+  it("normalizes an empty label to an inherited or unset value", async () => {
+    await store.setGlobal({ defaults: { pullRequestLabel: "   " } });
+    await store.setRepoSettings("acme/web", {
+      alwaysUseDraftMode: false,
+      pullRequestLabel: "   ",
+    });
+
+    expect(delegate.setGlobal).toHaveBeenCalledWith("scm", { defaults: {} });
+    expect(delegate.setRepoSettings).toHaveBeenCalledWith("scm", "acme/web", {
+      alwaysUseDraftMode: false,
+    });
   });
 
   it("rejects unknown keys and unsupported global config and does not write", async () => {
@@ -119,13 +155,13 @@ describe("ScmSettingsStore", () => {
   it("resolves a repo's effective settings from the underlying merged config", async () => {
     delegate.getResolvedConfig.mockResolvedValue({
       enabledRepos: null,
-      settings: { alwaysUseDraftMode: false },
+      settings: { alwaysUseDraftMode: false, pullRequestLabel: "generated" },
     });
 
     const resolved = await store.getResolvedSettings("acme/web");
 
     expect(delegate.getResolvedConfig).toHaveBeenCalledWith("scm", "acme/web");
-    expect(resolved).toEqual({ alwaysUseDraftMode: false });
+    expect(resolved).toEqual({ alwaysUseDraftMode: false, pullRequestLabel: "generated" });
   });
 
   it("constructs the underlying IntegrationSettingsStore", () => {

--- a/packages/control-plane/src/db/scm-settings.ts
+++ b/packages/control-plane/src/db/scm-settings.ts
@@ -57,14 +57,6 @@ function validateAndNormalizeScmSettings(settings: unknown): ScmSettings {
   };
 }
 
-function validateAndNormalizeScmRepoSettings(settings: unknown): ScmRepoSettings {
-  const normalized = validateAndNormalizeScmSettings(settings);
-  if (normalized.alwaysUseDraftMode === undefined) {
-    throw new ScmSettingsValidationError("alwaysUseDraftMode is required for repository overrides");
-  }
-  return { ...normalized, alwaysUseDraftMode: normalized.alwaysUseDraftMode };
-}
-
 /**
  * Global defaults + per-repo overrides for source-control (SCM) behavior, such
  * as always opening pull/merge requests as drafts. Applies to both GitHub and
@@ -110,7 +102,7 @@ export class ScmSettingsStore {
   }
 
   async setRepoSettings(repo: string, settings: ScmRepoSettings): Promise<void> {
-    const normalized = validateAndNormalizeScmRepoSettings(settings);
+    const normalized = validateAndNormalizeScmSettings(settings);
     await this.store.setRepoSettings(SCM_SETTINGS_KEY, repo, normalized);
   }
 

--- a/packages/control-plane/src/db/scm-settings.ts
+++ b/packages/control-plane/src/db/scm-settings.ts
@@ -47,6 +47,10 @@ function validateAndNormalizeScmSettings(settings: unknown): ScmSettings {
 
   const normalizedLabel =
     typeof pullRequestLabel === "string" ? pullRequestLabel.trim() : undefined;
+  if (normalizedLabel?.includes(",")) {
+    throw new ScmSettingsValidationError("pullRequestLabel must not contain commas");
+  }
+
   return {
     ...(alwaysUseDraftMode !== undefined ? { alwaysUseDraftMode } : {}),
     ...(normalizedLabel ? { pullRequestLabel: normalizedLabel } : {}),

--- a/packages/control-plane/src/db/scm-settings.ts
+++ b/packages/control-plane/src/db/scm-settings.ts
@@ -20,9 +20,9 @@ export class ScmSettingsValidationError extends Error {
   }
 }
 
-const ALLOWED_SCM_SETTING_KEYS = new Set(["alwaysUseDraftMode"]);
+const ALLOWED_SCM_SETTING_KEYS = new Set(["alwaysUseDraftMode", "pullRequestLabel"]);
 
-function validateScmSettings(settings: unknown): asserts settings is ScmSettings {
+function validateAndNormalizeScmSettings(settings: unknown): ScmSettings {
   if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
     throw new ScmSettingsValidationError("SCM settings must be an object");
   }
@@ -33,17 +33,32 @@ function validateScmSettings(settings: unknown): asserts settings is ScmSettings
     }
   }
 
-  const { alwaysUseDraftMode } = settings as { alwaysUseDraftMode?: unknown };
+  const { alwaysUseDraftMode, pullRequestLabel } = settings as {
+    alwaysUseDraftMode?: unknown;
+    pullRequestLabel?: unknown;
+  };
   if (alwaysUseDraftMode !== undefined && typeof alwaysUseDraftMode !== "boolean") {
     throw new ScmSettingsValidationError("alwaysUseDraftMode must be a boolean");
   }
+
+  if (pullRequestLabel !== undefined && typeof pullRequestLabel !== "string") {
+    throw new ScmSettingsValidationError("pullRequestLabel must be a string");
+  }
+
+  const normalizedLabel =
+    typeof pullRequestLabel === "string" ? pullRequestLabel.trim() : undefined;
+  return {
+    ...(alwaysUseDraftMode !== undefined ? { alwaysUseDraftMode } : {}),
+    ...(normalizedLabel ? { pullRequestLabel: normalizedLabel } : {}),
+  };
 }
 
-function validateScmRepoSettings(settings: unknown): asserts settings is ScmRepoSettings {
-  validateScmSettings(settings);
-  if (settings.alwaysUseDraftMode === undefined) {
+function validateAndNormalizeScmRepoSettings(settings: unknown): ScmRepoSettings {
+  const normalized = validateAndNormalizeScmSettings(settings);
+  if (normalized.alwaysUseDraftMode === undefined) {
     throw new ScmSettingsValidationError("alwaysUseDraftMode is required for repository overrides");
   }
+  return { ...normalized, alwaysUseDraftMode: normalized.alwaysUseDraftMode };
 }
 
 /**
@@ -75,10 +90,11 @@ export class ScmSettingsStore {
         throw new ScmSettingsValidationError(`Unknown SCM global setting: ${key}`);
       }
     }
-    if (config.defaults !== undefined) {
-      validateScmSettings(config.defaults);
-    }
-    await this.store.setGlobal(SCM_SETTINGS_KEY, config);
+    const normalized: ScmGlobalConfig =
+      config.defaults === undefined
+        ? {}
+        : { defaults: validateAndNormalizeScmSettings(config.defaults) };
+    await this.store.setGlobal(SCM_SETTINGS_KEY, normalized);
   }
 
   deleteGlobal(): Promise<void> {
@@ -90,8 +106,8 @@ export class ScmSettingsStore {
   }
 
   async setRepoSettings(repo: string, settings: ScmRepoSettings): Promise<void> {
-    validateScmRepoSettings(settings);
-    await this.store.setRepoSettings(SCM_SETTINGS_KEY, repo, settings);
+    const normalized = validateAndNormalizeScmRepoSettings(settings);
+    await this.store.setRepoSettings(SCM_SETTINGS_KEY, repo, normalized);
   }
 
   deleteRepoSettings(repo: string): Promise<void> {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -12,6 +12,7 @@ import { initSchema } from "./schema";
 import { clientMessageSchema } from "@open-inspect/shared/types/websocket";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
+import type { ScmSettings } from "@open-inspect/shared/types/integrations";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { DEFAULT_MODEL } from "@open-inspect/shared/models";
@@ -590,7 +591,7 @@ export class SessionDO extends DurableObject<Env> {
             messenger: this.messenger,
             appName: resolveAppName(this.env),
             sessionPullRequests: this.db ? new SessionPullRequestStore(this.db) : undefined,
-            resolveAlwaysDraftDefault: (repo) => this.resolveAlwaysDraftDefault(repo),
+            resolveScmSettings: (repo) => this.resolveScmSettings(repo),
           });
 
           return pullRequestService.createPullRequest(input);
@@ -650,18 +651,15 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Resolves the "always use draft mode" SCM setting (global default merged
-   * with the per-repo override) for the pull request's target repository.
-   * A deployment without D1 cannot have this policy configured, so it retains
-   * the ready-for-review default; storage failures propagate to fail closed.
+   * Resolves SCM settings (global defaults merged with the per-repo override)
+   * for the pull request's target repository. A deployment without D1 cannot
+   * have this policy configured, so it retains the built-in defaults; storage
+   * failures propagate to fail closed.
    */
-  private async resolveAlwaysDraftDefault(repo: RepoIdentity): Promise<boolean> {
-    if (!this.db) return false;
+  private async resolveScmSettings(repo: RepoIdentity): Promise<ScmSettings> {
+    if (!this.db) return {};
     const scmSettingsStore = new ScmSettingsStore(this.db);
-    const settings = await scmSettingsStore.getResolvedSettings(
-      `${repo.repoOwner}/${repo.repoName}`
-    );
-    return settings.alwaysUseDraftMode === true;
+    return scmSettingsStore.getResolvedSettings(`${repo.repoOwner}/${repo.repoName}`);
   }
 
   private get alarmHandler(): AlarmHandler {

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScmSettings } from "@open-inspect/shared/types/integrations";
 import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
 import * as branchResolution from "../source-control/branch-resolution";
@@ -124,7 +125,7 @@ function createRepositoryRow(overrides: Partial<SessionRepositoryRow> = {}): Ses
   };
 }
 
-function createTestHarness(options: { alwaysDraftDefault?: boolean } = {}) {
+function createTestHarness(options: { scmSettings?: ScmSettings } = {}) {
   const log = createMockLogger();
   const provider = createMockProvider();
   const artifacts: ArtifactRow[] = [];
@@ -182,7 +183,7 @@ function createTestHarness(options: { alwaysDraftDefault?: boolean } = {}) {
     messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
     appName: "Open-Inspect",
     sessionPullRequests,
-    resolveAlwaysDraftDefault: vi.fn(async () => options.alwaysDraftDefault ?? false),
+    resolveScmSettings: vi.fn(async () => options.scmSettings ?? {}),
   };
 
   const service = new SessionPullRequestService(deps);
@@ -345,7 +346,7 @@ describe("SessionPullRequestService", () => {
   });
 
   it("falls back to the always-draft default when draft is unspecified", async () => {
-    harness = createTestHarness({ alwaysDraftDefault: true });
+    harness = createTestHarness({ scmSettings: { alwaysUseDraftMode: true } });
 
     await harness.service.createPullRequest(createInput());
 
@@ -356,7 +357,7 @@ describe("SessionPullRequestService", () => {
   });
 
   it("forces draft when always-draft is enabled, even if the request sets draft=false", async () => {
-    harness = createTestHarness({ alwaysDraftDefault: true });
+    harness = createTestHarness({ scmSettings: { alwaysUseDraftMode: true } });
 
     await harness.service.createPullRequest(createInput({ draft: false }));
 
@@ -366,20 +367,29 @@ describe("SessionPullRequestService", () => {
     );
   });
 
-  it("fails before push when the draft policy cannot be resolved", async () => {
-    vi.mocked(harness.deps.resolveAlwaysDraftDefault).mockRejectedValueOnce(
-      new Error("D1 unavailable")
-    );
+  it("fails before push when SCM policy cannot be resolved", async () => {
+    vi.mocked(harness.deps.resolveScmSettings).mockRejectedValueOnce(new Error("D1 unavailable"));
 
     const result = await harness.service.createPullRequest(createInput());
 
     expect(result).toEqual({
       kind: "error",
       status: 503,
-      error: "Pull request draft policy is temporarily unavailable",
+      error: "Pull request policy is temporarily unavailable",
     });
     expect(harness.provider.generatePushAuth).not.toHaveBeenCalled();
     expect(harness.deps.pushBranchToRemote).not.toHaveBeenCalled();
+  });
+
+  it("passes the configured pull request label to the provider", async () => {
+    harness = createTestHarness({ scmSettings: { pullRequestLabel: "open-inspect" } });
+
+    await harness.service.createPullRequest(createInput());
+
+    expect(harness.provider.createPullRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ labels: ["open-inspect"] })
+    );
   });
 
   it("creates PR with OAuth token and stores PR artifact", async () => {
@@ -543,22 +553,24 @@ describe("SessionPullRequestService", () => {
       );
     });
 
-    it("resolves the draft policy for the target member repository", async () => {
-      vi.mocked(harness.deps.resolveAlwaysDraftDefault).mockImplementation(
-        async (repo) => repo.repoName === "backend"
+    it("resolves SCM policy for the target member repository", async () => {
+      vi.mocked(harness.deps.resolveScmSettings).mockImplementation(async (repo) =>
+        repo.repoName === "backend"
+          ? { alwaysUseDraftMode: true, pullRequestLabel: "backend-generated" }
+          : {}
       );
 
       await harness.service.createPullRequest(
         createInput({ repoOwner: "acme", repoName: "backend", draft: false })
       );
 
-      expect(harness.deps.resolveAlwaysDraftDefault).toHaveBeenCalledWith({
+      expect(harness.deps.resolveScmSettings).toHaveBeenCalledWith({
         repoOwner: "acme",
         repoName: "backend",
       });
       expect(harness.provider.createPullRequest).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ draft: true })
+        expect.objectContaining({ draft: true, labels: ["backend-generated"] })
       );
     });
 

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,5 +1,6 @@
 import { generateBranchName } from "@open-inspect/shared/git";
 import { toDisplayStatus } from "@open-inspect/shared";
+import type { ScmSettings } from "@open-inspect/shared/types/integrations";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,
@@ -128,11 +129,8 @@ export interface PullRequestServiceDeps {
    * deployment has no D1 binding; the write is best-effort either way.
    */
   sessionPullRequests?: Pick<SessionPullRequestStore, "upsert">;
-  /**
-   * Resolves the "always use draft mode" policy (global default merged with
-   * repo override) for the pull request's target repository.
-   */
-  resolveAlwaysDraftDefault: (repo: RepoIdentity) => Promise<boolean>;
+  /** Resolves SCM policy for the pull request's target repository. */
+  resolveScmSettings: (repo: RepoIdentity) => Promise<ScmSettings>;
 }
 
 /**
@@ -193,11 +191,11 @@ export class SessionPullRequestService {
         return this.duplicatePrError(targetRepo);
       }
 
-      let alwaysDraft: boolean;
+      let scmSettings: ScmSettings;
       try {
-        alwaysDraft = await this.deps.resolveAlwaysDraftDefault(targetRepo);
+        scmSettings = await this.deps.resolveScmSettings(targetRepo);
       } catch (error) {
-        this.deps.log.error("Failed to resolve pull request draft policy", {
+        this.deps.log.error("Failed to resolve pull request SCM policy", {
           repo_owner: targetRepo.repoOwner,
           repo_name: targetRepo.repoName,
           error: error instanceof Error ? error : String(error),
@@ -205,10 +203,10 @@ export class SessionPullRequestService {
         return {
           kind: "error",
           status: 503,
-          error: "Pull request draft policy is temporarily unavailable",
+          error: "Pull request policy is temporarily unavailable",
         };
       }
-      const draft = alwaysDraft || (input.draft ?? false);
+      const draft = scmSettings.alwaysUseDraftMode === true || (input.draft ?? false);
 
       let pushAuth: GitPushAuthContext;
       try {
@@ -315,6 +313,7 @@ export class SessionPullRequestService {
         sourceBranch: sanitizedHeadBranch,
         targetBranch: baseBranch,
         draft,
+        labels: scmSettings.pullRequestLabel ? [scmSettings.pullRequestLabel] : undefined,
       });
 
       const artifactId = this.deps.generateId();

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -546,6 +546,111 @@ describe("GitHubSourceControlProvider", () => {
       expect(sentBody.draft).toBe(true);
     });
 
+    it("adds an existing label without trying to create it", async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(makeResponse(prResponseBody, 201))
+        .mockResolvedValueOnce(makeResponse({ name: "open inspect" }))
+        .mockResolvedValueOnce(makeResponse([]));
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      await provider.createPullRequest(fakeAuth, {
+        repository: fakeRepository,
+        title: "Add feature",
+        body: "Body",
+        sourceBranch: "feature",
+        targetBranch: "main",
+        labels: ["open inspect"],
+      });
+
+      expect(mockFetchWithTimeout).toHaveBeenCalledTimes(3);
+      expect(mockFetchWithTimeout.mock.calls[1][0]).toMatch(
+        /\/repos\/acme\/web\/labels\/open%20inspect$/
+      );
+      expect(mockFetchWithTimeout.mock.calls[1][1]?.method).toBeUndefined();
+      expect(mockFetchWithTimeout.mock.calls[2][0]).toMatch(/\/issues\/7\/labels$/);
+      expect(JSON.parse(mockFetchWithTimeout.mock.calls[2][1]?.body as string)).toEqual({
+        labels: ["open inspect"],
+      });
+    });
+
+    it("creates a missing label before adding it to the pull request", async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(makeResponse(prResponseBody, 201))
+        .mockResolvedValueOnce(makeResponse({ message: "Not Found" }, 404))
+        .mockResolvedValueOnce(makeResponse({ name: "generated" }, 201))
+        .mockResolvedValueOnce(makeResponse([]));
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      await provider.createPullRequest(fakeAuth, {
+        repository: fakeRepository,
+        title: "Add feature",
+        body: "Body",
+        sourceBranch: "feature",
+        targetBranch: "main",
+        labels: ["generated"],
+      });
+
+      expect(mockFetchWithTimeout).toHaveBeenCalledTimes(4);
+      expect(mockFetchWithTimeout.mock.calls[2][0]).toMatch(/\/repos\/acme\/web\/labels$/);
+      expect(mockFetchWithTimeout.mock.calls[2][1]?.method).toBe("POST");
+      expect(JSON.parse(mockFetchWithTimeout.mock.calls[2][1]?.body as string)).toEqual({
+        name: "generated",
+        color: "ededed",
+      });
+      expect(mockFetchWithTimeout.mock.calls[3][0]).toMatch(/\/issues\/7\/labels$/);
+    });
+
+    it("confirms a concurrent label creation after a 422 response", async () => {
+      mockFetchWithTimeout
+        .mockResolvedValueOnce(makeResponse(prResponseBody, 201))
+        .mockResolvedValueOnce(makeResponse({ message: "Not Found" }, 404))
+        .mockResolvedValueOnce(makeResponse({ message: "Validation Failed" }, 422))
+        .mockResolvedValueOnce(makeResponse({ name: "generated" }))
+        .mockResolvedValueOnce(makeResponse([]));
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      await provider.createPullRequest(fakeAuth, {
+        repository: fakeRepository,
+        title: "Add feature",
+        body: "Body",
+        sourceBranch: "feature",
+        targetBranch: "main",
+        labels: ["generated"],
+      });
+
+      expect(mockFetchWithTimeout).toHaveBeenCalledTimes(5);
+      expect(mockFetchWithTimeout.mock.calls[3][0]).toMatch(/\/labels\/generated$/);
+      expect(mockFetchWithTimeout.mock.calls[4][0]).toMatch(/\/issues\/7\/labels$/);
+    });
+
+    it("logs an unconfirmed 422 label creation failure", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        mockFetchWithTimeout
+          .mockResolvedValueOnce(makeResponse(prResponseBody, 201))
+          .mockResolvedValueOnce(makeResponse({ message: "Not Found" }, 404))
+          .mockResolvedValueOnce(makeResponse({ message: "Validation Failed" }, 422))
+          .mockResolvedValueOnce(makeResponse({ message: "Not Found" }, 404))
+          .mockResolvedValueOnce(makeResponse([]));
+
+        const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+        await provider.createPullRequest(fakeAuth, {
+          repository: fakeRepository,
+          title: "Add feature",
+          body: "Body",
+          sourceBranch: "feature",
+          targetBranch: "main",
+          labels: ["generated"],
+        });
+
+        expect(warn).toHaveBeenCalledWith('Failed to create label "generated" in acme/web: 422');
+        expect(mockFetchWithTimeout.mock.calls[3][0]).toMatch(/\/labels\/generated$/);
+        expect(mockFetchWithTimeout.mock.calls[4][0]).toMatch(/\/issues\/7\/labels$/);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
     it("throws a SourceControlProviderError when PR creation fails", async () => {
       mockFetchWithTimeout.mockResolvedValueOnce(
         makeResponse("Validation failed: head branch does not exist", 422)

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -249,6 +249,12 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
 
     // Add labels if requested
     if (config.labels && config.labels.length > 0) {
+      await this.ensureLabels(
+        auth.token,
+        config.repository.owner,
+        config.repository.name,
+        config.labels
+      );
       await this.addLabels(
         auth.token,
         config.repository.owner,
@@ -619,6 +625,55 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       repoName: config.name,
       force,
     };
+  }
+
+  /** Ensure requested labels exist without generating repeated mutating 422 responses. */
+  private async ensureLabels(
+    accessToken: string,
+    owner: string,
+    repo: string,
+    labels: string[]
+  ): Promise<void> {
+    const encodedOwner = encodeURIComponent(owner);
+    const encodedRepo = encodeURIComponent(repo);
+    const headers = {
+      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": this.userAgent,
+    };
+
+    for (const label of labels) {
+      const labelUrl = `${GITHUB_API_BASE}/repos/${encodedOwner}/${encodedRepo}/labels/${encodeURIComponent(label)}`;
+      try {
+        const existing = await fetchWithTimeout(labelUrl, { headers });
+        if (existing.ok) continue;
+        if (existing.status !== 404) {
+          console.warn(`Failed to check label "${label}" in ${owner}/${repo}: ${existing.status}`);
+          continue;
+        }
+
+        const created = await fetchWithTimeout(
+          `${GITHUB_API_BASE}/repos/${encodedOwner}/${encodedRepo}/labels`,
+          {
+            method: "POST",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({ name: label, color: "ededed" }),
+          }
+        );
+        if (created.ok) continue;
+
+        // A concurrent creator can win between the GET and POST. Confirm the
+        // label now exists rather than treating every validation failure as a duplicate.
+        if (created.status === 422) {
+          const raced = await fetchWithTimeout(labelUrl, { headers });
+          if (raced.ok) continue;
+        }
+
+        console.warn(`Failed to create label "${label}" in ${owner}/${repo}: ${created.status}`);
+      } catch (error) {
+        console.warn(`Failed to ensure label "${label}" in ${owner}/${repo}:`, error);
+      }
+    }
   }
 
   /**

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -329,6 +329,46 @@ describe("GitLabSourceControlProvider", () => {
       expect(capturedBody?.title).toBe("Draft: WIP change");
     });
 
+    it("passes labels through GitLab merge request creation", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      mockFetch.mockImplementationOnce((_url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+        return Promise.resolve(
+          makeResponse({
+            iid: 6,
+            web_url: "https://gitlab.com/acme/web/-/merge_requests/6",
+            _links: { self: "https://gitlab.com/api/v4/projects/acme%2Fweb/merge_requests/6" },
+            state: "opened",
+            draft: false,
+            source_branch: "feature/labels",
+            target_branch: "main",
+          })
+        );
+      });
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      await provider.createPullRequest(
+        { authType: "pat", token: "user-token" },
+        {
+          repository: {
+            owner: "acme",
+            name: "web",
+            fullName: "acme/web",
+            defaultBranch: "main",
+            isPrivate: true,
+            providerRepoId: 42,
+          },
+          title: "Labelled change",
+          body: "",
+          sourceBranch: "feature/labels",
+          targetBranch: "main",
+          labels: ["generated", "agent"],
+        }
+      );
+
+      expect(capturedBody?.labels).toBe("generated,agent");
+    });
+
     it("does not double-prefix when title already starts with 'Draft: '", async () => {
       let capturedBody: Record<string, unknown> | undefined;
       mockFetch.mockImplementationOnce((_url: string, init: RequestInit) => {

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -36,6 +36,8 @@ export interface GitHubBotSettings {
 export interface ScmSettings {
   /** Always open pull/merge requests created by sessions as drafts. */
   alwaysUseDraftMode?: boolean;
+  /** Label applied to pull/merge requests created by sessions. */
+  pullRequestLabel?: string;
 }
 
 /** A repository override must choose an explicit value rather than inherit. */

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -40,10 +40,8 @@ export interface ScmSettings {
   pullRequestLabel?: string;
 }
 
-/** A repository override must choose an explicit value rather than inherit. */
-export interface ScmRepoSettings extends ScmSettings {
-  alwaysUseDraftMode: boolean;
-}
+/** Repository SCM settings are field-level overrides; omitted fields inherit globally. */
+export type ScmRepoSettings = ScmSettings;
 
 /** Overridable behavior settings for the Linear bot. Used at both global (defaults) and per-repo (overrides) levels. */
 export interface LinearBotSettings {

--- a/packages/web/src/components/settings/scm-settings.test.tsx
+++ b/packages/web/src/components/settings/scm-settings.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import type { ScmGlobalConfig, ScmRepoSettings } from "@open-inspect/shared";
+import type { EnrichedRepository, ScmGlobalConfig, ScmRepoSettings } from "@open-inspect/shared";
 import { getScmRepoSettingsPath, ScmSettingsPage } from "./scm-settings";
 
 expect.extend(matchers);
@@ -35,6 +35,34 @@ let globalData: unknown;
 let globalError: unknown;
 let repoSettingsData: unknown;
 let repoSettingsError: unknown;
+let availableReposData: EnrichedRepository[];
+
+function repo(fullName: string): EnrichedRepository {
+  const [owner, name] = fullName.split("/");
+  return {
+    id: 1,
+    owner,
+    name,
+    fullName,
+    private: false,
+    description: null,
+    defaultBranch: "main",
+    archived: false,
+  };
+}
+
+// Radix Select uses pointer-capture APIs that jsdom doesn't implement.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
 
 beforeEach(() => {
   globalData = {
@@ -47,6 +75,7 @@ beforeEach(() => {
     ] satisfies RepoSettingsEntry[],
   };
   repoSettingsError = undefined;
+  availableReposData = [];
   mutateMock.mockReset();
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
@@ -59,7 +88,7 @@ beforeEach(() => {
       return { data: repoSettingsData, error: repoSettingsError, isLoading: false };
     }
     if (key === "/api/repos") {
-      return { data: { repos: [] }, isLoading: false };
+      return { data: { repos: availableReposData }, isLoading: false };
     }
     return { data: undefined, isLoading: false };
   });
@@ -85,9 +114,10 @@ describe("getScmRepoSettingsPath", () => {
     const user = userEvent.setup();
     const { rerender } = render(<ScmSettingsPage />);
 
-    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
-    expect(screen.getAllByRole("checkbox")[0]).not.toBeChecked();
-    expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked();
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(
+      screen.getByRole("combobox", { name: "Draft mode override for acme/web" })
+    ).toHaveTextContent("Override: ready unless requested");
 
     globalData = { settings: { defaults: { alwaysUseDraftMode: true } } };
     repoSettingsData = {
@@ -96,12 +126,17 @@ describe("getScmRepoSettingsPath", () => {
     rerender(<ScmSettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
-      expect(screen.getAllByRole("checkbox")[1]).toBeChecked();
+      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(
+        screen.getByRole("combobox", { name: "Draft mode override for acme/web" })
+      ).toHaveTextContent("Override: always draft");
     });
 
-    await user.click(screen.getAllByRole("checkbox")[0]);
-    await user.click(screen.getAllByRole("checkbox")[1]);
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("combobox", { name: "Draft mode override for acme/web" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Override: ready unless requested" })
+    );
 
     globalData = { settings: { defaults: { alwaysUseDraftMode: true } } };
     repoSettingsData = {
@@ -109,8 +144,10 @@ describe("getScmRepoSettingsPath", () => {
     };
     rerender(<ScmSettingsPage />);
 
-    expect(screen.getAllByRole("checkbox")[0]).not.toBeChecked();
-    expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked();
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(
+      screen.getByRole("combobox", { name: "Draft mode override for acme/web" })
+    ).toHaveTextContent("Override: ready unless requested");
   });
 
   it("does not render editable controls when a required settings query fails", () => {
@@ -123,7 +160,9 @@ describe("getScmRepoSettingsPath", () => {
   });
 
   it("does not render editable controls for an unexpected settings response", () => {
-    repoSettingsData = { repos: [{ repo: "acme/web", settings: {} }] };
+    repoSettingsData = {
+      repos: [{ repo: "acme/web", settings: { alwaysUseDraftMode: "yes" } }],
+    };
 
     render(<ScmSettingsPage />);
 
@@ -141,7 +180,7 @@ describe("getScmRepoSettingsPath", () => {
       repos: [
         {
           repo: "acme/web",
-          settings: { alwaysUseDraftMode: false, pullRequestLabel: "repo-generated" },
+          settings: { pullRequestLabel: "repo-generated" },
         },
       ],
     };
@@ -154,6 +193,9 @@ describe("getScmRepoSettingsPath", () => {
     expect(
       screen.getByRole("textbox", { name: "Pull request label override for acme/web" })
     ).toHaveValue("repo-generated");
+    expect(
+      screen.getByRole("combobox", { name: "Draft mode override for acme/web" })
+    ).toHaveTextContent("Inherit global (ready unless requested)");
   });
 
   it("trims and saves the global pull request label", async () => {
@@ -181,6 +223,9 @@ describe("getScmRepoSettingsPath", () => {
   it("trims and saves a repository pull request label override", async () => {
     const user = userEvent.setup();
     fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    repoSettingsData = {
+      repos: [{ repo: "acme/web", settings: {} }],
+    };
     render(<ScmSettingsPage />);
 
     const input = screen.getByRole("textbox", {
@@ -194,8 +239,49 @@ describe("getScmRepoSettingsPath", () => {
       expect.objectContaining({
         method: "PUT",
         body: JSON.stringify({
-          settings: { alwaysUseDraftMode: false, pullRequestLabel: "repo-generated" },
+          settings: { pullRequestLabel: "repo-generated" },
         }),
+      })
+    );
+  });
+
+  it("saves an explicit repository draft override independently", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    repoSettingsData = {
+      repos: [{ repo: "acme/web", settings: {} }],
+    };
+    render(<ScmSettingsPage />);
+
+    await user.click(screen.getByRole("combobox", { name: "Draft mode override for acme/web" }));
+    await user.click(await screen.findByRole("option", { name: "Override: always draft" }));
+    await user.click(screen.getAllByRole("button", { name: "Save" })[1]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/scm-settings/repos/acme/web",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ settings: { alwaysUseDraftMode: true } }),
+      })
+    );
+  });
+
+  it("adds a repository override without snapshotting global settings", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    repoSettingsData = { repos: [] };
+    availableReposData = [repo("acme/api")];
+    render(<ScmSettingsPage />);
+
+    await user.click(screen.getByRole("combobox", { name: "Select a repository" }));
+    await user.click(await screen.findByRole("option", { name: "acme/api" }));
+    await user.click(screen.getByRole("button", { name: "Add Override" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/scm-settings/repos/acme/api",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ settings: {} }),
       })
     );
   });

--- a/packages/web/src/components/settings/scm-settings.test.tsx
+++ b/packages/web/src/components/settings/scm-settings.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { EnrichedRepository, ScmGlobalConfig, ScmRepoSettings } from "@open-inspect/shared";
+import { parseRepositoryFullName } from "@open-inspect/shared/types/repositories";
 import { getScmRepoSettingsPath, ScmSettingsPage } from "./scm-settings";
 
 expect.extend(matchers);
@@ -38,11 +39,12 @@ let repoSettingsError: unknown;
 let availableReposData: EnrichedRepository[];
 
 function repo(fullName: string): EnrichedRepository {
-  const [owner, name] = fullName.split("/");
+  const repository = parseRepositoryFullName(fullName);
+  if (!repository) throw new Error(`Invalid repository full name: ${fullName}`);
   return {
     id: 1,
-    owner,
-    name,
+    owner: repository.repoOwner,
+    name: repository.repoName,
     fullName,
     private: false,
     description: null,
@@ -270,15 +272,15 @@ describe("getScmRepoSettingsPath", () => {
     const user = userEvent.setup();
     fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
     repoSettingsData = { repos: [] };
-    availableReposData = [repo("acme/api")];
+    availableReposData = [repo("group/subgroup/repository")];
     render(<ScmSettingsPage />);
 
     await user.click(screen.getByRole("combobox", { name: "Select a repository" }));
-    await user.click(await screen.findByRole("option", { name: "acme/api" }));
+    await user.click(await screen.findByRole("option", { name: "group/subgroup/repository" }));
     await user.click(screen.getByRole("button", { name: "Add Override" }));
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/scm-settings/repos/acme/api",
+      "/api/scm-settings/repos/group%2Fsubgroup/repository",
       expect.objectContaining({
         method: "PUT",
         body: JSON.stringify({ settings: {} }),

--- a/packages/web/src/components/settings/scm-settings.test.tsx
+++ b/packages/web/src/components/settings/scm-settings.test.tsx
@@ -20,6 +20,8 @@ const { useSWRMock, mutateMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
 }));
 
+const fetchMock = vi.fn();
+
 vi.mock("swr", () => ({
   default: useSWRMock,
   mutate: mutateMock,
@@ -46,6 +48,8 @@ beforeEach(() => {
   };
   repoSettingsError = undefined;
   mutateMock.mockReset();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
   useSWRMock.mockReset();
   useSWRMock.mockImplementation((key: string) => {
     if (key === "/api/scm-settings") {
@@ -63,6 +67,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe("getScmRepoSettingsPath", () => {
@@ -124,5 +129,74 @@ describe("getScmRepoSettingsPath", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("Unable to load source control settings");
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("renders global and repository label settings", () => {
+    globalData = {
+      settings: {
+        defaults: { alwaysUseDraftMode: false, pullRequestLabel: "global-generated" },
+      },
+    };
+    repoSettingsData = {
+      repos: [
+        {
+          repo: "acme/web",
+          settings: { alwaysUseDraftMode: false, pullRequestLabel: "repo-generated" },
+        },
+      ],
+    };
+
+    render(<ScmSettingsPage />);
+
+    expect(screen.getByRole("textbox", { name: "Pull request label" })).toHaveValue(
+      "global-generated"
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Pull request label override for acme/web" })
+    ).toHaveValue("repo-generated");
+  });
+
+  it("trims and saves the global pull request label", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    render(<ScmSettingsPage />);
+
+    const input = screen.getByRole("textbox", { name: "Pull request label" });
+    await user.type(input, "  generated  ");
+    await user.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/scm-settings",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: { alwaysUseDraftMode: false, pullRequestLabel: "generated" },
+          },
+        }),
+      })
+    );
+  });
+
+  it("trims and saves a repository pull request label override", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    render(<ScmSettingsPage />);
+
+    const input = screen.getByRole("textbox", {
+      name: "Pull request label override for acme/web",
+    });
+    await user.type(input, "  repo-generated  ");
+    await user.click(screen.getAllByRole("button", { name: "Save" })[1]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/scm-settings/repos/acme/web",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          settings: { alwaysUseDraftMode: false, pullRequestLabel: "repo-generated" },
+        }),
+      })
+    );
   });
 });

--- a/packages/web/src/components/settings/scm-settings.tsx
+++ b/packages/web/src/components/settings/scm-settings.tsx
@@ -79,7 +79,7 @@ function isScmSettings(value: unknown): value is ScmSettings {
 }
 
 function isScmRepoSettings(value: unknown): value is ScmRepoSettings {
-  return isScmSettings(value) && typeof value.alwaysUseDraftMode === "boolean";
+  return isScmSettings(value);
 }
 
 function isGlobalResponse(value: unknown): value is GlobalResponse {
@@ -341,9 +341,7 @@ function RepoOverridesSection({
       const res = await browserApiFetch(settingsPath, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        // Seed the new override from the current global default so adding one
-        // doesn't silently flip a repo to draft when the global is off.
-        body: JSON.stringify({ settings: { alwaysUseDraftMode: globalDefault } }),
+        body: JSON.stringify({ settings: {} }),
       });
 
       if (res.ok) {
@@ -364,7 +362,12 @@ function RepoOverridesSection({
       {overrides.length > 0 ? (
         <div className="space-y-2 mb-4">
           {overrides.map((entry) => (
-            <RepoOverrideRow key={entry.repo} entry={entry} globalLabel={globalLabel} />
+            <RepoOverrideRow
+              key={entry.repo}
+              entry={entry}
+              globalDefault={globalDefault}
+              globalLabel={globalLabel}
+            />
           ))}
         </div>
       ) : (
@@ -375,7 +378,7 @@ function RepoOverridesSection({
 
       <div className="flex items-center gap-2">
         <Select value={addingRepo} onValueChange={setAddingRepo}>
-          <SelectTrigger className="flex-1">
+          <SelectTrigger className="flex-1" aria-label="Select a repository">
             <SelectValue placeholder="Select a repository..." />
           </SelectTrigger>
           <SelectContent>
@@ -394,24 +397,34 @@ function RepoOverridesSection({
   );
 }
 
+type DraftOverrideMode = "inherit" | "draft" | "ready";
+
+function deriveDraftOverrideMode(settings: ScmRepoSettings): DraftOverrideMode {
+  if (settings.alwaysUseDraftMode === undefined) return "inherit";
+  return settings.alwaysUseDraftMode ? "draft" : "ready";
+}
+
 function RepoOverrideRow({
   entry,
+  globalDefault,
   globalLabel,
 }: {
   entry: RepoSettingsEntry;
+  globalDefault: boolean;
   globalLabel?: string;
 }) {
-  const [alwaysUseDraftMode, setAlwaysUseDraftMode] = useState(entry.settings.alwaysUseDraftMode);
+  const [draftMode, setDraftMode] = useState<DraftOverrideMode>(() =>
+    deriveDraftOverrideMode(entry.settings)
+  );
   const [pullRequestLabel, setPullRequestLabel] = useState(entry.settings.pullRequestLabel ?? "");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
-    if (!dirty) {
-      setAlwaysUseDraftMode(entry.settings.alwaysUseDraftMode);
-      setPullRequestLabel(entry.settings.pullRequestLabel ?? "");
-    }
-  }, [entry.settings.alwaysUseDraftMode, entry.settings.pullRequestLabel, dirty]);
+    if (dirty || saving) return;
+    setDraftMode(deriveDraftOverrideMode(entry.settings));
+    setPullRequestLabel(entry.settings.pullRequestLabel ?? "");
+  }, [entry.settings, dirty, saving]);
 
   const handleSave = async () => {
     const settingsPath = getScmRepoSettingsPath(entry.repo);
@@ -419,10 +432,10 @@ function RepoOverrideRow({
     setSaving(true);
 
     const normalizedLabel = pullRequestLabel.trim();
-    const settings: ScmRepoSettings = {
-      alwaysUseDraftMode,
-      ...(normalizedLabel ? { pullRequestLabel: normalizedLabel } : {}),
-    };
+    const settings: ScmRepoSettings = {};
+    if (draftMode === "draft") settings.alwaysUseDraftMode = true;
+    if (draftMode === "ready") settings.alwaysUseDraftMode = false;
+    if (normalizedLabel) settings.pullRequestLabel = normalizedLabel;
 
     try {
       const res = await browserApiFetch(settingsPath, {
@@ -483,17 +496,26 @@ function RepoOverrideRow({
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        <label className="flex items-center gap-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
-            checked={alwaysUseDraftMode}
-            onChange={() => {
-              setAlwaysUseDraftMode(!alwaysUseDraftMode);
+        <label className="text-sm">
+          <span className="block text-muted-foreground mb-1">Draft mode override</span>
+          <Select
+            value={draftMode}
+            onValueChange={(value: DraftOverrideMode) => {
+              setDraftMode(value);
               setDirty(true);
             }}
-            className="rounded border-border"
-          />
-          <span className="text-muted-foreground">Always use draft mode</span>
+          >
+            <SelectTrigger density="compact" aria-label={`Draft mode override for ${entry.repo}`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inherit">
+                Inherit global ({globalDefault ? "always draft" : "ready unless requested"})
+              </SelectItem>
+              <SelectItem value="draft">Override: always draft</SelectItem>
+              <SelectItem value="ready">Override: ready unless requested</SelectItem>
+            </SelectContent>
+          </Select>
         </label>
 
         <label className="text-sm">

--- a/packages/web/src/components/settings/scm-settings.tsx
+++ b/packages/web/src/components/settings/scm-settings.tsx
@@ -38,6 +38,7 @@ import {
 const GLOBAL_SETTINGS_KEY = "/api/scm-settings";
 const REPO_SETTINGS_KEY = "/api/scm-settings/repos";
 const DEFAULT_ALWAYS_USE_DRAFT_MODE = false;
+const DEFAULT_PULL_REQUEST_LABEL = "";
 
 export function getScmRepoSettingsPath(fullName: string): `/api/${string}` | null {
   const repository = parseRepositoryFullName(fullName);
@@ -167,7 +168,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
     settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE
   );
   const [pullRequestLabel, setPullRequestLabel] = useState(
-    settings?.defaults?.pullRequestLabel ?? ""
+    settings?.defaults?.pullRequestLabel ?? DEFAULT_PULL_REQUEST_LABEL
   );
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -178,7 +179,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
       setAlwaysUseDraftMode(
         settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE
       );
-      setPullRequestLabel(settings?.defaults?.pullRequestLabel ?? "");
+      setPullRequestLabel(settings?.defaults?.pullRequestLabel ?? DEFAULT_PULL_REQUEST_LABEL);
     }
   }, [settings, dirty]);
 
@@ -193,7 +194,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
       if (res.ok) {
         await mutate(GLOBAL_SETTINGS_KEY);
         setAlwaysUseDraftMode(DEFAULT_ALWAYS_USE_DRAFT_MODE);
-        setPullRequestLabel("");
+        setPullRequestLabel(DEFAULT_PULL_REQUEST_LABEL);
         setDirty(false);
         toast.success("Settings reset to defaults.");
       } else {
@@ -416,14 +417,16 @@ function RepoOverrideRow({
   const [draftMode, setDraftMode] = useState<DraftOverrideMode>(() =>
     deriveDraftOverrideMode(entry.settings)
   );
-  const [pullRequestLabel, setPullRequestLabel] = useState(entry.settings.pullRequestLabel ?? "");
+  const [pullRequestLabel, setPullRequestLabel] = useState(
+    entry.settings.pullRequestLabel ?? DEFAULT_PULL_REQUEST_LABEL
+  );
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     if (dirty || saving) return;
     setDraftMode(deriveDraftOverrideMode(entry.settings));
-    setPullRequestLabel(entry.settings.pullRequestLabel ?? "");
+    setPullRequestLabel(entry.settings.pullRequestLabel ?? DEFAULT_PULL_REQUEST_LABEL);
   }, [entry.settings, dirty, saving]);
 
   const handleSave = async () => {

--- a/packages/web/src/components/settings/scm-settings.tsx
+++ b/packages/web/src/components/settings/scm-settings.tsx
@@ -16,6 +16,7 @@ import {
 import { IntegrationSettingsSkeleton } from "./integrations/integration-settings-skeleton";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -64,18 +65,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isScmSettings(value: unknown): value is ScmSettings {
+  if (!isRecord(value)) return false;
+  if (
+    Object.keys(value).some((key) => key !== "alwaysUseDraftMode" && key !== "pullRequestLabel")
+  ) {
+    return false;
+  }
+  return (
+    (value.alwaysUseDraftMode === undefined || typeof value.alwaysUseDraftMode === "boolean") &&
+    (value.pullRequestLabel === undefined || typeof value.pullRequestLabel === "string")
+  );
+}
+
+function isScmRepoSettings(value: unknown): value is ScmRepoSettings {
+  return isScmSettings(value) && typeof value.alwaysUseDraftMode === "boolean";
+}
+
 function isGlobalResponse(value: unknown): value is GlobalResponse {
   if (!isRecord(value) || !("settings" in value)) return false;
   if (value.settings === null) return true;
   if (!isRecord(value.settings)) return false;
   if (Object.keys(value.settings).some((key) => key !== "defaults")) return false;
   if (value.settings.defaults === undefined) return true;
-  if (!isRecord(value.settings.defaults)) return false;
-  return (
-    Object.keys(value.settings.defaults).every((key) => key === "alwaysUseDraftMode") &&
-    (value.settings.defaults.alwaysUseDraftMode === undefined ||
-      typeof value.settings.defaults.alwaysUseDraftMode === "boolean")
-  );
+  return isScmSettings(value.settings.defaults);
 }
 
 function isRepoListResponse(value: unknown): value is RepoListResponse {
@@ -84,11 +97,7 @@ function isRepoListResponse(value: unknown): value is RepoListResponse {
     Array.isArray(value.repos) &&
     value.repos.every(
       (entry) =>
-        isRecord(entry) &&
-        typeof entry.repo === "string" &&
-        isRecord(entry.settings) &&
-        Object.keys(entry.settings).every((key) => key === "alwaysUseDraftMode") &&
-        typeof entry.settings.alwaysUseDraftMode === "boolean"
+        isRecord(entry) && typeof entry.repo === "string" && isScmRepoSettings(entry.settings)
     )
   );
 }
@@ -140,12 +149,13 @@ export function ScmSettingsPage() {
 
       <Section
         title="Repository Overrides"
-        description="Override the draft default for specific repositories."
+        description="Override pull and merge request defaults for specific repositories."
       >
         <RepoOverridesSection
           overrides={repoOverrides}
           availableRepos={availableRepos}
           globalDefault={settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE}
+          globalLabel={settings?.defaults?.pullRequestLabel}
         />
       </Section>
     </div>
@@ -156,6 +166,9 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
   const [alwaysUseDraftMode, setAlwaysUseDraftMode] = useState(
     settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE
   );
+  const [pullRequestLabel, setPullRequestLabel] = useState(
+    settings?.defaults?.pullRequestLabel ?? ""
+  );
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
@@ -165,6 +178,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
       setAlwaysUseDraftMode(
         settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE
       );
+      setPullRequestLabel(settings?.defaults?.pullRequestLabel ?? "");
     }
   }, [settings, dirty]);
 
@@ -179,6 +193,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
       if (res.ok) {
         await mutate(GLOBAL_SETTINGS_KEY);
         setAlwaysUseDraftMode(DEFAULT_ALWAYS_USE_DRAFT_MODE);
+        setPullRequestLabel("");
         setDirty(false);
         toast.success("Settings reset to defaults.");
       } else {
@@ -195,7 +210,11 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
   const handleSave = async () => {
     setSaving(true);
 
-    const defaults: ScmSettings = { alwaysUseDraftMode };
+    const normalizedLabel = pullRequestLabel.trim();
+    const defaults: ScmSettings = {
+      alwaysUseDraftMode,
+      ...(normalizedLabel ? { pullRequestLabel: normalizedLabel } : {}),
+    };
     const body: ScmGlobalConfig = { defaults };
 
     try {
@@ -207,6 +226,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
 
       if (res.ok) {
         await mutate(GLOBAL_SETTINGS_KEY);
+        setPullRequestLabel(normalizedLabel);
         toast.success("Settings saved.");
         setDirty(false);
       } else {
@@ -245,6 +265,24 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
         </label>
       </div>
 
+      <div className="mb-4">
+        <label htmlFor="pull-request-label" className="block text-sm font-medium mb-1">
+          Pull request label
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Applied to pull and merge requests created by sessions. Leave blank to apply no label.
+        </p>
+        <Input
+          id="pull-request-label"
+          value={pullRequestLabel}
+          onChange={(event) => {
+            setPullRequestLabel(event.target.value);
+            setDirty(true);
+          }}
+          placeholder="e.g., open-inspect"
+        />
+      </div>
+
       <div className="flex items-center gap-2">
         <Button onClick={handleSave} disabled={saving || !dirty}>
           {saving ? "Saving..." : "Save"}
@@ -280,10 +318,12 @@ function RepoOverridesSection({
   overrides,
   availableRepos,
   globalDefault,
+  globalLabel,
 }: {
   overrides: RepoSettingsEntry[];
   availableRepos: EnrichedRepository[];
   globalDefault: boolean;
+  globalLabel?: string;
 }) {
   const [addingRepo, setAddingRepo] = useState("");
 
@@ -324,12 +364,12 @@ function RepoOverridesSection({
       {overrides.length > 0 ? (
         <div className="space-y-2 mb-4">
           {overrides.map((entry) => (
-            <RepoOverrideRow key={entry.repo} entry={entry} />
+            <RepoOverrideRow key={entry.repo} entry={entry} globalLabel={globalLabel} />
           ))}
         </div>
       ) : (
         <p className="text-sm text-muted-foreground mb-4">
-          No repository overrides yet. Add one to set the draft default per repo.
+          No repository overrides yet. Add one to customize pull and merge request defaults.
         </p>
       )}
 
@@ -354,23 +394,35 @@ function RepoOverridesSection({
   );
 }
 
-function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
+function RepoOverrideRow({
+  entry,
+  globalLabel,
+}: {
+  entry: RepoSettingsEntry;
+  globalLabel?: string;
+}) {
   const [alwaysUseDraftMode, setAlwaysUseDraftMode] = useState(entry.settings.alwaysUseDraftMode);
+  const [pullRequestLabel, setPullRequestLabel] = useState(entry.settings.pullRequestLabel ?? "");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
 
   useEffect(() => {
     if (!dirty) {
       setAlwaysUseDraftMode(entry.settings.alwaysUseDraftMode);
+      setPullRequestLabel(entry.settings.pullRequestLabel ?? "");
     }
-  }, [entry.settings.alwaysUseDraftMode, dirty]);
+  }, [entry.settings.alwaysUseDraftMode, entry.settings.pullRequestLabel, dirty]);
 
   const handleSave = async () => {
     const settingsPath = getScmRepoSettingsPath(entry.repo);
     if (!settingsPath) return;
     setSaving(true);
 
-    const settings: ScmRepoSettings = { alwaysUseDraftMode };
+    const normalizedLabel = pullRequestLabel.trim();
+    const settings: ScmRepoSettings = {
+      alwaysUseDraftMode,
+      ...(normalizedLabel ? { pullRequestLabel: normalizedLabel } : {}),
+    };
 
     try {
       const res = await browserApiFetch(settingsPath, {
@@ -381,6 +433,7 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
 
       if (res.ok) {
         await mutate(REPO_SETTINGS_KEY);
+        setPullRequestLabel(normalizedLabel);
         setDirty(false);
         toast.success(`Override for ${entry.repo} saved.`);
       } else {
@@ -416,9 +469,20 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
   };
 
   return (
-    <div className="flex items-center justify-between gap-2 px-4 py-3 border border-border rounded-sm">
-      <div className="flex items-center gap-3 flex-1 min-w-0">
+    <div className="px-4 py-3 border border-border rounded-sm space-y-3">
+      <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-foreground truncate">{entry.repo}</span>
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={handleSave} disabled={saving || !dirty}>
+            {saving ? "..." : "Save"}
+          </Button>
+          <Button variant="destructive" size="sm" onClick={handleDelete}>
+            Remove
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
         <label className="flex items-center gap-2 text-sm cursor-pointer">
           <input
             type="checkbox"
@@ -431,15 +495,22 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
           />
           <span className="text-muted-foreground">Always use draft mode</span>
         </label>
-      </div>
 
-      <div className="flex items-center gap-2">
-        <Button size="sm" onClick={handleSave} disabled={saving || !dirty}>
-          {saving ? "..." : "Save"}
-        </Button>
-        <Button variant="destructive" size="sm" onClick={handleDelete}>
-          Remove
-        </Button>
+        <label className="text-sm">
+          <span className="block text-muted-foreground mb-1">Pull request label override</span>
+          <Input
+            value={pullRequestLabel}
+            onChange={(event) => {
+              setPullRequestLabel(event.target.value);
+              setDirty(true);
+            }}
+            placeholder={globalLabel ? `Global: ${globalLabel}` : "No global label"}
+            aria-label={`Pull request label override for ${entry.repo}`}
+          />
+          <span className="block text-xs text-muted-foreground mt-1">
+            Leave blank to use the global default.
+          </span>
+        </label>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- add a user-defined pull/merge-request label to provider-neutral SCM settings, including global defaults and repository overrides
- resolve the effective SCM policy once for the canonical target repository before creating a pull request
- ensure missing GitHub labels with read-before-create behavior, confirm `422` races instead of treating every validation failure as success, and preserve GitLab label mapping
- add settings, resolution, multi-repository, GitHub, GitLab, and UI coverage

## Context

This supersedes #867 because the original contributor fork cannot be updated. Thank you to @kadams54 for the original feature and UX direction.

The replacement keeps session pull-request policy in the existing provider-neutral SCM settings model rather than GitHub Bot settings, and applies repository policy to the actual selected PR target in multi-repository sessions.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -w @open-inspect/control-plane` (155 files, 2,328 tests)
- `npm test -w @open-inspect/web` (115 files, 897 tests)
- `npm run build -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/web`

## Review

A thermo-nuclear maintainability review found one low-severity test-isolation issue in the new GitHub provider test. The warning spy is now restored in `finally`; the review found no other maintainability or scope issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable labels for session-created pull and merge requests.
  * Labels can be set globally or customized per repository, with blank values inheriting global defaults.
  * Repository draft-mode settings can now be managed independently from labels and global defaults.
  * Pull request creation supports labels across GitHub and GitLab.
  * GitHub creates missing labels when possible without blocking pull request creation.

* **Bug Fixes**
  * Improved handling of whitespace, invalid values, and label creation conflicts.
  * SCM settings failures now return a clear service-unavailable response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->