### PR TITLE
Adopt shared session, artifact, and API imports

### DIFF
--- a/packages/control-plane/src/auth/identity-enforcement.ts
+++ b/packages/control-plane/src/auth/identity-enforcement.ts
@@ -10,7 +10,7 @@
  */
 
 import type { AutomationEventSource } from "@open-inspect/shared/triggers";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { ServiceName } from "@open-inspect/shared/service-auth";
 import { createLogger } from "./../logger";
 import { CALLBACK_DESTINATIONS } from "./service/callback-signing";

--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -5,7 +5,7 @@ import type {
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
 } from "@open-inspect/shared/types/analytics";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { SqlDatabase } from "./sql-database";
 
 /** Spawn sources that represent direct human-initiated sessions. */

--- a/packages/control-plane/src/db/pull-request-analytics-store.ts
+++ b/packages/control-plane/src/db/pull-request-analytics-store.ts
@@ -11,7 +11,7 @@
  */
 
 import type { AnalyticsPullRequestsResponse } from "@open-inspect/shared/types/analytics";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { SqlDatabase, SqlResult } from "./sql-database";
 
 /** `now` anchors the open-inventory age computation. */

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -5,7 +5,7 @@ import type {
   SessionReadState,
   SessionStatus,
   SpawnSource,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/sessions";
 import type { SessionListRepository } from "@open-inspect/shared/types/repositories";
 import { SessionPullRequestStore } from "./session-pull-request-store";
 import type { SqlDatabase } from "./sql-database";

--- a/packages/control-plane/src/db/session-pull-request-store.ts
+++ b/packages/control-plane/src/db/session-pull-request-store.ts
@@ -1,4 +1,5 @@
-import type { PullRequestLifecycleState, PullRequestSummary } from "@open-inspect/shared";
+import type { PullRequestLifecycleState } from "@open-inspect/shared";
+import type { PullRequestSummary } from "@open-inspect/shared/types/sessions";
 import type { SqlDatabase } from "./sql-database";
 
 /**

--- a/packages/control-plane/src/db/session-pull-request-store.ts
+++ b/packages/control-plane/src/db/session-pull-request-store.ts
@@ -1,5 +1,5 @@
-import type { PullRequestLifecycleState } from "@open-inspect/shared";
 import type { PullRequestSummary } from "@open-inspect/shared/types/sessions";
+import type { PullRequestLifecycleState } from "@open-inspect/shared/types/artifacts";
 import type { SqlDatabase } from "./sql-database";
 
 /**

--- a/packages/control-plane/src/media.ts
+++ b/packages/control-plane/src/media.ts
@@ -1,4 +1,4 @@
-import { type VideoArtifactMetadata } from "@open-inspect/shared";
+import type { VideoArtifactMetadata } from "@open-inspect/shared/types/artifacts";
 import {
   SESSION_ATTACHMENT_IMAGE_MAX_BYTES,
   SESSION_ATTACHMENT_IMAGE_MIME_TYPES,

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -1,4 +1,4 @@
-import type { CreateSessionRequest } from "@open-inspect/shared";
+import type { CreateSessionRequest } from "@open-inspect/shared/types/session-api";
 import type { RepositoryRef } from "@open-inspect/shared/types/repositories";
 import type { Env } from "../types";
 import type { Logger } from "../logger";

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -1,4 +1,4 @@
-import { spawnChildSessionRequestSchema } from "@open-inspect/shared";
+import { spawnChildSessionRequestSchema } from "@open-inspect/shared/types/session-api";
 import {
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -1,9 +1,9 @@
 import {
   cancelChildSessionRequestSchema,
   childFollowUpPromptRequestSchema,
-  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   type CancelChildSessionRequest,
 } from "@open-inspect/shared/types/session-api";
+import { DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS } from "@open-inspect/shared/types/integrations";
 import { SessionIndexStore, type ChildAdmissionLease } from "../db/session-index";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -3,7 +3,7 @@ import {
   childFollowUpPromptRequestSchema,
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   type CancelChildSessionRequest,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-api";
 import { SessionIndexStore, type ChildAdmissionLease } from "../db/session-index";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -1,5 +1,6 @@
 import type { RepositoryRef, RepositoryPair } from "@open-inspect/shared/types/repositories";
 import { getValidModelOrDefault, isValidReasoningEffort } from "@open-inspect/shared/models";
+import type { CreateSessionResponse } from "@open-inspect/shared/types/session-api";
 import { generateId } from "../auth/crypto";
 import { resolveGitHubCredentialAuthority } from "../source-control/github-credential-authority";
 import { applyIdentityEnforcement, resolveCanonicalUserId } from "../auth/identity-enforcement";
@@ -12,7 +13,7 @@ import { parseCreateSessionInput } from "../session/create-session-input";
 import { initializeSession, type SessionInitInput } from "../session/initialize";
 import { resolveGitHubEnrichmentForRequest } from "../session/identity";
 import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
-import type { CreateSessionResponse, Env } from "../types";
+import type { Env } from "../types";
 import {
   normalizeOptionalRepositoryPair,
   RepositoryPairValidationError,

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -1,4 +1,4 @@
-import { sessionReadActionSchema, type SessionStatus } from "@open-inspect/shared";
+import { sessionReadActionSchema, type SessionStatus } from "@open-inspect/shared/types/sessions";
 import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { SessionIndexStore } from "../db/session-index";
 import {

--- a/packages/control-plane/src/routes/session-media-artifacts.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.ts
@@ -1,12 +1,12 @@
 import {
   sessionArtifactSchema,
-  type ArtifactResponse,
   type ScreenshotArtifactMetadata,
   type SessionArtifact,
   type VideoArtifactMetadata,
 } from "@open-inspect/shared/types/artifacts";
 import { z } from "zod";
 import { createLogger } from "../logger";
+import type { NormalizedArtifactResponse } from "../session/artifacts";
 import { SessionInternalPaths } from "../session/contracts";
 import type { ObjectStorage } from "../storage/object-storage";
 import { error } from "./shared";
@@ -21,10 +21,6 @@ const listArtifactsResponseSchema = z.object({
 const getArtifactResponseSchema = z.object({
   artifact: sessionArtifactSchema.nullable(),
 });
-
-export type NormalizedArtifactResponse = Omit<ArtifactResponse, "updatedAt"> & {
-  updatedAt: number;
-};
 
 /**
  * Reads a runtime response body as JSON, normalizing empty/non-JSON bodies to

--- a/packages/control-plane/src/routes/session-media-artifacts.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.ts
@@ -1,14 +1,14 @@
-import type {
-  ScreenshotArtifactMetadata,
-  SessionArtifact,
-  VideoArtifactMetadata,
-} from "@open-inspect/shared";
-import { sessionArtifactSchema } from "@open-inspect/shared";
+import {
+  sessionArtifactSchema,
+  type ArtifactResponse,
+  type ScreenshotArtifactMetadata,
+  type SessionArtifact,
+  type VideoArtifactMetadata,
+} from "@open-inspect/shared/types/artifacts";
 import { z } from "zod";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
 import type { ObjectStorage } from "../storage/object-storage";
-import type { ArtifactResponse } from "../types";
 import { error } from "./shared";
 import type { SessionRouteContext } from "./session-route";
 

--- a/packages/control-plane/src/routes/session-media-artifacts.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.ts
@@ -22,6 +22,10 @@ const getArtifactResponseSchema = z.object({
   artifact: sessionArtifactSchema.nullable(),
 });
 
+export type NormalizedArtifactResponse = Omit<ArtifactResponse, "updatedAt"> & {
+  updatedAt: number;
+};
+
 /**
  * Reads a runtime response body as JSON, normalizing empty/non-JSON bodies to
  * `null` so the schema boundary below rejects them instead of throwing.
@@ -35,7 +39,7 @@ async function readJsonBody(response: Response): Promise<unknown> {
  * tracking, so fall back to `createdAt` (the documented consumer rule) rather
  * than rejecting the response.
  */
-function toArtifactResponse(artifact: SessionArtifact): ArtifactResponse {
+function toArtifactResponse(artifact: SessionArtifact): NormalizedArtifactResponse {
   return { ...artifact, updatedAt: artifact.updatedAt ?? artifact.createdAt };
 }
 
@@ -119,7 +123,7 @@ export async function persistMediaArtifact(input: {
 export async function listSessionArtifactsFromRuntime(
   sessionId: string,
   ctx: SessionRouteContext
-): Promise<ArtifactResponse[] | Response> {
+): Promise<NormalizedArtifactResponse[] | Response> {
   const response = await ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.artifacts);
   if (!response.ok) {
     return response.status === 404
@@ -136,7 +140,7 @@ export async function getSessionArtifactFromRuntime(
   sessionId: string,
   artifactId: string,
   ctx: SessionRouteContext
-): Promise<ArtifactResponse | null | Response> {
+): Promise<NormalizedArtifactResponse | null | Response> {
   const response = await ctx.sessionRuntime.fetch(
     sessionId,
     SessionInternalPaths.artifacts,

--- a/packages/control-plane/src/routes/session-media-artifacts.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.ts
@@ -1,4 +1,5 @@
 import {
+  listArtifactsResponseSchema,
   sessionArtifactSchema,
   type ScreenshotArtifactMetadata,
   type SessionArtifact,
@@ -13,10 +14,6 @@ import { error } from "./shared";
 import type { SessionRouteContext } from "./session-route";
 
 const logger = createLogger("router:session-media");
-
-const listArtifactsResponseSchema = z.object({
-  artifacts: z.array(sessionArtifactSchema),
-});
 
 const getArtifactResponseSchema = z.object({
   artifact: sessionArtifactSchema.nullable(),

--- a/packages/control-plane/src/routes/session-media-stream.ts
+++ b/packages/control-plane/src/routes/session-media-stream.ts
@@ -1,7 +1,8 @@
 import { createLogger } from "../logger";
+import type { ArtifactResponse } from "@open-inspect/shared/types/artifacts";
 import { isSupportedScreenshotMimeType, isSupportedVideoMimeType } from "../media";
 import { createMediaObjectStorage, type ObjectStorageMetadata } from "../storage/object-storage";
-import type { ArtifactResponse, Env } from "../types";
+import type { Env } from "../types";
 import { parseByteRangeHeader, type ByteRange } from "./requests/byte-range";
 import {
   createPartialStoredObjectResponse,

--- a/packages/control-plane/src/routes/session-media-stream.ts
+++ b/packages/control-plane/src/routes/session-media-stream.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "../logger";
 import { isSupportedScreenshotMimeType, isSupportedVideoMimeType } from "../media";
+import type { NormalizedArtifactResponse } from "../session/artifacts";
 import { createMediaObjectStorage, type ObjectStorageMetadata } from "../storage/object-storage";
 import type { Env } from "../types";
 import { parseByteRangeHeader, type ByteRange } from "./requests/byte-range";
@@ -8,10 +9,7 @@ import {
   createRangeNotSatisfiableResponse,
   createStoredObjectResponse,
 } from "./responses/stored-object-response";
-import {
-  getSessionArtifactFromRuntime,
-  type NormalizedArtifactResponse,
-} from "./session-media-artifacts";
+import { getSessionArtifactFromRuntime } from "./session-media-artifacts";
 import { error, parsePattern, type Route } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";
 export { parseByteRangeHeader } from "./requests/byte-range";

--- a/packages/control-plane/src/routes/session-media-stream.ts
+++ b/packages/control-plane/src/routes/session-media-stream.ts
@@ -1,5 +1,4 @@
 import { createLogger } from "../logger";
-import type { ArtifactResponse } from "@open-inspect/shared/types/artifacts";
 import { isSupportedScreenshotMimeType, isSupportedVideoMimeType } from "../media";
 import { createMediaObjectStorage, type ObjectStorageMetadata } from "../storage/object-storage";
 import type { Env } from "../types";
@@ -9,7 +8,10 @@ import {
   createRangeNotSatisfiableResponse,
   createStoredObjectResponse,
 } from "./responses/stored-object-response";
-import { getSessionArtifactFromRuntime } from "./session-media-artifacts";
+import {
+  getSessionArtifactFromRuntime,
+  type NormalizedArtifactResponse,
+} from "./session-media-artifacts";
 import { error, parsePattern, type Route } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";
 export { parseByteRangeHeader } from "./requests/byte-range";
@@ -17,7 +19,7 @@ export { parseByteRangeHeader } from "./requests/byte-range";
 const logger = createLogger("router:session-media");
 
 function getMediaMimeType(
-  artifact: ArtifactResponse
+  artifact: NormalizedArtifactResponse
 ): "image/png" | "image/jpeg" | "image/webp" | "video/mp4" | null {
   const mimeType = artifact.metadata?.mimeType;
   if (typeof mimeType !== "string") return null;
@@ -34,7 +36,7 @@ function getStoredContentType(metadata: ObjectStorageMetadata): string | null {
 }
 
 function resolveMediaContentType(
-  artifact: ArtifactResponse,
+  artifact: NormalizedArtifactResponse,
   metadata: ObjectStorageMetadata
 ): string | null {
   const storedContentType = getStoredContentType(metadata);

--- a/packages/control-plane/src/routes/session-media-upload.ts
+++ b/packages/control-plane/src/routes/session-media-upload.ts
@@ -1,4 +1,7 @@
-import type { ScreenshotArtifactMetadata, VideoArtifactMetadata } from "@open-inspect/shared";
+import type {
+  ScreenshotArtifactMetadata,
+  VideoArtifactMetadata,
+} from "@open-inspect/shared/types/artifacts";
 import { generateId } from "../auth/crypto";
 import {
   buildMediaObjectKey,

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -2,7 +2,7 @@ import {
   callbackContextSchema,
   sendPromptRequestSchema,
   type CallbackContext,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-api";
 import {
   MAX_SESSION_ATTACHMENTS_PER_MESSAGE,
   sessionAttachmentReferencesSchema,

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -2,7 +2,7 @@ import { applyIdentityEnforcement } from "../auth/identity-enforcement";
 import type {
   SessionParticipantProfilesResponse,
   SessionParticipantProfile,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/sessions";
 import { z } from "zod";
 import { UserStore } from "../db/user-store";
 import { SessionInternalPaths, type SessionInternalPath } from "../session/contracts";

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionStatus } from "@open-inspect/shared";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { SECTION_TEXT_MAX_CHARS } from "@open-inspect/shared/slack";
 import { handleSlackNotify } from "./slack-notify";
 import type { RequestContext } from "./shared";

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -9,7 +9,7 @@
  * then executes the appropriate side effects (API calls, broadcasts, etc.)
  */
 
-import type { SandboxStatus } from "../../types";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 
 // ==================== Dead-Sandbox Policy ====================
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -36,7 +36,7 @@ import {
   type StopResult,
 } from "../provider";
 import type { SandboxRow, SessionRow } from "../../session/types";
-import type { SandboxStatus } from "../../types";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 
 // ==================== Mock Factories ====================
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -12,7 +12,7 @@
 
 import type { McpServerConfig, SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { extractProviderAndModel } from "@open-inspect/shared/models";
-import type { SandboxStatus } from "../../types";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { sessionHasRepository, type SandboxRow, type SessionRow } from "../../session/types";
 import {
   SandboxProviderError,

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -20,7 +20,10 @@ import {
 } from "@open-inspect/shared/triggers";
 import { nextCronOccurrence } from "@open-inspect/shared/cron";
 import type { AutomationInvocationSource } from "@open-inspect/shared/types/automations";
-import type { AutomationCallbackContext, SlackCallbackContext } from "@open-inspect/shared";
+import type {
+  AutomationCallbackContext,
+  SlackCallbackContext,
+} from "@open-inspect/shared/types/session-api";
 import { computeHmacHex } from "@open-inspect/shared/auth";
 import { z } from "zod";
 import { callbackSigningSecret } from "../auth/service/callback-signing";

--- a/packages/control-plane/src/session/artifacts.ts
+++ b/packages/control-plane/src/session/artifacts.ts
@@ -1,4 +1,8 @@
-import type { ArtifactType } from "@open-inspect/shared/types/artifacts";
+import type { ArtifactResponse, ArtifactType } from "@open-inspect/shared/types/artifacts";
+
+export type NormalizedArtifactResponse = Omit<ArtifactResponse, "updatedAt"> & {
+  updatedAt: number;
+};
 
 const VALID_ARTIFACT_TYPES = [
   "pr",

--- a/packages/control-plane/src/session/artifacts.ts
+++ b/packages/control-plane/src/session/artifacts.ts
@@ -1,4 +1,4 @@
-import type { ArtifactType } from "../types";
+import type { ArtifactType } from "@open-inspect/shared/types/artifacts";
 
 const VALID_ARTIFACT_TYPES = [
   "pr",

--- a/packages/control-plane/src/session/create-session-input.ts
+++ b/packages/control-plane/src/session/create-session-input.ts
@@ -1,6 +1,7 @@
-import { createSessionInputSchema, type CreateSessionInput } from "@open-inspect/shared";
-
-export type { CreateSessionInput };
+import {
+  createSessionInputSchema,
+  type CreateSessionInput,
+} from "@open-inspect/shared/types/session-api";
 
 export type CreateSessionInputParseResult =
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -54,12 +54,7 @@ import {
   type SourceControlProvider,
   type GitPushSpec,
 } from "../source-control";
-import type {
-  Env,
-  ClientInfo,
-  ServerMessage,
-  SessionRepositoryState,
-} from "../types";
+import type { Env, ClientInfo, ServerMessage, SessionRepositoryState } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -15,6 +15,7 @@ import {
   type SessionSnapshotState,
 } from "@open-inspect/shared/types/server-messages";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import type { ScmSettings } from "@open-inspect/shared/types/integrations";
 import { resolveAppName } from "@open-inspect/shared/app-name";
@@ -58,7 +59,6 @@ import type {
   ClientInfo,
   ServerMessage,
   SessionRepositoryState,
-  SandboxStatus,
 } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";

--- a/packages/control-plane/src/session/enqueue-prompt-contract.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.ts
@@ -1,4 +1,4 @@
-import { messageSourceSchema } from "@open-inspect/shared";
+import { messageSourceSchema } from "@open-inspect/shared/types/sessions";
 import { sessionAttachmentReferencesSchema } from "@open-inspect/shared/types/session-attachments";
 import { z } from "zod";
 

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -1,9 +1,9 @@
-import {
-  type ChildSessionDetail,
-  type ChildSessionFinalResponse,
-  type ChildSessionTrajectory,
-} from "@open-inspect/shared";
 import type { ArtifactInfo } from "@open-inspect/shared/types/artifacts";
+import type {
+  ChildSessionDetail,
+  ChildSessionFinalResponse,
+  ChildSessionTrajectory,
+} from "@open-inspect/shared/types/session-api";
 import type { EventResponse } from "@open-inspect/shared/types/sandbox-events";
 import {
   buildAgentResponseFromEvents,

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -1,9 +1,9 @@
 import {
-  type ArtifactInfo,
   type ChildSessionDetail,
   type ChildSessionFinalResponse,
   type ChildSessionTrajectory,
 } from "@open-inspect/shared";
+import type { ArtifactInfo } from "@open-inspect/shared/types/artifacts";
 import type { EventResponse } from "@open-inspect/shared/types/sandbox-events";
 import {
   buildAgentResponseFromEvents,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { MAX_CHILD_FOLLOW_UP_PROMPT_CHARS } from "@open-inspect/shared";
+import { MAX_CHILD_FOLLOW_UP_PROMPT_CHARS } from "@open-inspect/shared/types/session-api";
 import { createChildSessionsHandler, MAX_PENDING_CHILD_PROMPTS } from "./child-sessions.handler";
 import { SessionNotPromptableError } from "../../message-queue";
 import {

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,4 +1,4 @@
-import { childFollowUpPromptRequestSchema } from "@open-inspect/shared";
+import { childFollowUpPromptRequestSchema } from "@open-inspect/shared/types/session-api";
 import { z } from "zod";
 import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { parsePersistedSandboxSettings } from "../../../sandbox/settings";

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,6 +1,6 @@
 import { childFollowUpPromptRequestSchema } from "@open-inspect/shared";
 import { z } from "zod";
-import type { SessionStatus } from "../../../types";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { parsePersistedSandboxSettings } from "../../../sandbox/settings";
 import type { SessionMessenger } from "../../messenger";
 import { isPromptableSessionStatus, SessionNotPromptableError } from "../../message-queue";

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -2,7 +2,7 @@ import type { Logger } from "../../../logger";
 import {
   createMediaArtifactRequestSchema,
   type CreateMediaArtifactRequest,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-api";
 import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { ParticipantRole } from "@open-inspect/shared/types/sessions";

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -2,8 +2,8 @@ import type { Logger } from "../../../logger";
 import {
   createMediaArtifactRequestSchema,
   type CreateMediaArtifactRequest,
-  type SessionArtifact,
 } from "@open-inspect/shared";
+import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { ParticipantRole } from "@open-inspect/shared/types/sessions";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -5,7 +5,7 @@ import {
   type SessionArtifact,
 } from "@open-inspect/shared";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
-import type { ParticipantRole } from "../../../types";
+import type { ParticipantRole } from "@open-inspect/shared/types/sessions";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { XaiTokenRefreshResult } from "../../xai-token-refresh-service";

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -3,7 +3,11 @@ import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import type { RepositoryRef } from "@open-inspect/shared/types/repositories";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { getValidModelOrDefault, isValidModel } from "@open-inspect/shared/models";
-import type { SandboxStatus, SessionStatus, SpawnSource } from "../../../types";
+import type {
+  SandboxStatus,
+  SessionStatus,
+  SpawnSource,
+} from "@open-inspect/shared/types/sessions";
 import type { SessionRepository } from "../../repository";
 import type { SessionStatusService } from "../../session-status-service";
 import {

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import type { RequestContext } from "../routes/shared";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { RepositoryRef } from "@open-inspect/shared/types/repositories";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { SessionIndexStore } from "../db/session-index";

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -12,7 +12,8 @@ import {
   isValidModel,
 } from "@open-inspect/shared/models";
 import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
-import type { ClientInfo, MessageSource } from "../types";
+import type { MessageSource } from "@open-inspect/shared/types/sessions";
+import type { ClientInfo } from "../types";
 import type { SourceControlProviderName } from "../source-control";
 import type { AlarmScheduler, SandboxLifecycle } from "../sandbox/lifecycle/manager";
 import type { ParticipantRow, PromptGitIdentity, SandboxCommand, SessionRow } from "./types";

--- a/packages/control-plane/src/session/pull-request-refresh.ts
+++ b/packages/control-plane/src/session/pull-request-refresh.ts
@@ -10,7 +10,7 @@
  * and per-artifact failures — and the caller broadcasts and logs them.
  */
 
-import type { SessionArtifact } from "@open-inspect/shared";
+import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import type { SessionPullRequestStore } from "../db/session-pull-request-store";
 import type { PullRequestSnapshot, SourceControlProvider } from "../source-control";
 import {

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,6 +1,6 @@
 import { generateBranchName } from "@open-inspect/shared/git";
-import { toDisplayStatus } from "@open-inspect/shared";
 import type { ScmSettings } from "@open-inspect/shared/types/integrations";
+import { toDisplayStatus } from "@open-inspect/shared/types/artifacts";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,

--- a/packages/control-plane/src/session/pull-request-snapshot.ts
+++ b/packages/control-plane/src/session/pull-request-snapshot.ts
@@ -12,7 +12,7 @@
  * broadcast they prescribe.
  */
 
-import { toDisplayStatus, type SessionArtifact } from "@open-inspect/shared";
+import { toDisplayStatus, type SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { z } from "zod";
 import type { SessionPullRequestRecord } from "../db/session-pull-request-store";
 import type { UpdateArtifactData } from "./repository";

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -24,8 +24,8 @@ import type {
   MessageSource,
   ParticipantRole,
   SpawnSource,
-  ArtifactType,
-} from "../types";
+} from "@open-inspect/shared/types/sessions";
+import type { ArtifactType } from "../types";
 import {
   eventTimelineCursorFromRow,
   type EventListCursor,

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -25,7 +25,7 @@ import type {
   ParticipantRole,
   SpawnSource,
 } from "@open-inspect/shared/types/sessions";
-import type { ArtifactType } from "../types";
+import type { ArtifactType } from "@open-inspect/shared/types/artifacts";
 import {
   eventTimelineCursorFromRow,
   type EventListCursor,

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -1,4 +1,4 @@
-import type { SessionArtifact } from "@open-inspect/shared";
+import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { generateId } from "../auth/crypto";
 import type { Logger } from "../logger";
 import type { GitPushSpec } from "../source-control";

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,7 +1,7 @@
 import type { ArtifactRow } from "../types";
 import type { SessionMessage } from "@open-inspect/shared/types/sessions";
-import type { ArtifactResponse } from "@open-inspect/shared/types/artifacts";
 import type { ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
+import type { NormalizedArtifactResponse } from "../artifacts";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 import type { EnqueuePromptRequest } from "../enqueue-prompt-contract";
@@ -45,16 +45,7 @@ export class MessageService {
     return this.eventStream.listEvents(request);
   }
 
-  listArtifacts(): {
-    artifacts: Array<{
-      id: string;
-      type: ArtifactRow["type"];
-      url: string | null;
-      metadata: Record<string, unknown> | null;
-      createdAt: number;
-      updatedAt: number;
-    }>;
-  } {
+  listArtifacts(): { artifacts: NormalizedArtifactResponse[] } {
     const artifacts = this.deps.repository.listArtifacts();
     return {
       artifacts: artifacts.map((artifact) => ({
@@ -68,7 +59,7 @@ export class MessageService {
     };
   }
 
-  getArtifact(artifactId: string): { artifact: ArtifactResponse | null } {
+  getArtifact(artifactId: string): { artifact: NormalizedArtifactResponse | null } {
     const artifact = this.deps.repository.getArtifactById(artifactId);
     if (!artifact) {
       return { artifact: null };

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,5 +1,5 @@
 import type { ArtifactRow } from "../types";
-import type { SessionMessage } from "@open-inspect/shared";
+import type { SessionMessage } from "@open-inspect/shared/types/sessions";
 import type { ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
 import type { ArtifactResponse } from "../../types";
 import type { SessionRepository } from "../repository";

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,7 +1,7 @@
 import type { ArtifactRow } from "../types";
 import type { SessionMessage } from "@open-inspect/shared/types/sessions";
+import type { ArtifactResponse } from "@open-inspect/shared/types/artifacts";
 import type { ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
-import type { ArtifactResponse } from "../../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 import type { EnqueuePromptRequest } from "../enqueue-prompt-contract";

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -11,7 +11,7 @@
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import type { Logger } from "../logger";
 import type { SessionIndexStore } from "../db/session-index";
-import type { SessionStatus } from "../types";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import type { SessionRow } from "./types";
 import type { SessionRepository } from "./repository";
 import type { SessionMessenger } from "./messenger";

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -2,7 +2,7 @@
  * Session-specific type definitions.
  */
 
-import type { ResolvedSessionAttachment, ArtifactType } from "../types";
+import type { ResolvedSessionAttachment } from "../types";
 import type {
   SessionStatus,
   SandboxStatus,
@@ -11,6 +11,7 @@ import type {
   ParticipantRole,
   SpawnSource,
 } from "@open-inspect/shared/types/sessions";
+import type { ArtifactType } from "@open-inspect/shared/types/artifacts";
 import type { EventType, GitSyncStatus } from "@open-inspect/shared/types/sandbox-events";
 import type { GitPushSpec } from "../source-control";
 

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -2,16 +2,15 @@
  * Session-specific type definitions.
  */
 
+import type { ResolvedSessionAttachment, ArtifactType } from "../types";
 import type {
-  ResolvedSessionAttachment,
   SessionStatus,
   SandboxStatus,
   MessageStatus,
   MessageSource,
   ParticipantRole,
   SpawnSource,
-  ArtifactType,
-} from "../types";
+} from "@open-inspect/shared/types/sessions";
 import type { EventType, GitSyncStatus } from "@open-inspect/shared/types/sandbox-events";
 import type { GitPushSpec } from "../source-control";
 

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import type { InstallationRepository } from "@open-inspect/shared/types/repository-catalog";
-import type { PullRequestStatus } from "@open-inspect/shared";
+import type { PullRequestStatus } from "@open-inspect/shared/types/artifacts";
 import type {
   SourceControlProvider,
   SourceControlAuthContext,

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import type { InstallationRepository } from "@open-inspect/shared/types/repository-catalog";
-import type { PullRequestStatus } from "@open-inspect/shared";
+import type { PullRequestStatus } from "@open-inspect/shared/types/artifacts";
 import type {
   SourceControlProvider,
   SourceControlAuthContext,

--- a/packages/control-plane/src/source-control/types.ts
+++ b/packages/control-plane/src/source-control/types.ts
@@ -5,7 +5,7 @@
  */
 
 import type { InstallationRepository } from "@open-inspect/shared/types/repository-catalog";
-import type { PullRequestLifecycleState } from "@open-inspect/shared";
+import type { PullRequestLifecycleState } from "@open-inspect/shared/types/artifacts";
 
 /**
  * Repository information.

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -11,12 +11,7 @@ import type {
 import { z } from "zod";
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
 
-export type {
-  CreateSessionRequest,
-  CreateSessionResponse,
-  ParticipantPresence,
-  SessionState,
-} from "@open-inspect/shared";
+export type { ParticipantPresence, SessionState } from "@open-inspect/shared";
 export type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
 export type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 export type {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -2,13 +2,13 @@
  * Type definitions for Open-Inspect Control Plane.
  */
 
+import type { ArtifactType } from "@open-inspect/shared";
 import type {
-  ArtifactType,
   MessageSource,
   MessageStatus,
   ParticipantRole,
   SessionStatus,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/sessions";
 import { z } from "zod";
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
 
@@ -16,14 +16,8 @@ export type {
   ArtifactType,
   CreateSessionRequest,
   CreateSessionResponse,
-  MessageSource,
-  MessageStatus,
-  ParticipantRole,
   ParticipantPresence,
-  SpawnSource,
-  SandboxStatus,
   SessionState,
-  SessionStatus,
 } from "@open-inspect/shared";
 export type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
 export type { ServerMessage } from "@open-inspect/shared/types/server-messages";

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -2,7 +2,6 @@
  * Type definitions for Open-Inspect Control Plane.
  */
 
-import type { ArtifactType } from "@open-inspect/shared";
 import type {
   MessageSource,
   MessageStatus,
@@ -13,7 +12,6 @@ import { z } from "zod";
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
 
 export type {
-  ArtifactType,
   CreateSessionRequest,
   CreateSessionResponse,
   ParticipantPresence,
@@ -174,15 +172,6 @@ export interface MessageResponse {
   createdAt: number;
   startedAt: number | null;
   completedAt: number | null;
-}
-
-export interface ArtifactResponse {
-  id: string;
-  type: ArtifactType;
-  url: string | null;
-  metadata: Record<string, unknown> | null;
-  createdAt: number;
-  updatedAt: number;
 }
 
 export interface ParticipantResponse {

--- a/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
+++ b/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
@@ -19,7 +19,7 @@ import type {
   GitHubAutomationEvent,
   GitHubPullRequestEventFacts,
 } from "@open-inspect/shared/triggers";
-import type { PullRequestStatus } from "@open-inspect/shared";
+import type { PullRequestStatus } from "@open-inspect/shared/types/artifacts";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -5,7 +5,7 @@ import type {
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
 } from "@open-inspect/shared/types/analytics";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
 import { serviceFetch } from "./helpers";

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { env } from "cloudflare:test";
 import { cleanD1Tables } from "./cleanup";
 import { initSession, queryDO, seedEvents } from "./helpers";
-import type { ChildSessionDetail } from "@open-inspect/shared";
+import type { ChildSessionDetail } from "@open-inspect/shared/types/session-api";
 import type { SpawnContext } from "../../src/session/spawn-context";
 
 const originalFetch = globalThis.fetch;

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -1,7 +1,7 @@
 import { SELF, env, runInDurableObject } from "cloudflare:test";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
-import type { SandboxStatus } from "../../src/types";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import type { SessionDO } from "../../src/session/durable-object";
 import { hashToken } from "../../src/auth/crypto";
 

--- a/packages/control-plane/test/integration/pull-request-analytics.test.ts
+++ b/packages/control-plane/test/integration/pull-request-analytics.test.ts
@@ -8,7 +8,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
 import type { AnalyticsPullRequestsResponse } from "@open-inspect/shared/types/analytics";
-import type { SpawnSource } from "@open-inspect/shared";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import { SessionIndexStore } from "../../src/db/session-index";
 import {
   SessionPullRequestStore,

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,8 +1,8 @@
+import { escapeRegExp } from "@open-inspect/shared";
 import {
   createSessionResponseSchema,
-  escapeRegExp,
   sendPromptResponseSchema,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-api";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { signedControlPlaneFetch } from "./internal-auth";
 import type {

--- a/packages/linear-bot/src/callbacks/start-callback.ts
+++ b/packages/linear-bot/src/callbacks/start-callback.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { linearStartCallbackSchema } from "@open-inspect/shared";
+import { linearStartCallbackSchema } from "@open-inspect/shared/types/session-api";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 import { rejectInvalidCallback } from "./reject-invalid-callback";

--- a/packages/linear-bot/src/completion/extractor.ts
+++ b/packages/linear-bot/src/completion/extractor.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Env } from "../types";
-import type { AgentResponse } from "@open-inspect/shared";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
 import { extractAgentResponse as sharedExtract } from "@open-inspect/shared/completion/extractor";
 import { resolveOutboundCredential } from "@open-inspect/shared/service-auth";
 import { createLogger } from "../logger";

--- a/packages/linear-bot/src/kv-store.ts
+++ b/packages/linear-bot/src/kv-store.ts
@@ -10,13 +10,8 @@
  */
 
 import { issueSessionSchema } from "./types";
-import type {
-  Env,
-  TeamRepoMapping,
-  ProjectRepoMapping,
-  UserPreferences,
-  IssueSession,
-} from "./types";
+import type { UserPreferences } from "@open-inspect/shared/types/session-api";
+import type { Env, TeamRepoMapping, ProjectRepoMapping, IssueSession } from "./types";
 import { createLogger } from "./logger";
 
 const log = createLogger("kv-store");

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Linear bot.
  */
 
-import type { LinearCallbackContext } from "@open-inspect/shared";
+import type { LinearCallbackContext } from "@open-inspect/shared/types/session-api";
 import { z } from "zod";
 
 /**
@@ -115,9 +115,6 @@ export const issueSessionSchema = z.object({
 
 export type IssueSession = z.infer<typeof issueSessionSchema>;
 
-// Re-export CallbackContext types from shared
-export type { LinearCallbackContext, CallbackContext } from "@open-inspect/shared";
-
 /**
  * Completion callback payload from control-plane.
  */
@@ -155,10 +152,6 @@ export type {
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 
 export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
-
-// ─── User Preferences ────────────────────────────────────────────────────────
-
-export type { UserPreferences } from "@open-inspect/shared";
 
 // ─── Linear Issue Details ────────────────────────────────────────────────────
 

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -154,13 +154,6 @@ export type {
 
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 
-export type {
-  ArtifactResponse,
-  ListArtifactsResponse,
-  ToolCallSummary,
-  ArtifactInfo,
-  AgentResponse,
-} from "@open-inspect/shared";
 export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
 
 // ─── User Preferences ────────────────────────────────────────────────────────

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -3,11 +3,13 @@
  * Extracted from index.ts for modularity.
  */
 
-import { createSessionResponseSchema } from "@open-inspect/shared";
+import {
+  createSessionResponseSchema,
+  type LinearCallbackContext,
+} from "@open-inspect/shared/types/session-api";
 import { z } from "zod";
 import type {
   Env,
-  LinearCallbackContext,
   LinearIssueDetails,
   AgentSessionWebhook,
   AgentSessionWebhookIssue,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -110,6 +110,10 @@
       "import": "./dist/types/sandbox-events.js",
       "types": "./dist/types/sandbox-events.d.ts"
     },
+    "./types/sessions": {
+      "import": "./dist/types/sessions.js",
+      "types": "./dist/types/sessions.d.ts"
+    },
     "./types/session-attachments": {
       "import": "./dist/types/session-attachments.js",
       "types": "./dist/types/session-attachments.d.ts"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -118,6 +118,10 @@
       "import": "./dist/types/artifacts.js",
       "types": "./dist/types/artifacts.d.ts"
     },
+    "./types/session-api": {
+      "import": "./dist/types/session-api.js",
+      "types": "./dist/types/session-api.d.ts"
+    },
     "./types/session-attachments": {
       "import": "./dist/types/session-attachments.js",
       "types": "./dist/types/session-attachments.d.ts"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -114,6 +114,10 @@
       "import": "./dist/types/sessions.js",
       "types": "./dist/types/sessions.d.ts"
     },
+    "./types/artifacts": {
+      "import": "./dist/types/artifacts.js",
+      "types": "./dist/types/artifacts.d.ts"
+    },
     "./types/session-attachments": {
       "import": "./dist/types/session-attachments.js",
       "types": "./dist/types/session-attachments.d.ts"

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -14,11 +14,11 @@ import {
   RepositoryPairValidationError,
   sendPromptRequestSchema,
   serverMessageSchema,
-  sessionParticipantProfilesResponseSchema,
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
   cancelChildSessionRequestSchema,
 } from ".";
+import { sessionParticipantProfilesResponseSchema } from "./sessions";
 import {
   listEventsResponseSchema,
   sandboxEventSchema,

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -3,22 +3,24 @@ import {
   automationRepositoriesInputSchema,
   automationRepositoryInputSchema,
   clientMessageSchema,
-  childFollowUpPromptRequestSchema,
-  createSessionResponseSchema,
-  createSessionRequestSchema,
-  callbackContextSchema,
-  MAX_CHILD_FOLLOW_UP_PROMPT_CHARS,
   MAX_AUTOMATION_REPOSITORIES,
   normalizeOptionalRepositoryPair,
   RepositoryPairValidationError,
-  sendPromptRequestSchema,
   serverMessageSchema,
-  sendPromptResponseSchema,
-  spawnChildSessionRequestSchema,
-  cancelChildSessionRequestSchema,
 } from ".";
 import { sessionParticipantProfilesResponseSchema } from "./sessions";
 import { listArtifactsResponseSchema } from "./artifacts";
+import {
+  callbackContextSchema,
+  cancelChildSessionRequestSchema,
+  childFollowUpPromptRequestSchema,
+  createSessionRequestSchema,
+  createSessionResponseSchema,
+  MAX_CHILD_FOLLOW_UP_PROMPT_CHARS,
+  sendPromptRequestSchema,
+  sendPromptResponseSchema,
+  spawnChildSessionRequestSchema,
+} from "./session-api";
 import {
   listEventsResponseSchema,
   sandboxEventSchema,

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -8,7 +8,6 @@ import {
   createSessionRequestSchema,
   callbackContextSchema,
   MAX_CHILD_FOLLOW_UP_PROMPT_CHARS,
-  listArtifactsResponseSchema,
   MAX_AUTOMATION_REPOSITORIES,
   normalizeOptionalRepositoryPair,
   RepositoryPairValidationError,
@@ -19,6 +18,7 @@ import {
   cancelChildSessionRequestSchema,
 } from ".";
 import { sessionParticipantProfilesResponseSchema } from "./sessions";
+import { listArtifactsResponseSchema } from "./artifacts";
 import {
   listEventsResponseSchema,
   sandboxEventSchema,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -66,27 +66,6 @@ export type {
   ConfidenceLevel,
 } from "./repository-catalog";
 
-export { listArtifactsResponseSchema, toDisplayStatus } from "./artifacts";
-export type {
-  SessionArtifact,
-  ManualPullRequestArtifactMetadata,
-  ScreenshotArtifactMetadata,
-  VideoArtifactMetadata,
-  PullRequest,
-  PullRequestLifecycleState,
-  PullRequestStatus,
-  PullRequestDisplayStatus,
-  PullRequestArtifactMetadata,
-  ArtifactResponse,
-  ListArtifactsResponse,
-  ToolCallSummary,
-  ArtifactInfo,
-  MediaArtifactInfo,
-  AgentResponse,
-  ArtifactType,
-} from "./artifacts";
-export { sessionArtifactSchema } from "./artifacts";
-
 export {
   serverMessageSchema,
   sessionSnapshotSchema,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -126,45 +126,6 @@ export type {
 } from "./session-diffs";
 
 export {
-  automationCallbackContextSchema,
-  callbackContextSchema,
-  linearCallbackContextSchema,
-  linearStartCallbackSchema,
-  MAX_CHILD_FOLLOW_UP_PROMPT_CHARS,
-  childFollowUpPromptRequestSchema,
-  sendPromptRequestSchema,
-  slackCallbackContextSchema,
-  createSessionRequestSchema,
-  createSessionInputSchema,
-  createMediaArtifactRequestSchema,
-  createSessionResponseSchema,
-  sendPromptResponseSchema,
-  spawnChildSessionRequestSchema,
-  cancelChildSessionRequestSchema,
-} from "./session-api";
-export type {
-  UserPreferences,
-  SlackCallbackContext,
-  LinearCallbackContext,
-  LinearStartCallback,
-  AutomationCallbackContext,
-  CallbackContext,
-  ChildFollowUpPromptRequest,
-  SendPromptRequest,
-  CreateSessionRequest,
-  CreateSessionInput,
-  CreateMediaArtifactRequest,
-  CreateSessionResponse,
-  SendPromptResponse,
-  ListSessionsResponse,
-  SpawnChildSessionRequest,
-  CancelChildSessionRequest,
-  ChildSessionFinalResponse,
-  ChildSessionTrajectory,
-  ChildSessionDetail,
-} from "./session-api";
-
-export {
   MAX_ENVIRONMENT_NAME_LENGTH,
   MAX_ENVIRONMENT_DESCRIPTION_LENGTH,
   MAX_ENVIRONMENT_CHANNEL_ASSOCIATIONS,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -87,32 +87,6 @@ export type {
 } from "./artifacts";
 export { sessionArtifactSchema } from "./artifacts";
 
-export type {
-  SessionParticipant,
-  Session,
-  SessionMessage,
-  PullRequestSummary,
-  SessionReadState,
-  SessionReadAction,
-  SessionReadResult,
-  SessionParticipantProfile,
-  SessionParticipantProfilesResponse,
-  SessionStatus,
-  SandboxStatus,
-  MessageStatus,
-  MessageSource,
-  ParticipantRole,
-  SpawnSource,
-} from "./sessions";
-export {
-  messageSourceSchema,
-  sessionStatusSchema,
-  sessionReadActionSchema,
-  sessionReadResultSchema,
-  sessionParticipantProfileSchema,
-  sessionParticipantProfilesResponseSchema,
-} from "./sessions";
-
 export {
   serverMessageSchema,
   sessionSnapshotSchema,

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   automationRepositoriesInputSchema,
-  MAX_AUTOMATION_REPOSITORIES,
-  MAX_SESSION_REPOSITORIES,
   MAX_TARGET_REPOSITORIES,
   decodeRepositoryPathSegments,
   encodeRepositoryPathSegments,

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   automationRepositoriesInputSchema,
-  createSessionRequestSchema,
+  MAX_AUTOMATION_REPOSITORIES,
+  MAX_SESSION_REPOSITORIES,
   MAX_TARGET_REPOSITORIES,
   decodeRepositoryPathSegments,
   encodeRepositoryPathSegments,
@@ -13,6 +14,7 @@ import {
   toRepositoryRef,
 } from "./index";
 import { sandboxEventSchema } from "./sandbox-events";
+import { createSessionRequestSchema } from "./session-api";
 
 describe("repository full names", () => {
   it("round-trips a repository with a nested owner namespace", () => {

--- a/packages/shared/src/types/type-contracts.test.ts
+++ b/packages/shared/src/types/type-contracts.test.ts
@@ -13,19 +13,22 @@ import type {
   Automation,
   AutomationRepositoryInput,
   CreateEnvironmentInput,
-  CreateSessionInput,
-  CreateSessionRequest,
+  ListAutomationsResponse,
   RepositoryInput,
   ServerMessage,
   UpdateEnvironmentInput,
   createEnvironmentInputSchema,
-  createSessionInputSchema,
-  createSessionRequestSchema,
   repositoryInputSchema,
   serverMessageSchema,
   updateEnvironmentInputSchema,
 } from ".";
 import type { SandboxEvent, sandboxEventSchema } from "./sandbox-events";
+import type {
+  CreateSessionInput,
+  CreateSessionRequest,
+  createSessionInputSchema,
+  createSessionRequestSchema,
+} from "./session-api";
 
 it("preserves public Zod input and output relationships", () => {
   expectTypeOf<RepositoryInput>().toEqualTypeOf<z.input<typeof repositoryInputSchema>>();

--- a/packages/shared/src/types/type-contracts.test.ts
+++ b/packages/shared/src/types/type-contracts.test.ts
@@ -13,7 +13,6 @@ import type {
   Automation,
   AutomationRepositoryInput,
   CreateEnvironmentInput,
-  ListAutomationsResponse,
   RepositoryInput,
   ServerMessage,
   UpdateEnvironmentInput,

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildCompletionBlocks } from "./blocks";
 import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
-import type { SlackCallbackContext } from "../types";
+import type { SlackCallbackContext } from "@open-inspect/shared/types/session-api";
 
 const BASE_CONTEXT: SlackCallbackContext = {
   source: "slack",

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildCompletionBlocks } from "./blocks";
-import type { AgentResponse, SlackCallbackContext } from "../types";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
+import type { SlackCallbackContext } from "../types";
 
 const BASE_CONTEXT: SlackCallbackContext = {
   source: "slack",

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -2,7 +2,8 @@
  * Build Slack Block Kit messages for completion notifications.
  */
 
-import type { AgentResponse, SlackCallbackContext } from "../types";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
+import type { SlackCallbackContext } from "../types";
 import type {
   SlackActionsBlock,
   SlackButtonElement,
@@ -10,7 +11,7 @@ import type {
   SlackSectionBlock,
 } from "../slack-blocks";
 import { escapeMrkdwnText, splitIntoSlackSections } from "@open-inspect/shared/slack";
-import type { ManualPullRequestArtifactMetadata } from "@open-inspect/shared";
+import type { ManualPullRequestArtifactMetadata } from "@open-inspect/shared/types/artifacts";
 
 type CompletionSlackBlock = SlackSectionBlock | SlackContextBlock | SlackActionsBlock;
 

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
-import type { SlackCallbackContext } from "../types";
+import type { SlackCallbackContext } from "@open-inspect/shared/types/session-api";
 import type {
   SlackActionsBlock,
   SlackButtonElement,

--- a/packages/slack-bot/src/completion/delivery.test.ts
+++ b/packages/slack-bot/src/completion/delivery.test.ts
@@ -3,7 +3,7 @@ import { processSlackCompletion, shouldDeclineReply } from "./delivery";
 import { extractAgentResponse } from "./extractor";
 import { deliverMediaArtifacts } from "./media-upload";
 import type { SlackCompletionJob } from "./job";
-import type { AgentResponse } from "@open-inspect/shared";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
 import type { Env } from "../types";
 import type * as ExtractorModule from "./extractor";
 import type * as MediaUploadModule from "./media-upload";

--- a/packages/slack-bot/src/completion/delivery.ts
+++ b/packages/slack-bot/src/completion/delivery.ts
@@ -1,5 +1,6 @@
 import { postBlocks, postMessage, removeReaction } from "@open-inspect/shared/slack";
-import type { AgentResponse, Env } from "../types";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
+import type { Env } from "../types";
 import { createLogger } from "../logger";
 import { extractAgentResponse } from "./extractor";
 import { buildCompletionBlocks, truncateError } from "./blocks";

--- a/packages/slack-bot/src/completion/extractor.ts
+++ b/packages/slack-bot/src/completion/extractor.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Env } from "../types";
-import type { AgentResponse } from "@open-inspect/shared";
+import type { AgentResponse } from "@open-inspect/shared/types/artifacts";
 import { extractAgentResponse as sharedExtract } from "@open-inspect/shared/completion/extractor";
 import { resolveOutboundCredential } from "@open-inspect/shared/service-auth";
 import { createLogger } from "../logger";

--- a/packages/slack-bot/src/completion/media-upload.test.ts
+++ b/packages/slack-bot/src/completion/media-upload.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { MediaArtifactInfo } from "@open-inspect/shared";
+import type { MediaArtifactInfo } from "@open-inspect/shared/types/artifacts";
 import { deliverMediaArtifacts, SLACK_MEDIA_MAX_FILES_PER_COMPLETION } from "./media-upload";
 import type { Env } from "../types";
 

--- a/packages/slack-bot/src/completion/media-upload.ts
+++ b/packages/slack-bot/src/completion/media-upload.ts
@@ -3,7 +3,7 @@ import {
   getExternalUploadUrl,
   uploadToExternalUrl,
 } from "@open-inspect/shared/slack";
-import type { MediaArtifactInfo } from "@open-inspect/shared";
+import type { MediaArtifactInfo } from "@open-inspect/shared/types/artifacts";
 import type { Env } from "../types";
 import { signedControlPlaneFetch } from "../internal-auth";
 import { createLogger } from "../logger";

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -10,7 +10,7 @@ import {
   classifyThreadSpeaker,
   updateMessage,
 } from "@open-inspect/shared/slack";
-import type { CallbackContext } from "@open-inspect/shared";
+import type { CallbackContext } from "@open-inspect/shared/types/session-api";
 import type { SlackMessageAttachment, SlackMessageFile } from "@open-inspect/shared/slack";
 import {
   IMAGE_ONLY_PROMPT_TEXT,

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -3,12 +3,13 @@ import {
   sendPromptResponseSchema,
   type CreateSessionResponse,
   type SendPromptResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/session-api";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { signedControlPlaneFetch } from "../internal-auth";
 import { createLogger } from "../logger";
 import { buildSessionTargetRequestFields, targetId, type SlackSessionTarget } from "../targets";
-import type { CallbackContext, Env } from "../types";
+import type { CallbackContext } from "@open-inspect/shared/types/session-api";
+import type { Env } from "../types";
 import { OUTBOUND_REQUEST_TIMEOUT_MS } from "../request-options";
 
 const log = createLogger("handler");

--- a/packages/slack-bot/src/sessions/prompt-delivery.ts
+++ b/packages/slack-bot/src/sessions/prompt-delivery.ts
@@ -6,7 +6,7 @@
  * so the sequencing lives in exactly one place.
  */
 
-import type { CallbackContext, SendPromptResponse } from "@open-inspect/shared";
+import type { CallbackContext, SendPromptResponse } from "@open-inspect/shared/types/session-api";
 import {
   notifyDroppedAttachments,
   uploadPreparedAttachments,

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -1,5 +1,5 @@
 import { getUserInfo, postMessage } from "@open-inspect/shared/slack";
-import type { CallbackContext } from "@open-inspect/shared";
+import type { CallbackContext } from "@open-inspect/shared/types/session-api";
 import { getAvailableModels } from "../app-home/models";
 import {
   notifyDroppedAttachments,

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -131,14 +131,7 @@ export interface SlackAppMentionEvent {
 
 export type { SlackInteractionPayload } from "../interaction-payload";
 
-/**
- * Callback context passed with prompts for follow-up notifications.
- */
-export type { SlackCallbackContext, CallbackContext } from "@open-inspect/shared";
-import type { SlackCallbackContext } from "@open-inspect/shared";
-
-// Keep backward-compatible alias
-export type SlackBotCallbackContext = SlackCallbackContext;
+import type { SlackCallbackContext } from "@open-inspect/shared/types/session-api";
 
 /**
  * Thread-to-session mapping stored in KV for conversation continuity.
@@ -190,5 +183,4 @@ export interface ToolCallCallback {
 /**
  * Event response from control-plane events API.
  */
-export type { UserPreferences } from "@open-inspect/shared";
 export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -190,12 +190,5 @@ export interface ToolCallCallback {
 /**
  * Event response from control-plane events API.
  */
-export type {
-  ArtifactResponse,
-  ListArtifactsResponse,
-  ToolCallSummary,
-  ArtifactInfo,
-  AgentResponse,
-  UserPreferences,
-} from "@open-inspect/shared";
+export type { UserPreferences } from "@open-inspect/shared";
 export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -7,7 +7,8 @@ import {
   resolveEnabledModel,
 } from "@open-inspect/shared/models";
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
-import type { Env, UserPreferences } from "./types";
+import type { UserPreferences } from "@open-inspect/shared/types/session-api";
+import type { Env } from "./types";
 import {
   getValidatedBranch,
   isValidBranchName,

--- a/packages/web/src/app/api/sessions/[id]/read-state/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/read-state/route.ts
@@ -2,7 +2,10 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
-import { sessionReadActionSchema, type SessionReadAction } from "@open-inspect/shared";
+import {
+  sessionReadActionSchema,
+  type SessionReadAction,
+} from "@open-inspect/shared/types/sessions";
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerAuthSession();

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { Session } from "@open-inspect/shared";
+import type { Session } from "@open-inspect/shared/types/sessions";
 import { formatRelativeTime } from "@/lib/time";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";

--- a/packages/web/src/components/pr-state-icon.tsx
+++ b/packages/web/src/components/pr-state-icon.tsx
@@ -1,4 +1,4 @@
-import type { PullRequestDisplayStatus } from "@open-inspect/shared";
+import type { PullRequestDisplayStatus } from "@open-inspect/shared/types/artifacts";
 import { GitMergeIcon, GitPrClosedIcon, GitPrDraftIcon, GitPrIcon } from "@/components/ui/icons";
 
 const PR_STATE_ICON_TEXT_CLASS: Record<PullRequestDisplayStatus, string> = {

--- a/packages/web/src/components/session-actions.ts
+++ b/packages/web/src/components/session-actions.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { SessionStatus } from "@open-inspect/shared";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { toast } from "sonner";
 import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 import { getSafeExternalUrl } from "@/lib/urls";

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -11,7 +11,7 @@ import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useAttachmentDropZone } from "@/hooks/use-attachment-drop-zone";
 import { ATTACHMENT_ACCEPT, type PendingAttachment } from "@/hooks/use-session-attachments";
 import type { Artifact } from "@/types/session";
-import type { SessionStatus } from "@open-inspect/shared";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 
 type SessionPromptComposerProps = {
   session: {

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -22,7 +22,7 @@ import {
   type ToolCallEvent,
 } from "@/lib/timeline-items";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import type { SessionParticipantProfile } from "@open-inspect/shared";
+import type { SessionParticipantProfile } from "@open-inspect/shared/types/sessions";
 import { CheckIcon, CopyIcon, ErrorIcon } from "@/components/ui/icons";
 import { resolveParticipantDisplay } from "@/lib/participant-display";
 import { TerminalMessageReadObserver } from "./terminal-message-read-observer";

--- a/packages/web/src/components/sidebar/code-server-section.tsx
+++ b/packages/web/src/components/sidebar/code-server-section.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { copyToClipboard } from "@/lib/format";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { TerminalIcon, KeyIcon, CheckIcon } from "@/components/ui/icons";
-import type { SandboxStatus } from "@open-inspect/shared";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { ACTIVE_SANDBOX_STATUSES, STARTING_SANDBOX_STATUSES } from "./sandbox-statuses";
 
 interface CodeServerSectionProps {

--- a/packages/web/src/components/sidebar/sandbox-statuses.ts
+++ b/packages/web/src/components/sidebar/sandbox-statuses.ts
@@ -1,4 +1,4 @@
-import type { SandboxStatus } from "@open-inspect/shared";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 
 /** Sandbox statuses where sandbox service links are usable. */
 export const ACTIVE_SANDBOX_STATUSES: Set<SandboxStatus> = new Set([

--- a/packages/web/src/components/sidebar/tunnel-urls-section.tsx
+++ b/packages/web/src/components/sidebar/tunnel-urls-section.tsx
@@ -2,7 +2,7 @@
 
 import { getSafeExternalUrl } from "@/lib/urls";
 import { GlobeIcon } from "@/components/ui/icons";
-import type { SandboxStatus } from "@open-inspect/shared";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { ACTIVE_SANDBOX_STATUSES } from "./sandbox-statuses";
 
 interface TunnelUrlsSectionProps {

--- a/packages/web/src/components/sidebar/vnc-section.tsx
+++ b/packages/web/src/components/sidebar/vnc-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SandboxStatus } from "@open-inspect/shared";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { MonitorIcon } from "@/components/ui/icons";
 import { buildVncUrl } from "@/lib/urls";
 import { ACTIVE_SANDBOX_STATUSES, STARTING_SANDBOX_STATUSES } from "./sandbox-statuses";

--- a/packages/web/src/hooks/use-session-participant-profiles.ts
+++ b/packages/web/src/hooks/use-session-participant-profiles.ts
@@ -1,11 +1,11 @@
 "use client";
 
+import type { ParticipantPresence } from "@open-inspect/shared";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import {
   sessionParticipantProfilesResponseSchema,
-  type ParticipantPresence,
   type SessionParticipantProfile,
-} from "@open-inspect/shared";
-import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+} from "@open-inspect/shared/types/sessions";
 import { useEffect, useMemo, useRef } from "react";
 import useSWR from "swr";
 import { resolveParticipantDisplay } from "@/lib/participant-display";

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -3,7 +3,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { SessionArtifact, SessionState } from "@open-inspect/shared";
+import type { SessionState } from "@open-inspect/shared";
+import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import type { ServerMessage, SessionSnapshot } from "@open-inspect/shared/types/server-messages";
 import type * as SwrModule from "swr";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -17,7 +17,7 @@ import {
   SESSIONS_PAGE_SIZE,
   type SessionListResponse,
 } from "@/lib/session-list";
-import type { Session } from "@open-inspect/shared";
+import type { Session } from "@open-inspect/shared/types/sessions";
 import {
   markLatestMessageRead,
   reconcileSessionReadState,

--- a/packages/web/src/lib/participant-display.ts
+++ b/packages/web/src/lib/participant-display.ts
@@ -1,4 +1,4 @@
-import type { SessionParticipantProfile } from "@open-inspect/shared";
+import type { SessionParticipantProfile } from "@open-inspect/shared/types/sessions";
 
 export function resolveParticipantDisplay(
   fallback: { name: string; avatar?: string },

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -1,4 +1,5 @@
-import type { PullRequestDisplayStatus, PullRequestSummary } from "@open-inspect/shared";
+import type { PullRequestDisplayStatus } from "@open-inspect/shared";
+import type { PullRequestSummary } from "@open-inspect/shared/types/sessions";
 
 /**
  * Everything a session-list row shows for its PRs, computed in one pass so

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -1,5 +1,5 @@
-import type { PullRequestDisplayStatus } from "@open-inspect/shared";
 import type { PullRequestSummary } from "@open-inspect/shared/types/sessions";
+import type { PullRequestDisplayStatus } from "@open-inspect/shared/types/artifacts";
 
 /**
  * Everything a session-list row shows for its PRs, computed in one pass so

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -10,7 +10,7 @@ import {
   isUnarchivedSessionListKey,
   type SessionListResponse,
 } from "./session-list";
-import type { Session } from "@open-inspect/shared";
+import type { Session } from "@open-inspect/shared/types/sessions";
 
 function session(id: string, overrides: Partial<Session> = {}): Session {
   return {

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -1,4 +1,4 @@
-import type { Session } from "@open-inspect/shared";
+import type { Session } from "@open-inspect/shared/types/sessions";
 import type { BrowserApiPath } from "./browser-api-fetch";
 import { formatRepoLabel } from "./repo-label";
 

--- a/packages/web/src/lib/session-read-state.ts
+++ b/packages/web/src/lib/session-read-state.ts
@@ -6,7 +6,7 @@ import {
   type SessionReadAction,
   type SessionReadResult,
   type SessionReadState,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/sessions";
 
 export type SessionReadAttemptDisposition = "complete" | "retry" | "permanent_failure";
 

--- a/packages/web/src/lib/session-socket/artifact-metadata.ts
+++ b/packages/web/src/lib/session-socket/artifact-metadata.ts
@@ -1,11 +1,11 @@
 import type { Artifact } from "@/types/session";
-import { toDisplayStatus } from "@open-inspect/shared";
-import type {
-  PullRequestDisplayStatus,
-  ScreenshotArtifactMetadata,
-  SessionArtifact,
-  VideoArtifactMetadata,
-} from "@open-inspect/shared";
+import {
+  toDisplayStatus,
+  type PullRequestDisplayStatus,
+  type ScreenshotArtifactMetadata,
+  type SessionArtifact,
+  type VideoArtifactMetadata,
+} from "@open-inspect/shared/types/artifacts";
 
 /**
  * Maps the wire artifact shape (`SessionArtifact`, with loosely-typed

--- a/packages/web/src/lib/session-socket/swr-revalidation.test.ts
+++ b/packages/web/src/lib/session-socket/swr-revalidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
-import type { SessionArtifact } from "@open-inspect/shared";
+import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { swrKeysToRevalidate } from "./swr-revalidation";
 
 const SESSION_ID = "session-1";

--- a/packages/web/src/types/session.ts
+++ b/packages/web/src/types/session.ts
@@ -2,7 +2,7 @@ import type {
   PullRequestDisplayStatus,
   ScreenshotArtifactMetadata,
   VideoArtifactMetadata,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/artifacts";
 import type { SandboxEvent as SharedSandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 
 // Session-related type definitions


### PR DESCRIPTION
## Summary

- expose the existing `types/sessions`, `types/artifacts`, and `types/session-api` owners through exact shared-package paths
- migrate every repository consumer to those direct paths
- remove these names from the shared root barrel and remove control-plane, Slack, and Linear intermediary reexports
- preserve the control-plane normalized artifact response guarantee beside its mapper

## Scope

This combines the final three mixed Session-owner import sets because they overlap in shared manifest/barrel files and nine consumer files. Publishing them separately would make the PRs conflict after the first merge.

The change does not move declarations, alter schemas or serialized behavior, create facade modules, add import-only tests, introduce enforcement rules, or change Node ESM support.

The exact owner paths intentionally expose `sandboxStatusSchema` and `artifactTypeSchema` alongside their inferred types following the prior status/session/artifact ownership cleanup. The Session API path exposes its complete current owner surface, including the child follow-up request added on `main`.

The branch is rebased onto `edd5121ae`. The conflict resolution preserves upstream Session snapshot, child admission/follow-up, Slack context, VNC, and sidebar behavior while migrating the newly added consumers to their direct owners.

## Structural result

- root imports or reexports for these three owner surfaces: **0**
- control-plane, Slack, or Linear intermediary reexports for these owners: **0**
- new dependency cycles: **0**
- diff: **94 files, net -98 lines**

## Validation

- `npm ci`
- `npm run typecheck`
- affected-package lint
- `npm run format:check`
- shared, control-plane, web, Slack, Linear, and GitHub bot tests: **4,632 passed**
- shared and affected production builds
- child-session integration tests after conflict resolution: **24 passed**
- AST import/reexport audit
- `git diff --check`

An independent architecture and simplicity review found one type-precision issue, which was fixed by retaining a locally owned `NormalizedArtifactResponse`; the re-review found no remaining blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Organized shared session, artifact, and session API types into dedicated modules.
  * Simplified shared interfaces and improved consistency across session, media, and integration features.
* **Bug Fixes**
  * Standardized artifact timestamps so `updatedAt` is consistently numeric.
  * Preserved fallback behavior when an updated timestamp is unavailable, ensuring accurate timestamp display for session media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->