### PR TITLE
fix(slack): keep fenced sections within character limit

### DIFF
--- a/packages/shared/src/slack/sections.test.ts
+++ b/packages/shared/src/slack/sections.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { splitIntoSlackSections } from "./sections";
+
+describe("splitIntoSlackSections", () => {
+  it("preserves whitespace exactly across section boundaries", () => {
+    const text = `\n  alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}  \n`;
+    const sections = splitIntoSlackSections(text);
+
+    expect(sections.join("")).toBe(text);
+  });
+
+  it("keeps Unicode code points intact across hard section boundaries", () => {
+    const text = `${"a".repeat(2999)}😀${"b".repeat(10)}`;
+    const sections = splitIntoSlackSections(text);
+
+    expect(sections.join("")).toBe(text);
+    for (const section of sections) {
+      const firstCodeUnit = section.charCodeAt(0);
+      const lastCodeUnit = section.charCodeAt(section.length - 1);
+      expect(firstCodeUnit >= 0xdc00 && firstCodeUnit <= 0xdfff).toBe(false);
+      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
+    }
+  });
+
+  it("rejects a section budget that cannot fit the next Unicode code point", () => {
+    expect(() => splitIntoSlackSections("😀", 1)).toThrow(
+      new RangeError("Section budget is too small to fit the next Unicode code point")
+    );
+  });
+
+  it("keeps Unicode code points intact when adding the truncation marker", () => {
+    for (let prefixLength = 2900; prefixLength <= 3000; prefixLength += 1) {
+      const text = `${"a".repeat(prefixLength)}😀${"b".repeat(4000)}\n\nmore`;
+      const [section] = splitIntoSlackSections(text, 3000, 1);
+      const markerIndex = section.indexOf("_...truncated");
+      expect(markerIndex).toBeGreaterThanOrEqual(0);
+      const content = section.slice(0, markerIndex).trimEnd();
+      const lastCodeUnit = content.charCodeAt(content.length - 1);
+      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
+    }
+  });
+
+  it("balances fences that open and close on the same line", () => {
+    const fence = "```";
+    const sections = splitIntoSlackSections(`${fence}code${fence}\n${"after ".repeat(700)}`);
+
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  it("caps and preserves one oversized token that opens and closes a fence", () => {
+    const fenceInfo = "x".repeat(32);
+    const reopenRepair = `\`\`\`${fenceInfo}\n`;
+    const closeRepair = "\n```";
+    const text = `\`\`\`${"x".repeat(4000)}\`\`\``;
+    const sections = splitIntoSlackSections(text);
+
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect(section.length).toBeLessThanOrEqual(3000);
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+
+    const recovered = sections
+      .map((section, index) => {
+        if (index > 0) expect(section.startsWith(reopenRepair)).toBe(true);
+        if (index < sections.length - 1) expect(section.endsWith(closeRepair)).toBe(true);
+        const withoutReopen = index > 0 ? section.slice(reopenRepair.length) : section;
+        return index < sections.length - 1
+          ? withoutReopen.slice(0, -closeRepair.length)
+          : withoutReopen;
+      })
+      .join("");
+    expect(recovered).toBe(text);
+  });
+
+  it("loses no characters when hard-slicing inside a fence", () => {
+    const payload = "b".repeat(7000);
+    const sections = splitIntoSlackSections(`\`\`\`js\n${payload}\n\`\`\``);
+    const recovered = sections
+      .join("")
+      .split("```")
+      .join("")
+      .replace(/^js$/gm, "")
+      .replace(/\n/g, "");
+    expect(recovered).toBe(payload);
+  });
+
+  it("keeps fences balanced in the truncated final section", () => {
+    const text = `\`\`\`ts\n${Array.from({ length: 400 }, () => "y".repeat(2900)).join("\n")}\n\`\`\``;
+    const sections = splitIntoSlackSections(text);
+    const last = sections[sections.length - 1];
+    expect(last).toContain("truncated");
+    expect(last.length).toBeLessThanOrEqual(3000);
+    for (const section of sections) {
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  // The truncation cut can land inside a fence the final section both opened and
+  // closed, which a trailing-fence check cannot detect. Sweep the section length
+  // through the window where slicing actually happens, moving the fence across the
+  // cut point, and assert the invariant holds for every shape.
+  it("keeps fences balanced when the truncation cut lands inside a fence", () => {
+    const fence = "```";
+    for (let sectionLen = 2949; sectionLen <= 3000; sectionLen += 1) {
+      for (const codeLen of [20, 45, 200]) {
+        const block = `\n${fence}ts\n${"h".repeat(codeLen)}\n${fence}`;
+        const fill = sectionLen - block.length;
+        if (fill < 1) continue;
+        const paragraphs = [
+          ...Array.from({ length: 19 }, () => "f".repeat(2900)),
+          "g".repeat(fill) + block,
+          ...Array.from({ length: 5 }, () => "z".repeat(2900)),
+        ];
+        const sections = splitIntoSlackSections(paragraphs.join("\n\n"));
+        const last = sections[sections.length - 1];
+        expect(last).toContain("truncated");
+        expect(last.length).toBeLessThanOrEqual(3000);
+        expect((last.match(/```/g) ?? []).length % 2).toBe(0);
+      }
+    }
+  });
+
+  it("carries the fence language across a split", () => {
+    const sections = splitIntoSlackSections(`\`\`\`python\n${"c".repeat(6500)}\n\`\`\``);
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections.slice(1)) {
+      expect(section.startsWith("```python\n")).toBe(true);
+    }
+  });
+});
+
+describe("fence info bounding", () => {
+  // Regression: `info` was captured unbounded from the fence line, so an
+  // oversized fence-opener was re-emitted on every continuation section and
+  // overflowed Slack's per-section cap.
+  it("keeps sections within the cap for an oversized fence-opener line", () => {
+    const monsterInfo = "x".repeat(4000);
+    const sections = splitIntoSlackSections(`\`\`\`${monsterInfo}\n${"c".repeat(5000)}\n\`\`\``);
+    for (const section of sections) {
+      expect(section.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
+  it("keeps only the language token when the fence line carries trailing text", () => {
+    const sections = splitIntoSlackSections(
+      `\`\`\`python title="a very long annotation ${"y".repeat(200)}"\n${"c".repeat(6500)}\n\`\`\``
+    );
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections.slice(1)) {
+      expect(section.startsWith("```python\n")).toBe(true);
+    }
+  });
+
+  it("never overflows across a sweep of fence-opener and body lengths", () => {
+    for (let infoLen = 0; infoLen <= 4200; infoLen += 350) {
+      for (let bodyLen = 2900; bodyLen <= 6200; bodyLen += 550) {
+        const text = `\`\`\`${"i".repeat(infoLen)}\n${"b".repeat(bodyLen)}\n\`\`\``;
+        for (const section of splitIntoSlackSections(text)) {
+          expect(section.length).toBeLessThanOrEqual(3000);
+          expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+        }
+      }
+    }
+  });
+});

--- a/packages/shared/src/slack/sections.ts
+++ b/packages/shared/src/slack/sections.ts
@@ -33,7 +33,6 @@ interface FenceState {
 }
 
 const CLOSED_FENCE: FenceState = { open: false, info: "" };
-const OPEN_FENCE: FenceState = { open: true, info: "" };
 
 /**
  * Cap on the retained fence info string. An info string is a language token
@@ -167,21 +166,26 @@ class SlackSectionAccumulator {
 
   private takeHardSlice(text: string): string {
     const start = this.sectionEnd;
-    // Reserve the closing fence whenever this slice could end inside one.
-    const reserveClose = start.open || advanceFence(start, text).open;
-    const budget =
-      this.maxChars -
-      reopenPrefix(start).length -
-      (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
-    const taken = sliceAtCodePointBoundary(text, Math.max(1, budget));
-    if (!taken) {
-      throw new RangeError("Section budget is too small to fit the next Unicode code point");
+    let budget = this.maxChars - reopenPrefix(start).length;
+    while (budget > 0) {
+      const taken = sliceAtCodePointBoundary(text, budget);
+      if (!taken) break;
+
+      const end = advanceFence(start, taken);
+      const renderedLength = reopenPrefix(start).length + taken.length + closeSuffix(end).length;
+      if (renderedLength <= this.maxChars) {
+        this.sectionStart = start;
+        this.body = taken;
+        this.sectionEnd = end;
+        return taken;
+      }
+
+      // Fence state must be measured at the actual cut: a token can close a
+      // fence after this slice, while this section still needs a closing repair.
+      budget -= renderedLength - this.maxChars;
     }
 
-    this.sectionStart = start;
-    this.body = taken;
-    this.sectionEnd = advanceFence(start, taken);
-    return taken;
+    throw new RangeError("Section budget is too small to fit the next Unicode code point");
   }
 
   private flush(): void {

--- a/packages/shared/src/slack/sections.ts
+++ b/packages/shared/src/slack/sections.ts
@@ -166,26 +166,29 @@ class SlackSectionAccumulator {
 
   private takeHardSlice(text: string): string {
     const start = this.sectionEnd;
-    let budget = this.maxChars - reopenPrefix(start).length;
-    while (budget > 0) {
-      const taken = sliceAtCodePointBoundary(text, budget);
-      if (!taken) break;
-
-      const end = advanceFence(start, taken);
-      const renderedLength = reopenPrefix(start).length + taken.length + closeSuffix(end).length;
-      if (renderedLength <= this.maxChars) {
-        this.sectionStart = start;
-        this.body = taken;
-        this.sectionEnd = end;
-        return taken;
-      }
-
-      // Fence state must be measured at the actual cut: a token can close a
-      // fence after this slice, while this section still needs a closing repair.
-      budget -= renderedLength - this.maxChars;
+    const prefix = reopenPrefix(start);
+    let taken = sliceAtCodePointBoundary(text, Math.max(0, this.maxChars - prefix.length));
+    if (!taken) {
+      throw new RangeError("Section budget is too small to fit the next Unicode code point");
     }
 
-    throw new RangeError("Section budget is too small to fit the next Unicode code point");
+    let end = advanceFence(start, taken);
+    const suffix = closeSuffix(end);
+    if (prefix.length + taken.length + suffix.length > this.maxChars) {
+      taken = sliceAtCodePointBoundary(
+        text,
+        Math.max(0, this.maxChars - prefix.length - suffix.length)
+      );
+      if (!taken) {
+        throw new RangeError("Section budget is too small to fit the next Unicode code point");
+      }
+      end = advanceFence(start, taken);
+    }
+
+    this.sectionStart = start;
+    this.body = taken;
+    this.sectionEnd = end;
+    return taken;
   }
 
   private flush(): void {

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { buildCompletionBlocks } from "./blocks";
-import { splitIntoSlackSections } from "@open-inspect/shared/slack";
 import type { AgentResponse, SlackCallbackContext } from "../types";
 
 const BASE_CONTEXT: SlackCallbackContext = {
@@ -226,44 +225,6 @@ describe("long response handling", () => {
     }
   });
 
-  it("preserves whitespace exactly across section boundaries", () => {
-    const textContent = `\n  alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}  \n`;
-    const sections = splitIntoSlackSections(textContent);
-
-    expect(sections.join("")).toBe(textContent);
-  });
-
-  it("keeps Unicode code points intact across hard section boundaries", () => {
-    const textContent = `${"a".repeat(2999)}😀${"b".repeat(10)}`;
-    const sections = splitIntoSlackSections(textContent);
-
-    expect(sections.join("")).toBe(textContent);
-    for (const section of sections) {
-      const firstCodeUnit = section.charCodeAt(0);
-      const lastCodeUnit = section.charCodeAt(section.length - 1);
-      expect(firstCodeUnit >= 0xdc00 && firstCodeUnit <= 0xdfff).toBe(false);
-      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
-    }
-  });
-
-  it("rejects a section budget that cannot fit the next Unicode code point", () => {
-    expect(() => splitIntoSlackSections("😀", 1)).toThrow(
-      new RangeError("Section budget is too small to fit the next Unicode code point")
-    );
-  });
-
-  it("keeps Unicode code points intact when adding the truncation marker", () => {
-    for (let prefixLength = 2900; prefixLength <= 3000; prefixLength += 1) {
-      const textContent = `${"a".repeat(prefixLength)}😀${"b".repeat(4000)}\n\nmore`;
-      const [section] = splitIntoSlackSections(textContent, 3000, 1);
-      const markerIndex = section.indexOf("_...truncated");
-      expect(markerIndex).toBeGreaterThanOrEqual(0);
-      const content = section.slice(0, markerIndex).trimEnd();
-      const lastCodeUnit = content.charCodeAt(content.length - 1);
-      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
-    }
-  });
-
   it("never exceeds Slack's per-section character limit", () => {
     const textContent = "x".repeat(25_000);
     const blocks = buildCompletionBlocks(
@@ -307,19 +268,6 @@ describe("long response handling", () => {
     }
   });
 
-  it("balances fences that open and close on the same line", () => {
-    const fence = "```";
-    const sections = splitIntoSlackSections(`${fence}code${fence}\n${"after ".repeat(700)}`);
-
-    expect(sections.length).toBeGreaterThan(1);
-    for (const section of sections) {
-      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
-    }
-  });
-
-  // The two checks above pass on fence-free and short-line input respectively, so
-  // neither exercises a split *inside* a fence — which is where the section repair
-  // adds characters after the fit check and where the hard slice drops them.
   it("respects the section cap when a fence is split (repair chars are budgeted)", () => {
     const textContent = `\`\`\`json\n${"a".repeat(9000)}\n\`\`\``;
     const blocks = buildCompletionBlocks(
@@ -330,73 +278,6 @@ describe("long response handling", () => {
     );
     for (const text of sectionTexts(blocks)) {
       expect(text.length).toBeLessThanOrEqual(3000);
-    }
-  });
-
-  it("respects the section cap when one oversized token opens and closes a fence", () => {
-    const sections = splitIntoSlackSections(`\`\`\`${"x".repeat(4000)}\`\`\``);
-
-    expect(sections.length).toBeGreaterThan(1);
-    for (const section of sections) {
-      expect(section.length).toBeLessThanOrEqual(3000);
-      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
-    }
-  });
-
-  it("loses no characters when hard-slicing inside a fence", () => {
-    const payload = "b".repeat(7000);
-    const sections = splitIntoSlackSections(`\`\`\`js\n${payload}\n\`\`\``);
-    const recovered = sections
-      .join("")
-      .split("```")
-      .join("")
-      .replace(/^js$/gm, "")
-      .replace(/\n/g, "");
-    expect(recovered).toBe(payload);
-  });
-
-  it("keeps fences balanced in the truncated final section", () => {
-    const textContent = `\`\`\`ts\n${Array.from({ length: 400 }, () => "y".repeat(2900)).join("\n")}\n\`\`\``;
-    const sections = splitIntoSlackSections(textContent);
-    const last = sections[sections.length - 1];
-    expect(last).toContain("truncated");
-    expect(last.length).toBeLessThanOrEqual(3000);
-    for (const section of sections) {
-      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
-    }
-  });
-
-  // The truncation cut can land inside a fence the final section both opened and
-  // closed, which a trailing-fence check cannot detect. Sweep the section length
-  // through the window where slicing actually happens, moving the fence across the
-  // cut point, and assert the invariant holds for every shape.
-  it("keeps fences balanced when the truncation cut lands inside a fence", () => {
-    const fence = "```";
-    for (let sectionLen = 2949; sectionLen <= 3000; sectionLen += 1) {
-      for (const codeLen of [20, 45, 200]) {
-        const block = `\n${fence}ts\n${"h".repeat(codeLen)}\n${fence}`;
-        const fill = sectionLen - block.length;
-        if (fill < 1) continue;
-        const paragraphs = [
-          ...Array.from({ length: 19 }, () => "f".repeat(2900)),
-          "g".repeat(fill) + block,
-          ...Array.from({ length: 5 }, () => "z".repeat(2900)),
-        ];
-        const sections = splitIntoSlackSections(paragraphs.join("\n\n"));
-        const last = sections[sections.length - 1];
-        expect(last).toContain("truncated");
-        expect(last.length).toBeLessThanOrEqual(3000);
-        expect((last.match(/```/g) ?? []).length % 2).toBe(0);
-      }
-    }
-  });
-
-  it("carries the fence language across a split", () => {
-    const sections = splitIntoSlackSections(`\`\`\`python\n${"c".repeat(6500)}\n\`\`\``);
-    expect(sections.length).toBeGreaterThan(1);
-    // Every continuation section reopens the fence with its original language.
-    for (const section of sections.slice(1)) {
-      expect(section.startsWith("```python\n")).toBe(true);
     }
   });
 
@@ -433,44 +314,5 @@ describe("long response handling", () => {
       "https://inspect.example.com"
     );
     expect(sectionTexts(blocks)[0]).toBe("_Agent completed._");
-  });
-});
-
-describe("fence info bounding", () => {
-  // Regression: `info` was captured unbounded from the fence line, so an
-  // oversized fence-opener (a single ≥3000-char line beginning with ```) was
-  // re-emitted by reopenPrefix on every continuation section and overflowed
-  // Slack's per-section cap. Slack rejects the whole message on overflow rather
-  // than trimming the block, so the cap has to hold for every input shape.
-  it("keeps sections within the cap for an oversized fence-opener line", () => {
-    const monsterInfo = "x".repeat(4000);
-    const sections = splitIntoSlackSections(`\`\`\`${monsterInfo}\n${"c".repeat(5000)}\n\`\`\``);
-    for (const section of sections) {
-      expect(section.length).toBeLessThanOrEqual(3000);
-    }
-  });
-
-  it("keeps only the language token when the fence line carries trailing text", () => {
-    const sections = splitIntoSlackSections(
-      `\`\`\`python title="a very long annotation ${"y".repeat(200)}"\n${"c".repeat(6500)}\n\`\`\``
-    );
-    expect(sections.length).toBeGreaterThan(1);
-    for (const section of sections.slice(1)) {
-      expect(section.startsWith("```python\n")).toBe(true);
-    }
-  });
-
-  // The bot's review caught the original overflow by fuzzing rather than by a
-  // single case, and a single case would have missed it here too.
-  it("never overflows across a sweep of fence-opener and body lengths", () => {
-    for (let infoLen = 0; infoLen <= 4200; infoLen += 350) {
-      for (let bodyLen = 2900; bodyLen <= 6200; bodyLen += 550) {
-        const text = `\`\`\`${"i".repeat(infoLen)}\n${"b".repeat(bodyLen)}\n\`\`\``;
-        for (const section of splitIntoSlackSections(text)) {
-          expect(section.length).toBeLessThanOrEqual(3000);
-          expect((section.match(/```/g) ?? []).length % 2).toBe(0);
-        }
-      }
-    }
   });
 });

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -333,6 +333,16 @@ describe("long response handling", () => {
     }
   });
 
+  it("respects the section cap when one oversized token opens and closes a fence", () => {
+    const sections = splitIntoSlackSections(`\`\`\`${"x".repeat(4000)}\`\`\``);
+
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect(section.length).toBeLessThanOrEqual(3000);
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
   it("loses no characters when hard-slicing inside a fence", () => {
     const payload = "b".repeat(7000);
     const sections = splitIntoSlackSections(`\`\`\`js\n${payload}\n\`\`\``);


### PR DESCRIPTION
## Summary

- calculate hard-slice fence repairs from the text retained in each Slack section rather than the final state of the full oversized token
- guarantee repaired fenced sections remain within Slack's 3,000-character API limit
- add a regression test for a long single-line fenced token that previously produced section lengths of 3,004 and 1,042 characters

## Root cause

When one oversized token both opened and closed a code fence, the chunker inspected the fence state after the entire token and reserved no closing repair. The first hard slice could still end inside the fence, so balancing it added four characters after taking the full 3,000-character budget.

## Verification

- `npm test -w @open-inspect/slack-bot` (408 tests)
- `npm test -w @open-inspect/control-plane -- src/routes/slack-notify.test.ts` (21 tests)
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/slack-bot -- src/completion/blocks.test.ts` (27 tests, rerun after commit hooks)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/371c2771ee6babf58914bb22686d8a8f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long Slack messages to keep sections within the 3,000-character limit.
  * Preserved balanced code blocks when splitting oversized content.
  * Improved Unicode text handling to prevent characters from being split incorrectly.
  * Improved preservation of whitespace, truncation markers, and code-block language information.

* **Tests**
  * Added coverage for oversized tokens containing code fences.
  * Added comprehensive coverage for section limits, fence balancing, truncation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->