### PR TITLE
docs: clarify GitHub PR label permission

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -135,7 +135,9 @@ user selected GitHub:
    users"): `{deployed-web-app-url}/api/auth/callback/github`
    - **CRITICAL**: The origin must exactly match the Homepage URL selected above.
 6. **Repository permissions**: Contents (Read & Write), Issues (Read & Write), Pull requests (Read &
-   Write), Metadata (Read-only)
+   Write), Metadata (Read-only). Issues permission is needed for labels on session-created pull
+   requests even when the GitHub bot is disabled. For an existing App, republish the settings and
+   request/approve the installation update after adding the permission.
 7. If GitHub sign-in uses email/domain admission, set **Account permissions**: Email addresses
    (Read-only)
 8. Create app, note **App ID**

--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -134,10 +134,10 @@ user selected GitHub:
 5. If GitHub sign-in is selected, set the **Callback URL** (under "Identifying and authorizing
    users"): `{deployed-web-app-url}/api/auth/callback/github`
    - **CRITICAL**: The origin must exactly match the Homepage URL selected above.
-6. **Repository permissions**: Contents (Read & Write), Issues (Read & Write), Pull requests (Read &
-   Write), Metadata (Read-only). Issues permission is needed for labels on session-created pull
-   requests even when the GitHub bot is disabled. For an existing App, republish the settings and
-   request/approve the installation update after adding the permission.
+6. **Repository permissions**: Contents (Read & Write), Pull requests (Read & Write), Metadata
+   (Read-only), and Issues (Read & Write) only if the GitHub bot is enabled. Pull requests
+   permission also authorizes creating and applying labels to session-created pull requests;
+   labeling does not require Issues permission.
 7. If GitHub sign-in uses email/domain admission, set **Account permissions**: Email addresses
    (Read-only)
 8. Create app, note **App ID**

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -308,9 +308,13 @@ GitHub OAuth sign-in, but its client pair is optional when Google is the only si
 
 5. Set **Repository permissions**:
    - Contents: **Read & Write**
-   - Issues: **Read & Write** _(required if enabling GitHub bot)_
+   - Issues: **Read & Write** _(required for labels on session-created pull requests and for the
+     GitHub bot)_
    - Pull requests: **Read & Write**
    - Metadata: **Read-only**
+   - Existing installations that add Issues permission must republish the App settings and
+     request/approve the installation update. This applies even when `enable_github_bot = false` if
+     a pull request label is configured under **Settings > Source Control**.
 6. If using `ALLOWED_GITHUB_ORGS`/`allowed_github_orgs`, set **Organization permissions**:
    - Members: **Read-only**
    - For existing GitHub Apps, republish the permission change and request/approve installation

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -308,13 +308,10 @@ GitHub OAuth sign-in, but its client pair is optional when Google is the only si
 
 5. Set **Repository permissions**:
    - Contents: **Read & Write**
-   - Issues: **Read & Write** _(required for labels on session-created pull requests and for the
-     GitHub bot)_
-   - Pull requests: **Read & Write**
+   - Issues: **Read & Write** _(required if enabling GitHub bot)_
+   - Pull requests: **Read & Write** _(also authorizes creating and applying labels to
+     session-created pull requests)_
    - Metadata: **Read-only**
-   - Existing installations that add Issues permission must republish the App settings and
-     request/approve the installation update. This applies even when `enable_github_bot = false` if
-     a pull request label is configured under **Settings > Source Control**.
 6. If using `ALLOWED_GITHUB_ORGS`/`allowed_github_orgs`, set **Organization permissions**:
    - Members: **Read-only**
    - For existing GitHub Apps, republish the permission change and request/approve installation

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -86,10 +86,10 @@ particular, it requires:
 
 **Permissions**: `Pull requests: Read & write`, `Issues: Read & write`
 
-`Issues: Read & write` is also required outside the bot when the control plane applies labels to
-session-created pull requests. See the
+The control plane does not need Issues permission to label session-created pull requests; the
+required `Pull requests: Read & write` permission authorizes those label operations. See the
 [GitHub App setup](../../docs/GETTING_STARTED.md#step-3-create-github-app) for the complete
-permission list and existing-installation upgrade steps.
+permission list.
 
 **Event subscriptions**: `Pull request`, `Issue comment`, `Pull request review comment`
 

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -81,9 +81,15 @@ The bot is deployed via Terraform as a standalone Cloudflare Worker alongside th
 
 ### GitHub App Configuration
 
-The existing GitHub App needs these additions:
+The GitHub bot uses the same repository permissions configured for the main GitHub App setup. In
+particular, it requires:
 
 **Permissions**: `Pull requests: Read & write`, `Issues: Read & write`
+
+`Issues: Read & write` is also required outside the bot when the control plane applies labels to
+session-created pull requests. See the
+[GitHub App setup](../../docs/GETTING_STARTED.md#step-3-create-github-app) for the complete
+permission list and existing-installation upgrade steps.
 
 **Event subscriptions**: `Pull request`, `Issue comment`, `Pull request review comment`
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -65,9 +65,14 @@ sign-in with that App:
 > setting should allow users outside the organization to authenticate, but this has not been
 > extensively tested. Please verify this works for your use case.
 
-Always-required repository permission for the GitHub App:
+Required repository permissions for the GitHub App:
 
-- **Repository permissions**: Contents (read & write) - for repo operations
+- **Contents: Read & write** - for repository operations
+- **Pull requests: Read & write** - for session pull request creation
+- **Metadata: Read-only**
+- **Issues: Read & write** - when a pull request label is configured under **Settings > Source
+  Control**, or when the GitHub bot is enabled. Existing installations must republish the App
+  settings and request/approve the installation update after adding this permission.
 
 When GitHub sign-in uses email/domain admission, also grant **Account permissions: Email addresses
 (read-only)**.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -68,11 +68,9 @@ sign-in with that App:
 Required repository permissions for the GitHub App:
 
 - **Contents: Read & write** - for repository operations
-- **Pull requests: Read & write** - for session pull request creation
+- **Pull requests: Read & write** - for session pull request creation and labeling
 - **Metadata: Read-only**
-- **Issues: Read & write** - when a pull request label is configured under **Settings > Source
-  Control**, or when the GitHub bot is enabled. Existing installations must republish the App
-  settings and request/approve the installation update after adding this permission.
+- **Issues: Read & write** - only when the GitHub bot is enabled
 
 When GitHub sign-in uses email/domain admission, also grant **Account permissions: Email addresses
 (read-only)**.


### PR DESCRIPTION
## Summary

- clarify that the existing GitHub App `Pull requests: Read & write` permission authorizes creating and applying labels to session-created pull requests
- keep `Issues: Read & write` conditional on enabling the GitHub bot
- align the canonical setup guide, onboarding workflow, web setup README, and GitHub bot permission guidance

## Context

Commit `b63d017` added control-plane support for ensuring and applying labels to session-created GitHub pull requests. Although these operations use label endpoints under Issues API routes, GitHub App permission mapping authorizes them through `Pull requests: Read & write`; installations do not need an Issues permission upgrade solely for session PR labeling.

Terraform configures GitHub App credentials but does not create or update the App itself, and there is no checked-in GitHub App permission manifest to change.

## Verification

- `npx prettier --check "docs/GETTING_STARTED.md" "packages/web/README.md" ".claude/skills/onboarding/SKILL.md" "packages/github-bot/README.md"`
- `git diff --check`
- targeted searches confirmed no documentation still claims Issues permission is required for session PR labeling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified GitHub App permission requirements for contents, pull requests, issues, and metadata.
  - Documented that pull request write access supports labeling session-created pull requests.
  - Specified that Issues read/write access is required for labeling and GitHub bot functionality when enabled.
  - Added guidance for updating existing installations, including republishing settings and approving permission changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->