### PR TITLE
fix(linear-bot): use top-level prompt context

### DIFF
--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -165,15 +165,17 @@ On any Linear issue:
 
 ## Repo Resolution
 
-When an issue is triggered, the agent resolves the session target using a 4-step cascade:
+When an issue is triggered, the agent resolves the session target using a 5-step cascade:
 
 1. **Project → target mapping** — static mapping from Linear project IDs to a repository or a saved
    environment (highest priority)
 2. **Team → target mapping** — static mapping from Linear team IDs to repositories or saved
    environments, with optional label filtering
-3. **Linear's `issueRepositorySuggestions` API** — Linear's built-in repo suggestion (>= 70%
+3. **Explicit `owner/repo` mention** — deterministically selects a single available repository named
+   in the trigger comment or clarification reply
+4. **Linear's `issueRepositorySuggestions` API** — Linear's built-in repo suggestion (>= 70%
    confidence)
-4. **LLM classifier** — uses Claude Haiku to classify based on issue content, labels, and available
+5. **LLM classifier** — uses Claude Haiku to classify based on issue content, labels, and available
    repo descriptions. Asks the user to clarify if confidence is low.
 
 Environment sessions clone the environment's full repository set; integration settings (model,

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -67,11 +67,14 @@ describe("matchExplicitRepo", () => {
 
   it("does not match inside a period-delimited repository path", () => {
     expect(matchExplicitRepo("see acme/backend.docs for context", repos)).toBeNull();
+    expect(matchExplicitRepo("see acme/backend..docs for context", repos)).toBeNull();
     expect(matchExplicitRepo("see not.acme/backend for context", repos)).toBeNull();
+    expect(matchExplicitRepo("see not..acme/backend for context", repos)).toBeNull();
   });
 
   it("accepts ordinary terminal punctuation", () => {
     expect(matchExplicitRepo("use acme/backend.", repos)?.fullName).toBe("acme/backend");
+    expect(matchExplicitRepo("use acme/backend...", repos)?.fullName).toBe("acme/backend");
     expect(matchExplicitRepo("acme/backend, please", repos)?.fullName).toBe("acme/backend");
   });
 });

--- a/packages/linear-bot/src/index.test.ts
+++ b/packages/linear-bot/src/index.test.ts
@@ -32,9 +32,9 @@ function makeAgentSessionPayload(webhookId = "webhook-config-1") {
     organizationId: "org-1",
     appUserId: "app-user-1",
     webhookId,
+    promptContext: "Implement the Linear issue.",
     agentSession: {
       id: "agent-session-1",
-      promptContext: "Implement the Linear issue.",
     },
   };
 }

--- a/packages/linear-bot/src/target-resolution.ts
+++ b/packages/linear-bot/src/target-resolution.ts
@@ -30,6 +30,17 @@ import { getProjectRepoMapping, getTeamRepoMapping } from "./kv-store";
 import { createLogger } from "./logger";
 
 const log = createLogger("target-resolution");
+const REPO_PATH_CHAR = /[\w/-]/;
+
+function extendsRepositoryPath(text: string, index: number, direction: -1 | 1): boolean {
+  const neighbor = text[index] ?? "";
+  if (REPO_PATH_CHAR.test(neighbor)) return true;
+  if (neighbor !== ".") return false;
+
+  let cursor = index + direction;
+  while (text[cursor] === ".") cursor += direction;
+  return REPO_PATH_CHAR.test(text[cursor] ?? "");
+}
 
 /**
  * Find the single available repository a comment names explicitly.
@@ -41,21 +52,16 @@ const log = createLogger("target-resolution");
  */
 export function matchExplicitRepo(text: string, repos: RepoConfig[]): RepoConfig | null {
   const haystack = text.toLowerCase();
-  const pathChar = /[\w/-]/;
   const named = repos.filter((repo) => {
     const needle = repo.fullName.toLowerCase();
     for (let at = haystack.indexOf(needle); at !== -1; at = haystack.indexOf(needle, at + 1)) {
       const end = at + needle.length;
-      const before = haystack[at - 1] ?? "";
-      const after = haystack[end] ?? "";
       // A neighbor extends the repository path when it is a path character,
-      // or a period connecting to one (`not.acme/api`, `acme/api.docs`). A
-      // period followed by nothing path-like is ordinary terminal
-      // punctuation (`use acme/api.`).
-      const beforeExtends =
-        pathChar.test(before) || (before === "." && pathChar.test(haystack[at - 2] ?? ""));
-      const afterExtends =
-        pathChar.test(after) || (after === "." && pathChar.test(haystack[end + 1] ?? ""));
+      // or a run of periods connecting to one (`not..acme/api`,
+      // `acme/api..docs`). Periods followed by nothing path-like are ordinary
+      // terminal punctuation (`use acme/api...`).
+      const beforeExtends = extendsRepositoryPath(haystack, at - 1, -1);
+      const afterExtends = extendsRepositoryPath(haystack, end, 1);
       if (!beforeExtends && !afterExtends) return true;
     }
     return false;

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -268,12 +268,12 @@ export interface AgentSessionWebhook {
   organizationId: string;
   webhookId: string;
   appUserId: string;
+  promptContext?: string;
   agentSession: {
     id: string;
     creatorId?: string | null;
     issue?: AgentSessionWebhookIssue;
     comment?: { body: string; userId?: string };
-    promptContext?: string;
   };
   agentActivity?: {
     userId?: string;

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -506,6 +506,27 @@ describe("handleAgentSessionEvent environment targets", () => {
     expect(issueSession).not.toHaveProperty("environmentId");
   });
 
+  it("sends a created event's top-level prompt context to the session", async () => {
+    const { kv } = createFakeKV({
+      "oauth:client-credentials:org-1": validToken(),
+      "config:project-repos": JSON.stringify({
+        "project-1": { owner: "acme", name: "backend" },
+      }),
+    });
+    const env = makeLinearBotEnv(kv);
+    const fetchMock = stubControlPlane(env);
+    const webhook = {
+      ...makeWebhook(),
+      promptContext: "Use the parent issue's migration constraints.",
+    };
+
+    await handleAgentSessionEvent(webhook, env, "trace-prompt-context");
+
+    expect(promptBody(fetchMock)?.content).toContain(
+      '<user_content source="linear_prompt_context" author="linear">\nUse the parent issue\'s migration constraints.'
+    );
+  });
+
   it("omits actor identity and issue transition for an automation-created session", async () => {
     const { kv } = createFakeKV({
       "oauth:client-credentials:org-1": validToken(),
@@ -617,7 +638,7 @@ describe("handleAgentSessionEvent environment targets", () => {
     webhook.action = "prompted";
     webhook.agentActivity = {
       userId: "human-user-1",
-      content: { type: "prompt", body: "acme/backend" },
+      content: { type: "prompt", body: "Use acme/backend and preserve the migration." },
     };
 
     await handleAgentSessionEvent(webhook, env, "trace-clarification-reply");
@@ -633,6 +654,9 @@ describe("handleAgentSessionEvent environment targets", () => {
       repoOwner: "acme",
       repoName: "backend",
     });
+    expect(promptBody(fetchMock)?.content).toContain(
+      "Use acme/backend and preserve the migration."
+    );
   });
 
   it("attributes the clarification-reply session to the replier, not the elicitation creator", async () => {

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -639,8 +639,8 @@ async function handleNewSession(
   // ─── Build and send prompt ────────────────────────────────────────────
 
   // Prefer Linear's promptContext (includes issue, comments, guidance)
-  let prompt = webhook.agentSession.promptContext
-    ? buildPromptContextPrompt(webhook.agentSession.promptContext)
+  let prompt = webhook.promptContext
+    ? buildPromptContextPrompt(webhook.promptContext)
     : buildPrompt(issue, issueDetails, comment);
 
   if (integrationConfig.issueSessionInstructions) {


### PR DESCRIPTION
Follow-up to #1277.

## Problem

A second pass over the merged clarification-routing change found two contract edge cases:

- Linear sends promptContext at the top level of an AgentSessionEvent payload, but the bot typed and read it from agentSession. Created sessions therefore discarded Linear's complete issue, thread, parent-issue, and guidance context and rebuilt a smaller fallback prompt.
- Explicit repository matching rejected single-period continuations such as acme/backend.docs, but repeated periods such as acme/backend..docs could still produce a false acme/backend match.

## Changes

- Model and consume promptContext at the webhook payload's top level.
- Add a handler integration test that verifies the top-level context reaches the control-plane session prompt.
- Scan the entire adjacent period run when deciding whether owner/repo is embedded in a longer path, while retaining ordinary terminal ellipses.
- Verify that an unmapped prompted clarification reply retains its full instruction text in the newly created session prompt.
- Document the actual five-stage repository-resolution cascade.

## Linear documentation

- [Developing the Agent Interaction](https://linear.app/developers/agent-interaction) documents promptContext as the formatted context for created events and the separate prompted-event flow.
- [Pinned AgentSessionEventWebhookPayload schema](https://github.com/linear/linear/blob/eabc85d0df87617b4647e56d2f236e60bc2ed117/packages/sdk/src/schema.graphql#L964-L1006) shows promptContext on the top-level event payload and marks it as present only for created events.

## Testing

- npm run build -w @open-inspect/shared
- npm test -w @open-inspect/linear-bot — 221 passed
- npm run typecheck -w @open-inspect/linear-bot
- npm run lint -w @open-inspect/linear-bot
- npm run build -w @open-inspect/linear-bot
- Prettier check and git diff --check

An independent thermo-review found no actionable maintainability findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Repository detection now more accurately handles punctuation and path-like text, reducing incorrect matches.
  - Repository resolution documentation now explains the full five-step matching process.
  - Prompt context is consistently accepted and forwarded from webhook events, including clarification instructions.

- **Bug Fixes**
  - Corrected handling of top-level prompt context for newly created sessions.
  - Added coverage for repository names followed by ellipses and rejection of ambiguous repeated-period matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->