### PR TITLE
fix: correct replay hasMore at exact limit

### DIFF
--- a/packages/control-plane/src/session/event-stream.test.ts
+++ b/packages/control-plane/src/session/event-stream.test.ts
@@ -38,13 +38,13 @@ function gitSyncEvent(status: "in_progress" | "completed", timestamp: number) {
 
 describe("SessionEventStream", () => {
   describe("getReplay", () => {
-    it("loads replay rows with the default replay limit", () => {
+    it("loads one extra replay row to determine whether history remains", () => {
       const { stream, repository } = createStream();
       vi.mocked(repository.getEventsForReplay).mockReturnValue([]);
 
       stream.getReplay();
 
-      expect(repository.getEventsForReplay).toHaveBeenCalledWith(500);
+      expect(repository.getEventsForReplay).toHaveBeenCalledWith(501);
     });
 
     it("returns parsed replay events and the oldest cursor from the loaded window", () => {
@@ -66,9 +66,10 @@ describe("SessionEventStream", () => {
       });
     });
 
-    it("marks replay as having more when the loaded window reaches the limit", () => {
+    it("marks replay as having more and removes the oldest lookahead row", () => {
       const { stream, repository } = createStream();
       vi.mocked(repository.getEventsForReplay).mockReturnValue([
+        eventRow("e0", "git_sync", gitSyncEvent("in_progress", 0), 500, 0),
         eventRow("e1", "git_sync", gitSyncEvent("in_progress", 1), 1000, 1),
         eventRow("e2", "git_sync", gitSyncEvent("completed", 2), 2000, 2),
       ]);
@@ -76,6 +77,8 @@ describe("SessionEventStream", () => {
       const replay = stream.getReplay(2);
 
       expect(replay.hasMore).toBe(true);
+      expect(replay.events.map((event) => event.eventId)).toEqual(["e1", "e2"]);
+      expect(replay.cursor).toEqual({ timestamp: 1000, id: "e1", sequence: 1 });
     });
 
     it("skips malformed replay event JSON", () => {

--- a/packages/control-plane/src/session/event-stream.test.ts
+++ b/packages/control-plane/src/session/event-stream.test.ts
@@ -4,7 +4,6 @@ import type { EventRow } from "./types";
 
 function createStream() {
   const repository = {
-    getEventsForReplay: vi.fn(),
     getEventTimelinePage: vi.fn(),
     listEventPage: vi.fn(),
   } as unknown as SessionEventStreamRepository;
@@ -38,21 +37,32 @@ function gitSyncEvent(status: "in_progress" | "completed", timestamp: number) {
 
 describe("SessionEventStream", () => {
   describe("getReplay", () => {
-    it("loads one extra replay row to determine whether history remains", () => {
+    it("loads replay through the canonical timeline pager", () => {
       const { stream, repository } = createStream();
-      vi.mocked(repository.getEventsForReplay).mockReturnValue([]);
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [],
+        hasMore: false,
+        nextCursor: null,
+      });
 
       stream.getReplay();
 
-      expect(repository.getEventsForReplay).toHaveBeenCalledWith(501);
+      expect(repository.getEventTimelinePage).toHaveBeenCalledWith({
+        excludeTypes: ["heartbeat"],
+        limit: 500,
+      });
     });
 
     it("returns parsed replay events and the oldest cursor from the loaded window", () => {
       const { stream, repository } = createStream();
-      vi.mocked(repository.getEventsForReplay).mockReturnValue([
-        eventRow("e1", "git_sync", gitSyncEvent("in_progress", 1), 1000, 41),
-        eventRow("e2", "git_sync", gitSyncEvent("completed", 2), 2000, 42),
-      ]);
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [
+          eventRow("e1", "git_sync", gitSyncEvent("in_progress", 1), 1000, 41),
+          eventRow("e2", "git_sync", gitSyncEvent("completed", 2), 2000, 42),
+        ],
+        hasMore: false,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "e1", sequence: 41 },
+      });
 
       const replay = stream.getReplay();
 
@@ -66,13 +76,16 @@ describe("SessionEventStream", () => {
       });
     });
 
-    it("marks replay as having more and removes the oldest lookahead row", () => {
+    it("returns the canonical page's pagination state", () => {
       const { stream, repository } = createStream();
-      vi.mocked(repository.getEventsForReplay).mockReturnValue([
-        eventRow("e0", "git_sync", gitSyncEvent("in_progress", 0), 500, 0),
-        eventRow("e1", "git_sync", gitSyncEvent("in_progress", 1), 1000, 1),
-        eventRow("e2", "git_sync", gitSyncEvent("completed", 2), 2000, 2),
-      ]);
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [
+          eventRow("e1", "git_sync", gitSyncEvent("in_progress", 1), 1000, 1),
+          eventRow("e2", "git_sync", gitSyncEvent("completed", 2), 2000, 2),
+        ],
+        hasMore: true,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "e1", sequence: 1 },
+      });
 
       const replay = stream.getReplay(2);
 
@@ -83,10 +96,14 @@ describe("SessionEventStream", () => {
 
     it("skips malformed replay event JSON", () => {
       const { stream, repository } = createStream();
-      vi.mocked(repository.getEventsForReplay).mockReturnValue([
-        eventRow("bad", "tool_call", "{bad", 1000),
-        eventRow("good", "git_sync", gitSyncEvent("completed", 2), 2000, 42),
-      ]);
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [
+          eventRow("bad", "tool_call", "{bad", 1000),
+          eventRow("good", "git_sync", gitSyncEvent("completed", 2), 2000, 42),
+        ],
+        hasMore: false,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "bad" },
+      });
 
       const replay = stream.getReplay();
 

--- a/packages/control-plane/src/session/event-stream.test.ts
+++ b/packages/control-plane/src/session/event-stream.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { SessionEventStream, type SessionEventStreamRepository } from "./event-stream";
+import {
+  DEFAULT_REPLAY_LIMIT,
+  SessionEventStream,
+  type SessionEventStreamRepository,
+} from "./event-stream";
 import type { EventRow } from "./types";
 
 function createStream() {
@@ -49,7 +53,7 @@ describe("SessionEventStream", () => {
 
       expect(repository.getEventTimelinePage).toHaveBeenCalledWith({
         excludeTypes: ["heartbeat"],
-        limit: 500,
+        limit: DEFAULT_REPLAY_LIMIT,
       });
     });
 

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -12,7 +12,7 @@ import {
   type SessionTimelineEvent,
 } from "@open-inspect/shared/types/server-messages";
 
-const DEFAULT_REPLAY_LIMIT = 500;
+export const DEFAULT_REPLAY_LIMIT = 500;
 const DEFAULT_HISTORY_LIMIT = 200;
 const MIN_HISTORY_LIMIT = 1;
 const MAX_HISTORY_LIMIT = 500;

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -38,12 +38,14 @@ export class SessionEventStream {
   constructor(private readonly repository: SessionEventStreamRepository) {}
 
   getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionTimeline {
-    const rows = this.repository.getEventsForReplay(limit);
-    const cursor = rows.length > 0 ? cursorFromRow(rows[0]) : null;
+    const rows = this.repository.getEventsForReplay(limit + 1);
+    const hasMore = rows.length > limit;
+    const replayRows = hasMore ? rows.slice(1) : rows;
+    const cursor = replayRows.length > 0 ? cursorFromRow(replayRows[0]) : null;
 
     return {
-      events: parseSessionTimelineEvents(rows),
-      hasMore: rows.length >= limit,
+      events: parseSessionTimelineEvents(replayRows),
+      hasMore,
       cursor,
     };
   }

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -1,6 +1,10 @@
 import type { ClientMessage, ServerMessage } from "../types";
 import type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";
-import { encodeEventTimelineCursor, type EventListCursor } from "./event-cursor";
+import {
+  encodeEventTimelineCursor,
+  type EventListCursor,
+  type EventTimelineCursor,
+} from "./event-cursor";
 import type { EventRow } from "./types";
 import type { SessionRepository } from "./repository";
 import {
@@ -24,7 +28,7 @@ export type SessionHistoryPage = Omit<Extract<ServerMessage, { type: "history_pa
 
 export type SessionEventStreamRepository = Pick<
   SessionRepository,
-  "getEventsForReplay" | "getEventTimelinePage" | "listEventPage"
+  "getEventTimelinePage" | "listEventPage"
 >;
 
 export interface SessionEventListRequest {
@@ -38,15 +42,15 @@ export class SessionEventStream {
   constructor(private readonly repository: SessionEventStreamRepository) {}
 
   getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionTimeline {
-    const rows = this.repository.getEventsForReplay(limit + 1);
-    const hasMore = rows.length > limit;
-    const replayRows = hasMore ? rows.slice(1) : rows;
-    const cursor = replayRows.length > 0 ? cursorFromRow(replayRows[0]) : null;
+    const page = this.repository.getEventTimelinePage({
+      excludeTypes: HISTORY_EXCLUDED_TYPES,
+      limit,
+    });
 
     return {
-      events: parseSessionTimelineEvents(replayRows),
-      hasMore,
-      cursor,
+      events: parseSessionTimelineEvents(page.events),
+      hasMore: page.hasMore,
+      cursor: page.nextCursor ? toEventStreamCursor(page.nextCursor) : null,
     };
   }
 
@@ -65,15 +69,7 @@ export class SessionEventStream {
     return {
       items: parseSessionTimelineEvents(page.events),
       hasMore: page.hasMore,
-      cursor: page.nextCursor
-        ? {
-            timestamp: page.nextCursor.createdAt,
-            id: page.nextCursor.id,
-            ...(page.nextCursor.sequence === undefined
-              ? {}
-              : { sequence: page.nextCursor.sequence }),
-          }
-        : null,
+      cursor: page.nextCursor ? toEventStreamCursor(page.nextCursor) : null,
     };
   }
 
@@ -110,13 +106,11 @@ function parseSessionTimelineEvents(rows: EventRow[]): SessionTimelineEvent[] {
   return events;
 }
 
-function cursorFromRow(
-  row: Pick<EventRow, "created_at" | "id" | "timeline_sequence">
-): EventStreamCursor {
+function toEventStreamCursor(cursor: EventTimelineCursor): EventStreamCursor {
   return {
-    timestamp: row.created_at,
-    id: row.id,
-    ...(row.timeline_sequence === undefined ? {} : { sequence: row.timeline_sequence }),
+    timestamp: cursor.createdAt,
+    id: cursor.id,
+    ...(cursor.sequence === undefined ? {} : { sequence: cursor.sequence }),
   };
 }
 

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -1104,21 +1104,6 @@ describe("SessionRepository", () => {
     });
   });
 
-  describe("getEventsForReplay", () => {
-    it("returns newest events in ascending order via DESC subquery", () => {
-      repo.getEventsForReplay(500);
-
-      expect(mock.calls.length).toBe(1);
-      // Inner subquery selects newest events via DESC
-      expect(mock.calls[0].query).toContain(
-        "ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?"
-      );
-      // Outer query re-sorts to chronological ASC for replay
-      expect(mock.calls[0].query).toContain("ORDER BY created_at ASC, timeline_sequence ASC");
-      expect(mock.calls[0].params).toEqual([500]);
-    });
-  });
-
   // === ARTIFACTS ===
 
   describe("createArtifact", () => {

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -1018,17 +1018,6 @@ export class SessionRepository {
     return { events: pageEvents, hasMore, nextCursor };
   }
 
-  getEventsForReplay(limit: number): EventRow[] {
-    const result = this.sql.exec(
-      `SELECT * FROM (
-         SELECT * FROM events WHERE type != 'heartbeat'
-         ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?
-       ) sub ORDER BY created_at ASC, timeline_sequence ASC`,
-      limit
-    );
-    return this.rows<EventRow>(result);
-  }
-
   // === ARTIFACTS ===
 
   createArtifact(data: CreateArtifactData): void {

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -8,6 +8,7 @@ import {
   queryDO,
   waitForSandboxStatus,
 } from "./helpers";
+import { DEFAULT_REPLAY_LIMIT } from "../../src/session/event-stream";
 
 describe("Client WebSocket (via SELF.fetch)", () => {
   it("upgrade returns 101 with webSocket", async () => {
@@ -238,8 +239,8 @@ describe("Client WebSocket (via SELF.fetch)", () => {
   });
 
   it.each([
-    { eventCount: 500, expectedHasMore: false },
-    { eventCount: 501, expectedHasMore: true },
+    { eventCount: DEFAULT_REPLAY_LIMIT, expectedHasMore: false },
+    { eventCount: DEFAULT_REPLAY_LIMIT + 1, expectedHasMore: true },
   ])(
     "subscribe reports hasMore=$expectedHasMore for $eventCount replay events",
     async ({ eventCount, expectedHasMore }) => {
@@ -273,7 +274,7 @@ describe("Client WebSocket (via SELF.fetch)", () => {
         hasMore: boolean;
       };
 
-      expect(timeline.events).toHaveLength(500);
+      expect(timeline.events).toHaveLength(DEFAULT_REPLAY_LIMIT);
       expect(timeline.hasMore).toBe(expectedHasMore);
 
       ws.close();

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -237,6 +237,49 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
+  it.each([
+    { eventCount: 500, expectedHasMore: false },
+    { eventCount: 501, expectedHasMore: true },
+  ])(
+    "subscribe reports hasMore=$expectedHasMore for $eventCount replay events",
+    async ({ eventCount, expectedHasMore }) => {
+      const name = `ws-client-replay-limit-${eventCount}-${Date.now()}`;
+      const { stub } = await initNamedSession(name);
+      const now = Date.now();
+
+      await seedEvents(
+        stub,
+        Array.from({ length: eventCount }, (_, index) => ({
+          id: `ev-${index}`,
+          type: "git_sync",
+          data: JSON.stringify({
+            type: "git_sync",
+            status: "completed",
+            sandboxId: "sandbox-1",
+            timestamp: now - (eventCount - index),
+          }),
+          createdAt: now - (eventCount - index),
+        }))
+      );
+
+      const { ws, messages } = await openClientWs(name, { subscribe: true });
+
+      const subscribed = messages!.find((message) => message.type === "subscribed") as Record<
+        string,
+        unknown
+      >;
+      const timeline = subscribed.timeline as {
+        events: unknown[];
+        hasMore: boolean;
+      };
+
+      expect(timeline.events).toHaveLength(500);
+      expect(timeline.hasMore).toBe(expectedHasMore);
+
+      ws.close();
+    }
+  );
+
   it("subscribe includes historical events in batched replay", async () => {
     const name = `ws-client-replay-events-${Date.now()}`;
     const { stub } = await initNamedSession(name);


### PR DESCRIPTION
## Summary

- fetch one lookahead row when building the initial session replay
- report `hasMore` only when that lookahead row exists
- trim the oldest lookahead row so replay still returns at most 500 newest events
- cover the exact 500-event and 501-event boundaries through the real WebSocket subscription flow

## Root cause

The replay query fetched at most the configured limit and inferred additional history from `rows.length >= limit`. Exactly 500 events therefore looked indistinguishable from 501 or more events, causing an unnecessary empty history request.

## Testing

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane` (2,344 passed)
- `npm run test:integration -w @open-inspect/control-plane -- websocket-client.test.ts` (19 passed)
- `npm run typecheck -w @open-inspect/control-plane`
- scoped ESLint and Prettier checks
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event replay pagination and cursor handling.
  * Replay requests now return up to 500 events and accurately indicate when more are available.
  * Heartbeat events are excluded from replay results.
  * Improved handling of parsed and malformed replayed event data.
  * Added coverage for sessions containing exactly 500 and more than 500 events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->