### PR TITLE
fix(linear-bot): preserve instruction after repo clarification

### DIFF
--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -624,7 +624,7 @@ describe("handleAgentSessionEvent environment targets", () => {
     return fetchMock;
   }
 
-  it("resolves an explicit owner/repo from a clarification reply without classifying", async () => {
+  it("resolves a clarification reply and preserves the original instruction", async () => {
     // The elicitation path created no session, so no issue mapping exists; the
     // user's reply arrives as a prompted event whose text lives on the agent
     // activity. It must reach target resolution and match deterministically —
@@ -635,10 +635,18 @@ describe("handleAgentSessionEvent environment targets", () => {
     const env = makeLinearBotEnv(kv, { SERVICE_AUTH_SECRET: "service-auth-secret" });
     const fetchMock = stubClarificationControlPlane(env);
     const webhook = makeWebhook();
+    const originalInstruction =
+      "Preserve the original task requirements exactly. " +
+      "x".repeat(200) +
+      " ORIGINAL_INSTRUCTION_END";
     webhook.action = "prompted";
+    webhook.agentSession.comment = {
+      body: originalInstruction,
+      userId: "creator-user-1",
+    };
     webhook.agentActivity = {
       userId: "human-user-1",
-      content: { type: "prompt", body: "Use acme/backend and preserve the migration." },
+      content: { type: "prompt", body: "acme/backend" },
     };
 
     await handleAgentSessionEvent(webhook, env, "trace-clarification-reply");
@@ -654,8 +662,11 @@ describe("handleAgentSessionEvent environment targets", () => {
       repoOwner: "acme",
       repoName: "backend",
     });
-    expect(promptBody(fetchMock)?.content).toContain(
-      "Use acme/backend and preserve the migration."
+    const prompt = String(promptBody(fetchMock)?.content);
+    expect(prompt).toContain(originalInstruction);
+    expect(prompt).toContain('<user_content source="linear_agent_instruction" author="unknown">');
+    expect(prompt).toContain(
+      '<user_content source="linear_repository_clarification" author="unknown">\nacme/backend'
     );
   });
 

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -264,28 +264,38 @@ async function handleStop(webhook: AgentSessionWebhook, env: Env, traceId: strin
 }
 
 /**
- * The comment and actor driving a new session. A "prompted" event that
+ * The comments and actor driving a new session. A "prompted" event that
  * reaches new-session handling is a reply to an elicitation — no
  * issue→session mapping existed, so no session was ever created. The reply
- * text lives on the agent activity, not on the session's original trigger
- * comment, and its author is the replier — not necessarily the user whose
- * comment created the elicitation — so both must come from the activity.
+ * text lives on the agent activity and drives target resolution, while the
+ * session comment remains the original instruction. Its author is the replier
+ * — not necessarily the user whose comment created the elicitation.
  */
 function getNewSessionInput(webhook: AgentSessionWebhook): {
-  comment: { body: string } | undefined;
+  resolutionComment: { body: string } | undefined;
+  instructionComment: { body: string } | undefined;
+  clarificationReply: { body: string } | undefined;
   actorUserId: string | undefined;
 } {
-  const sessionActor =
-    webhook.agentSession.comment?.userId ?? webhook.agentSession.creatorId ?? undefined;
+  const instructionComment = webhook.agentSession.comment;
+  const sessionActor = instructionComment?.userId ?? webhook.agentSession.creatorId ?? undefined;
   const replyBody =
     webhook.action === "prompted" ? webhook.agentActivity?.content?.body?.trim() : undefined;
   if (replyBody) {
+    const clarificationReply = { body: replyBody };
     return {
-      comment: { body: replyBody },
+      resolutionComment: clarificationReply,
+      instructionComment,
+      clarificationReply,
       actorUserId: webhook.agentActivity?.userId ?? sessionActor,
     };
   }
-  return { comment: webhook.agentSession.comment, actorUserId: sessionActor };
+  return {
+    resolutionComment: instructionComment,
+    instructionComment,
+    clarificationReply: undefined,
+    actorUserId: sessionActor,
+  };
 }
 
 function shouldTransitionIssueOnStart(webhook: AgentSessionWebhook): boolean {
@@ -471,7 +481,12 @@ async function handleNewSession(
 ): Promise<void> {
   const startTime = Date.now();
   const agentSessionId = webhook.agentSession.id;
-  const { comment, actorUserId: sessionActorUserId } = getNewSessionInput(webhook);
+  const {
+    resolutionComment,
+    instructionComment,
+    clarificationReply,
+    actorUserId: sessionActorUserId,
+  } = getNewSessionInput(webhook);
   const orgId = webhook.organizationId;
 
   const client = await getAgentSessionLinearClient({
@@ -511,7 +526,7 @@ async function handleNewSession(
     issue,
     labelNames,
     projectInfo,
-    comment,
+    comment: resolutionComment,
     traceId,
   });
   if (!resolved) return;
@@ -641,7 +656,7 @@ async function handleNewSession(
   // Prefer Linear's promptContext (includes issue, comments, guidance)
   let prompt = webhook.promptContext
     ? buildPromptContextPrompt(webhook.promptContext)
-    : buildPrompt(issue, issueDetails, comment);
+    : buildPrompt(issue, issueDetails, instructionComment, clarificationReply);
 
   if (integrationConfig.issueSessionInstructions) {
     prompt += `\n\n## Additional Instructions\n\n${integrationConfig.issueSessionInstructions}`;
@@ -749,7 +764,8 @@ export async function handleAgentSessionEvent(
 export function buildPrompt(
   issue: { identifier: string; title: string; description?: string | null; url: string },
   issueDetails: LinearIssueDetails | null,
-  comment?: { body: string } | null
+  comment?: { body: string } | null,
+  clarificationReply?: { body: string } | null
 ): string {
   const parts: string[] = [
     `Linear Issue: ${issue.identifier}`,
@@ -817,6 +833,19 @@ export function buildPrompt(
         source: "linear_agent_instruction",
         author: "unknown",
         content: comment.body,
+      })
+    );
+  }
+
+  if (clarificationReply?.body) {
+    parts.push(
+      "",
+      "---",
+      "**Repository clarification:**",
+      buildUntrustedUserContentBlock({
+        source: "linear_repository_clarification",
+        author: "unknown",
+        content: clarificationReply.body,
       })
     );
   }


### PR DESCRIPTION
## Summary

- keep the original Linear session comment as the coding-session instruction after repository clarification
- use the prompted `agentActivity` reply independently for deterministic repository resolution
- include the clarification reply as a separate untrusted prompt block so additional constraints in that reply are also preserved
- add regression coverage proving a full original instruction longer than the recent-comment truncation limit reaches the session prompt

## Problem

PR #1277 made a `prompted` clarification reply such as `owner/repo` take precedence over the original trigger comment so repository resolution could succeed. The same selected comment was later reused to build the coding-session prompt, so the clarification reply replaced the original task instruction. A session could therefore start in the correct repository with only `owner/repo` as its direct instruction.

The issue-details fallback is not sufficient: it fetches only the first page of 10 comments, includes at most five of them in the prompt, and truncates each included comment to 200 characters.

## Linear Contract Validation

This implementation was checked against Linear's published agent documentation and webhook schema:

- [Developing the Agent Interaction](https://linear.app/developers/agent-interaction) distinguishes `created` events, which carry the initial session context, from `prompted` events, whose new user message is carried by the agent activity.
- Linear's [`AgentSessionEventWebhookPayload` schema](https://github.com/linear/linear/blob/eabc85d0df87617b4647e56d2f236e60bc2ed117/packages/sdk/src/schema.graphql#L964-L1006) marks top-level `promptContext` as present only for `created` events, so it cannot recover the initial directive on the later clarification event.
- The same [pinned webhook schema](https://github.com/linear/linear/blob/eabc85d0df87617b4647e56d2f236e60bc2ed117/packages/sdk/src/schema.graphql) defines prompted activity content separately from `AgentSessionWebhookPayload.comment`, the root comment attached to the session. This allows the bot to preserve the original comment while using the prompted activity as the repository answer.

Accordingly, this change keeps the two webhook fields separate instead of trying to reconstruct the original instruction from recent issue comments.

## Testing

- `npm test -w @open-inspect/linear-bot` (221 passed)
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/linear-bot`
- `npm run build -w @open-inspect/linear-bot`
- Prettier check
- `git diff --check`

The regression test verifies that:

- an exact `acme/backend` clarification resolves without classification
- the final prompt contains the complete original instruction, including a sentinel beyond 200 characters
- the final prompt contains the repository clarification in a distinct prompt block

Follow-up to #1277 and #1325.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ce57d390c9aad9fe9914a562295eecfb)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of clarification replies when starting a new session.
  * Preserved the original instruction separately from repository clarification details.
  * Ensured prompts clearly distinguish instructions from supplementary clarification content.
  * Corrected target resolution to use the appropriate resolution comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->