### PR TITLE
feat: show running task indicator

### DIFF
--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -515,10 +515,17 @@ describe("task activity grouping", () => {
       args: { description: "Review code" },
       status: "running",
     });
-    const { rerender } = render(<SessionTimeline {...baseTimelineProps} events={[runningTask]} />);
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[runningTask]} />
+    );
 
-    const indicator = screen.getByRole("status", { name: "Task in progress" });
-    expect(indicator).toHaveClass("bg-accent", "animate-pulse");
+    const indicator = screen.getByRole("status");
+    expect(indicator).toHaveClass("sr-only");
+    expect(indicator).toHaveTextContent("Task in progress");
+    expect(indicator.closest("button")).toBeNull();
+    expect(container.querySelector("button [aria-hidden='true'].animate-pulse")).toHaveClass(
+      "bg-accent"
+    );
 
     rerender(
       <SessionTimeline
@@ -533,7 +540,8 @@ describe("task activity grouping", () => {
       />
     );
 
-    expect(screen.queryByRole("status", { name: "Task in progress" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(container.querySelector("button [aria-hidden='true'].animate-pulse")).toBeNull();
   });
 
   it("nests child tools beneath their Task and keeps parallel Tasks separate", () => {

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -510,6 +510,32 @@ function toolEvent(
 }
 
 describe("task activity grouping", () => {
+  it("pulses while a Task is running and stops after its completion update", () => {
+    const runningTask = toolEvent("task", "task-call", 1, {
+      args: { description: "Review code" },
+      status: "running",
+    });
+    const { rerender } = render(<SessionTimeline {...baseTimelineProps} events={[runningTask]} />);
+
+    const indicator = screen.getByRole("status", { name: "Task in progress" });
+    expect(indicator).toHaveClass("bg-accent", "animate-pulse");
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          runningTask,
+          toolEvent("task", "task-call", 2, {
+            args: { description: "Review code" },
+            status: "completed",
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.queryByRole("status", { name: "Task in progress" })).not.toBeInTheDocument();
+  });
+
   it("nests child tools beneath their Task and keeps parallel Tasks separate", () => {
     const groups = buildTimelineItems([
       toolEvent("task", "task-a", 1, { childSessionId: "child-a" }),

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -80,8 +80,7 @@ export function TaskActivityItem({
         <BoxIcon className="w-3.5 h-3.5 text-secondary-foreground" />
         {isRunning && (
           <span
-            role="status"
-            aria-label="Task in progress"
+            aria-hidden="true"
             className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse flex-shrink-0"
           />
         )}
@@ -92,6 +91,11 @@ export function TaskActivityItem({
           {formatSessionEventTime(event.timestamp)}
         </span>
       </button>
+      {isRunning && (
+        <span role="status" className="sr-only">
+          Task in progress
+        </span>
+      )}
 
       {isExpanded && (
         <div className="mt-2 ml-5 space-y-2">

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -63,6 +63,7 @@ export function TaskActivityItem({
   const agent = stringArg(event, "subagent_type");
   const taskId = stringArg(event, "task_id");
   const result = cleanTaskResult(event.output);
+  const isRunning = event.status === "running";
   return (
     <div className="py-0.5">
       <button
@@ -77,6 +78,13 @@ export function TaskActivityItem({
           }`}
         />
         <BoxIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+        {isRunning && (
+          <span
+            role="status"
+            aria-label="Task in progress"
+            className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse flex-shrink-0"
+          />
+        )}
         <span className="truncate">
           {formatted.toolName} {formatted.summary}
         </span>


### PR DESCRIPTION
## Summary
- show the existing pulsing accent dot beside Task activity while its `tool_call` status is `running`
- remove the indicator naturally when the deduplicated Task event is updated to a terminal status
- expose an accessible `Task in progress` status label
- cover the running-to-completed lifecycle in the session timeline tests

## Validation
- `npm test -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --quiet`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/4678fe659bd745aa8f1fffed30084f76)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear, animated “Task in progress” indicator for running tasks.
  * The indicator is accessible and automatically disappears when the task finishes.
* **Bug Fixes**
  * Improved task activity status visibility so ongoing and completed tasks are accurately distinguished.
  * Updated task timelines to reflect status changes immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->