### PR TITLE
fix: stabilize participant sidebar loading

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -70,6 +70,7 @@ export default function SessionPage() {
     connected,
     connecting,
     ready,
+    presenceSynced,
     authError,
     connectionError,
     sessionState,
@@ -339,6 +340,7 @@ export default function SessionPage() {
                 sessionId={sessionId}
                 sessionState={sessionState}
                 participants={profiledParticipants}
+                presenceSynced={presenceSynced}
                 events={events}
                 artifacts={artifacts}
                 terminalOpen={terminalOpen}
@@ -371,6 +373,7 @@ export default function SessionPage() {
               sessionId={sessionId}
               sessionState={sessionState}
               participants={profiledParticipants}
+              presenceSynced={presenceSynced}
               events={events}
               artifacts={artifacts}
               terminalOpen={terminalOpen}
@@ -394,6 +397,7 @@ export default function SessionPage() {
           sessionId={sessionId}
           sessionState={sessionState}
           participants={profiledParticipants}
+          presenceSynced={presenceSynced}
           events={events}
           artifacts={artifacts}
           terminalOpen={terminalOpen}

--- a/packages/web/src/components/session-details-overlay.tsx
+++ b/packages/web/src/components/session-details-overlay.tsx
@@ -37,6 +37,7 @@ export function SessionDetailsOverlay({
   sessionId,
   sessionState,
   participants,
+  presenceSynced,
   events,
   artifacts,
   terminalOpen,
@@ -164,6 +165,7 @@ export function SessionDetailsOverlay({
       sessionId={sessionId}
       sessionState={sessionState}
       participants={participants}
+      presenceSynced={presenceSynced}
       events={events}
       artifacts={artifacts}
       terminalOpen={terminalOpen}

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -29,6 +29,7 @@ interface SessionRightSidebarProps {
   sessionId: string;
   sessionState: SessionState | null;
   participants: ParticipantPresence[];
+  presenceSynced: boolean;
   events: SandboxEvent[];
   artifacts: Artifact[];
   terminalOpen?: boolean;
@@ -46,6 +47,7 @@ export function SessionRightSidebarContent({
   sessionId,
   sessionState,
   participants,
+  presenceSynced,
   events,
   artifacts,
   terminalOpen,
@@ -99,7 +101,7 @@ export function SessionRightSidebarContent({
     <>
       {/* Participants */}
       <div className="px-4 py-4 border-b border-border-muted">
-        <ParticipantsSection participants={participants} />
+        <ParticipantsSection participants={participants} presenceSynced={presenceSynced} />
       </div>
 
       {/* Metadata */}
@@ -270,6 +272,7 @@ export function SessionRightSidebar({
   sessionId,
   sessionState,
   participants,
+  presenceSynced,
   events,
   artifacts,
   terminalOpen,
@@ -286,6 +289,7 @@ export function SessionRightSidebar({
         sessionId={sessionId}
         sessionState={sessionState}
         participants={participants}
+        presenceSynced={presenceSynced}
         events={events}
         artifacts={artifacts}
         terminalOpen={terminalOpen}

--- a/packages/web/src/components/sidebar/participants-section.test.tsx
+++ b/packages/web/src/components/sidebar/participants-section.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, describe, expect, it } from "vitest";
+import { ParticipantsSection } from "./participants-section";
+
+expect.extend(matchers);
+
+afterEach(cleanup);
+
+describe("ParticipantsSection", () => {
+  it("reserves participant height until initial presence synchronizes", () => {
+    render(<ParticipantsSection participants={[]} presenceSynced={false} />);
+
+    expect(screen.getByTestId("participants-skeleton")).toHaveClass("h-6", "animate-pulse");
+  });
+
+  it("renders synchronized participants", () => {
+    render(
+      <ParticipantsSection
+        presenceSynced
+        participants={[
+          {
+            participantId: "participant-1",
+            userId: "user-1",
+            name: "Ada",
+            status: "active",
+            lastSeen: 1,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("1 prompt engineer")).toBeInTheDocument();
+    expect(screen.queryByTestId("participants-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing after an empty presence sync", () => {
+    const { container } = render(<ParticipantsSection participants={[]} presenceSynced />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/components/sidebar/participants-section.tsx
+++ b/packages/web/src/components/sidebar/participants-section.tsx
@@ -11,6 +11,7 @@ export function ParticipantsSection({ participants, presenceSynced }: Participan
   if (!presenceSynced) {
     return (
       <div
+        aria-hidden="true"
         className="flex h-6 items-center gap-2 animate-pulse"
         data-testid="participants-skeleton"
       >

--- a/packages/web/src/components/sidebar/participants-section.tsx
+++ b/packages/web/src/components/sidebar/participants-section.tsx
@@ -4,9 +4,22 @@ import type { ParticipantPresence } from "@open-inspect/shared";
 
 interface ParticipantsSectionProps {
   participants: ParticipantPresence[];
+  presenceSynced: boolean;
 }
 
-export function ParticipantsSection({ participants }: ParticipantsSectionProps) {
+export function ParticipantsSection({ participants, presenceSynced }: ParticipantsSectionProps) {
+  if (!presenceSynced) {
+    return (
+      <div
+        className="flex h-6 items-center gap-2 animate-pulse"
+        data-testid="participants-skeleton"
+      >
+        <div className="h-6 w-6 rounded-full bg-muted" />
+        <div className="h-4 w-28 rounded bg-muted" />
+      </div>
+    );
+  }
+
   if (participants.length === 0) return null;
 
   const count = participants.length;

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -37,6 +37,7 @@ interface UseSessionSocketReturn {
   connected: boolean;
   connecting: boolean;
   ready: boolean;
+  presenceSynced: boolean;
   authError: string | null;
   connectionError: string | null;
   sessionState: SessionState | null;
@@ -305,6 +306,7 @@ export function useSessionSocket(
     connected: transport.connected,
     connecting: transport.connecting,
     ready: state.ready,
+    presenceSynced: state.presenceSynced,
     authError: transport.authError,
     connectionError: transport.connectionError,
     sessionState,

--- a/packages/web/src/lib/session-socket/reducer.test.ts
+++ b/packages/web/src/lib/session-socket/reducer.test.ts
@@ -408,7 +408,7 @@ describe("sessionSocketReducer", () => {
       expect(state.participants).toEqual([]);
     });
 
-    it("keeps initial presence synchronized while reconnecting", () => {
+    it("waits for a new presence sync while reconnecting", () => {
       const synced = reduce(
         subscribedState(),
         serverMessage({
@@ -426,10 +426,16 @@ describe("sessionSocketReducer", () => {
       );
       const disconnected = reduce(synced, { type: "socket_closed" });
       const resubscribed = reduce(disconnected, serverMessage(createSubscribedMessage()));
+      const resynced = reduce(
+        resubscribed,
+        serverMessage({ type: "presence_sync", participants: [] })
+      );
 
-      expect(disconnected.presenceSynced).toBe(true);
+      expect(disconnected.presenceSynced).toBe(false);
       expect(disconnected.participants).toEqual([]);
-      expect(resubscribed.presenceSynced).toBe(true);
+      expect(resubscribed.presenceSynced).toBe(false);
+      expect(resynced.presenceSynced).toBe(true);
+      expect(resynced.participants).toEqual([]);
     });
   });
 

--- a/packages/web/src/lib/session-socket/reducer.test.ts
+++ b/packages/web/src/lib/session-socket/reducer.test.ts
@@ -86,6 +86,7 @@ describe("sessionSocketReducer", () => {
       const state = createSessionSocketState(createSnapshot());
 
       expect(state.ready).toBe(false);
+      expect(state.presenceSynced).toBe(false);
       expect(state.events).toHaveLength(1);
       expect(state.cursor).toEqual({ timestamp: 1, id: "event-1", sequence: 1 });
     });
@@ -390,10 +391,45 @@ describe("sessionSocketReducer", () => {
         subscribedState(),
         serverMessage({ type: "presence_sync", participants })
       );
+      expect(synced.presenceSynced).toBe(true);
       expect(synced.participants).toEqual(participants);
 
       const left = reduce(synced, serverMessage({ type: "presence_leave", userId: "user-1" }));
       expect(left.participants.map((p) => p.userId)).toEqual(["user-2"]);
+    });
+
+    it("marks an empty presence sync as synchronized", () => {
+      const state = reduce(
+        subscribedState(),
+        serverMessage({ type: "presence_sync", participants: [] })
+      );
+
+      expect(state.presenceSynced).toBe(true);
+      expect(state.participants).toEqual([]);
+    });
+
+    it("keeps initial presence synchronized while reconnecting", () => {
+      const synced = reduce(
+        subscribedState(),
+        serverMessage({
+          type: "presence_sync",
+          participants: [
+            {
+              participantId: "participant-1",
+              userId: "user-1",
+              name: "A",
+              status: "active",
+              lastSeen: 1,
+            },
+          ],
+        })
+      );
+      const disconnected = reduce(synced, { type: "socket_closed" });
+      const resubscribed = reduce(disconnected, serverMessage(createSubscribedMessage()));
+
+      expect(disconnected.presenceSynced).toBe(true);
+      expect(disconnected.participants).toEqual([]);
+      expect(resubscribed.presenceSynced).toBe(true);
     });
   });
 

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -21,6 +21,7 @@ export interface HistoryCursor {
  */
 export interface SessionSocketState {
   ready: boolean;
+  presenceSynced: boolean;
   sessionState: SessionState | null;
   events: SandboxEvent[];
   participants: ParticipantPresence[];
@@ -33,6 +34,7 @@ export interface SessionSocketState {
 
 export const initialSessionSocketState: SessionSocketState = {
   ready: false,
+  presenceSynced: false,
   sessionState: null,
   events: [],
   participants: [],
@@ -195,6 +197,8 @@ function reduceServerMessage(
     }
 
     case "presence_sync":
+      return { ...state, presenceSynced: true, participants: message.participants };
+
     case "presence_update":
       return { ...state, participants: message.participants };
 

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -326,6 +326,7 @@ export function sessionSocketReducer(
       return {
         ...state,
         ready: false,
+        presenceSynced: false,
         participants: [],
       };
   }


### PR DESCRIPTION
## Summary

- track explicit `presenceSynced` state because the server-rendered session snapshot does not include participant presence
- distinguish initial/reconnect loading from a synchronized-empty participant list
- render a fixed-height participant skeleton during initial load and reconnect to prevent right-sidebar layout shift
- thread synchronization state through desktop, mobile, and details overlay sidebar paths

## Verification

- focused participant/reducer tests: 32 passed
- web typecheck: passed
- web lint: passed
- full web suite: 902/904 passed; two unrelated ESLint-boundary tests timed out under full-suite concurrency and each passed when rerun individually

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d13b9dd1c3b46cb9b59426b421fe7609)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participant lists now show a loading indicator until presence data is synchronized.
  * Empty participant lists display correctly after synchronization completes.
  * Presence synchronization status is reflected consistently across desktop and mobile session views.

* **Bug Fixes**
  * Participant data and loading states now reset correctly when a session connection closes or reconnects.

* **Tests**
  * Added coverage for presence synchronization, loading states, populated lists, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->