### PR TITLE
fix: contain session timeline auto-scroll

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -294,7 +294,7 @@ export default function SessionPage() {
   );
 
   return (
-    <div className="h-full min-w-0 overflow-x-hidden flex flex-col">
+    <div className="h-full min-w-0 overflow-hidden flex flex-col">
       <SessionHeader
         sessionState={sessionState}
         fallbackSessionInfo={fallbackSessionInfo}

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { buildTimelineItems } from "@/lib/timeline-items";
@@ -508,6 +508,73 @@ function toolEvent(
     ...extra,
   };
 }
+
+describe("timeline auto-scrolling", () => {
+  it("confines sub-task auto-scrolling to the timeline", () => {
+    const task = toolEvent("task", "task-call", 1, {
+      childSessionId: "child-1",
+      status: "running",
+    });
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[task]} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          task,
+          toolEvent("Read", "child-call", 2, {
+            isSubtask: true,
+            childSessionId: "child-1",
+            taskCallId: "task-call",
+          }),
+        ]}
+      />
+    );
+
+    expect(timeline.scrollTop).toBe(1_000);
+    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not move the timeline when the user has scrolled away from the bottom", () => {
+    const task = toolEvent("task", "task-call", 1, {
+      childSessionId: "child-1",
+      status: "running",
+    });
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[task]} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 300, writable: true },
+    });
+    fireEvent.scroll(timeline);
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          task,
+          toolEvent("Read", "child-call", 2, {
+            isSubtask: true,
+            childSessionId: "child-1",
+            taskCallId: "task-call",
+          }),
+        ]}
+      />
+    );
+
+    expect(timeline.scrollTop).toBe(300);
+  });
+});
 
 describe("task activity grouping", () => {
   it("pulses while a Task is running and stops after its completion update", () => {

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -85,7 +85,6 @@ export function SessionTimeline({
   }, [timelineItems, latestTerminalMessageId]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
   const isPrependingRef = useRef(false);
   const didPrependRef = useRef(false);
@@ -139,7 +138,8 @@ export function SessionTimeline({
       return;
     }
     if (isNearBottomRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "auto" });
+      const container = scrollContainerRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
     }
   }, [events]);
 
@@ -248,7 +248,7 @@ export function SessionTimeline({
         )}
         {isProcessing && <ThinkingIndicator />}
 
-        <div ref={messagesEndRef} />
+        <div />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- confine timeline auto-scrolling to the timeline container instead of using `scrollIntoView`, which could move scrollable ancestors
- prevent the fixed-height session root from becoming a vertical scroll container
- add regression coverage for streamed sub-task updates and user-controlled scroll position

## Root cause
Streaming sub-task events repeatedly changed the event array and triggered `scrollIntoView` on the timeline end marker. Since `scrollIntoView` can scroll every eligible ancestor, it moved the session page itself. Nested task activity updates amplified the behavior by changing content height earlier in the timeline.

## Testing
- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `git diff --check`

## Visual verification
Local browser verification was limited by unavailable authentication. The authentication shell was captured at 1512x982; behavior is covered by the targeted timeline tests.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3886bd7eb5cc6538a7b21e9f57ad619f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session timeline scrolling so new activity keeps the view at the bottom when you’re already there.
  - Preserved your current position when reviewing earlier timeline activity.
  - Prevented unwanted page overflow on the session view.

- **Tests**
  - Added coverage for timeline auto-scrolling and position preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->