### PR TITLE
fix: restore typed snapshot session config support

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -560,7 +560,7 @@ class SandboxManager:
     async def restore_from_snapshot(
         self,
         snapshot_image_id: str,
-        session_config: dict,
+        session_config: SessionConfig | dict,
         sandbox_id: str | None = None,
         control_plane_url: str = "",
         sandbox_auth_token: str = "",
@@ -591,9 +591,14 @@ class SandboxManager:
         """
         start_time = time.time()
 
-        repo_owner = session_config.get("repo_owner")
-        repo_name = session_config.get("repo_name")
-        session_config_json = json.dumps(session_config)
+        if isinstance(session_config, dict):
+            repo_owner = session_config.get("repo_owner")
+            repo_name = session_config.get("repo_name")
+            session_config_json = json.dumps(session_config)
+        else:
+            repo_owner = session_config.repo_owner
+            repo_name = session_config.repo_name
+            session_config_json = session_config.model_dump_json()
         has_repository = _has_repository(repo_owner, repo_name)
 
         # Use provided sandbox_id or generate one

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -7,6 +7,7 @@ from sandbox_runtime.constants import (
     VNC_PASSWORD_ENV_VAR,
     VNC_PASSWORD_MAX_BYTES,
 )
+from sandbox_runtime.types import SessionConfig
 from src.sandbox.manager import (
     DEFAULT_SANDBOX_TIMEOUT_SECONDS,
     SandboxConfig,
@@ -365,6 +366,26 @@ async def test_restore_omits_branch_when_none(monkeypatch):
 
     session_config = json.loads(captured["env"]["SESSION_CONFIG"])
     assert "branch" not in session_config
+
+
+@pytest.mark.asyncio
+async def test_restore_serializes_typed_session_config(monkeypatch):
+    captured = _fake_restore_setup(monkeypatch)
+
+    await SandboxManager().restore_from_snapshot(
+        snapshot_image_id="img-abc",
+        session_config=SessionConfig(
+            session_id="sess-1",
+            repo_owner="acme",
+            repo_name="repo",
+            branch="develop",
+        ),
+    )
+
+    session_config = json.loads(captured["env"]["SESSION_CONFIG"])
+    assert session_config["repo_owner"] == "acme"
+    assert session_config["repo_name"] == "repo"
+    assert session_config["branch"] == "develop"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- restore `SessionConfig | dict` support in `SandboxManager.restore_from_snapshot()`
- preserve raw dictionary serialization with `json.dumps()` so unknown and future HTTP fields continue to pass through unchanged
- serialize typed `SessionConfig` values with `model_dump_json()` while reading repository identity from typed attributes
- add focused regression coverage for typed config serialization, including the branch field

## Verification

- `uv run pytest tests/test_sandbox_env_vars.py tests/test_web_api_create_sandbox.py -v` (56 passed)
- `uv run ruff check src/sandbox/manager.py tests/test_sandbox_env_vars.py` (passed)
- `uv run ruff format --check src/sandbox/manager.py tests/test_sandbox_env_vars.py` (2 files already formatted)
- `git diff --check` (passed)

## Worktree Note

The pre-existing unrelated `package-lock.json` modification was intentionally excluded from this commit.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c774c45c16b907f2c9ddcd5653eac2c1)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot restoration now accepts session configuration objects in addition to dictionaries.
  * Typed session configurations are serialized correctly while preserving repository ownership and branch details.

* **Bug Fixes**
  * Improved session configuration handling during sandbox restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->