### PR TITLE
fix: handle early sandbox bridge connections

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -419,6 +419,81 @@ describe("SandboxLifecycleManager", () => {
       expect(JSON.stringify(broadcaster.messages)).not.toContain("secret");
     });
 
+    it("preserves an early bridge connection until spawn access is persisted", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(
+        createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
+        sandbox
+      );
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager(false);
+      const alarmScheduler = createMockAlarmScheduler();
+      const accessAtBroadcast: Array<
+        Pick<
+          SandboxRow,
+          "code_server_url" | "code_server_password" | "vnc_url" | "vnc_password" | "tunnel_urls"
+        >
+      > = [];
+      vi.mocked(broadcaster.broadcast).mockImplementation((message: object) => {
+        broadcaster.messages.push(message);
+        if ((message as { type?: string }).type === "sandbox_access_changed") {
+          accessAtBroadcast.push({
+            code_server_url: sandbox.code_server_url,
+            code_server_password: sandbox.code_server_password,
+            vnc_url: sandbox.vnc_url,
+            vnc_password: sandbox.vnc_password,
+            tunnel_urls: sandbox.tunnel_urls,
+          });
+        }
+      });
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async (config) => {
+          sandbox.status = "ready";
+          vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
+          broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
+          return {
+            sandboxId: config.sandboxId,
+            status: "connecting",
+            createdAt: Date.now(),
+            codeServerUrl: "https://code.test",
+            codeServerPassword: "code-secret",
+            vncAccess: { url: "https://vnc.test", password: "vnc-secret" },
+            tunnelUrls: { "3000": "https://preview.test" },
+          };
+        }),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        wsManager,
+        alarmScheduler,
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(sandbox.status).toBe("ready");
+      expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
+      expect(alarmScheduler.alarms).toEqual([]);
+      expect(
+        broadcaster.messages.filter(
+          (message) => (message as { type: string }).type === "sandbox_access_changed"
+        )
+      ).toHaveLength(1);
+      expect(broadcaster.messages.at(-1)).toEqual({ type: "sandbox_access_changed" });
+      expect(accessAtBroadcast).toEqual([
+        {
+          code_server_url: "https://code.test",
+          code_server_password: "code-secret",
+          vnc_url: "https://vnc.test",
+          vnc_password: "vnc-secret",
+          tunnel_urls: JSON.stringify({ "3000": "https://preview.test" }),
+        },
+      ]);
+    });
+
     it("logs one terminal sandbox.spawn event for success", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(createMockSession(), sandbox);
@@ -910,6 +985,91 @@ describe("SandboxLifecycleManager", () => {
       const scheduledTime = alarmScheduler.alarms[0];
       expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
       expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
+    });
+
+    it("preserves an early bridge connection until restore access is persisted", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(
+        createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
+        sandbox
+      );
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager(false);
+      const alarmScheduler = createMockAlarmScheduler();
+      const accessAtBroadcast: Array<
+        Pick<
+          SandboxRow,
+          "code_server_url" | "code_server_password" | "vnc_url" | "vnc_password" | "tunnel_urls"
+        >
+      > = [];
+      vi.mocked(broadcaster.broadcast).mockImplementation((message: object) => {
+        broadcaster.messages.push(message);
+        if ((message as { type?: string }).type === "sandbox_access_changed") {
+          accessAtBroadcast.push({
+            code_server_url: sandbox.code_server_url,
+            code_server_password: sandbox.code_server_password,
+            vnc_url: sandbox.vnc_url,
+            vnc_password: sandbox.vnc_password,
+            tunnel_urls: sandbox.tunnel_urls,
+          });
+        }
+      });
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async (config) => {
+          sandbox.status = "ready";
+          vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
+          broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
+          return {
+            success: true,
+            sandboxId: config.sandboxId,
+            codeServerUrl: "https://restored-code.test",
+            codeServerPassword: "restored-code-secret",
+            vncAccess: { url: "https://restored-vnc.test", password: "restored-vnc-secret" },
+            tunnelUrls: { "8080": "https://restored-preview.test" },
+          };
+        }),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        wsManager,
+        alarmScheduler,
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(sandbox.status).toBe("ready");
+      expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
+      expect(alarmScheduler.alarms).toEqual([]);
+      expect(
+        broadcaster.messages.filter(
+          (message) => (message as { type: string }).type === "sandbox_access_changed"
+        )
+      ).toHaveLength(1);
+      expect(
+        broadcaster.messages.findIndex(
+          (message) => (message as { type: string }).type === "sandbox_access_changed"
+        )
+      ).toBeLessThan(
+        broadcaster.messages.findIndex(
+          (message) => (message as { type: string }).type === "sandbox_restored"
+        )
+      );
+      expect(accessAtBroadcast).toEqual([
+        {
+          code_server_url: "https://restored-code.test",
+          code_server_password: "restored-code-secret",
+          vnc_url: "https://restored-vnc.test",
+          vnc_password: "restored-vnc-secret",
+          tunnel_urls: JSON.stringify({ "8080": "https://restored-preview.test" }),
+        },
+      ]);
     });
 
     it("stores providerObjectId after successful restore for future snapshots", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -354,6 +354,113 @@ function createTestConfig(): SandboxLifecycleConfig {
   };
 }
 
+type ProviderStartupKind = "spawn" | "restore" | "resume";
+
+async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void> {
+  const sandbox = createMockSandbox({
+    status: kind === "spawn" ? "pending" : "stopped",
+    created_at: Date.now() - 60000,
+    snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+  });
+  const storage = createMockStorage(
+    createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
+    sandbox
+  );
+  const broadcaster = createMockBroadcaster();
+  const wsManager = createMockWebSocketManager(false);
+  const alarmScheduler = createMockAlarmScheduler();
+  const accessAtBroadcast: Array<
+    Pick<
+      SandboxRow,
+      "code_server_url" | "code_server_password" | "vnc_url" | "vnc_password" | "tunnel_urls"
+    >
+  > = [];
+  vi.mocked(broadcaster.broadcast).mockImplementation((message: object) => {
+    broadcaster.messages.push(message);
+    if ((message as { type?: string }).type === "sandbox_access_changed") {
+      accessAtBroadcast.push({
+        code_server_url: sandbox.code_server_url,
+        code_server_password: sandbox.code_server_password,
+        vnc_url: sandbox.vnc_url,
+        vnc_password: sandbox.vnc_password,
+        tunnel_urls: sandbox.tunnel_urls,
+      });
+    }
+  });
+  const connectBridge = () => {
+    sandbox.status = "ready";
+    vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
+    broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
+  };
+  const access = {
+    codeServerUrl: `https://${kind}-code.test`,
+    codeServerPassword: `${kind}-code-secret`,
+    vncAccess: { url: `https://${kind}-vnc.test`, password: `${kind}-vnc-secret` },
+    tunnelUrls: { "3000": `https://${kind}-preview.test` },
+  };
+  const provider = createMockProvider({
+    capabilities: { supportsPersistentResume: kind === "resume" },
+    createSandbox: vi.fn(async (config) => {
+      connectBridge();
+      return {
+        sandboxId: config.sandboxId,
+        status: "connecting",
+        createdAt: Date.now(),
+        ...access,
+      };
+    }),
+    restoreFromSnapshot: vi.fn(async (config) => {
+      connectBridge();
+      return { success: true, sandboxId: config.sandboxId, ...access };
+    }),
+    resumeSandbox: vi.fn(async () => {
+      connectBridge();
+      return { success: true, ...access };
+    }),
+  });
+  const manager = new SandboxLifecycleManager(
+    provider,
+    storage,
+    broadcaster,
+    wsManager,
+    alarmScheduler,
+    createMockIdGenerator(),
+    createTestConfig()
+  );
+
+  await manager.spawnSandbox();
+
+  expect(sandbox.status).toBe("ready");
+  expect(storage.calls.filter((call) => call === "updateSandboxStatus:connecting")).toHaveLength(
+    kind === "resume" ? 1 : 0
+  );
+  expect(alarmScheduler.alarms).toEqual([]);
+  expect(manager.isProviderStartupPending()).toBe(false);
+  const readyIndex = broadcaster.messages.findIndex(
+    (message) =>
+      (message as { type?: string; status?: string }).type === "sandbox_status" &&
+      (message as { status?: string }).status === "ready"
+  );
+  expect(broadcaster.messages.slice(readyIndex + 1)).not.toContainEqual({
+    type: "sandbox_status",
+    status: "connecting",
+  });
+  expect(
+    broadcaster.messages.filter(
+      (message) => (message as { type: string }).type === "sandbox_access_changed"
+    )
+  ).toHaveLength(1);
+  expect(accessAtBroadcast).toEqual([
+    {
+      code_server_url: access.codeServerUrl,
+      code_server_password: access.codeServerPassword,
+      vnc_url: access.vncAccess.url,
+      vnc_password: access.vncAccess.password,
+      tunnel_urls: JSON.stringify(access.tunnelUrls),
+    },
+  ]);
+}
+
 // ==================== Tests ====================
 
 describe("SandboxLifecycleManager", () => {
@@ -419,80 +526,10 @@ describe("SandboxLifecycleManager", () => {
       expect(JSON.stringify(broadcaster.messages)).not.toContain("secret");
     });
 
-    it("preserves an early bridge connection until spawn access is persisted", async () => {
-      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
-      const storage = createMockStorage(
-        createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
-        sandbox
-      );
-      const broadcaster = createMockBroadcaster();
-      const wsManager = createMockWebSocketManager(false);
-      const alarmScheduler = createMockAlarmScheduler();
-      const accessAtBroadcast: Array<
-        Pick<
-          SandboxRow,
-          "code_server_url" | "code_server_password" | "vnc_url" | "vnc_password" | "tunnel_urls"
-        >
-      > = [];
-      vi.mocked(broadcaster.broadcast).mockImplementation((message: object) => {
-        broadcaster.messages.push(message);
-        if ((message as { type?: string }).type === "sandbox_access_changed") {
-          accessAtBroadcast.push({
-            code_server_url: sandbox.code_server_url,
-            code_server_password: sandbox.code_server_password,
-            vnc_url: sandbox.vnc_url,
-            vnc_password: sandbox.vnc_password,
-            tunnel_urls: sandbox.tunnel_urls,
-          });
-        }
-      });
-      const provider = createMockProvider({
-        createSandbox: vi.fn(async (config) => {
-          sandbox.status = "ready";
-          vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
-          broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
-          return {
-            sandboxId: config.sandboxId,
-            status: "connecting",
-            createdAt: Date.now(),
-            codeServerUrl: "https://code.test",
-            codeServerPassword: "code-secret",
-            vncAccess: { url: "https://vnc.test", password: "vnc-secret" },
-            tunnelUrls: { "3000": "https://preview.test" },
-          };
-        }),
-      });
-      const manager = new SandboxLifecycleManager(
-        provider,
-        storage,
-        broadcaster,
-        wsManager,
-        alarmScheduler,
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      await manager.spawnSandbox();
-
-      expect(sandbox.status).toBe("ready");
-      expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
-      expect(alarmScheduler.alarms).toEqual([]);
-      expect(
-        broadcaster.messages.filter(
-          (message) => (message as { type: string }).type === "sandbox_access_changed"
-        )
-      ).toHaveLength(1);
-      expect(broadcaster.messages.at(-1)).toEqual({ type: "sandbox_access_changed" });
-      expect(accessAtBroadcast).toEqual([
-        {
-          code_server_url: "https://code.test",
-          code_server_password: "code-secret",
-          vnc_url: "https://vnc.test",
-          vnc_password: "vnc-secret",
-          tunnel_urls: JSON.stringify({ "3000": "https://preview.test" }),
-        },
-      ]);
-    });
+    it.each(["spawn", "restore", "resume"] as const)(
+      "preserves an early bridge connection until %s access is persisted",
+      expectEarlyBridgeStartup
+    );
 
     it("logs one terminal sandbox.spawn event for success", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
@@ -985,91 +1022,6 @@ describe("SandboxLifecycleManager", () => {
       const scheduledTime = alarmScheduler.alarms[0];
       expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
       expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
-    });
-
-    it("preserves an early bridge connection until restore access is persisted", async () => {
-      const sandbox = createMockSandbox({
-        status: "stopped",
-        snapshot_image_id: "img-abc123",
-      });
-      const storage = createMockStorage(
-        createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
-        sandbox
-      );
-      const broadcaster = createMockBroadcaster();
-      const wsManager = createMockWebSocketManager(false);
-      const alarmScheduler = createMockAlarmScheduler();
-      const accessAtBroadcast: Array<
-        Pick<
-          SandboxRow,
-          "code_server_url" | "code_server_password" | "vnc_url" | "vnc_password" | "tunnel_urls"
-        >
-      > = [];
-      vi.mocked(broadcaster.broadcast).mockImplementation((message: object) => {
-        broadcaster.messages.push(message);
-        if ((message as { type?: string }).type === "sandbox_access_changed") {
-          accessAtBroadcast.push({
-            code_server_url: sandbox.code_server_url,
-            code_server_password: sandbox.code_server_password,
-            vnc_url: sandbox.vnc_url,
-            vnc_password: sandbox.vnc_password,
-            tunnel_urls: sandbox.tunnel_urls,
-          });
-        }
-      });
-      const provider = createMockProvider({
-        restoreFromSnapshot: vi.fn(async (config) => {
-          sandbox.status = "ready";
-          vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
-          broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
-          return {
-            success: true,
-            sandboxId: config.sandboxId,
-            codeServerUrl: "https://restored-code.test",
-            codeServerPassword: "restored-code-secret",
-            vncAccess: { url: "https://restored-vnc.test", password: "restored-vnc-secret" },
-            tunnelUrls: { "8080": "https://restored-preview.test" },
-          };
-        }),
-      });
-      const manager = new SandboxLifecycleManager(
-        provider,
-        storage,
-        broadcaster,
-        wsManager,
-        alarmScheduler,
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      await manager.spawnSandbox();
-
-      expect(sandbox.status).toBe("ready");
-      expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
-      expect(alarmScheduler.alarms).toEqual([]);
-      expect(
-        broadcaster.messages.filter(
-          (message) => (message as { type: string }).type === "sandbox_access_changed"
-        )
-      ).toHaveLength(1);
-      expect(
-        broadcaster.messages.findIndex(
-          (message) => (message as { type: string }).type === "sandbox_access_changed"
-        )
-      ).toBeLessThan(
-        broadcaster.messages.findIndex(
-          (message) => (message as { type: string }).type === "sandbox_restored"
-        )
-      );
-      expect(accessAtBroadcast).toEqual([
-        {
-          code_server_url: "https://restored-code.test",
-          code_server_password: "restored-code-secret",
-          vnc_url: "https://restored-vnc.test",
-          vnc_password: "restored-vnc-secret",
-          tunnel_urls: JSON.stringify({ "8080": "https://restored-preview.test" }),
-        },
-      ]);
     });
 
     it("stores providerObjectId after successful restore for future snapshots", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -293,6 +293,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * The persisted sandbox status ("spawning", "connecting") handles cross-request protection.
    */
   private isSpawningSandbox = false;
+  private providerStartupPending = false;
 
   /** Session-scoped logger. Falls back to module-level logger if no sessionId configured. */
   private readonly log: Logger;
@@ -407,6 +408,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    */
   private async doSpawn(): Promise<void> {
     this.isSpawningSandbox = true;
+    this.providerStartupPending = true;
     const spawnStartedAt = Date.now();
     let session: SessionRow | null = null;
 
@@ -596,6 +598,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     } finally {
       this.isSpawningSandbox = false;
+      this.providerStartupPending = false;
     }
   }
 
@@ -721,6 +724,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
 
     this.isSpawningSandbox = true;
+    this.providerStartupPending = true;
     const restoreStartedAt = Date.now();
     let session: SessionRow | null = null;
 
@@ -854,6 +858,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     } finally {
       this.isSpawningSandbox = false;
+      this.providerStartupPending = false;
     }
   }
 
@@ -867,6 +872,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
 
     this.isSpawningSandbox = true;
+    this.providerStartupPending = true;
 
     try {
       const session = this.storage.getSession();
@@ -927,7 +933,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
 
       await this.storeAndBroadcastTunnelUrls(result.tunnelUrls);
-      await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
+      await this.finishProviderStartup();
       this.storage.resetCircuitBreaker();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to resume sandbox";
@@ -942,6 +948,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     } finally {
       this.isSpawningSandbox = false;
+      this.providerStartupPending = false;
     }
   }
 
@@ -1434,13 +1441,17 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   }
 
   private async finishProviderStartup(): Promise<void> {
+    this.providerStartupPending = false;
+
     if (this.wsManager.getSandboxWebSocket()) {
       this.broadcaster.broadcast({ type: "sandbox_access_changed" });
       return;
     }
 
-    this.storage.updateSandboxStatus("connecting");
-    this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
+    if (this.storage.getSandbox()?.status !== "connecting") {
+      this.storage.updateSandboxStatus("connecting");
+      this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
+    }
 
     // The bridge replaces this with its inactivity alarm when it connects.
     await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
@@ -1452,6 +1463,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    */
   isSpawning(): boolean {
     return this.isSpawningSandbox;
+  }
+
+  isProviderStartupPending(): boolean {
+    return this.providerStartupPending;
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -546,13 +546,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         await this.storeTtyd(result.ttydUrl, sandboxAuthToken, sessionId, expectedSandboxId);
       }
 
-      this.storage.updateSandboxStatus("connecting");
-      this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
-
-      // Schedule connecting timeout watchdog — if the bridge doesn't connect
-      // within the allowed window, handleAlarm() will fail the sandbox.
-      // This alarm is naturally replaced by the inactivity alarm on successful connect.
-      await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
+      await this.finishProviderStartup();
 
       // Reset circuit breaker on successful spawn initiation
       this.storage.resetCircuitBreaker();
@@ -804,13 +798,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           );
         }
 
-        this.storage.updateSandboxStatus("connecting");
-        this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
-
-        // Schedule connecting timeout watchdog
-        await this.alarmScheduler.scheduleAlarm(
-          Date.now() + this.config.connectingTimeout.timeoutMs
-        );
+        await this.finishProviderStartup();
 
         this.broadcaster.broadcast({
           type: "sandbox_restored",
@@ -1443,6 +1431,19 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
     this.log.info("Storing ttyd info", { url });
     await this.storage.updateSandboxTtyd(url, token);
+  }
+
+  private async finishProviderStartup(): Promise<void> {
+    if (this.wsManager.getSandboxWebSocket()) {
+      this.broadcaster.broadcast({ type: "sandbox_access_changed" });
+      return;
+    }
+
+    this.storage.updateSandboxStatus("connecting");
+    this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
+
+    // The bridge replaces this with its inactivity alarm when it connects.
+    await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1086,6 +1086,10 @@ export class SessionDO extends DurableObject<Env> {
       const sandboxId = request.headers.get("X-Sandbox-ID");
 
       if (isSandbox) {
+        // A bridge can arrive while the provider call is still resolving access
+        // URLs. In that case the lifecycle manager publishes access after the
+        // values are persisted.
+        const accessIsPersisted = this.getSandbox()?.status !== "spawning";
         const { replaced } = this.wsManager.acceptAndSetSandboxSocket(
           server,
           sandboxId ?? undefined
@@ -1095,7 +1099,9 @@ export class SessionDO extends DurableObject<Env> {
         this.lifecycleManager.onSandboxConnected();
         this.updateSandboxStatus("ready");
         this.broadcast({ type: "sandbox_status", status: "ready" });
-        this.broadcast({ type: "sandbox_access_changed" });
+        if (accessIsPersisted) {
+          this.broadcast({ type: "sandbox_access_changed" });
+        }
 
         // Set initial activity timestamp and schedule inactivity check
         // IMPORTANT: Must await to ensure alarm is scheduled before returning

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1086,10 +1086,9 @@ export class SessionDO extends DurableObject<Env> {
       const sandboxId = request.headers.get("X-Sandbox-ID");
 
       if (isSandbox) {
-        // A bridge can arrive while the provider call is still resolving access
-        // URLs. In that case the lifecycle manager publishes access after the
-        // values are persisted.
-        const accessIsPersisted = this.getSandbox()?.status !== "spawning";
+        // The lifecycle manager publishes access after any pending provider
+        // startup has persisted its URLs and credentials.
+        const accessIsPersisted = !this.lifecycleManager.isProviderStartupPending();
         const { replaced } = this.wsManager.acceptAndSetSandboxSocket(
           server,
           sandboxId ?? undefined

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -160,7 +160,7 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     clientWs.close();
   });
 
-  it("does not publish sandbox access when the bridge arrives during spawning", async () => {
+  it("does not publish sandbox access for replacement bridges during provider startup", async () => {
     const name = `ws-sandbox-access-spawning-${Date.now()}`;
     const { stub } = await initNamedSession(name);
     await seedSandboxAuth(stub, {
@@ -168,21 +168,38 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
       sandboxId: SANDBOX_ID,
       status: "spawning",
     });
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      const lifecycleManager = (
+        instance as unknown as {
+          lifecycleManager: { providerStartupPending: boolean };
+        }
+      ).lifecycleManager;
+      lifecycleManager.providerStartupPending = true;
+    });
     const { ws: clientWs } = await openClientWs(name, { subscribe: true });
     const collector = collectMessages(clientWs, { timeoutMs: 100 });
 
-    const { ws: sandboxWs } = await openSandboxWs(name, {
+    const { ws: firstSandboxWs } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,
       sandboxId: SANDBOX_ID,
     });
-    expect(sandboxWs).not.toBeNull();
-    sandboxWs!.accept();
+    expect(firstSandboxWs).not.toBeNull();
+    firstSandboxWs!.accept();
+
+    const { ws: replacementSandboxWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(replacementSandboxWs).not.toBeNull();
+    replacementSandboxWs!.accept();
 
     const messages = await collector;
-    expect(messages).toContainEqual({ type: "sandbox_status", status: "ready" });
+    expect(
+      messages.filter((message) => message.type === "sandbox_status" && message.status === "ready")
+    ).toHaveLength(2);
     expect(messages).not.toContainEqual({ type: "sandbox_access_changed" });
 
-    sandboxWs!.close();
+    replacementSandboxWs!.close();
     clientWs.close();
   });
 

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { runInDurableObject } from "cloudflare:test";
+import { env, runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
+import { encryptToken } from "../../src/auth/crypto";
 import {
   collectMessages,
   initNamedSession,
@@ -112,6 +113,24 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
       sandboxId: SANDBOX_ID,
       status: "connecting",
     });
+    const [codePassword, vncPassword, terminalToken] = await Promise.all([
+      encryptToken("code-secret", env.REPO_SECRETS_ENCRYPTION_KEY),
+      encryptToken("vnc-secret", env.REPO_SECRETS_ENCRYPTION_KEY),
+      encryptToken("terminal-token", env.REPO_SECRETS_ENCRYPTION_KEY),
+    ]);
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE sandbox
+         SET code_server_url = ?, code_server_password = ?, vnc_url = ?, vnc_password = ?,
+             ttyd_url = ?, ttyd_token = ?`,
+        "https://code.test",
+        codePassword,
+        "https://vnc.test",
+        vncPassword,
+        "https://terminal.test",
+        terminalToken
+      );
+    });
     const { ws: clientWs } = await openClientWs(name, { subscribe: true });
     const collector = collectMessages(clientWs, {
       until: (message) => message.type === "sandbox_access_changed",
@@ -131,6 +150,37 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     ]);
     const accessResponse = await stub.fetch("http://internal/internal/sandbox-access");
     expect(accessResponse.status).toBe(200);
+    await expect(accessResponse.json()).resolves.toEqual({
+      codeServer: { url: "https://code.test", password: "code-secret" },
+      vnc: { url: "https://vnc.test", password: "vnc-secret" },
+      ttyd: { url: "https://terminal.test", token: "terminal-token" },
+    });
+
+    sandboxWs!.close();
+    clientWs.close();
+  });
+
+  it("does not publish sandbox access when the bridge arrives during spawning", async () => {
+    const name = `ws-sandbox-access-spawning-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "spawning",
+    });
+    const { ws: clientWs } = await openClientWs(name, { subscribe: true });
+    const collector = collectMessages(clientWs, { timeoutMs: 100 });
+
+    const { ws: sandboxWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(sandboxWs).not.toBeNull();
+    sandboxWs!.accept();
+
+    const messages = await collector;
+    expect(messages).toContainEqual({ type: "sandbox_status", status: "ready" });
+    expect(messages).not.toContainEqual({ type: "sandbox_access_changed" });
 
     sandboxWs!.close();
     clientWs.close();


### PR DESCRIPTION
## Summary
- defer `sandbox_access_changed` when an authenticated bridge connects while provider access data is still pending
- after spawn or snapshot restore access is persisted, preserve an already-connected bridge's ready state and inactivity alarm instead of regressing to connecting and scheduling a watchdog
- retain the existing connecting transition, access event, and watchdog behavior when the bridge arrives after the provider returns
- add deterministic spawn and restore race regressions plus integration coverage for access event ordering and readable credentials

## Testing
- `npm test -w @open-inspect/control-plane -- src/sandbox/lifecycle/manager.test.ts` (104 passed)
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-sandbox.test.ts` (14 passed)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/sandbox/lifecycle/manager.ts packages/control-plane/src/sandbox/lifecycle/manager.test.ts packages/control-plane/src/session/durable-object.ts packages/control-plane/test/integration/websocket-sandbox.test.ts`
- `npx prettier --check packages/control-plane/src/sandbox/lifecycle/manager.ts packages/control-plane/src/sandbox/lifecycle/manager.test.ts packages/control-plane/src/session/durable-object.ts packages/control-plane/test/integration/websocket-sandbox.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f7733bedb51880ae7479c519c77bf71e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox startup, restoration, and resume flows when connections are established early.
  - Prevented premature access notifications until credentials and URLs are fully available.
  - Ensured sandboxes transition to ready without unnecessary connecting alerts or timeout behavior.
  - Improved reliability and timing of access details for code-server, VNC, and terminal connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->