### PR TITLE
fix: preserve assistant text across compaction

### DIFF
--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -934,6 +934,16 @@ describe("SessionRepository", () => {
     });
   });
 
+  describe("sealTokenEvent", () => {
+    it("moves the current token to a compaction-specific event ID", () => {
+      repo.sealTokenEvent("msg-1", "compaction-1");
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].query).toContain("UPDATE events SET id = ? WHERE id = ?");
+      expect(mock.calls[0].params).toEqual(["token:msg-1:compaction-1", "token:msg-1"]);
+    });
+  });
+
   describe("upsertToolCallEvent", () => {
     it("scopes child call IDs and preserves the first event position on updates", () => {
       const event = {

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -71,12 +71,17 @@ function createMockSql() {
 describe("SessionRepository", () => {
   let mock: ReturnType<typeof createMockSql>;
   let repo: SessionRepository;
+  let transactionSyncCalls: number;
 
   beforeEach(() => {
     mock = createMockSql();
+    transactionSyncCalls = 0;
     repo = new SessionRepository(
       mock.sql,
-      (closure) => closure(),
+      (closure) => {
+        transactionSyncCalls += 1;
+        return closure();
+      },
       new SessionAttachmentRepository(mock.sql)
     );
   });
@@ -934,13 +939,28 @@ describe("SessionRepository", () => {
     });
   });
 
-  describe("sealTokenEvent", () => {
-    it("moves the current token to a compaction-specific event ID", () => {
-      repo.sealTokenEvent("msg-1", "compaction-1");
+  describe("createContextCompactionEvent", () => {
+    it("atomically seals the current token and inserts the compaction marker", () => {
+      repo.createContextCompactionEvent({
+        id: "compaction-1",
+        type: "context_compacted",
+        data: '{"type":"context_compacted"}',
+        messageId: "msg-1",
+        createdAt: 1000,
+      });
 
-      expect(mock.calls).toHaveLength(1);
+      expect(transactionSyncCalls).toBe(1);
+      expect(mock.calls).toHaveLength(2);
       expect(mock.calls[0].query).toContain("UPDATE events SET id = ? WHERE id = ?");
       expect(mock.calls[0].params).toEqual(["token:msg-1:compaction-1", "token:msg-1"]);
+      expect(mock.calls[1].query).toContain("INSERT INTO events");
+      expect(mock.calls[1].params).toEqual([
+        "compaction-1",
+        "context_compacted",
+        '{"type":"context_compacted"}',
+        "msg-1",
+        1000,
+      ]);
     });
   });
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -959,6 +959,14 @@ export class SessionRepository {
     this.upsertEventByMessageId("token", messageId, event, createdAt);
   }
 
+  sealTokenEvent(messageId: string, boundaryId: string): void {
+    this.sql.exec(
+      `UPDATE events SET id = ? WHERE id = ?`,
+      `token:${messageId}:${boundaryId}`,
+      `token:${messageId}`
+    );
+  }
+
   upsertToolCallEvent(messageId: string, event: ToolCallEvent, createdAt: number): void {
     const id = `tool_call:${toolCallIdentityKey(event)}`;
     this.sql.exec(

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -933,6 +933,17 @@ export class SessionRepository {
     );
   }
 
+  createContextCompactionEvent(data: CreateEventData & { messageId: string }): void {
+    this.transactionSync(() => {
+      this.sql.exec(
+        `UPDATE events SET id = ? WHERE id = ?`,
+        `token:${data.messageId}:${data.id}`,
+        `token:${data.messageId}`
+      );
+      this.createEvent(data);
+    });
+  }
+
   private upsertEventByMessageId<TType extends UpsertableEventType>(
     type: TType,
     messageId: string,
@@ -957,14 +968,6 @@ export class SessionRepository {
 
   upsertTokenEvent(messageId: string, event: TokenEvent, createdAt: number): void {
     this.upsertEventByMessageId("token", messageId, event, createdAt);
-  }
-
-  sealTokenEvent(messageId: string, boundaryId: string): void {
-    this.sql.exec(
-      `UPDATE events SET id = ? WHERE id = ?`,
-      `token:${messageId}:${boundaryId}`,
-      `token:${messageId}`
-    );
   }
 
   upsertToolCallEvent(messageId: string, event: ToolCallEvent, createdAt: number): void {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -27,7 +27,7 @@ function createProcessor() {
     updateSandboxHeartbeat: vi.fn(),
     getProcessingMessage,
     upsertTokenEvent: vi.fn(),
-    sealTokenEvent: vi.fn(),
+    createContextCompactionEvent: vi.fn(),
     upsertToolCallEvent: vi.fn(),
     createArtifact: vi.fn(),
     createEvent: vi.fn(),
@@ -225,22 +225,18 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
     await h.processor.processSandboxEvent({ ...event, timestamp: 1001 });
 
-    expect(h.repository.createEvent).toHaveBeenCalledTimes(2);
-    expect(h.repository.sealTokenEvent).toHaveBeenCalledTimes(2);
-    expect(h.repository.sealTokenEvent).toHaveBeenNthCalledWith(
-      1,
-      "msg-1",
-      h.repository.createEvent.mock.calls[0][0].id
-    );
-    expect(h.repository.sealTokenEvent).toHaveBeenNthCalledWith(
-      2,
-      "msg-1",
-      h.repository.createEvent.mock.calls[1][0].id
-    );
-    expect(h.repository.createEvent).toHaveBeenNthCalledWith(1, {
+    expect(h.repository.createContextCompactionEvent).toHaveBeenCalledTimes(2);
+    expect(h.repository.createContextCompactionEvent).toHaveBeenNthCalledWith(1, {
       id: expect.any(String),
       type: "context_compacted",
       data: JSON.stringify(event),
+      messageId: "msg-1",
+      createdAt: expect.any(Number),
+    });
+    expect(h.repository.createContextCompactionEvent).toHaveBeenNthCalledWith(2, {
+      id: expect.any(String),
+      type: "context_compacted",
+      data: JSON.stringify({ ...event, timestamp: 1001 }),
       messageId: "msg-1",
       createdAt: expect.any(Number),
     });

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -27,6 +27,7 @@ function createProcessor() {
     updateSandboxHeartbeat: vi.fn(),
     getProcessingMessage,
     upsertTokenEvent: vi.fn(),
+    sealTokenEvent: vi.fn(),
     upsertToolCallEvent: vi.fn(),
     createArtifact: vi.fn(),
     createEvent: vi.fn(),
@@ -225,6 +226,17 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent({ ...event, timestamp: 1001 });
 
     expect(h.repository.createEvent).toHaveBeenCalledTimes(2);
+    expect(h.repository.sealTokenEvent).toHaveBeenCalledTimes(2);
+    expect(h.repository.sealTokenEvent).toHaveBeenNthCalledWith(
+      1,
+      "msg-1",
+      h.repository.createEvent.mock.calls[0][0].id
+    );
+    expect(h.repository.sealTokenEvent).toHaveBeenNthCalledWith(
+      2,
+      "msg-1",
+      h.repository.createEvent.mock.calls[1][0].id
+    );
     expect(h.repository.createEvent).toHaveBeenNthCalledWith(1, {
       id: expect.any(String),
       type: "context_compacted",

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -141,14 +141,11 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "context_compacted") {
       const eventId = generateId();
-      if (messageId) {
-        this.repository.sealTokenEvent(messageId, eventId);
-      }
-      this.repository.createEvent({
+      this.repository.createContextCompactionEvent({
         id: eventId,
         type: event.type,
         data: JSON.stringify(event),
-        messageId,
+        messageId: event.messageId,
         createdAt: now,
       });
       this.messenger.broadcast({ type: "sandbox_event", event });

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -139,6 +139,22 @@ export class SessionSandboxEventProcessor {
       return;
     }
 
+    if (event.type === "context_compacted") {
+      const eventId = generateId();
+      if (messageId) {
+        this.repository.sealTokenEvent(messageId, eventId);
+      }
+      this.repository.createEvent({
+        id: eventId,
+        type: event.type,
+        data: JSON.stringify(event),
+        messageId,
+        createdAt: now,
+      });
+      this.messenger.broadcast({ type: "sandbox_event", event });
+      return;
+    }
+
     if (event.type === "step_start" || event.type === "step_finish") {
       this.updateLastActivity(now);
       if (

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -289,7 +289,7 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     ws!.close();
   });
 
-  it("stores and broadcasts context compaction events", async () => {
+  it("preserves token segments around context compaction for replay", async () => {
     const name = `ws-sandbox-compaction-${Date.now()}`;
     const { stub } = await initNamedSession(name);
     const { ws: clientWs } = await openClientWs(name, { subscribe: true });
@@ -303,32 +303,70 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
 
     const collector = collectMessages(clientWs, {
       until: (message) =>
-        message.type === "sandbox_event" && message.event.type === "context_compacted",
+        message.type === "sandbox_event" &&
+        message.event.type === "token" &&
+        message.event.content === "After compaction",
     });
-    const event = {
+    const before = {
+      type: "token",
+      content: "Before compaction",
+      messageId: "msg-compaction-1",
+      sandboxId: SANDBOX_ID,
+      timestamp: 1,
+    } as const;
+    const compacted = {
       type: "context_compacted",
       messageId: "msg-compaction-1",
       sandboxId: SANDBOX_ID,
-      timestamp: Date.now() / 1000,
+      timestamp: 2,
     } as const;
-    sandboxWs!.send(JSON.stringify(event));
+    const after = {
+      type: "token",
+      content: "After compaction",
+      messageId: "msg-compaction-1",
+      sandboxId: SANDBOX_ID,
+      timestamp: 3,
+    } as const;
+    sandboxWs!.send(JSON.stringify(before));
+    sandboxWs!.send(JSON.stringify(compacted));
+    sandboxWs!.send(JSON.stringify(after));
 
     const messages = await collector;
-    expect(messages).toContainEqual({ type: "sandbox_event", event });
-    const events = await queryDO<{ type: string; data: string; message_id: string }>(
+    expect(messages).toContainEqual({ type: "sandbox_event", event: compacted });
+    const events = await queryDO<{
+      id: string;
+      type: string;
+      data: string;
+      timeline_sequence: number;
+    }>(
       stub,
-      "SELECT type, data, message_id FROM events WHERE type = ?",
-      "context_compacted"
+      "SELECT id, type, data, timeline_sequence FROM events WHERE message_id = ? ORDER BY timeline_sequence",
+      "msg-compaction-1"
     );
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      type: "context_compacted",
-      message_id: "msg-compaction-1",
+    expect(events.map(({ type, data }) => ({ type, event: JSON.parse(data) }))).toEqual([
+      { type: "token", event: before },
+      { type: "context_compacted", event: compacted },
+      { type: "token", event: after },
+    ]);
+    expect(events[0].id).toMatch(/^token:msg-compaction-1:/);
+    expect(events[2].id).toBe("token:msg-compaction-1");
+
+    const { ws: replayWs, messages: replayMessages } = await openClientWs(name, {
+      subscribe: true,
+      userId: "user-replay",
     });
-    expect(JSON.parse(events[0].data)).toEqual(event);
+    const subscribed = replayMessages.find((message) => message.type === "subscribed") as
+      | { timeline: { events: Array<{ event: unknown }> } }
+      | undefined;
+    expect(subscribed?.timeline.events.map(({ event }) => event)).toEqual([
+      before,
+      compacted,
+      after,
+    ]);
 
     sandboxWs!.close();
     clientWs.close();
+    replayWs.close();
   });
 
   it("accepts step_finish messages with structured token usage", async () => {

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -171,6 +171,28 @@ describe("context compaction", () => {
       "single",
     ]);
   });
+
+  it("keeps assistant segments on both sides of a marker", () => {
+    const token = (content: string, timestamp: number): SandboxEvent => ({
+      type: "token",
+      content,
+      messageId: "message-1",
+      sandboxId: "sandbox-1",
+      timestamp,
+    });
+
+    const items = buildTimelineItems([
+      token("before compaction", 1),
+      compaction(2),
+      token("after compaction", 3),
+    ]);
+
+    expect(items).toMatchObject([
+      { type: "single", event: { type: "token", content: "before compaction" } },
+      { type: "single", event: { type: "context_compacted" } },
+      { type: "single", event: { type: "token", content: "after compaction" } },
+    ]);
+  });
 });
 
 const baseTimelineProps = {

--- a/packages/web/src/lib/session-socket/event-log.test.ts
+++ b/packages/web/src/lib/session-socket/event-log.test.ts
@@ -16,6 +16,10 @@ function completionEvent(messageId: string, timestamp = 2): SandboxEvent {
   return { type: "execution_complete", messageId, success: true, sandboxId: "sb-1", timestamp };
 }
 
+function compactionEvent(messageId: string, timestamp = 2): SandboxEvent {
+  return { type: "context_compacted", messageId, sandboxId: "sb-1", timestamp };
+}
+
 describe("toUiSandboxEvent", () => {
   it("keeps a numeric timestamp", () => {
     expect(toUiSandboxEvent(tokenEvent("msg-1", "hi", 42)).timestamp).toBe(42);
@@ -45,6 +49,24 @@ describe("collapseReplayTokenEvents", () => {
     expect(collapseReplayTokenEvents(events)).toEqual([
       tokenEvent("msg-1", "final", 2),
       completionEvent("msg-1", 3),
+    ]);
+  });
+
+  it("keeps final tokens from both sides of a compaction boundary", () => {
+    const events = [
+      tokenEvent("msg-1", "pre-partial", 1),
+      tokenEvent("msg-1", "before compaction", 2),
+      compactionEvent("msg-1", 3),
+      tokenEvent("msg-1", "post-partial", 4),
+      tokenEvent("msg-1", "after compaction", 5),
+      completionEvent("msg-1", 6),
+    ];
+
+    expect(collapseReplayTokenEvents(events)).toEqual([
+      tokenEvent("msg-1", "before compaction", 2),
+      compactionEvent("msg-1", 3),
+      tokenEvent("msg-1", "after compaction", 5),
+      completionEvent("msg-1", 6),
     ]);
   });
 
@@ -128,7 +150,7 @@ describe("ingestLiveSandboxEvent", () => {
     expect(result.append).toEqual([toolCall]);
   });
 
-  it("passes context compaction through without flushing pending text", () => {
+  it("flushes pending text before context compaction", () => {
     const pending: PendingAssistantText = {
       content: "in flight",
       messageId: "msg-1",
@@ -144,8 +166,8 @@ describe("ingestLiveSandboxEvent", () => {
 
     const result = ingestLiveSandboxEvent(pending, compaction);
 
-    expect(result.pending).toBe(pending);
-    expect(result.append).toEqual([compaction]);
+    expect(result.pending).toBeNull();
+    expect(result.append).toEqual([pendingToTokenEvent(pending), compaction]);
   });
 });
 

--- a/packages/web/src/lib/session-socket/event-log.ts
+++ b/packages/web/src/lib/session-socket/event-log.ts
@@ -3,17 +3,18 @@ import type { SandboxEvent } from "@/types/session";
 /**
  * The displayable event log built from raw sandbox events.
  *
- * Token events carry the full accumulated text (not incremental deltas), so
- * the log must show exactly one final token per message: collapsed after the
- * fact during replay (`collapseReplayTokenEvents`), and buffered until the
- * execution completes on the live path (`ingestLiveSandboxEvent`).
+ * Token events carry the full accumulated text for one assistant segment (not
+ * incremental deltas), so the log keeps one final token per segment. Context
+ * compaction ends the current segment before another starts for the same
+ * message.
  */
 
 export type AssistantTokenEvent = Extract<SandboxEvent, { type: "token" }>;
 
 /**
- * The latest streamed assistant text for an in-flight message. Only the most
- * recent token needs to be retained because each one supersedes the last.
+ * The latest streamed assistant text for an in-flight segment. Only the most
+ * recent token within that segment needs to be retained because it supersedes
+ * the last.
  */
 export type PendingAssistantText = Pick<
   AssistantTokenEvent,
@@ -32,43 +33,61 @@ function isRenderableTokenEvent(event: SandboxEvent): event is AssistantTokenEve
 }
 
 /**
- * Replay should show one final token per message, independent of tied storage
- * ordering between token and completion.
+ * Replay should show one final token per compaction-delimited segment,
+ * independent of tied storage ordering between token and completion.
  */
 export function collapseReplayTokenEvents(events: SandboxEvent[]): SandboxEvent[] {
-  const tokenByMessageId = new Map<string, AssistantTokenEvent>();
+  const tokenBySegment = new Map<string, AssistantTokenEvent>();
+  const segmentByMessageId = new Map<string, number>();
+  const segmentKey = (messageId: string) =>
+    JSON.stringify([messageId, segmentByMessageId.get(messageId) ?? 0]);
 
   for (const event of events) {
     if (isRenderableTokenEvent(event)) {
-      tokenByMessageId.set(event.messageId, event);
+      tokenBySegment.set(segmentKey(event.messageId), event);
+    } else if (event.type === "context_compacted") {
+      segmentByMessageId.set(event.messageId, (segmentByMessageId.get(event.messageId) ?? 0) + 1);
     }
   }
 
-  if (tokenByMessageId.size === 0) {
+  if (tokenBySegment.size === 0) {
     return events;
   }
 
   const result: SandboxEvent[] = [];
-  const emittedTokenMessageIds = new Set<string>();
+  const emittedSegments = new Set<string>();
+  segmentByMessageId.clear();
+
+  const emitSegmentToken = (messageId: string) => {
+    const key = segmentKey(messageId);
+    const token = tokenBySegment.get(key);
+    if (token && !emittedSegments.has(key)) {
+      result.push(token);
+      emittedSegments.add(key);
+    }
+  };
 
   for (const evt of events) {
     if (isRenderableTokenEvent(evt)) {
       continue;
     }
 
+    if (evt.type === "context_compacted") {
+      emitSegmentToken(evt.messageId);
+      result.push(evt);
+      segmentByMessageId.set(evt.messageId, (segmentByMessageId.get(evt.messageId) ?? 0) + 1);
+      continue;
+    }
+
     if (evt.type === "execution_complete") {
-      const token = tokenByMessageId.get(evt.messageId);
-      if (token && !emittedTokenMessageIds.has(evt.messageId)) {
-        result.push(token);
-        emittedTokenMessageIds.add(evt.messageId);
-      }
+      emitSegmentToken(evt.messageId);
     }
 
     result.push(evt);
   }
 
-  for (const [messageId, token] of tokenByMessageId) {
-    if (!emittedTokenMessageIds.has(messageId)) {
+  for (const [key, token] of tokenBySegment) {
+    if (!emittedSegments.has(key)) {
       result.push(token);
     }
   }
@@ -109,6 +128,13 @@ export function ingestLiveSandboxEvent(
     return {
       pending: null,
       append: pending ? [pendingToTokenEvent(pending), event] : [event],
+    };
+  }
+
+  if (event.type === "context_compacted" && pending?.messageId === event.messageId) {
+    return {
+      pending: null,
+      append: [pendingToTokenEvent(pending), event],
     };
   }
 

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -86,6 +86,7 @@ function dedupeEvents(events: SandboxEvent[]): SandboxEvent[] {
       tokenIndexes.set(event.messageId, result.length);
       result.push(event);
     } else {
+      if (event.type === "context_compacted") tokenIndexes.delete(event.messageId);
       result.push(event);
     }
   }


### PR DESCRIPTION
## Summary

- seal the current persisted token row when a context compaction marker arrives so post-compaction tokens start a distinct persisted segment
- flush live assistant text before rendering the compaction marker
- collapse replay tokens per compaction-delimited segment and preserve both segments through timeline dedupe
- add deterministic unit and workerd integration coverage for live ordering, persisted ordering, and subscription replay

## Root cause

OpenCode emits pre- and post-compaction text as separate non-cumulative parts, but both use the same control-plane message ID. The live buffer, token upsert, replay collapse, and timeline dedupe treated every token for that message as one cumulative stream, causing post-compaction text to replace the earlier segment.

## Verification

- `npm test -w @open-inspect/web -- src/lib/session-socket/event-log.test.ts src/components/session-timeline.test.tsx`
- `npm test -w @open-inspect/control-plane -- src/session/repository.test.ts src/session/sandbox-events.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-sandbox.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- targeted ESLint and Prettier checks for all changed files
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/501344ae2c92a9f37b01673e06cf8b9f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timelines around context compaction events.
  * Assistant responses remain correctly separated before and after compaction markers.
  * Preserved event ordering and token content during live updates and replayed session history.
  * Prevented later token updates from overwriting content recorded before a compaction boundary.
  * Ensured context compaction events are persisted and broadcast consistently.
* **Tests**
  * Added coverage for live sessions, replay history, event persistence, and timeline rendering across compaction events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->