### PR TITLE
Import Slack shared types from canonical modules

### DIFF
--- a/packages/slack-bot/src/app-home.test.ts
+++ b/packages/slack-bot/src/app-home.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import { buildAppHomeIntroText, buildAppHomeView } from "./app-home";
-import type { RepoConfig } from "./types";
 
 describe("buildAppHomeIntroText", () => {
   it("uses the configured app name", () => {

--- a/packages/slack-bot/src/app-home/modals.ts
+++ b/packages/slack-bot/src/app-home/modals.ts
@@ -6,7 +6,8 @@ import {
   REPO_BRANCH_MODAL_CALLBACK_ID,
 } from "../branch-preferences";
 import { createLogger } from "../logger";
-import type { Env, RepoConfig } from "../types";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import type { Env } from "../types";
 import { encodeBranchModalMetadata, encodeRepoBranchModalMetadata } from "./metadata";
 import type { AppHomeModalBlock } from "./slack-types";
 import type { SlackInputBlock } from "../slack-blocks";

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -1,6 +1,6 @@
 import { getDefaultReasoningEffort, getReasoningConfig } from "@open-inspect/shared/models";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import { CLEAR_REPO_BRANCH_ACTION_ID, REPO_BRANCH_SELECTOR_ACTION_ID } from "../branch-preferences";
-import type { RepoConfig } from "../types";
 import {
   CLEAR_BRANCH_PREFERENCE_ACTION_ID,
   MAX_RENDERED_REPO_OVERRIDES,

--- a/packages/slack-bot/src/classifier/catalog.ts
+++ b/packages/slack-bot/src/classifier/catalog.ts
@@ -5,7 +5,9 @@
  * is a single explicit value rather than a fetch threaded through each stage.
  */
 
-import type { Env, Environment, RepoConfig } from "../types";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import type { Env } from "../types";
 import { getAvailableRepos } from "./repos";
 import { getAvailableEnvironments } from "./environments";
 

--- a/packages/slack-bot/src/classifier/environments.test.ts
+++ b/packages/slack-bot/src/classifier/environments.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Env, Environment } from "../types";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { Env } from "../types";
 import {
   clearEnvironmentsLocalCache,
   getAvailableEnvironments,

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Env, Environment, RepoConfig } from "../types";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import type { Env } from "../types";
 
 const {
   mockMessagesCreate,

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -6,7 +6,7 @@
  * GitHub App installation to get the list of accessible repositories.
  */
 
-import type { Env, RepoConfig } from "../types";
+import type { Env } from "../types";
 import { normalizeRepoId } from "../utils/repo";
 import {
   normalizeRoutingRules,
@@ -16,6 +16,7 @@ import {
 import {
   controlPlaneReposResponseSchema,
   repoConfigSchema,
+  type RepoConfig,
 } from "@open-inspect/shared/types/repository-catalog";
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { createCachedResource } from "./cached-resource";

--- a/packages/slack-bot/src/target-clarification.test.ts
+++ b/packages/slack-bot/src/target-clarification.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Env, Environment, RepoConfig, SlackSessionTarget } from "./types";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import type { Env, SlackSessionTarget } from "./types";
 import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
 
 const { mockGetAvailableRepos, mockGetAvailableEnvironments, mockGetEnvironmentById } = vi.hoisted(

--- a/packages/slack-bot/src/target-clarification.ts
+++ b/packages/slack-bot/src/target-clarification.ts
@@ -10,6 +10,8 @@
 
 import { getAvailableRepos, filterReposByQuery } from "./classifier/repos";
 import { getEnvironmentById } from "./classifier/environments";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import { loadTargetCatalog, type TargetCatalog } from "./classifier/catalog";
 import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
 import { plainTextOption } from "./slack-options";
@@ -23,7 +25,7 @@ import type {
   SlackSelectOptionGroup,
   SlackStaticSelectElement,
 } from "./slack-blocks";
-import type { Env, Environment, RepoConfig } from "./types";
+import type { Env } from "./types";
 
 /**
  * Action ID for the target picker shown when the classifier can't decide what

--- a/packages/slack-bot/src/targets.test.ts
+++ b/packages/slack-bot/src/targets.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { Environment, RepoConfig } from "./types";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import {
   branchPreferenceRepo,
   buildSessionTargetRequestFields,

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -42,16 +42,6 @@ export interface Env {
 }
 
 /**
- * Repository configuration for the classifier.
- */
-export type {
-  RepoConfig,
-  RepoMetadata,
-  ControlPlaneRepo,
-  ControlPlaneReposResponse,
-} from "@open-inspect/shared/types/repository-catalog";
-
-/**
  * Thread context for classification.
  */
 export interface ThreadContext {
@@ -81,8 +71,6 @@ export interface ClassificationResult {
   needsClarification: boolean;
 }
 
-export type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
-export type { Environment } from "@open-inspect/shared/types/environments";
 export type { SlackSessionTarget } from "../targets";
 
 /**
@@ -179,8 +167,3 @@ export interface ToolCallCallback {
   signature: string;
   context: SlackCallbackContext;
 }
-
-/**
- * Event response from control-plane events API.
- */
-export type { EventResponse, ListEventsResponse } from "@open-inspect/shared/types/sandbox-events";


### PR DESCRIPTION
## Summary
- import `RepoConfig` and `Environment` directly from their canonical shared modules in Slack production and test consumers
- remove the Slack types barrel reexports for those types and six unused shared types
- preserve type-only imports and all runtime/package interfaces

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run build -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npm test -w @open-inspect/slack-bot` (33 files, 412 tests)
- `npx prettier --check packages/slack-bot/src`
- `git diff --check`
- TypeScript AST and ripgrep audits: zero remaining Slack intermediary imports or reexports for all eight shared types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized shared repository, environment, and event type definitions.
  - Updated Slack bot components and tests to use the shared type definitions.
  - Removed duplicate type re-exports from the Slack bot’s local types module.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->