### PR TITLE
Add typed Modal image request models

### DIFF
--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -96,12 +96,29 @@ def _parse_request[RequestModelT: BaseModel](
         error = e.errors(include_input=False)[0]
         location = error["loc"]
         field = str(location[0]) if location else "request"
-        detail = {
-            "missing": f"{field} is required",
-            "string_too_short": f"{field} is required",
-            "string_type": f"{field} must be a string",
-            "int_type": f"{field} must be an integer",
-        }.get(error["type"], f"{field} has an invalid value")
+        error_type = error["type"]
+        if field == "repositories":
+            detail = {
+                "list_type": "repositories must be a list",
+                "model_type": "repositories entries must be objects",
+                "missing": "repositories entries require repo_owner, repo_name, and branch",
+                "string_too_short": (
+                    "repositories entries require repo_owner, repo_name, and branch"
+                ),
+                "string_type": "repositories entry fields must be strings",
+            }.get(error_type, "repositories has an invalid value")
+        elif field == "user_env_vars":
+            detail = {
+                "dict_type": "user_env_vars must be an object",
+                "string_type": "user_env_vars values must be strings",
+            }.get(error_type, "user_env_vars has an invalid value")
+        else:
+            detail = {
+                "missing": f"{field} is required",
+                "string_too_short": f"{field} is required",
+                "string_type": f"{field} must be a string",
+                "int_type": f"{field} must be an integer",
+            }.get(error_type, f"{field} has an invalid value")
         raise HTTPException(status_code=400, detail=detail) from None
 
 

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -13,9 +13,11 @@ The control plane must include an Authorization header with a valid token.
 
 import time
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import Header, HTTPException
 from modal import fastapi_endpoint
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from sandbox_runtime.auth import AuthConfigurationError, verify_internal_token
 from sandbox_runtime.repo_config import RepoConfigError, parse_repositories
@@ -33,6 +35,67 @@ from .log_config import configure_logging, get_logger
 configure_logging()
 log = get_logger("web_api")
 IMAGE_BUILD_FINALIZATION_GRACE_SECONDS = 10 * 60
+
+
+class _ModalRequestModel(BaseModel):
+    model_config = ConfigDict(extra="ignore", strict=True)
+
+
+NonEmptyString = Annotated[str, Field(min_length=1)]
+
+
+class SnapshotBuildSandboxRequest(_ModalRequestModel):
+    build_id: NonEmptyString
+    provider_session_id: NonEmptyString
+
+
+class CreateBuildSandboxRequest(_ModalRequestModel):
+    scope_kind: NonEmptyString
+    scope_id: NonEmptyString
+    build_id: NonEmptyString
+    repositories: list[dict[str, object]]
+    callback_url: NonEmptyString
+    failure_callback_url: NonEmptyString
+    clone_token: str | None = None
+    clone_host: str | None = None
+    clone_username: str | None = None
+    user_env_vars: dict[str, str] | None = None
+    build_execution_timeout_seconds: int | None = None
+    provider_session_timeout_seconds: int | None = None
+
+
+class StartBuildSandboxRequest(_ModalRequestModel):
+    build_id: NonEmptyString
+    provider_session_id: NonEmptyString
+    callback_token: NonEmptyString
+
+
+class TerminateBuildSandboxRequest(_ModalRequestModel):
+    build_id: NonEmptyString
+    provider_session_id: NonEmptyString
+    reason: NonEmptyString
+
+
+class DeleteProviderImageRequest(_ModalRequestModel):
+    provider_image_id: NonEmptyString
+
+
+def _parse_request[RequestModelT: BaseModel](
+    model: type[RequestModelT], request: dict[str, object]
+) -> RequestModelT:
+    try:
+        return model.model_validate(request)
+    except ValidationError as e:
+        error = e.errors(include_input=False)[0]
+        location = error["loc"]
+        field = str(location[0]) if location else "request"
+        detail = {
+            "missing": f"{field} is required",
+            "string_too_short": f"{field} is required",
+            "string_type": f"{field} must be a string",
+            "int_type": f"{field} must be an integer",
+        }.get(error["type"], f"{field} has an invalid value")
+        raise HTTPException(status_code=400, detail=detail) from None
 
 
 def require_auth(authorization: str | None) -> None:
@@ -357,7 +420,7 @@ async def api_snapshot_sandbox(
 @app.function(image=function_image, secrets=[internal_api_secret])
 @fastapi_endpoint(method="POST")
 async def api_snapshot_build_sandbox(
-    request: dict,
+    request: dict[str, object],
     authorization: str | None = Header(None),
     x_trace_id: str | None = Header(None),
     x_request_id: str | None = Header(None),
@@ -377,8 +440,9 @@ async def api_snapshot_build_sandbox(
             ModalBuildSessionService,
         )
 
-        build_id = _required_string(request, "build_id")
-        provider_session_id = _required_string(request, "provider_session_id")
+        parsed_request = _parse_request(SnapshotBuildSandboxRequest, request)
+        build_id = parsed_request.build_id
+        provider_session_id = parsed_request.provider_session_id
         image_id = await ModalBuildSessionService().snapshot(
             build_id=build_id,
             provider_session_id=provider_session_id,
@@ -569,7 +633,7 @@ async def api_restore_sandbox(
 )
 @fastapi_endpoint(method="POST")
 async def api_create_build_sandbox(
-    request: dict,
+    request: dict[str, object],
     authorization: str | None = Header(None),
     x_trace_id: str | None = Header(None),
     x_request_id: str | None = Header(None),
@@ -590,30 +654,29 @@ async def api_create_build_sandbox(
             ModalBuildSessionService,
         )
 
-        build_id = _required_string(request, "build_id")
-        scope_kind = _required_string(request, "scope_kind")
-        scope_id = _required_string(request, "scope_id")
+        parsed_request = _parse_request(CreateBuildSandboxRequest, request)
+        build_id = parsed_request.build_id
+        scope_kind = parsed_request.scope_kind
+        scope_id = parsed_request.scope_id
         if scope_kind not in {"repo", "environment"}:
             raise HTTPException(status_code=400, detail="scope_kind must be repo or environment")
-        repositories = _validated_build_repositories(request.get("repositories"))
+        repositories = _validated_build_repositories(parsed_request.repositories)
         build_execution_timeout_seconds = _validated_timeout_seconds(
-            request,
-            "build_execution_timeout_seconds",
+            parsed_request.build_execution_timeout_seconds,
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
         provider_session_timeout_seconds = _validated_timeout_seconds(
-            request,
-            "provider_session_timeout_seconds",
+            parsed_request.provider_session_timeout_seconds,
             default_seconds=(
                 DEFAULT_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS
             ),
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS + IMAGE_BUILD_FINALIZATION_GRACE_SECONDS,
         )
-        clone_host = _optional_string(request, "clone_host")
-        clone_username = _optional_string(request, "clone_username")
-        callback_url = _required_string(request, "callback_url")
-        failure_callback_url = _required_string(request, "failure_callback_url")
+        clone_host = parsed_request.clone_host or None
+        clone_username = parsed_request.clone_username or None
+        callback_url = parsed_request.callback_url
+        failure_callback_url = parsed_request.failure_callback_url
         if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
             failure_callback_url
         ):
@@ -628,10 +691,10 @@ async def api_create_build_sandbox(
             repositories=repositories,
             callback_url=callback_url,
             failure_callback_url=failure_callback_url,
-            clone_token=request.get("clone_token") or "",
+            clone_token=parsed_request.clone_token or "",
             clone_host=clone_host,
             clone_username=clone_username,
-            user_env_vars=request.get("user_env_vars") or None,
+            user_env_vars=parsed_request.user_env_vars or None,
             build_execution_timeout_seconds=build_execution_timeout_seconds,
             timeout_seconds=provider_session_timeout_seconds,
         )
@@ -665,7 +728,7 @@ async def api_create_build_sandbox(
 @app.function(image=function_image, secrets=[internal_api_secret])
 @fastapi_endpoint(method="POST")
 async def api_start_build_sandbox(
-    request: dict,
+    request: dict[str, object],
     authorization: str | None = Header(None),
     x_trace_id: str | None = Header(None),
     x_request_id: str | None = Header(None),
@@ -682,12 +745,13 @@ async def api_start_build_sandbox(
     try:
         from .sandbox.build_session import ModalBuildSessionService
 
-        build_id = _required_string(request, "build_id")
-        provider_session_id = _required_string(request, "provider_session_id")
+        parsed_request = _parse_request(StartBuildSandboxRequest, request)
+        build_id = parsed_request.build_id
+        provider_session_id = parsed_request.provider_session_id
         await ModalBuildSessionService().start(
             build_id=build_id,
             provider_session_id=provider_session_id,
-            callback_token=_required_string(request, "callback_token"),
+            callback_token=parsed_request.callback_token,
         )
         return {"success": True, "data": {"started": True}}
     except HTTPException as e:
@@ -716,7 +780,7 @@ async def api_start_build_sandbox(
 @app.function(image=function_image, secrets=[internal_api_secret])
 @fastapi_endpoint(method="POST")
 async def api_terminate_build_sandbox(
-    request: dict,
+    request: dict[str, object],
     authorization: str | None = Header(None),
     x_trace_id: str | None = Header(None),
     x_request_id: str | None = Header(None),
@@ -733,12 +797,13 @@ async def api_terminate_build_sandbox(
     try:
         from .sandbox.build_session import ModalBuildSessionService
 
-        build_id = _required_string(request, "build_id")
-        provider_session_id = _required_string(request, "provider_session_id")
+        parsed_request = _parse_request(TerminateBuildSandboxRequest, request)
+        build_id = parsed_request.build_id
+        provider_session_id = parsed_request.provider_session_id
         await ModalBuildSessionService().terminate(
             build_id=build_id,
             provider_session_id=provider_session_id,
-            reason=_required_string(request, "reason"),
+            reason=parsed_request.reason,
         )
         return {"success": True, "data": {"terminated": True}}
     except HTTPException as e:
@@ -762,22 +827,6 @@ async def api_terminate_build_sandbox(
             build_id=build_id,
             provider_session_id=provider_session_id,
         )
-
-
-def _required_string(request: dict, field: str) -> str:
-    value = request.get(field)
-    if not isinstance(value, str) or not value:
-        raise HTTPException(status_code=400, detail=f"{field} is required")
-    return value
-
-
-def _optional_string(request: dict, field: str) -> str | None:
-    value = request.get(field)
-    if value is None or value == "":
-        return None
-    if not isinstance(value, str):
-        raise HTTPException(status_code=400, detail=f"{field} must be a string")
-    return value
 
 
 def _log_build_http_request(
@@ -808,17 +857,13 @@ def _log_build_http_request(
 
 
 def _validated_timeout_seconds(
-    request: dict,
-    field: str,
+    value: int | None,
     *,
     default_seconds: int,
     max_seconds: int,
 ) -> int:
-    value = request.get(field)
     if value is None:
         return default_seconds
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
     return min(max_seconds, max(1, value))
 
 
@@ -852,7 +897,7 @@ def _validated_build_repositories(value: object) -> list[dict]:
 )
 @fastapi_endpoint(method="POST")
 async def api_delete_provider_image(
-    request: dict,
+    request: dict[str, object],
     authorization: str | None = Header(None),
     x_trace_id: str | None = Header(None),
     x_request_id: str | None = Header(None),
@@ -873,9 +918,8 @@ async def api_delete_provider_image(
 
     require_auth(authorization)
 
-    provider_image_id = request.get("provider_image_id")
-    if not provider_image_id:
-        raise HTTPException(status_code=400, detail="provider_image_id is required")
+    parsed_request = _parse_request(DeleteProviderImageRequest, request)
+    provider_image_id = parsed_request.provider_image_id
 
     try:
         # Modal doesn't have an explicit delete API for images;

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -49,11 +49,18 @@ class SnapshotBuildSandboxRequest(_ModalRequestModel):
     provider_session_id: NonEmptyString
 
 
+class BuildRepositoryRequest(_ModalRequestModel):
+    repo_owner: NonEmptyString
+    repo_name: NonEmptyString
+    branch: NonEmptyString
+    base_sha: str | None = None
+
+
 class CreateBuildSandboxRequest(_ModalRequestModel):
     scope_kind: NonEmptyString
     scope_id: NonEmptyString
     build_id: NonEmptyString
-    repositories: list[dict[str, object]]
+    repositories: list[BuildRepositoryRequest]
     callback_url: NonEmptyString
     failure_callback_url: NonEmptyString
     clone_token: str | None = None
@@ -867,28 +874,34 @@ def _validated_timeout_seconds(
     return min(max_seconds, max(1, value))
 
 
-def _validated_build_repositories(value: object) -> list[dict]:
-    if not isinstance(value, list) or not value:
+def _validated_build_repositories(
+    value: list[BuildRepositoryRequest],
+) -> list[dict[str, str]]:
+    if not value:
         raise HTTPException(status_code=400, detail="repositories must be a non-empty list")
-    for entry in value:
-        if (
-            not isinstance(entry, dict)
-            or not entry.get("repo_owner")
-            or not entry.get("repo_name")
-            or not entry.get("branch")
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="repositories entries require repo_owner, repo_name, and branch",
-            )
+
+    request_repositories = [entry.model_dump(exclude_none=True) for entry in value]
     try:
-        parse_repositories(
-            {"repositories": value},
+        repositories = parse_repositories(
+            {"repositories": request_repositories},
             workspace_path=Path("/workspace"),
         )
     except RepoConfigError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    return value
+    if len(repositories) != len(value):
+        raise HTTPException(
+            status_code=400,
+            detail="repositories entries require repo_owner, repo_name, and branch",
+        )
+    return [
+        {
+            "repo_owner": repository.owner,
+            "repo_name": repository.name,
+            "branch": repository.branch,
+            **({"base_sha": repository.base_sha} if repository.base_sha else {}),
+        }
+        for repository in repositories
+    ]
 
 
 @app.function(

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -112,6 +112,8 @@ def _parse_request[RequestModelT: BaseModel](
                 "dict_type": "user_env_vars must be an object",
                 "string_type": "user_env_vars values must be strings",
             }.get(error_type, "user_env_vars has an invalid value")
+        elif len(location) > 1:
+            detail = f"{field} has an invalid value"
         else:
             detail = {
                 "missing": f"{field} is required",

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -918,10 +918,10 @@ async def api_delete_provider_image(
 
     require_auth(authorization)
 
-    parsed_request = _parse_request(DeleteProviderImageRequest, request)
-    provider_image_id = parsed_request.provider_image_id
-
     try:
+        parsed_request = _parse_request(DeleteProviderImageRequest, request)
+        provider_image_id = parsed_request.provider_image_id
+
         # Modal doesn't have an explicit delete API for images;
         # images are garbage-collected when no longer referenced.
         # We log the request for auditability.

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -327,6 +327,28 @@ async def test_create_clamps_build_execution_timeout_independently(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["repo_owner", "repo_name", "branch"])
+async def test_create_rejects_non_string_repository_fields(monkeypatch, field):
+    service = _patch_dependencies(monkeypatch)
+    repository = {**REPOSITORIES[0], field: True}
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_create_build_sandbox,
+            {
+                "scope_kind": "repo",
+                "scope_id": "acme/repo",
+                "build_id": "imgb-1",
+                "repositories": [repository],
+                **CALLBACK_CONTEXT,
+            },
+        )
+
+    assert exc.value.status_code == 400
+    service.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_create_rejects_case_insensitive_repository_path_collisions(monkeypatch):
     service = _patch_dependencies(monkeypatch)
 

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -492,6 +492,51 @@ async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(mo
 
 
 @pytest.mark.asyncio
+async def test_delete_provider_image_accepts_valid_request(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+
+    result = await _call(
+        web_api.api_delete_provider_image,
+        {"provider_image_id": "im-1"},
+    )
+
+    assert result == {
+        "success": True,
+        "data": {"provider_image_id": "im-1", "deleted": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_delete_provider_image,
+            {"provider_image_id": 123},
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "provider_image_id must be a string"
+
+
+@pytest.mark.asyncio
+async def test_image_request_validation_runs_after_authentication(monkeypatch):
+    def reject_auth(_authorization):
+        raise web_api.HTTPException(status_code=401, detail="Unauthorized")
+
+    monkeypatch.setattr(web_api, "require_auth", reject_auth)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_delete_provider_image,
+            {"provider_image_id": 123},
+        )
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_generic_snapshot_reason_cannot_select_build_identity_rules(monkeypatch):
     monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
     handle = SimpleNamespace()

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -566,6 +566,8 @@ async def test_delete_provider_image_accepts_valid_request(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
     monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    info = MagicMock()
+    monkeypatch.setattr(web_api.log, "info", info)
 
     with pytest.raises(web_api.HTTPException) as exc:
         await _call(
@@ -575,6 +577,8 @@ async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
 
     assert exc.value.status_code == 400
     assert exc.value.detail == "provider_image_id must be a string"
+    assert info.call_args.kwargs["http_status"] == 400
+    assert info.call_args.kwargs["outcome"] == "error"
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -345,6 +345,41 @@ async def test_create_rejects_non_string_repository_fields(monkeypatch, field):
         )
 
     assert exc.value.status_code == 400
+    assert exc.value.detail == "repositories entry fields must be strings"
+    service.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("request_update", "expected_detail"),
+    [
+        ({"repositories": "not-a-list"}, "repositories must be a list"),
+        (
+            {"user_env_vars": {"TOKEN": 123}},
+            "user_env_vars values must be strings",
+        ),
+    ],
+)
+async def test_create_reports_container_validation_errors_without_echoing_values(
+    monkeypatch, request_update, expected_detail
+):
+    service = _patch_dependencies(monkeypatch)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_create_build_sandbox,
+            {
+                "scope_kind": "repo",
+                "scope_id": "acme/repo",
+                "build_id": "imgb-1",
+                "repositories": REPOSITORIES,
+                **CALLBACK_CONTEXT,
+                **request_update,
+            },
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == expected_detail
     service.create.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- add strict endpoint-specific Pydantic models for Modal image create, start, terminate, snapshot, and delete requests
- parse requests after authentication to preserve current auth precedence and endpoint logging
- retain unknown-field compatibility, existing URL and repository validation, timeout defaults and clamping, and response shapes
- map validation failures to stable HTTP 400 messages without including request values

## Scope

This is the minimal image-lifecycle slice of Set 3B. It does not add API versioning, shared schemas, response models, create or restore session models, or control-plane changes.

## Validation

- `uv run --python 3.12 ruff format --check src/ tests/`
- `uv run --python 3.12 ruff check src/ tests/`
- `uv run --python 3.12 pytest tests/ -q` (182 passed)
- architecture and simplicity self-review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for build sandbox and provider-image requests.
  * Invalid, missing, empty, or incorrectly typed values now return consistent HTTP 400 responses.
  * Unexpected request fields are handled safely.
  * Timeout values now use sensible defaults and enforce allowed limits.
* **Tests**
  * Added coverage for provider-image deletion, including valid and invalid identifiers and authentication handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->