### PR TITLE
refactor: remove confirmed unused code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,7 +75,6 @@ export default tseslint.config(
                 "generateInternalToken",
                 "verifyCallbackSignature",
                 "verifyCallbackFromControlPlane",
-                "verifyInternalToken",
               ],
               message: "Import auth-owned names from @open-inspect/shared/auth.",
             },

--- a/packages/control-plane/src/db/errors.ts
+++ b/packages/control-plane/src/db/errors.ts
@@ -7,8 +7,3 @@ export function isUniqueConstraintError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.toLowerCase().includes("unique constraint failed");
 }
-
-export function isCheckConstraintError(err: unknown, constraint: string): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return message.toLowerCase().includes(`check constraint failed: ${constraint.toLowerCase()}`);
-}

--- a/packages/control-plane/src/image-builds/scheduler.ts
+++ b/packages/control-plane/src/image-builds/scheduler.ts
@@ -45,7 +45,7 @@ export class ImageBuildScheduler {
     private readonly provider: ImageBuildProvider | null,
     private readonly store: ImageBuildStore,
     private readonly workflow: ImageBuildWorkflow,
-    private readonly adapterFactory: ImageBuildAdapterFactory,
+    adapterFactory: ImageBuildAdapterFactory,
     private readonly sourceControl: SourceControlProvider | null,
     private readonly resolveTarget: typeof resolveScopeTarget = resolveScopeTarget,
     private readonly listScopes: typeof listEnabledScopes = listEnabledScopes

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -211,21 +211,3 @@ export type SandboxCommand =
   | AckCommand
   | PushCommand
   | RefreshDiffCommand;
-
-// Internal session update types
-
-export interface SessionUpdate {
-  title?: string;
-  branchName?: string;
-  baseSha?: string;
-  currentSha?: string;
-  opencodeSessionId?: string;
-  status?: SessionStatus;
-}
-
-export interface SandboxUpdate {
-  modalSandboxId?: string;
-  snapshotId?: string;
-  status?: SandboxStatus;
-  gitSyncStatus?: GitSyncStatus;
-}

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -2,12 +2,7 @@
  * Type definitions for Open-Inspect Control Plane.
  */
 
-import type {
-  MessageSource,
-  MessageStatus,
-  ParticipantRole,
-  SessionStatus,
-} from "@open-inspect/shared/types/sessions";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { z } from "zod";
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
 
@@ -147,27 +142,6 @@ export interface ListSessionsResponse {
   sessions: SessionResponse[];
   total: number;
   hasMore: boolean;
-}
-
-export interface MessageResponse {
-  id: string;
-  authorId: string;
-  content: string;
-  source: MessageSource;
-  status: MessageStatus;
-  createdAt: number;
-  startedAt: number | null;
-  completedAt: number | null;
-}
-
-export interface ParticipantResponse {
-  id: string;
-  userId: string;
-  canonicalUserId?: string | null;
-  scmLogin: string | null;
-  scmName: string | null;
-  role: ParticipantRole;
-  joinedAt: number;
 }
 
 // GitHub OAuth types

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -103,37 +103,3 @@ export async function verifyCallbackFromControlPlane<T extends { signature: stri
     env.SERVICE_AUTH_SECRET && (await verifyCallbackSignature(payload, env.SERVICE_AUTH_SECRET))
   );
 }
-
-/**
- * Verify an internal API token from the Authorization header.
- *
- * @param authHeader - The Authorization header value (e.g., "Bearer timestamp.signature")
- * @param secret - The shared secret for HMAC verification
- * @returns true if the token is valid, false otherwise
- */
-export async function verifyInternalToken(
-  authHeader: string | null,
-  secret: string
-): Promise<boolean> {
-  if (!authHeader?.startsWith("Bearer ")) {
-    return false;
-  }
-
-  const token = authHeader.slice(7);
-  const [timestamp, signature] = token.split(".");
-
-  if (!timestamp || !signature) {
-    return false;
-  }
-
-  // Reject tokens outside the validity window
-  const tokenTime = parseInt(timestamp, 10);
-  const now = Date.now();
-  if (isNaN(tokenTime) || Math.abs(now - tokenTime) > TOKEN_VALIDITY_MS) {
-    return false;
-  }
-
-  // Verify HMAC signature
-  const expectedHex = await computeHmacHex(timestamp, secret);
-  return timingSafeEqual(signature, expectedHex);
-}

--- a/packages/shared/src/completion/extractor.ts
+++ b/packages/shared/src/completion/extractor.ts
@@ -25,11 +25,6 @@ import {
 
 export type { ControlPlaneFetcher };
 
-/**
- * Tool names included in summary display.
- */
-export const SUMMARY_TOOL_NAMES = ["Edit", "Write", "Bash", "Grep", "Read"] as const;
-
 /** Server-side limit for the events API. */
 const EVENTS_PAGE_LIMIT = 200;
 

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -313,30 +313,6 @@ export function filterReposByQuery(repos: RepoConfig[], query: string | undefine
 }
 
 /**
- * Find a repository by owner and name.
- */
-export async function getRepoByFullName(
-  env: Env,
-  fullName: string,
-  traceId?: string
-): Promise<RepoConfig | undefined> {
-  const repos = await getAvailableRepos(env, traceId);
-  return repos.find((r) => r.fullName.toLowerCase() === fullName.toLowerCase());
-}
-
-/**
- * Find a repository by its ID.
- */
-export async function getRepoById(
-  env: Env,
-  id: string,
-  traceId?: string
-): Promise<RepoConfig | undefined> {
-  const repos = await getAvailableRepos(env, traceId);
-  return repos.find((r) => r.id.toLowerCase() === id.toLowerCase());
-}
-
-/**
  * Build a description string for the given repos.
  * Used in the classification prompt.
  */

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -73,50 +73,6 @@ export interface ClassificationResult {
 
 export type { SlackSessionTarget } from "../targets";
 
-/**
- * Slack event types.
- */
-export interface SlackEvent {
-  type: string;
-  event: {
-    type: string;
-    text?: string;
-    user?: string;
-    channel?: string;
-    ts?: string;
-    thread_ts?: string;
-    bot_id?: string;
-  };
-  event_id: string;
-  event_time: number;
-  team_id: string;
-}
-
-/**
- * Slack message event.
- */
-export interface SlackMessageEvent {
-  type: "message";
-  text: string;
-  user: string;
-  channel: string;
-  ts: string;
-  thread_ts?: string;
-  bot_id?: string;
-}
-
-/**
- * Slack app_mention event.
- */
-export interface SlackAppMentionEvent {
-  type: "app_mention";
-  text: string;
-  user: string;
-  channel: string;
-  ts: string;
-  thread_ts?: string;
-}
-
 export type { SlackInteractionPayload } from "../interaction-payload";
 
 import type { SlackCallbackContext } from "@open-inspect/shared/types/session-api";


### PR DESCRIPTION
## Summary
- remove audit item 8 declarations confirmed unused across the repository
- retain live shared auth primitives and `generateInternalToken`
- keep the image-build adapter factory constructor dependency for `ImageBuildSessionCleanup` without storing it on the scheduler
- update imports and the auth import lint restriction after removals

## Validation
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (578 tests)
- `npm test -w @open-inspect/slack-bot` (412 tests)
- `npm test -w @open-inspect/control-plane` (2,391 tests)
- `npm run typecheck`
- commit hooks: ESLint and Prettier

The unrelated pre-existing `package-lock.json` worktree change was not included.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8c43c74d6f9877729c55b46876e11fcb)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal authentication, session, event, repository, and response type handling.
  - Consolidated Slack interaction type exports and streamlined image-build scheduling.
  - Removed unused internal helpers and legacy interfaces.

- **Chores**
  - Reduced internal API surface and improved maintainability.
  - No user-facing behavior or workflow changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->