### PR TITLE
test: update image build callback fixtures

### DIFF
--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -806,8 +806,8 @@ describe("OpenComputerSandboxProvider", () => {
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
       ],
-      callbackUrl: "https://control.example/environment-images/build-complete",
-      failureCallbackUrl: "https://control.example/environment-images/build-failed",
+      callbackUrl: "https://control.example/image-builds/build-complete",
+      failureCallbackUrl: "https://control.example/image-builds/build-failed",
       callbackToken: "callback-token",
       buildExecutionTimeoutSeconds: 1800,
       providerSessionTimeoutSeconds: 2400,
@@ -825,9 +825,9 @@ describe("OpenComputerSandboxProvider", () => {
       REPO_NAME: "web",
       SANDBOX_ID: "build-env-env_flagship",
       OI_REPO_IMAGE_BUILD_ID: "envimg-1",
-      OI_REPO_IMAGE_CALLBACK_URL: "https://control.example/environment-images/build-complete",
+      OI_REPO_IMAGE_CALLBACK_URL: "https://control.example/image-builds/build-complete",
       OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
-      OI_REPO_IMAGE_FAILURE_CALLBACK_URL: "https://control.example/environment-images/build-failed",
+      OI_REPO_IMAGE_FAILURE_CALLBACK_URL: "https://control.example/image-builds/build-failed",
     });
     expect(JSON.parse(createCall.env!.SESSION_CONFIG)).toEqual({
       branch: "main",

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -701,21 +701,13 @@ describe("VercelSandboxProvider", () => {
     const provider = new VercelSandboxProvider(client, providerConfig);
 
     await provider.triggerImageBuild({
-      buildId: "envimg-1",
-      scopeKind: "environment",
-      scopeId: "env_flagship",
+      ...environmentBuildConfig(),
       repositories: [
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
       ],
-      callbackUrl: "https://control-plane.test/image-builds/build-complete",
-      failureCallbackUrl: "https://control-plane.test/image-builds/build-failed",
-      callbackToken: "callback-token",
-      buildExecutionTimeoutSeconds: 1800,
-      providerSessionTimeoutSeconds: 2400,
       cloneToken: "clone-token",
       onProviderSessionCreated,
-      correlation: { trace_id: "trace-1", request_id: "request-1" },
     });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -708,8 +708,8 @@ describe("VercelSandboxProvider", () => {
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
       ],
-      callbackUrl: "https://control-plane.test/environment-images/build-complete",
-      failureCallbackUrl: "https://control-plane.test/environment-images/build-failed",
+      callbackUrl: "https://control-plane.test/image-builds/build-complete",
+      failureCallbackUrl: "https://control-plane.test/image-builds/build-failed",
       callbackToken: "callback-token",
       buildExecutionTimeoutSeconds: 1800,
       providerSessionTimeoutSeconds: 2400,
@@ -751,11 +751,10 @@ describe("VercelSandboxProvider", () => {
           OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS: "1800",
           OI_REPO_IMAGE_PROVIDER_SESSION_ID: "vercel-session-1",
           OI_REPO_IMAGE_BUILD_ID: "envimg-1",
-          OI_REPO_IMAGE_CALLBACK_URL:
-            "https://control-plane.test/environment-images/build-complete",
+          OI_REPO_IMAGE_CALLBACK_URL: "https://control-plane.test/image-builds/build-complete",
           OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
           OI_REPO_IMAGE_FAILURE_CALLBACK_URL:
-            "https://control-plane.test/environment-images/build-failed",
+            "https://control-plane.test/image-builds/build-failed",
         },
       }),
       { trace_id: "trace-1", request_id: "request-1" }


### PR DESCRIPTION
## Summary
- update OpenComputer environment image-build fixtures to use `/image-builds/build-complete` and `/image-builds/build-failed`
- update equivalent Vercel provider fixtures
- confirm no retired `/environment-images/build-*` references remain
- do not add runtime compatibility routes

## Tests
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/opencomputer-provider.test.ts src/sandbox/providers/vercel/provider.test.ts` (63 passed)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a707508c27b591bfea8e12328228974d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated image build callback scenarios to use the current `/image-builds/` URL format.
  * Standardized test configuration and verification for successful and failed image build callbacks across supported environment providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->