### PR TITLE
Remove provider from image build plans

### DIFF
--- a/packages/control-plane/src/image-builds/modal-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.test.ts
@@ -17,7 +17,6 @@ function createProvider(): ModalImageBuildProvider {
 
 function createPlan(): ImageBuildPlan {
   return {
-    provider: "modal",
     buildId: "build-1",
     scope: { kind: "repo", id: "acme/repo" },
     repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -14,7 +14,6 @@ function createProvider(): OpenComputerSandboxProvider {
 
 function createPlan(): ImageBuildPlan {
   return {
-    provider: "opencomputer",
     buildId: "build-1",
     scope: { kind: "repo", id: "acme/repo" },
     repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -10,7 +10,7 @@ import {
   hashImageBuildCallbackToken,
   IMAGE_BUILD_CALLBACK_TOKEN_TTL_MS,
 } from "./callback-auth";
-import type { ImageBuildProvider, ImageBuildScope } from "./model";
+import type { ImageBuildScope } from "./model";
 import {
   loadScopeBuildSecrets,
   resolveScopeSandboxSettings,
@@ -47,8 +47,7 @@ export type { ResolvedImageBuildTarget } from "./scope";
 export class ImageBuildPlanner {
   constructor(
     private readonly env: Env,
-    private readonly db: SqlDatabase,
-    private readonly provider: ImageBuildProvider
+    private readonly db: SqlDatabase
   ) {}
 
   async resolveTarget(scope: ImageBuildScope): Promise<ResolvedImageBuildTarget> {
@@ -101,7 +100,6 @@ export class ImageBuildPlanner {
 
     return {
       ...basePlan,
-      provider: this.provider,
       callbackToken: params.callbackAuth.token,
       cloneAuth,
     };

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -1,6 +1,6 @@
 import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
 import type { CorrelationContext } from "../logger";
-import type { ImageBuildProvider, ImageBuildProviderImageRef, ImageBuildScope } from "./model";
+import type { ImageBuildProviderImageRef, ImageBuildScope } from "./model";
 
 export type ImageBuildWorkflowContext = CorrelationContext;
 
@@ -52,7 +52,6 @@ export type ImageBuildCloneAuth =
 
 /** Every supported provider uses the same create-bind-launch session contract. */
 export interface ImageBuildPlan extends BaseImageBuildPlan {
-  provider: ImageBuildProvider;
   callbackToken: string;
   cloneAuth: ImageBuildCloneAuth;
 }

--- a/packages/control-plane/src/image-builds/vercel-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.test.ts
@@ -14,7 +14,6 @@ function createProvider(): VercelSandboxProvider {
 
 function createPlan(buildTimeoutMs = 1_800_001): ImageBuildPlan {
   return {
-    provider: "vercel",
     buildId: "build-1",
     scope: { kind: "repo", id: "acme/repo" },
     repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -88,7 +88,6 @@ function plannedBuild(overrides: Record<string, unknown> = {}): ImageBuildPlan {
     failureCallbackUrl: "https://worker.test/image-builds/build-failed",
     buildTimeoutMs: 1800_000,
     correlation: { trace_id: "t", request_id: "r" },
-    provider: "modal",
     callbackToken: MODAL_CALLBACK_TOKEN,
     cloneAuth: { type: "unavailable" },
     ...overrides,
@@ -105,7 +104,6 @@ function vercelPlannedBuild(): ImageBuildPlan {
     failureCallbackUrl: "https://worker.test/image-builds/build-failed",
     buildTimeoutMs: 1800_000,
     correlation: { trace_id: "t", request_id: "r" },
-    provider: "vercel",
     callbackToken: "callback-token",
     cloneAuth: { type: "unavailable" },
   };

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -537,7 +537,7 @@ export function createImageBuildWorkflowFromEnv(env: Env, db: SqlDatabase): Imag
     env,
     new ImageBuildStore(db),
     createImageBuildAdapterFactory(env),
-    provider ? { provider, planner: new ImageBuildPlanner(env, db, provider) } : null,
+    provider ? { provider, planner: new ImageBuildPlanner(env, db) } : null,
     finalizationQueue
   );
 }


### PR DESCRIPTION
## Summary
- remove the unread `provider` field from `ImageBuildPlan`
- remove the provider dependency from `ImageBuildPlanner` and update workflow construction
- update image-build plan fixtures while retaining the workflow provider used for adapter selection and persisted state

## Tests
- `npm test -w @open-inspect/control-plane -- src/image-builds`
- `npm run typecheck`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9d28f63781bddc2416cb25f635080b22)*