### PR TITLE
Fix invalid session title route export

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/title/parse-request.ts
+++ b/packages/web/src/app/api/sessions/[id]/title/parse-request.ts
@@ -1,0 +1,8 @@
+export function parseSessionTitlePatchBody(body: unknown): { title?: string } | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+
+  const title = (body as { title?: unknown }).title;
+  if (title !== undefined && typeof title !== "string") return null;
+
+  return { title };
+}

--- a/packages/web/src/app/api/sessions/[id]/title/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/title/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseSessionTitlePatchBody } from "./route";
+import { parseSessionTitlePatchBody } from "./parse-request";
 
 describe("session title API route", () => {
   describe("parseSessionTitlePatchBody", () => {

--- a/packages/web/src/app/api/sessions/[id]/title/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/title/route.ts
@@ -2,15 +2,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
-
-export function parseSessionTitlePatchBody(body: unknown): { title?: string } | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
-
-  const title = (body as { title?: unknown }).title;
-  if (title !== undefined && typeof title !== "string") return null;
-
-  return { title };
-}
+import { parseSessionTitlePatchBody } from "./parse-request";
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerAuthSession();


### PR DESCRIPTION
## Summary
- move `parseSessionTitlePatchBody` into a sibling request-parsing module
- keep the App Router route module limited to supported Next.js exports
- preserve direct parser unit coverage from the new module

## Validation
- `npm test -w @open-inspect/web -- 'src/app/api/sessions/[id]/title/route.test.ts'`
- `npm run typecheck -w @open-inspect/web`
- targeted ESLint for the changed files
- `npm run build -w @open-inspect/web` passes compilation and TypeScript; later prerendering currently fails on `/_global-error` with an unrelated React `useContext` error under the non-standard `NODE_ENV` environment

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/22208c7f92980d919b4af8cd47f3dd7c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for session title update requests.
  * Invalid request formats or non-string titles are now rejected consistently.

* **Tests**
  * Updated session title API tests to use the dedicated request validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->