### PR TITLE
Fix session timeline scroll containment

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -259,9 +259,13 @@ export default function SessionPage() {
   }, [focusDetailsTrigger, isBelowLg]);
 
   const sessionWorkspace = (
-    <div className="flex h-full flex-1 flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <PanelGroup orientation="vertical" id="session-terminal">
-        <Panel defaultSize={showTerminal ? "70%" : "100%"} minSize="30%">
+        <Panel
+          defaultSize={showTerminal ? "70%" : "100%"}
+          minSize="30%"
+          style={{ minHeight: 0, overflow: "hidden" }}
+        >
           <SessionTimeline
             events={events}
             sessionId={sessionId}
@@ -294,7 +298,7 @@ export default function SessionPage() {
   );
 
   return (
-    <div className="h-full min-w-0 overflow-hidden flex flex-col">
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-clip">
       <SessionHeader
         sessionState={sessionState}
         fallbackSessionInfo={fallbackSessionInfo}
@@ -331,7 +335,7 @@ export default function SessionPage() {
       )}
 
       {/* Main content */}
-      <main className="min-w-0 flex-1 flex overflow-hidden">
+      <main className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
         {!isBelowLg ? (
           <SessionDesktopLayout
             workspace={sessionWorkspace}

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -259,12 +259,12 @@ export default function SessionPage() {
   }, [focusDetailsTrigger, isBelowLg]);
 
   const sessionWorkspace = (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-      <PanelGroup orientation="vertical" id="session-terminal">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-clip">
+      <PanelGroup orientation="vertical" id="session-terminal" style={{ overflow: "clip" }}>
         <Panel
           defaultSize={showTerminal ? "70%" : "100%"}
           minSize="30%"
-          style={{ minHeight: 0, overflow: "hidden" }}
+          style={{ minHeight: 0, overflow: "clip" }}
         >
           <SessionTimeline
             events={events}
@@ -335,7 +335,7 @@ export default function SessionPage() {
       )}
 
       {/* Main content */}
-      <main className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+      <main className="flex min-h-0 min-w-0 flex-1 overflow-clip">
         {!isBelowLg ? (
           <SessionDesktopLayout
             workspace={sessionWorkspace}

--- a/packages/web/src/components/session-desktop-layout.test.tsx
+++ b/packages/web/src/components/session-desktop-layout.test.tsx
@@ -10,12 +10,14 @@ vi.mock("react-resizable-panels", () => ({
     children,
     id,
     defaultSize,
+    style,
   }: {
     children: React.ReactNode;
     id: string;
     defaultSize: string;
+    style?: React.CSSProperties;
   }) => (
-    <div data-testid={id} data-default-size={defaultSize}>
+    <div data-testid={id} data-default-size={defaultSize} style={style}>
       {children}
     </div>
   ),
@@ -38,6 +40,22 @@ describe("SessionDesktopLayout", () => {
 
     expect(screen.getByTestId("session-main")).toHaveAttribute("data-default-size", "45%");
     expect(screen.getByTestId("session-changes")).toHaveAttribute("data-default-size", "55%");
+  });
+
+  it("contains overflow within the session workspace panel", () => {
+    render(
+      <SessionDesktopLayout
+        workspace={<main>timeline and terminal</main>}
+        sidebar={<aside>details</aside>}
+        changes={null}
+      />
+    );
+
+    expect(screen.getByTestId("session-main")).toHaveStyle({
+      minWidth: "0",
+      minHeight: "0",
+      overflow: "hidden",
+    });
   });
 
   it("keeps the session workspace mounted when the changes panel opens and closes", () => {

--- a/packages/web/src/components/session-desktop-layout.test.tsx
+++ b/packages/web/src/components/session-desktop-layout.test.tsx
@@ -2,31 +2,36 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { useEffect } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as ResizablePanels from "react-resizable-panels";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("react-resizable-panels", () => ({
-  Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  Panel: ({
-    children,
-    id,
-    defaultSize,
-    style,
-  }: {
-    children: React.ReactNode;
-    id: string;
-    defaultSize: string;
-    style?: React.CSSProperties;
-  }) => (
-    <div data-testid={id} data-default-size={defaultSize} style={style}>
-      {children}
-    </div>
-  ),
-  Separator: () => <div />,
-}));
+vi.mock("react-resizable-panels", async (importOriginal) => {
+  const actual = await importOriginal<typeof ResizablePanels>();
+  return {
+    ...actual,
+    Panel: ({ defaultSize, ...props }: React.ComponentProps<typeof actual.Panel>) => (
+      <actual.Panel {...props} defaultSize={defaultSize} data-default-size={defaultSize} />
+    ),
+  };
+});
 
-import { SessionDesktopLayout } from "./session-desktop-layout";
+import { SESSION_CHANGES_LAYOUT_ID, SessionDesktopLayout } from "./session-desktop-layout";
 
-afterEach(cleanup);
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("SessionDesktopLayout", () => {
   it("gives the changes panel most of the workspace when it opens", () => {
@@ -42,7 +47,7 @@ describe("SessionDesktopLayout", () => {
     expect(screen.getByTestId("session-changes")).toHaveAttribute("data-default-size", "55%");
   });
 
-  it("contains overflow within the session workspace panel", () => {
+  it("clips overflow on the real panel group and nested content wrapper", () => {
     render(
       <SessionDesktopLayout
         workspace={<main>timeline and terminal</main>}
@@ -51,10 +56,11 @@ describe("SessionDesktopLayout", () => {
       />
     );
 
-    expect(screen.getByTestId("session-main")).toHaveStyle({
+    expect(screen.getByTestId(SESSION_CHANGES_LAYOUT_ID)).toHaveStyle({ overflow: "clip" });
+    expect(screen.getByTestId("session-main").firstElementChild).toHaveStyle({
       minWidth: "0",
       minHeight: "0",
-      overflow: "hidden",
+      overflow: "clip",
     });
   });
 

--- a/packages/web/src/components/session-desktop-layout.tsx
+++ b/packages/web/src/components/session-desktop-layout.tsx
@@ -33,12 +33,13 @@ export function SessionDesktopLayout({
         id={SESSION_CHANGES_LAYOUT_ID}
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
+        style={{ overflow: "clip" }}
       >
         <Panel
           id="session-main"
           defaultSize={changes ? "45%" : "100%"}
           minSize="25%"
-          style={{ minWidth: 0, minHeight: 0, overflow: "hidden" }}
+          style={{ minWidth: 0, minHeight: 0, overflow: "clip" }}
         >
           {workspace}
         </Panel>

--- a/packages/web/src/components/session-desktop-layout.tsx
+++ b/packages/web/src/components/session-desktop-layout.tsx
@@ -34,7 +34,12 @@ export function SessionDesktopLayout({
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
       >
-        <Panel id="session-main" defaultSize={changes ? "45%" : "100%"} minSize="25%">
+        <Panel
+          id="session-main"
+          defaultSize={changes ? "45%" : "100%"}
+          minSize="25%"
+          style={{ minWidth: 0, minHeight: 0, overflow: "hidden" }}
+        >
           {workspace}
         </Panel>
         {changes && (

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { useLayoutEffect, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SandboxEvent } from "@/types/session";
+import { SessionTimeline } from "./session-timeline";
+
+const baseTimelineProps = {
+  sessionId: "session-1",
+  currentParticipantId: null,
+  participantProfiles: {},
+  isProcessing: false,
+  loadingHistory: false,
+  showSkeleton: false,
+  onLoadOlder: () => {},
+  onOpenMedia: () => {},
+} as const;
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete (HTMLElement.prototype as { scrollIntoView?: () => void }).scrollIntoView;
+});
+
+function toolEvent(
+  tool: string,
+  callId: string,
+  timestamp: number,
+  extra: Partial<Extract<SandboxEvent, { type: "tool_call" }>> = {}
+): Extract<SandboxEvent, { type: "tool_call" }> {
+  return {
+    type: "tool_call",
+    tool,
+    args: {},
+    callId,
+    status: "completed",
+    messageId: "message-1",
+    sandboxId: "sandbox-1",
+    timestamp,
+    ...extra,
+  };
+}
+
+describe("timeline auto-scrolling", () => {
+  it("confines sub-task auto-scrolling to the timeline", () => {
+    const task = toolEvent("task", "task-call", 1, {
+      childSessionId: "child-1",
+      status: "running",
+    });
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[task]} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          task,
+          toolEvent("Read", "child-call", 2, {
+            isSubtask: true,
+            childSessionId: "child-1",
+            taskCallId: "task-call",
+          }),
+        ]}
+      />
+    );
+
+    expect(timeline.scrollTop).toBe(1_000);
+    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does not move the timeline when the user has scrolled away from the bottom", () => {
+    const task = toolEvent("task", "task-call", 1, {
+      childSessionId: "child-1",
+      status: "running",
+    });
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[task]} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 300, writable: true },
+    });
+    fireEvent.scroll(timeline);
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          task,
+          toolEvent("Read", "child-call", 2, {
+            isSubtask: true,
+            childSessionId: "child-1",
+            taskCallId: "task-call",
+          }),
+        ]}
+      />
+    );
+
+    expect(timeline.scrollTop).toBe(300);
+  });
+
+  it("follows processing indicator height changes before passive effects", () => {
+    const events: SandboxEvent[] = [
+      {
+        type: "user_message",
+        content: "hello",
+        messageId: "message-1",
+        timestamp: 1,
+      },
+    ];
+    const observedScrollTop = vi.fn();
+
+    function LayoutObserver({ isProcessing }: { isProcessing: boolean }) {
+      const hostRef = useRef<HTMLDivElement>(null);
+      useLayoutEffect(() => {
+        observedScrollTop((hostRef.current?.firstElementChild as HTMLDivElement).scrollTop);
+      }, [isProcessing]);
+      return (
+        <div ref={hostRef}>
+          <SessionTimeline {...baseTimelineProps} events={events} isProcessing={isProcessing} />
+        </div>
+      );
+    }
+
+    const { container, rerender } = render(<LayoutObserver isProcessing={false} />);
+    const timeline = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    let scrollTop = 0;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = Math.min(value, 800);
+        },
+      },
+    });
+    observedScrollTop.mockClear();
+
+    rerender(<LayoutObserver isProcessing />);
+
+    expect(observedScrollTop).toHaveBeenLastCalledWith(800);
+    expect(scrollTop).toBe(800);
+  });
+});

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { buildTimelineItems } from "@/lib/timeline-items";
@@ -530,89 +530,6 @@ function toolEvent(
     ...extra,
   };
 }
-
-describe("timeline auto-scrolling", () => {
-  it("confines sub-task auto-scrolling to the timeline", () => {
-    const task = toolEvent("task", "task-call", 1, {
-      childSessionId: "child-1",
-      status: "running",
-    });
-    const { container, rerender } = render(
-      <SessionTimeline {...baseTimelineProps} events={[task]} />
-    );
-    const timeline = container.firstElementChild as HTMLDivElement;
-    Object.defineProperties(timeline, {
-      clientHeight: { configurable: true, value: 200 },
-      scrollHeight: { configurable: true, value: 1_000 },
-    });
-
-    rerender(
-      <SessionTimeline
-        {...baseTimelineProps}
-        events={[
-          task,
-          toolEvent("Read", "child-call", 2, {
-            isSubtask: true,
-            childSessionId: "child-1",
-            taskCallId: "task-call",
-          }),
-        ]}
-      />
-    );
-
-    expect(timeline.scrollTop).toBe(1_000);
-    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
-  });
-
-  it("does not move the timeline when the user has scrolled away from the bottom", () => {
-    const task = toolEvent("task", "task-call", 1, {
-      childSessionId: "child-1",
-      status: "running",
-    });
-    const { container, rerender } = render(
-      <SessionTimeline {...baseTimelineProps} events={[task]} />
-    );
-    const timeline = container.firstElementChild as HTMLDivElement;
-    Object.defineProperties(timeline, {
-      clientHeight: { configurable: true, value: 200 },
-      scrollHeight: { configurable: true, value: 1_000 },
-      scrollTop: { configurable: true, value: 300, writable: true },
-    });
-    fireEvent.scroll(timeline);
-
-    rerender(
-      <SessionTimeline
-        {...baseTimelineProps}
-        events={[
-          task,
-          toolEvent("Read", "child-call", 2, {
-            isSubtask: true,
-            childSessionId: "child-1",
-            taskCallId: "task-call",
-          }),
-        ]}
-      />
-    );
-
-    expect(timeline.scrollTop).toBe(300);
-  });
-
-  it("follows processing indicator height changes before paint", () => {
-    const events = [event()];
-    const { container, rerender } = render(
-      <SessionTimeline {...baseTimelineProps} events={events} />
-    );
-    const timeline = container.firstElementChild as HTMLDivElement;
-    Object.defineProperties(timeline, {
-      clientHeight: { configurable: true, value: 200 },
-      scrollHeight: { configurable: true, value: 1_000 },
-    });
-
-    rerender(<SessionTimeline {...baseTimelineProps} events={events} isProcessing />);
-
-    expect(timeline.scrollTop).toBe(1_000);
-  });
-});
 
 describe("task activity grouping", () => {
   it("pulses while a Task is running and stops after its completion update", () => {

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -596,6 +596,22 @@ describe("timeline auto-scrolling", () => {
 
     expect(timeline.scrollTop).toBe(300);
   });
+
+  it("follows processing indicator height changes before paint", () => {
+    const events = [event()];
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={events} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+
+    rerender(<SessionTimeline {...baseTimelineProps} events={events} isProcessing />);
+
+    expect(timeline.scrollTop).toBe(1_000);
+  });
 });
 
 describe("task activity grouping", () => {

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -132,7 +132,7 @@ export function SessionTimeline({
     }
   }, [events]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (didPrependRef.current) {
       didPrependRef.current = false;
       return;
@@ -141,7 +141,7 @@ export function SessionTimeline({
       const container = scrollContainerRef.current;
       if (container) container.scrollTop = container.scrollHeight;
     }
-  }, [events]);
+  }, [events, isProcessing]);
 
   const toggleToolCall = useCallback((event: ToolCallEvent) => {
     const key = toolCallKey(event);


### PR DESCRIPTION
## Summary

- contain the resizable timeline and desktop workspace panels so their implicit content wrappers cannot become competing scroll containers
- add `min-h-0` through the session flex hierarchy and use `overflow-clip` at the session root
- run bottom-following in a layout effect for both event and processing-state changes while keeping history-prepend compensation in its own earlier layout effect
- add focused regressions for panel overflow containment and processing-indicator height changes

## Why PR #1340 was incomplete

PR #1340 correctly removed streaming-triggered `scrollIntoView` calls and scoped auto-follow writes to `timeline.scrollTop`. That prevented direct page-level scrolling, but it did not eliminate the other scroll containers surrounding the timeline.

`react-resizable-panels` v4 wraps each `Panel` child in an implicit element whose default `overflow: auto` can make it independently scrollable. When nested sub-task activity grows beneath an earlier Task row, browser scroll anchoring can adjust those panel wrappers even though the timeline code only writes to the intended timeline element. This is most visible while a sub-task is thinking because activity is inserted retroactively rather than only appended at the end.

The timeline also performed bottom-following in a passive effect keyed only by `events`. Toggling `isProcessing` adds or removes the Thinking indicator without necessarily changing the event array, so its height change was not corrected before paint. The follow effect now uses `useLayoutEffect` and depends on both `events` and `isProcessing`.

History prepend compensation remains a separate layout effect that runs first. This preserves the reader's viewport and marks that render so the following bottom-follow effect does not race the prepend adjustment when processing state changes at the same time.

## Testing

- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx src/components/session-desktop-layout.test.tsx` (29 passed)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `git diff --check`

The unrelated pre-existing `package-lock.json` modification is not included.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c0a07b8b0a40607f2b209aafade7bd0a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session workspace sizing and overflow handling to keep content contained within its panels.
  * Improved timeline scrolling so new activity and processing updates remain visible without disrupting the user’s current position.

* **Tests**
  * Added coverage for workspace overflow and nested panel behavior.
  * Added coverage for timeline auto-scrolling, processing updates, and preserving the user’s scroll position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->