### PR TITLE
refactor: deduplicate Slack user identity lookups

### DIFF
--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -33,6 +33,7 @@ import {
   type BackgroundTaskScheduler,
 } from "../messages/blocks";
 import {
+  formatAttributedRequest,
   formatChannelContext,
   formatForwardedContext,
   formatInterimThreadContext,
@@ -48,7 +49,7 @@ import {
 import { buildTargetClarificationBlocks } from "../target-clarification";
 import { targetLabel } from "../targets";
 import type { Env } from "../types";
-import { resolveSlackActorIdentity } from "../user-identity";
+import { resolveSlackActorIdentity, type SlackActorIdentity } from "../user-identity";
 
 const log = createLogger("handler");
 const THREAD_HISTORY_MESSAGE_LIMIT = 10;
@@ -160,7 +161,6 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     );
     return;
   }
-  const actor = await resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, user);
   // A message with no text of its own still needs prompt content for the agent
   // to act on; what it carried instead decides which stand-in to use.
   const imageOnly = !messageText && !forwarded.hasBody;
@@ -171,7 +171,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   // instruction and reads as one when it comes last.
   const forwardedContext = formatForwardedContext(forwarded.entries);
   const promptText = forwardedContext + requestText;
-  const deliveredPromptText = forwardedContext + `[${actor.senderLabel}]: ${requestText}`;
+  let actor: SlackActorIdentity | undefined;
 
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
@@ -190,17 +190,24 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         : "";
       // The session already has its own turns, so only forward the human
       // discussion that happened in the thread since the last prompt.
-      const interimMessages = existingSession.lastPromptTs
-        ? await fetchThreadHistory(env, channel, threadTs, {
-            excludeTs: ts,
-            sinceTs: existingSession.lastPromptTs,
-            includeBotMessages: false,
-          })
-        : undefined;
+      const [resolvedActor, interimMessages] = await Promise.all([
+        resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, user),
+        existingSession.lastPromptTs
+          ? fetchThreadHistory(env, channel, threadTs, {
+              excludeTs: ts,
+              sinceTs: existingSession.lastPromptTs,
+              includeBotMessages: false,
+            })
+          : Promise.resolve(undefined),
+      ]);
+      actor = resolvedActor;
       const interimContext = interimMessages ? formatInterimThreadContext(interimMessages) : "";
       const promptResult = await deliverPrompt(env, {
         sessionId: existingSession.sessionId,
-        content: channelContext + interimContext + deliveredPromptText,
+        content:
+          channelContext +
+          interimContext +
+          formatAttributedRequest(actor.senderLabel, requestText, forwarded.entries),
         authorId: `slack:${user}`,
         attachments: await prepareImageAttachments(env, images, traceId),
         imageOnly,
@@ -273,8 +280,9 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       return;
     }
     await storePendingRequest(env, channel, threadTs || ts, {
-      message: deliveredPromptText,
+      message: requestText,
       userId: user,
+      unattributedPrompt: { forwardedMessages: forwarded.entries },
       previousMessages,
       channelName,
       channelDescription,
@@ -303,11 +311,12 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
   scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
+  actor ??= await resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, user);
   const sessionResult = await startSessionAndSendPrompt(env, {
     target: result.target,
     channel,
     threadTs: threadKey,
-    messageText: deliveredPromptText,
+    messageText: formatAttributedRequest(actor.senderLabel, requestText, forwarded.entries),
     actor,
     messageTs: ts,
     previousMessages,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -4,7 +4,6 @@ import {
   getChannelInfo,
   getMessageDetails,
   getThreadMessages,
-  getUserInfo,
   postMessage,
   resolveUserNames,
   selectThreadWindow,
@@ -49,6 +48,7 @@ import {
 import { buildTargetClarificationBlocks } from "../target-clarification";
 import { targetLabel } from "../targets";
 import type { Env } from "../types";
+import { resolveSlackActorIdentity } from "../user-identity";
 
 const log = createLogger("handler");
 const THREAD_HISTORY_MESSAGE_LIMIT = 10;
@@ -160,13 +160,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     );
     return;
   }
-  const userInfo = await getUserInfo(env.SLACK_BOT_TOKEN, user);
-  const senderName = (userInfo.ok ? userInfo.user?.profile?.display_name || user : user)
-    .replace(/[[\]\r\n]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 80);
-  const senderLabel = senderName && senderName !== user ? `${senderName} (${user})` : user;
+  const actor = await resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, user);
   // A message with no text of its own still needs prompt content for the agent
   // to act on; what it carried instead decides which stand-in to use.
   const imageOnly = !messageText && !forwarded.hasBody;
@@ -177,7 +171,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   // instruction and reads as one when it comes last.
   const forwardedContext = formatForwardedContext(forwarded.entries);
   const promptText = forwardedContext + requestText;
-  const deliveredPromptText = forwardedContext + `[${senderLabel}]: ${requestText}`;
+  const deliveredPromptText = forwardedContext + `[${actor.senderLabel}]: ${requestText}`;
 
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
@@ -314,7 +308,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     channel,
     threadTs: threadKey,
     messageText: deliveredPromptText,
-    userId: user,
+    actor,
     messageTs: ts,
     previousMessages,
     channelName,

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -408,7 +408,7 @@ describe("POST /events", () => {
     vi.clearAllMocks();
     clearLocalCache();
     mockVerifySlackSignature.mockResolvedValue(true);
-    mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
+    mockGetUserInfo.mockResolvedValue({ ok: false, error: "user_not_found" });
   });
 
   it("publishes App Home when the home tab is opened", async () => {
@@ -522,6 +522,7 @@ describe("POST /events", () => {
     expect(startingStatusBodies(slackFetch)).toHaveLength(3);
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("channelInfo"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
+    expect(mockGetUserInfo).toHaveBeenCalledOnce();
 
     const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
     expect(postBodies.some((body) => String(body.text).includes("Session started!"))).toBe(false);
@@ -1584,7 +1585,7 @@ describe("POST /interactions", () => {
     clearLocalCache();
     mockVerifySlackSignature.mockResolvedValue(true);
     mockOpenView.mockResolvedValue({ ok: true });
-    mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
+    mockGetUserInfo.mockResolvedValue({ ok: false, error: "user_not_found" });
   });
 
   it("sets Starting status for repo-selection starts before session creation", async () => {
@@ -2263,6 +2264,7 @@ describe("POST /interactions", () => {
     const body = JSON.parse(String(init.body)) as Record<string, unknown>;
     expect(body.actorDisplayName).toBe("Jane");
     expect(body.actorEmail).toBe("jane@example.com");
+    expect(mockGetUserInfo).toHaveBeenCalledOnce();
     // Identity travels via the signed actor assertion, never the body.
     expect(body.actorUserId).toBeUndefined();
     expect(body.spawnSource).toBeUndefined();

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -564,9 +564,14 @@ describe("POST /events", () => {
     slackFetch.mockRestore();
   });
 
-  it("embeds repo options in clarification messages when the repo list fits inline", async () => {
-    const slackFetch = mockSlackFetch([]);
+  it("resolves the actor once across clarification and selection", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order);
     const env = makeEnv();
+    mockGetUserInfo.mockResolvedValue({
+      ok: true,
+      user: { id: "U123", name: "ajan", profile: { display_name: "Ajan" } },
+    });
     (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       async (input: RequestInfo | URL) => {
         const url = typeof input === "string" ? input : input.toString();
@@ -597,6 +602,22 @@ describe("POST /events", () => {
             }),
             { status: 200, headers: { "Content-Type": "application/json" } }
           );
+        }
+
+        if (url.endsWith("/sessions")) {
+          order.push("session");
+          return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        if (url.includes("/prompt")) {
+          order.push("prompt");
+          return new Response(JSON.stringify({ messageId: "msg-1" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
         }
 
         return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
@@ -645,6 +666,54 @@ describe("POST /events", () => {
         ]),
       })
     );
+
+    expect(mockGetUserInfo).not.toHaveBeenCalled();
+    await expect(
+      (env.SLACK_KV as unknown as { get: (key: string, type: string) => Promise<unknown> }).get(
+        "pending:C123:111.222",
+        "json"
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        message: "frontend backend help",
+        userId: "U123",
+        unattributedPrompt: { forwardedMessages: [] },
+      })
+    );
+
+    const selectionCtx = makeCtx();
+    const selectionResponse = await app.fetch(
+      new Request("http://localhost/interactions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "x-slack-signature": "v0=test",
+          "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+        },
+        body: new URLSearchParams({
+          payload: JSON.stringify({
+            type: "block_actions",
+            user: { id: "U123" },
+            channel: { id: "C123" },
+            message: { ts: "111.222" },
+            actions: [{ action_id: "select_repo", selected_option: { value: "acme/web" } }],
+          }),
+        }),
+      }),
+      env,
+      selectionCtx
+    );
+
+    expect(selectionResponse.status).toBe(200);
+    await flushWaitUntil(selectionCtx);
+    expect(mockGetUserInfo).toHaveBeenCalledOnce();
+    expect(
+      promptFetchBodies(env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>)
+    ).toEqual([
+      expect.objectContaining({
+        content: expect.stringContaining("[Ajan (U123)]: frontend backend help"),
+      }),
+    ]);
 
     slackFetch.mockRestore();
   });

--- a/packages/slack-bot/src/interactions/target-selection.test.ts
+++ b/packages/slack-bot/src/interactions/target-selection.test.ts
@@ -5,6 +5,7 @@ import { handleTargetSelection } from "./target-selection";
 import { getPendingRequest, deletePendingRequest } from "../pending-requests/pending-request-store";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import { resolveTargetValue } from "../target-clarification";
+import { resolveSlackActorIdentity } from "../user-identity";
 
 vi.mock(import("@open-inspect/shared/slack"), async (importOriginal) => ({
   ...(await importOriginal()),
@@ -32,6 +33,10 @@ vi.mock("../target-clarification", () => ({
   resolveTargetValue: vi.fn(),
 }));
 
+vi.mock("../user-identity", () => ({
+  resolveSlackActorIdentity: vi.fn(),
+}));
+
 const repositoryTarget = {
   kind: "repository" as const,
   repo: {
@@ -57,6 +62,11 @@ function makeEnv(): Env {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(resolveTargetValue).mockResolvedValue(repositoryTarget);
+  vi.mocked(resolveSlackActorIdentity).mockResolvedValue({
+    userId: "U123",
+    senderLabel: "Ajan (U123)",
+    displayName: "Ajan",
+  });
 });
 
 describe("handleTargetSelection", () => {
@@ -88,7 +98,11 @@ describe("handleTargetSelection", () => {
       env,
       expect.objectContaining({
         messageText: "What is wrong in this screenshot?",
-        userId: "U123",
+        actor: {
+          userId: "U123",
+          senderLabel: "Ajan (U123)",
+          displayName: "Ajan",
+        },
         images: [
           {
             id: "F1",

--- a/packages/slack-bot/src/interactions/target-selection.test.ts
+++ b/packages/slack-bot/src/interactions/target-selection.test.ts
@@ -74,6 +74,7 @@ describe("handleTargetSelection", () => {
     vi.mocked(getPendingRequest).mockResolvedValue({
       message: "What is wrong in this screenshot?",
       userId: "U123",
+      unattributedPrompt: { forwardedMessages: ["Forwarded body"] },
       sourceMessage: { ts: "111.222" },
     });
     vi.mocked(getMessageDetails).mockResolvedValue({
@@ -97,7 +98,9 @@ describe("handleTargetSelection", () => {
     expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
       env,
       expect.objectContaining({
-        messageText: "What is wrong in this screenshot?",
+        messageText:
+          "Slack messages forwarded with this request:\n---\nForwarded body\n---\n\n" +
+          "[Ajan (U123)]: What is wrong in this screenshot?",
         actor: {
           userId: "U123",
           senderLabel: "Ajan (U123)",

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -12,6 +12,7 @@ import {
   scheduleStartingStatus,
   type BackgroundTaskScheduler,
 } from "../messages/blocks";
+import { formatAttributedRequest } from "../messages/context";
 import { deletePendingRequest, getPendingRequest } from "../pending-requests/pending-request-store";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import { resolveTargetValue } from "../target-clarification";
@@ -50,6 +51,7 @@ export async function handleTargetSelection(
     channelDescription,
     imageOnly,
     sourceMessage,
+    unattributedPrompt,
   } = pendingData;
   const target = await resolveTargetValue(env, selectedValue, traceId);
   if (!target) {
@@ -73,8 +75,8 @@ export async function handleTargetSelection(
       sourceMessage.threadTs
     );
     if (lookup.ok) {
-      // The saved request text already quotes any forwarded message, but its
-      // images live on the attachment and are re-fetched here like the rest.
+      // The pending prompt already preserves any forwarded-message text, but
+      // its images live on the attachment and are re-fetched here like the rest.
       const forwarded = collectForwardedMessages(lookup.attachments);
       images = toImageAttachments([...lookup.files, ...forwarded.files], traceId);
     } else {
@@ -105,11 +107,15 @@ export async function handleTargetSelection(
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
   const actor = await resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, userId);
+  // Records written before deferred attribution already contain deliverable text.
+  const messageText = unattributedPrompt
+    ? formatAttributedRequest(actor.senderLabel, message, unattributedPrompt.forwardedMessages)
+    : message;
   const sessionResult = await startSessionAndSendPrompt(env, {
     target,
     channel,
     threadTs: threadKey,
-    messageText: message,
+    messageText,
     actor,
     // The original message ts isn't persisted with the pending request, so
     // the "Working on..." ack — or the interaction message when the ack post

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -17,6 +17,7 @@ import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import { resolveTargetValue } from "../target-clarification";
 import { targetLabel } from "../targets";
 import type { Env } from "../types";
+import { resolveSlackActorIdentity } from "../user-identity";
 
 const log = createLogger("target-selection");
 
@@ -103,12 +104,13 @@ export async function handleTargetSelection(
     blocks: buildWorkingMessageBlocks(label),
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
+  const actor = await resolveSlackActorIdentity(env.SLACK_BOT_TOKEN, userId);
   const sessionResult = await startSessionAndSendPrompt(env, {
     target,
     channel,
     threadTs: threadKey,
     messageText: message,
-    userId,
+    actor,
     // The original message ts isn't persisted with the pending request, so
     // the "Working on..." ack — or the interaction message when the ack post
     // fails — marks where interim thread context resumes.

--- a/packages/slack-bot/src/messages/context.test.ts
+++ b/packages/slack-bot/src/messages/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatChannelContext, formatThreadContext } from "./context";
+import { formatAttributedRequest, formatChannelContext, formatThreadContext } from "./context";
 
 describe("message context", () => {
   it("formats thread messages with the prompt delimiter", () => {
@@ -10,6 +10,13 @@ describe("message context", () => {
 
   it("omits empty thread context", () => {
     expect(formatThreadContext([])).toBe("");
+  });
+
+  it("places sender attribution after forwarded-message context", () => {
+    expect(formatAttributedRequest("Ada (U123)", "Please handle this", ["Forwarded body"])).toBe(
+      "Slack messages forwarded with this request:\n---\nForwarded body\n---\n\n" +
+        "[Ada (U123)]: Please handle this"
+    );
   });
 
   it("formats channel context with an optional description", () => {

--- a/packages/slack-bot/src/messages/context.ts
+++ b/packages/slack-bot/src/messages/context.ts
@@ -18,6 +18,14 @@ export function formatForwardedContext(forwardedMessages: string[]): string {
   return formatMessageSection("Slack messages forwarded with this request", forwardedMessages);
 }
 
+export function formatAttributedRequest(
+  senderLabel: string,
+  requestText: string,
+  forwardedMessages: string[]
+): string {
+  return formatForwardedContext(forwardedMessages) + `[${senderLabel}]: ${requestText}`;
+}
+
 export function formatChannelContext(channelName: string, channelDescription?: string): string {
   let context = `Slack channel context:\n---\nChannel: #${channelName}`;
   if (channelDescription) context += `\nDescription: ${channelDescription}`;

--- a/packages/slack-bot/src/pending-requests/pending-request-store.test.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.test.ts
@@ -28,6 +28,7 @@ describe("pending request store", () => {
     const request: PendingRequest = {
       message: "Fix the tests",
       userId: "U123",
+      unattributedPrompt: { forwardedMessages: ["Forwarded body"] },
       previousMessages: ["Earlier context"],
       channelName: "engineering",
       channelDescription: "Build discussion",
@@ -66,6 +67,8 @@ describe("pending request store", () => {
     { message: 123, userId: "U123" },
     { message: "Fix it", userId: "" },
     { message: "Fix it", userId: "U123", previousMessages: ["valid", 123] },
+    { message: "Fix it", userId: "U123", unattributedPrompt: {} },
+    { message: "Fix it", userId: "U123", unattributedPrompt: { forwardedMessages: [123] } },
     { message: "Fix it", userId: "U123", channelName: 123 },
   ])("rejects malformed records: %j", async (record) => {
     mocks.get.mockResolvedValue(record);
@@ -77,6 +80,7 @@ describe("pending request store", () => {
     const minimal = { message: "Fix it", userId: "U123" };
     const complete = {
       ...minimal,
+      unattributedPrompt: { forwardedMessages: ["Forwarded body"] },
       previousMessages: ["Earlier context"],
       channelName: "engineering",
       channelDescription: "Build discussion",

--- a/packages/slack-bot/src/pending-requests/pending-request-store.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.ts
@@ -14,9 +14,15 @@ const sourceMessageSchema = z.object({
   threadTs: z.string().optional(),
 });
 
+const unattributedPromptSchema = z.object({
+  forwardedMessages: z.array(z.string()),
+});
+
 const pendingRequestSchema = z.object({
   message: z.string().min(1),
   userId: z.string().min(1),
+  /** Present when `message` still needs sender attribution before delivery. */
+  unattributedPrompt: unattributedPromptSchema.optional(),
   previousMessages: z.array(z.string()).optional(),
   channelName: z.string().optional(),
   channelDescription: z.string().optional(),

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
 import type { SlackSessionTarget } from "../targets";
+import type { SlackActorIdentity } from "../user-identity";
 import { startSessionAndSendPrompt } from "./session-launcher";
 import { getAvailableModels } from "../app-home/models";
 import { getUserRepoBranchPreference } from "../branch-preferences";
@@ -9,7 +10,7 @@ import { createSession } from "./control-plane-client";
 import { getSlackSettings } from "../slack-settings";
 import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
-import { getUserInfo, postMessage } from "@open-inspect/shared/slack";
+import { postMessage } from "@open-inspect/shared/slack";
 import {
   notifyDroppedAttachments,
   prepareImageAttachments,
@@ -17,7 +18,6 @@ import {
 } from "../attachments";
 
 vi.mock("@open-inspect/shared/slack", () => ({
-  getUserInfo: vi.fn(),
   postMessage: vi.fn(),
 }));
 
@@ -98,6 +98,13 @@ const environmentTarget: SlackSessionTarget = {
   },
 };
 
+const actor: SlackActorIdentity = {
+  userId: "U123",
+  senderLabel: "Display Name (U123)",
+  displayName: "Display Name",
+  email: "user@example.com",
+};
+
 describe("startSessionAndSendPrompt", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,15 +121,6 @@ describe("startSessionAndSendPrompt", () => {
       branch: "user-default-branch",
     });
     vi.mocked(getUserRepoBranchPreference).mockResolvedValue("repo-override-branch");
-    vi.mocked(getUserInfo).mockResolvedValue({
-      ok: true,
-      user: {
-        id: "U123",
-        name: "fallback-name",
-        real_name: "Real Name",
-        profile: { display_name: "Display Name", email: "user@example.com" },
-      },
-    } as Awaited<ReturnType<typeof getUserInfo>>);
     vi.mocked(createSession).mockResolvedValue({ sessionId: "session-1", status: "created" });
     vi.mocked(prepareImageAttachments).mockResolvedValue({ files: [], dropped: [] });
     vi.mocked(deliverPrompt).mockResolvedValue({ ok: true, data: { messageId: "message-1" } });
@@ -146,7 +144,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "Fix the failing deploy",
-        userId: "U123",
+        actor,
         previousMessages: ["[Alice]: Earlier request", "[Bot]: Earlier response"],
         channelName: "engineering",
         channelDescription: "Build and deploy discussion",
@@ -219,7 +217,7 @@ describe("startSessionAndSendPrompt", () => {
       channel: "C123",
       threadTs: "111.222",
       messageText: "Fix the failing deploy",
-      userId: "U123",
+      actor,
       traceId: "trace-1",
     });
 
@@ -241,7 +239,7 @@ describe("startSessionAndSendPrompt", () => {
       channel: "C123",
       threadTs: "111.222",
       messageText: "Inspect production",
-      userId: "U123",
+      actor,
     });
 
     expect(getUserRepoBranchPreference).not.toHaveBeenCalled();
@@ -268,7 +266,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "Fix it",
-        userId: "U123",
+        actor,
       })
     ).resolves.toBeNull();
 
@@ -292,7 +290,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "Fix it",
-        userId: "U123",
+        actor,
       })
     ).resolves.toBeNull();
 
@@ -327,7 +325,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "What is wrong in this screenshot?",
-        userId: "U123",
+        actor,
         images,
         traceId: "trace-1",
       })
@@ -361,7 +359,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "See the attached image(s).",
-        userId: "U123",
+        actor,
         images: [
           {
             id: "F1",
@@ -409,7 +407,7 @@ describe("startSessionAndSendPrompt", () => {
         channel: "C123",
         threadTs: "111.222",
         messageText: "See the attached image(s).",
-        userId: "U123",
+        actor,
         images: [
           {
             id: "F1",

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -1,4 +1,4 @@
-import { getUserInfo, postMessage } from "@open-inspect/shared/slack";
+import { postMessage } from "@open-inspect/shared/slack";
 import type { CallbackContext } from "@open-inspect/shared/types/session-api";
 import { getAvailableModels } from "../app-home/models";
 import {
@@ -10,6 +10,7 @@ import { getUserRepoBranchPreference } from "../branch-preferences";
 import { formatChannelContext, formatThreadContext } from "../messages/context";
 import { branchPreferenceRepo, targetLabel, type SlackSessionTarget } from "../targets";
 import type { Env } from "../types";
+import type { SlackActorIdentity } from "../user-identity";
 import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession } from "./control-plane-client";
 import { getSlackSettings } from "../slack-settings";
@@ -21,7 +22,7 @@ export interface StartSessionOptions {
   channel: string;
   threadTs: string;
   messageText: string;
-  userId: string;
+  actor: SlackActorIdentity;
   /**
    * Slack ts of the triggering message. Persisted on the thread mapping so
    * follow-ups can scope interim thread context to newer messages.
@@ -46,7 +47,7 @@ export async function startSessionAndSendPrompt(
     channel,
     threadTs,
     messageText,
-    userId,
+    actor,
     messageTs,
     previousMessages,
     channelName,
@@ -72,7 +73,7 @@ export async function startSessionAndSendPrompt(
     getAvailableModels(env, traceId),
     getSlackSettings(env, traceId),
   ]);
-  const userPrefs = await getResolvedUserPreferences(env, userId, {
+  const userPrefs = await getResolvedUserPreferences(env, actor.userId, {
     defaultModel: slackConfig.defaultModel ?? env.DEFAULT_MODEL,
     enabledModels: availableModels.map((modelOption) => modelOption.value),
   });
@@ -81,24 +82,8 @@ export async function startSessionAndSendPrompt(
   const preferenceRepo = branchPreferenceRepo(target);
   let branch: string | undefined;
   if (preferenceRepo) {
-    const repoBranch = await getUserRepoBranchPreference(env, userId, preferenceRepo.id);
+    const repoBranch = await getUserRepoBranchPreference(env, actor.userId, preferenceRepo.id);
     branch = repoBranch ?? userPrefs.branch;
-  }
-
-  let displayName: string | undefined;
-  let email: string | undefined;
-  try {
-    const userInfo = await getUserInfo(env.SLACK_BOT_TOKEN, userId);
-    if (userInfo.ok) {
-      displayName =
-        userInfo.user.profile?.display_name ||
-        userInfo.user.real_name ||
-        userInfo.user.name ||
-        undefined;
-      email = userInfo.user.profile?.email || undefined;
-    }
-  } catch {
-    // Identity linking is best effort.
   }
 
   const session = await createSession(env, {
@@ -107,9 +92,9 @@ export async function startSessionAndSendPrompt(
     reasoningEffort,
     branch,
     traceId,
-    slackUserId: userId,
-    actorDisplayName: displayName,
-    actorEmail: email,
+    slackUserId: actor.userId,
+    actorDisplayName: actor.displayName,
+    actorEmail: actor.email,
   });
   if (!session) {
     await postMessage(
@@ -138,7 +123,7 @@ export async function startSessionAndSendPrompt(
   const delivery = await deliverPrompt(env, {
     sessionId: session.sessionId,
     content,
-    authorId: `slack:${userId}`,
+    authorId: `slack:${actor.userId}`,
     attachments: preparedImages,
     imageOnly: Boolean(imageOnly),
     callbackContext,

--- a/packages/slack-bot/src/user-identity.test.ts
+++ b/packages/slack-bot/src/user-identity.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserInfo } from "@open-inspect/shared/slack";
+import { resolveSlackActorIdentity } from "./user-identity";
+
+vi.mock("@open-inspect/shared/slack", () => ({
+  getUserInfo: vi.fn(),
+}));
+
+describe("resolveSlackActorIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves prompt and session identity from one Slack response", async () => {
+    vi.mocked(getUserInfo).mockResolvedValue({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "ajan",
+        real_name: "Ajan Raj",
+        profile: { display_name: "Ajan\n[Admin]", email: "ajan@example.com" },
+      },
+    });
+
+    await expect(resolveSlackActorIdentity("xoxb-test", "U123")).resolves.toEqual({
+      userId: "U123",
+      senderLabel: "Ajan Admin (U123)",
+      displayName: "Ajan\n[Admin]",
+      email: "ajan@example.com",
+    });
+    expect(getUserInfo).toHaveBeenCalledOnce();
+  });
+
+  it("uses the user ID for prompts while retaining session display-name fallbacks", async () => {
+    vi.mocked(getUserInfo).mockResolvedValue({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "ajan",
+        real_name: "Ajan Raj",
+        profile: { display_name: "" },
+      },
+    });
+
+    await expect(resolveSlackActorIdentity("xoxb-test", "U123")).resolves.toEqual({
+      userId: "U123",
+      senderLabel: "U123",
+      displayName: "Ajan Raj",
+      email: undefined,
+    });
+  });
+
+  it("falls back to the user ID when Slack rejects the lookup", async () => {
+    vi.mocked(getUserInfo).mockResolvedValue({ ok: false, error: "user_not_found" });
+
+    await expect(resolveSlackActorIdentity("xoxb-test", "U123")).resolves.toEqual({
+      userId: "U123",
+      senderLabel: "U123",
+    });
+  });
+
+  it("falls back to the user ID when the lookup throws", async () => {
+    vi.mocked(getUserInfo).mockRejectedValue(new Error("Slack unavailable"));
+
+    await expect(resolveSlackActorIdentity("xoxb-test", "U123")).resolves.toEqual({
+      userId: "U123",
+      senderLabel: "U123",
+    });
+  });
+});

--- a/packages/slack-bot/src/user-identity.ts
+++ b/packages/slack-bot/src/user-identity.ts
@@ -1,0 +1,39 @@
+import { getUserInfo } from "@open-inspect/shared/slack";
+
+export interface SlackActorIdentity {
+  userId: string;
+  senderLabel: string;
+  displayName?: string;
+  email?: string;
+}
+
+function formatSenderLabel(displayName: string | undefined, userId: string): string {
+  const normalizedName = (displayName ?? "")
+    .replace(/[[\]\r\n]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80);
+  return normalizedName && normalizedName !== userId ? `${normalizedName} (${userId})` : userId;
+}
+
+/** Resolve the Slack identity used by both prompt attribution and session creation. */
+export async function resolveSlackActorIdentity(
+  token: string,
+  userId: string
+): Promise<SlackActorIdentity> {
+  const fallback: SlackActorIdentity = { userId, senderLabel: userId };
+  try {
+    const result = await getUserInfo(token, userId);
+    if (!result.ok) return fallback;
+
+    const profileDisplayName = result.user.profile?.display_name;
+    return {
+      userId,
+      senderLabel: formatSenderLabel(profileDisplayName, userId),
+      displayName: profileDisplayName || result.user.real_name || result.user.name || undefined,
+      email: result.user.profile?.email || undefined,
+    };
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/slack-bot/src/user-identity.ts
+++ b/packages/slack-bot/src/user-identity.ts
@@ -1,5 +1,7 @@
 import { getUserInfo } from "@open-inspect/shared/slack";
 
+const MAX_SENDER_LABEL_LENGTH = 80;
+
 export interface SlackActorIdentity {
   userId: string;
   senderLabel: string;
@@ -12,7 +14,7 @@ function formatSenderLabel(displayName: string | undefined, userId: string): str
     .replace(/[[\]\r\n]/g, " ")
     .replace(/\s+/g, " ")
     .trim()
-    .slice(0, 80);
+    .slice(0, MAX_SENDER_LABEL_LENGTH);
   return normalizedName && normalizedName !== userId ? `${normalizedName} (${userId})` : userId;
 }
 


### PR DESCRIPTION
## Summary

- resolve each Slack actor once into a typed identity used for prompt attribution and session metadata
- pass that identity through `startSessionAndSendPrompt` so session creation performs no hidden `users.info` request
- preserve display-name sanitization, stable-ID fallback, actor email/display metadata, and clarification-resume behavior
- add unit and integration coverage for identity fallbacks and the one-lookup invariant

## Why

Follow-up to #1360. The sender-attribution change resolved the current Slack user before routing, while new-session creation resolved the same user again. That duplicated the network request and split identity formatting from session actor metadata.

This change gives Slack actor resolution one owner and makes the session launcher consume an already-resolved value.

## Verification

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/slack-bot -- --run` (416 tests)
- `npm run typecheck -w @open-inspect/slack-bot`
- ESLint and Prettier checks for all changed files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Slack actor identity handling for session creation and prompt delivery.
  - Sender labels now use resolved display names, with safe fallbacks when profile data is unavailable.
  - Session records can include the actor’s display name and email when available.
  - Forwarded-message context is preserved and displayed before sender attribution, including across follow-up and repository-selection flows.

- **Bug Fixes**
  - Improved handling of missing or failed Slack user lookups.

- **Tests**
  - Added coverage for identity resolution, fallback behavior, and session startup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->