### PR TITLE
fix: validate child session reasoning effort

### DIFF
--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -174,7 +174,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: "low" });
   });
 
-  it("clears an explicit reasoning effort incompatible with the resolved model", async () => {
+  it("rejects an explicit reasoning effort incompatible with the resolved model", async () => {
     const store = makeStore();
     vi.mocked(SessionIndexStore).mockImplementation(function () {
       return store as never;
@@ -187,8 +187,60 @@ describe("handleSpawnChild prompt enqueue handling", () => {
       reasoningEffort: "xhigh",
     });
 
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'Invalid reasoning effort "xhigh" for model "anthropic/claude-sonnet-4-6". Valid efforts: low, medium, high, max',
+    });
+    expect(childStub.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects "x-high" and reports the canonical "xhigh" value', async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    vi.mocked(getEffectiveEnabledModels).mockResolvedValue([
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.6-sol",
+    ]);
+    const { env, childStub } = makeSuccessfulEnv(spawnContext);
+
+    const response = await makeRequest(env, {
+      title: "Child task",
+      prompt: "Do the thing",
+      model: "openai/gpt-5.6-sol",
+      reasoningEffort: "x-high",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'Invalid reasoning effort "x-high" for model "openai/gpt-5.6-sol". Valid efforts: none, low, medium, high, xhigh',
+    });
+    expect(childStub.fetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts canonical "xhigh" for a model that supports it', async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    vi.mocked(getEffectiveEnabledModels).mockResolvedValue([
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.6-sol",
+    ]);
+    const { env, childStub } = makeSuccessfulEnv(spawnContext);
+
+    const response = await makeRequest(env, {
+      title: "Child task",
+      prompt: "Do the thing",
+      model: "openai/gpt-5.6-sol",
+      reasoningEffort: "xhigh",
+    });
+
     expect(response.status).toBe(201);
-    await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: null });
+    await expect(getInitBody(childStub)).resolves.toMatchObject({ reasoningEffort: "xhigh" });
   });
 
   it("returns 201 when child prompt enqueue succeeds", async () => {

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -5,6 +5,7 @@ import {
   type SandboxSettings,
 } from "@open-inspect/shared/types/integrations";
 import {
+  getReasoningConfig,
   getValidModelOrDefault,
   isValidModel,
   isValidReasoningEffort,
@@ -152,6 +153,16 @@ async function handleSpawnChild(
     return error(`Model "${body.model}" is not enabled`, 400);
   }
   const model = resolveEnabledModel({ model: requestedModel, enabledModels });
+  if (body.reasoningEffort !== undefined && !isValidReasoningEffort(model, body.reasoningEffort)) {
+    const validEfforts = getReasoningConfig(model)?.efforts;
+    const suffix = validEfforts?.length
+      ? ` Valid efforts: ${validEfforts.join(", ")}`
+      : " This model does not support reasoning effort overrides.";
+    return error(
+      `Invalid reasoning effort "${body.reasoningEffort}" for model "${model}".${suffix}`,
+      400
+    );
+  }
   const requestedReasoningEffort = body.reasoningEffort ?? spawnContext.reasoningEffort;
   const reasoningEffort =
     requestedReasoningEffort && isValidReasoningEffort(model, requestedReasoningEffort)

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -29,7 +29,7 @@ export default tool({
       .string()
       .optional()
       .describe(
-        "Overrides the reasoning effort for the child. Defaults to the parent's reasoning effort."
+        "Overrides the reasoning effort for the child. Valid values depend on the model and may include 'none', 'low', 'medium', 'high', 'xhigh', and 'max'. Use 'xhigh', not 'x-high'. Defaults to the parent's reasoning effort."
       ),
   },
   async execute(args) {

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -29,7 +29,7 @@ export default tool({
       .string()
       .optional()
       .describe(
-        "Overrides the reasoning effort for the child. Valid values depend on the model and may include 'none', 'low', 'medium', 'high', 'xhigh', and 'max'. Use 'xhigh', not 'x-high'. Defaults to the parent's reasoning effort."
+        "Overrides the reasoning effort for the child. Valid values depend on the model and may include 'none', 'low', 'medium', 'high', 'xhigh', and 'max'. Use 'xhigh', not 'x-high'. Defaults to the parent's reasoning effort when the selected model supports it."
       ),
   },
   async execute(args) {


### PR DESCRIPTION
## Summary
- reject explicit invalid or model-incompatible reasoning efforts before creating a child session
- return valid model-specific effort values in the error response so `x-high` clearly points callers to canonical `xhigh`
- document accepted reasoning values in the agent-facing `spawn-child` tool
- add regression coverage for typo rejection, incompatible effort rejection, and canonical `xhigh` acceptance

## Testing
- `npm test -w @open-inspect/control-plane -- src/router.spawn-child.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `uv run pytest tests/test_spawn_child_tool.py -v`
- Prettier and `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/35f10a73927a7d8efddab06c8eaf4806)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid reasoning-effort requests now return a clear HTTP 400 error instead of being silently ignored.
  * Corrected handling of the `xhigh` reasoning-effort value when spawning child sessions.
  * Valid reasoning settings are now preserved and passed to compatible child sessions.

* **Documentation**
  * Updated reasoning-effort guidance to list supported values and the correct `xhigh` spelling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->