### PR TITLE
refactor: throw typed OpenAI errors

### DIFF
--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -204,6 +204,9 @@ export class OpenAITokenBroker {
           poll_attempt: pollIndex + 1,
           error: error instanceof Error ? error.message : String(error),
         });
+        if (pollIndex === OPENAI_CONCURRENT_ROTATION_POLL_DELAYS_MS.length - 1) {
+          throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
+        }
         continue;
       }
       if (reread?.type === "cached") {

--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -16,13 +16,17 @@ type OpenAITokenState =
   | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
   | { type: "refresh"; refreshToken: string; scope: OAuthSecretScope; accountId?: string };
 
-export type OpenAITokenRefreshResult =
-  | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
-  | { ok: false; status: number; error: string };
+export type OpenAIToken = { accessToken: string; expiresIn?: number; accountId?: string };
+
+export class OpenAITokenBrokerError extends Error {}
+export class OpenAITokenNotConfiguredError extends OpenAITokenBrokerError {}
+export class OpenAITokenStorageError extends OpenAITokenBrokerError {}
+export class OpenAITokenUnauthorizedError extends OpenAITokenBrokerError {}
+export class OpenAITokenUpstreamError extends OpenAITokenBrokerError {}
 
 // Requests handled by the same Worker isolate share this coordinator. D1 rereads
 // below cover concurrent rotations performed by other isolates and Durable Objects.
-const openAIRefreshCoordinator = new OAuthRefreshSingleFlight<OpenAITokenRefreshResult>();
+const openAIRefreshCoordinator = new OAuthRefreshSingleFlight<OpenAIToken>();
 
 /** Provider-level broker shared by session adapters and global OAuth consumers. */
 export class OpenAITokenBroker {
@@ -36,11 +40,11 @@ export class OpenAITokenBroker {
     this.secrets = new ScopedOAuthSecretsStore(db, encryptionKey);
   }
 
-  refreshGlobal(): Promise<OpenAITokenRefreshResult> {
+  refreshGlobal(): Promise<OpenAIToken> {
     return this.refreshScopes([{ kind: "global" }]);
   }
 
-  async refreshScopes(scopes: readonly OAuthSecretScope[]): Promise<OpenAITokenRefreshResult> {
+  async refreshScopes(scopes: readonly OAuthSecretScope[]): Promise<OpenAIToken> {
     let tokenState: OpenAITokenState | null;
     try {
       tokenState = await this.readTokenState(scopes);
@@ -48,16 +52,15 @@ export class OpenAITokenBroker {
       this.log.error("Failed to read OpenAI token state from secrets", {
         error: error instanceof Error ? error.message : String(error),
       });
-      return { ok: false, status: 500, error: "Failed to read token state" };
+      throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
     }
 
     if (!tokenState) {
-      return { ok: false, status: 404, error: "OPENAI_OAUTH_REFRESH_TOKEN not configured" };
+      throw new OpenAITokenNotConfiguredError("OPENAI_OAUTH_REFRESH_TOKEN not configured");
     }
 
     if (tokenState.type === "cached") {
       return {
-        ok: true,
         accessToken: tokenState.accessToken,
         expiresIn: tokenState.expiresIn,
         accountId: tokenState.accountId,
@@ -67,6 +70,7 @@ export class OpenAITokenBroker {
     try {
       return await this.refreshSingleFlight(tokenState);
     } catch (error) {
+      if (error instanceof OpenAITokenBrokerError) throw error;
       if (error instanceof OpenAITokenRefreshError && error.status === 401) {
         return this.handleUnauthorizedRefresh(tokenState, scopes);
       }
@@ -74,7 +78,7 @@ export class OpenAITokenBroker {
       this.log.error("OpenAI token refresh failed", {
         error: error instanceof Error ? error.message : String(error),
       });
-      return { ok: false, status: 502, error: "OpenAI token refresh failed" };
+      throw new OpenAITokenUpstreamError("OpenAI token refresh failed", { cause: error });
     }
   }
 
@@ -118,7 +122,7 @@ export class OpenAITokenBroker {
 
   private async attemptRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>
-  ): Promise<OpenAITokenRefreshResult> {
+  ): Promise<OpenAIToken> {
     const tokens = await refreshOpenAIToken(tokenState.refreshToken);
     const accountId = extractOpenAIAccountId(tokens) ?? tokenState.accountId;
     const expiresAt =
@@ -133,17 +137,13 @@ export class OpenAITokenBroker {
     };
     if (accountId) secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
 
-    const persisted = await this.persistRotatedTokens(tokenState.scope, secretsToWrite);
-    if (!persisted) {
-      return { ok: false, status: 500, error: OPENAI_TOKEN_PERSIST_FAILURE };
-    }
+    await this.persistRotatedTokens(tokenState.scope, secretsToWrite);
 
     this.log.info("OpenAI tokens rotated and cached", {
       scope: tokenState.scope.kind,
       has_account_id: !!accountId,
     });
     return {
-      ok: true,
       accessToken: tokens.access_token,
       expiresIn: tokens.expires_in,
       accountId,
@@ -152,7 +152,7 @@ export class OpenAITokenBroker {
 
   private refreshSingleFlight(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>
-  ): Promise<OpenAITokenRefreshResult> {
+  ): Promise<OpenAIToken> {
     return openAIRefreshCoordinator.run(tokenState.scope, tokenState.refreshToken, () =>
       this.attemptRefresh(tokenState)
     );
@@ -161,11 +161,11 @@ export class OpenAITokenBroker {
   private async persistRotatedTokens(
     scope: OAuthSecretScope,
     secrets: Record<string, string>
-  ): Promise<boolean> {
+  ): Promise<void> {
     for (let attempt = 1; attempt <= OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS; attempt++) {
       try {
         await this.secrets.write(scope, secrets);
-        return true;
+        return;
       } catch (error) {
         const finalAttempt = attempt === OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS;
         const context = {
@@ -176,19 +176,18 @@ export class OpenAITokenBroker {
         };
         if (finalAttempt) {
           this.log.error("Failed to store rotated OpenAI tokens", context);
-          return false;
+          throw new OpenAITokenStorageError(OPENAI_TOKEN_PERSIST_FAILURE, { cause: error });
         }
         this.log.warn("Failed to store rotated OpenAI tokens; retrying", context);
         await new Promise((resolve) => setTimeout(resolve, OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS));
       }
     }
-    return false;
   }
 
   private async handleUnauthorizedRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
     scopes: readonly OAuthSecretScope[]
-  ): Promise<OpenAITokenRefreshResult> {
+  ): Promise<OpenAIToken> {
     this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
       scope: tokenState.scope.kind,
     });
@@ -210,7 +209,6 @@ export class OpenAITokenBroker {
       if (reread?.type === "cached") {
         this.log.info("Using cached access token from concurrent rotation");
         return {
-          ok: true,
           accessToken: reread.accessToken,
           expiresIn: reread.expiresIn,
           accountId: reread.accountId,
@@ -222,14 +220,15 @@ export class OpenAITokenBroker {
         try {
           return await this.refreshSingleFlight(reread);
         } catch (error) {
+          if (error instanceof OpenAITokenBrokerError) throw error;
           if (error instanceof OpenAITokenRefreshError && error.status === 401) continue;
           this.log.error("OpenAI token refresh retry failed", {
             error: error instanceof Error ? error.message : String(error),
           });
-          return { ok: false, status: 502, error: "OpenAI token refresh failed" };
+          throw new OpenAITokenUpstreamError("OpenAI token refresh failed", { cause: error });
         }
       }
     }
-    return { ok: false, status: 401, error: "OpenAI token refresh failed: unauthorized" };
+    throw new OpenAITokenUnauthorizedError("OpenAI token refresh failed: unauthorized");
   }
 }

--- a/packages/control-plane/src/openai/codex-errors.ts
+++ b/packages/control-plane/src/openai/codex-errors.ts
@@ -1,0 +1,11 @@
+export class OpenAICodexUpstreamError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+  }
+}
+
+export class InvalidOpenAICodexResponseError extends Error {}

--- a/packages/control-plane/src/openai/codex-responses.test.ts
+++ b/packages/control-plane/src/openai/codex-responses.test.ts
@@ -4,6 +4,7 @@ import {
   requestOpenAICodexFunction,
   type OpenAICodexFunctionRequest,
 } from "./codex-responses";
+import { InvalidOpenAICodexResponseError, OpenAICodexUpstreamError } from "./codex-errors";
 
 const TOOL_NAME = "classify_target";
 const output = { targetId: "acme/api", confidence: "high" };
@@ -95,7 +96,7 @@ describe("OpenAI Codex Responses client", () => {
   });
 
   it("sends a correlated forced-function request and parses fragmented SSE", async () => {
-    await expect(request()).resolves.toEqual({ kind: "completed", output });
+    await expect(request()).resolves.toEqual(output);
 
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
@@ -145,7 +146,7 @@ describe("OpenAI Codex Responses client", () => {
       )
     );
 
-    await expect(request()).resolves.toEqual({ kind: "completed", output });
+    await expect(request()).resolves.toEqual(output);
   });
 
   it("falls back to streamed function-call arguments", async () => {
@@ -170,7 +171,7 @@ describe("OpenAI Codex Responses client", () => {
       )
     );
 
-    await expect(request()).resolves.toEqual({ kind: "completed", output });
+    await expect(request()).resolves.toEqual(output);
   });
 
   it("rejects malformed authoritative output instead of a completed fallback", async () => {
@@ -184,7 +185,7 @@ describe("OpenAI Codex Responses client", () => {
       )
     );
 
-    await expect(request()).resolves.toEqual({ kind: "invalid_response" });
+    await expect(request()).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
   it.each([
@@ -212,24 +213,24 @@ describe("OpenAI Codex Responses client", () => {
         Array.from({ length: 1_001 }, () => sseEvent({ type: "response.created" })).join("")
       ),
     ],
-  ])("returns invalid_response for %s", async (_name, response) => {
+  ])("rejects invalid output for %s", async (_name, response) => {
     vi.mocked(fetch).mockResolvedValueOnce(response);
-    await expect(request()).resolves.toEqual({ kind: "invalid_response" });
+    await expect(request()).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
-  it("returns invalid_response when the stream ends before a terminal event", async () => {
+  it("rejects when the stream ends before a terminal event", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       fragmentedSseResponse({ type: "response.created", response: { id: "resp-classify" } })
     );
 
-    await expect(request()).resolves.toEqual({ kind: "invalid_response" });
+    await expect(request()).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
   it.each(["response.failed", "error"])("sanitizes %s events", async (type) => {
     vi.mocked(fetch).mockResolvedValueOnce(
       fragmentedSseResponse({ type, error: { message: "upstream secret details" } })
     );
-    await expect(request()).resolves.toEqual({ kind: "upstream_error" });
+    await expect(request()).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
   });
 
   it("times out a stream whose reader and cancellation never finish", async () => {
@@ -238,10 +239,11 @@ describe("OpenAI Codex Responses client", () => {
     vi.mocked(fetch).mockResolvedValueOnce(openStreamResponse(undefined, cancel));
 
     const result = request();
+    const rejection = expect(result).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
     await vi.advanceTimersByTimeAsync(CODEX_RESPONSES_TIMEOUT_MS);
 
-    await expect(result).resolves.toEqual({ kind: "upstream_error" });
+    await rejection;
     expect(cancel).toHaveBeenCalledOnce();
   });
 
@@ -250,10 +252,11 @@ describe("OpenAI Codex Responses client", () => {
     vi.mocked(fetch).mockImplementationOnce(() => new Promise<Response>(() => undefined));
 
     const result = request();
+    const rejection = expect(result).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
     await vi.advanceTimersByTimeAsync(CODEX_RESPONSES_TIMEOUT_MS);
 
-    await expect(result).resolves.toEqual({ kind: "upstream_error" });
+    await rejection;
     expect(vi.mocked(fetch).mock.calls[0][1]?.signal?.aborted).toBe(true);
   });
 
@@ -268,16 +271,18 @@ describe("OpenAI Codex Responses client", () => {
     );
     vi.mocked(fetch).mockResolvedValueOnce(response);
 
-    await expect(request()).resolves.toEqual({ kind: "completed", output });
+    await expect(request()).resolves.toEqual(output);
     expect(cancel).toHaveBeenCalledOnce();
     expect(response.body?.locked).toBe(false);
   });
 
-  it("maps non-OK responses without reading their body", async () => {
+  it("throws an upstream error for non-OK responses without reading their body", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response("upstream secret details", { status: 429 })
     );
-    await expect(request()).resolves.toEqual({ kind: "upstream_error", status: 429 });
+    const error = await request().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(OpenAICodexUpstreamError);
+    expect(error).toMatchObject({ status: 429 });
   });
 
   it("omits the account header when no account id is available", async () => {

--- a/packages/control-plane/src/openai/codex-responses.ts
+++ b/packages/control-plane/src/openai/codex-responses.ts
@@ -1,4 +1,5 @@
 import { waitForAbort } from "./bounded-json-sse";
+import { OpenAICodexUpstreamError } from "./codex-errors";
 import { parseOpenAIResponsesStream } from "./responses-stream";
 
 const CODEX_SUBSCRIPTION_RESPONSES_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
@@ -18,11 +19,6 @@ export type OpenAICodexFunctionRequest = {
     parameters: object;
   };
 };
-
-type OpenAICodexResult =
-  | { kind: "completed"; output: unknown }
-  | { kind: "upstream_error"; status?: number }
-  | { kind: "invalid_response" };
 
 function buildHeaders(request: OpenAICodexFunctionRequest): Headers {
   const headers = new Headers({
@@ -59,7 +55,7 @@ function buildBody(request: OpenAICodexFunctionRequest): string {
 /** Executes one standard Responses function call through the Codex subscription endpoint. */
 export async function requestOpenAICodexFunction(
   request: OpenAICodexFunctionRequest
-): Promise<OpenAICodexResult> {
+): Promise<unknown> {
   const abortController = new AbortController();
   const timeout = setTimeout(() => abortController.abort(), CODEX_RESPONSES_TIMEOUT_MS);
   try {
@@ -74,11 +70,18 @@ export async function requestOpenAICodexFunction(
         }),
         abortController.signal
       );
-    } catch {
-      return { kind: "upstream_error" };
+    } catch (error) {
+      throw new OpenAICodexUpstreamError("OpenAI Codex request failed", undefined, {
+        cause: error,
+      });
     }
 
-    if (!response.ok) return { kind: "upstream_error", status: response.status };
+    if (!response.ok) {
+      throw new OpenAICodexUpstreamError(
+        `OpenAI Codex request failed with status ${response.status}`,
+        response.status
+      );
+    }
     return await parseOpenAIResponsesStream(response, abortController.signal, request.tool.name);
   } finally {
     clearTimeout(timeout);

--- a/packages/control-plane/src/openai/responses-stream.test.ts
+++ b/packages/control-plane/src/openai/responses-stream.test.ts
@@ -158,4 +158,22 @@ describe("OpenAI Responses stream reducer", () => {
       parseOpenAIResponsesStream(sseResponse(), controller.signal, TOOL_NAME)
     ).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
   });
+
+  it("gives an abort precedence over a malformed event already read from the stream", async () => {
+    const controller = new AbortController();
+    const event = new TextEncoder().encode("data: null\n\n");
+    const response = new Response(
+      new ReadableStream({
+        pull(streamController) {
+          streamController.enqueue(event);
+          streamController.close();
+          queueMicrotask(() => controller.abort());
+        },
+      })
+    );
+
+    await expect(
+      parseOpenAIResponsesStream(response, controller.signal, TOOL_NAME)
+    ).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
+  });
 });

--- a/packages/control-plane/src/openai/responses-stream.test.ts
+++ b/packages/control-plane/src/openai/responses-stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InvalidOpenAICodexResponseError, OpenAICodexUpstreamError } from "./codex-errors";
 import { parseOpenAIResponsesStream } from "./responses-stream";
 
 const TOOL_NAME = "classify_target";
@@ -49,14 +50,14 @@ describe("OpenAI Responses stream reducer", () => {
       },
     ],
   ])("rejects %s", async (_name, event) => {
-    await expect(parse(event)).resolves.toEqual({ kind: "invalid_response" });
+    await expect(parse(event)).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
   it.each([
     ["an error event", { type: "error", message: "upstream failure" }],
     ["a failed response", { type: "response.failed", response: {} }],
   ])("maps %s to an upstream error", async (_name, event) => {
-    await expect(parse(event)).resolves.toEqual({ kind: "upstream_error" });
+    await expect(parse(event)).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
   });
 
   it("rejects a stream that ends without a completed response", async () => {
@@ -65,7 +66,7 @@ describe("OpenAI Responses stream reducer", () => {
         type: "response.output_item.added",
         item: { type: "function_call", id: "fc-1", name: TOOL_NAME, arguments: "" },
       })
-    ).resolves.toEqual({ kind: "invalid_response" });
+    ).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
   it.each([
@@ -75,7 +76,7 @@ describe("OpenAI Responses stream reducer", () => {
   ])("rejects a completed response with %s", async (_name, item) => {
     await expect(
       parse({ type: "response.completed", response: { output: [item] } })
-    ).resolves.toEqual({ kind: "invalid_response" });
+    ).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
   it("uses the tool name supplied by an arguments-done event", async () => {
@@ -93,7 +94,7 @@ describe("OpenAI Responses stream reducer", () => {
         },
         { type: "response.completed", response: {} }
       )
-    ).resolves.toEqual({ kind: "completed", output });
+    ).resolves.toEqual(output);
   });
 
   it("assembles function-call argument deltas", async () => {
@@ -117,7 +118,7 @@ describe("OpenAI Responses stream reducer", () => {
         },
         { type: "response.completed", response: {} }
       )
-    ).resolves.toEqual({ kind: "completed", output });
+    ).resolves.toEqual(output);
   });
 
   it("ignores unrelated events", async () => {
@@ -126,7 +127,7 @@ describe("OpenAI Responses stream reducer", () => {
         { type: "response.created", response: {} },
         { type: "response.completed", response: { output: [functionCall()] } }
       )
-    ).resolves.toEqual({ kind: "completed", output });
+    ).resolves.toEqual(output);
   });
 
   it("ignores a non-function output item before the completed response", async () => {
@@ -138,7 +139,7 @@ describe("OpenAI Responses stream reducer", () => {
           response: { output: [functionCall()] },
         }
       )
-    ).resolves.toEqual({ kind: "completed", output });
+    ).resolves.toEqual(output);
   });
 
   it("normalizes malformed SSE as an invalid response", async () => {
@@ -146,15 +147,15 @@ describe("OpenAI Responses stream reducer", () => {
 
     await expect(
       parseOpenAIResponsesStream(response, new AbortController().signal, TOOL_NAME)
-    ).resolves.toEqual({ kind: "invalid_response" });
+    ).rejects.toBeInstanceOf(InvalidOpenAICodexResponseError);
   });
 
-  it("maps an aborted stream to an upstream error", async () => {
+  it("throws an upstream error for an aborted stream", async () => {
     const controller = new AbortController();
     controller.abort();
 
     await expect(
       parseOpenAIResponsesStream(sseResponse(), controller.signal, TOOL_NAME)
-    ).resolves.toEqual({ kind: "upstream_error" });
+    ).rejects.toBeInstanceOf(OpenAICodexUpstreamError);
   });
 });

--- a/packages/control-plane/src/openai/responses-stream.ts
+++ b/packages/control-plane/src/openai/responses-stream.ts
@@ -188,13 +188,13 @@ export async function parseOpenAIResponsesStream(
       }
     }
   } catch (error) {
-    if (error instanceof OpenAICodexUpstreamError) throw error;
-    if (error instanceof InvalidOpenAICodexResponseError) throw error;
     if (error instanceof BoundedJsonSseAbortError || signal.aborted) {
       throw new OpenAICodexUpstreamError("OpenAI Responses stream aborted", undefined, {
         cause: error,
       });
     }
+    if (error instanceof OpenAICodexUpstreamError) throw error;
+    if (error instanceof InvalidOpenAICodexResponseError) throw error;
     throw new InvalidOpenAICodexResponseError("Invalid OpenAI Responses stream", {
       cause: error,
     });

--- a/packages/control-plane/src/openai/responses-stream.ts
+++ b/packages/control-plane/src/openai/responses-stream.ts
@@ -1,4 +1,5 @@
 import { BoundedJsonSseAbortError, decodeBoundedJsonSse } from "./bounded-json-sse";
+import { InvalidOpenAICodexResponseError, OpenAICodexUpstreamError } from "./codex-errors";
 
 const MAX_TOOL_ARGUMENT_BYTES = 32 * 1024;
 const RESPONSES_SSE_LIMITS = {
@@ -6,11 +7,6 @@ const RESPONSES_SSE_LIMITS = {
   maxEventBytes: 64 * 1024,
   maxEvents: 1_000,
 };
-
-type OpenAIResponsesStreamResult =
-  | { kind: "completed"; output: unknown }
-  | { kind: "upstream_error" }
-  | { kind: "invalid_response" };
 
 type PendingFunctionCall = {
   name?: string;
@@ -23,8 +19,6 @@ type ResponseState = {
   outputItem: unknown;
   completedOutput: unknown;
 };
-
-type EventAction = "continue" | "completed" | "upstream_error" | "invalid";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -78,31 +72,37 @@ function applyFunctionCallDelta(
   state: ResponseState,
   event: Record<string, unknown>,
   encoder: TextEncoder
-): EventAction {
+): void {
   const itemId = typeof event.item_id === "string" ? event.item_id : null;
-  if (!itemId || typeof event.delta !== "string") return "invalid";
+  if (!itemId || typeof event.delta !== "string") {
+    throw new InvalidOpenAICodexResponseError("Invalid function-call argument delta");
+  }
   const call = state.pendingCalls.get(itemId) ?? { arguments: "", argumentBytes: 0 };
   call.arguments += event.delta;
   call.argumentBytes += encoder.encode(event.delta).byteLength;
-  if (call.argumentBytes > MAX_TOOL_ARGUMENT_BYTES) return "invalid";
+  if (call.argumentBytes > MAX_TOOL_ARGUMENT_BYTES) {
+    throw new InvalidOpenAICodexResponseError("Function-call arguments exceed the byte limit");
+  }
   state.pendingCalls.set(itemId, call);
-  return "continue";
 }
 
 function applyFunctionCallDone(
   state: ResponseState,
   event: Record<string, unknown>,
   encoder: TextEncoder
-): EventAction {
+): void {
   const itemId = typeof event.item_id === "string" ? event.item_id : null;
-  if (!itemId || typeof event.arguments !== "string") return "invalid";
+  if (!itemId || typeof event.arguments !== "string") {
+    throw new InvalidOpenAICodexResponseError("Invalid completed function-call arguments");
+  }
   const call = state.pendingCalls.get(itemId) ?? { arguments: "", argumentBytes: 0 };
   call.arguments = event.arguments;
   call.argumentBytes = encoder.encode(event.arguments).byteLength;
   if (typeof event.name === "string") call.name = event.name;
-  if (call.argumentBytes > MAX_TOOL_ARGUMENT_BYTES) return "invalid";
+  if (call.argumentBytes > MAX_TOOL_ARGUMENT_BYTES) {
+    throw new InvalidOpenAICodexResponseError("Function-call arguments exceed the byte limit");
+  }
   state.pendingCalls.set(itemId, call);
-  return "continue";
 }
 
 function applyResponseEvent(
@@ -110,9 +110,13 @@ function applyResponseEvent(
   event: unknown,
   toolName: string,
   encoder: TextEncoder
-): EventAction {
-  if (!isRecord(event) || typeof event.type !== "string") return "invalid";
-  if (event.type === "error" || event.type === "response.failed") return "upstream_error";
+): boolean {
+  if (!isRecord(event) || typeof event.type !== "string") {
+    throw new InvalidOpenAICodexResponseError("Invalid OpenAI Responses event");
+  }
+  if (event.type === "error" || event.type === "response.failed") {
+    throw new OpenAICodexUpstreamError("OpenAI Responses stream reported an error");
+  }
 
   if (event.type === "response.output_item.added" && isRecord(event.item)) {
     const id = typeof event.item.id === "string" ? event.item.id : null;
@@ -124,25 +128,30 @@ function applyResponseEvent(
         argumentBytes: encoder.encode(argumentsValue).byteLength,
       });
     }
-    return "continue";
+    return false;
   }
 
   if (event.type === "response.function_call_arguments.delta") {
-    return applyFunctionCallDelta(state, event, encoder);
+    applyFunctionCallDelta(state, event, encoder);
+    return false;
   }
   if (event.type === "response.function_call_arguments.done") {
-    return applyFunctionCallDone(state, event, encoder);
+    applyFunctionCallDone(state, event, encoder);
+    return false;
   }
   if (event.type === "response.output_item.done") {
-    if (!isRecord(event.item) || event.item.type !== "function_call") return "continue";
+    if (!isRecord(event.item) || event.item.type !== "function_call") return false;
     state.outputItem = parseFunctionCallItem(event.item, toolName, encoder);
-    return state.outputItem === null ? "invalid" : "continue";
+    if (state.outputItem === null) {
+      throw new InvalidOpenAICodexResponseError("Invalid completed function-call output");
+    }
+    return false;
   }
   if (event.type === "response.completed") {
     state.completedOutput = extractCompletedOutput(event.response, toolName, encoder);
-    return "completed";
+    return true;
   }
-  return "continue";
+  return false;
 }
 
 function resolveOutput(state: ResponseState, toolName: string): unknown {
@@ -160,7 +169,7 @@ export async function parseOpenAIResponsesStream(
   response: Response,
   signal: AbortSignal,
   toolName: string
-): Promise<OpenAIResponsesStreamResult> {
+): Promise<unknown> {
   const state: ResponseState = {
     pendingCalls: new Map(),
     outputItem: null,
@@ -170,19 +179,26 @@ export async function parseOpenAIResponsesStream(
 
   try {
     for await (const event of decodeBoundedJsonSse(response, signal, RESPONSES_SSE_LIMITS)) {
-      const action = applyResponseEvent(state, event, toolName, encoder);
-      if (action === "upstream_error") return { kind: "upstream_error" };
-      if (action === "invalid") return { kind: "invalid_response" };
-      if (action === "completed") {
+      if (applyResponseEvent(state, event, toolName, encoder)) {
         const output = resolveOutput(state, toolName);
-        return output === null ? { kind: "invalid_response" } : { kind: "completed", output };
+        if (output === null) {
+          throw new InvalidOpenAICodexResponseError("OpenAI Responses stream has no tool output");
+        }
+        return output;
       }
     }
   } catch (error) {
-    return error instanceof BoundedJsonSseAbortError || signal.aborted
-      ? { kind: "upstream_error" }
-      : { kind: "invalid_response" };
+    if (error instanceof OpenAICodexUpstreamError) throw error;
+    if (error instanceof InvalidOpenAICodexResponseError) throw error;
+    if (error instanceof BoundedJsonSseAbortError || signal.aborted) {
+      throw new OpenAICodexUpstreamError("OpenAI Responses stream aborted", undefined, {
+        cause: error,
+      });
+    }
+    throw new InvalidOpenAICodexResponseError("Invalid OpenAI Responses stream", {
+      cause: error,
+    });
   }
 
-  return { kind: "invalid_response" };
+  throw new InvalidOpenAICodexResponseError("OpenAI Responses stream ended before completion");
 }

--- a/packages/control-plane/src/routes/target-classifications.test.ts
+++ b/packages/control-plane/src/routes/target-classifications.test.ts
@@ -3,6 +3,12 @@ import {
   TARGET_CLASSIFIER_SYSTEM_PROMPT,
 } from "@open-inspect/shared/types/target-classification";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OpenAITokenNotConfiguredError,
+  OpenAITokenUnauthorizedError,
+} from "../auth/openai-token-broker";
+import type * as OpenAITokenBrokerModule from "../auth/openai-token-broker";
+import { InvalidOpenAICodexResponseError, OpenAICodexUpstreamError } from "../openai/codex-errors";
 import { handleRequest } from "../router";
 import { signedServiceRequest, TEST_SERVICE_SECRETS } from "../router.test-support";
 
@@ -11,11 +17,15 @@ const mocks = vi.hoisted(() => ({
   requestFunction: vi.fn(),
 }));
 
-vi.mock("../auth/openai-token-broker", () => ({
-  OpenAITokenBroker: class {
-    refreshGlobal = mocks.refreshGlobal;
-  },
-}));
+vi.mock("../auth/openai-token-broker", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenAITokenBrokerModule>();
+  return {
+    ...actual,
+    OpenAITokenBroker: class {
+      refreshGlobal = mocks.refreshGlobal;
+    },
+  };
+});
 
 vi.mock("../openai/codex-responses", () => ({
   requestOpenAICodexFunction: mocks.requestFunction,
@@ -73,12 +83,11 @@ describe("POST /internal/target-classifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.refreshGlobal.mockResolvedValue({
-      ok: true,
       accessToken: "secret-access-token",
       expiresIn: 1800,
       accountId: "account-123",
     });
-    mocks.requestFunction.mockResolvedValue({ kind: "completed", output: decision });
+    mocks.requestFunction.mockResolvedValue(decision);
   });
 
   it("rejects requests without service authentication", async () => {
@@ -133,11 +142,9 @@ describe("POST /internal/target-classifications", () => {
   });
 
   it("returns 503 without configured global OAuth", async () => {
-    mocks.refreshGlobal.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: "OPENAI_OAUTH_REFRESH_TOKEN not configured",
-    });
+    mocks.refreshGlobal.mockRejectedValue(
+      new OpenAITokenNotConfiguredError("OPENAI_OAUTH_REFRESH_TOKEN not configured")
+    );
 
     const response = await targetClassificationRequest(validRequest());
 
@@ -184,10 +191,7 @@ describe("POST /internal/target-classifications", () => {
   });
 
   it("rejects invalid structured classifier output", async () => {
-    mocks.requestFunction.mockResolvedValue({
-      kind: "completed",
-      output: { ...decision, confidence: "certain" },
-    });
+    mocks.requestFunction.mockResolvedValue({ ...decision, confidence: "certain" });
 
     const response = await targetClassificationRequest(validRequest());
 
@@ -201,7 +205,7 @@ describe("POST /internal/target-classifications", () => {
     ["primary target", { ...decision, targetId: "acme/unknown" }],
     ["alternative", { ...decision, alternatives: ["acme/unknown"] }],
   ])("rejects a classifier decision with an unknown %s", async (_name, output) => {
-    mocks.requestFunction.mockResolvedValue({ kind: "completed", output });
+    mocks.requestFunction.mockResolvedValue(output);
 
     const response = await targetClassificationRequest(validRequest());
 
@@ -212,7 +216,9 @@ describe("POST /internal/target-classifications", () => {
   });
 
   it("maps invalid provider output without exposing details", async () => {
-    mocks.requestFunction.mockResolvedValue({ kind: "invalid_response" });
+    mocks.requestFunction.mockRejectedValue(
+      new InvalidOpenAICodexResponseError("sensitive provider output")
+    );
 
     const response = await targetClassificationRequest(validRequest());
 
@@ -223,7 +229,9 @@ describe("POST /internal/target-classifications", () => {
   });
 
   it("maps upstream failures without exposing details", async () => {
-    mocks.requestFunction.mockResolvedValue({ kind: "upstream_error", status: 429 });
+    mocks.requestFunction.mockRejectedValue(
+      new OpenAICodexUpstreamError("sensitive upstream failure", 429)
+    );
 
     const response = await targetClassificationRequest(validRequest());
 
@@ -231,12 +239,17 @@ describe("POST /internal/target-classifications", () => {
     await expect(response.json()).resolves.toEqual({ error: "Classifier upstream unavailable" });
   });
 
+  it("does not misclassify unexpected Codex client failures", async () => {
+    mocks.requestFunction.mockRejectedValue(new Error("unexpected client failure"));
+
+    const response = await targetClassificationRequest(validRequest());
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.not.toContain("unexpected client failure");
+  });
+
   it("maps broker authorization failure to 502", async () => {
-    mocks.refreshGlobal.mockResolvedValue({
-      ok: false,
-      status: 401,
-      error: "refresh token rejected",
-    });
+    mocks.refreshGlobal.mockRejectedValue(new OpenAITokenUnauthorizedError("refresh rejected"));
 
     const response = await targetClassificationRequest(validRequest());
 

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
+import {
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+} from "../../openai-token-refresh-service";
 import type { SandboxRow, SessionRow } from "../../types";
 import { createSandboxHandler } from "./sandbox.handler";
 
@@ -488,20 +494,36 @@ describe("createSandboxHandler", () => {
     expect(await response.json()).toEqual({ error: "Secrets not configured" });
   });
 
-  it("returns mapped service error from openai token refresh", async () => {
+  it.each([
+    [OpenAITokenNotConfiguredError, 404, "OPENAI_OAUTH_REFRESH_TOKEN not configured"],
+    [OpenAITokenUnauthorizedError, 401, "OpenAI token refresh failed: unauthorized"],
+    [OpenAITokenStorageError, 500, "Failed to read token state"],
+    [
+      OpenAITokenStorageError,
+      500,
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
+    ],
+    [OpenAITokenUpstreamError, 502, "OpenAI token refresh failed"],
+  ])("maps %s to status %i", async (ErrorType, status, message) => {
     const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
     getSession.mockReturnValue({ id: "session-1" } as SessionRow);
     isManagedSecretsConfigured.mockReturnValue(true);
-    refreshOpenAIToken.mockResolvedValue({
-      ok: false,
-      status: 502,
-      error: "OpenAI token refresh failed",
-    });
+    refreshOpenAIToken.mockRejectedValue(new ErrorType(message));
 
     const response = await handler.openaiTokenRefresh();
 
-    expect(response.status).toBe(502);
-    expect(await response.json()).toEqual({ error: "OpenAI token refresh failed" });
+    expect(response.status).toBe(status);
+    expect(await response.json()).toEqual({ error: message });
+  });
+
+  it("does not mask unexpected OpenAI token refresh failures", async () => {
+    const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
+    getSession.mockReturnValue({ id: "session-1" } as SessionRow);
+    isManagedSecretsConfigured.mockReturnValue(true);
+    const unexpected = new Error("unexpected refresh failure");
+    refreshOpenAIToken.mockRejectedValue(unexpected);
+
+    await expect(handler.openaiTokenRefresh()).rejects.toBe(unexpected);
   });
 
   it("returns openai access token payload on success", async () => {
@@ -511,7 +533,6 @@ describe("createSandboxHandler", () => {
     getSession.mockReturnValue(session);
     isManagedSecretsConfigured.mockReturnValue(true);
     refreshOpenAIToken.mockResolvedValue({
-      ok: true,
       accessToken: "access-token",
       expiresIn: 3600,
       accountId: "acct_123",

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -7,7 +7,13 @@ import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { ParticipantRole } from "@open-inspect/shared/types/sessions";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
-import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
+import {
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+  type OpenAIToken,
+} from "../../openai-token-refresh-service";
 import type { XaiTokenRefreshResult } from "../../xai-token-refresh-service";
 import type { ScmCredentialsResult } from "../../scm-credentials-service";
 import type { SessionMessenger } from "../../messenger";
@@ -36,7 +42,7 @@ export interface SandboxHandlerDeps {
   getSandbox: () => SandboxRow | null;
   isValidSandboxToken: (token: string | null, sandbox: SandboxRow | null) => Promise<boolean>;
   getSession: () => SessionRow | null;
-  refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAITokenRefreshResult>;
+  refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAIToken>;
   refreshXaiToken: (session: SessionRow, log: Logger) => Promise<XaiTokenRefreshResult>;
   isManagedSecretsConfigured: () => boolean;
   getScmCredentials: (log: Logger) => Promise<ScmCredentialsResult>;
@@ -232,16 +238,30 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ error: "Secrets not configured" }, { status: 500 });
       }
 
-      const result = await deps.refreshOpenAIToken(session, log);
-      if (!result.ok) {
-        return Response.json({ error: result.error }, { status: result.status });
+      let token: OpenAIToken;
+      try {
+        token = await deps.refreshOpenAIToken(session, log);
+      } catch (error) {
+        if (error instanceof OpenAITokenNotConfiguredError) {
+          return Response.json({ error: error.message }, { status: 404 });
+        }
+        if (error instanceof OpenAITokenUnauthorizedError) {
+          return Response.json({ error: error.message }, { status: 401 });
+        }
+        if (error instanceof OpenAITokenStorageError) {
+          return Response.json({ error: error.message }, { status: 500 });
+        }
+        if (error instanceof OpenAITokenUpstreamError) {
+          return Response.json({ error: error.message }, { status: 502 });
+        }
+        throw error;
       }
 
       return Response.json(
         {
-          access_token: result.accessToken,
-          expires_in: result.expiresIn,
-          account_id: result.accountId,
+          access_token: token.accessToken,
+          expires_in: token.expiresIn,
+          account_id: token.accountId,
         },
         { status: 200, headers: { "Cache-Control": "no-store" } }
       );

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -527,7 +527,7 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
   });
 
-  it("throws an unauthorized error when the post-401 secret reread fails", async () => {
+  it("continues polling after a transient post-401 secret reread failure", async () => {
     vi.useFakeTimers();
     mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
     mockState.refreshImpl.mockRejectedValue(
@@ -542,6 +542,24 @@ describe("OpenAITokenRefreshService", () => {
     await vi.runAllTimersAsync();
 
     await rejection;
+  });
+
+  it("throws a storage error when post-401 secret rereads keep failing", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
+    );
+    mockState.globalReadImpl
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValue(new Error("D1 reread failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.globalReadImpl).toHaveBeenCalledTimes(5);
   });
 
   it("throws a secrets-read error when repository scope resolution fails", async () => {

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
 import type { SessionRow } from "./types";
-import { OpenAITokenBroker } from "../auth/openai-token-broker";
+import {
+  OpenAITokenBroker,
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+} from "../auth/openai-token-broker";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { OpenAITokenRefreshError } from "../auth/openai";
 
@@ -192,7 +198,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession());
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "cached-access",
       expiresIn: expect.any(Number),
       accountId: "acct_cached",
@@ -216,7 +221,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "global-cached-access",
       expiresIn: expect.any(Number),
       accountId: "acct_global",
@@ -239,7 +243,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "global-access-new",
       expiresIn: 1800,
       accountId: "acct_global",
@@ -268,7 +271,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
 
     expect(result).toMatchObject({
-      ok: true,
       accessToken: "global-access-new",
       accountId: "acct_stored",
     });
@@ -295,12 +297,12 @@ describe("OpenAITokenRefreshService", () => {
     const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
     await vi.runAllTimersAsync();
 
-    await expect(promise).resolves.toMatchObject({ ok: true, accessToken: "global-access-new" });
+    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
     expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(2);
     expect(mockState.globalWrites).toHaveLength(1);
   });
 
-  it("returns an actionable failure when rotated global credentials cannot be persisted", async () => {
+  it("throws an actionable error when rotated global credentials cannot be persisted", async () => {
     vi.useFakeTimers();
     mockState.globalSecrets = {
       OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
@@ -314,15 +316,15 @@ describe("OpenAITokenRefreshService", () => {
     mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
 
     const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const errorPromise = promise.catch((caught: unknown) => caught);
     await vi.runAllTimersAsync();
 
-    const result = await promise;
-    expect(result).toEqual({
-      ok: false,
-      status: 500,
-      error: "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
-    });
-    expect(result.ok).toBe(false);
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OpenAITokenStorageError);
+    expect(error).toHaveProperty(
+      "message",
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
+    );
     expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
     expect(mockState.globalWrites).toHaveLength(0);
   });
@@ -346,7 +348,6 @@ describe("OpenAITokenRefreshService", () => {
     await vi.runAllTimersAsync();
 
     await expect(promise).resolves.toMatchObject({
-      ok: true,
       accessToken: "global-access-concurrent",
     });
     expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
@@ -381,13 +382,11 @@ describe("OpenAITokenRefreshService", () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual([
       {
-        ok: true,
         accessToken: "global-access-new",
         expiresIn: 1800,
         accountId: undefined,
       },
       {
-        ok: true,
         accessToken: "global-access-new",
         expiresIn: 1800,
         accountId: undefined,
@@ -418,13 +417,12 @@ describe("OpenAITokenRefreshService", () => {
     await vi.runAllTimersAsync();
 
     await expect(result).resolves.toMatchObject({
-      ok: true,
       accessToken: "global-access-concurrent",
     });
     expect(mockState.refreshImpl).toHaveBeenCalledOnce();
   });
 
-  it("returns a bounded 401 when a concurrently rotated token is also rejected", async () => {
+  it("throws an unauthorized error when a concurrently rotated token is also rejected", async () => {
     vi.useFakeTimers();
     mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
     mockState.refreshImpl
@@ -435,17 +433,14 @@ describe("OpenAITokenRefreshService", () => {
       .mockRejectedValueOnce(new OpenAITokenRefreshError("unauthorized", 401, "unauthorized"));
 
     const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
     await vi.runAllTimersAsync();
 
-    await expect(result).resolves.toEqual({
-      ok: false,
-      status: 401,
-      error: "OpenAI token refresh failed: unauthorized",
-    });
+    await rejection;
     expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
   });
 
-  it("returns a bounded failure when retrying a concurrently rotated token fails", async () => {
+  it("throws an upstream error when retrying a concurrently rotated token fails", async () => {
     vi.useFakeTimers();
     mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
     mockState.refreshImpl
@@ -456,17 +451,38 @@ describe("OpenAITokenRefreshService", () => {
       .mockRejectedValueOnce(new Error("upstream connection failed"));
 
     const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUpstreamError);
     await vi.runAllTimersAsync();
 
-    await expect(result).resolves.toEqual({
-      ok: false,
-      status: 502,
-      error: "OpenAI token refresh failed",
-    });
+    await rejection;
     expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
   });
 
-  it("returns 404 when refresh token is missing in repo and global secrets", async () => {
+  it("preserves a persistence error when retrying a concurrently rotated token", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({
+        access_token: "global-access-new",
+        refresh_token: "global-refresh-new",
+        expires_in: 1800,
+      });
+    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws a not-configured error when refresh token is missing", async () => {
     const service = new OpenAITokenRefreshService(
       TEST_DB,
       "enc-key",
@@ -474,30 +490,24 @@ describe("OpenAITokenRefreshService", () => {
       createLogger()
     );
 
-    const result = await service.refresh(createSession());
-
-    expect(result).toEqual({
-      ok: false,
-      status: 404,
-      error: "OPENAI_OAUTH_REFRESH_TOKEN not configured",
-    });
+    await expect(service.refresh(createSession())).rejects.toThrow(OpenAITokenNotConfiguredError);
   });
 
-  it("returns a bounded failure when scoped secrets cannot be read", async () => {
+  it("throws a secrets-read error when scoped secrets cannot be read", async () => {
     mockState.globalReadImpl.mockRejectedValue(new Error("D1 read failed"));
 
-    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-
-    expect(result).toEqual({ ok: false, status: 500, error: "Failed to read token state" });
+    await expect(
+      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
+    ).rejects.toThrow(OpenAITokenStorageError);
   });
 
-  it("returns a bounded failure when token refresh fails unexpectedly", async () => {
+  it("throws an upstream error when token refresh fails unexpectedly", async () => {
     mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh" };
     mockState.refreshImpl.mockRejectedValue(new Error("upstream connection failed"));
 
-    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-
-    expect(result).toEqual({ ok: false, status: 502, error: "OpenAI token refresh failed" });
+    await expect(
+      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
+    ).rejects.toThrow(OpenAITokenUpstreamError);
   });
 
   it("retries with a refresh token written by a concurrent rotation", async () => {
@@ -513,11 +523,11 @@ describe("OpenAITokenRefreshService", () => {
     const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
     await vi.runAllTimersAsync();
 
-    await expect(result).resolves.toMatchObject({ ok: true, accessToken: "fresh-access" });
+    await expect(result).resolves.toMatchObject({ accessToken: "fresh-access" });
     expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
   });
 
-  it("returns unauthorized when the post-401 secret reread fails", async () => {
+  it("throws an unauthorized error when the post-401 secret reread fails", async () => {
     vi.useFakeTimers();
     mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
     mockState.refreshImpl.mockRejectedValue(
@@ -528,16 +538,13 @@ describe("OpenAITokenRefreshService", () => {
       .mockRejectedValueOnce(new Error("D1 reread failed"));
 
     const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
     await vi.runAllTimersAsync();
 
-    await expect(result).resolves.toEqual({
-      ok: false,
-      status: 401,
-      error: "OpenAI token refresh failed: unauthorized",
-    });
+    await rejection;
   });
 
-  it("returns a bounded failure when repository scope resolution fails", async () => {
+  it("throws a secrets-read error when repository scope resolution fails", async () => {
     const service = new OpenAITokenRefreshService(
       TEST_DB,
       "enc-key",
@@ -547,11 +554,7 @@ describe("OpenAITokenRefreshService", () => {
       createLogger()
     );
 
-    await expect(service.refresh(createSession())).resolves.toEqual({
-      ok: false,
-      status: 500,
-      error: "Failed to read token state",
-    });
+    await expect(service.refresh(createSession())).rejects.toThrow(OpenAITokenStorageError);
   });
 
   it("refreshes token and persists rotated credentials to repo secrets", async () => {
@@ -577,7 +580,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession());
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "access-new",
       expiresIn: 1800,
       accountId: "acct_new",
@@ -591,7 +593,7 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_ACCESS_TOKEN).toBe("access-new");
   });
 
-  it("returns an actionable failure when rotated session credentials cannot be persisted", async () => {
+  it("throws an actionable error when rotated session credentials cannot be persisted", async () => {
     vi.useFakeTimers();
     const repoId = 123;
     mockState.repoSecrets.set(repoId, {
@@ -612,15 +614,15 @@ describe("OpenAITokenRefreshService", () => {
       createLogger()
     );
     const promise = service.refresh(createSession());
+    const errorPromise = promise.catch((caught: unknown) => caught);
     await vi.runAllTimersAsync();
 
-    const result = await promise;
-    expect(result).toEqual({
-      ok: false,
-      status: 500,
-      error: "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
-    });
-    expect(result.ok).toBe(false);
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OpenAITokenStorageError);
+    expect(error).toHaveProperty(
+      "message",
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
+    );
     expect(mockState.repoWriteImpl).toHaveBeenCalledTimes(3);
     expect(mockState.repoWrites).toHaveLength(0);
   });
@@ -656,7 +658,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await promise;
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "access-concurrent",
       expiresIn: expect.any(Number),
       accountId: "acct_concurrent",
@@ -692,7 +693,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "env-access-new",
       expiresIn: 1800,
       accountId: "acct_env",
@@ -725,7 +725,6 @@ describe("OpenAITokenRefreshService", () => {
 
     const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
 
-    expect(result.ok).toBe(true);
     expect(result).toMatchObject({ accessToken: "global-access" });
     expect(mockState.refreshImpl).not.toHaveBeenCalled();
   });

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -1,11 +1,22 @@
-import { OpenAITokenBroker, type OpenAITokenRefreshResult } from "../auth/openai-token-broker";
+import {
+  OpenAITokenBroker,
+  OpenAITokenStorageError,
+  type OpenAIToken,
+} from "../auth/openai-token-broker";
 import type { OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Logger } from "../logger";
 import { resolveSessionOAuthSecretScope } from "./session-target-secrets";
 import type { SessionRow } from "./types";
 
-export type { OpenAITokenRefreshResult } from "../auth/openai-token-broker";
+export {
+  OpenAITokenBrokerError,
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+  type OpenAIToken,
+} from "../auth/openai-token-broker";
 
 /** Resolves a session into OAuth secret scopes before delegating to the provider broker. */
 export class OpenAITokenRefreshService {
@@ -20,7 +31,7 @@ export class OpenAITokenRefreshService {
     this.broker = new OpenAITokenBroker(db, encryptionKey, log);
   }
 
-  async refresh(session: SessionRow): Promise<OpenAITokenRefreshResult> {
+  async refresh(session: SessionRow): Promise<OpenAIToken> {
     let sessionScope: OAuthSecretScope | null;
     try {
       sessionScope = await resolveSessionOAuthSecretScope(session, this.ensureRepoId);
@@ -28,7 +39,7 @@ export class OpenAITokenRefreshService {
       this.log.error("Failed to resolve OpenAI token secret scope", {
         error: error instanceof Error ? error.message : String(error),
       });
-      return { ok: false, status: 500, error: "Failed to read token state" };
+      throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
     }
     const scopes: OAuthSecretScope[] = sessionScope
       ? [sessionScope, { kind: "global" }]

--- a/packages/control-plane/src/target-classifications/service.ts
+++ b/packages/control-plane/src/target-classifications/service.ts
@@ -7,10 +7,16 @@ import {
   type TargetClassificationDecision,
   type TargetClassificationRequest,
 } from "@open-inspect/shared/types/target-classification";
-import { OpenAITokenBroker } from "../auth/openai-token-broker";
+import {
+  OpenAITokenBroker,
+  OpenAITokenBrokerError,
+  OpenAITokenNotConfiguredError,
+  type OpenAIToken,
+} from "../auth/openai-token-broker";
 import type { SqlDatabase } from "../db/sql-database";
 import { createLogger } from "../logger";
 import { requestOpenAICodexFunction } from "../openai/codex-responses";
+import { InvalidOpenAICodexResponseError, OpenAICodexUpstreamError } from "../openai/codex-errors";
 
 const logger = createLogger("target-classifications");
 const OPENAI_MODEL = "gpt-5.6-luna";
@@ -32,46 +38,53 @@ export async function createTargetClassification(
   context: TargetClassificationServiceContext
 ): Promise<TargetClassificationDecision> {
   const broker = new OpenAITokenBroker(context.db, context.encryptionKey, logger);
-  const tokenResult = await broker.refreshGlobal();
-  if (!tokenResult.ok) {
-    if (tokenResult.status === 404) throw new OpenAIOAuthNotConfiguredError();
-    throw new OpenAIOAuthUnavailableError();
+  let token: OpenAIToken;
+  try {
+    token = await broker.refreshGlobal();
+  } catch (error) {
+    if (error instanceof OpenAITokenNotConfiguredError) throw new OpenAIOAuthNotConfiguredError();
+    if (error instanceof OpenAITokenBrokerError) throw new OpenAIOAuthUnavailableError();
+    throw error;
   }
 
-  const result = await requestOpenAICodexFunction({
-    accessToken: tokenResult.accessToken,
-    accountId: tokenResult.accountId,
-    requestId: context.requestId,
-    traceId: context.traceId,
-    model: OPENAI_MODEL,
-    systemPrompt: TARGET_CLASSIFIER_SYSTEM_PROMPT,
-    prompt: buildTargetClassificationPrompt(request),
-    tool: {
-      name: CLASSIFY_TARGET_TOOL_NAME,
-      description: "Select the best target for the Slack request.",
-      parameters: targetClassificationJsonSchema,
-    },
-  });
-
-  if (result.kind === "upstream_error") {
-    logger.warn("Classifier upstream unavailable", {
-      event: "classifier.upstream_error",
-      upstream_status: result.status,
-      request_id: context.requestId,
-      trace_id: context.traceId,
+  let output: unknown;
+  try {
+    output = await requestOpenAICodexFunction({
+      accessToken: token.accessToken,
+      accountId: token.accountId,
+      requestId: context.requestId,
+      traceId: context.traceId,
+      model: OPENAI_MODEL,
+      systemPrompt: TARGET_CLASSIFIER_SYSTEM_PROMPT,
+      prompt: buildTargetClassificationPrompt(request),
+      tool: {
+        name: CLASSIFY_TARGET_TOOL_NAME,
+        description: "Select the best target for the Slack request.",
+        parameters: targetClassificationJsonSchema,
+      },
     });
-    throw new TargetClassifierUpstreamUnavailableError();
-  }
-  if (result.kind === "invalid_response") {
-    logger.warn("Classifier returned an unparsable response", {
-      event: "classifier.invalid_response",
-      request_id: context.requestId,
-      trace_id: context.traceId,
-    });
-    throw new InvalidTargetClassificationResponseError();
+  } catch (error) {
+    if (error instanceof OpenAICodexUpstreamError) {
+      logger.warn("Classifier upstream unavailable", {
+        event: "classifier.upstream_error",
+        upstream_status: error.status,
+        request_id: context.requestId,
+        trace_id: context.traceId,
+      });
+      throw new TargetClassifierUpstreamUnavailableError();
+    }
+    if (error instanceof InvalidOpenAICodexResponseError) {
+      logger.warn("Classifier returned an unparsable response", {
+        event: "classifier.invalid_response",
+        request_id: context.requestId,
+        trace_id: context.traceId,
+      });
+      throw new InvalidTargetClassificationResponseError();
+    }
+    throw error;
   }
 
-  const decision = targetClassificationDecisionSchema.safeParse(result.output);
+  const decision = targetClassificationDecisionSchema.safeParse(output);
   if (!decision.success) {
     logger.warn("Classifier decision failed schema validation", {
       event: "classifier.invalid_decision",


### PR DESCRIPTION
## Summary

- replace `OpenAITokenRefreshResult` success/error unions with a flat `OpenAIToken` return type and typed broker exceptions
- replace Codex Responses `completed` / `upstream_error` / `invalid_response` unions with direct tool output and typed exceptions
- make Responses reducer helpers throw immediately for invalid or upstream events instead of returning error actions
- preserve existing HTTP status codes and sanitized response bodies at the session and classifier route boundaries
- preserve unexpected exceptions rather than misclassifying them as expected provider failures
- retain concurrent refresh behavior while preserving storage errors from rotated-token retries

## Error boundaries

- `OpenAITokenBroker` throws not-configured, unauthorized, storage, or upstream errors
- `requestOpenAICodexFunction` and `parseOpenAIResponsesStream` throw upstream or invalid-response errors
- the session sandbox handler maps broker exceptions to HTTP responses
- the classifier service maps provider exceptions into its route-facing domain errors

## Validation

- full control-plane suite: 2,503 tests passed
- control-plane typecheck, lint, and build
- Prettier and `git diff --check`
- focused changed-boundary coverage: 100% statements, lines, and functions; 93.37% branches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAI token refresh failures, including configuration, authorization, storage, and upstream errors.
  * Added clearer HTTP responses for token refresh and classification failures.
  * Improved handling of interrupted, malformed, incomplete, or oversized OpenAI response streams.
  * Sanitized upstream error details while preserving useful status information.

* **Refactor**
  * OpenAI token and Codex operations now return successful results directly and report failures through consistent typed errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->