### PR TITLE
fix(slack-bot): mock buildRepoDescriptions as a sync function

### DIFF
--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -103,7 +103,9 @@ describe("RepoClassifier", () => {
     mockGetAvailableRepos.mockResolvedValue(TEST_REPOS);
     mockGetRoutingRules.mockResolvedValue([]);
     mockGetAvailableEnvironments.mockResolvedValue([]);
-    mockBuildRepoDescriptions.mockResolvedValue("- acme/prod\n- acme/web");
+    // buildRepoDescriptions is synchronous — a resolved-value mock would interpolate
+    // "[object Promise]" into the prompt instead of the repository list.
+    mockBuildRepoDescriptions.mockReturnValue("- acme/prod\n- acme/web");
   });
 
   it("uses tool output when provider returns valid structured classification", async () => {
@@ -139,6 +141,8 @@ describe("RepoClassifier", () => {
         tools: [expect.objectContaining({ name: "classify_target" })],
       })
     );
+    const prompt = mockMessagesCreate.mock.calls[0][0].messages[0].content as string;
+    expect(prompt).toContain("## Available Repositories\n- acme/prod\n- acme/web");
   });
 
   it("asks for clarification when tool payload is invalid", async () => {


### PR DESCRIPTION
Fixes the test bug CodeRabbit surfaced while reviewing #1375 ([comment](https://github.com/ColeMurray/background-agents/pull/1375#discussion_r3763678985)). Tracked as item 5 on #1376.

## The bug

`buildRepoDescriptions` is a **synchronous** function (`packages/slack-bot/src/classifier/repos.ts:343`), but the classifier test mocked it with `mockResolvedValue`:

```ts
mockBuildRepoDescriptions.mockResolvedValue("- acme/prod\n- acme/web");
```

The mock therefore returned a `Promise`, and `buildClassificationPrompt` interpolated it straight into the template — so every prompt the tests built contained:

```
## Available Repositories
[object Promise]
```

No assertion covered the repository list, so nothing failed. The suite validated prompts that never contained a repository.

This is pre-existing: the file predates #1366 and was restored byte-identical by the revert (#1375). The revert surfaced it; it did not introduce it.

## The fix

- `mockResolvedValue` → `mockReturnValue` (same value), with a comment explaining why the distinction matters here.
- The first LLM classification test now asserts the outgoing prompt actually contains the mocked repository list under its header:

  ```ts
  expect(prompt).toContain("## Available Repositories\n- acme/prod\n- acme/web");
  ```

  Verified this assertion catches the original bug: with the old async mock it fails with `+ [object Promise]` in exactly that spot.

## Audit for siblings

Checked every other mock in the classifier tests against the real signatures:

- `getAvailableRepos`, `getRoutingRules`, `getAvailableEnvironments` are genuinely `async` — their `mockResolvedValue` calls are correct and unchanged.
- `buildEnvironmentDescriptions` is sync but is deliberately kept **real** via `importOriginal` in the `./environments` mock, so it was never affected.
- `repos.test.ts` / `environments.test.ts` only mock async things (`fetch`, cache `get`/`put`/`delete`) — nothing to fix.

So this was the only instance of the pattern in the classifier tests.

## Testing

- `npm run test -w @open-inspect/slack-bot` — 419 passed (34 files)
- `npm run typecheck -w @open-inspect/slack-bot` — clean
- `npm run lint -w @open-inspect/slack-bot` + `prettier --check` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated classifier test setup for more reliable mocking.
  * Added coverage to verify that generated prompts include the available repository list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->