### PR TITLE
refactor(control-plane): re-land scoped OAuth token-refresh infrastructure

### DIFF
--- a/packages/control-plane/src/auth/oauth-refresh-single-flight.test.ts
+++ b/packages/control-plane/src/auth/oauth-refresh-single-flight.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { OAuthRefreshSingleFlight } from "./oauth-refresh-single-flight";
+
+describe("OAuthRefreshSingleFlight", () => {
+  it("coalesces the same refresh-token version within a scope", async () => {
+    const coordinator = new OAuthRefreshSingleFlight<string>();
+    let resolveRefresh!: (result: string) => void;
+    const refresh = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const first = coordinator.run({ kind: "global" }, "refresh-v1", refresh);
+    const second = coordinator.run({ kind: "global" }, "refresh-v1", refresh);
+    resolveRefresh("access-v1");
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["access-v1", "access-v1"]);
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("does not let an older refresh clear a newer token version", async () => {
+    const coordinator = new OAuthRefreshSingleFlight<string>();
+    let resolveOld!: (result: string) => void;
+    let resolveNew!: (result: string) => void;
+    const oldRefresh = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveOld = resolve;
+        })
+    );
+    const newRefresh = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveNew = resolve;
+        })
+    );
+
+    const oldResult = coordinator.run({ kind: "global" }, "refresh-v1", oldRefresh);
+    const newResult = coordinator.run({ kind: "global" }, "refresh-v2", newRefresh);
+    resolveOld("access-v1");
+    await expect(oldResult).resolves.toBe("access-v1");
+
+    const coalescedNewResult = coordinator.run(
+      { kind: "global" },
+      "refresh-v2",
+      vi.fn().mockResolvedValue("unused")
+    );
+    resolveNew("access-v2");
+
+    await expect(Promise.all([newResult, coalescedNewResult])).resolves.toEqual([
+      "access-v2",
+      "access-v2",
+    ]);
+    expect(oldRefresh).toHaveBeenCalledOnce();
+    expect(newRefresh).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/control-plane/src/auth/oauth-refresh-single-flight.ts
+++ b/packages/control-plane/src/auth/oauth-refresh-single-flight.ts
@@ -1,0 +1,38 @@
+import type { OAuthSecretScope } from "../db/scoped-oauth-secrets";
+
+type InFlightRefresh<TResult> = {
+  refreshToken: string;
+  promise: Promise<TResult>;
+};
+
+/** Coalesces refresh-token rotation for one provider within a Worker isolate. */
+export class OAuthRefreshSingleFlight<TResult> {
+  private readonly inFlight = new Map<string, InFlightRefresh<TResult>>();
+
+  run(
+    scope: OAuthSecretScope,
+    refreshToken: string,
+    refresh: () => Promise<TResult>
+  ): Promise<TResult> {
+    const key = this.scopeKey(scope);
+    const existing = this.inFlight.get(key);
+    if (existing?.refreshToken === refreshToken) return existing.promise;
+
+    const promise = refresh().finally(() => {
+      if (this.inFlight.get(key)?.promise === promise) this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, { refreshToken, promise });
+    return promise;
+  }
+
+  private scopeKey(scope: OAuthSecretScope): string {
+    switch (scope.kind) {
+      case "environment":
+        return `environment:${scope.environmentId}`;
+      case "repo":
+        return `repo:${scope.repoId}`;
+      case "global":
+        return "global";
+    }
+  }
+}

--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -1,0 +1,237 @@
+import { extractOpenAIAccountId, OpenAITokenRefreshError, refreshOpenAIToken } from "./openai";
+import { ScopedOAuthSecretsStore, type OAuthSecretScope } from "../db/scoped-oauth-secrets";
+import type { SqlDatabase } from "../db/sql-database";
+import type { Logger } from "../logger";
+import { OAuthRefreshSingleFlight } from "./oauth-refresh-single-flight";
+
+const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const OPENAI_DEFAULT_TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+const OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS = 3;
+const OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS = 100;
+const OPENAI_CONCURRENT_ROTATION_POLL_DELAYS_MS = [100, 250, 500, 1_000] as const;
+const OPENAI_TOKEN_PERSIST_FAILURE =
+  "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth";
+
+type OpenAITokenState =
+  | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
+  | { type: "refresh"; refreshToken: string; scope: OAuthSecretScope; accountId?: string };
+
+export type OpenAIToken = { accessToken: string; expiresIn?: number; accountId?: string };
+
+export class OpenAITokenBrokerError extends Error {}
+export class OpenAITokenNotConfiguredError extends OpenAITokenBrokerError {}
+export class OpenAITokenStorageError extends OpenAITokenBrokerError {}
+export class OpenAITokenUnauthorizedError extends OpenAITokenBrokerError {}
+export class OpenAITokenUpstreamError extends OpenAITokenBrokerError {}
+
+// Requests handled by the same Worker isolate share this coordinator. D1 rereads
+// below cover concurrent rotations performed by other isolates and Durable Objects.
+const openAIRefreshCoordinator = new OAuthRefreshSingleFlight<OpenAIToken>();
+
+/** Provider-level broker shared by session adapters and global OAuth consumers. */
+export class OpenAITokenBroker {
+  private readonly secrets: ScopedOAuthSecretsStore;
+
+  constructor(
+    db: SqlDatabase,
+    encryptionKey: string,
+    private readonly log: Logger
+  ) {
+    this.secrets = new ScopedOAuthSecretsStore(db, encryptionKey);
+  }
+
+  refreshGlobal(): Promise<OpenAIToken> {
+    return this.refreshScopes([{ kind: "global" }]);
+  }
+
+  async refreshScopes(scopes: readonly OAuthSecretScope[]): Promise<OpenAIToken> {
+    let tokenState: OpenAITokenState | null;
+    try {
+      tokenState = await this.readTokenState(scopes);
+    } catch (error) {
+      this.log.error("Failed to read OpenAI token state from secrets", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
+    }
+
+    if (!tokenState) {
+      throw new OpenAITokenNotConfiguredError("OPENAI_OAUTH_REFRESH_TOKEN not configured");
+    }
+
+    if (tokenState.type === "cached") {
+      return {
+        accessToken: tokenState.accessToken,
+        expiresIn: tokenState.expiresIn,
+        accountId: tokenState.accountId,
+      };
+    }
+
+    try {
+      return await this.refreshSingleFlight(tokenState);
+    } catch (error) {
+      if (error instanceof OpenAITokenBrokerError) throw error;
+      if (error instanceof OpenAITokenRefreshError && error.status === 401) {
+        return this.handleUnauthorizedRefresh(tokenState, scopes);
+      }
+
+      this.log.error("OpenAI token refresh failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new OpenAITokenUpstreamError("OpenAI token refresh failed", { cause: error });
+    }
+  }
+
+  private stateFromSecrets(
+    secrets: Record<string, string>,
+    scope: OAuthSecretScope
+  ): OpenAITokenState | null {
+    const refreshToken = secrets.OPENAI_OAUTH_REFRESH_TOKEN;
+    if (!refreshToken) return null;
+
+    const cachedToken = secrets.OPENAI_OAUTH_ACCESS_TOKEN;
+    const expiresAt = Number.parseInt(secrets.OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT || "0", 10);
+    const now = Date.now();
+
+    if (cachedToken && expiresAt - now > OPENAI_TOKEN_REFRESH_BUFFER_MS) {
+      return {
+        type: "cached",
+        accessToken: cachedToken,
+        expiresIn: Math.floor((expiresAt - now) / 1000),
+        accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
+      };
+    }
+
+    return {
+      type: "refresh",
+      refreshToken,
+      scope,
+      accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
+    };
+  }
+
+  private async readTokenState(
+    scopes: readonly OAuthSecretScope[]
+  ): Promise<OpenAITokenState | null> {
+    for (const scope of scopes) {
+      const state = this.stateFromSecrets(await this.secrets.read(scope), scope);
+      if (state) return state;
+    }
+    return null;
+  }
+
+  private async attemptRefresh(
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
+  ): Promise<OpenAIToken> {
+    const tokens = await refreshOpenAIToken(tokenState.refreshToken);
+    const accountId = extractOpenAIAccountId(tokens) ?? tokenState.accountId;
+    const expiresAt =
+      Date.now() +
+      (tokens.expires_in === undefined
+        ? OPENAI_DEFAULT_TOKEN_LIFETIME_MS
+        : tokens.expires_in * 1000);
+    const secretsToWrite: Record<string, string> = {
+      OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
+      OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
+    };
+    if (accountId) secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
+
+    await this.persistRotatedTokens(tokenState.scope, secretsToWrite);
+
+    this.log.info("OpenAI tokens rotated and cached", {
+      scope: tokenState.scope.kind,
+      has_account_id: !!accountId,
+    });
+    return {
+      accessToken: tokens.access_token,
+      expiresIn: tokens.expires_in,
+      accountId,
+    };
+  }
+
+  private refreshSingleFlight(
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
+  ): Promise<OpenAIToken> {
+    return openAIRefreshCoordinator.run(tokenState.scope, tokenState.refreshToken, () =>
+      this.attemptRefresh(tokenState)
+    );
+  }
+
+  private async persistRotatedTokens(
+    scope: OAuthSecretScope,
+    secrets: Record<string, string>
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.secrets.write(scope, secrets);
+        return;
+      } catch (error) {
+        const finalAttempt = attempt === OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS;
+        const context = {
+          scope: scope.kind,
+          attempt,
+          max_attempts: OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        if (finalAttempt) {
+          this.log.error("Failed to store rotated OpenAI tokens", context);
+          throw new OpenAITokenStorageError(OPENAI_TOKEN_PERSIST_FAILURE, { cause: error });
+        }
+        this.log.warn("Failed to store rotated OpenAI tokens; retrying", context);
+        await new Promise((resolve) => setTimeout(resolve, OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS));
+      }
+    }
+  }
+
+  private async handleUnauthorizedRefresh(
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
+    scopes: readonly OAuthSecretScope[]
+  ): Promise<OpenAIToken> {
+    this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
+      scope: tokenState.scope.kind,
+    });
+    let observedRefreshToken = tokenState.refreshToken;
+
+    for (const [pollIndex, delayMs] of OPENAI_CONCURRENT_ROTATION_POLL_DELAYS_MS.entries()) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+      let reread: OpenAITokenState | null;
+      try {
+        reread = await this.readTokenState(scopes);
+      } catch (error) {
+        this.log.error("Failed to reread OpenAI token state after 401", {
+          poll_attempt: pollIndex + 1,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (pollIndex === OPENAI_CONCURRENT_ROTATION_POLL_DELAYS_MS.length - 1) {
+          throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
+        }
+        continue;
+      }
+      if (reread?.type === "cached") {
+        this.log.info("Using cached access token from concurrent rotation");
+        return {
+          accessToken: reread.accessToken,
+          expiresIn: reread.expiresIn,
+          accountId: reread.accountId,
+        };
+      }
+      if (reread?.type === "refresh" && reread.refreshToken !== observedRefreshToken) {
+        observedRefreshToken = reread.refreshToken;
+        this.log.info("Detected concurrent token rotation, retrying");
+        try {
+          return await this.refreshSingleFlight(reread);
+        } catch (error) {
+          if (error instanceof OpenAITokenBrokerError) throw error;
+          if (error instanceof OpenAITokenRefreshError && error.status === 401) continue;
+          this.log.error("OpenAI token refresh retry failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw new OpenAITokenUpstreamError("OpenAI token refresh failed", { cause: error });
+        }
+      }
+    }
+    throw new OpenAITokenUnauthorizedError("OpenAI token refresh failed: unauthorized");
+  }
+}

--- a/packages/control-plane/src/auth/openai.test.ts
+++ b/packages/control-plane/src/auth/openai.test.ts
@@ -32,6 +32,7 @@ describe("openai", () => {
       const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe("https://auth.openai.com/oauth/token");
       expect(init.method).toBe("POST");
+      expect(init.signal).toBeInstanceOf(AbortSignal);
       expect(init.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
       expect(init.body).toContain("grant_type=refresh_token");
       expect(init.body).toContain("refresh_token=rt_old");

--- a/packages/control-plane/src/auth/openai.ts
+++ b/packages/control-plane/src/auth/openai.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 const OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENAI_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
 export const openAITokenResponseSchema = z.object({
   id_token: z.string(),
@@ -32,6 +33,7 @@ export class OpenAITokenRefreshError extends Error {
 export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAITokenResponse> {
   const response = await fetch(OPENAI_TOKEN_URL, {
     method: "POST",
+    signal: AbortSignal.timeout(OPENAI_TOKEN_REQUEST_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
     },

--- a/packages/control-plane/src/db/scoped-oauth-secrets.ts
+++ b/packages/control-plane/src/db/scoped-oauth-secrets.ts
@@ -1,0 +1,51 @@
+import { EnvironmentSecretsStore } from "./environment-secrets";
+import { GlobalSecretsStore } from "./global-secrets";
+import { RepoSecretsStore } from "./repo-secrets";
+import type { SqlDatabase } from "./sql-database";
+
+export type OAuthSecretScope =
+  | { kind: "environment"; environmentId: string }
+  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
+  | { kind: "global" };
+
+/** Reads and writes provider OAuth credentials in their original secret scope. */
+export class ScopedOAuthSecretsStore {
+  constructor(
+    private readonly db: SqlDatabase,
+    private readonly encryptionKey: string
+  ) {}
+
+  read(scope: OAuthSecretScope): Promise<Record<string, string>> {
+    switch (scope.kind) {
+      case "environment":
+        return new EnvironmentSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(
+          scope.environmentId
+        );
+      case "repo":
+        return new RepoSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(scope.repoId);
+      case "global":
+        return new GlobalSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets();
+    }
+  }
+
+  async write(scope: OAuthSecretScope, secrets: Record<string, string>): Promise<void> {
+    switch (scope.kind) {
+      case "environment":
+        await new EnvironmentSecretsStore(this.db, this.encryptionKey).setSecrets(
+          scope.environmentId,
+          secrets
+        );
+        return;
+      case "repo":
+        await new RepoSecretsStore(this.db, this.encryptionKey).setSecrets(
+          scope.repoId,
+          scope.repoOwner,
+          scope.repoName,
+          secrets
+        );
+        return;
+      case "global":
+        await new GlobalSecretsStore(this.db, this.encryptionKey).setSecrets(secrets);
+    }
+  }
+}

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
+import {
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+} from "../../openai-token-refresh-service";
 import type { SandboxRow, SessionRow } from "../../types";
 import { createSandboxHandler } from "./sandbox.handler";
 
@@ -488,20 +494,36 @@ describe("createSandboxHandler", () => {
     expect(await response.json()).toEqual({ error: "Secrets not configured" });
   });
 
-  it("returns mapped service error from openai token refresh", async () => {
+  it.each([
+    [OpenAITokenNotConfiguredError, 404, "OPENAI_OAUTH_REFRESH_TOKEN not configured"],
+    [OpenAITokenUnauthorizedError, 401, "OpenAI token refresh failed: unauthorized"],
+    [OpenAITokenStorageError, 500, "Failed to read token state"],
+    [
+      OpenAITokenStorageError,
+      500,
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth",
+    ],
+    [OpenAITokenUpstreamError, 502, "OpenAI token refresh failed"],
+  ])("maps %s to status %i", async (ErrorType, status, message) => {
     const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
     getSession.mockReturnValue({ id: "session-1" } as SessionRow);
     isManagedSecretsConfigured.mockReturnValue(true);
-    refreshOpenAIToken.mockResolvedValue({
-      ok: false,
-      status: 502,
-      error: "OpenAI token refresh failed",
-    });
+    refreshOpenAIToken.mockRejectedValue(new ErrorType(message));
 
     const response = await handler.openaiTokenRefresh();
 
-    expect(response.status).toBe(502);
-    expect(await response.json()).toEqual({ error: "OpenAI token refresh failed" });
+    expect(response.status).toBe(status);
+    expect(await response.json()).toEqual({ error: message });
+  });
+
+  it("does not mask unexpected OpenAI token refresh failures", async () => {
+    const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
+    getSession.mockReturnValue({ id: "session-1" } as SessionRow);
+    isManagedSecretsConfigured.mockReturnValue(true);
+    const unexpected = new Error("unexpected refresh failure");
+    refreshOpenAIToken.mockRejectedValue(unexpected);
+
+    await expect(handler.openaiTokenRefresh()).rejects.toBe(unexpected);
   });
 
   it("returns openai access token payload on success", async () => {
@@ -511,7 +533,6 @@ describe("createSandboxHandler", () => {
     getSession.mockReturnValue(session);
     isManagedSecretsConfigured.mockReturnValue(true);
     refreshOpenAIToken.mockResolvedValue({
-      ok: true,
       accessToken: "access-token",
       expiresIn: 3600,
       accountId: "acct_123",

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -7,7 +7,13 @@ import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import { sandboxEventSchema, type SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type { ParticipantRole } from "@open-inspect/shared/types/sessions";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
-import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
+import {
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+  type OpenAIToken,
+} from "../../openai-token-refresh-service";
 import type { XaiTokenRefreshResult } from "../../xai-token-refresh-service";
 import type { ScmCredentialsResult } from "../../scm-credentials-service";
 import type { SessionMessenger } from "../../messenger";
@@ -36,7 +42,7 @@ export interface SandboxHandlerDeps {
   getSandbox: () => SandboxRow | null;
   isValidSandboxToken: (token: string | null, sandbox: SandboxRow | null) => Promise<boolean>;
   getSession: () => SessionRow | null;
-  refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAITokenRefreshResult>;
+  refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAIToken>;
   refreshXaiToken: (session: SessionRow, log: Logger) => Promise<XaiTokenRefreshResult>;
   isManagedSecretsConfigured: () => boolean;
   getScmCredentials: (log: Logger) => Promise<ScmCredentialsResult>;
@@ -232,16 +238,30 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ error: "Secrets not configured" }, { status: 500 });
       }
 
-      const result = await deps.refreshOpenAIToken(session, log);
-      if (!result.ok) {
-        return Response.json({ error: result.error }, { status: result.status });
+      let token: OpenAIToken;
+      try {
+        token = await deps.refreshOpenAIToken(session, log);
+      } catch (error) {
+        if (error instanceof OpenAITokenNotConfiguredError) {
+          return Response.json({ error: error.message }, { status: 404 });
+        }
+        if (error instanceof OpenAITokenUnauthorizedError) {
+          return Response.json({ error: error.message }, { status: 401 });
+        }
+        if (error instanceof OpenAITokenStorageError) {
+          return Response.json({ error: error.message }, { status: 500 });
+        }
+        if (error instanceof OpenAITokenUpstreamError) {
+          return Response.json({ error: error.message }, { status: 502 });
+        }
+        throw error;
       }
 
       return Response.json(
         {
-          access_token: result.accessToken,
-          expires_in: result.expiresIn,
-          account_id: result.accountId,
+          access_token: token.accessToken,
+          expires_in: token.expiresIn,
+          account_id: token.accountId,
         },
         { status: 200, headers: { "Cache-Control": "no-store" } }
       );

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
-import type { Env } from "../types";
 import type { SessionRow } from "./types";
+import {
+  OpenAITokenBroker,
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+} from "../auth/openai-token-broker";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { OpenAITokenRefreshError } from "../auth/openai";
 
@@ -18,7 +24,29 @@ const mockState = vi.hoisted(() => ({
   }>,
   globalWrites: [] as Array<Record<string, string>>,
   environmentWrites: [] as Array<{ environmentId: string; secrets: Record<string, string> }>,
+  repoWriteImpl: vi.fn(),
+  globalWriteImpl: vi.fn(),
+  repoReadImpl: vi.fn(),
+  globalReadImpl: vi.fn(),
 }));
+
+const TEST_DB: D1Database = {
+  prepare(_query: string): D1PreparedStatement {
+    throw new Error("Unexpected D1 prepare call");
+  },
+  async batch<T = unknown>(_statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    return [];
+  },
+  async exec(_query: string): Promise<D1ExecResult> {
+    throw new Error("Unexpected D1 exec call");
+  },
+  withSession(): D1DatabaseSession {
+    throw new Error("Unexpected D1 session call");
+  },
+  async dump(): Promise<ArrayBuffer> {
+    return new ArrayBuffer(0);
+  },
+};
 
 vi.mock("../auth/openai", () => {
   class MockOpenAITokenRefreshError extends Error {
@@ -41,6 +69,7 @@ vi.mock("../auth/openai", () => {
 vi.mock("../db/repo-secrets", () => ({
   RepoSecretsStore: class {
     async getDecryptedSecrets(repoId: number): Promise<Record<string, string>> {
+      await mockState.repoReadImpl(repoId);
       return mockState.repoSecrets.get(repoId) ?? {};
     }
 
@@ -50,6 +79,7 @@ vi.mock("../db/repo-secrets", () => ({
       name: string,
       secrets: Record<string, string>
     ): Promise<void> {
+      await mockState.repoWriteImpl(repoId, owner, name, secrets);
       mockState.repoWrites.push({ repoId, owner, name, secrets });
       const existing = mockState.repoSecrets.get(repoId) ?? {};
       mockState.repoSecrets.set(repoId, { ...existing, ...secrets });
@@ -60,10 +90,12 @@ vi.mock("../db/repo-secrets", () => ({
 vi.mock("../db/global-secrets", () => ({
   GlobalSecretsStore: class {
     async getDecryptedSecrets(): Promise<Record<string, string>> {
+      await mockState.globalReadImpl();
       return mockState.globalSecrets;
     }
 
     async setSecrets(secrets: Record<string, string>): Promise<void> {
+      await mockState.globalWriteImpl(secrets);
       mockState.globalWrites.push(secrets);
       mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
     }
@@ -133,6 +165,14 @@ describe("OpenAITokenRefreshService", () => {
     mockState.globalWrites = [];
     mockState.environmentWrites = [];
     mockState.refreshImpl.mockReset();
+    mockState.repoWriteImpl.mockReset();
+    mockState.repoWriteImpl.mockResolvedValue(undefined);
+    mockState.globalWriteImpl.mockReset();
+    mockState.globalWriteImpl.mockResolvedValue(undefined);
+    mockState.repoReadImpl.mockReset();
+    mockState.repoReadImpl.mockResolvedValue(undefined);
+    mockState.globalReadImpl.mockReset();
+    mockState.globalReadImpl.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -149,7 +189,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
@@ -158,7 +198,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession());
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "cached-access",
       expiresIn: expect.any(Number),
       accountId: "acct_cached",
@@ -166,21 +205,374 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.refreshImpl).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when refresh token is missing in repo and global secrets", async () => {
+  it("returns a cached global access token without consulting session scopes", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-cached-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    };
+    mockState.repoSecrets.set(123, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "repo-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+    });
+
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+
+    expect(result).toEqual({
+      accessToken: "global-cached-access",
+      expiresIn: expect.any(Number),
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and rotates global credentials", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+      account_id: "acct_global",
+    });
+
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+
+    expect(result).toEqual({
+      accessToken: "global-access-new",
+      expiresIn: 1800,
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledWith("global-refresh-old");
+    expect(mockState.globalWrites).toHaveLength(1);
+    expect(mockState.globalWrites[0]).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-access-new",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    });
+  });
+
+  it("preserves the stored account id when refresh omits it", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+
+    expect(result).toMatchObject({
+      accessToken: "global-access-new",
+      accountId: "acct_stored",
+    });
+    expect(mockState.globalWrites[0]).toMatchObject({
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
+    });
+  });
+
+  it("retries a transient global persistence failure and returns success after saving", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalWriteImpl
+      .mockRejectedValueOnce(new Error("D1 temporarily unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("throws an actionable error when rotated global credentials cannot be persisted", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const errorPromise = promise.catch((caught: unknown) => caught);
+    await vi.runAllTimersAsync();
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OpenAITokenStorageError);
+    expect(error).toHaveProperty(
+      "message",
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
+    );
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.globalWrites).toHaveLength(0);
+  });
+
+  it("uses a concurrently rotated global access token after refresh gets 401", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      mockState.globalSecrets = {
+        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+        OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+      };
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent refreshes for the same scope and refresh token", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    let resolveRefresh!: (tokens: {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    }) => void;
+    mockState.refreshImpl.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+    const firstBroker = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger());
+    const secondBroker = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger());
+
+    const first = firstBroker.refreshGlobal();
+    const second = secondBroker.refreshGlobal();
+    await vi.waitFor(() => expect(mockState.refreshImpl).toHaveBeenCalledOnce());
+    resolveRefresh({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        accessToken: "global-access-new",
+        expiresIn: 1800,
+        accountId: undefined,
+      },
+      {
+        accessToken: "global-access-new",
+        expiresIn: 1800,
+        accountId: undefined,
+      },
+    ]);
+    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("waits for a slow concurrent rotation from another isolate", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      setTimeout(() => {
+        mockState.globalSecrets = {
+          OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+          OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+          OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+        };
+      }, 750);
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
+  });
+
+  it("throws an unauthorized error when a concurrently rotated token is also rejected", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockRejectedValueOnce(new OpenAITokenRefreshError("unauthorized", 401, "unauthorized"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws an upstream error when retrying a concurrently rotated token fails", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockRejectedValueOnce(new Error("upstream connection failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUpstreamError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a persistence error when retrying a concurrently rotated token", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({
+        access_token: "global-access-new",
+        refresh_token: "global-refresh-new",
+        expires_in: 1800,
+      });
+    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws a not-configured error when refresh token is missing", async () => {
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()
     );
 
-    const result = await service.refresh(createSession());
+    await expect(service.refresh(createSession())).rejects.toThrow(OpenAITokenNotConfiguredError);
+  });
 
-    expect(result).toEqual({
-      ok: false,
-      status: 404,
-      error: "OPENAI_OAUTH_REFRESH_TOKEN not configured",
-    });
+  it("throws a secrets-read error when scoped secrets cannot be read", async () => {
+    mockState.globalReadImpl.mockRejectedValue(new Error("D1 read failed"));
+
+    await expect(
+      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
+    ).rejects.toThrow(OpenAITokenStorageError);
+  });
+
+  it("throws an upstream error when token refresh fails unexpectedly", async () => {
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh" };
+    mockState.refreshImpl.mockRejectedValue(new Error("upstream connection failed"));
+
+    await expect(
+      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
+    ).rejects.toThrow(OpenAITokenUpstreamError);
+  });
+
+  it("retries with a refresh token written by a concurrent rotation", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "rotated-refresh" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({ access_token: "fresh-access", expires_in: 1800 });
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({ accessToken: "fresh-access" });
+    expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
+  });
+
+  it("continues polling after a transient post-401 secret reread failure", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
+    );
+    mockState.globalReadImpl
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("D1 reread failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+  });
+
+  it("throws a storage error when post-401 secret rereads keep failing", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
+    );
+    mockState.globalReadImpl
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValue(new Error("D1 reread failed"));
+
+    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.globalReadImpl).toHaveBeenCalledTimes(5);
+  });
+
+  it("throws a secrets-read error when repository scope resolution fails", async () => {
+    const service = new OpenAITokenRefreshService(
+      TEST_DB,
+      "enc-key",
+      async () => {
+        throw new Error("repository lookup failed");
+      },
+      createLogger()
+    );
+
+    await expect(service.refresh(createSession())).rejects.toThrow(OpenAITokenStorageError);
   });
 
   it("refreshes token and persists rotated credentials to repo secrets", async () => {
@@ -197,7 +589,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
@@ -206,7 +598,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession());
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "access-new",
       expiresIn: 1800,
       accountId: "acct_new",
@@ -218,6 +609,40 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.repoWrites[0].name).toBe("web");
     expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_REFRESH_TOKEN).toBe("refresh-new");
     expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_ACCESS_TOKEN).toBe("access-new");
+  });
+
+  it("throws an actionable error when rotated session credentials cannot be persisted", async () => {
+    vi.useFakeTimers();
+    const repoId = 123;
+    mockState.repoSecrets.set(repoId, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "access-new",
+      refresh_token: "refresh-new",
+      expires_in: 1800,
+    });
+    mockState.repoWriteImpl.mockRejectedValue(new Error("storage unavailable"));
+
+    const service = new OpenAITokenRefreshService(
+      TEST_DB,
+      "enc-key",
+      async () => repoId,
+      createLogger()
+    );
+    const promise = service.refresh(createSession());
+    const errorPromise = promise.catch((caught: unknown) => caught);
+    await vi.runAllTimersAsync();
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OpenAITokenStorageError);
+    expect(error).toHaveProperty(
+      "message",
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
+    );
+    expect(mockState.repoWriteImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.repoWrites).toHaveLength(0);
   });
 
   it("uses cached token after concurrent rotation when refresh gets 401", async () => {
@@ -240,18 +665,17 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => repoId,
       createLogger()
     );
 
     const promise = service.refresh(createSession());
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.runAllTimersAsync();
     const result = await promise;
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "access-concurrent",
       expiresIn: expect.any(Number),
       accountId: "acct_concurrent",
@@ -278,7 +702,7 @@ describe("OpenAITokenRefreshService", () => {
     });
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()
@@ -287,7 +711,6 @@ describe("OpenAITokenRefreshService", () => {
     const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
 
     expect(result).toEqual({
-      ok: true,
       accessToken: "env-access-new",
       expiresIn: 1800,
       accountId: "acct_env",
@@ -312,7 +735,7 @@ describe("OpenAITokenRefreshService", () => {
     };
 
     const service = new OpenAITokenRefreshService(
-      {} as Env["DB"],
+      TEST_DB,
       "enc-key",
       async () => 123,
       createLogger()
@@ -320,7 +743,6 @@ describe("OpenAITokenRefreshService", () => {
 
     const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
 
-    expect(result.ok).toBe(true);
     expect(result).toMatchObject({ accessToken: "global-access" });
     expect(mockState.refreshImpl).not.toHaveBeenCalled();
   });

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -1,258 +1,49 @@
 import {
-  refreshOpenAIToken,
-  extractOpenAIAccountId,
-  OpenAITokenRefreshError,
-} from "../auth/openai";
-import { GlobalSecretsStore } from "../db/global-secrets";
-import { RepoSecretsStore } from "../db/repo-secrets";
-import { EnvironmentSecretsStore } from "../db/environment-secrets";
+  OpenAITokenBroker,
+  OpenAITokenStorageError,
+  type OpenAIToken,
+} from "../auth/openai-token-broker";
+import type { OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Logger } from "../logger";
+import { resolveSessionOAuthSecretScope } from "./session-target-secrets";
 import type { SessionRow } from "./types";
 
-const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+export {
+  OpenAITokenBrokerError,
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+  type OpenAIToken,
+} from "../auth/openai-token-broker";
 
-/**
- * Where a session's OpenAI OAuth tokens are read from and rotated back to. A
- * session reads from its own secret scope first — the environment for
- * environment-launched sessions, the repo for repo-launched ones (§6.4/§7.4) —
- * then falls back to global. Each variant carries everything needed to write
- * the rotated tokens back to the same place, so refresh never has to re-derive
- * the identity (and the old repoId-null guard disappears).
- */
-type TokenSecretSource =
-  | { kind: "environment"; environmentId: string }
-  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
-  | { kind: "global" };
-
-type OpenAITokenState =
-  | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-  | { type: "refresh"; refreshToken: string; source: TokenSecretSource };
-
-export type OpenAITokenRefreshResult =
-  | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
-  | { ok: false; status: number; error: string };
-
+/** Resolves a session into OAuth secret scopes before delegating to the provider broker. */
 export class OpenAITokenRefreshService {
+  private readonly broker: OpenAITokenBroker;
+
   constructor(
-    private readonly db: SqlDatabase,
-    private readonly encryptionKey: string,
+    db: SqlDatabase,
+    encryptionKey: string,
     private readonly ensureRepoId: (session: SessionRow) => Promise<number>,
     private readonly log: Logger
-  ) {}
+  ) {
+    this.broker = new OpenAITokenBroker(db, encryptionKey, log);
+  }
 
-  async refresh(session: SessionRow): Promise<OpenAITokenRefreshResult> {
-    const readTokenState = () => this.readTokenState(session);
-
-    let tokenState: OpenAITokenState | null;
+  async refresh(session: SessionRow): Promise<OpenAIToken> {
+    let sessionScope: OAuthSecretScope | null;
     try {
-      tokenState = await readTokenState();
-    } catch (e) {
-      this.log.error("Failed to read OpenAI token state from secrets", {
-        error: e instanceof Error ? e.message : String(e),
+      sessionScope = await resolveSessionOAuthSecretScope(session, this.ensureRepoId);
+    } catch (error) {
+      this.log.error("Failed to resolve OpenAI token secret scope", {
+        error: error instanceof Error ? error.message : String(error),
       });
-      return { ok: false, status: 500, error: "Failed to read token state" };
+      throw new OpenAITokenStorageError("Failed to read token state", { cause: error });
     }
-
-    if (!tokenState) {
-      return { ok: false, status: 404, error: "OPENAI_OAUTH_REFRESH_TOKEN not configured" };
-    }
-
-    if (tokenState.type === "cached") {
-      return {
-        ok: true,
-        accessToken: tokenState.accessToken,
-        expiresIn: tokenState.expiresIn,
-        accountId: tokenState.accountId,
-      };
-    }
-
-    try {
-      return await this.attemptRefresh(tokenState);
-    } catch (e) {
-      if (e instanceof OpenAITokenRefreshError && e.status === 401) {
-        return this.handleUnauthorizedRefresh(tokenState, readTokenState);
-      }
-
-      this.log.error("OpenAI token refresh failed", {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return { ok: false, status: 502, error: "OpenAI token refresh failed" };
-    }
-  }
-
-  private getTokenStateFromSecrets(
-    secrets: Record<string, string>,
-    source: TokenSecretSource
-  ): OpenAITokenState | null {
-    if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) {
-      return null;
-    }
-
-    const cachedToken = secrets.OPENAI_OAUTH_ACCESS_TOKEN;
-    const expiresAt = parseInt(secrets.OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT || "0", 10);
-    const now = Date.now();
-
-    if (cachedToken && expiresAt - now > OPENAI_TOKEN_REFRESH_BUFFER_MS) {
-      return {
-        type: "cached",
-        accessToken: cachedToken,
-        expiresIn: Math.floor((expiresAt - now) / 1000),
-        accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
-      };
-    }
-
-    return {
-      type: "refresh",
-      refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN,
-      source,
-    };
-  }
-
-  /**
-   * The session's own secret source, or null for repo-less sessions with no
-   * environment (global-only). Environment-launched sessions resolve to the
-   * environment and never read member repo secrets (§6.4/§7.4).
-   */
-  private async resolveSessionSecretSource(session: SessionRow): Promise<TokenSecretSource | null> {
-    if (session.environment_id) {
-      return { kind: "environment", environmentId: session.environment_id };
-    }
-    if (session.repo_owner && session.repo_name) {
-      const repoId = await this.ensureRepoId(session);
-      return {
-        kind: "repo",
-        repoId,
-        repoOwner: session.repo_owner,
-        repoName: session.repo_name,
-      };
-    }
-    return null;
-  }
-
-  private async readSecretsForSource(source: TokenSecretSource): Promise<Record<string, string>> {
-    switch (source.kind) {
-      case "environment":
-        return new EnvironmentSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(
-          source.environmentId
-        );
-      case "repo":
-        return new RepoSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(source.repoId);
-      case "global":
-        return new GlobalSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets();
-    }
-  }
-
-  private async writeSecretsForSource(
-    source: TokenSecretSource,
-    secrets: Record<string, string>
-  ): Promise<void> {
-    switch (source.kind) {
-      case "environment":
-        await new EnvironmentSecretsStore(this.db, this.encryptionKey).setSecrets(
-          source.environmentId,
-          secrets
-        );
-        return;
-      case "repo":
-        await new RepoSecretsStore(this.db, this.encryptionKey).setSecrets(
-          source.repoId,
-          source.repoOwner,
-          source.repoName,
-          secrets
-        );
-        return;
-      case "global":
-        await new GlobalSecretsStore(this.db, this.encryptionKey).setSecrets(secrets);
-        return;
-    }
-  }
-
-  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    const source = await this.resolveSessionSecretSource(session);
-    if (source) {
-      const secrets = await this.readSecretsForSource(source);
-      const state = this.getTokenStateFromSecrets(secrets, source);
-      if (state) {
-        return state;
-      }
-    }
-
-    const globalSecrets = await this.readSecretsForSource({ kind: "global" });
-    return this.getTokenStateFromSecrets(globalSecrets, { kind: "global" });
-  }
-
-  private async attemptRefresh(
-    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
-  ): Promise<OpenAITokenRefreshResult> {
-    const tokens = await refreshOpenAIToken(tokenState.refreshToken);
-    const accountId = extractOpenAIAccountId(tokens);
-    const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
-
-    try {
-      const secretsToWrite: Record<string, string> = {
-        OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
-        OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
-        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
-      };
-
-      if (accountId) {
-        secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
-      }
-
-      await this.writeSecretsForSource(tokenState.source, secretsToWrite);
-
-      this.log.info("OpenAI tokens rotated and cached", {
-        source: tokenState.source.kind,
-        has_account_id: !!accountId,
-      });
-    } catch (e) {
-      this.log.error("Failed to store rotated OpenAI tokens", {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
-
-    return {
-      ok: true,
-      accessToken: tokens.access_token,
-      expiresIn: tokens.expires_in,
-      accountId,
-    };
-  }
-
-  private async handleUnauthorizedRefresh(
-    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    readTokenState: () => Promise<OpenAITokenState | null>
-  ): Promise<OpenAITokenRefreshResult> {
-    this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
-      source: tokenState.source.kind,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    try {
-      const reread = await readTokenState();
-
-      if (reread?.type === "cached") {
-        this.log.info("Using cached access token from concurrent rotation");
-        return {
-          ok: true,
-          accessToken: reread.accessToken,
-          expiresIn: reread.expiresIn,
-          accountId: reread.accountId,
-        };
-      }
-
-      if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
-        this.log.info("Detected concurrent token rotation, retrying");
-        return this.attemptRefresh(reread);
-      }
-    } catch (retryErr) {
-      this.log.error("Retry after 401 also failed", {
-        error: retryErr instanceof Error ? retryErr.message : String(retryErr),
-      });
-    }
-
-    return { ok: false, status: 401, error: "OpenAI token refresh failed: unauthorized" };
+    const scopes: OAuthSecretScope[] = sessionScope
+      ? [sessionScope, { kind: "global" }]
+      : [{ kind: "global" }];
+    return this.broker.refreshScopes(scopes);
   }
 }

--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildSessionTargetSecretSources } from "./session-target-secrets";
+import {
+  buildSessionTargetSecretSources,
+  resolveSessionOAuthSecretScope,
+} from "./session-target-secrets";
 import type { SessionRepositoryEntry } from "./repository-target";
+import type { SessionRow } from "./types";
 
 function member(
   repoOwner: string,
@@ -13,6 +17,96 @@ function member(
 
 /** Repo-launched sessions never load environment secrets; a stub keeps that explicit. */
 const noEnvironmentSecrets = async (): Promise<Record<string, string>> => ({});
+
+function session(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "session-1",
+    title: null,
+    repo_owner: null,
+    repo_name: null,
+    repo_id: null,
+    base_branch: null,
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "xai/grok-build-0.1",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    code_server_enabled: 0,
+    vnc_enabled: 0,
+    total_cost: 0,
+    sandbox_settings: null,
+    environment_id: null,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+describe("resolveSessionOAuthSecretScope", () => {
+  it.each([
+    { repo_owner: "acme", repo_name: null },
+    { repo_owner: null, repo_name: "web" },
+    { repo_owner: "acme", repo_name: null, environment_id: "env_1" },
+    { repo_owner: "", repo_name: "web" },
+    { repo_owner: "acme", repo_name: "" },
+    { repo_owner: "", repo_name: "" },
+    { repo_owner: " ", repo_name: "web" },
+  ])("rejects incomplete or empty repository context", async (overrides) => {
+    const ensureRepoId = vi.fn();
+
+    await expect(resolveSessionOAuthSecretScope(session(overrides), ensureRepoId)).rejects.toThrow(
+      "Session has incomplete repository context"
+    );
+    expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+
+  it("resolves a complete historical repository target", async () => {
+    const ensureRepoId = vi.fn().mockResolvedValue(123);
+    const target = session({ repo_owner: "acme", repo_name: "web", repo_id: null });
+
+    await expect(resolveSessionOAuthSecretScope(target, ensureRepoId)).resolves.toEqual({
+      kind: "repo",
+      repoId: 123,
+      repoOwner: "acme",
+      repoName: "web",
+    });
+    expect(ensureRepoId).toHaveBeenCalledWith(target);
+  });
+
+  it("resolves an environment target without repository context", async () => {
+    const ensureRepoId = vi.fn();
+
+    await expect(
+      resolveSessionOAuthSecretScope(session({ environment_id: "env_1" }), ensureRepoId)
+    ).resolves.toEqual({ kind: "environment", environmentId: "env_1" });
+    expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+
+  it("gives an environment target precedence over complete repository context", async () => {
+    const ensureRepoId = vi.fn();
+
+    await expect(
+      resolveSessionOAuthSecretScope(
+        session({ environment_id: "env_1", repo_owner: "group/subgroup", repo_name: "web" }),
+        ensureRepoId
+      )
+    ).resolves.toEqual({ kind: "environment", environmentId: "env_1" });
+    expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+
+  it("returns no scope only when repository context is fully absent", async () => {
+    const ensureRepoId = vi.fn();
+
+    await expect(resolveSessionOAuthSecretScope(session(), ensureRepoId)).resolves.toBeNull();
+    expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+});
 
 describe("buildSessionTargetSecretSources", () => {
   it("folds members lowest-precedence-first with the primary (position 0) last", async () => {

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -1,5 +1,34 @@
+import type { OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SecretSource } from "../db/secrets-validation";
 import type { SessionRepositoryEntry } from "./repository-target";
+import type { SessionRow } from "./types";
+
+/** Maps a session target to the secret scope that owns its provider OAuth credentials. */
+export async function resolveSessionOAuthSecretScope(
+  session: SessionRow,
+  ensureRepoId: (session: SessionRow) => Promise<number>
+): Promise<OAuthSecretScope | null> {
+  const { repo_owner: repoOwner, repo_name: repoName } = session;
+  const hasEmptyRepositoryIdentifier =
+    (repoOwner !== null && repoOwner.trim().length === 0) ||
+    (repoName !== null && repoName.trim().length === 0);
+  if (hasEmptyRepositoryIdentifier || (repoOwner === null) !== (repoName === null)) {
+    throw new Error("Session has incomplete repository context");
+  }
+
+  if (session.environment_id) {
+    return { kind: "environment", environmentId: session.environment_id };
+  }
+  if (repoOwner !== null && repoName !== null) {
+    return {
+      kind: "repo",
+      repoId: await ensureRepoId(session),
+      repoOwner,
+      repoName,
+    };
+  }
+  return null;
+}
 
 export interface SessionTargetSecretSourcesInput {
   /**

--- a/packages/control-plane/src/session/xai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/xai-token-refresh-service.test.ts
@@ -212,7 +212,7 @@ describe("XaiTokenRefreshService", () => {
     });
 
     const result = service().refresh(session());
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.runAllTimersAsync();
 
     await expect(result).resolves.toMatchObject({ ok: true, accessToken: "concurrent-access" });
     expect(state.refresh).toHaveBeenCalledTimes(1);
@@ -241,7 +241,81 @@ describe("XaiTokenRefreshService", () => {
     });
     expect(log.error).toHaveBeenCalledWith(
       "xAI token refreshed but failed to persist rotated tokens",
-      { source: "repo", error: "write failed" }
+      { scope: "repo", error: "write failed" }
     );
+  });
+
+  it("returns a bounded failure when the session scope cannot be read", async () => {
+    const refreshService = new XaiTokenRefreshService(
+      {} as SqlDatabase,
+      "key",
+      async () => {
+        throw new Error("repository lookup failed");
+      },
+      logger()
+    );
+
+    await expect(refreshService.refresh(session())).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: "Failed to read token state",
+    });
+  });
+
+  it("returns a bounded failure when token refresh fails unexpectedly", async () => {
+    state.repo.set(123, { XAI_OAUTH_REFRESH_TOKEN: "refresh" });
+    state.refresh.mockRejectedValue(new Error("upstream connection failed"));
+
+    await expect(service().refresh(session())).resolves.toEqual({
+      ok: false,
+      status: 502,
+      error: "xAI token refresh failed",
+    });
+  });
+
+  it("retries with a refresh token written by a concurrent rotation", async () => {
+    vi.useFakeTimers();
+    state.repo.set(123, { XAI_OAUTH_REFRESH_TOKEN: "stale-refresh" });
+    state.refresh
+      .mockImplementationOnce(async () => {
+        state.repo.set(123, { XAI_OAUTH_REFRESH_TOKEN: "rotated-refresh" });
+        throw new XaiTokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({ access_token: "fresh-access", expires_in: 1800 });
+
+    const result = service().refresh(session());
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({
+      ok: true,
+      accessToken: "fresh-access",
+      expiresIn: 1800,
+    });
+    expect(state.refresh).toHaveBeenNthCalledWith(2, "rotated-refresh");
+  });
+
+  it("returns unauthorized when the post-401 scope reread fails", async () => {
+    vi.useFakeTimers();
+    state.repo.set(123, { XAI_OAUTH_REFRESH_TOKEN: "stale-refresh" });
+    state.refresh.mockRejectedValue(new XaiTokenRefreshError("unauthorized", 401, "unauthorized"));
+    const ensureRepoId = vi
+      .fn<() => Promise<number>>()
+      .mockResolvedValueOnce(123)
+      .mockRejectedValueOnce(new Error("repository reread failed"));
+    const refreshService = new XaiTokenRefreshService(
+      {} as SqlDatabase,
+      "key",
+      ensureRepoId,
+      logger()
+    );
+
+    const result = refreshService.refresh(session());
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({
+      ok: false,
+      status: 401,
+      error: "xAI token refresh failed: unauthorized",
+    });
   });
 });

--- a/packages/control-plane/src/session/xai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/xai-token-refresh-service.ts
@@ -1,41 +1,38 @@
 import { refreshXaiToken, XaiTokenRefreshError } from "../auth/xai";
-import { EnvironmentSecretsStore } from "../db/environment-secrets";
-import { GlobalSecretsStore } from "../db/global-secrets";
-import { RepoSecretsStore } from "../db/repo-secrets";
+import { ScopedOAuthSecretsStore, type OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Logger } from "../logger";
+import { resolveSessionOAuthSecretScope } from "./session-target-secrets";
 import type { SessionRow } from "./types";
 
 const XAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const XAI_DEFAULT_TOKEN_LIFETIME_MS = 60 * 60 * 1000;
 const XAI_CONCURRENT_ROTATION_DELAY_MS = 500;
 
-type TokenSecretSource =
-  | { kind: "environment"; environmentId: string }
-  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
-  | { kind: "global" };
-
 type XaiTokenState =
   | { type: "cached"; accessToken: string; expiresIn: number }
-  | { type: "refresh"; refreshToken: string; source: TokenSecretSource };
+  | { type: "refresh"; refreshToken: string; scope: OAuthSecretScope };
 
 export type XaiTokenRefreshResult =
   | { ok: true; accessToken: string; expiresIn: number }
   | { ok: false; status: number; error: string };
 
 export class XaiTokenRefreshService {
+  private readonly secrets: ScopedOAuthSecretsStore;
+
   constructor(
-    private readonly db: SqlDatabase,
-    private readonly encryptionKey: string,
+    db: SqlDatabase,
+    encryptionKey: string,
     private readonly ensureRepoId: (session: SessionRow) => Promise<number>,
     private readonly log: Logger
-  ) {}
+  ) {
+    this.secrets = new ScopedOAuthSecretsStore(db, encryptionKey);
+  }
 
   async refresh(session: SessionRow): Promise<XaiTokenRefreshResult> {
-    const readState = () => this.readTokenState(session);
     let state: XaiTokenState | null;
     try {
-      state = await readState();
+      state = await this.readTokenState(session);
     } catch (error) {
       this.log.error("Failed to read xAI token state from secrets", {
         error: error instanceof Error ? error.message : String(error),
@@ -54,7 +51,7 @@ export class XaiTokenRefreshService {
         error instanceof XaiTokenRefreshError &&
         (error.reason === "invalid_grant" || error.reason === "unauthorized")
       ) {
-        return this.handleUnauthorizedRefresh(state, readState);
+        return this.handleUnauthorizedRefresh(state, session);
       }
       this.log.error("xAI token refresh failed", {
         error: error instanceof Error ? error.message : String(error),
@@ -65,7 +62,7 @@ export class XaiTokenRefreshService {
 
   private stateFromSecrets(
     secrets: Record<string, string>,
-    source: TokenSecretSource
+    scope: OAuthSecretScope
   ): XaiTokenState | null {
     const refreshToken = secrets.XAI_OAUTH_REFRESH_TOKEN;
     if (!refreshToken) return null;
@@ -75,67 +72,17 @@ export class XaiTokenRefreshService {
     if (accessToken && expiresAt - now > XAI_TOKEN_REFRESH_BUFFER_MS) {
       return { type: "cached", accessToken, expiresIn: Math.floor((expiresAt - now) / 1000) };
     }
-    return { type: "refresh", refreshToken, source };
-  }
-
-  private async sessionSource(session: SessionRow): Promise<TokenSecretSource | null> {
-    if (session.environment_id) {
-      return { kind: "environment", environmentId: session.environment_id };
-    }
-    if (session.repo_owner && session.repo_name) {
-      return {
-        kind: "repo",
-        repoId: await this.ensureRepoId(session),
-        repoOwner: session.repo_owner,
-        repoName: session.repo_name,
-      };
-    }
-    return null;
-  }
-
-  private async readSecrets(source: TokenSecretSource): Promise<Record<string, string>> {
-    if (source.kind === "environment") {
-      return new EnvironmentSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(
-        source.environmentId
-      );
-    }
-    if (source.kind === "repo") {
-      return new RepoSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(source.repoId);
-    }
-    return new GlobalSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets();
-  }
-
-  private async writeSecrets(
-    source: TokenSecretSource,
-    secrets: Record<string, string>
-  ): Promise<void> {
-    if (source.kind === "environment") {
-      await new EnvironmentSecretsStore(this.db, this.encryptionKey).setSecrets(
-        source.environmentId,
-        secrets
-      );
-      return;
-    }
-    if (source.kind === "repo") {
-      await new RepoSecretsStore(this.db, this.encryptionKey).setSecrets(
-        source.repoId,
-        source.repoOwner,
-        source.repoName,
-        secrets
-      );
-      return;
-    }
-    await new GlobalSecretsStore(this.db, this.encryptionKey).setSecrets(secrets);
+    return { type: "refresh", refreshToken, scope };
   }
 
   private async readTokenState(session: SessionRow): Promise<XaiTokenState | null> {
-    const source = await this.sessionSource(session);
-    if (source) {
-      const state = this.stateFromSecrets(await this.readSecrets(source), source);
+    const scope = await resolveSessionOAuthSecretScope(session, this.ensureRepoId);
+    if (scope) {
+      const state = this.stateFromSecrets(await this.secrets.read(scope), scope);
       if (state) return state;
     }
-    const globalSource = { kind: "global" } as const;
-    return this.stateFromSecrets(await this.readSecrets(globalSource), globalSource);
+    const globalScope: OAuthSecretScope = { kind: "global" };
+    return this.stateFromSecrets(await this.secrets.read(globalScope), globalScope);
   }
 
   private async attemptRefresh(
@@ -149,11 +96,11 @@ export class XaiTokenRefreshService {
       XAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + expiresIn * 1000),
     };
     try {
-      await this.writeSecrets(state.source, secrets);
-      this.log.info("xAI tokens rotated and cached", { source: state.source.kind });
+      await this.secrets.write(state.scope, secrets);
+      this.log.info("xAI tokens rotated and cached", { scope: state.scope.kind });
     } catch (error) {
       this.log.error("xAI token refreshed but failed to persist rotated tokens", {
-        source: state.source.kind,
+        scope: state.scope.kind,
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -162,14 +109,14 @@ export class XaiTokenRefreshService {
 
   private async handleUnauthorizedRefresh(
     state: Extract<XaiTokenState, { type: "refresh" }>,
-    readState: () => Promise<XaiTokenState | null>
+    session: SessionRow
   ): Promise<XaiTokenRefreshResult> {
     this.log.warn("xAI refresh was rejected, checking for concurrent rotation", {
-      source: state.source.kind,
+      scope: state.scope.kind,
     });
     await new Promise((resolve) => setTimeout(resolve, XAI_CONCURRENT_ROTATION_DELAY_MS));
     try {
-      const current = await readState();
+      const current = await this.readTokenState(session);
       if (current?.type === "cached") {
         return { ok: true, accessToken: current.accessToken, expiresIn: current.expiresIn };
       }


### PR DESCRIPTION
Re-lands the classifier-independent OAuth token-refresh refactoring removed by the #1375 revert. Addresses items **1** and **4 (session path)** of #1376.

## What this restores

- **`db/scoped-oauth-secrets.ts`** — `ScopedOAuthSecretsStore`, the single owner of global/repo/environment scope dispatch for OAuth secrets
- **`session/session-target-secrets.ts`** — `resolveSessionOAuthSecretScope`, session → secret-scope resolution
- **`auth/oauth-refresh-single-flight.ts`** — `OAuthRefreshSingleFlight`, coalesces concurrent refreshes
- **`auth/openai-token-broker.ts`** — the `OpenAITokenBroker` extraction, including its typed exception surface from #1372
- **`session/openai-token-refresh-service.ts`** and **`session/xai-token-refresh-service.ts`** — both back to thin delegates over the shared infrastructure (the OpenAI service drops 258 → 49 lines)
- **`session/http/handlers/sandbox.handler.ts`** — the #1372 typed-error handling for the session token-refresh path, which consumes the services' exception surface and so comes along

## Why it is worth re-landing

After the revert, scope dispatch is duplicated provider-locally: `TokenSecretSource`, session-to-scope resolution, and three-way read/write branching appear **6× in each** of the OpenAI and xAI refresh services. This restores a single owner for scope semantics. None of it depends on OpenAI classification.

## Provenance — verbatim, already reviewed

Every file is extracted **byte-identical** from `c7181524c` (pre-revert `main`, the state reviewed and CI-validated in #1366/#1372):

```
for f in <the 14 files>; do git diff c7181524c -- "$f"; done   # all empty
```

Zero hand modifications. The classifier-only surface (`src/openai/*`, `target-classifications` service/routes/types, slack-bot classifier changes, Terraform) is **not** restored. #1376 items 2 and 3 (Terraform Tests CI step, `anthropic_api_key` validation) are deliberately left for separate PRs.

## Note on the global-scope refresh surface

The broker's global-scope refresh path (previously called by the reverted classifier route) has **no production caller** after this re-land. It is kept verbatim anyway: it is reviewed code, covered by the restored tests, and generic scope dispatch — one implementation across global/repo/environment — is the point of the refactor. Trimming it would deviate from the reviewed state for no behavioral gain.

## Care note

This touches the **live session token-refresh path for OpenAI and xAI sessions** — which is exactly why it was not folded into the #1375 rollback and gets its own review and validation here instead.

## Testing

- 14/14 restored files verified byte-identical to `c7181524c`
- `npm run build -w @open-inspect/shared` — pass
- `npm run typecheck -w @open-inspect/control-plane` — pass (prod + test tsconfigs)
- `npm run test -w @open-inspect/control-plane` — **2433 passed** (158 files)
- `npm run test:integration -w @open-inspect/control-plane` — **764 passed** (64 files, workerd)
- `eslint src/` and `prettier --check` on all changed files — clean

Background: #1374 (why the classifier itself cannot return), #1375 (the revert), #1376 (re-land tracking).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scoped OAuth credential support for global, repository, and environment configurations.
  - Improved OpenAI token caching, refresh handling, credential rotation, and concurrent request coordination.
  - Added clearer handling for configuration, authorization, storage, and upstream token errors.
  - Added request timeouts to OpenAI token refresh operations.

- **Bug Fixes**
  - Improved recovery when credentials are rotated concurrently.
  - Prevented older refresh operations from overwriting newer credential updates.
  - Standardized XAI and OpenAI credential resolution across session targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->