### PR TITLE
ci(terraform): re-land Terraform Tests step and anthropic_api_key validation

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -98,8 +98,13 @@ jobs:
         run: terraform validate -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
 
+      - name: Terraform Tests
+        id: test
+        run: terraform test -filter=tests/auth_provider_configuration.tftest.hcl
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
       - name: Post Validation Results
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v8
         with:
           script: |
@@ -115,6 +120,7 @@ jobs:
             | Format | ${{ steps.fmt.outcome == 'success' && '✅' || '⚠️' }} |
             | Init | ${{ steps.init.outcome == 'success' && '✅' || '❌' }} |
             | Validate | ${{ steps.validate.outcome == 'success' && '✅' || '❌' }} |
+            | Tests | ${{ steps.test.outcome == 'success' && '✅' || '❌' }} |
             ${planNote}
 
             *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;

--- a/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
+++ b/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
@@ -191,3 +191,16 @@ run "combined_with_github_only_admission" {
 
   expect_failures = [terraform_data.sign_in_provider_gate]
 }
+
+run "anthropic_api_key_blank" {
+  command = plan
+
+  variables {
+    enable_slack_bot     = true
+    slack_bot_token      = "test-slack-token"
+    slack_signing_secret = "test-slack-signing-secret"
+    anthropic_api_key    = ""
+  }
+
+  expect_failures = [var.anthropic_api_key]
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -295,6 +295,12 @@ variable "anthropic_api_key" {
   description = "Anthropic API key for Claude"
   type        = string
   sensitive   = true
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.anthropic_api_key) != ""
+    error_message = "anthropic_api_key must be non-blank."
+  }
 }
 
 # =============================================================================


### PR DESCRIPTION
Re-lands items **2** and **3** of #1376 — the last two open items (1, 4, and 5 landed via #1377 and #1378).

Closes #1376.

## What comes back

**Item 2 — `Terraform Tests` CI step.** The validation job now runs `terraform test -filter=tests/auth_provider_configuration.tftest.hcl` after `terraform validate`, the results comment gains a `Tests` row, and it posts under `if: always()` so a failing step still reports. All three hunks are verbatim from the pre-revert state (`c7181524c`).

**Item 3 — `anthropic_api_key` validation.** `nullable = false` plus a non-blank `validation` block, verbatim from `c7181524c`. Anthropic is the Slack classifier after the revert, so a blank credential now fails at plan time instead of surfacing as a runtime SDK error. The shipped regression test for this comes back with it: a run block asserting `anthropic_api_key = ""` trips `expect_failures = [var.anthropic_api_key]`.

## Deviations from the shipped state (all classifier-coupled)

- The two `TF_VAR_slack_classification_model` workflow lines and the `slack_classification_model` variable are **not** re-landed — the revert removed that variable and the worker wiring it fed.
- Three of the four shipped tftest run blocks (`slack_classification_anthropic`, `slack_classification_openai`, `slack_classification_invalid_model`) are **not** re-landed — they reference `var.slack_classification_model` and the `CLASSIFICATION_MODEL` worker binding, neither of which exists post-revert.
- The surviving run block is renamed `slack_classification_anthropic_missing_key` → `anthropic_api_key_blank`, since it tests the key validation, not classification. Its body is otherwise verbatim.

## The #1376 item-2 caveat, resolved

`auth_provider_configuration.tftest.hcl` pre-existed #1366 but CI never executed `terraform test`, so enabling the step needed proof the baseline actually passes. Verified locally (Terraform 1.14.6; CI pins 1.14.8):

```
tests/auth_provider_configuration.tftest.hcl... pass
Success! 10 passed, 0 failed.
```

That is all 9 baseline runs plus the new `anthropic_api_key_blank`. `terraform fmt -check -recursive` is clean.

## Context

#1375 (the revert) · #1378 (the code re-land) · #1379 (follow-ups from the #1378 review, tracked separately)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production deployments now reject blank or whitespace-only Anthropic API keys when the Slack bot is enabled.
  * Clear validation feedback is provided for invalid API key values.

* **Tests**
  * Added automated coverage to verify invalid API key configurations are rejected.
  * Pull-request validation results now include a Terraform Tests status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->