### PR TITLE
fix: collapse sub-tasks by default

### DIFF
--- a/packages/web/src/components/sidebar/child-sessions-section.test.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.test.tsx
@@ -3,6 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig } from "swr";
 import { ChildSessionsSection } from "./child-sessions-section";
@@ -20,8 +21,49 @@ vi.mock("next/link", () => ({
 }));
 
 describe("ChildSessionsSection", () => {
+  it("keeps sub-tasks collapsed until opened", async () => {
+    const sessionId = "parent-session";
+    const user = userEvent.setup();
+    render(
+      <SWRConfig
+        value={{
+          fallback: {
+            [`/api/sessions/${sessionId}/children`]: {
+              children: [
+                {
+                  id: "child-session",
+                  title: "Child session",
+                  repoOwner: "owner",
+                  repoName: "repo",
+                  parentSessionId: sessionId,
+                  spawnSource: "agent",
+                  spawnDepth: 1,
+                  status: "completed",
+                  createdAt: 1000,
+                  updatedAt: 2000,
+                },
+              ],
+            },
+          },
+          provider: () => new Map(),
+          revalidateOnFocus: false,
+        }}
+      >
+        <ChildSessionsSection sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    const toggle = await screen.findByRole("button", { name: "Sub-tasks" });
+    expect(screen.queryByRole("link", { name: /Child session/ })).not.toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(screen.getByRole("link", { name: /Child session/ })).toBeInTheDocument();
+  });
+
   it("renders a child's pull request state icon", async () => {
     const sessionId = "parent-session";
+    const user = userEvent.setup();
     render(
       <SWRConfig
         value={{
@@ -57,6 +99,8 @@ describe("ChildSessionsSection", () => {
         <ChildSessionsSection sessionId={sessionId} />
       </SWRConfig>
     );
+
+    await user.click(await screen.findByRole("button", { name: "Sub-tasks" }));
 
     const childLink = (await screen.findByText("Child session")).closest("a");
     expect(childLink).toBeInTheDocument();

--- a/packages/web/src/components/sidebar/child-sessions-section.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.tsx
@@ -46,7 +46,7 @@ export function ChildSessionsSection({ sessionId }: ChildSessionsSectionProps) {
   if (!children?.length) return null;
 
   return (
-    <CollapsibleSection title="Sub-tasks" defaultOpen={true}>
+    <CollapsibleSection title="Sub-tasks" defaultOpen={false}>
       <div className="space-y-2">
         {children.map((child) => {
           const prDisplay = pullRequestSummaryDisplay(child.pullRequestSummary);


### PR DESCRIPTION
## Summary
- default the session sidebar's Sub-tasks section to collapsed
- preserve manual expansion so child session details remain accessible
- add regression coverage for the initial collapsed state and opening interaction

## Testing
- `npm test -w @open-inspect/web -- src/components/sidebar/child-sessions-section.test.tsx`
- `npx eslint src/components/sidebar/child-sessions-section.tsx src/components/sidebar/child-sessions-section.test.tsx`
- `npx prettier --check src/components/sidebar/child-sessions-section.tsx src/components/sidebar/child-sessions-section.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/web -- src/lib/client-auth-boundary-eslint.test.ts`

## Notes
- The complete web suite passed 917 tests, but one unrelated ESLint-boundary test exceeded its 5-second timeout under full-suite load. That test passed when rerun independently (7/7).

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f4a8275dd59e4b468e3c043bb2bd25e0)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * The “Sub-tasks” section in the sidebar is now collapsed by default, keeping child sessions hidden until expanded.

* **Tests**
  * Added coverage confirming child sessions remain hidden until the section is opened.
  * Updated related checks to expand the section before verifying child-session details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->