### PR TITLE
fix(control-plane): CAS-guarded OpenAI token persistence and invalid_grant recovery

### DIFF
--- a/packages/control-plane/src/auth/openai-token-broker.test.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.test.ts
@@ -15,7 +15,6 @@ const mockState = vi.hoisted(() => ({
   globalSecrets: {} as Record<string, string>,
   refreshImpl: vi.fn(),
   globalWrites: [] as Array<Record<string, string>>,
-  globalWriteImpl: vi.fn(),
   globalCasImpl: vi.fn(),
   globalReadImpl: vi.fn(),
 }));
@@ -66,22 +65,17 @@ vi.mock("../db/global-secrets", () => ({
       return value === undefined ? null : { value, ciphertext: cipherOf(value) };
     }
 
-    async casUpdateSecret(
-      key: string,
+    async casWriteSecrets(
+      guardKey: string,
       expectedCiphertext: string,
-      value: string
+      secrets: Record<string, string>
     ): Promise<boolean> {
-      await mockState.globalCasImpl(key, expectedCiphertext, value);
-      const current = mockState.globalSecrets[key];
+      await mockState.globalCasImpl(guardKey, expectedCiphertext, secrets);
+      const current = mockState.globalSecrets[guardKey];
       if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
-      mockState.globalSecrets = { ...mockState.globalSecrets, [key]: value };
-      return true;
-    }
-
-    async setSecrets(secrets: Record<string, string>): Promise<void> {
-      await mockState.globalWriteImpl(secrets);
-      mockState.globalWrites.push(secrets);
       mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
+      mockState.globalWrites.push(secrets);
+      return true;
     }
   },
 }));
@@ -114,8 +108,6 @@ describe("OpenAITokenBroker", () => {
     mockState.globalSecrets = {};
     mockState.globalWrites = [];
     mockState.refreshImpl.mockReset();
-    mockState.globalWriteImpl.mockReset();
-    mockState.globalWriteImpl.mockResolvedValue(undefined);
     mockState.globalCasImpl.mockReset();
     mockState.globalCasImpl.mockResolvedValue(undefined);
     mockState.globalReadImpl.mockReset();
@@ -285,29 +277,32 @@ describe("OpenAITokenBroker", () => {
     expect(mockState.globalWrites).toHaveLength(0);
   });
 
-  it("keeps its fresh token when the companion write fails after the guard swap", async () => {
-    vi.useFakeTimers();
+  it("returns its fresh token and warns when the credential was removed mid-rotation", async () => {
     mockState.globalSecrets = {
       OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
       OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
     };
-    mockState.refreshImpl.mockResolvedValue({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      // The user disconnects OAuth between our read and our write.
+      mockState.globalSecrets = {};
+      return {
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        expires_in: 1800,
+      };
     });
-    mockState.globalWriteImpl.mockRejectedValue(new Error("companion write failed"));
+    const log = createLogger();
 
-    const promise = broker().refreshGlobal();
-    await vi.runAllTimersAsync();
+    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", log).refreshGlobal();
 
-    // The guard swap already persisted the new refresh token; the retry
-    // conflicts against our own write and the fresh token is still returned.
-    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
-    expect(mockState.globalSecrets).toMatchObject({
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
-    });
-    expect(mockState.globalSecrets.OPENAI_OAUTH_ACCESS_TOKEN).toBeUndefined();
+    expect(result).toMatchObject({ accessToken: "fresh-access" });
+    // Deletion is respected: nothing is written back.
+    expect(mockState.globalSecrets).toEqual({});
+    expect(mockState.globalWrites).toHaveLength(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      "OpenAI refresh token removed during rotation; using unsaved token",
+      { scope: "global" }
+    );
   });
 
   it("uses a concurrently rotated global access token after refresh gets 401", async () => {

--- a/packages/control-plane/src/auth/openai-token-broker.test.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.test.ts
@@ -1,0 +1,600 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import {
+  OpenAITokenBroker,
+  OpenAITokenNotConfiguredError,
+  OpenAITokenStorageError,
+  OpenAITokenUnauthorizedError,
+  OpenAITokenUpstreamError,
+} from "./openai-token-broker";
+import { OpenAITokenRefreshError } from "./openai";
+import type * as openAIAuthModule from "./openai";
+
+const mockState = vi.hoisted(() => ({
+  repoSecrets: new Map<number, Record<string, string>>(),
+  globalSecrets: {} as Record<string, string>,
+  refreshImpl: vi.fn(),
+  globalWrites: [] as Array<Record<string, string>>,
+  globalWriteImpl: vi.fn(),
+  globalCasImpl: vi.fn(),
+  globalReadImpl: vi.fn(),
+}));
+
+// Deterministic stand-in for stored ciphertext: equal plaintexts map to equal
+// "ciphertexts", so the CAS mock conflicts exactly when the stored value changed.
+const cipherOf = (value: string) => `cipher:${value}`;
+
+const TEST_DB: D1Database = {
+  prepare(_query: string): D1PreparedStatement {
+    throw new Error("Unexpected D1 prepare call");
+  },
+  async batch<T = unknown>(_statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    return [];
+  },
+  async exec(_query: string): Promise<D1ExecResult> {
+    throw new Error("Unexpected D1 exec call");
+  },
+  withSession(): D1DatabaseSession {
+    throw new Error("Unexpected D1 session call");
+  },
+  async dump(): Promise<ArrayBuffer> {
+    return new ArrayBuffer(0);
+  },
+};
+
+vi.mock("./openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof openAIAuthModule>();
+  return {
+    ...actual,
+    refreshOpenAIToken: (refreshToken: string) => mockState.refreshImpl(refreshToken),
+    extractOpenAIAccountId: (tokens: { account_id?: string }) => tokens.account_id,
+  };
+});
+
+vi.mock("../db/global-secrets", () => ({
+  GlobalSecretsStore: class {
+    async getDecryptedSecrets(): Promise<Record<string, string>> {
+      await mockState.globalReadImpl();
+      return mockState.globalSecrets;
+    }
+
+    async getSecretWithCiphertext(key: string): Promise<{
+      value: string;
+      ciphertext: string;
+    } | null> {
+      const value = mockState.globalSecrets[key];
+      return value === undefined ? null : { value, ciphertext: cipherOf(value) };
+    }
+
+    async casUpdateSecret(
+      key: string,
+      expectedCiphertext: string,
+      value: string
+    ): Promise<boolean> {
+      await mockState.globalCasImpl(key, expectedCiphertext, value);
+      const current = mockState.globalSecrets[key];
+      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
+      mockState.globalSecrets = { ...mockState.globalSecrets, [key]: value };
+      return true;
+    }
+
+    async setSecrets(secrets: Record<string, string>): Promise<void> {
+      await mockState.globalWriteImpl(secrets);
+      mockState.globalWrites.push(secrets);
+      mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
+    }
+  },
+}));
+
+vi.mock("../db/repo-secrets", () => ({
+  RepoSecretsStore: class {
+    async getDecryptedSecrets(repoId: number): Promise<Record<string, string>> {
+      return mockState.repoSecrets.get(repoId) ?? {};
+    }
+  },
+}));
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => createLogger()),
+  };
+}
+
+function broker(): OpenAITokenBroker {
+  return new OpenAITokenBroker(TEST_DB, "enc-key", createLogger());
+}
+
+describe("OpenAITokenBroker", () => {
+  beforeEach(() => {
+    mockState.repoSecrets.clear();
+    mockState.globalSecrets = {};
+    mockState.globalWrites = [];
+    mockState.refreshImpl.mockReset();
+    mockState.globalWriteImpl.mockReset();
+    mockState.globalWriteImpl.mockResolvedValue(undefined);
+    mockState.globalCasImpl.mockReset();
+    mockState.globalCasImpl.mockResolvedValue(undefined);
+    mockState.globalReadImpl.mockReset();
+    mockState.globalReadImpl.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a cached global access token without consulting session scopes", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-cached-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    };
+    mockState.repoSecrets.set(123, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "repo-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+    });
+
+    const result = await broker().refreshGlobal();
+
+    expect(result).toEqual({
+      accessToken: "global-cached-access",
+      expiresIn: expect.any(Number),
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and rotates global credentials", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+      account_id: "acct_global",
+    });
+
+    const result = await broker().refreshGlobal();
+
+    expect(result).toEqual({
+      accessToken: "global-access-new",
+      expiresIn: 1800,
+      accountId: "acct_global",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledWith("global-refresh-old");
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-access-new",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
+    });
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("preserves the stored account id when refresh omits it", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+
+    const result = await broker().refreshGlobal();
+
+    expect(result).toMatchObject({
+      accessToken: "global-access-new",
+      accountId: "acct_stored",
+    });
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
+    });
+  });
+
+  it("retries a transient global persistence failure and returns success after saving", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalCasImpl
+      .mockRejectedValueOnce(new Error("D1 temporarily unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    const promise = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
+    expect(mockState.globalCasImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
+    });
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("throws an actionable error when rotated global credentials cannot be persisted", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalCasImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const promise = broker().refreshGlobal();
+    const errorPromise = promise.catch((caught: unknown) => caught);
+    await vi.runAllTimersAsync();
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(OpenAITokenStorageError);
+    expect(error).toHaveProperty(
+      "message",
+      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
+    );
+    expect(mockState.globalCasImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+    });
+    expect(mockState.globalWrites).toHaveLength(0);
+  });
+
+  it("returns its fresh token without persisting when a concurrent rotation wins the CAS", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      // Another isolate rotates and persists between our read and our write.
+      mockState.globalSecrets = {
+        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-winner",
+        OPENAI_OAUTH_ACCESS_TOKEN: "winner-access",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+      };
+      return {
+        access_token: "loser-access",
+        refresh_token: "loser-refresh",
+        expires_in: 1800,
+      };
+    });
+
+    const result = await broker().refreshGlobal();
+
+    expect(result).toMatchObject({ accessToken: "loser-access" });
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-winner",
+      OPENAI_OAUTH_ACCESS_TOKEN: "winner-access",
+    });
+    expect(mockState.globalWrites).toHaveLength(0);
+  });
+
+  it("keeps its fresh token when the companion write fails after the guard swap", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+    mockState.globalWriteImpl.mockRejectedValue(new Error("companion write failed"));
+
+    const promise = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    // The guard swap already persisted the new refresh token; the retry
+    // conflicts against our own write and the fresh token is still returned.
+    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
+    expect(mockState.globalSecrets).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
+    });
+    expect(mockState.globalSecrets.OPENAI_OAUTH_ACCESS_TOKEN).toBeUndefined();
+  });
+
+  it("uses a concurrently rotated global access token after refresh gets 401", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      mockState.globalSecrets = {
+        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+        OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+      };
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const promise = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers from a 400 invalid_grant by using the concurrent rotation's token", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      mockState.globalSecrets = {
+        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+        OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+      };
+      throw new OpenAITokenRefreshError(
+        "invalid grant",
+        400,
+        JSON.stringify({ error: "invalid_grant" })
+      );
+    });
+
+    const promise = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toMatchObject({
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers from a 400 refresh_token_reused by retrying the rotated token", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "rotated-refresh" };
+        throw new OpenAITokenRefreshError(
+          "reused",
+          400,
+          JSON.stringify({ error: "refresh_token_reused" })
+        );
+      })
+      .mockResolvedValueOnce({
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        expires_in: 1800,
+      });
+
+    const result = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({ accessToken: "fresh-access" });
+    expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
+  });
+
+  it("treats a 400 without a consumed-token error code as an upstream failure", async () => {
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("bad request", 400, JSON.stringify({ error: "invalid_request" }))
+    );
+
+    await expect(broker().refreshGlobal()).rejects.toThrow(OpenAITokenUpstreamError);
+  });
+
+  it("coalesces concurrent refreshes for the same scope and refresh token", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    let resolveRefresh!: (tokens: {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    }) => void;
+    mockState.refreshImpl.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+    const firstBroker = broker();
+    const secondBroker = broker();
+
+    const first = firstBroker.refreshGlobal();
+    const second = secondBroker.refreshGlobal();
+    await vi.waitFor(() => expect(mockState.refreshImpl).toHaveBeenCalledOnce());
+    resolveRefresh({
+      access_token: "global-access-new",
+      refresh_token: "global-refresh-new",
+      expires_in: 1800,
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        accessToken: "global-access-new",
+        expiresIn: 1800,
+        accountId: undefined,
+      },
+      {
+        accessToken: "global-access-new",
+        expiresIn: 1800,
+        accountId: undefined,
+      },
+    ]);
+    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
+    expect(mockState.globalWrites).toHaveLength(1);
+  });
+
+  it("waits for a slow concurrent rotation from another isolate", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    };
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      setTimeout(() => {
+        mockState.globalSecrets = {
+          OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
+          OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
+          OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+        };
+      }, 750);
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const result = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({
+      accessToken: "global-access-concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
+  });
+
+  it("throws an unauthorized error when a concurrently rotated token is also rejected", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockRejectedValueOnce(new OpenAITokenRefreshError("unauthorized", 401, "unauthorized"));
+
+    const result = broker().refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws an upstream error when retrying a concurrently rotated token fails", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockRejectedValueOnce(new Error("upstream connection failed"));
+
+    const result = broker().refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUpstreamError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a persistence error when retrying a concurrently rotated token", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({
+        access_token: "global-access-new",
+        refresh_token: "global-refresh-new",
+        expires_in: 1800,
+      });
+    mockState.globalCasImpl.mockRejectedValue(new Error("D1 write failed"));
+
+    const result = broker().refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
+    expect(mockState.globalCasImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws a not-configured error when no scope has a refresh token", async () => {
+    await expect(broker().refreshGlobal()).rejects.toThrow(OpenAITokenNotConfiguredError);
+  });
+
+  it("throws a secrets-read error when scoped secrets cannot be read", async () => {
+    mockState.globalReadImpl.mockRejectedValue(new Error("D1 read failed"));
+
+    await expect(broker().refreshGlobal()).rejects.toThrow(OpenAITokenStorageError);
+  });
+
+  it("throws an upstream error when token refresh fails unexpectedly", async () => {
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh" };
+    mockState.refreshImpl.mockRejectedValue(new Error("upstream connection failed"));
+
+    await expect(broker().refreshGlobal()).rejects.toThrow(OpenAITokenUpstreamError);
+  });
+
+  it("retries with a refresh token written by a concurrent rotation", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl
+      .mockImplementationOnce(async () => {
+        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "rotated-refresh" };
+        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+      })
+      .mockResolvedValueOnce({
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        expires_in: 1800,
+      });
+
+    const result = broker().refreshGlobal();
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toMatchObject({ accessToken: "fresh-access" });
+    expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
+  });
+
+  it("continues polling after a transient post-rejection secret reread failure", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
+    );
+    mockState.globalReadImpl
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("D1 reread failed"));
+
+    const result = broker().refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+  });
+
+  it("throws a storage error when post-rejection secret rereads keep failing", async () => {
+    vi.useFakeTimers();
+    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
+    mockState.refreshImpl.mockRejectedValue(
+      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
+    );
+    mockState.globalReadImpl
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValue(new Error("D1 reread failed"));
+
+    const result = broker().refreshGlobal();
+    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(mockState.globalReadImpl).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -1,9 +1,15 @@
-import { extractOpenAIAccountId, OpenAITokenRefreshError, refreshOpenAIToken } from "./openai";
+import {
+  extractOpenAIAccountId,
+  isOpenAIRefreshTokenRejected,
+  OpenAITokenRefreshError,
+  refreshOpenAIToken,
+} from "./openai";
 import { ScopedOAuthSecretsStore, type OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Logger } from "../logger";
 import { OAuthRefreshSingleFlight } from "./oauth-refresh-single-flight";
 
+const OPENAI_REFRESH_TOKEN_KEY = "OPENAI_OAUTH_REFRESH_TOKEN";
 const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const OPENAI_DEFAULT_TOKEN_LIFETIME_MS = 60 * 60 * 1000;
 const OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS = 3;
@@ -14,7 +20,14 @@ const OPENAI_TOKEN_PERSIST_FAILURE =
 
 type OpenAITokenState =
   | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-  | { type: "refresh"; refreshToken: string; scope: OAuthSecretScope; accountId?: string };
+  | {
+      type: "refresh";
+      refreshToken: string;
+      /** Ciphertext the refresh token was read at — the CAS comparand when persisting its rotation. */
+      refreshTokenCiphertext: string;
+      scope: OAuthSecretScope;
+      accountId?: string;
+    };
 
 export type OpenAIToken = { accessToken: string; expiresIn?: number; accountId?: string };
 
@@ -71,8 +84,8 @@ export class OpenAITokenBroker {
       return await this.refreshSingleFlight(tokenState);
     } catch (error) {
       if (error instanceof OpenAITokenBrokerError) throw error;
-      if (error instanceof OpenAITokenRefreshError && error.status === 401) {
-        return this.handleUnauthorizedRefresh(tokenState, scopes);
+      if (error instanceof OpenAITokenRefreshError && isOpenAIRefreshTokenRejected(error)) {
+        return this.handleRejectedRefresh(tokenState, scopes, error.status);
       }
 
       this.log.error("OpenAI token refresh failed", {
@@ -82,30 +95,18 @@ export class OpenAITokenBroker {
     }
   }
 
-  private stateFromSecrets(
-    secrets: Record<string, string>,
-    scope: OAuthSecretScope
-  ): OpenAITokenState | null {
-    const refreshToken = secrets.OPENAI_OAUTH_REFRESH_TOKEN;
-    if (!refreshToken) return null;
-
+  private cachedStateFromSecrets(
+    secrets: Record<string, string>
+  ): Extract<OpenAITokenState, { type: "cached" }> | null {
     const cachedToken = secrets.OPENAI_OAUTH_ACCESS_TOKEN;
     const expiresAt = Number.parseInt(secrets.OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT || "0", 10);
     const now = Date.now();
-
-    if (cachedToken && expiresAt - now > OPENAI_TOKEN_REFRESH_BUFFER_MS) {
-      return {
-        type: "cached",
-        accessToken: cachedToken,
-        expiresIn: Math.floor((expiresAt - now) / 1000),
-        accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
-      };
-    }
+    if (!cachedToken || expiresAt - now <= OPENAI_TOKEN_REFRESH_BUFFER_MS) return null;
 
     return {
-      type: "refresh",
-      refreshToken,
-      scope,
+      type: "cached",
+      accessToken: cachedToken,
+      expiresIn: Math.floor((expiresAt - now) / 1000),
       accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
     };
   }
@@ -114,8 +115,24 @@ export class OpenAITokenBroker {
     scopes: readonly OAuthSecretScope[]
   ): Promise<OpenAITokenState | null> {
     for (const scope of scopes) {
-      const state = this.stateFromSecrets(await this.secrets.read(scope), scope);
-      if (state) return state;
+      const secrets = await this.secrets.read(scope);
+      if (!secrets[OPENAI_REFRESH_TOKEN_KEY]) continue;
+
+      const cached = this.cachedStateFromSecrets(secrets);
+      if (cached) return cached;
+
+      // Reread the refresh token together with its ciphertext so the value sent
+      // upstream and the CAS comparand come from the same stored row.
+      const stored = await this.secrets.readSecretWithCiphertext(scope, OPENAI_REFRESH_TOKEN_KEY);
+      if (!stored) continue;
+
+      return {
+        type: "refresh",
+        refreshToken: stored.value,
+        refreshTokenCiphertext: stored.ciphertext,
+        scope,
+        accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
+      };
     }
     return null;
   }
@@ -131,18 +148,25 @@ export class OpenAITokenBroker {
         ? OPENAI_DEFAULT_TOKEN_LIFETIME_MS
         : tokens.expires_in * 1000);
     const secretsToWrite: Record<string, string> = {
-      OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
+      [OPENAI_REFRESH_TOKEN_KEY]: tokens.refresh_token,
       OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
       OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
     };
     if (accountId) secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
 
-    await this.persistRotatedTokens(tokenState.scope, secretsToWrite);
-
-    this.log.info("OpenAI tokens rotated and cached", {
-      scope: tokenState.scope.kind,
-      has_account_id: !!accountId,
-    });
+    const persisted = await this.persistRotatedTokens(tokenState, secretsToWrite);
+    if (persisted) {
+      this.log.info("OpenAI tokens rotated and cached", {
+        scope: tokenState.scope.kind,
+        has_account_id: !!accountId,
+      });
+    } else {
+      // A concurrent rotation persisted first. Its refresh token stays
+      // authoritative; the one minted here is still valid to hand out once.
+      this.log.info("OpenAI token rotation lost the persistence race; using unsaved token", {
+        scope: tokenState.scope.kind,
+      });
+    }
     return {
       accessToken: tokens.access_token,
       expiresIn: tokens.expires_in,
@@ -158,18 +182,22 @@ export class OpenAITokenBroker {
     );
   }
 
+  /** Returns false when the guarded write lost to a concurrent rotation. */
   private async persistRotatedTokens(
-    scope: OAuthSecretScope,
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
     secrets: Record<string, string>
-  ): Promise<void> {
+  ): Promise<boolean> {
     for (let attempt = 1; attempt <= OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS; attempt++) {
       try {
-        await this.secrets.write(scope, secrets);
-        return;
+        return await this.secrets.casWrite(
+          tokenState.scope,
+          { key: OPENAI_REFRESH_TOKEN_KEY, expectedCiphertext: tokenState.refreshTokenCiphertext },
+          secrets
+        );
       } catch (error) {
         const finalAttempt = attempt === OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS;
         const context = {
-          scope: scope.kind,
+          scope: tokenState.scope.kind,
           attempt,
           max_attempts: OPENAI_TOKEN_PERSIST_MAX_ATTEMPTS,
           error: error instanceof Error ? error.message : String(error),
@@ -182,14 +210,17 @@ export class OpenAITokenBroker {
         await new Promise((resolve) => setTimeout(resolve, OPENAI_TOKEN_PERSIST_RETRY_DELAY_MS));
       }
     }
+    throw new OpenAITokenStorageError(OPENAI_TOKEN_PERSIST_FAILURE);
   }
 
-  private async handleUnauthorizedRefresh(
+  private async handleRejectedRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    scopes: readonly OAuthSecretScope[]
+    scopes: readonly OAuthSecretScope[],
+    rejectionStatus: number
   ): Promise<OpenAIToken> {
-    this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
+    this.log.warn("OpenAI refresh token rejected upstream, checking for concurrent rotation", {
       scope: tokenState.scope.kind,
+      status: rejectionStatus,
     });
     let observedRefreshToken = tokenState.refreshToken;
 
@@ -200,7 +231,7 @@ export class OpenAITokenBroker {
       try {
         reread = await this.readTokenState(scopes);
       } catch (error) {
-        this.log.error("Failed to reread OpenAI token state after 401", {
+        this.log.error("Failed to reread OpenAI token state after rejected refresh", {
           poll_attempt: pollIndex + 1,
           error: error instanceof Error ? error.message : String(error),
         });
@@ -224,7 +255,9 @@ export class OpenAITokenBroker {
           return await this.refreshSingleFlight(reread);
         } catch (error) {
           if (error instanceof OpenAITokenBrokerError) throw error;
-          if (error instanceof OpenAITokenRefreshError && error.status === 401) continue;
+          if (error instanceof OpenAITokenRefreshError && isOpenAIRefreshTokenRejected(error)) {
+            continue;
+          }
           this.log.error("OpenAI token refresh retry failed", {
             error: error instanceof Error ? error.message : String(error),
           });

--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -161,11 +161,24 @@ export class OpenAITokenBroker {
         has_account_id: !!accountId,
       });
     } else {
-      // A concurrent rotation persisted first. Its refresh token stays
-      // authoritative; the one minted here is still valid to hand out once.
-      this.log.info("OpenAI token rotation lost the persistence race; using unsaved token", {
-        scope: tokenState.scope.kind,
-      });
+      // The guard did not match: either a concurrent rotation persisted first
+      // (its refresh token stays authoritative) or the credential was removed
+      // mid-rotation (deletion is respected). The token minted here is still
+      // valid to hand out once. A reread failure must not fail the successful
+      // refresh, so it falls back to the benign concurrent-rotation reading.
+      const guardStillPresent = await this.secrets
+        .readSecretWithCiphertext(tokenState.scope, OPENAI_REFRESH_TOKEN_KEY)
+        .then((stored) => stored !== null)
+        .catch(() => true);
+      if (guardStillPresent) {
+        this.log.info("OpenAI token rotation lost the persistence race; using unsaved token", {
+          scope: tokenState.scope.kind,
+        });
+      } else {
+        this.log.warn("OpenAI refresh token removed during rotation; using unsaved token", {
+          scope: tokenState.scope.kind,
+        });
+      }
     }
     return {
       accessToken: tokens.access_token,

--- a/packages/control-plane/src/auth/openai.test.ts
+++ b/packages/control-plane/src/auth/openai.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { refreshOpenAIToken, extractOpenAIAccountId, OpenAITokenRefreshError } from "./openai";
+import {
+  refreshOpenAIToken,
+  extractOpenAIAccountId,
+  isOpenAIRefreshTokenRejected,
+  OpenAITokenRefreshError,
+} from "./openai";
 import type { OpenAITokenResponse } from "./openai";
 
 describe("openai", () => {
@@ -95,6 +100,39 @@ describe("openai", () => {
       globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
 
       await expect(refreshOpenAIToken("rt_any")).rejects.toThrow("fetch failed");
+    });
+  });
+
+  describe("isOpenAIRefreshTokenRejected", () => {
+    const refreshError = (status: number, body: string) =>
+      new OpenAITokenRefreshError("refresh failed", status, body);
+
+    it("treats any 401 as a rejected refresh token", () => {
+      expect(isOpenAIRefreshTokenRejected(refreshError(401, "unauthorized"))).toBe(true);
+    });
+
+    it.each(["invalid_grant", "refresh_token_reused"])(
+      "treats a 400 %s as a rejected refresh token",
+      (code) => {
+        const body = JSON.stringify({ error: code, error_description: "token consumed" });
+        expect(isOpenAIRefreshTokenRejected(refreshError(400, body))).toBe(true);
+      }
+    );
+
+    it("ignores a 400 with an unrelated error code", () => {
+      const body = JSON.stringify({ error: "invalid_request" });
+      expect(isOpenAIRefreshTokenRejected(refreshError(400, body))).toBe(false);
+    });
+
+    it("ignores a 400 with a non-JSON body", () => {
+      expect(isOpenAIRefreshTokenRejected(refreshError(400, "<html>Bad Request</html>"))).toBe(
+        false
+      );
+    });
+
+    it("ignores other statuses even with a consumed-token body", () => {
+      const body = JSON.stringify({ error: "invalid_grant" });
+      expect(isOpenAIRefreshTokenRejected(refreshError(500, body))).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/auth/openai.ts
+++ b/packages/control-plane/src/auth/openai.ts
@@ -27,6 +27,28 @@ export class OpenAITokenRefreshError extends Error {
   }
 }
 
+const OPENAI_CONSUMED_REFRESH_TOKEN_ERRORS = new Set(["invalid_grant", "refresh_token_reused"]);
+
+const oauthErrorResponseSchema = z.object({ error: z.string() });
+
+/**
+ * Whether a refresh failure means the refresh token itself was rejected —
+ * expired, revoked, or already consumed by a concurrent rotation — rather than
+ * a transient upstream fault. OpenAI reports consumed refresh tokens as HTTP
+ * 400 with an OAuth `invalid_grant`/`refresh_token_reused` error code, not
+ * only as 401.
+ */
+export function isOpenAIRefreshTokenRejected(error: OpenAITokenRefreshError): boolean {
+  if (error.status === 401) return true;
+  if (error.status !== 400) return false;
+  try {
+    const parsed = oauthErrorResponseSchema.safeParse(JSON.parse(error.body));
+    return parsed.success && OPENAI_CONSUMED_REFRESH_TOKEN_ERRORS.has(parsed.data.error);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Refresh an OpenAI OAuth access token using a refresh token.
  */

--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -16,11 +16,13 @@ import {
   SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
+  decryptStoredSecret,
   encryptSecretEntries,
+  encryptSecretValue,
   prepareSecretsForWrite,
   toSecretMetadata,
 } from "./scoped-secrets";
-import type { SecretsWriteResult } from "./scoped-secrets";
+import type { SecretsWriteResult, StoredSecretValue } from "./scoped-secrets";
 import { normalizeKey, validateKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
@@ -92,6 +94,52 @@ export class EnvironmentSecretsStore {
       }
       throw e;
     }
+  }
+
+  async getSecretWithCiphertext(
+    environmentId: string,
+    key: string
+  ): Promise<StoredSecretValue | null> {
+    const row = await this.db
+      .prepare(
+        "SELECT encrypted_value FROM environment_secrets WHERE environment_id = ? AND key = ?"
+      )
+      .bind(environmentId, normalizeKey(key))
+      .first<{ encrypted_value: string }>();
+    if (!row) return null;
+
+    try {
+      return await decryptStoredSecret(key, row.encrypted_value, this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt secret", {
+          environment_id: environmentId,
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt secret '${e.key}'`);
+      }
+      throw e;
+    }
+  }
+
+  async casUpdateSecret(
+    environmentId: string,
+    key: string,
+    expectedCiphertext: string,
+    value: string
+  ): Promise<boolean> {
+    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_secrets
+         SET encrypted_value = ?, updated_at = ?
+         WHERE environment_id = ? AND key = ? AND encrypted_value = ?`
+      )
+      .bind(encryptedValue, Date.now(), environmentId, normalizeKey(key), expectedCiphertext)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(environmentId: string, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -123,23 +123,70 @@ export class EnvironmentSecretsStore {
     }
   }
 
-  async casUpdateSecret(
+  /**
+   * Atomically persist a rotated credential bundle. Every statement in the
+   * batch is conditioned on `guardKey` still holding `expectedCiphertext`, and
+   * the guard row itself is swapped last, so the whole bundle commits or
+   * nothing does. Returns false — having written nothing — when the guard did
+   * not match: a concurrent rotation won, or the guard row was deleted.
+   */
+  async casWriteSecrets(
     environmentId: string,
-    key: string,
+    guardKey: string,
     expectedCiphertext: string,
-    value: string
+    secrets: Record<string, string>
   ): Promise<boolean> {
-    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
-    const result = await this.db
-      .prepare(
-        `UPDATE environment_secrets
-         SET encrypted_value = ?, updated_at = ?
-         WHERE environment_id = ? AND key = ? AND encrypted_value = ?`
-      )
-      .bind(encryptedValue, Date.now(), environmentId, normalizeKey(key), expectedCiphertext)
-      .run();
+    const now = Date.now();
+    const normalized = prepareSecretsForWrite(secrets);
+    const guard = normalizeKey(guardKey);
+    const { [guard]: guardValue, ...companionValues } = normalized;
+    if (guardValue === undefined) {
+      throw new Error(`casWriteSecrets requires secrets to include guard key '${guard}'`);
+    }
 
-    return (result.meta?.changes ?? 0) > 0;
+    const existingKeySet = await this.existingKeys(environmentId);
+    assertScopeKeyCapacity("Environment", existingKeySet, Object.keys(normalized));
+
+    const { entries } = await encryptSecretEntries(
+      companionValues,
+      existingKeySet,
+      this.encryptionKey
+    );
+    const guardEncrypted = await encryptSecretValue(guardValue, this.encryptionKey);
+
+    const statements = [
+      ...entries.map((entry) =>
+        this.db
+          .prepare(
+            `INSERT INTO environment_secrets (environment_id, key, encrypted_value, created_at, updated_at)
+             SELECT ?, ?, ?, ?, ?
+             WHERE EXISTS (SELECT 1 FROM environment_secrets WHERE environment_id = ? AND key = ? AND encrypted_value = ?)
+             ON CONFLICT(environment_id, key) DO UPDATE SET
+               encrypted_value = excluded.encrypted_value,
+               updated_at = excluded.updated_at`
+          )
+          .bind(
+            environmentId,
+            entry.key,
+            entry.encryptedValue,
+            now,
+            now,
+            environmentId,
+            guard,
+            expectedCiphertext
+          )
+      ),
+      this.db
+        .prepare(
+          `UPDATE environment_secrets
+           SET encrypted_value = ?, updated_at = ?
+           WHERE environment_id = ? AND key = ? AND encrypted_value = ?`
+        )
+        .bind(guardEncrypted, now, environmentId, guard, expectedCiphertext),
+    ];
+
+    const results = await this.db.batch(statements);
+    return (results[results.length - 1]?.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(environmentId: string, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/global-secrets.ts
+++ b/packages/control-plane/src/db/global-secrets.ts
@@ -107,18 +107,63 @@ export class GlobalSecretsStore {
     }
   }
 
-  async casUpdateSecret(key: string, expectedCiphertext: string, value: string): Promise<boolean> {
-    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
-    const result = await this.db
-      .prepare(
-        `UPDATE global_secrets
-         SET encrypted_value = ?, updated_at = ?
-         WHERE key = ? AND encrypted_value = ?`
-      )
-      .bind(encryptedValue, Date.now(), normalizeKey(key), expectedCiphertext)
-      .run();
+  /**
+   * Atomically persist a rotated credential bundle. Every statement in the
+   * batch is conditioned on `guardKey` still holding `expectedCiphertext`, and
+   * the guard row itself is swapped last, so the whole bundle commits or
+   * nothing does. Returns false — having written nothing — when the guard did
+   * not match: a concurrent rotation won, or the guard row was deleted.
+   */
+  async casWriteSecrets(
+    guardKey: string,
+    expectedCiphertext: string,
+    secrets: Record<string, string>
+  ): Promise<boolean> {
+    const now = Date.now();
+    const normalized = prepareSecretsForWrite(secrets);
+    const guard = normalizeKey(guardKey);
+    const { [guard]: guardValue, ...companionValues } = normalized;
+    if (guardValue === undefined) {
+      throw new Error(`casWriteSecrets requires secrets to include guard key '${guard}'`);
+    }
 
-    return (result.meta?.changes ?? 0) > 0;
+    const existingKeys = await this.db
+      .prepare("SELECT key FROM global_secrets")
+      .all<{ key: string }>();
+    const existingKeySet = new Set((existingKeys.results || []).map((r) => r.key));
+    assertScopeKeyCapacity("Global secrets", existingKeySet, Object.keys(normalized));
+
+    const { entries } = await encryptSecretEntries(
+      companionValues,
+      existingKeySet,
+      this.encryptionKey
+    );
+    const guardEncrypted = await encryptSecretValue(guardValue, this.encryptionKey);
+
+    const statements = [
+      ...entries.map((entry) =>
+        this.db
+          .prepare(
+            `INSERT INTO global_secrets (key, encrypted_value, created_at, updated_at)
+             SELECT ?, ?, ?, ?
+             WHERE EXISTS (SELECT 1 FROM global_secrets WHERE key = ? AND encrypted_value = ?)
+             ON CONFLICT(key) DO UPDATE SET
+               encrypted_value = excluded.encrypted_value,
+               updated_at = excluded.updated_at`
+          )
+          .bind(entry.key, entry.encryptedValue, now, now, guard, expectedCiphertext)
+      ),
+      this.db
+        .prepare(
+          `UPDATE global_secrets
+           SET encrypted_value = ?, updated_at = ?
+           WHERE key = ? AND encrypted_value = ?`
+        )
+        .bind(guardEncrypted, now, guard, expectedCiphertext),
+    ];
+
+    const results = await this.db.batch(statements);
+    return (results[results.length - 1]?.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/global-secrets.ts
+++ b/packages/control-plane/src/db/global-secrets.ts
@@ -3,11 +3,13 @@ import {
   SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
+  decryptStoredSecret,
   encryptSecretEntries,
+  encryptSecretValue,
   prepareSecretsForWrite,
   toSecretMetadata,
 } from "./scoped-secrets";
-import type { SecretsWriteResult } from "./scoped-secrets";
+import type { SecretsWriteResult, StoredSecretValue } from "./scoped-secrets";
 import { normalizeKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 import type { SqlDatabase } from "./sql-database";
@@ -82,6 +84,41 @@ export class GlobalSecretsStore {
       }
       throw e;
     }
+  }
+
+  async getSecretWithCiphertext(key: string): Promise<StoredSecretValue | null> {
+    const row = await this.db
+      .prepare("SELECT encrypted_value FROM global_secrets WHERE key = ?")
+      .bind(normalizeKey(key))
+      .first<{ encrypted_value: string }>();
+    if (!row) return null;
+
+    try {
+      return await decryptStoredSecret(key, row.encrypted_value, this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt global secret", {
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt global secret '${e.key}'`);
+      }
+      throw e;
+    }
+  }
+
+  async casUpdateSecret(key: string, expectedCiphertext: string, value: string): Promise<boolean> {
+    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
+    const result = await this.db
+      .prepare(
+        `UPDATE global_secrets
+         SET encrypted_value = ?, updated_at = ?
+         WHERE key = ? AND encrypted_value = ?`
+      )
+      .bind(encryptedValue, Date.now(), normalizeKey(key), expectedCiphertext)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/repo-secrets.ts
+++ b/packages/control-plane/src/db/repo-secrets.ts
@@ -3,11 +3,13 @@ import {
   SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
+  decryptStoredSecret,
   encryptSecretEntries,
+  encryptSecretValue,
   prepareSecretsForWrite,
   toSecretMetadata,
 } from "./scoped-secrets";
-import type { SecretsWriteResult } from "./scoped-secrets";
+import type { SecretsWriteResult, StoredSecretValue } from "./scoped-secrets";
 import { normalizeKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 import type { SqlDatabase } from "./sql-database";
@@ -100,6 +102,47 @@ export class RepoSecretsStore {
       }
       throw e;
     }
+  }
+
+  async getSecretWithCiphertext(repoId: number, key: string): Promise<StoredSecretValue | null> {
+    const row = await this.db
+      .prepare("SELECT encrypted_value FROM repo_secrets WHERE repo_id = ? AND key = ?")
+      .bind(repoId, normalizeKey(key))
+      .first<{ encrypted_value: string }>();
+    if (!row) return null;
+
+    try {
+      return await decryptStoredSecret(key, row.encrypted_value, this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt secret", {
+          repo_id: repoId,
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt secret '${e.key}'`);
+      }
+      throw e;
+    }
+  }
+
+  async casUpdateSecret(
+    repoId: number,
+    key: string,
+    expectedCiphertext: string,
+    value: string
+  ): Promise<boolean> {
+    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
+    const result = await this.db
+      .prepare(
+        `UPDATE repo_secrets
+         SET encrypted_value = ?, updated_at = ?
+         WHERE repo_id = ? AND key = ? AND encrypted_value = ?`
+      )
+      .bind(encryptedValue, Date.now(), repoId, normalizeKey(key), expectedCiphertext)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(repoId: number, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/repo-secrets.ts
+++ b/packages/control-plane/src/db/repo-secrets.ts
@@ -126,23 +126,82 @@ export class RepoSecretsStore {
     }
   }
 
-  async casUpdateSecret(
+  /**
+   * Atomically persist a rotated credential bundle. Every statement in the
+   * batch is conditioned on `guardKey` still holding `expectedCiphertext`, and
+   * the guard row itself is swapped last, so the whole bundle commits or
+   * nothing does. Returns false — having written nothing — when the guard did
+   * not match: a concurrent rotation won, or the guard row was deleted.
+   */
+  async casWriteSecrets(
     repoId: number,
-    key: string,
+    repoOwner: string,
+    repoName: string,
+    guardKey: string,
     expectedCiphertext: string,
-    value: string
+    secrets: Record<string, string>
   ): Promise<boolean> {
-    const encryptedValue = await encryptSecretValue(value, this.encryptionKey);
-    const result = await this.db
-      .prepare(
-        `UPDATE repo_secrets
-         SET encrypted_value = ?, updated_at = ?
-         WHERE repo_id = ? AND key = ? AND encrypted_value = ?`
-      )
-      .bind(encryptedValue, Date.now(), repoId, normalizeKey(key), expectedCiphertext)
-      .run();
+    const owner = repoOwner.toLowerCase();
+    const name = repoName.toLowerCase();
+    const now = Date.now();
+    const normalized = prepareSecretsForWrite(secrets);
+    const guard = normalizeKey(guardKey);
+    const { [guard]: guardValue, ...companionValues } = normalized;
+    if (guardValue === undefined) {
+      throw new Error(`casWriteSecrets requires secrets to include guard key '${guard}'`);
+    }
 
-    return (result.meta?.changes ?? 0) > 0;
+    const existingKeys = await this.db
+      .prepare("SELECT key FROM repo_secrets WHERE repo_id = ?")
+      .bind(repoId)
+      .all<{ key: string }>();
+    const existingKeySet = new Set((existingKeys.results || []).map((r) => r.key));
+    assertScopeKeyCapacity("Repository", existingKeySet, Object.keys(normalized));
+
+    const { entries } = await encryptSecretEntries(
+      companionValues,
+      existingKeySet,
+      this.encryptionKey
+    );
+    const guardEncrypted = await encryptSecretValue(guardValue, this.encryptionKey);
+
+    const statements = [
+      ...entries.map((entry) =>
+        this.db
+          .prepare(
+            `INSERT INTO repo_secrets (repo_id, repo_owner, repo_name, key, encrypted_value, created_at, updated_at)
+             SELECT ?, ?, ?, ?, ?, ?, ?
+             WHERE EXISTS (SELECT 1 FROM repo_secrets WHERE repo_id = ? AND key = ? AND encrypted_value = ?)
+             ON CONFLICT(repo_id, key) DO UPDATE SET
+               repo_owner = excluded.repo_owner,
+               repo_name = excluded.repo_name,
+               encrypted_value = excluded.encrypted_value,
+               updated_at = excluded.updated_at`
+          )
+          .bind(
+            repoId,
+            owner,
+            name,
+            entry.key,
+            entry.encryptedValue,
+            now,
+            now,
+            repoId,
+            guard,
+            expectedCiphertext
+          )
+      ),
+      this.db
+        .prepare(
+          `UPDATE repo_secrets
+           SET encrypted_value = ?, updated_at = ?
+           WHERE repo_id = ? AND key = ? AND encrypted_value = ?`
+        )
+        .bind(guardEncrypted, now, repoId, guard, expectedCiphertext),
+    ];
+
+    const results = await this.db.batch(statements);
+    return (results[results.length - 1]?.meta?.changes ?? 0) > 0;
   }
 
   async deleteSecret(repoId: number, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/scoped-oauth-secrets.ts
+++ b/packages/control-plane/src/db/scoped-oauth-secrets.ts
@@ -1,6 +1,7 @@
 import { EnvironmentSecretsStore } from "./environment-secrets";
 import { GlobalSecretsStore } from "./global-secrets";
 import { RepoSecretsStore } from "./repo-secrets";
+import type { StoredSecretValue } from "./scoped-secrets";
 import type { SqlDatabase } from "./sql-database";
 
 export type OAuthSecretScope =
@@ -46,6 +47,90 @@ export class ScopedOAuthSecretsStore {
         return;
       case "global":
         await new GlobalSecretsStore(this.db, this.encryptionKey).setSecrets(secrets);
+    }
+  }
+
+  /** Read one secret's decrypted value together with the ciphertext it is stored as. */
+  readSecretWithCiphertext(
+    scope: OAuthSecretScope,
+    key: string
+  ): Promise<StoredSecretValue | null> {
+    switch (scope.kind) {
+      case "environment":
+        return new EnvironmentSecretsStore(this.db, this.encryptionKey).getSecretWithCiphertext(
+          scope.environmentId,
+          key
+        );
+      case "repo":
+        return new RepoSecretsStore(this.db, this.encryptionKey).getSecretWithCiphertext(
+          scope.repoId,
+          key
+        );
+      case "global":
+        return new GlobalSecretsStore(this.db, this.encryptionKey).getSecretWithCiphertext(key);
+    }
+  }
+
+  /**
+   * Rotation write guarded by the ciphertext `guard.key` was read at: the guard
+   * row is swapped only if it is unchanged, then the remaining secrets are
+   * upserted. Returns false — writing nothing — when the guard row changed
+   * underneath us, i.e. a concurrent rotation persisted first. The guard row is
+   * written before the rest so a failure between the two writes can never leave
+   * an older guard value over a newer one; the worst case is a stale companion
+   * row (a cached access token), which ages out on its own.
+   */
+  async casWrite(
+    scope: OAuthSecretScope,
+    guard: { key: string; expectedCiphertext: string },
+    secrets: Record<string, string>
+  ): Promise<boolean> {
+    const { [guard.key]: guardValue, ...companions } = secrets;
+    if (guardValue === undefined) {
+      throw new Error(`casWrite requires secrets to include guard key '${guard.key}'`);
+    }
+
+    const swapped = await this.casUpdateSecret(
+      scope,
+      guard.key,
+      guard.expectedCiphertext,
+      guardValue
+    );
+    if (!swapped) return false;
+
+    if (Object.keys(companions).length > 0) {
+      await this.write(scope, companions);
+    }
+    return true;
+  }
+
+  private casUpdateSecret(
+    scope: OAuthSecretScope,
+    key: string,
+    expectedCiphertext: string,
+    value: string
+  ): Promise<boolean> {
+    switch (scope.kind) {
+      case "environment":
+        return new EnvironmentSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
+          scope.environmentId,
+          key,
+          expectedCiphertext,
+          value
+        );
+      case "repo":
+        return new RepoSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
+          scope.repoId,
+          key,
+          expectedCiphertext,
+          value
+        );
+      case "global":
+        return new GlobalSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
+          key,
+          expectedCiphertext,
+          value
+        );
     }
   }
 }

--- a/packages/control-plane/src/db/scoped-oauth-secrets.ts
+++ b/packages/control-plane/src/db/scoped-oauth-secrets.ts
@@ -72,64 +72,40 @@ export class ScopedOAuthSecretsStore {
   }
 
   /**
-   * Rotation write guarded by the ciphertext `guard.key` was read at: the guard
-   * row is swapped only if it is unchanged, then the remaining secrets are
-   * upserted. Returns false — writing nothing — when the guard row changed
-   * underneath us, i.e. a concurrent rotation persisted first. The guard row is
-   * written before the rest so a failure between the two writes can never leave
-   * an older guard value over a newer one; the worst case is a stale companion
-   * row (a cached access token), which ages out on its own.
+   * Atomic rotation write guarded by the ciphertext `guard.key` was read at:
+   * every statement in the underlying batch is conditioned on the guard row
+   * being unchanged, and the guard row itself is swapped last, so the whole
+   * bundle commits or nothing does. Returns false — having written nothing —
+   * when the guard did not match: a concurrent rotation persisted first, or
+   * the guard row was deleted (distinguish by re-reading the guard key).
    */
-  async casWrite(
+  casWrite(
     scope: OAuthSecretScope,
     guard: { key: string; expectedCiphertext: string },
     secrets: Record<string, string>
   ): Promise<boolean> {
-    const { [guard.key]: guardValue, ...companions } = secrets;
-    if (guardValue === undefined) {
-      throw new Error(`casWrite requires secrets to include guard key '${guard.key}'`);
-    }
-
-    const swapped = await this.casUpdateSecret(
-      scope,
-      guard.key,
-      guard.expectedCiphertext,
-      guardValue
-    );
-    if (!swapped) return false;
-
-    if (Object.keys(companions).length > 0) {
-      await this.write(scope, companions);
-    }
-    return true;
-  }
-
-  private casUpdateSecret(
-    scope: OAuthSecretScope,
-    key: string,
-    expectedCiphertext: string,
-    value: string
-  ): Promise<boolean> {
     switch (scope.kind) {
       case "environment":
-        return new EnvironmentSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
+        return new EnvironmentSecretsStore(this.db, this.encryptionKey).casWriteSecrets(
           scope.environmentId,
-          key,
-          expectedCiphertext,
-          value
+          guard.key,
+          guard.expectedCiphertext,
+          secrets
         );
       case "repo":
-        return new RepoSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
+        return new RepoSecretsStore(this.db, this.encryptionKey).casWriteSecrets(
           scope.repoId,
-          key,
-          expectedCiphertext,
-          value
+          scope.repoOwner,
+          scope.repoName,
+          guard.key,
+          guard.expectedCiphertext,
+          secrets
         );
       case "global":
-        return new GlobalSecretsStore(this.db, this.encryptionKey).casUpdateSecret(
-          key,
-          expectedCiphertext,
-          value
+        return new GlobalSecretsStore(this.db, this.encryptionKey).casWriteSecrets(
+          guard.key,
+          guard.expectedCiphertext,
+          secrets
         );
     }
   }

--- a/packages/control-plane/src/db/scoped-secrets.ts
+++ b/packages/control-plane/src/db/scoped-secrets.ts
@@ -95,6 +95,12 @@ export async function encryptSecretEntries(
   return { entries, created, updated };
 }
 
+/** Encrypt a single validated secret value for a store's guarded write. */
+export async function encryptSecretValue(value: string, encryptionKey: string): Promise<string> {
+  validateValue(value);
+  return encryptToken(value, encryptionKey);
+}
+
 /** Map `key, created_at, updated_at` rows to the wire metadata shape. */
 export function toSecretMetadata(
   rows: Array<{ key: string; created_at: number; updated_at: number }>
@@ -127,6 +133,30 @@ export class SecretDecryptionError extends Error {
  * record. Pure crypto: on failure, throws `SecretDecryptionError`; logging is
  * the caller's concern.
  */
+/**
+ * One stored secret decrypted alongside the exact ciphertext it was read from.
+ * The ciphertext is the compare-and-swap comparand for rotation writes: values
+ * encrypt non-deterministically, so equality is only meaningful against the
+ * stored bytes, never against a re-encryption.
+ */
+export interface StoredSecretValue {
+  value: string;
+  ciphertext: string;
+}
+
+/** Decrypt one stored ciphertext, wrapping failures like `decryptSecretRows`. */
+export async function decryptStoredSecret(
+  key: string,
+  ciphertext: string,
+  encryptionKey: string
+): Promise<StoredSecretValue> {
+  try {
+    return { value: await decryptToken(ciphertext, encryptionKey), ciphertext };
+  } catch (e) {
+    throw new SecretDecryptionError(key, { cause: e });
+  }
+}
+
 export async function decryptSecretRows(
   rows: Array<{ key: string; encrypted_value: string }>,
   encryptionKey: string

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -2,14 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
 import type { SessionRow } from "./types";
 import {
-  OpenAITokenBroker,
   OpenAITokenNotConfiguredError,
   OpenAITokenStorageError,
-  OpenAITokenUnauthorizedError,
-  OpenAITokenUpstreamError,
-} from "../auth/openai-token-broker";
-import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
+  OpenAITokenRefreshService,
+} from "./openai-token-refresh-service";
 import { OpenAITokenRefreshError } from "../auth/openai";
+import type * as openAIAuthModule from "../auth/openai";
 
 const mockState = vi.hoisted(() => ({
   repoSecrets: new Map<number, Record<string, string>>(),
@@ -22,13 +20,13 @@ const mockState = vi.hoisted(() => ({
     name: string;
     secrets: Record<string, string>;
   }>,
-  globalWrites: [] as Array<Record<string, string>>,
   environmentWrites: [] as Array<{ environmentId: string; secrets: Record<string, string> }>,
-  repoWriteImpl: vi.fn(),
-  globalWriteImpl: vi.fn(),
-  repoReadImpl: vi.fn(),
-  globalReadImpl: vi.fn(),
+  repoCasImpl: vi.fn(),
 }));
+
+// Deterministic stand-in for stored ciphertext: equal plaintexts map to equal
+// "ciphertexts", so the CAS mocks conflict exactly when the stored value changed.
+const cipherOf = (value: string) => `cipher:${value}`;
 
 const TEST_DB: D1Database = {
   prepare(_query: string): D1PreparedStatement {
@@ -48,19 +46,10 @@ const TEST_DB: D1Database = {
   },
 };
 
-vi.mock("../auth/openai", () => {
-  class MockOpenAITokenRefreshError extends Error {
-    status: number;
-    body: string;
-    constructor(message: string, status: number, body: string) {
-      super(message);
-      this.status = status;
-      this.body = body;
-    }
-  }
-
+vi.mock("../auth/openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof openAIAuthModule>();
   return {
-    OpenAITokenRefreshError: MockOpenAITokenRefreshError,
+    ...actual,
     refreshOpenAIToken: (refreshToken: string) => mockState.refreshImpl(refreshToken),
     extractOpenAIAccountId: (tokens: { account_id?: string }) => tokens.account_id,
   };
@@ -69,8 +58,29 @@ vi.mock("../auth/openai", () => {
 vi.mock("../db/repo-secrets", () => ({
   RepoSecretsStore: class {
     async getDecryptedSecrets(repoId: number): Promise<Record<string, string>> {
-      await mockState.repoReadImpl(repoId);
       return mockState.repoSecrets.get(repoId) ?? {};
+    }
+
+    async getSecretWithCiphertext(
+      repoId: number,
+      key: string
+    ): Promise<{ value: string; ciphertext: string } | null> {
+      const value = mockState.repoSecrets.get(repoId)?.[key];
+      return value === undefined ? null : { value, ciphertext: cipherOf(value) };
+    }
+
+    async casUpdateSecret(
+      repoId: number,
+      key: string,
+      expectedCiphertext: string,
+      value: string
+    ): Promise<boolean> {
+      await mockState.repoCasImpl(repoId, key, expectedCiphertext, value);
+      const existing = mockState.repoSecrets.get(repoId) ?? {};
+      const current = existing[key];
+      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
+      mockState.repoSecrets.set(repoId, { ...existing, [key]: value });
+      return true;
     }
 
     async setSecrets(
@@ -79,7 +89,6 @@ vi.mock("../db/repo-secrets", () => ({
       name: string,
       secrets: Record<string, string>
     ): Promise<void> {
-      await mockState.repoWriteImpl(repoId, owner, name, secrets);
       mockState.repoWrites.push({ repoId, owner, name, secrets });
       const existing = mockState.repoSecrets.get(repoId) ?? {};
       mockState.repoSecrets.set(repoId, { ...existing, ...secrets });
@@ -90,13 +99,29 @@ vi.mock("../db/repo-secrets", () => ({
 vi.mock("../db/global-secrets", () => ({
   GlobalSecretsStore: class {
     async getDecryptedSecrets(): Promise<Record<string, string>> {
-      await mockState.globalReadImpl();
       return mockState.globalSecrets;
     }
 
+    async getSecretWithCiphertext(key: string): Promise<{
+      value: string;
+      ciphertext: string;
+    } | null> {
+      const value = mockState.globalSecrets[key];
+      return value === undefined ? null : { value, ciphertext: cipherOf(value) };
+    }
+
+    async casUpdateSecret(
+      key: string,
+      expectedCiphertext: string,
+      value: string
+    ): Promise<boolean> {
+      const current = mockState.globalSecrets[key];
+      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
+      mockState.globalSecrets = { ...mockState.globalSecrets, [key]: value };
+      return true;
+    }
+
     async setSecrets(secrets: Record<string, string>): Promise<void> {
-      await mockState.globalWriteImpl(secrets);
-      mockState.globalWrites.push(secrets);
       mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
     }
   },
@@ -106,6 +131,27 @@ vi.mock("../db/environment-secrets", () => ({
   EnvironmentSecretsStore: class {
     async getDecryptedSecrets(environmentId: string): Promise<Record<string, string>> {
       return mockState.environmentSecrets.get(environmentId) ?? {};
+    }
+
+    async getSecretWithCiphertext(
+      environmentId: string,
+      key: string
+    ): Promise<{ value: string; ciphertext: string } | null> {
+      const value = mockState.environmentSecrets.get(environmentId)?.[key];
+      return value === undefined ? null : { value, ciphertext: cipherOf(value) };
+    }
+
+    async casUpdateSecret(
+      environmentId: string,
+      key: string,
+      expectedCiphertext: string,
+      value: string
+    ): Promise<boolean> {
+      const existing = mockState.environmentSecrets.get(environmentId) ?? {};
+      const current = existing[key];
+      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
+      mockState.environmentSecrets.set(environmentId, { ...existing, [key]: value });
+      return true;
     }
 
     async setSecrets(environmentId: string, secrets: Record<string, string>): Promise<void> {
@@ -162,17 +208,10 @@ describe("OpenAITokenRefreshService", () => {
     mockState.globalSecrets = {};
     mockState.environmentSecrets.clear();
     mockState.repoWrites = [];
-    mockState.globalWrites = [];
     mockState.environmentWrites = [];
     mockState.refreshImpl.mockReset();
-    mockState.repoWriteImpl.mockReset();
-    mockState.repoWriteImpl.mockResolvedValue(undefined);
-    mockState.globalWriteImpl.mockReset();
-    mockState.globalWriteImpl.mockResolvedValue(undefined);
-    mockState.repoReadImpl.mockReset();
-    mockState.repoReadImpl.mockResolvedValue(undefined);
-    mockState.globalReadImpl.mockReset();
-    mockState.globalReadImpl.mockResolvedValue(undefined);
+    mockState.repoCasImpl.mockReset();
+    mockState.repoCasImpl.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -205,283 +244,6 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.refreshImpl).not.toHaveBeenCalled();
   });
 
-  it("returns a cached global access token without consulting session scopes", async () => {
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
-      OPENAI_OAUTH_ACCESS_TOKEN: "global-cached-access",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
-      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
-    };
-    mockState.repoSecrets.set(123, {
-      OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh",
-      OPENAI_OAUTH_ACCESS_TOKEN: "repo-access",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
-    });
-
-    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-
-    expect(result).toEqual({
-      accessToken: "global-cached-access",
-      expiresIn: expect.any(Number),
-      accountId: "acct_global",
-    });
-    expect(mockState.refreshImpl).not.toHaveBeenCalled();
-  });
-
-  it("refreshes and rotates global credentials", async () => {
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    mockState.refreshImpl.mockResolvedValue({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
-      account_id: "acct_global",
-    });
-
-    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-
-    expect(result).toEqual({
-      accessToken: "global-access-new",
-      expiresIn: 1800,
-      accountId: "acct_global",
-    });
-    expect(mockState.refreshImpl).toHaveBeenCalledWith("global-refresh-old");
-    expect(mockState.globalWrites).toHaveLength(1);
-    expect(mockState.globalWrites[0]).toMatchObject({
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-new",
-      OPENAI_OAUTH_ACCESS_TOKEN: "global-access-new",
-      OPENAI_OAUTH_ACCOUNT_ID: "acct_global",
-    });
-  });
-
-  it("preserves the stored account id when refresh omits it", async () => {
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
-    };
-    mockState.refreshImpl.mockResolvedValue({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
-    });
-
-    const result = await new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-
-    expect(result).toMatchObject({
-      accessToken: "global-access-new",
-      accountId: "acct_stored",
-    });
-    expect(mockState.globalWrites[0]).toMatchObject({
-      OPENAI_OAUTH_ACCOUNT_ID: "acct_stored",
-    });
-  });
-
-  it("retries a transient global persistence failure and returns success after saving", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    mockState.refreshImpl.mockResolvedValue({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
-    });
-    mockState.globalWriteImpl
-      .mockRejectedValueOnce(new Error("D1 temporarily unavailable"))
-      .mockResolvedValueOnce(undefined);
-
-    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    await vi.runAllTimersAsync();
-
-    await expect(promise).resolves.toMatchObject({ accessToken: "global-access-new" });
-    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(2);
-    expect(mockState.globalWrites).toHaveLength(1);
-  });
-
-  it("throws an actionable error when rotated global credentials cannot be persisted", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-old",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    mockState.refreshImpl.mockResolvedValue({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
-    });
-    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
-
-    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const errorPromise = promise.catch((caught: unknown) => caught);
-    await vi.runAllTimersAsync();
-
-    const error = await errorPromise;
-    expect(error).toBeInstanceOf(OpenAITokenStorageError);
-    expect(error).toHaveProperty(
-      "message",
-      "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
-    );
-    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
-    expect(mockState.globalWrites).toHaveLength(0);
-  });
-
-  it("uses a concurrently rotated global access token after refresh gets 401", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    mockState.refreshImpl.mockImplementationOnce(async () => {
-      mockState.globalSecrets = {
-        OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
-        OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
-        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
-      };
-      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-    });
-
-    const promise = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    await vi.runAllTimersAsync();
-
-    await expect(promise).resolves.toMatchObject({
-      accessToken: "global-access-concurrent",
-    });
-    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
-  });
-
-  it("coalesces concurrent refreshes for the same scope and refresh token", async () => {
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    let resolveRefresh!: (tokens: {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    }) => void;
-    mockState.refreshImpl.mockReturnValue(
-      new Promise((resolve) => {
-        resolveRefresh = resolve;
-      })
-    );
-    const firstBroker = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger());
-    const secondBroker = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger());
-
-    const first = firstBroker.refreshGlobal();
-    const second = secondBroker.refreshGlobal();
-    await vi.waitFor(() => expect(mockState.refreshImpl).toHaveBeenCalledOnce());
-    resolveRefresh({
-      access_token: "global-access-new",
-      refresh_token: "global-refresh-new",
-      expires_in: 1800,
-    });
-
-    await expect(Promise.all([first, second])).resolves.toEqual([
-      {
-        accessToken: "global-access-new",
-        expiresIn: 1800,
-        accountId: undefined,
-      },
-      {
-        accessToken: "global-access-new",
-        expiresIn: 1800,
-        accountId: undefined,
-      },
-    ]);
-    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
-    expect(mockState.globalWrites).toHaveLength(1);
-  });
-
-  it("waits for a slow concurrent rotation from another isolate", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = {
-      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
-    };
-    mockState.refreshImpl.mockImplementationOnce(async () => {
-      setTimeout(() => {
-        mockState.globalSecrets = {
-          OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated",
-          OPENAI_OAUTH_ACCESS_TOKEN: "global-access-concurrent",
-          OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
-        };
-      }, 750);
-      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-    });
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    await vi.runAllTimersAsync();
-
-    await expect(result).resolves.toMatchObject({
-      accessToken: "global-access-concurrent",
-    });
-    expect(mockState.refreshImpl).toHaveBeenCalledOnce();
-  });
-
-  it("throws an unauthorized error when a concurrently rotated token is also rejected", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
-    mockState.refreshImpl
-      .mockImplementationOnce(async () => {
-        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
-        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-      })
-      .mockRejectedValueOnce(new OpenAITokenRefreshError("unauthorized", 401, "unauthorized"));
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
-    await vi.runAllTimersAsync();
-
-    await rejection;
-    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
-  });
-
-  it("throws an upstream error when retrying a concurrently rotated token fails", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
-    mockState.refreshImpl
-      .mockImplementationOnce(async () => {
-        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
-        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-      })
-      .mockRejectedValueOnce(new Error("upstream connection failed"));
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const rejection = expect(result).rejects.toThrow(OpenAITokenUpstreamError);
-    await vi.runAllTimersAsync();
-
-    await rejection;
-    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
-  });
-
-  it("preserves a persistence error when retrying a concurrently rotated token", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-stale" };
-    mockState.refreshImpl
-      .mockImplementationOnce(async () => {
-        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh-rotated" };
-        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-      })
-      .mockResolvedValueOnce({
-        access_token: "global-access-new",
-        refresh_token: "global-refresh-new",
-        expires_in: 1800,
-      });
-    mockState.globalWriteImpl.mockRejectedValue(new Error("D1 write failed"));
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
-    await vi.runAllTimersAsync();
-
-    await rejection;
-    expect(mockState.refreshImpl).toHaveBeenCalledTimes(2);
-    expect(mockState.globalWriteImpl).toHaveBeenCalledTimes(3);
-  });
-
   it("throws a not-configured error when refresh token is missing", async () => {
     const service = new OpenAITokenRefreshService(
       TEST_DB,
@@ -491,75 +253,6 @@ describe("OpenAITokenRefreshService", () => {
     );
 
     await expect(service.refresh(createSession())).rejects.toThrow(OpenAITokenNotConfiguredError);
-  });
-
-  it("throws a secrets-read error when scoped secrets cannot be read", async () => {
-    mockState.globalReadImpl.mockRejectedValue(new Error("D1 read failed"));
-
-    await expect(
-      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
-    ).rejects.toThrow(OpenAITokenStorageError);
-  });
-
-  it("throws an upstream error when token refresh fails unexpectedly", async () => {
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh" };
-    mockState.refreshImpl.mockRejectedValue(new Error("upstream connection failed"));
-
-    await expect(
-      new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal()
-    ).rejects.toThrow(OpenAITokenUpstreamError);
-  });
-
-  it("retries with a refresh token written by a concurrent rotation", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
-    mockState.refreshImpl
-      .mockImplementationOnce(async () => {
-        mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "rotated-refresh" };
-        throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
-      })
-      .mockResolvedValueOnce({ access_token: "fresh-access", expires_in: 1800 });
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    await vi.runAllTimersAsync();
-
-    await expect(result).resolves.toMatchObject({ accessToken: "fresh-access" });
-    expect(mockState.refreshImpl).toHaveBeenNthCalledWith(2, "rotated-refresh");
-  });
-
-  it("continues polling after a transient post-401 secret reread failure", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
-    mockState.refreshImpl.mockRejectedValue(
-      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
-    );
-    mockState.globalReadImpl
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("D1 reread failed"));
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const rejection = expect(result).rejects.toThrow(OpenAITokenUnauthorizedError);
-    await vi.runAllTimersAsync();
-
-    await rejection;
-  });
-
-  it("throws a storage error when post-401 secret rereads keep failing", async () => {
-    vi.useFakeTimers();
-    mockState.globalSecrets = { OPENAI_OAUTH_REFRESH_TOKEN: "stale-refresh" };
-    mockState.refreshImpl.mockRejectedValue(
-      new OpenAITokenRefreshError("unauthorized", 401, "unauthorized")
-    );
-    mockState.globalReadImpl
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValue(new Error("D1 reread failed"));
-
-    const result = new OpenAITokenBroker(TEST_DB, "enc-key", createLogger()).refreshGlobal();
-    const rejection = expect(result).rejects.toThrow(OpenAITokenStorageError);
-    await vi.runAllTimersAsync();
-
-    await rejection;
-    expect(mockState.globalReadImpl).toHaveBeenCalledTimes(5);
   });
 
   it("throws a secrets-read error when repository scope resolution fails", async () => {
@@ -603,12 +296,13 @@ describe("OpenAITokenRefreshService", () => {
       accountId: "acct_new",
     });
     expect(mockState.refreshImpl).toHaveBeenCalledWith("refresh-old");
+    expect(mockState.repoSecrets.get(repoId)).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-new",
+      OPENAI_OAUTH_ACCESS_TOKEN: "access-new",
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_new",
+    });
     expect(mockState.repoWrites).toHaveLength(1);
-    expect(mockState.repoWrites[0].repoId).toBe(repoId);
-    expect(mockState.repoWrites[0].owner).toBe("acme");
-    expect(mockState.repoWrites[0].name).toBe("web");
-    expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_REFRESH_TOKEN).toBe("refresh-new");
-    expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_ACCESS_TOKEN).toBe("access-new");
+    expect(mockState.repoWrites[0]).toMatchObject({ repoId, owner: "acme", name: "web" });
   });
 
   it("throws an actionable error when rotated session credentials cannot be persisted", async () => {
@@ -623,7 +317,7 @@ describe("OpenAITokenRefreshService", () => {
       refresh_token: "refresh-new",
       expires_in: 1800,
     });
-    mockState.repoWriteImpl.mockRejectedValue(new Error("storage unavailable"));
+    mockState.repoCasImpl.mockRejectedValue(new Error("storage unavailable"));
 
     const service = new OpenAITokenRefreshService(
       TEST_DB,
@@ -641,7 +335,7 @@ describe("OpenAITokenRefreshService", () => {
       "message",
       "OpenAI tokens rotated but could not be saved; reconnect OpenAI OAuth"
     );
-    expect(mockState.repoWriteImpl).toHaveBeenCalledTimes(3);
+    expect(mockState.repoCasImpl).toHaveBeenCalledTimes(3);
     expect(mockState.repoWrites).toHaveLength(0);
   });
 
@@ -719,11 +413,12 @@ describe("OpenAITokenRefreshService", () => {
     expect(mockState.refreshImpl).toHaveBeenCalledWith("env-refresh-old");
     // Rotated credentials persisted back to the environment, never the repo.
     expect(mockState.repoWrites).toHaveLength(0);
+    expect(mockState.environmentSecrets.get("env_flagship")).toMatchObject({
+      OPENAI_OAUTH_REFRESH_TOKEN: "env-refresh-new",
+      OPENAI_OAUTH_ACCESS_TOKEN: "env-access-new",
+    });
     expect(mockState.environmentWrites).toHaveLength(1);
     expect(mockState.environmentWrites[0].environmentId).toBe("env_flagship");
-    expect(mockState.environmentWrites[0].secrets.OPENAI_OAUTH_REFRESH_TOKEN).toBe(
-      "env-refresh-new"
-    );
   });
 
   it("falls back to global for an environment session with no environment token", async () => {

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -69,29 +69,21 @@ vi.mock("../db/repo-secrets", () => ({
       return value === undefined ? null : { value, ciphertext: cipherOf(value) };
     }
 
-    async casUpdateSecret(
-      repoId: number,
-      key: string,
-      expectedCiphertext: string,
-      value: string
-    ): Promise<boolean> {
-      await mockState.repoCasImpl(repoId, key, expectedCiphertext, value);
-      const existing = mockState.repoSecrets.get(repoId) ?? {};
-      const current = existing[key];
-      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
-      mockState.repoSecrets.set(repoId, { ...existing, [key]: value });
-      return true;
-    }
-
-    async setSecrets(
+    async casWriteSecrets(
       repoId: number,
       owner: string,
       name: string,
+      guardKey: string,
+      expectedCiphertext: string,
       secrets: Record<string, string>
-    ): Promise<void> {
-      mockState.repoWrites.push({ repoId, owner, name, secrets });
+    ): Promise<boolean> {
+      await mockState.repoCasImpl(repoId, guardKey, expectedCiphertext, secrets);
       const existing = mockState.repoSecrets.get(repoId) ?? {};
+      const current = existing[guardKey];
+      if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
       mockState.repoSecrets.set(repoId, { ...existing, ...secrets });
+      mockState.repoWrites.push({ repoId, owner, name, secrets });
+      return true;
     }
   },
 }));
@@ -110,19 +102,15 @@ vi.mock("../db/global-secrets", () => ({
       return value === undefined ? null : { value, ciphertext: cipherOf(value) };
     }
 
-    async casUpdateSecret(
-      key: string,
+    async casWriteSecrets(
+      guardKey: string,
       expectedCiphertext: string,
-      value: string
+      secrets: Record<string, string>
     ): Promise<boolean> {
-      const current = mockState.globalSecrets[key];
+      const current = mockState.globalSecrets[guardKey];
       if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
-      mockState.globalSecrets = { ...mockState.globalSecrets, [key]: value };
-      return true;
-    }
-
-    async setSecrets(secrets: Record<string, string>): Promise<void> {
       mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
+      return true;
     }
   },
 }));
@@ -141,23 +129,18 @@ vi.mock("../db/environment-secrets", () => ({
       return value === undefined ? null : { value, ciphertext: cipherOf(value) };
     }
 
-    async casUpdateSecret(
+    async casWriteSecrets(
       environmentId: string,
-      key: string,
+      guardKey: string,
       expectedCiphertext: string,
-      value: string
+      secrets: Record<string, string>
     ): Promise<boolean> {
       const existing = mockState.environmentSecrets.get(environmentId) ?? {};
-      const current = existing[key];
+      const current = existing[guardKey];
       if (current === undefined || cipherOf(current) !== expectedCiphertext) return false;
-      mockState.environmentSecrets.set(environmentId, { ...existing, [key]: value });
-      return true;
-    }
-
-    async setSecrets(environmentId: string, secrets: Record<string, string>): Promise<void> {
-      mockState.environmentWrites.push({ environmentId, secrets });
-      const existing = mockState.environmentSecrets.get(environmentId) ?? {};
       mockState.environmentSecrets.set(environmentId, { ...existing, ...secrets });
+      mockState.environmentWrites.push({ environmentId, secrets });
+      return true;
     }
   },
 }));

--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -83,6 +83,10 @@ describe("resolveSessionOAuthSecretScope", () => {
         ensureRepoId
       )
     ).resolves.toEqual({ kind: "repo", repoId: 123, repoOwner: "acme", repoName: "web" });
+    // The resolver must see the same canonical identity the scope reports.
+    expect(ensureRepoId).toHaveBeenCalledWith(
+      expect.objectContaining({ repo_owner: "acme", repo_name: "web" })
+    );
   });
 
   it("resolves a complete historical repository target", async () => {

--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -55,15 +55,34 @@ describe("resolveSessionOAuthSecretScope", () => {
     { repo_owner: "acme", repo_name: null, environment_id: "env_1" },
     { repo_owner: "", repo_name: "web" },
     { repo_owner: "acme", repo_name: "" },
-    { repo_owner: "", repo_name: "" },
     { repo_owner: " ", repo_name: "web" },
-  ])("rejects incomplete or empty repository context", async (overrides) => {
+  ])("rejects a partial repository pair", async (overrides) => {
     const ensureRepoId = vi.fn();
 
     await expect(resolveSessionOAuthSecretScope(session(overrides), ensureRepoId)).rejects.toThrow(
       "Session has incomplete repository context"
     );
     expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+
+  it("treats a fully blank repository pair as no repository context", async () => {
+    const ensureRepoId = vi.fn();
+
+    await expect(
+      resolveSessionOAuthSecretScope(session({ repo_owner: "", repo_name: " " }), ensureRepoId)
+    ).resolves.toBeNull();
+    expect(ensureRepoId).not.toHaveBeenCalled();
+  });
+
+  it("normalizes repository identifiers into the scope", async () => {
+    const ensureRepoId = vi.fn().mockResolvedValue(123);
+
+    await expect(
+      resolveSessionOAuthSecretScope(
+        session({ repo_owner: " Acme ", repo_name: "Web" }),
+        ensureRepoId
+      )
+    ).resolves.toEqual({ kind: "repo", repoId: 123, repoOwner: "acme", repoName: "web" });
   });
 
   it("resolves a complete historical repository target", async () => {

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -24,7 +24,13 @@ export async function resolveSessionOAuthSecretScope(
     return { kind: "environment", environmentId: session.environment_id };
   }
   if (pair) {
-    return { kind: "repo", repoId: await ensureRepoId(session), ...pair };
+    // ensureRepoId must resolve the same canonical identity the scope reports.
+    const normalizedSession: SessionRow = {
+      ...session,
+      repo_owner: pair.repoOwner,
+      repo_name: pair.repoName,
+    };
+    return { kind: "repo", repoId: await ensureRepoId(normalizedSession), ...pair };
   }
   return null;
 }

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -1,31 +1,30 @@
+import { normalizeOptionalRepositoryPair } from "@open-inspect/shared/types/repositories";
 import type { OAuthSecretScope } from "../db/scoped-oauth-secrets";
 import type { SecretSource } from "../db/secrets-validation";
 import type { SessionRepositoryEntry } from "./repository-target";
 import type { SessionRow } from "./types";
 
-/** Maps a session target to the secret scope that owns its provider OAuth credentials. */
+/**
+ * Maps a session target to the secret scope that owns its provider OAuth
+ * credentials. Repository identifiers follow the canonical
+ * `normalizeOptionalRepositoryPair` contract: values are trimmed and
+ * lowercased, a fully blank pair counts as absent (global scope), and a
+ * partial pair throws.
+ */
 export async function resolveSessionOAuthSecretScope(
   session: SessionRow,
   ensureRepoId: (session: SessionRow) => Promise<number>
 ): Promise<OAuthSecretScope | null> {
-  const { repo_owner: repoOwner, repo_name: repoName } = session;
-  const hasEmptyRepositoryIdentifier =
-    (repoOwner !== null && repoOwner.trim().length === 0) ||
-    (repoName !== null && repoName.trim().length === 0);
-  if (hasEmptyRepositoryIdentifier || (repoOwner === null) !== (repoName === null)) {
-    throw new Error("Session has incomplete repository context");
-  }
+  const pair = normalizeOptionalRepositoryPair(
+    { repoOwner: session.repo_owner, repoName: session.repo_name },
+    "Session has incomplete repository context"
+  );
 
   if (session.environment_id) {
     return { kind: "environment", environmentId: session.environment_id };
   }
-  if (repoOwner !== null && repoName !== null) {
-    return {
-      kind: "repo",
-      repoId: await ensureRepoId(session),
-      repoOwner,
-      repoName,
-    };
+  if (pair) {
+    return { kind: "repo", repoId: await ensureRepoId(session), ...pair };
   }
   return null;
 }

--- a/packages/control-plane/test/integration/scoped-oauth-secrets.test.ts
+++ b/packages/control-plane/test/integration/scoped-oauth-secrets.test.ts
@@ -100,6 +100,22 @@ describe("ScopedOAuthSecretsStore", () => {
     expect(stored.ciphertext).toBe(row?.encrypted_value);
   });
 
+  it("returns false and writes nothing when the guard row was deleted", async () => {
+    const scope: OAuthSecretScope = { kind: "global" };
+    await store().write(scope, { [REFRESH_KEY]: "rt-old" });
+    const stale = await readGuard(scope);
+    await env.DB.prepare("DELETE FROM global_secrets WHERE key = ?").bind(REFRESH_KEY).run();
+
+    const swapped = await store().casWrite(
+      scope,
+      { key: REFRESH_KEY, expectedCiphertext: stale.ciphertext },
+      { [REFRESH_KEY]: "rt-new", OPENAI_OAUTH_ACCESS_TOKEN: "at-new" }
+    );
+
+    expect(swapped).toBe(false);
+    await expect(store().read(scope)).resolves.toEqual({});
+  });
+
   it("returns null for a missing secret", async () => {
     await expect(
       store().readSecretWithCiphertext({ kind: "global" }, REFRESH_KEY)

--- a/packages/control-plane/test/integration/scoped-oauth-secrets.test.ts
+++ b/packages/control-plane/test/integration/scoped-oauth-secrets.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { ScopedOAuthSecretsStore, type OAuthSecretScope } from "../../src/db/scoped-oauth-secrets";
+import type { StoredSecretValue } from "../../src/db/scoped-secrets";
+import { cleanD1Tables } from "./cleanup";
+
+// base64 of exactly 32 bytes — encryptToken imports the decoded bytes as a raw AES-256 key.
+const ENCRYPTION_KEY = "aW50ZWdyYXRpb24tdGVzdC1rZXktMzItYnl0ZXMhISE=";
+const REFRESH_KEY = "OPENAI_OAUTH_REFRESH_TOKEN";
+
+function store(): ScopedOAuthSecretsStore {
+  return new ScopedOAuthSecretsStore(env.DB, ENCRYPTION_KEY);
+}
+
+async function readGuard(scope: OAuthSecretScope): Promise<StoredSecretValue> {
+  const stored = await store().readSecretWithCiphertext(scope, REFRESH_KEY);
+  if (!stored) throw new Error("expected a stored refresh token");
+  return stored;
+}
+
+const SCOPES: Array<{ name: string; scope: OAuthSecretScope }> = [
+  { name: "global", scope: { kind: "global" } },
+  { name: "repo", scope: { kind: "repo", repoId: 4242, repoOwner: "acme", repoName: "web" } },
+  { name: "environment", scope: { kind: "environment", environmentId: "env-itest" } },
+];
+
+describe("ScopedOAuthSecretsStore", () => {
+  beforeEach(async () => {
+    await cleanD1Tables();
+    // environment_secrets has an FK to environments; the repo scope needs no parent row.
+    await env.DB.prepare(
+      "INSERT INTO environments (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)"
+    )
+      .bind("env-itest", "scoped-oauth-itest", Date.now(), Date.now())
+      .run();
+  });
+
+  describe.each(SCOPES)("$name scope", ({ scope }) => {
+    it("reads a secret together with its stored ciphertext", async () => {
+      await store().write(scope, { [REFRESH_KEY]: "rt-old" });
+
+      const stored = await readGuard(scope);
+
+      expect(stored.value).toBe("rt-old");
+      expect(stored.ciphertext).toBeTruthy();
+      expect(stored.ciphertext).not.toContain("rt-old");
+    });
+
+    it("swaps the guard row and writes companions when the ciphertext matches", async () => {
+      await store().write(scope, { [REFRESH_KEY]: "rt-old" });
+      const stored = await readGuard(scope);
+
+      const swapped = await store().casWrite(
+        scope,
+        { key: REFRESH_KEY, expectedCiphertext: stored.ciphertext },
+        { [REFRESH_KEY]: "rt-new", OPENAI_OAUTH_ACCESS_TOKEN: "at-new" }
+      );
+
+      expect(swapped).toBe(true);
+      await expect(store().read(scope)).resolves.toMatchObject({
+        [REFRESH_KEY]: "rt-new",
+        OPENAI_OAUTH_ACCESS_TOKEN: "at-new",
+      });
+    });
+
+    it("refuses a stale guard and leaves the winner's write intact", async () => {
+      await store().write(scope, { [REFRESH_KEY]: "rt-old" });
+      const stale = await readGuard(scope);
+
+      const winner = await store().casWrite(
+        scope,
+        { key: REFRESH_KEY, expectedCiphertext: stale.ciphertext },
+        { [REFRESH_KEY]: "rt-winner", OPENAI_OAUTH_ACCESS_TOKEN: "at-winner" }
+      );
+      expect(winner).toBe(true);
+
+      const loser = await store().casWrite(
+        scope,
+        { key: REFRESH_KEY, expectedCiphertext: stale.ciphertext },
+        { [REFRESH_KEY]: "rt-loser", OPENAI_OAUTH_ACCESS_TOKEN: "at-loser" }
+      );
+
+      expect(loser).toBe(false);
+      await expect(store().read(scope)).resolves.toMatchObject({
+        [REFRESH_KEY]: "rt-winner",
+        OPENAI_OAUTH_ACCESS_TOKEN: "at-winner",
+      });
+    });
+  });
+
+  it("returns the exact stored ciphertext bytes", async () => {
+    const scope: OAuthSecretScope = { kind: "global" };
+    await store().write(scope, { [REFRESH_KEY]: "rt-bytes" });
+
+    const stored = await readGuard(scope);
+    const row = await env.DB.prepare("SELECT encrypted_value FROM global_secrets WHERE key = ?")
+      .bind(REFRESH_KEY)
+      .first<{ encrypted_value: string }>();
+
+    expect(stored.ciphertext).toBe(row?.encrypted_value);
+  });
+
+  it("returns null for a missing secret", async () => {
+    await expect(
+      store().readSecretWithCiphertext({ kind: "global" }, REFRESH_KEY)
+    ).resolves.toBeNull();
+  });
+
+  it("rejects a casWrite whose secrets omit the guard key", async () => {
+    await expect(
+      store().casWrite(
+        { kind: "global" },
+        { key: REFRESH_KEY, expectedCiphertext: "irrelevant" },
+        { OPENAI_OAUTH_ACCESS_TOKEN: "at-only" }
+      )
+    ).rejects.toThrow("guard key");
+  });
+});


### PR DESCRIPTION
Closes #1379 — all four findings from the #1378 re-land review. These describe the shipped design (the re-land was byte-exact), so this PR is where they get fixed rather than carried.

## 1. CAS persistence for rotated refresh tokens

The broker's persist-with-retry could stale-write: if the first write failed and another isolate rotated and persisted before the retry, the retry overwrote the newer refresh token with the older bundle.

Persistence is now a compare-and-swap in the `UserScmTokenStore.casUpdateTokens()` mold, adapted for the scoped-secrets stores:

- `ScopedOAuthSecretsStore.readSecretWithCiphertext(scope, key)` returns a secret's decrypted value **together with the exact ciphertext it is stored as** — the CAS comparand. Values encrypt non-deterministically, so equality is only meaningful against the stored bytes. The broker reads the refresh token this way, so the value sent upstream and the comparand come from the same row.
- `ScopedOAuthSecretsStore.casWrite(scope, guard, secrets)` swaps the guard row via `UPDATE … WHERE key = ? AND encrypted_value = ?` (per-scope `casUpdateSecret` on the global/repo/environment stores), then upserts the companion rows (access token, expiry, account id). **Guard row first**: a failure between the two writes can never leave an older refresh token over a newer one — the worst case is a stale cached access token, which ages out and self-heals on the next refresh.
- On CAS conflict the broker keeps the token it just minted (still valid) and skips persisting entirely, leaving the winner's refresh token authoritative. No polling needed — the conflict itself proves the winner already persisted.

The existing retry loop is preserved and is now safe: every attempt is guarded, so a retry can no longer clobber a concurrent rotation.

## 2. Route HTTP 400 `invalid_grant` / `refresh_token_reused` through recovery

`refreshScopes` recovered only from 401, but OpenAI reports consumed refresh tokens as **400** with an OAuth error code — those surfaced as 502 instead of entering the concurrent-rotation poll. New `isOpenAIRefreshTokenRejected()` (401, or 400 with a standard-form `{"error": "invalid_grant" | "refresh_token_reused"}` body, parsed with zod) replaces both status checks — the initial rejection and the in-poll retry. A 400 with any other error code still fails as an upstream error.

## 3. Canonical repository-pair parsing

`resolveSessionOAuthSecretScope` had grown a second parser with different semantics from shared's `normalizeOptionalRepositoryPair` (whitespace inspected but untrimmed/case-preserving values returned; blank pair rejected instead of mapped to null). It now builds the repo scope from the canonical helper: identifiers are trimmed and lowercased, a fully blank pair counts as absent (global fallback), and a partial pair still throws with the same message. This is shared by the OpenAI **and** xAI refresh paths, which both resolve scopes through this function.

## 4. Broker tests co-located

The 16 tests that instantiated `OpenAITokenBroker` directly move out of the session-service suite into a new `auth/openai-token-broker.test.ts`; the session suite keeps only session-to-scope resolution and delegation. The store mocks model ciphertext deterministically (`cipher:<plaintext>`), so the CAS mocks conflict exactly when the stored value changed.

## New coverage

- Broker: CAS conflict returns the fresh token without persisting and leaves the winner intact; companion-write failure after the guard swap keeps the fresh token and the new refresh token; 400 `invalid_grant` recovers via the concurrent rotation's cached token; 400 `refresh_token_reused` retries the rotated token; 400 with an unrelated code fails as upstream.
- `isOpenAIRefreshTokenRejected`: 6 predicate cases (401, both 400 codes, unrelated code, non-JSON body, non-400/401 status).
- Scope resolution: blank-pair-to-global and normalization cases.
- **Integration (real D1, workerd)**: new `test/integration/scoped-oauth-secrets.test.ts` exercises `readSecretWithCiphertext`/`casWrite` per scope (global/repo/environment): guard swap + companion write, stale-guard refusal leaving the winner's write intact, exact ciphertext round-trip against the raw `encrypted_value` column, and the missing-guard-key rejection.

Two pre-existing test fixtures returned refresh responses without `refresh_token` — a shape the real `refreshOpenAIToken` zod contract forbids; the old code silently wrote `undefined` into the store, the new guard refuses. The fixtures now honor the contract.

## Notes

- The xAI refresh service still uses plain `write()` for its rotation; it has the same theoretical race. Kept out of scope here per #1379, and worth a small follow-up now that `casWrite` exists.
- No wire, route, or schema changes; control-plane only.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` (prod + test configs) clean
- Unit: 2446 passed (was 2433)
- Integration (workerd + real D1): 776 passed across 65 files (was 764), including the new scoped-oauth-secrets suite
- eslint + prettier clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI token refresh handling for invalid, reused, and provider-rejected refresh tokens.
  * Prevented concurrent credential rotations from overwriting one another.
  * Added retry handling for token persistence conflicts.
  * Improved conditional updates for repository, environment, and global credentials.
  * Normalized repository identifiers and handled blank or incomplete repository context more reliably.

* **Tests**
  * Expanded coverage for token refresh errors, concurrency, retries, encryption, and scoped credential storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->