### PR TITLE
fix(sandbox-runtime): scope post-compaction message acceptance to the active prompt

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -88,8 +88,8 @@ class _PromptState:
     pending_parts_total: int = 0
     pending_drop_logged: bool = False
     child_activity: ChildActivityCorrelator = field(default_factory=ChildActivityCorrelator)
-    # Compaction tracking: after compaction, parentID changes so we must
-    # accept all non-summary assistant messages from the parent session
+    # Compaction tracking: after compaction, parentID changes so acceptance
+    # falls back to non-summary assistant messages created after this prompt
     compaction_occurred: bool = False
     correlated_compaction_summary_ids: set[str] = field(default_factory=set)
     emitted_error_messages: set[str] = field(default_factory=set)
@@ -405,7 +405,10 @@ class OpenCodePromptStream:
                 belongs_to_prompt = (
                     parent_matches
                     or oc_msg_id in state.correlated_compaction_summary_ids
-                    or (state.compaction_occurred and not is_compaction_summary)
+                    or (
+                        not is_compaction_summary
+                        and self._compaction_fallback_accepts(state, oc_msg_id)
+                    )
                 )
                 if belongs_to_prompt and info.get("error"):
                     error_event = self._parent_error_event_once(state, info["error"])
@@ -418,11 +421,14 @@ class OpenCodePromptStream:
                         events.append(error_event)
 
                 # Accept if: parentID matches our message, OR compaction
-                # happened — but never the compaction summary itself, whose
-                # text is internal context, not assistant output. Its parentID
-                # is the compaction user message, so parentID alone cannot
-                # exclude it.
-                if not is_compaction_summary and (parent_matches or state.compaction_occurred):
+                # happened and the message postdates this prompt — but never
+                # the compaction summary itself, whose text is internal
+                # context, not assistant output. Its parentID is the
+                # compaction user message, so parentID alone cannot exclude
+                # it.
+                if not is_compaction_summary and (
+                    parent_matches or self._compaction_fallback_accepts(state, oc_msg_id)
+                ):
                     state.allowed_assistant_msg_ids.add(oc_msg_id)
                     events.extend(self._drain_pending_parts(state, oc_msg_id, is_subtask=False))
 
@@ -449,6 +455,21 @@ class OpenCodePromptStream:
                 return self._drain_pending_parts(state, oc_msg_id, is_subtask=True)
 
         return []
+
+    @staticmethod
+    def _compaction_fallback_accepts(state: _PromptState, oc_msg_id: str) -> bool:
+        """Whether the post-compaction fallback may claim an assistant message.
+
+        Compaction rewrites the message chain, so parentID correlation stops
+        matching and acceptance falls back to unparented assistant messages.
+        OpenCode also reports the session's full history (over SSE and from
+        the message-list API), so the fallback must be scoped to messages
+        created during this prompt or prior turns' output would be replayed
+        as current output. Ascending OpenCode IDs order by creation time,
+        making an ID comparison against this prompt's user message exactly
+        that scope.
+        """
+        return state.compaction_occurred and oc_msg_id > state.opencode_message_id
 
     def _on_part_updated(self, state: _PromptState, props: dict[str, Any]) -> list[dict[str, Any]]:
         """Forward parts of authorized messages; buffer parts that arrive early."""
@@ -929,8 +950,12 @@ class OpenCodePromptStream:
         Accepts an assistant message when its parentID matches one of the
         prompt's user message IDs, when it was already authorized during SSE
         streaming, or after compaction, which rewrites the message chain.
-        The compaction summary itself is never accepted: its text is internal
-        context, and its parentID (the compaction user message) matches.
+        The compaction fallback is limited to messages created after this
+        prompt's user message: the API returns the whole session history, and
+        re-emitting prior turns' text here would overwrite this prompt's
+        final output with stale messages. The compaction summary itself is
+        never accepted: its text is internal context, and its parentID (the
+        compaction user message) matches.
         """
         if not state.opencode_session_id:
             return
@@ -954,10 +979,13 @@ class OpenCodePromptStream:
                 is_compaction_summary = info.get("summary") is True
 
                 # Accept if: parentID matches, was tracked during SSE, or
-                # compaction occurred — but never the compaction summary
-                # itself; its parentID (the compaction user message) matches.
+                # compaction occurred and the message postdates this prompt —
+                # never the compaction summary itself; its parentID (the
+                # compaction user message) matches.
                 should_accept = not is_compaction_summary and (
-                    parent_matches or in_tracked_set or state.compaction_occurred
+                    parent_matches
+                    or in_tracked_set
+                    or self._compaction_fallback_accepts(state, msg_id)
                 )
                 if not should_accept:
                     continue

--- a/packages/sandbox-runtime/tests/conftest.py
+++ b/packages/sandbox-runtime/tests/conftest.py
@@ -71,3 +71,16 @@ class MockResponse:
                 request=httpx.Request("GET", "http://test"),
                 response=httpx.Response(self.status_code),
             )
+
+
+def oc_message_id(timestamp_ms: int, counter: int, suffix: str = "a") -> str:
+    """Build a valid OpenCode ascending message ID at a chosen creation point.
+
+    Mirrors OpenCodeIdentifier's format: ``msg_`` + 12 hex chars encoding
+    ``timestamp_ms * 0x1000 + counter`` + 14 base62 chars. Deterministic
+    inputs let boundary tests place IDs immediately before, at, or after a
+    prompt's user message instead of relying on ad-hoc strings that happen
+    to compare in the desired order.
+    """
+    encoded = (timestamp_ms * 0x1000 + counter) & 0xFFFFFFFFFFFF
+    return "msg_" + encoded.to_bytes(6, byteorder="big").hex() + (suffix * 14)[:14]

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -1064,6 +1064,70 @@ class TestFetchFinalMessageState:
         assert len(events) == 1
         assert events[0]["content"] == "Assistant response"
 
+    @pytest.mark.asyncio
+    async def test_compaction_fallback_skips_prior_prompt_messages(
+        self, bridge_with_mock_client: AgentBridge
+    ):
+        """After compaction the API's full-history response must not replay
+        prior turns' text: their parts were never streamed this prompt, so
+        every one of them reads as "longer than sent" and the last re-emitted
+        part would overwrite this prompt's final output. Only messages created
+        after this prompt's user message are eligible."""
+        bridge = bridge_with_mock_client
+
+        all_messages = [
+            {
+                "info": {
+                    "id": "msg_0001prior1",
+                    "role": "assistant",
+                    "parentID": "msg_0001prior0",
+                },
+                "parts": [{"id": "part-prior", "type": "text", "text": "Prior turn final report"}],
+            },
+            {
+                "info": {
+                    "id": "msg_0003summary",
+                    "role": "assistant",
+                    "parentID": "msg_0003compaction",
+                    "summary": True,
+                },
+                "parts": [{"id": "part-summary", "type": "text", "text": "Internal summary"}],
+            },
+            {
+                "info": {
+                    "id": "msg_0004continue",
+                    "role": "assistant",
+                    "parentID": "msg_0004synthetic",
+                },
+                "parts": [
+                    {
+                        "id": "part-continue",
+                        "type": "text",
+                        "text": "Final answer after compaction",
+                    }
+                ],
+            },
+        ]
+
+        bridge.http_client.get = AsyncMock(return_value=MockResponse(200, all_messages))
+
+        # The continuation's text was partially streamed before idle.
+        cumulative_text = {"part-continue": "Final answer"}
+
+        events = []
+        state = make_prompt_state(
+            "cp-msg-1",
+            "msg_0002prompt",
+            cumulative_text=cumulative_text,
+            compaction_occurred=True,
+        )
+        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0]["content"] == "Final answer after compaction"
+        assert events[0]["messageId"] == "cp-msg-1"
+
 
 class TestExtractErrorMessage:
     """Tests for _extract_error_message static method."""

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -26,7 +26,7 @@ from sandbox_runtime.prompt_stream import (
     OpenCodePromptStream,
     _PromptState,
 )
-from tests.conftest import MockResponse, wire_opencode_transport
+from tests.conftest import MockResponse, oc_message_id, wire_opencode_transport
 
 MOCK_HTTP_TIMEOUT_SECONDS = 30.0
 PROMPT_TIMEOUT_TEST_BUDGET_SECONDS = 0.8
@@ -1075,29 +1075,38 @@ class TestFetchFinalMessageState:
         after this prompt's user message are eligible."""
         bridge = bridge_with_mock_client
 
+        prompt_ts_ms = 1_754_000_000_000
+        prompt_user_id = oc_message_id(prompt_ts_ms, 2, "p")
+        prior_assistant_id = oc_message_id(prompt_ts_ms - 60_000, 1, "a")
+        prior_user_id = oc_message_id(prompt_ts_ms - 61_000, 1, "u")
+        compaction_user_id = oc_message_id(prompt_ts_ms + 900, 1, "w")
+        summary_id = oc_message_id(prompt_ts_ms + 1_000, 1, "s")
+        continue_user_id = oc_message_id(prompt_ts_ms + 1_500, 1, "v")
+        continuation_id = oc_message_id(prompt_ts_ms + 2_000, 1, "c")
+
         all_messages = [
             {
                 "info": {
-                    "id": "msg_0001prior1",
+                    "id": prior_assistant_id,
                     "role": "assistant",
-                    "parentID": "msg_0001prior0",
+                    "parentID": prior_user_id,
                 },
                 "parts": [{"id": "part-prior", "type": "text", "text": "Prior turn final report"}],
             },
             {
                 "info": {
-                    "id": "msg_0003summary",
+                    "id": summary_id,
                     "role": "assistant",
-                    "parentID": "msg_0003compaction",
+                    "parentID": compaction_user_id,
                     "summary": True,
                 },
                 "parts": [{"id": "part-summary", "type": "text", "text": "Internal summary"}],
             },
             {
                 "info": {
-                    "id": "msg_0004continue",
+                    "id": continuation_id,
                     "role": "assistant",
-                    "parentID": "msg_0004synthetic",
+                    "parentID": continue_user_id,
                 },
                 "parts": [
                     {
@@ -1117,7 +1126,7 @@ class TestFetchFinalMessageState:
         events = []
         state = make_prompt_state(
             "cp-msg-1",
-            "msg_0002prompt",
+            prompt_user_id,
             cumulative_text=cumulative_text,
             compaction_occurred=True,
         )

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -644,6 +644,115 @@ class TestApplySseEventDispositions:
         assert state.pending_overflow_error == "parent overflow"
         assert step.events == []
 
+    def test_post_compaction_prior_prompt_message_is_not_accepted(self):
+        """The compaction fallback must not claim messages that predate the
+        prompt (IDs below the prompt's user message): forwarding them would
+        replay prior turns' text as current output."""
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-prior",
+                        "sessionID": PARENT_SESSION_ID,
+                        "messageID": "msg_a-prior-turn",
+                        "text": "Stale text from an earlier turn",
+                    }
+                },
+            ),
+        )
+        stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
+
+        step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg_a-prior-turn",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg_a-prior-user",
+                    }
+                },
+            ),
+        )
+
+        assert "msg_a-prior-turn" not in state.allowed_assistant_msg_ids
+        assert "msg_a-prior-turn" in state.pending_parts
+        assert step.events == []
+
+    def test_post_compaction_later_message_is_accepted(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
+
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg_x-continuation",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg_x-continue-user",
+                    }
+                },
+            ),
+        )
+        step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-continuation",
+                        "sessionID": PARENT_SESSION_ID,
+                        "messageID": "msg_x-continuation",
+                        "text": "Continuing after compaction",
+                    }
+                },
+            ),
+        )
+
+        assert "msg_x-continuation" in state.allowed_assistant_msg_ids
+        assert step.events == [
+            {
+                "type": "token",
+                "content": "Continuing after compaction",
+                "messageId": "cp-msg-1",
+            }
+        ]
+
+    def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
+
+        step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg_a-prior-turn",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg_a-prior-user",
+                        "error": {"name": "SomeError", "data": {"message": "Old failure"}},
+                    }
+                },
+            ),
+        )
+
+        assert step.events == []
+
     def test_session_created_tracks_direct_children_only(self):
         state = make_state()
         stream = make_stream()

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -12,14 +12,21 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.constants import MAX_SNAPSHOT_RESERVE_SECONDS
+from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
 from sandbox_runtime.prompt_stream import (
     OpenCodePromptStream,
     _Disposition,
     _PromptState,
 )
+from tests.conftest import oc_message_id
 
 PARENT_SESSION_ID = "oc-session-123"
 CHILD_SESSION_ID = "oc-child-456"
+
+# Anchor for ID-boundary tests: the prompt's user message sits at a fixed
+# (timestamp, counter) so neighbouring IDs can be placed exactly around it.
+PROMPT_TS_MS = 1_754_000_000_000
+PROMPT_MESSAGE_ID = oc_message_id(PROMPT_TS_MS, 2, "p")
 
 
 def make_stream() -> OpenCodePromptStream:
@@ -33,19 +40,30 @@ def make_stream() -> OpenCodePromptStream:
     )
 
 
-def make_state() -> _PromptState:
+def make_state(opencode_message_id: str = "msg_test") -> _PromptState:
     state = _PromptState(
         opencode_session_id=PARENT_SESSION_ID,
         message_id="cp-msg-1",
-        opencode_message_id="msg_test",
+        opencode_message_id=opencode_message_id,
         start_time=time.time(),
     )
-    state.user_message_ids.add("msg_test")
+    state.user_message_ids.add(opencode_message_id)
     return state
 
 
 def sse(event_type: str, properties: dict) -> dict:
     return {"type": event_type, "properties": properties}
+
+
+def test_oc_message_id_matches_real_generator_format():
+    """The fixture helper must reproduce OpenCodeIdentifier's encoding, so
+    boundary tests exercise the real ID contract rather than ad-hoc strings."""
+    real = OpenCodeIdentifier.ascending("message")
+    encoded = int(real[4:16], 16)
+    rebuilt = oc_message_id(encoded // 0x1000, encoded % 0x1000)
+
+    assert rebuilt[:16] == real[:16]
+    assert len(rebuilt) == len(real)
 
 
 class TestApplySseEventDispositions:
@@ -648,8 +666,10 @@ class TestApplySseEventDispositions:
         """The compaction fallback must not claim messages that predate the
         prompt (IDs below the prompt's user message): forwarding them would
         replay prior turns' text as current output."""
+        prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")
+        prior_user_id = oc_message_id(PROMPT_TS_MS - 61_000, 1, "u")
         stream = make_stream()
-        state = make_state()
+        state = make_state(PROMPT_MESSAGE_ID)
         stream._apply_sse_event(
             state,
             sse(
@@ -659,7 +679,7 @@ class TestApplySseEventDispositions:
                         "type": "text",
                         "id": "part-prior",
                         "sessionID": PARENT_SESSION_ID,
-                        "messageID": "msg_a-prior-turn",
+                        "messageID": prior_assistant_id,
                         "text": "Stale text from an earlier turn",
                     }
                 },
@@ -673,22 +693,24 @@ class TestApplySseEventDispositions:
                 "message.updated",
                 {
                     "info": {
-                        "id": "msg_a-prior-turn",
+                        "id": prior_assistant_id,
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
-                        "parentID": "msg_a-prior-user",
+                        "parentID": prior_user_id,
                     }
                 },
             ),
         )
 
-        assert "msg_a-prior-turn" not in state.allowed_assistant_msg_ids
-        assert "msg_a-prior-turn" in state.pending_parts
+        assert prior_assistant_id not in state.allowed_assistant_msg_ids
+        assert prior_assistant_id in state.pending_parts
         assert step.events == []
 
     def test_post_compaction_later_message_is_accepted(self):
+        continuation_id = oc_message_id(PROMPT_TS_MS + 5_000, 1, "r")
+        continue_user_id = oc_message_id(PROMPT_TS_MS + 4_000, 1, "v")
         stream = make_stream()
-        state = make_state()
+        state = make_state(PROMPT_MESSAGE_ID)
         stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
 
         stream._apply_sse_event(
@@ -697,10 +719,10 @@ class TestApplySseEventDispositions:
                 "message.updated",
                 {
                     "info": {
-                        "id": "msg_x-continuation",
+                        "id": continuation_id,
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
-                        "parentID": "msg_x-continue-user",
+                        "parentID": continue_user_id,
                     }
                 },
             ),
@@ -714,14 +736,14 @@ class TestApplySseEventDispositions:
                         "type": "text",
                         "id": "part-continuation",
                         "sessionID": PARENT_SESSION_ID,
-                        "messageID": "msg_x-continuation",
+                        "messageID": continuation_id,
                         "text": "Continuing after compaction",
                     }
                 },
             ),
         )
 
-        assert "msg_x-continuation" in state.allowed_assistant_msg_ids
+        assert continuation_id in state.allowed_assistant_msg_ids
         assert step.events == [
             {
                 "type": "token",
@@ -730,9 +752,39 @@ class TestApplySseEventDispositions:
             }
         ]
 
-    def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
+    def test_post_compaction_same_timestamp_counter_boundary(self):
+        """Within one millisecond the encoded counter decides ordering: an
+        assistant ID one counter tick below the prompt's user message is
+        rejected, one tick above is accepted."""
+        same_ms_below_id = oc_message_id(PROMPT_TS_MS, 1, "s")
+        same_ms_above_id = oc_message_id(PROMPT_TS_MS, 3, "t")
         stream = make_stream()
-        state = make_state()
+        state = make_state(PROMPT_MESSAGE_ID)
+        stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
+
+        for oc_msg_id in (same_ms_below_id, same_ms_above_id):
+            stream._apply_sse_event(
+                state,
+                sse(
+                    "message.updated",
+                    {
+                        "info": {
+                            "id": oc_msg_id,
+                            "role": "assistant",
+                            "sessionID": PARENT_SESSION_ID,
+                            "parentID": oc_message_id(PROMPT_TS_MS, 0, "w"),
+                        }
+                    },
+                ),
+            )
+
+        assert same_ms_below_id not in state.allowed_assistant_msg_ids
+        assert same_ms_above_id in state.allowed_assistant_msg_ids
+
+    def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
+        prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")
+        stream = make_stream()
+        state = make_state(PROMPT_MESSAGE_ID)
         stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
 
         step = stream._apply_sse_event(
@@ -741,10 +793,10 @@ class TestApplySseEventDispositions:
                 "message.updated",
                 {
                     "info": {
-                        "id": "msg_a-prior-turn",
+                        "id": prior_assistant_id,
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
-                        "parentID": "msg_a-prior-user",
+                        "parentID": oc_message_id(PROMPT_TS_MS - 61_000, 1, "u"),
                         "error": {"name": "SomeError", "data": {"message": "Old failure"}},
                     }
                 },


### PR DESCRIPTION
## Summary

After a context compaction, the session timeline could end a turn by displaying a **repeat of an earlier turn's final message** instead of the turn's real closing message. The timeline rendered exactly what was persisted — the corruption happened in the bridge.

## Root cause

When `session.compacted` fires, the bridge sets `compaction_occurred` and falls back to accepting assistant messages whose `parentID` no longer matches (compaction rewrites the message chain). That fallback was unscoped: it matched **every** non-summary assistant message in the OpenCode session, including messages from **previous turns**.

The visible damage comes from `_fetch_final_message_state`, which runs at idle (and on the timeout/disconnect paths) against `GET /session/:id/message` — the **full session history**. Prior turns' text parts were never streamed during the current prompt, so every one of them reads as "longer than sent" (`previously_sent = ""`) and gets re-emitted as a `token` event bound to the **current** control-plane message ID. The control plane upserts tokens into one row per segment, so the last re-emitted part — an old turn's text — overwrites the current turn's final output right before `execution_complete`.

Observed in production: a compaction turn ended by displaying a verbatim copy of an earlier turn's review report (timestamped at completion), while the turn's real final message was never shown. The same over-broad predicate also existed on the live SSE path (`_on_message_updated`), where it could authorize any old assistant message OpenCode re-touches after compaction.

## Fix

Scope the compaction fallback to messages created during this prompt. OpenCode message IDs are ascending (12 hex chars of `timestamp_ms * 0x1000 + counter`, fixed length — lexicographic order is creation order), and the bridge already generates its user-message ID with the same scheme and relies on this ordering (`stream_prompt` docstring). The new `_compaction_fallback_accepts` requires:

```
compaction_occurred and oc_msg_id > state.opencode_message_id
```

Applied in both `_fetch_final_message_state` and the `_on_message_updated` acceptance/error paths. Post-compaction continuations (created after the prompt's user message) still pass; prior turns' messages never do.

## Notes

- Verified against OpenCode v1.18.11 source: `Session.messages` returns full history (newest-first for ≤50 messages), the compaction summary is `summary: true` with `parentID` = the compaction user message, and `Identifier.create` makes ascending IDs lexicographically time-ordered.
- Turns already affected in stored timelines keep their overwritten text; the real final text was never persisted by the control plane.

## Verification

- `uv run --extra dev pytest tests/` — 723 passed
- New tests fail against the unfixed code (verified via stash) and pass with the fix:
  - `test_post_compaction_prior_prompt_message_is_not_accepted`
  - `test_post_compaction_error_on_prior_prompt_message_is_ignored`
  - `test_post_compaction_later_message_is_accepted`
  - `test_compaction_fallback_skips_prior_prompt_messages` (models the incident: history replay must not clobber the continuation's backfill)
- `uv run --extra dev ruff check` / `ruff format --check` — clean
- `uv run --extra dev mypy src/sandbox_runtime/prompt_stream.py` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented previous-session assistant responses from being replayed after conversation compaction.
  * Ensured only messages created after the current prompt are accepted during recovery and streaming.
  * Improved handling of older-message errors so they do not interrupt current output.
  * Ensured continuation responses are streamed correctly, including messages sharing the same timestamp.

* **Tests**
  * Added coverage for post-compaction message filtering, continuation output, message ordering, and final-message recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->