### PR TITLE
Validate sessions before WebSocket upgrades

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -43,6 +43,7 @@ const QUERY_PATTERNS = {
   SELECT_PR_SUMMARIES: /FROM session_pull_requests WHERE session_id IN/,
   DELETE_SESSION_REPOS: /^DELETE FROM session_repositories WHERE session_id = \?$/,
   SELECT_BY_ID: /^SELECT \* FROM sessions WHERE id = \?$/,
+  SELECT_EXISTS: /^SELECT 1 AS ok FROM sessions WHERE id = \?$/,
   SELECT_COUNT: /^SELECT COUNT\(\*\) as count FROM sessions\b/,
   SELECT_LIST: /^SELECT \* FROM sessions\b.*ORDER BY updated_at DESC LIMIT/,
   UPDATE_STATUS: /^UPDATE sessions SET status = \?/,
@@ -87,6 +88,11 @@ class FakeD1Database {
     if (QUERY_PATTERNS.SELECT_BY_ID.test(normalized)) {
       const id = args[0] as string;
       return this.rows.get(id) ?? null;
+    }
+
+    if (QUERY_PATTERNS.SELECT_EXISTS.test(normalized)) {
+      const id = args[0] as string;
+      return this.rows.has(id) ? { ok: 1 } : null;
     }
 
     if (QUERY_PATTERNS.SELECT_COUNT.test(normalized)) {
@@ -576,6 +582,15 @@ describe("SessionIndexStore", () => {
     it("returns null when not found", async () => {
       const result = await store.get("nonexistent");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("exists", () => {
+    it("returns whether the session exists without loading it", async () => {
+      await store.create(makeSession());
+
+      await expect(store.exists("test-id")).resolves.toBe(true);
+      await expect(store.exists("nonexistent")).resolves.toBe(false);
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -218,6 +218,14 @@ function normalizeSessionRepository(session: SessionEntry): {
 export class SessionIndexStore {
   constructor(private readonly db: SqlDatabase) {}
 
+  async exists(id: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("SELECT 1 AS ok FROM sessions WHERE id = ?")
+      .bind(id)
+      .first<{ ok: number }>();
+    return result !== null;
+  }
+
   async create(session: SessionEntry): Promise<void> {
     const repository = normalizeSessionRepository(session);
 

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -9,6 +9,9 @@ import { createLogger } from "./logger";
 import type { Env } from "./types";
 import { consumeImageBuildFinalizations } from "./image-builds/finalization-consumer";
 import { IMAGE_BUILD_SCHEDULER_CRON, runImageBuildScheduler } from "./image-builds/scheduler";
+import { createRequestMetrics, instrumentD1, type RequestMetrics } from "./db/instrumented-d1";
+import { SessionIndexStore } from "./db/session-index";
+import type { SqlDatabase } from "./db/sql-database";
 
 const logger = createLogger("worker");
 
@@ -26,7 +29,10 @@ export default {
     // WebSocket upgrade for session
     const upgradeHeader = request.headers.get("Upgrade");
     if (upgradeHeader?.toLowerCase() === "websocket") {
-      return handleWebSocket(request, env, url);
+      const metrics = createRequestMetrics();
+      // eslint-disable-next-line no-restricted-syntax -- composition root: construct the request-scoped database adapter
+      const db = instrumentD1(env.DB, metrics);
+      return handleWebSocket(request, env, url, db, metrics);
     }
 
     // Regular API request — logged by the router with requestId and timing
@@ -69,7 +75,13 @@ export default {
 /**
  * Handle WebSocket connections.
  */
-async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Response> {
+async function handleWebSocket(
+  request: Request,
+  env: Env,
+  url: URL,
+  db: SqlDatabase,
+  metrics: RequestMetrics
+): Promise<Response> {
   // Extract session ID from path: /sessions/:id/ws
   const match = url.pathname.match(/^\/sessions\/([^/]+)\/ws$/);
 
@@ -79,15 +91,12 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
   }
 
   const sessionId = match[1];
-  // eslint-disable-next-line no-restricted-syntax -- composition root: reject invalid upgrades before allocating a session DO
-  const session = await env.DB.prepare("SELECT 1 FROM sessions WHERE id = ?")
-    .bind(sessionId)
-    .first();
-  if (!session) {
+  if (!(await new SessionIndexStore(db).exists(sessionId))) {
     logger.warn("WebSocket session not found", {
       event: "ws.session_not_found",
       http_path: url.pathname,
       session_id: sessionId,
+      ...metrics.summarize(),
     });
     return new Response("Session not found", { status: 404 });
   }
@@ -96,6 +105,7 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
     event: "ws.connect",
     http_path: url.pathname,
     session_id: sessionId,
+    ...metrics.summarize(),
   });
 
   // Get Durable Object and forward WebSocket

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -79,6 +79,19 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
   }
 
   const sessionId = match[1];
+  // eslint-disable-next-line no-restricted-syntax -- composition root: reject invalid upgrades before allocating a session DO
+  const session = await env.DB.prepare("SELECT 1 FROM sessions WHERE id = ?")
+    .bind(sessionId)
+    .first();
+  if (!session) {
+    logger.warn("WebSocket session not found", {
+      event: "ws.session_not_found",
+      http_path: url.pathname,
+      session_id: sessionId,
+    });
+    return new Response("Session not found", { status: 404 });
+  }
+
   logger.info("WebSocket upgrade", {
     event: "ws.connect",
     http_path: url.pathname,

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -5,6 +5,7 @@ import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
 import {
   initNamedSession,
+  initNamedSessionDO,
   seedSandboxAuth,
   queryDO,
   seedEvents,
@@ -27,7 +28,7 @@ describe("Child session operations (list, get, cancel)", () => {
     const childName = `child-ops-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
 
     // Create parent DO
-    const { stub: parentStub } = await initNamedSession(pName, {
+    const { stub: parentStub } = await initNamedSessionDO(pName, {
       repoOwner: "acme",
       repoName: "web-app",
       userId: "user-1",
@@ -53,7 +54,7 @@ describe("Child session operations (list, get, cancel)", () => {
     });
 
     // Create child DO
-    const { stub: childStub } = await initNamedSession(childName, {
+    const { stub: childStub } = await initNamedSessionDO(childName, {
       repoOwner: "acme",
       repoName: "web-app",
       userId: "user-1",
@@ -107,7 +108,7 @@ describe("Child session operations (list, get, cancel)", () => {
     prefix: string
   ): Promise<string> {
     const id = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    await initNamedSession(id, { repoOwner: "acme", repoName: "web-app" });
+    await initNamedSessionDO(id, { repoOwner: "acme", repoName: "web-app" });
     const now = Date.now();
     await store.create({
       id,
@@ -245,7 +246,7 @@ describe("Child session operations (list, get, cancel)", () => {
 
       // Create a different "parent" session with sandbox auth
       const fakeName = `fake-parent-${Date.now()}`;
-      const { stub: fakeStub } = await initNamedSession(fakeName, {
+      const { stub: fakeStub } = await initNamedSessionDO(fakeName, {
         repoOwner: "acme",
         repoName: "web-app",
       });
@@ -458,7 +459,7 @@ describe("Child session operations (list, get, cancel)", () => {
 
       // Create a different parent with sandbox auth
       const fakeName = `fake-cancel-${Date.now()}`;
-      const { stub: fakeStub } = await initNamedSession(fakeName, {
+      const { stub: fakeStub } = await initNamedSessionDO(fakeName, {
         repoOwner: "acme",
         repoName: "web-app",
       });
@@ -722,7 +723,7 @@ describe("Child session operations (list, get, cancel)", () => {
     it("returns 404 without touching a child owned by another parent", async () => {
       const { childName, childStub } = await setupParentAndChild();
       const fakeName = `fake-prompt-${Date.now()}`;
-      const { stub: fakeStub } = await initNamedSession(fakeName);
+      const { stub: fakeStub } = await initNamedSessionDO(fakeName);
       const fakeToken = `sb-tok-fake-prompt-${Date.now()}`;
       await seedSandboxAuth(fakeStub, { authToken: fakeToken, sandboxId: "sb-fake-prompt" });
       const store = new SessionIndexStore(env.DB);
@@ -765,7 +766,7 @@ describe("Child session operations (list, get, cancel)", () => {
   describe("POST /internal/child-session-update", () => {
     it("broadcasts child_session_update to authenticated clients", async () => {
       const pName = parentName();
-      await initNamedSession(pName, { repoOwner: "acme", repoName: "web-app" });
+      await initNamedSessionDO(pName, { repoOwner: "acme", repoName: "web-app" });
 
       // Seed D1 row so WS token generation works
       const store = new SessionIndexStore(env.DB);

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -4,6 +4,7 @@ import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import type { SessionDO } from "../../src/session/durable-object";
 import { hashToken } from "../../src/auth/crypto";
+import { SessionIndexStore } from "../../src/db/session-index";
 
 const DEFAULT_WAIT_FOR_SANDBOX_STATUS_TIMEOUT_MS = 3000;
 const TEST_BROWSER_USER_ID = "11111111111111111111111111111111";
@@ -266,6 +267,25 @@ export async function seedMessage(
 // WebSocket test helpers
 // ---------------------------------------------------------------------------
 
+async function ensureSessionIndexed(sessionName: string): Promise<void> {
+  const sessionStore = new SessionIndexStore(env.DB);
+  if (await sessionStore.get(sessionName)) return;
+
+  const now = Date.now();
+  await sessionStore.create({
+    id: sessionName,
+    title: null,
+    repoOwner: null,
+    repoName: null,
+    model: "anthropic/claude-haiku-4-5",
+    reasoningEffort: null,
+    baseBranch: null,
+    status: "created",
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
 /**
  * Create a session using idFromName() so the worker's /sessions/:name/ws
  * route can locate the DO via the same name. Returns stub + sessionName.
@@ -346,6 +366,8 @@ export async function openClientWs(
   sessionName: string,
   opts?: { subscribe?: boolean; userId?: string; canonicalUserId?: string }
 ) {
+  await ensureSessionIndexed(sessionName);
+
   const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws`, {
     headers: { Upgrade: "websocket" },
   });
@@ -401,6 +423,7 @@ export async function openSandboxWs(
   sessionName: string,
   opts: { authToken: string; sandboxId: string }
 ) {
+  await ensureSessionIndexed(sessionName);
   const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws?type=sandbox`, {
     headers: {
       Upgrade: "websocket",

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -13,6 +13,12 @@ const TEST_BROWSER_PROVIDER_SUBJECT = "583231";
 const TEST_BROWSER_SESSION_ID = "test-browser-session";
 const TEST_BROWSER_SESSION_TOKEN = "test-browser-session-token";
 const TEST_BROWSER_SESSION_COOKIE = "__Secure-openinspect.session_token";
+const TEST_NAMED_SESSION_DEFAULTS = {
+  repoOwner: "acme",
+  repoName: "web-app",
+  repoId: 12345,
+  userId: "user-1",
+} as const;
 
 async function signCookieValue(value: string, secret: string): Promise<string> {
   const key = await crypto.subtle.importKey(
@@ -267,28 +273,8 @@ export async function seedMessage(
 // WebSocket test helpers
 // ---------------------------------------------------------------------------
 
-async function ensureSessionIndexed(sessionName: string): Promise<void> {
-  const sessionStore = new SessionIndexStore(env.DB);
-  if (await sessionStore.get(sessionName)) return;
-
-  const now = Date.now();
-  await sessionStore.create({
-    id: sessionName,
-    title: null,
-    repoOwner: null,
-    repoName: null,
-    model: "anthropic/claude-haiku-4-5",
-    reasoningEffort: null,
-    baseBranch: null,
-    status: "created",
-    createdAt: now,
-    updatedAt: now,
-  });
-}
-
 /**
- * Create a session using idFromName() so the worker's /sessions/:name/ws
- * route can locate the DO via the same name. Returns stub + sessionName.
+ * Create a production-shaped named session: D1 index first, then the session DO.
  */
 export async function initNamedSession(
   sessionName: string,
@@ -310,25 +296,45 @@ export async function initNamedSession(
     canonicalUserId?: string;
     scmLogin?: string;
     parentSessionId?: string;
-    spawnSource?: string;
+    spawnSource?: "user" | "agent" | "automation";
     spawnDepth?: number;
     sandboxSettings?: Record<string, unknown>;
   }
 ) {
-  const id = env.SESSION.idFromName(sessionName);
-  const stub = env.SESSION.get(id);
   const defaults = {
     sessionName,
-    repoOwner: "acme",
-    repoName: "web-app",
-    repoId: 12345,
-    userId: "user-1",
+    ...TEST_NAMED_SESSION_DEFAULTS,
     ...overrides,
   };
+  const now = Date.now();
+  await new SessionIndexStore(env.DB).create({
+    id: sessionName,
+    title: defaults.title ?? null,
+    repoOwner: defaults.repoOwner ?? null,
+    repoName: defaults.repoName ?? null,
+    model: defaults.model ?? "anthropic/claude-haiku-4-5",
+    reasoningEffort: defaults.reasoningEffort ?? null,
+    baseBranch: defaults.defaultBranch ?? "main",
+    status: "created",
+    parentSessionId: defaults.parentSessionId ?? null,
+    spawnSource: defaults.spawnSource ?? "user",
+    spawnDepth: defaults.spawnDepth ?? 0,
+    userId: defaults.canonicalUserId ?? defaults.userId,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return initNamedSessionDO(sessionName, defaults);
+}
+
+/** Create only the named session DO for tests that manage the D1 row explicitly. */
+export async function initNamedSessionDO(sessionName: string, init: Record<string, unknown> = {}) {
+  const id = env.SESSION.idFromName(sessionName);
+  const stub = env.SESSION.get(id);
   const res = await stub.fetch("http://internal/internal/init", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(defaults),
+    body: JSON.stringify({ sessionName, ...TEST_NAMED_SESSION_DEFAULTS, ...init }),
   });
   if (res.status !== 200) throw new Error(`Init failed: ${res.status}`);
   return { stub, id, sessionName };
@@ -366,8 +372,6 @@ export async function openClientWs(
   sessionName: string,
   opts?: { subscribe?: boolean; userId?: string; canonicalUserId?: string }
 ) {
-  await ensureSessionIndexed(sessionName);
-
   const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws`, {
     headers: { Upgrade: "websocket" },
   });
@@ -423,7 +427,6 @@ export async function openSandboxWs(
   sessionName: string,
   opts: { authToken: string; sandboxId: string }
 ) {
-  await ensureSessionIndexed(sessionName);
   const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws?type=sandbox`, {
     headers: {
       Upgrade: "websocket",

--- a/packages/control-plane/test/integration/slack-notify.test.ts
+++ b/packages/control-plane/test/integration/slack-notify.test.ts
@@ -3,7 +3,7 @@ import { SELF, env } from "cloudflare:test";
 import { IntegrationSettingsStore } from "../../src/db/integration-settings";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
-import { initNamedSession, queryDO, seedSandboxAuth } from "./helpers";
+import { initNamedSessionDO, queryDO, seedSandboxAuth } from "./helpers";
 
 async function setupSession(opts?: {
   agentNotificationsEnabled?: boolean;
@@ -13,7 +13,7 @@ async function setupSession(opts?: {
   userId?: string;
 }) {
   const sessionName = `sess-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-  const { stub } = await initNamedSession(sessionName, {
+  const { stub } = await initNamedSessionDO(sessionName, {
     repoOwner: "acme",
     repoName: "web-app",
     userId: opts?.userId ?? "user-1",

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -4,7 +4,7 @@ import type { SessionDO } from "../../src/session/durable-object";
 import { ModelPreferencesStore } from "../../src/db/model-preferences";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
-import { initNamedSession, queryDO, seedMessage, seedSandboxAuth } from "./helpers";
+import { initNamedSessionDO, queryDO, seedMessage, seedSandboxAuth } from "./helpers";
 
 describe("POST /sessions/:parentId/children — spawn child", () => {
   beforeEach(cleanD1Tables);
@@ -25,7 +25,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     reasoningEffort?: string | null;
   }) {
     const parentName = `parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    const { stub } = await initNamedSession(parentName, {
+    const { stub } = await initNamedSessionDO(parentName, {
       repoOwner: "acme",
       repoName: "web-app",
       ...(opts?.repoId != null && { repoId: opts.repoId }),

--- a/packages/control-plane/test/integration/webhooks-github-pr-lifecycle.test.ts
+++ b/packages/control-plane/test/integration/webhooks-github-pr-lifecycle.test.ts
@@ -4,10 +4,10 @@ import { SessionIndexStore } from "../../src/db/session-index";
 import { SessionPullRequestStore } from "../../src/db/session-pull-request-store";
 import type { SessionPullRequestRecord } from "../../src/db/session-pull-request-store";
 import { cleanD1Tables } from "./cleanup";
-import { initNamedSession, queryDO, serviceFetch } from "./helpers";
+import { initNamedSessionDO, queryDO, serviceFetch } from "./helpers";
 
 async function createIndexedSession(sessionName: string) {
-  const { stub } = await initNamedSession(sessionName);
+  const { stub } = await initNamedSessionDO(sessionName);
   await new SessionIndexStore(env.DB).create({
     id: sessionName,
     title: null,

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { env } from "cloudflare:test";
+import { SELF, env } from "cloudflare:test";
 import {
   initNamedSession,
   openClientWs,
@@ -11,6 +11,24 @@ import {
 import { DEFAULT_REPLAY_LIMIT } from "../../src/session/event-stream";
 
 describe("Client WebSocket (via SELF.fetch)", () => {
+  it("rejects a nonexistent session before initializing its Durable Object", async () => {
+    const name = `ws-client-nonexistent-${Date.now()}`;
+
+    const response = await SELF.fetch(`https://test.local/sessions/${name}/ws`, {
+      headers: { Upgrade: "websocket" },
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.webSocket).toBeNull();
+
+    const stub = env.SESSION.get(env.SESSION.idFromName(name));
+    const tables = await queryDO<{ name: string }>(
+      stub,
+      "SELECT name FROM sqlite_master WHERE type = 'table'"
+    );
+    expect(tables).toEqual([]);
+  });
+
   it("upgrade returns 101 with webSocket", async () => {
     const name = `ws-client-upgrade-${Date.now()}`;
     await initNamedSession(name);


### PR DESCRIPTION
## Summary

- check the D1 session index before forwarding WebSocket upgrades to a session runtime
- return `404` for unknown session IDs
- align WebSocket integration helpers with the session index prerequisite
- cover unknown-session upgrades without creating session runtime storage

## Testing

- `npm test -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- focused WebSocket integration suites
- full integration suite: 766/767 passed; one existing 5-second timing-sensitive test timed out under full-suite load and passed on immediate focused rerun

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a8b49e942bca25a8ca2b8339bdd22135)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket requests for nonexistent sessions now return a 404 response instead of creating or contacting a session.
  * Invalid session requests no longer establish a WebSocket connection.
  * Valid session connections continue to upgrade normally with improved request tracking.

* **Tests**
  * Added integration coverage confirming the correct response and preventing unnecessary session initialization.
  * Expanded session validation coverage for existing and missing sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->