### PR TITLE
refactor: extract OpenCode message attribution

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
@@ -19,30 +19,38 @@ class MessageAttribution:
     """Own message eligibility state for one prompt and its compaction chain."""
 
     prompt_user_message_id: str
-    user_message_ids: set[str] = field(default_factory=set)
-    allowed_assistant_message_ids: set[str] = field(default_factory=set)
-    correlated_summary_ids: set[str] = field(default_factory=set)
-    compaction_occurred: bool = False
+    _user_message_ids: set[str] = field(default_factory=set, init=False)
+    _allowed_assistant_message_ids: set[str] = field(default_factory=set, init=False)
+    _correlated_summary_ids: set[str] = field(default_factory=set, init=False)
+    _compaction_occurred: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
-        self.user_message_ids.add(self.prompt_user_message_id)
+        self._user_message_ids.add(self.prompt_user_message_id)
 
     def add_user_message(self, message_id: str) -> bool:
-        is_new = message_id not in self.user_message_ids
-        self.user_message_ids.add(message_id)
+        is_new = message_id not in self._user_message_ids
+        self._user_message_ids.add(message_id)
         return is_new
 
     def parent_matches(self, parent_id: str) -> bool:
-        return parent_id in self.user_message_ids
+        return parent_id in self._user_message_ids
 
     def allow_assistant(self, message_id: str) -> None:
-        self.allowed_assistant_message_ids.add(message_id)
+        self._allowed_assistant_message_ids.add(message_id)
 
     def is_assistant_allowed(self, message_id: str) -> bool:
-        return message_id in self.allowed_assistant_message_ids
+        return message_id in self._allowed_assistant_message_ids
+
+    @property
+    def allowed_assistant_count(self) -> int:
+        return len(self._allowed_assistant_message_ids)
+
+    @property
+    def is_compacted(self) -> bool:
+        return self._compaction_occurred
 
     def mark_compacted(self) -> None:
-        self.compaction_occurred = True
+        self._compaction_occurred = True
 
     def assistant_disposition(
         self, message_id: str, parent_id: str, *, is_summary: bool
@@ -50,8 +58,8 @@ class MessageAttribution:
         parent_matches = self.parent_matches(parent_id)
         if is_summary:
             if parent_matches:
-                self.correlated_summary_ids.add(message_id)
-        if message_id in self.correlated_summary_ids:
+                self._correlated_summary_ids.add(message_id)
+        if message_id in self._correlated_summary_ids:
             return AssistantMessageDisposition.ERROR_ONLY
         if is_summary:
             return AssistantMessageDisposition.REJECT
@@ -67,6 +75,6 @@ class MessageAttribution:
 
     def _compaction_fallback_accepts(self, message_id: str) -> bool:
         """Claim only post-prompt messages after compaction rewrites the chain."""
-        return self.compaction_occurred and OpenCodeIdentifier.is_after(
+        return self._compaction_occurred and OpenCodeIdentifier.is_after(
             message_id, self.prompt_user_message_id
         )

--- a/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
@@ -1,0 +1,72 @@
+"""Parent-message attribution for one OpenCode prompt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .opencode_identifier import OpenCodeIdentifier
+
+
+class AssistantMessageDisposition(Enum):
+    REJECT = "reject"
+    ERROR_ONLY = "error_only"
+    OUTPUT = "output"
+
+
+@dataclass
+class MessageAttribution:
+    """Own message eligibility state for one prompt and its compaction chain."""
+
+    prompt_user_message_id: str
+    user_message_ids: set[str] = field(default_factory=set)
+    allowed_assistant_message_ids: set[str] = field(default_factory=set)
+    correlated_summary_ids: set[str] = field(default_factory=set)
+    compaction_occurred: bool = False
+
+    def __post_init__(self) -> None:
+        self.user_message_ids.add(self.prompt_user_message_id)
+
+    def add_user_message(self, message_id: str) -> bool:
+        is_new = message_id not in self.user_message_ids
+        self.user_message_ids.add(message_id)
+        return is_new
+
+    def parent_matches(self, parent_id: str) -> bool:
+        return parent_id in self.user_message_ids
+
+    def allow_assistant(self, message_id: str) -> None:
+        self.allowed_assistant_message_ids.add(message_id)
+
+    def is_assistant_allowed(self, message_id: str) -> bool:
+        return message_id in self.allowed_assistant_message_ids
+
+    def mark_compacted(self) -> None:
+        self.compaction_occurred = True
+
+    def assistant_disposition(
+        self, message_id: str, parent_id: str, *, is_summary: bool
+    ) -> AssistantMessageDisposition:
+        parent_matches = self.parent_matches(parent_id)
+        if is_summary:
+            if parent_matches:
+                self.correlated_summary_ids.add(message_id)
+        if message_id in self.correlated_summary_ids:
+            return AssistantMessageDisposition.ERROR_ONLY
+        if is_summary:
+            return AssistantMessageDisposition.REJECT
+
+        if (
+            parent_matches
+            or self.is_assistant_allowed(message_id)
+            or self._compaction_fallback_accepts(message_id)
+        ):
+            self.allow_assistant(message_id)
+            return AssistantMessageDisposition.OUTPUT
+        return AssistantMessageDisposition.REJECT
+
+    def _compaction_fallback_accepts(self, message_id: str) -> bool:
+        """Claim only post-prompt messages after compaction rewrites the chain."""
+        return self.compaction_occurred and OpenCodeIdentifier.is_after(
+            message_id, self.prompt_user_message_id
+        )

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
@@ -60,6 +60,11 @@ class OpenCodeIdentifier:
 
         return f"{prefix_str}_{timestamp_hex}{random_suffix}"
 
+    @staticmethod
+    def is_after(candidate: str, boundary: str) -> bool:
+        """Return whether an ascending ID was created after another ID."""
+        return candidate > boundary
+
     @classmethod
     def _random_base62(cls, length: int) -> str:
         """Generate random base62 string."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -18,6 +18,7 @@ from .child_activity import (
     PendingChildError,
     PendingChildMessage,
 )
+from .message_attribution import AssistantMessageDisposition, MessageAttribution
 from .opencode_client import (
     SSEConnectionError,
     SSEInactivityTimeoutError,
@@ -82,21 +83,35 @@ class _PromptState:
     start_time: float
     cumulative_text: dict[str, str] = field(default_factory=dict)
     emitted_tool_states: set[str] = field(default_factory=set)
-    allowed_assistant_msg_ids: set[str] = field(default_factory=set)
-    user_message_ids: set[str] = field(default_factory=set)
+    attribution: MessageAttribution = field(init=False)
     pending_parts: dict[str, list[_PendingPart]] = field(default_factory=dict)
     pending_parts_total: int = 0
     pending_drop_logged: bool = False
     child_activity: ChildActivityCorrelator = field(default_factory=ChildActivityCorrelator)
-    # Compaction tracking: after compaction, parentID changes so acceptance
-    # falls back to non-summary assistant messages created after this prompt
-    compaction_occurred: bool = False
-    correlated_compaction_summary_ids: set[str] = field(default_factory=set)
     emitted_error_messages: set[str] = field(default_factory=set)
     # Set when a parent context-overflow announcement was swallowed; cleared by
     # session.compacted. If still set at idle with no error emitted, the
     # promised compaction never happened and the prompt must fail.
     pending_overflow_error: str | None = None
+
+    def __post_init__(self) -> None:
+        self.attribution = MessageAttribution(self.opencode_message_id)
+
+    @property
+    def allowed_assistant_msg_ids(self) -> set[str]:
+        return self.attribution.allowed_assistant_message_ids
+
+    @property
+    def user_message_ids(self) -> set[str]:
+        return self.attribution.user_message_ids
+
+    @property
+    def compaction_occurred(self) -> bool:
+        return self.attribution.compaction_occurred
+
+    @compaction_occurred.setter
+    def compaction_occurred(self, value: bool) -> None:
+        self.attribution.compaction_occurred = value
 
 
 class _Disposition(Enum):
@@ -183,7 +198,6 @@ class OpenCodePromptStream:
             opencode_message_id=opencode_message_id,
             start_time=time.time(),
         )
-        state.user_message_ids.add(opencode_message_id)
         loop = asyncio.get_running_loop()
         prompt_deadline = loop.time() + self._prompt_max_duration_seconds
         try:
@@ -345,7 +359,7 @@ class OpenCodePromptStream:
 
         elif event_type == "session.compacted":
             if props.get("sessionID") == state.opencode_session_id:
-                state.compaction_occurred = True
+                state.attribution.mark_compacted()
                 state.pending_overflow_error = None
                 self._log.info("bridge.session_compacted", message_id=state.message_id)
                 events.append({"type": "context_compacted", "messageId": state.message_id})
@@ -378,15 +392,14 @@ class OpenCodePromptStream:
             finish = info.get("finish", "")
 
             if role == "user" and oc_msg_id:
-                if oc_msg_id not in state.user_message_ids:
+                if state.attribution.add_user_message(oc_msg_id):
                     self._log.info(
                         "bridge.user_message_id_discovered",
                         expected_id=state.opencode_message_id,
                         actual_id=oc_msg_id,
                     )
-                state.user_message_ids.add(oc_msg_id)
 
-            parent_matches = parent_id in state.user_message_ids
+            parent_matches = state.attribution.parent_matches(parent_id)
             is_compaction_summary = info.get("summary") is True
 
             self._log.debug(
@@ -400,17 +413,10 @@ class OpenCodePromptStream:
 
             events: list[dict[str, Any]] = []
             if role == "assistant" and oc_msg_id:
-                if is_compaction_summary and parent_matches:
-                    state.correlated_compaction_summary_ids.add(oc_msg_id)
-                belongs_to_prompt = (
-                    parent_matches
-                    or oc_msg_id in state.correlated_compaction_summary_ids
-                    or (
-                        not is_compaction_summary
-                        and self._compaction_fallback_accepts(state, oc_msg_id)
-                    )
+                disposition = state.attribution.assistant_disposition(
+                    oc_msg_id, parent_id, is_summary=is_compaction_summary
                 )
-                if belongs_to_prompt and info.get("error"):
+                if disposition is not AssistantMessageDisposition.REJECT and info.get("error"):
                     error_event = self._parent_error_event_once(state, info["error"])
                     if error_event:
                         self._log.error(
@@ -420,16 +426,7 @@ class OpenCodePromptStream:
                         )
                         events.append(error_event)
 
-                # Accept if: parentID matches our message, OR compaction
-                # happened and the message postdates this prompt — but never
-                # the compaction summary itself, whose text is internal
-                # context, not assistant output. Its parentID is the
-                # compaction user message, so parentID alone cannot exclude
-                # it.
-                if not is_compaction_summary and (
-                    parent_matches or self._compaction_fallback_accepts(state, oc_msg_id)
-                ):
-                    state.allowed_assistant_msg_ids.add(oc_msg_id)
+                if disposition is AssistantMessageDisposition.OUTPUT:
                     events.extend(self._drain_pending_parts(state, oc_msg_id, is_subtask=False))
 
             if finish and finish not in ("tool-calls", ""):
@@ -443,33 +440,18 @@ class OpenCodePromptStream:
             oc_msg_id = info.get("id", "")
             role = info.get("role", "")
             if role == "assistant" and oc_msg_id:
-                disposition = state.child_activity.authorize_or_queue_message(
+                child_disposition = state.child_activity.authorize_or_queue_message(
                     msg_session_id, oc_msg_id
                 )
-                if disposition is MessageDisposition.DROPPED:
+                if child_disposition is MessageDisposition.DROPPED:
                     self._log_pending_child_drop(state)
                     return []
-                if disposition is MessageDisposition.QUEUED:
+                if child_disposition is MessageDisposition.QUEUED:
                     return []
-                state.allowed_assistant_msg_ids.add(oc_msg_id)
+                state.attribution.allow_assistant(oc_msg_id)
                 return self._drain_pending_parts(state, oc_msg_id, is_subtask=True)
 
         return []
-
-    @staticmethod
-    def _compaction_fallback_accepts(state: _PromptState, oc_msg_id: str) -> bool:
-        """Whether the post-compaction fallback may claim an assistant message.
-
-        Compaction rewrites the message chain, so parentID correlation stops
-        matching and acceptance falls back to unparented assistant messages.
-        OpenCode also reports the session's full history (over SSE and from
-        the message-list API), so the fallback must be scoped to messages
-        created during this prompt or prior turns' output would be replayed
-        as current output. Ascending OpenCode IDs order by creation time,
-        making an ID comparison against this prompt's user message exactly
-        that scope.
-        """
-        return state.compaction_occurred and oc_msg_id > state.opencode_message_id
 
     def _on_part_updated(self, state: _PromptState, props: dict[str, Any]) -> list[dict[str, Any]]:
         """Forward parts of authorized messages; buffer parts that arrive early."""
@@ -499,7 +481,7 @@ class OpenCodePromptStream:
                         source="task_metadata",
                     )
 
-        if oc_msg_id in state.allowed_assistant_msg_ids:
+        if state.attribution.is_assistant_allowed(oc_msg_id):
             is_subtask = state.child_activity.is_tracked(part_session_id)
             events.extend(self._handle_part(state, part, delta, is_subtask=is_subtask))
         elif oc_msg_id:
@@ -726,7 +708,7 @@ class OpenCodePromptStream:
 
         if not isinstance(activity, PendingChildMessage):
             return []
-        state.allowed_assistant_msg_ids.add(activity.message_id)
+        state.attribution.allow_assistant(activity.message_id)
         return self._drain_pending_parts(state, activity.message_id, is_subtask=True)
 
     def _log_pending_child_drop(self, state: _PromptState) -> None:
@@ -974,20 +956,11 @@ class OpenCodePromptStream:
                 if role != "assistant":
                     continue
 
-                parent_matches = parent_id in state.user_message_ids
-                in_tracked_set = msg_id in state.allowed_assistant_msg_ids
                 is_compaction_summary = info.get("summary") is True
-
-                # Accept if: parentID matches, was tracked during SSE, or
-                # compaction occurred and the message postdates this prompt —
-                # never the compaction summary itself; its parentID (the
-                # compaction user message) matches.
-                should_accept = not is_compaction_summary and (
-                    parent_matches
-                    or in_tracked_set
-                    or self._compaction_fallback_accepts(state, msg_id)
+                disposition = state.attribution.assistant_disposition(
+                    msg_id, parent_id, is_summary=is_compaction_summary
                 )
-                if not should_accept:
+                if disposition is not AssistantMessageDisposition.OUTPUT:
                     continue
 
                 parts = msg.get("parts", [])

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -97,22 +97,6 @@ class _PromptState:
     def __post_init__(self) -> None:
         self.attribution = MessageAttribution(self.opencode_message_id)
 
-    @property
-    def allowed_assistant_msg_ids(self) -> set[str]:
-        return self.attribution.allowed_assistant_message_ids
-
-    @property
-    def user_message_ids(self) -> set[str]:
-        return self.attribution.user_message_ids
-
-    @property
-    def compaction_occurred(self) -> bool:
-        return self.attribution.compaction_occurred
-
-    @compaction_occurred.setter
-    def compaction_occurred(self, value: bool) -> None:
-        self.attribution.compaction_occurred = value
-
 
 class _Disposition(Enum):
     """What the stream loop should do after applying one SSE event."""
@@ -407,7 +391,7 @@ class OpenCodePromptStream:
                 role=role,
                 oc_msg_id=oc_msg_id,
                 parent_match=parent_matches,
-                compaction_occurred=state.compaction_occurred,
+                compaction_occurred=state.attribution.is_compacted,
                 is_compaction_summary=is_compaction_summary,
             )
 
@@ -769,7 +753,7 @@ class OpenCodePromptStream:
         self._log.debug(
             log_event,
             elapsed_s=round(time.time() - state.start_time, 1),
-            tracked_msgs=len(state.allowed_assistant_msg_ids),
+            tracked_msgs=state.attribution.allowed_assistant_count,
         )
 
     def _tool_call_event(

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -66,14 +66,12 @@ def bridge() -> AgentBridge:
 
 def make_state(message_id: str) -> _PromptState:
     """Per-prompt state as stream_prompt would build it."""
-    state = _PromptState(
+    return _PromptState(
         opencode_session_id="oc-session-123",
         message_id=message_id,
         opencode_message_id="msg_test",
         start_time=0.0,
     )
-    state.user_message_ids.add("msg_test")
-    return state
 
 
 class TestToolCallEvent:

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -114,10 +114,10 @@ def make_prompt_state(
         opencode_message_id=opencode_message_id,
         start_time=0.0,
     )
-    state.user_message_ids.add(opencode_message_id)
     if cumulative_text is not None:
         state.cumulative_text = cumulative_text
-    state.compaction_occurred = compaction_occurred
+    if compaction_occurred:
+        state.attribution.mark_compacted()
     return state
 
 

--- a/packages/sandbox-runtime/tests/test_message_attribution.py
+++ b/packages/sandbox-runtime/tests/test_message_attribution.py
@@ -1,0 +1,84 @@
+from sandbox_runtime.message_attribution import (
+    AssistantMessageDisposition,
+    MessageAttribution,
+)
+from tests.conftest import oc_message_id
+
+PROMPT_TS_MS = 1_754_000_000_000
+PROMPT_MESSAGE_ID = oc_message_id(PROMPT_TS_MS, 2, "p")
+
+
+def test_direct_parent_message_is_accepted_and_tracked():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+
+    disposition = attribution.assistant_disposition(
+        "assistant-message", PROMPT_MESSAGE_ID, is_summary=False
+    )
+
+    assert disposition is AssistantMessageDisposition.OUTPUT
+    assert attribution.is_assistant_allowed("assistant-message")
+
+
+def test_discovered_user_message_can_parent_output():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution.add_user_message("server-generated-user-message")
+
+    disposition = attribution.assistant_disposition(
+        "assistant-message", "server-generated-user-message", is_summary=False
+    )
+
+    assert disposition is AssistantMessageDisposition.OUTPUT
+
+
+def test_correlated_summary_is_error_only_and_remains_correlated():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+
+    first = attribution.assistant_disposition("summary-message", PROMPT_MESSAGE_ID, is_summary=True)
+    repeated = attribution.assistant_disposition("summary-message", "", is_summary=False)
+
+    assert first is AssistantMessageDisposition.ERROR_ONLY
+    assert repeated is AssistantMessageDisposition.ERROR_ONLY
+    assert not attribution.is_assistant_allowed("summary-message")
+
+
+def test_tracked_message_is_accepted_during_reconciliation():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution.allow_assistant("assistant-message")
+
+    disposition = attribution.assistant_disposition(
+        "assistant-message", "unknown-parent", is_summary=False
+    )
+
+    assert disposition is AssistantMessageDisposition.OUTPUT
+
+
+def test_compaction_fallback_only_accepts_messages_after_prompt_boundary():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    before_prompt = oc_message_id(PROMPT_TS_MS, 1, "b")
+    after_prompt = oc_message_id(PROMPT_TS_MS, 3, "a")
+
+    assert (
+        attribution.assistant_disposition(after_prompt, "unknown", is_summary=False)
+        is AssistantMessageDisposition.REJECT
+    )
+
+    attribution.mark_compacted()
+
+    assert (
+        attribution.assistant_disposition(before_prompt, "unknown", is_summary=False)
+        is AssistantMessageDisposition.REJECT
+    )
+    assert (
+        attribution.assistant_disposition(after_prompt, "unknown", is_summary=False)
+        is AssistantMessageDisposition.OUTPUT
+    )
+
+
+def test_compaction_summary_is_never_accepted_as_output():
+    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution.mark_compacted()
+    after_prompt = oc_message_id(PROMPT_TS_MS, 3, "s")
+
+    disposition = attribution.assistant_disposition(after_prompt, "unknown", is_summary=True)
+
+    assert disposition is AssistantMessageDisposition.REJECT

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -47,7 +47,6 @@ def make_state(opencode_message_id: str = "msg_test") -> _PromptState:
         opencode_message_id=opencode_message_id,
         start_time=time.time(),
     )
-    state.user_message_ids.add(opencode_message_id)
     return state
 
 
@@ -293,7 +292,7 @@ class TestApplySseEventDispositions:
             ),
         )
 
-        assert "oc-summary" not in state.allowed_assistant_msg_ids
+        assert not state.attribution.is_assistant_allowed("oc-summary")
         assert step.events == []
 
     def test_child_context_overflow_continues_without_error(self):
@@ -425,7 +424,7 @@ class TestApplySseEventDispositions:
 
     def test_late_child_part_keeps_message_ownership_after_task_completion(self):
         state = make_state()
-        state.allowed_assistant_msg_ids.add("parent-msg")
+        state.attribution.allow_assistant("parent-msg")
         state.child_activity.associate(CHILD_SESSION_ID, "task-call")
         stream = make_stream()
 
@@ -479,7 +478,7 @@ class TestApplySseEventDispositions:
 
     def test_child_message_after_completion_keeps_completed_task_ownership(self):
         state = make_state()
-        state.allowed_assistant_msg_ids.add("parent-msg")
+        state.attribution.allow_assistant("parent-msg")
         stream = make_stream()
 
         completed_task = stream._apply_sse_event(
@@ -630,7 +629,7 @@ class TestApplySseEventDispositions:
             state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID})
         )
 
-        assert state.compaction_occurred is True
+        assert state.attribution.is_compacted
         assert step.events == [{"type": "context_compacted", "messageId": "cp-msg-1"}]
         assert step.disposition is _Disposition.CONTINUE
 
@@ -658,7 +657,7 @@ class TestApplySseEventDispositions:
             state, sse("session.compacted", {"sessionID": CHILD_SESSION_ID})
         )
 
-        assert state.compaction_occurred is False
+        assert not state.attribution.is_compacted
         assert state.pending_overflow_error == "parent overflow"
         assert step.events == []
 
@@ -702,7 +701,7 @@ class TestApplySseEventDispositions:
             ),
         )
 
-        assert prior_assistant_id not in state.allowed_assistant_msg_ids
+        assert not state.attribution.is_assistant_allowed(prior_assistant_id)
         assert prior_assistant_id in state.pending_parts
         assert step.events == []
 
@@ -743,7 +742,7 @@ class TestApplySseEventDispositions:
             ),
         )
 
-        assert continuation_id in state.allowed_assistant_msg_ids
+        assert state.attribution.is_assistant_allowed(continuation_id)
         assert step.events == [
             {
                 "type": "token",
@@ -778,8 +777,8 @@ class TestApplySseEventDispositions:
                 ),
             )
 
-        assert same_ms_below_id not in state.allowed_assistant_msg_ids
-        assert same_ms_above_id in state.allowed_assistant_msg_ids
+        assert not state.attribution.is_assistant_allowed(same_ms_below_id)
+        assert state.attribution.is_assistant_allowed(same_ms_above_id)
 
     def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
         prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")
@@ -828,7 +827,7 @@ class TestApplySseEventDispositions:
 
     def test_task_metadata_reemits_same_status_and_releases_buffered_child_activity(self):
         state = make_state()
-        state.allowed_assistant_msg_ids.add("parent-msg")
+        state.attribution.allow_assistant("parent-msg")
         state.child_activity.track(CHILD_SESSION_ID)
         stream = make_stream()
 


### PR DESCRIPTION
## Summary

- extract parent-message eligibility into a focused `MessageAttribution` object
- share one assistant disposition across live SSE handling and final-state reconciliation
- centralize the post-compaction ID boundary with `OpenCodeIdentifier`
- preserve compaction summaries as error-only and keep child-message authorization behavior unchanged

Closes #1388.

## TDD

Added focused policy tests before implementation for:

- direct and discovered user-message parent correlation
- tracked assistant reconciliation
- compaction summary error-only handling
- pre/post-prompt compaction boundaries
- summary output exclusion

## Verification

- `PYTHONPATH=src uv run --extra dev pytest tests/test_message_attribution.py tests/test_prompt_stream.py tests/test_bridge_sse.py tests/test_bridge_message_tracking.py -q` (123 passed)
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev ruff format --check src/sandbox_runtime/message_attribution.py src/sandbox_runtime/opencode_identifier.py src/sandbox_runtime/prompt_stream.py tests/test_message_attribution.py`
- `uv run --extra dev mypy src/sandbox_runtime/message_attribution.py src/sandbox_runtime/opencode_identifier.py src/sandbox_runtime/prompt_stream.py`

The full sandbox-runtime suite has unrelated failures on current `main`: `test_start_opencode_copies_js_plugin` expects one plugin copy although both Codex and xAI plugins are deployed, and `test_runs_setup_script` observes repo-image state from the environment.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6887534738f9921790caa548a9664298)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response attribution for prompts involving message compaction.
  - Prevented unrelated, duplicate, or rejected assistant messages from appearing in results.
  - Improved handling of assistant errors and responses across compacted conversation history.
  - Added more reliable fallback behavior when message relationships are discovered indirectly.
  - Improved message ordering to ensure responses are associated with the correct prompt.

- **Tests**
  - Expanded coverage for prompt tracking, compacted summaries, response authorization, and message ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->