### PR TITLE
Fix mobile session timeline text wrapping

### DIFF
--- a/packages/web/src/components/safe-markdown.tsx
+++ b/packages/web/src/components/safe-markdown.tsx
@@ -63,7 +63,9 @@ interface SafeMarkdownProps {
 
 export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
   return (
-    <div className={`prose prose-sm dark:prose-invert max-w-none break-words ${className}`}>
+    <div
+      className={`prose prose-sm dark:prose-invert min-w-0 max-w-none break-words [overflow-wrap:anywhere] ${className}`}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight, [rehypeSanitize, sanitizeSchema]]}
@@ -82,7 +84,10 @@ export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
           ),
           // Code blocks with styling
           pre: ({ children, ...props }: ComponentPropsWithoutRef<"pre">) => (
-            <pre className="not-prose overflow-x-auto text-sm leading-relaxed rounded" {...props}>
+            <pre
+              className="not-prose max-w-full overflow-x-auto text-sm leading-relaxed rounded"
+              {...props}
+            >
               {children}
             </pre>
           ),
@@ -133,7 +138,7 @@ export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
           ),
           // Tables
           table: ({ children, ...props }: ComponentPropsWithoutRef<"table">) => (
-            <div className="overflow-x-auto">
+            <div className="max-w-full overflow-x-auto">
               <table className="min-w-full border-collapse text-sm" {...props}>
                 {children}
               </table>

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -257,30 +257,6 @@ describe("prompt queue status", () => {
 });
 
 describe("tool call groups", () => {
-  it("keeps complete long commands in collapsed tool rows", () => {
-    const command = `PYTHONPATH=src uv run pytest ${"tests/very_long_directory/".repeat(4)}test_file.py`;
-    render(
-      <SessionTimeline
-        {...baseTimelineProps}
-        events={[
-          {
-            type: "tool_call",
-            sandboxId: "sandbox-1",
-            messageId: "message-call-1",
-            callId: "call-1",
-            tool: "Bash",
-            args: { command },
-            timestamp: 1,
-          },
-        ]}
-      />
-    );
-
-    const button = screen.getByRole("button", { name: new RegExp(command) });
-    expect(button).toHaveTextContent(command);
-    expect(button.querySelector(".truncate")).toBeNull();
-  });
-
   it("preserves expanded group and row state when history is prepended", async () => {
     const readEvents = [
       toolCall("call-1", "Read", "/workspace/one.ts"),

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -257,6 +257,30 @@ describe("prompt queue status", () => {
 });
 
 describe("tool call groups", () => {
+  it("keeps complete long commands in collapsed tool rows", () => {
+    const command = `PYTHONPATH=src uv run pytest ${"tests/very_long_directory/".repeat(4)}test_file.py`;
+    render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          {
+            type: "tool_call",
+            sandboxId: "sandbox-1",
+            messageId: "message-call-1",
+            callId: "call-1",
+            tool: "Bash",
+            args: { command },
+            timestamp: 1,
+          },
+        ]}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: new RegExp(command) });
+    expect(button).toHaveTextContent(command);
+    expect(button.querySelector(".truncate")).toBeNull();
+  });
+
   it("preserves expanded group and row state when history is prepended", async () => {
     const readEvents = [
       toolCall("call-1", "Read", "/workspace/one.ts"),
@@ -264,7 +288,7 @@ describe("tool call groups", () => {
     ];
     const { rerender } = render(<SessionTimeline {...baseTimelineProps} events={readEvents} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /Read2 files/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Read 2 files/i }));
     await userEvent.click(screen.getByRole("button", { name: /Read one\.ts/i }));
     expect(screen.getByText("Arguments:")).toBeInTheDocument();
 
@@ -927,7 +951,7 @@ describe("task activity grouping", () => {
     };
     const view = render(<SessionTimeline {...props} events={initial} />);
 
-    await user.click(screen.getByRole("button", { name: /Bash2 commands/ }));
+    await user.click(screen.getByRole("button", { name: /Bash 2 commands/ }));
     expect(screen.getByText(/Bash first/)).toBeInTheDocument();
     view.rerender(
       <SessionTimeline
@@ -971,7 +995,7 @@ describe("task activity grouping", () => {
       />
     );
 
-    await user.click(screen.getByRole("button", { name: /Bash2 commands/ }));
+    await user.click(screen.getByRole("button", { name: /Bash 2 commands/ }));
     expect(screen.getByText(/Bash first/)).toBeInTheDocument();
     expect(screen.getByText(/Bash second/)).toBeInTheDocument();
     expect(consoleError.mock.calls.some((call) => String(call[0]).includes("same key"))).toBe(

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -221,7 +221,7 @@ export function SessionTimeline({
     <div
       ref={scrollContainerRef}
       onScroll={handleScroll}
-      className="h-full overflow-y-auto overflow-x-hidden p-4"
+      className="h-full overflow-y-auto overflow-x-hidden p-3 sm:p-4"
     >
       <div className="w-full min-w-0 max-w-3xl mx-auto space-y-2">
         <div ref={topSentinelRef} className="h-1" />
@@ -282,16 +282,16 @@ function ThinkingIndicator() {
 function TimelineSkeleton() {
   return (
     <div className="space-y-3 py-2 animate-pulse">
-      <div className="bg-card p-4 space-y-2">
+      <div className="bg-card p-3 space-y-2 sm:p-4">
         <div className="h-3 w-24 bg-muted rounded" />
         <div className="h-3 w-full bg-muted rounded" />
         <div className="h-3 w-5/6 bg-muted rounded" />
       </div>
-      <div className="bg-accent-muted p-4 ml-8 space-y-2">
+      <div className="bg-accent-muted p-3 space-y-2 sm:ml-8 sm:p-4">
         <div className="h-3 w-20 bg-muted rounded" />
         <div className="h-3 w-4/5 bg-muted rounded" />
       </div>
-      <div className="bg-card p-4 space-y-2">
+      <div className="bg-card p-3 space-y-2 sm:p-4">
         <div className="h-3 w-32 bg-muted rounded" />
         <div className="h-3 w-3/4 bg-muted rounded" />
       </div>
@@ -353,10 +353,10 @@ function MessageFrame({
   children,
 }: MessageFrameProps) {
   return (
-    <div className={className}>
-      <div className="flex items-center justify-between mb-2">
+    <div className={`min-w-0 ${className}`}>
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
         {label}
-        <div className="flex items-center gap-1.5">
+        <div className="flex shrink-0 items-center gap-1.5">
           <CopyButton
             copied={copied}
             className={copyButtonClassName}
@@ -397,10 +397,16 @@ function StatusRow({
           : "text-muted-foreground";
 
   return (
-    <div className={`flex items-center gap-2 text-sm ${textClassName}`}>
-      <span className={`w-2 h-2 rounded-full ${dotClassName}`} />
-      {children}
-      <span className="text-xs text-secondary-foreground">{time}</span>
+    <div className={`flex min-w-0 items-start gap-2 text-sm ${textClassName}`}>
+      <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${dotClassName}`} />
+      <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+        <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+          {children}
+        </span>
+        <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+          {time}
+        </span>
+      </span>
     </div>
   );
 }
@@ -474,12 +480,14 @@ function UserMessageEvent({
       time={formatEventTime(event)}
       copied={copied}
       content={event.content}
-      className="group bg-accent-muted p-4 ml-8"
+      className="group bg-accent-muted p-3 sm:ml-8 sm:p-4"
       copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
       onCopyContent={onCopyContent}
     >
       {event.content && (
-        <pre className="whitespace-pre-wrap text-sm text-foreground">{event.content}</pre>
+        <pre className="whitespace-pre-wrap text-sm text-foreground [overflow-wrap:anywhere]">
+          {event.content}
+        </pre>
       )}
       {attachments.length > 0 && (
         <UserMessageAttachments attachments={attachments} sessionId={sessionId} />
@@ -497,7 +505,7 @@ function AssistantMessageEvent({ event, copied, onCopyContent }: EventRendererPr
       time={formatEventTime(event)}
       copied={copied}
       content={event.content}
-      className="group bg-card p-4"
+      className="group bg-card p-3 sm:p-4"
       copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
       onCopyContent={onCopyContent}
     >
@@ -510,10 +518,16 @@ function ToolResultEvent({ event }: EventRendererProps) {
   if (event.type !== "tool_result" || !event.error) return null;
 
   return (
-    <div className="flex items-center gap-2 text-sm text-destructive py-1">
-      <ErrorIcon className="w-4 h-4" />
-      <span className="truncate">{event.error}</span>
-      <span className="text-xs text-secondary-foreground ml-auto">{formatEventTime(event)}</span>
+    <div className="flex min-w-0 items-start gap-2 py-1 text-sm text-destructive">
+      <ErrorIcon className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+        <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+          {event.error}
+        </span>
+        <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+          {formatEventTime(event)}
+        </span>
+      </span>
     </div>
   );
 }
@@ -538,7 +552,7 @@ function ArtifactEvent({ event, sessionId, onOpenMedia }: EventRendererProps) {
   }
 
   return (
-    <div className="space-y-2 border border-border-muted bg-card p-4">
+    <div className="space-y-2 border border-border-muted bg-card p-3 sm:p-4">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">
           {event.artifactType === "video" ? "Video" : "Screenshot"}

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -13,6 +13,7 @@ import {
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
 import { TaskActivityItem } from "@/components/task-activity-item";
+import { TimelineRowContent } from "@/components/timeline-row-content";
 import { ToolCallGroup } from "@/components/tool-call-group";
 import { copyToClipboard } from "@/lib/format";
 import {
@@ -399,14 +400,7 @@ function StatusRow({
   return (
     <div className={`flex min-w-0 items-start gap-2 text-sm ${textClassName}`}>
       <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${dotClassName}`} />
-      <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-        <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-          {children}
-        </span>
-        <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-          {time}
-        </span>
-      </span>
+      <TimelineRowContent time={time}>{children}</TimelineRowContent>
     </div>
   );
 }
@@ -520,14 +514,7 @@ function ToolResultEvent({ event }: EventRendererProps) {
   return (
     <div className="flex min-w-0 items-start gap-2 py-1 text-sm text-destructive">
       <ErrorIcon className="h-4 w-4 shrink-0" />
-      <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-        <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-          {event.error}
-        </span>
-        <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-          {formatEventTime(event)}
-        </span>
-      </span>
+      <TimelineRowContent time={formatEventTime(event)}>{event.error}</TimelineRowContent>
     </div>
   );
 }

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -12,6 +12,7 @@ import { formatSessionEventTime } from "@/lib/time";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { APP_NAME } from "@/lib/site-config";
 import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
+import { TimelineRowContent } from "./timeline-row-content";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 
@@ -115,16 +116,9 @@ export function SlackNotifyEvent({
         ) : (
           <SlackIcon className="w-3.5 h-3.5 shrink-0 text-secondary-foreground" />
         )}
-        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-            slack-notify {summaryLine}
-          </span>
-          {showTime && (
-            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-              {time}
-            </span>
-          )}
-        </span>
+        <TimelineRowContent time={showTime ? time : undefined}>
+          slack-notify {summaryLine}
+        </TimelineRowContent>
       </button>
 
       {isExpanded && (

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -103,26 +103,32 @@ export function SlackNotifyEvent({
       <button
         type="button"
         onClick={onToggle}
-        className="w-full flex items-center gap-1.5 text-sm text-left text-muted-foreground hover:text-foreground transition-colors"
+        className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
-          className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
+          className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
             isExpanded ? "rotate-90" : ""
           }`}
         />
         {denial ? (
-          <ErrorIcon className="w-3.5 h-3.5 text-destructive" />
+          <ErrorIcon className="w-3.5 h-3.5 shrink-0 text-destructive" />
         ) : (
-          <SlackIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+          <SlackIcon className="w-3.5 h-3.5 shrink-0 text-secondary-foreground" />
         )}
-        <span className="truncate">slack-notify {summaryLine}</span>
-        {showTime && (
-          <span className="text-xs text-secondary-foreground flex-shrink-0 ml-auto">{time}</span>
-        )}
+        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+            slack-notify {summaryLine}
+          </span>
+          {showTime && (
+            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+              {time}
+            </span>
+          )}
+        </span>
       </button>
 
       {isExpanded && (
-        <div className="mt-2 ml-5 p-3 bg-card border border-border-muted text-xs overflow-hidden">
+        <div className="mt-2 ml-0 overflow-hidden border border-border-muted bg-card p-3 text-xs [overflow-wrap:anywhere] sm:ml-5">
           {success ? (
             <SlackNotifySuccessBody success={success} />
           ) : denial ? (

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -40,7 +40,7 @@ function TaskDisclosure({ label, content }: { label: string; content: string }) 
         {label}
       </button>
       {isExpanded && (
-        <pre className="border-t border-border-muted px-3 py-2 overflow-x-auto max-h-64 text-xs text-foreground whitespace-pre-wrap break-words">
+        <pre className="max-h-64 whitespace-pre-wrap border-t border-border-muted px-3 py-2 text-xs text-foreground [overflow-wrap:anywhere]">
           {content}
         </pre>
       )}
@@ -70,25 +70,27 @@ export function TaskActivityItem({
         type="button"
         aria-expanded={isExpanded}
         onClick={() => setIsExpanded((expanded) => !expanded)}
-        className="w-full flex items-center gap-1.5 text-sm text-left text-muted-foreground hover:text-foreground transition-colors"
+        className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
-          className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
+          className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
             isExpanded ? "rotate-90" : ""
           }`}
         />
-        <BoxIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+        <BoxIcon className="w-3.5 h-3.5 shrink-0 text-secondary-foreground" />
         {isRunning && (
           <span
             aria-hidden="true"
             className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse flex-shrink-0"
           />
         )}
-        <span className="truncate">
-          {formatted.toolName} {formatted.summary}
-        </span>
-        <span className="text-xs text-secondary-foreground flex-shrink-0 ml-auto">
-          {formatSessionEventTime(event.timestamp)}
+        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+            {formatted.toolName} {formatted.summary}
+          </span>
+          <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+            {formatSessionEventTime(event.timestamp)}
+          </span>
         </span>
       </button>
       {isRunning && (
@@ -98,7 +100,7 @@ export function TaskActivityItem({
       )}
 
       {isExpanded && (
-        <div className="mt-2 ml-5 space-y-2">
+        <div className="mt-2 ml-0 space-y-2 sm:ml-5">
           {(agent || taskId) && (
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-secondary-foreground">
               {agent && <span>Agent: {agent}</span>}
@@ -106,7 +108,7 @@ export function TaskActivityItem({
             </div>
           )}
           {hasActivity && (
-            <div className="border-l-2 border-border pl-3 py-1 space-y-1">
+            <div className="space-y-1 border-l-2 border-border py-1 pl-2 sm:pl-3">
               <div className="text-[11px] font-medium uppercase tracking-wide text-secondary-foreground mb-1">
                 Task activity
               </div>

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -5,6 +5,7 @@ import { formatSessionEventTime } from "@/lib/time";
 import { formatToolCall } from "@/lib/tool-formatters";
 import type { ToolCallEvent } from "@/lib/timeline-items";
 import { BoxIcon, ChevronRightIcon } from "@/components/ui/icons";
+import { TimelineRowContent } from "./timeline-row-content";
 
 function stringArg(event: ToolCallEvent, key: string): string | null {
   const value = event.args?.[key];
@@ -84,14 +85,9 @@ export function TaskActivityItem({
             className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse flex-shrink-0"
           />
         )}
-        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-            {formatted.toolName} {formatted.summary}
-          </span>
-          <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-            {formatSessionEventTime(event.timestamp)}
-          </span>
-        </span>
+        <TimelineRowContent time={formatSessionEventTime(event.timestamp)}>
+          {formatted.toolName} {formatted.summary}
+        </TimelineRowContent>
       </button>
       {isRunning && (
         <span role="status" className="sr-only">

--- a/packages/web/src/components/timeline-row-content.tsx
+++ b/packages/web/src/components/timeline-row-content.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export function TimelineRowContent({ children, time }: { children: ReactNode; time?: string }) {
+  return (
+    <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+      <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+        {children}
+      </span>
+      {time && (
+        <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+          {time}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -6,6 +6,7 @@ import { formatSessionEventTime } from "@/lib/time";
 import { formatToolGroup } from "@/lib/tool-formatters";
 import { toolCallKey } from "@/lib/timeline-items";
 import { ToolCallItem } from "./tool-call-item";
+import { TimelineRowContent } from "./timeline-row-content";
 import {
   ChevronRightIcon,
   FileIcon,
@@ -73,15 +74,10 @@ export const ToolCallGroup = memo(
             }`}
           />
           <ToolIcon toolName={formatted.toolName} />
-          <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-            <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-              <span className="font-medium text-foreground">{formatted.toolName}</span>{" "}
-              <span className="text-muted-foreground">{formatted.summary}</span>
-            </span>
-            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-              {time}
-            </span>
-          </span>
+          <TimelineRowContent time={time}>
+            <span className="font-medium text-foreground">{formatted.toolName}</span>{" "}
+            <span className="text-muted-foreground">{formatted.summary}</span>
+          </TimelineRowContent>
         </button>
 
         {isExpanded && (

--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/icons";
 
 function ToolIcon({ toolName }: { toolName: string }) {
-  const iconClass = "w-3.5 h-3.5 text-secondary-foreground";
+  const iconClass = "w-3.5 h-3.5 shrink-0 text-secondary-foreground";
 
   switch (toolName) {
     case "Read":
@@ -65,21 +65,27 @@ export const ToolCallGroup = memo(
         <button
           type="button"
           onClick={onToggleGroup}
-          className="w-full flex items-center gap-2 text-sm text-left hover:bg-muted px-2 py-1 -mx-2 transition-colors"
+          className="-mx-2 flex w-full min-w-0 items-start gap-2 px-2 py-1 text-left text-sm transition-colors hover:bg-muted"
         >
           <ChevronRightIcon
-            className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
+            className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
               isExpanded ? "rotate-90" : ""
             }`}
           />
           <ToolIcon toolName={formatted.toolName} />
-          <span className="font-medium text-foreground">{formatted.toolName}</span>
-          <span className="text-muted-foreground">{formatted.summary}</span>
-          <span className="text-xs text-secondary-foreground ml-auto flex-shrink-0">{time}</span>
+          <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+            <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+              <span className="font-medium text-foreground">{formatted.toolName}</span>{" "}
+              <span className="text-muted-foreground">{formatted.summary}</span>
+            </span>
+            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+              {time}
+            </span>
+          </span>
         </button>
 
         {isExpanded && (
-          <div className="ml-4 mt-1 pl-2 border-l-2 border-border">
+          <div className="ml-2 mt-1 border-l-2 border-border pl-2 sm:ml-4">
             {events.map((event) => (
               <ToolCallItem
                 key={toolCallKey(event)}

--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SandboxEvent } from "@/types/session";
+import { ToolCallItem } from "./tool-call-item";
+
+afterEach(cleanup);
+
+describe("ToolCallItem", () => {
+  it("keeps complete long commands in collapsed rows", () => {
+    const command = `PYTHONPATH=src uv run pytest ${"tests/very_long_directory/".repeat(4)}test_file.py`;
+    const event: Extract<SandboxEvent, { type: "tool_call" }> = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-call-1",
+      callId: "call-1",
+      tool: "Bash",
+      args: { command },
+      timestamp: 1,
+    };
+
+    render(<ToolCallItem event={event} isExpanded={false} onToggle={() => {}} />);
+
+    const button = screen.getByRole("button", { name: new RegExp(command) });
+    expect(button).toHaveTextContent(command);
+    expect(button.querySelector(".truncate")).toBeNull();
+  });
+});

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -4,6 +4,7 @@ import type { SandboxEvent } from "@/types/session";
 import { formatSessionEventTime } from "@/lib/time";
 import { formatToolCall } from "@/lib/tool-formatters";
 import { SlackNotifyEvent } from "./slack-notify-event";
+import { TimelineRowContent } from "./timeline-row-content";
 import {
   ChevronRightIcon,
   FileIcon,
@@ -122,16 +123,9 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
           }`}
         />
         <ToolIcon name={formatted.icon} />
-        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
-          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
-            {formatted.toolName} {formatted.summary}
-          </span>
-          {showTime && (
-            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
-              {time}
-            </span>
-          )}
-        </span>
+        <TimelineRowContent time={showTime ? time : undefined}>
+          {formatted.toolName} {formatted.summary}
+        </TimelineRowContent>
       </button>
 
       {isExpanded && (

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -26,7 +26,7 @@ interface ToolCallItemProps {
 function ToolIcon({ name }: { name: string | null }) {
   if (!name) return null;
 
-  const iconClass = "w-3.5 h-3.5 text-secondary-foreground";
+  const iconClass = "w-3.5 h-3.5 shrink-0 text-secondary-foreground";
 
   switch (name) {
     case "file":
@@ -66,7 +66,7 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
       {hasNonPatchArgs && (
         <div className="mb-2">
           <div className="text-muted-foreground mb-1 font-medium">Arguments:</div>
-          <pre className="overflow-x-auto text-foreground whitespace-pre-wrap">
+          <pre className="max-w-full overflow-x-auto whitespace-pre text-foreground">
             {JSON.stringify(nonPatchArgs, null, 2)}
           </pre>
         </div>
@@ -74,7 +74,7 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
       {patchText && (
         <div className="mb-2">
           <div className="text-muted-foreground mb-1 font-medium">Patch:</div>
-          <pre className="overflow-x-auto max-h-64 text-foreground whitespace-pre-wrap">
+          <pre className="max-h-64 max-w-full overflow-x-auto whitespace-pre text-foreground">
             {patchText}
           </pre>
         </div>
@@ -82,7 +82,7 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
       {output && (
         <div>
           <div className="text-muted-foreground mb-1 font-medium">Output:</div>
-          <pre className="overflow-x-auto max-h-48 text-foreground whitespace-pre-wrap">
+          <pre className="max-h-48 max-w-full overflow-x-auto whitespace-pre text-foreground">
             {output}
           </pre>
         </div>
@@ -114,24 +114,28 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
       <button
         type="button"
         onClick={onToggle}
-        className="w-full flex items-center gap-1.5 text-sm text-left text-muted-foreground hover:text-foreground transition-colors"
+        className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
-          className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
+          className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
             isExpanded ? "rotate-90" : ""
           }`}
         />
         <ToolIcon name={formatted.icon} />
-        <span className="truncate">
-          {formatted.toolName} {formatted.summary}
+        <span className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-2">
+          <span className="block whitespace-normal [overflow-wrap:anywhere] sm:min-w-0 sm:flex-1">
+            {formatted.toolName} {formatted.summary}
+          </span>
+          {showTime && (
+            <span className="mt-0.5 block shrink-0 text-xs text-secondary-foreground sm:ml-auto sm:mt-0">
+              {time}
+            </span>
+          )}
         </span>
-        {showTime && (
-          <span className="text-xs text-secondary-foreground flex-shrink-0 ml-auto">{time}</span>
-        )}
       </button>
 
       {isExpanded && (
-        <div className="mt-2 ml-5">
+        <div className="mt-2 ml-0 sm:ml-5">
           <ToolCallDetails event={event} />
         </div>
       )}

--- a/packages/web/src/lib/tool-formatters.test.ts
+++ b/packages/web/src/lib/tool-formatters.test.ts
@@ -54,4 +54,12 @@ describe("formatToolCall summaries", () => {
     expect(formatToolCall(toolCall("task", { prompt })).summary).toBe("task");
     expect(formatToolCall(toolCall("custom-tool", args)).summary).toBe("2 arguments");
   });
+
+  it("uses fallback summaries for empty and whitespace-only display arguments", () => {
+    expect(formatToolCall(toolCall("task", { description: "   " })).summary).toBe("task");
+    expect(formatToolCall(toolCall("webfetch", { url: "" })).summary).toBe("url");
+    expect(formatToolCall(toolCall("get-child-status", { childId: "\t" })).summary).toBe(
+      "List Children"
+    );
+  });
 });

--- a/packages/web/src/lib/tool-formatters.test.ts
+++ b/packages/web/src/lib/tool-formatters.test.ts
@@ -31,3 +31,27 @@ describe("formatToolCall child session tools", () => {
     });
   });
 });
+
+describe("formatToolCall summaries", () => {
+  it("preserves complete commands in the collapsed summary", () => {
+    const command = `PYTHONPATH=src uv run pytest ${"tests/very_long_directory/".repeat(4)}test_file.py`;
+
+    expect(formatToolCall(toolCall("bash", { command })).summary).toBe(command);
+  });
+
+  it("preserves complete task descriptions and URLs", () => {
+    const description = "Investigate the complete responsive timeline overflow behavior";
+    const url = `https://example.com/${"deeply/nested/".repeat(5)}resource`;
+
+    expect(formatToolCall(toolCall("task", { description })).summary).toBe(description);
+    expect(formatToolCall(toolCall("webfetch", { url })).summary).toBe(url);
+  });
+
+  it("does not render full task prompts or unknown-tool arguments in collapsed summaries", () => {
+    const prompt = "x".repeat(1_000);
+    const args = { query: "y".repeat(1_000), limit: 10 };
+
+    expect(formatToolCall(toolCall("task", { prompt })).summary).toBe("task");
+    expect(formatToolCall(toolCall("custom-tool", args)).summary).toBe("2 arguments");
+  });
+});

--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -36,7 +36,7 @@ function getStringArg(
 ): string | undefined {
   for (const key of keys) {
     const value = args?.[key];
-    if (typeof value === "string") return value;
+    if (typeof value === "string" && value.trim()) return value;
   }
   return undefined;
 }

--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -12,15 +12,6 @@ function basename(filePath: string | undefined): string {
 }
 
 /**
- * Truncate a string to a maximum length with ellipsis
- */
-function truncate(str: string | undefined, maxLen: number): string {
-  if (!str) return "";
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen) + "...";
-}
-
-/**
  * Count lines in a string
  */
 function countLines(str: string | undefined): number {
@@ -182,7 +173,7 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       const command = getStringArg(args, "command");
       return {
         toolName: "Bash",
-        summary: truncate(command, 50),
+        summary: command ?? "",
         icon: "terminal",
         getDetails: () => ({ args, output }),
       };
@@ -194,7 +185,7 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       return {
         toolName: "Grep",
         summary: pattern
-          ? `"${truncate(pattern, 30)}"${matchCount > 0 ? ` (${matchCount} matches)` : ""}`
+          ? `"${pattern}"${matchCount > 0 ? ` (${matchCount} matches)` : ""}`
           : "search",
         icon: "search",
         getDetails: () => ({ args, output }),
@@ -206,9 +197,7 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       const fileCount = output ? countLines(output) : 0;
       return {
         toolName: "Glob",
-        summary: pattern
-          ? `${truncate(pattern, 30)}${fileCount > 0 ? ` (${fileCount} files)` : ""}`
-          : "search",
+        summary: pattern ? `${pattern}${fileCount > 0 ? ` (${fileCount} files)` : ""}` : "search",
         icon: "folder",
         getDetails: () => ({ args, output }),
       };
@@ -216,10 +205,9 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
 
     case "task": {
       const description = getStringArg(args, "description");
-      const prompt = getStringArg(args, "prompt");
       return {
         toolName: "Task",
-        summary: description ? truncate(description, 40) : prompt ? truncate(prompt, 40) : "task",
+        summary: description ?? "task",
         icon: "box",
         getDetails: () => ({ args, output }),
       };
@@ -229,7 +217,7 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       const url = getStringArg(args, "url");
       return {
         toolName: "WebFetch",
-        summary: url ? truncate(url, 40) : "url",
+        summary: url ?? "url",
         icon: "globe",
         getDetails: () => ({ args, output }),
       };
@@ -239,7 +227,7 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       const query = getStringArg(args, "query");
       return {
         toolName: "WebSearch",
-        summary: query ? `"${truncate(query, 40)}"` : "search",
+        summary: query ? `"${query}"` : "search",
         icon: "search",
         getDetails: () => ({ args, output }),
       };
@@ -284,19 +272,22 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
 
       return {
         toolName: "Child Status",
-        summary: childId ? truncate(childId, 20) : "List Children",
+        summary: childId ?? "List Children",
         icon: "box",
         getDetails: () => ({ args, output }),
       };
     }
 
-    default:
+    default: {
+      const argumentCount = args ? Object.keys(args).length : 0;
       return {
         toolName: tool || "Unknown",
-        summary: args && Object.keys(args).length > 0 ? truncate(JSON.stringify(args), 50) : "",
+        summary:
+          argumentCount > 0 ? `${argumentCount} argument${argumentCount === 1 ? "" : "s"}` : "",
         icon: null,
         getDetails: () => ({ args, output }),
       };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing single-scroller timeline containment while making timeline content responsive within that boundary
- wrap complete tool, task, Slack, status, error, user, and Markdown text instead of clipping or ellipsizing it
- move timestamps below summaries on narrow screens and reduce nested mobile indentation
- keep code, patches, JSON, output, and Markdown tables in contained horizontal scrollers
- preserve useful complete tool summaries while keeping task prompt fallbacks and unknown-tool arguments compact

## Why

Recent scroll-containment fixes correctly prevented resizable panel wrappers and timeline auto-follow from scrolling the page. However, the timeline's horizontal safety boundary exposed collapsed rows whose text could not shrink or wrap, causing long commands and arguments to be cut off on mobile.

This fixes overflow at each content boundary without reverting the scroll-containment architecture or hiding important information behind ellipses.

## Testing

- `npm test -w @open-inspect/web` (944 passed)
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- Prettier check for all touched files
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/17a8832a3b20be5f70e0ed961aeb3f1e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Long commands, URLs, task descriptions, and tool details are now shown in full instead of being truncated.
  * Improved handling of long content, tables, code blocks, status messages, and error text.
  * Tool summaries now provide clearer fallback information when details are unavailable.

* **Responsive Design**
  * Updated timeline, task activity, Slack notifications, and tool call layouts for smaller screens.
  * Long content now wraps or scrolls horizontally while timestamps and icons remain properly aligned.
  * Improved spacing and indentation across expanded and collapsed activity details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->