### PR TITLE
Fix mobile expanded tool detail scrolling

### DIFF
--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -27,37 +27,26 @@ describe("ToolCallItem", () => {
     expect(button.querySelector(".truncate")).toBeNull();
   });
 
-  it("wraps complete long Grep arguments and output", () => {
-    const pattern = `needle-${"x".repeat(160)}`;
-    const path = `/workspace/${"deep-directory/".repeat(12)}source.ts`;
-    const output = `${path}:42:${"matching-source-text".repeat(12)}`;
-    const args = { pattern, path };
+  it("keeps long TodoWrite arguments in a contained horizontal scroller", () => {
+    const content = `implement-${"unbroken-task-description".repeat(20)}`;
+    const args = {
+      todos: [{ content, status: "in_progress", priority: "high" }],
+    };
     const event: Extract<SandboxEvent, { type: "tool_call" }> = {
       type: "tool_call",
       sandboxId: "sandbox-1",
       messageId: "message-call-2",
       callId: "call-2",
-      tool: "Grep",
+      tool: "TodoWrite",
       args,
-      output,
       timestamp: 1,
     };
 
     render(<ToolCallItem event={event} isExpanded onToggle={() => {}} />);
 
     const argumentsPre = screen.getByText("Arguments:").nextElementSibling;
-    const outputPre = screen.getByText("Output:").nextElementSibling;
-    expect(argumentsPre).toHaveTextContent(pattern);
     expect(argumentsPre?.textContent).toBe(JSON.stringify(args, null, 2));
-    expect(argumentsPre).toHaveClass("whitespace-pre-wrap", "[overflow-wrap:anywhere]");
-    expect(argumentsPre).not.toHaveClass("overflow-x-auto", "whitespace-pre");
-    expect(outputPre?.textContent).toBe(output);
-    expect(outputPre).toHaveClass(
-      "overflow-y-auto",
-      "whitespace-pre-wrap",
-      "[overflow-wrap:anywhere]"
-    );
-    expect(outputPre).not.toHaveClass("overflow-x-auto", "whitespace-pre");
+    expect(argumentsPre).toHaveClass("w-full", "max-w-full", "overflow-x-auto", "whitespace-pre");
   });
 
   it("keeps Apply Patch content preformatted and horizontally scrollable", () => {

--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -25,6 +25,9 @@ describe("ToolCallItem", () => {
     const button = screen.getByRole("button", { name: new RegExp(command) });
     expect(button).toHaveTextContent(command);
     expect(button.querySelector(".truncate")).toHaveTextContent(`Bash ${command}`);
+    expect(
+      [...button.querySelectorAll("svg")].every((icon) => icon.classList.contains("mt-[3px]"))
+    ).toBe(true);
   });
 
   it("keeps long TodoWrite arguments in a contained horizontal scroller", () => {

--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -8,7 +8,7 @@ import { ToolCallItem } from "./tool-call-item";
 afterEach(cleanup);
 
 describe("ToolCallItem", () => {
-  it("keeps complete long commands in collapsed rows", () => {
+  it("ellipsizes long collapsed summaries while retaining complete text", () => {
     const command = `PYTHONPATH=src uv run pytest ${"tests/very_long_directory/".repeat(4)}test_file.py`;
     const event: Extract<SandboxEvent, { type: "tool_call" }> = {
       type: "tool_call",
@@ -24,7 +24,7 @@ describe("ToolCallItem", () => {
 
     const button = screen.getByRole("button", { name: new RegExp(command) });
     expect(button).toHaveTextContent(command);
-    expect(button.querySelector(".truncate")).toBeNull();
+    expect(button.querySelector(".truncate")).toHaveTextContent(`Bash ${command}`);
   });
 
   it("keeps long TodoWrite arguments in a contained horizontal scroller", () => {

--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -26,4 +26,78 @@ describe("ToolCallItem", () => {
     expect(button).toHaveTextContent(command);
     expect(button.querySelector(".truncate")).toBeNull();
   });
+
+  it("wraps complete long Grep arguments and output", () => {
+    const pattern = `needle-${"x".repeat(160)}`;
+    const path = `/workspace/${"deep-directory/".repeat(12)}source.ts`;
+    const output = `${path}:42:${"matching-source-text".repeat(12)}`;
+    const args = { pattern, path };
+    const event: Extract<SandboxEvent, { type: "tool_call" }> = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-call-2",
+      callId: "call-2",
+      tool: "Grep",
+      args,
+      output,
+      timestamp: 1,
+    };
+
+    render(<ToolCallItem event={event} isExpanded onToggle={() => {}} />);
+
+    const argumentsPre = screen.getByText("Arguments:").nextElementSibling;
+    const outputPre = screen.getByText("Output:").nextElementSibling;
+    expect(argumentsPre).toHaveTextContent(pattern);
+    expect(argumentsPre?.textContent).toBe(JSON.stringify(args, null, 2));
+    expect(argumentsPre).toHaveClass("whitespace-pre-wrap", "[overflow-wrap:anywhere]");
+    expect(argumentsPre).not.toHaveClass("overflow-x-auto", "whitespace-pre");
+    expect(outputPre?.textContent).toBe(output);
+    expect(outputPre).toHaveClass(
+      "overflow-y-auto",
+      "whitespace-pre-wrap",
+      "[overflow-wrap:anywhere]"
+    );
+    expect(outputPre).not.toHaveClass("overflow-x-auto", "whitespace-pre");
+  });
+
+  it("keeps Apply Patch content preformatted and horizontally scrollable", () => {
+    const patchText = `*** Begin Patch\n*** Update File: source.ts\n-${"old".repeat(80)}\n+${"new".repeat(80)}\n*** End Patch`;
+    const event: Extract<SandboxEvent, { type: "tool_call" }> = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-call-3",
+      callId: "call-3",
+      tool: "apply_patch",
+      args: { patchText },
+      timestamp: 1,
+    };
+
+    render(<ToolCallItem event={event} isExpanded onToggle={() => {}} />);
+
+    const patchPre = screen.getByText("Patch:").nextElementSibling;
+    expect(patchPre?.textContent).toBe(patchText);
+    expect(patchPre).toHaveClass("overflow-x-auto", "whitespace-pre");
+    expect(patchPre).not.toHaveClass("whitespace-pre-wrap", "[overflow-wrap:anywhere]");
+  });
+
+  it("keeps Bash output preformatted and horizontally scrollable", () => {
+    const output = `COLUMN_A    COLUMN_B    ${"wide-terminal-value".repeat(20)}`;
+    const event: Extract<SandboxEvent, { type: "tool_call" }> = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-call-4",
+      callId: "call-4",
+      tool: "Bash",
+      args: { command: "print-table" },
+      output,
+      timestamp: 1,
+    };
+
+    render(<ToolCallItem event={event} isExpanded onToggle={() => {}} />);
+
+    const outputPre = screen.getByText("Output:").nextElementSibling;
+    expect(outputPre?.textContent).toBe(output);
+    expect(outputPre).toHaveClass("overflow-x-auto", "whitespace-pre");
+    expect(outputPre).not.toHaveClass("whitespace-pre-wrap", "[overflow-wrap:anywhere]");
+  });
 });

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -24,12 +24,6 @@ interface ToolCallItemProps {
   showTime?: boolean;
 }
 
-const WRAPPING_OUTPUT_TOOLS = new Set(["grep", "glob", "read", "search", "webfetch", "websearch"]);
-
-function shouldWrapOutput(tool: string | undefined): boolean {
-  return WRAPPING_OUTPUT_TOOLS.has(tool?.toLowerCase() ?? "");
-}
-
 function ToolIcon({ name }: { name: string | null }) {
   if (!name) return null;
 
@@ -60,7 +54,6 @@ function ToolIcon({ name }: { name: string | null }) {
 function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
   const formatted = formatToolCall(event);
   const isApplyPatch = event.tool?.toLowerCase() === "apply_patch";
-  const wrapsOutput = shouldWrapOutput(event.tool);
   const { args, output } = formatted.getDetails();
   const patchText = isApplyPatch && typeof args?.patchText === "string" ? args.patchText : null;
   const nonPatchArgs =
@@ -70,33 +63,27 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
   const hasNonPatchArgs = !!nonPatchArgs && Object.keys(nonPatchArgs).length > 0;
 
   return (
-    <div className="p-3 bg-card border border-border-muted text-xs overflow-hidden">
+    <div className="min-w-0 max-w-full overflow-hidden border border-border-muted bg-card p-3 text-xs">
       {hasNonPatchArgs && (
-        <div className="mb-2">
+        <div className="mb-2 min-w-0 max-w-full">
           <div className="text-muted-foreground mb-1 font-medium">Arguments:</div>
-          <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] text-foreground">
+          <pre className="w-full max-w-full overflow-x-auto whitespace-pre text-foreground">
             {JSON.stringify(nonPatchArgs, null, 2)}
           </pre>
         </div>
       )}
       {patchText && (
-        <div className="mb-2">
+        <div className="mb-2 min-w-0 max-w-full">
           <div className="text-muted-foreground mb-1 font-medium">Patch:</div>
-          <pre className="max-h-64 max-w-full overflow-x-auto whitespace-pre text-foreground">
+          <pre className="max-h-64 w-full max-w-full overflow-x-auto whitespace-pre text-foreground">
             {patchText}
           </pre>
         </div>
       )}
       {output && (
-        <div>
+        <div className="min-w-0 max-w-full">
           <div className="text-muted-foreground mb-1 font-medium">Output:</div>
-          <pre
-            className={`max-h-48 max-w-full text-foreground ${
-              wrapsOutput
-                ? "overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]"
-                : "overflow-x-auto whitespace-pre"
-            }`}
-          >
+          <pre className="max-h-48 w-full max-w-full overflow-x-auto whitespace-pre text-foreground">
             {output}
           </pre>
         </div>
@@ -124,7 +111,7 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
   const time = formatSessionEventTime(event.timestamp);
 
   return (
-    <div className="py-0.5">
+    <div className="min-w-0 max-w-full py-0.5">
       <button
         type="button"
         onClick={onToggle}
@@ -142,7 +129,7 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
       </button>
 
       {isExpanded && (
-        <div className="mt-2 ml-0 sm:ml-5">
+        <div className="mt-2 min-w-0 w-full max-w-full sm:ml-5 sm:w-[calc(100%_-_1.25rem)]">
           <ToolCallDetails event={event} />
         </div>
       )}

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -124,7 +124,9 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
         />
         <ToolIcon name={formatted.icon} />
         <TimelineRowContent time={showTime ? time : undefined}>
-          {formatted.toolName} {formatted.summary}
+          <span className="block truncate">
+            {formatted.toolName} {formatted.summary}
+          </span>
         </TimelineRowContent>
       </button>
 

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -24,6 +24,12 @@ interface ToolCallItemProps {
   showTime?: boolean;
 }
 
+const WRAPPING_OUTPUT_TOOLS = new Set(["grep", "glob", "read", "search", "webfetch", "websearch"]);
+
+function shouldWrapOutput(tool: string | undefined): boolean {
+  return WRAPPING_OUTPUT_TOOLS.has(tool?.toLowerCase() ?? "");
+}
+
 function ToolIcon({ name }: { name: string | null }) {
   if (!name) return null;
 
@@ -54,6 +60,7 @@ function ToolIcon({ name }: { name: string | null }) {
 function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
   const formatted = formatToolCall(event);
   const isApplyPatch = event.tool?.toLowerCase() === "apply_patch";
+  const wrapsOutput = shouldWrapOutput(event.tool);
   const { args, output } = formatted.getDetails();
   const patchText = isApplyPatch && typeof args?.patchText === "string" ? args.patchText : null;
   const nonPatchArgs =
@@ -67,7 +74,7 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
       {hasNonPatchArgs && (
         <div className="mb-2">
           <div className="text-muted-foreground mb-1 font-medium">Arguments:</div>
-          <pre className="max-w-full overflow-x-auto whitespace-pre text-foreground">
+          <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] text-foreground">
             {JSON.stringify(nonPatchArgs, null, 2)}
           </pre>
         </div>
@@ -83,7 +90,13 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
       {output && (
         <div>
           <div className="text-muted-foreground mb-1 font-medium">Output:</div>
-          <pre className="max-h-48 max-w-full overflow-x-auto whitespace-pre text-foreground">
+          <pre
+            className={`max-h-48 max-w-full text-foreground ${
+              wrapsOutput
+                ? "overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]"
+                : "overflow-x-auto whitespace-pre"
+            }`}
+          >
             {output}
           </pre>
         </div>

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -27,7 +27,7 @@ interface ToolCallItemProps {
 function ToolIcon({ name }: { name: string | null }) {
   if (!name) return null;
 
-  const iconClass = "w-3.5 h-3.5 shrink-0 text-secondary-foreground";
+  const iconClass = "mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground";
 
   switch (name) {
     case "file":
@@ -118,7 +118,7 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
         className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
-          className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
+          className={`mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
             isExpanded ? "rotate-90" : ""
           }`}
         />


### PR DESCRIPTION
## Summary

- truncate top-level collapsed tool summaries to a single ellipsized row while retaining the complete text in the DOM and accessible name
- render every expanded argument, output, and patch block as exact preformatted text with contained horizontal scrolling
- make the ToolCallItem, expanded detail wrapper, card, sections, and `<pre>` elements explicitly shrinkable/full-width so intrinsic content width cannot be clipped by timeline containment
- keep the existing single vertical timeline scroller and outer `overflow-x-hidden` architecture unchanged

## Why

PR #1394 added `overflow-x-auto` to expanded `<pre>` blocks, but long TodoWrite JSON could still be cut off. The `<pre>` retained a large intrinsic min-content width and was clipped by an ancestor before its own horizontal overflow became usable.

This fixes the containment chain rather than classifying tool content. Collapsed tool calls now match the compact Codex-style behavior with one-line ellipsis; expanded details preserve exact whitespace and scroll locally when wider than the card. Other timeline event types retain their existing wrapping behavior.

## Tests

- focused ToolCallItem coverage for collapsed summary truncation with complete text retained
- focused TodoWrite coverage for long JSON values
- Apply Patch and Bash exact-line horizontal scrolling coverage
- `npm test -w @open-inspect/web -- src/components/tool-call-item.test.tsx` (4 passed)
- `npm run lint -w @open-inspect/web` (passed)
- `npm run typecheck -w @open-inspect/web` (passed)
- `npx prettier --check packages/web/src/components/tool-call-item.tsx packages/web/src/components/tool-call-item.test.tsx` (passed)
- `git diff --check` (passed)

The earlier full web suite was attempted twice. Those runs completed with 946/948 and 939/948 tests passing; remaining unrelated tests exceeded the suite's fixed 5-second timeout under this environment. The changed component's focused suite consistently passes.

## Visual verification

Verified expanded TodoWrite behavior at a 390x844 viewport using a temporary local-only fixture rendering the real `ToolCallItem`; the fixture was removed before commit.

- TodoWrite contained scrollers: artifact `94d5f79c7273285a64f324eac9461669`
- source: `http://127.0.0.1:3010/tool-call-overflow-fixture`

Runtime measurements confirmed the document remained exactly 390px wide. The TodoWrite argument `<pre>` had a 340px client width and 6408px local scroll width; output had a 340px client width and 4457px local scroll width. Both reported `overflow-x:auto` and `white-space:pre`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call detail layouts to use available screen width responsively.
  * Preserved complete content, preformatted whitespace, and horizontal scrolling for long TodoWrite arguments, Apply Patch content, and Bash output.
  * Prevented unnecessary wrapping or clipping while keeping lengthy tool-call content readable.
  * Improved collapsed Bash summaries by shortening very long commands without losing access to the complete command text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->