### PR TITLE
fix: contain queued follow-ups within session workspace

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -268,41 +268,79 @@ export default function SessionPage() {
 
   const sessionWorkspace = (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-clip">
-      <PanelGroup orientation="vertical" id="session-terminal" style={{ overflow: "clip" }}>
-        <Panel
-          defaultSize={showTerminal ? "70%" : "100%"}
-          minSize="30%"
-          style={{ minHeight: 0, overflow: "clip" }}
-        >
-          <SessionTimeline
-            events={events}
-            sessionId={sessionId}
-            currentParticipantId={currentParticipantId}
-            participantProfiles={profiles}
-            isProcessing={isProcessing}
-            promptQueue={promptQueue}
-            loadingHistory={loadingHistory}
-            showSkeleton={false}
-            onLoadOlder={loadOlderEvents}
-            onOpenMedia={setSelectedMediaArtifactId}
-            terminalMessageReadObservationEnabled={
-              !loadingHistory &&
-              !isDetailsOpen &&
-              selectedMediaArtifactId === null &&
-              resolvedDiff === null
-            }
-            onMarkMessageRead={attemptMarkVisibleMessageRead}
-          />
-        </Panel>
-        {showTerminal && (
-          <>
-            <PanelResizeHandle className="h-1.5 cursor-row-resize bg-border-muted transition-colors hover:bg-accent" />
-            <Panel defaultSize="30%" minSize="15%" maxSize="70%">
-              <TerminalPanel url={ttydUrl!} token={ttydToken!} onClose={closeTerminal} />
-            </Panel>
-          </>
-        )}
-      </PanelGroup>
+      <div className="min-h-0 min-w-0 flex-1 overflow-clip">
+        <PanelGroup orientation="vertical" id="session-terminal" style={{ overflow: "clip" }}>
+          <Panel
+            defaultSize={showTerminal ? "70%" : "100%"}
+            minSize="30%"
+            style={{ minHeight: 0, overflow: "clip" }}
+          >
+            <SessionTimeline
+              events={events}
+              sessionId={sessionId}
+              currentParticipantId={currentParticipantId}
+              participantProfiles={profiles}
+              isProcessing={isProcessing}
+              promptQueue={promptQueue}
+              loadingHistory={loadingHistory}
+              showSkeleton={false}
+              onLoadOlder={loadOlderEvents}
+              onOpenMedia={setSelectedMediaArtifactId}
+              terminalMessageReadObservationEnabled={
+                !loadingHistory &&
+                !isDetailsOpen &&
+                selectedMediaArtifactId === null &&
+                resolvedDiff === null
+              }
+              onMarkMessageRead={attemptMarkVisibleMessageRead}
+            />
+          </Panel>
+          {showTerminal && (
+            <>
+              <PanelResizeHandle className="h-1.5 cursor-row-resize bg-border-muted transition-colors hover:bg-accent" />
+              <Panel defaultSize="30%" minSize="15%" maxSize="70%">
+                <TerminalPanel url={ttydUrl!} token={ttydToken!} onClose={closeTerminal} />
+              </Panel>
+            </>
+          )}
+        </PanelGroup>
+      </div>
+      <QueuedPromptStack promptQueue={promptQueue} />
+      <SessionPromptComposer
+        session={{
+          id: sessionId,
+          status: sessionState?.status ?? "created",
+          artifacts,
+          primaryRepo,
+          onArchive: handleArchive,
+          onUnarchive: handleUnarchive,
+        }}
+        prompt={{
+          value: prompt,
+          isProcessing: ready && isProcessing,
+          draftLocked: !ready || isSubmitting || sessionAttachments.isUploading,
+          submitError,
+          inputRef,
+          onSubmit: handleSubmit,
+          onChange: handleInputChange,
+          onKeyDown: handleKeyDown,
+          onStopExecution: stopExecution,
+        }}
+        attachments={{
+          items: sessionAttachments.attachments,
+          error: sessionAttachments.attachmentError,
+          isUploading: sessionAttachments.isUploading,
+          onAdd: sessionAttachments.addFiles,
+          onRemove: sessionAttachments.removeAttachment,
+        }}
+        model={{
+          selectedModel,
+          reasoningEffort,
+          items: modelItems,
+          onModelChange: handleModelChange,
+          onReasoningEffortChange: setReasoningEffort,
+        }}
+      />
     </div>
   );
 
@@ -452,43 +490,6 @@ export default function SessionPage() {
           if (!open) {
             setSelectedMediaArtifactId(null);
           }
-        }}
-      />
-
-      <QueuedPromptStack promptQueue={promptQueue} />
-      <SessionPromptComposer
-        session={{
-          id: sessionId,
-          status: sessionState?.status ?? "created",
-          artifacts,
-          primaryRepo,
-          onArchive: handleArchive,
-          onUnarchive: handleUnarchive,
-        }}
-        prompt={{
-          value: prompt,
-          isProcessing: ready && isProcessing,
-          draftLocked: !ready || isSubmitting || sessionAttachments.isUploading,
-          submitError,
-          inputRef,
-          onSubmit: handleSubmit,
-          onChange: handleInputChange,
-          onKeyDown: handleKeyDown,
-          onStopExecution: stopExecution,
-        }}
-        attachments={{
-          items: sessionAttachments.attachments,
-          error: sessionAttachments.attachmentError,
-          isUploading: sessionAttachments.isUploading,
-          onAdd: sessionAttachments.addFiles,
-          onRemove: sessionAttachments.removeAttachment,
-        }}
-        model={{
-          selectedModel,
-          reasoningEffort,
-          items: modelItems,
-          onModelChange: handleModelChange,
-          onReasoningEffortChange: setReasoningEffort,
         }}
       />
     </div>

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -284,7 +284,7 @@ export function SessionRightSidebar({
   onOpenDiff,
 }: SessionRightSidebarProps) {
   return (
-    <aside className="w-80 border-l border-border-muted overflow-y-auto hidden lg:block">
+    <aside className="hidden w-80 shrink-0 overflow-y-auto border-l border-border-muted lg:block">
       <SessionRightSidebarContent
         sessionId={sessionId}
         sessionState={sessionState}


### PR DESCRIPTION
## Summary
- render the queued prompt stack and prompt composer inside the session workspace column
- ensure the timeline panel can shrink without forcing horizontal overflow
- keep the desktop right sidebar at its intended fixed width

## Verification
- `npm run typecheck -w @open-inspect/web`
- `npx vitest run src/components/session-desktop-layout.test.tsx src/components/queued-prompt-stack.test.tsx src/components/session-prompt-composer.test.tsx src/components/session-timeline-scroll.test.tsx`
- ESLint and Prettier checks for the changed files
- visually verified at a 1366x900 viewport with two pending follow-ups and the desktop right sidebar visible

Visual artifact: `989287d8b2a8cb9264c58dce9da22c28`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f358b445c6e14a146423384f8f732557)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the session workspace layout by placing queued prompts and the prompt composer directly within the workspace.
  * Preserved existing timeline, terminal, and composer behavior while improving panel organization.

* **Style**
  * Applied minor layout styling cleanup to the session sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->