### PR TITLE
fix: align task activity row markers

### DIFF
--- a/packages/web/src/components/task-activity-item.test.tsx
+++ b/packages/web/src/components/task-activity-item.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ToolCallEvent } from "@/lib/timeline-items";
+import { TaskActivityItem } from "./task-activity-item";
+
+afterEach(cleanup);
+
+describe("TaskActivityItem", () => {
+  it("aligns the task icons and running indicator with the text", () => {
+    const event: ToolCallEvent = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-1",
+      callId: "call-1",
+      tool: "Task",
+      args: {
+        description: "Explore timeline rendering",
+        subagent_type: "explore",
+      },
+      status: "running",
+      timestamp: 1,
+    };
+
+    render(
+      <TaskActivityItem event={event} hasActivity={false}>
+        {null}
+      </TaskActivityItem>
+    );
+
+    const button = screen.getByRole("button", { name: /Task Explore timeline rendering/ });
+    const icons = button.querySelectorAll("svg");
+    const indicator = button.querySelector('[aria-hidden="true"]');
+
+    expect(icons).toHaveLength(2);
+    expect([...icons].every((icon) => icon.classList.contains("mt-[3px]"))).toBe(true);
+    expect(indicator).toHaveClass("mt-1.5");
+  });
+});

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -74,15 +74,15 @@ export function TaskActivityItem({
         className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
-          className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
+          className={`mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
             isExpanded ? "rotate-90" : ""
           }`}
         />
-        <BoxIcon className="w-3.5 h-3.5 shrink-0 text-secondary-foreground" />
+        <BoxIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground" />
         {isRunning && (
           <span
             aria-hidden="true"
-            className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse flex-shrink-0"
+            className="mt-1.5 inline-block h-2 w-2 flex-shrink-0 animate-pulse rounded-full bg-accent"
           />
         )}
         <TimelineRowContent time={formatSessionEventTime(event.timestamp)}>


### PR DESCRIPTION
## Summary
- vertically align the disclosure icon and task icon with the task label
- center the running/thinking indicator on the same text line
- add a focused component regression test for marker alignment

## Verification
- `npm test -w @open-inspect/web -- src/components/task-activity-item.test.tsx src/components/tool-call-item.test.tsx`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `git diff origin/main...HEAD --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9d8dba8771f6d8f4b0ec7c83fb3b01f6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment of task activity icons and running-status indicators.
* **Tests**
  * Added coverage to verify consistent activity-row styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->