### PR TITLE
fix: collapse timeline tasks by default

### DIFF
--- a/docs/plans/task-activity-nesting.md
+++ b/docs/plans/task-activity-nesting.md
@@ -77,8 +77,8 @@ The timeline grouping pass will:
 3. Associate child events only through `(messageId, taskCallId)`.
 4. Keep each Task at its own stable persisted position.
 5. Apply the existing consecutive same-tool grouping inside each Task.
-6. Render Task groups expanded initially, with a left guide and nested activity. Users can collapse
-   a Task to reduce noise or expand its existing arguments/output details.
+6. Render Task groups collapsed initially to reduce timeline noise. Users can expand a Task to see
+   its nested activity and existing arguments/output details.
 
 Legacy and malformed correlations degrade safely: an event without a matching Task remains in the
 normal top-level flow.

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -713,6 +713,13 @@ describe("task activity grouping", () => {
       />
     );
 
+    const task = screen.getByRole("button", { name: /Task Review code/ });
+    expect(task).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "Instructions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Result" })).not.toBeInTheDocument();
+
+    await user.click(task);
+    expect(task).toHaveAttribute("aria-expanded", "true");
     expect(screen.queryByText("Arguments:")).not.toBeInTheDocument();
     expect(screen.queryByText("Output:")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Instructions" })).toBeInTheDocument();
@@ -745,6 +752,7 @@ describe("task activity grouping", () => {
       />
     );
 
+    await user.click(screen.getByRole("button", { name: /Task Investigate failure/ }));
     expect(screen.queryByText("Output:")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Result" }));
     expect(screen.getByText("Agent could not finish.")).toBeInTheDocument();
@@ -807,6 +815,14 @@ describe("task activity grouping", () => {
       />
     );
 
+    const task = screen.getByRole("button", { name: /Task Review code/ });
+    expect(task).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Task activity")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent: explore")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Instructions" })).not.toBeInTheDocument();
+
+    await user.click(task);
+    expect(task).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("Task activity")).toBeInTheDocument();
     expect(screen.getByText("Agent: explore")).toBeInTheDocument();
     expect(screen.getByText("Task ID: ses_resumed")).toBeInTheDocument();
@@ -855,6 +871,10 @@ describe("task activity grouping", () => {
     );
     expect(screen.getByRole("button", { name: "Result" })).toHaveAttribute("aria-expanded", "true");
 
+    expect(screen.getByRole("button", { name: /Task Review code/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
     await user.click(screen.getByRole("button", { name: /Task Review code/ }));
     expect(screen.queryByText("Task activity")).not.toBeInTheDocument();
   });
@@ -894,6 +914,11 @@ describe("task activity grouping", () => {
         onOpenMedia={() => {}}
       />
     );
+
+    const tasks = screen.getAllByRole("button", { name: /Task (Review code|Investigate failure)/ });
+    expect(tasks).toHaveLength(2);
+    await user.click(tasks[0]);
+    await user.click(tasks[1]);
 
     expect(screen.queryByRole("button", { name: "Instructions" })).not.toBeInTheDocument();
     expect(screen.queryByText(/Agent:/)).not.toBeInTheDocument();

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -58,7 +58,7 @@ export function TaskActivityItem({
   hasActivity: boolean;
   children: ReactNode;
 }) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const formatted = formatToolCall(event);
   const prompt = stringArg(event, "prompt");
   const agent = stringArg(event, "subagent_type");


### PR DESCRIPTION
## Summary
- default timeline Task activity rows to collapsed
- preserve user-controlled expansion and stable disclosure state across timeline rerenders
- update regression coverage and the task activity nesting design note

## Root cause
PR #1381 (`7fe04a4`, `fix: collapse sub-tasks by default`) was merged and remains active, but it only changed the right-sidebar **Sub-tasks** section that lists child coding sessions.

The reported UI is a separate timeline component, `TaskActivityItem`. That component was introduced with task activity nesting and still explicitly initialized `isExpanded` to `true`, consistent with its original design note. The overlapping Task/Sub-task terminology made the sidebar fix appear ineffective even though it was working as implemented.

## Testing
- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx eslint packages/web/src/components/task-activity-item.tsx packages/web/src/components/session-timeline.test.tsx`
- `npx prettier --check packages/web/src/components/task-activity-item.tsx packages/web/src/components/session-timeline.test.tsx docs/plans/task-activity-nesting.md`
- Full web suite: 949/951 passed; two unrelated ESLint-boundary tests exceeded their 5-second timeout under full-suite load. Both passed independently:
  - `npm test -w @open-inspect/web -- src/lib/client-auth-boundary-eslint.test.ts`
  - `npm test -w @open-inspect/web -- src/lib/server-auth-boundary-eslint.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9fce8043e8c169b5d5b2352290f5fc52)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task groups in the web timeline now appear collapsed by default.
  * Expand a task to view nested activity, arguments, output, and other details.
* **Bug Fixes**
  * Removed the previous always-expanded layout and left-side guide.
  * Task details now remain hidden until expanded, reducing visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->