### PR TITLE
feat: collapse completed session activity

### DIFF
--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -256,6 +256,108 @@ describe("prompt queue status", () => {
   });
 });
 
+describe("completed turn activity", () => {
+  const completedTurnEvents: SandboxEvent[] = [
+    { ...event(), content: "Update the dependency", timestamp: 100 },
+    {
+      type: "token",
+      messageId: "message-1",
+      content: "I will inspect the current dependency before updating it.",
+      sandboxId: "sandbox-1",
+      timestamp: 101,
+    },
+    {
+      type: "context_compacted",
+      messageId: "message-1",
+      sandboxId: "sandbox-1",
+      timestamp: 102,
+    },
+    {
+      type: "tool_call",
+      tool: "Read",
+      args: { filePath: "/workspace/package.json" },
+      callId: "call-1",
+      messageId: "message-1",
+      sandboxId: "sandbox-1",
+      timestamp: 110,
+    },
+    {
+      type: "token",
+      messageId: "message-1",
+      content: "The dependency is updated.",
+      sandboxId: "sandbox-1",
+      timestamp: 188,
+    },
+    {
+      type: "execution_complete",
+      messageId: "message-1",
+      success: true,
+      sandboxId: "sandbox-1",
+      timestamp: 189,
+    },
+  ];
+
+  it("collapses completed activity behind the worked duration", async () => {
+    render(<SessionTimeline {...baseTimelineProps} events={completedTurnEvents} />);
+
+    const disclosure = screen.getByRole("button", { name: "Worked for 1m 29s" });
+    expect(disclosure).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("The dependency is updated.")).toBeInTheDocument();
+    expect(screen.getByText("Execution complete")).toBeInTheDocument();
+    expect(
+      screen.queryByText("I will inspect the current dependency before updating it.")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Read package\.json/i })).not.toBeInTheDocument();
+
+    await userEvent.click(disclosure);
+
+    expect(disclosure).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByText("I will inspect the current dependency before updating it.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Read package\.json/i })).toBeInTheDocument();
+    expect(screen.getByText("Context compacted")).toBeInTheDocument();
+  });
+
+  it("leaves activity visible until the turn completes", () => {
+    render(<SessionTimeline {...baseTimelineProps} events={completedTurnEvents.slice(0, -2)} />);
+
+    expect(screen.queryByRole("button", { name: /Worked for/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByText("I will inspect the current dependency before updating it.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Read package\.json/i })).toBeInTheDocument();
+  });
+
+  it("shows a duration for completed turns without tool activity", () => {
+    render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          { ...event(), timestamp: 10 },
+          {
+            type: "token",
+            messageId: "message-1",
+            content: "Finished.",
+            sandboxId: "sandbox-1",
+            timestamp: 14,
+          },
+          {
+            type: "execution_complete",
+            messageId: "message-1",
+            success: true,
+            sandboxId: "sandbox-1",
+            timestamp: 15,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Worked for 5s" })).toBeInTheDocument();
+    expect(screen.getByText("Finished.")).toBeInTheDocument();
+  });
+});
+
 describe("tool call groups", () => {
   it("preserves expanded group and row state when history is prepended", async () => {
     const readEvents = [

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -12,14 +12,16 @@ import {
 } from "react";
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
+import { SessionWorkGroup } from "@/components/session-work-group";
 import { TaskActivityItem } from "@/components/task-activity-item";
 import { TimelineRowContent } from "@/components/timeline-row-content";
 import { ToolCallGroup } from "@/components/tool-call-group";
 import { copyToClipboard } from "@/lib/format";
 import {
-  buildTimelineItems,
+  buildSessionTimelineItems,
   toolCallKey,
   type FlatTimelineItem,
+  type TimelineItem,
   type ToolCallEvent,
 } from "@/lib/timeline-items";
 import type { Artifact, SandboxEvent } from "@/types/session";
@@ -57,7 +59,7 @@ export function SessionTimeline({
   terminalMessageReadObservationEnabled?: boolean;
   onMarkMessageRead?: (messageId: string) => Promise<SessionReadAttemptDisposition>;
 }) {
-  const timelineItems = useMemo(() => buildTimelineItems(events), [events]);
+  const timelineItems = useMemo(() => buildSessionTimelineItems(events), [events]);
   const pendingMessageIds = useMemo(
     () =>
       new Set(
@@ -67,6 +69,7 @@ export function SessionTimeline({
   );
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
+  const [expandedWorkGroups, setExpandedWorkGroups] = useState<Set<string>>(new Set());
   const latestTerminalMessageId = useMemo(() => {
     for (let index = events.length - 1; index >= 0; index -= 1) {
       const event = events[index];
@@ -177,6 +180,15 @@ export function SessionTimeline({
     });
   }, []);
 
+  const toggleWorkGroup = useCallback((messageId: string) => {
+    setExpandedWorkGroups((expanded) => {
+      const next = new Set(expanded);
+      if (next.has(messageId)) next.delete(messageId);
+      else next.add(messageId);
+      return next;
+    });
+  }, []);
+
   const renderFlatItem = (item: FlatTimelineItem): ReactNode => {
     if (item.type === "tool_group") {
       return (
@@ -209,13 +221,27 @@ export function SessionTimeline({
     );
   };
 
-  const renderTimelineItem = (item: (typeof timelineItems)[number]): ReactNode =>
+  const renderBaseTimelineItem = (item: TimelineItem): ReactNode =>
     item.type === "task_group" ? (
       <TaskActivityItem key={item.id} event={item.event} hasActivity={item.activity.length > 0}>
         {item.activity.map(renderFlatItem)}
       </TaskActivityItem>
     ) : (
       renderFlatItem(item)
+    );
+
+  const renderTimelineItem = (item: (typeof timelineItems)[number]): ReactNode =>
+    item.type === "work_group" ? (
+      <SessionWorkGroup
+        key={item.id}
+        durationSeconds={item.durationSeconds}
+        isExpanded={expandedWorkGroups.has(item.messageId)}
+        onToggle={() => toggleWorkGroup(item.messageId)}
+      >
+        {item.activity.map(renderBaseTimelineItem)}
+      </SessionWorkGroup>
+    ) : (
+      renderBaseTimelineItem(item)
     );
 
   return (
@@ -256,6 +282,7 @@ export function SessionTimeline({
             }
             if (
               latestTerminalMessageGroupRange &&
+              onMarkMessageRead &&
               index > latestTerminalMessageGroupRange.start &&
               index <= latestTerminalMessageGroupRange.end
             ) {

--- a/packages/web/src/components/session-work-group.tsx
+++ b/packages/web/src/components/session-work-group.tsx
@@ -34,7 +34,7 @@ export function SessionWorkGroup({
         type="button"
         aria-expanded={isExpanded}
         onClick={onToggle}
-        className="flex w-full items-center gap-2 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground sm:text-base"
+        className="flex w-full items-center gap-2 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <span>{label}</span>
         <ChevronRightIcon

--- a/packages/web/src/components/session-work-group.tsx
+++ b/packages/web/src/components/session-work-group.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ChevronRightIcon } from "@/components/ui/icons";
+
+function formatDuration(durationSeconds: number): string {
+  const totalSeconds = Math.round(durationSeconds);
+  if (totalSeconds < 1) return "less than a second";
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours > 0 ? `${hours}h` : null, minutes > 0 ? `${minutes}m` : null, `${seconds}s`]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function SessionWorkGroup({
+  durationSeconds,
+  isExpanded,
+  onToggle,
+  children,
+}: {
+  durationSeconds: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  const label = `Worked for ${formatDuration(durationSeconds)}`;
+
+  return (
+    <div className="border-b border-border-muted py-1">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground sm:text-base"
+      >
+        <span>{label}</span>
+        <ChevronRightIcon
+          className={`h-4 w-4 shrink-0 text-secondary-foreground transition-transform duration-200 ${
+            isExpanded ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      {isExpanded && <div className="space-y-2 pb-2 pt-1">{children}</div>}
+    </div>
+  );
+}

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -11,6 +11,16 @@ export type TimelineItem =
   | FlatTimelineItem
   | { type: "task_group"; event: ToolCallEvent; activity: FlatTimelineItem[]; id: string };
 
+export type SessionTimelineItem =
+  | TimelineItem
+  | {
+      type: "work_group";
+      messageId: string;
+      durationSeconds: number;
+      activity: TimelineItem[];
+      id: string;
+    };
+
 export function toolCallKey(event: ToolCallEvent): string {
   return toolCallIdentityKey(event);
 }
@@ -144,4 +154,90 @@ export function buildTimelineItems(events: SandboxEvent[]): TimelineItem[] {
 
   flushFlatEvents();
   return items;
+}
+
+function isVisibleActivity(item: TimelineItem): boolean {
+  if (item.type !== "single") return true;
+
+  const event = item.event;
+  switch (event.type) {
+    case "token":
+      return Boolean(event.content);
+    case "tool_result":
+      return Boolean(event.error);
+    case "git_sync":
+    case "artifact":
+    case "error":
+    case "warning":
+    case "context_compacted":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Collapses completed turn activity while leaving in-flight and partial-history
+ * events in their existing flat presentation.
+ */
+export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimelineItem[] {
+  const items = buildTimelineItems(events);
+  const result: SessionTimelineItem[] = [];
+
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (item.type !== "single" || item.event.type !== "user_message") {
+      result.push(item);
+      continue;
+    }
+    const userMessage = item.event;
+
+    const completionIndex = items.findIndex(
+      (candidate, candidateIndex) =>
+        candidateIndex > index &&
+        candidate.type === "single" &&
+        candidate.event.type === "execution_complete" &&
+        candidate.event.messageId === userMessage.messageId
+    );
+    if (completionIndex < 0) {
+      result.push(item);
+      continue;
+    }
+
+    let finalOutputIndex = -1;
+    for (let candidateIndex = index + 1; candidateIndex < completionIndex; candidateIndex += 1) {
+      const candidate = items[candidateIndex];
+      if (
+        candidate.type === "single" &&
+        candidate.event.type === "token" &&
+        candidate.event.messageId === userMessage.messageId
+      ) {
+        finalOutputIndex = candidateIndex;
+      }
+    }
+
+    const activityEndIndex = finalOutputIndex >= 0 ? finalOutputIndex : completionIndex;
+    const activity = items.slice(index + 1, activityEndIndex).filter(isVisibleActivity);
+    result.push(item);
+    const completion = items[completionIndex];
+    if (completion.type !== "single" || completion.event.type !== "execution_complete") continue;
+    result.push({
+      type: "work_group",
+      messageId: userMessage.messageId,
+      durationSeconds: Math.max(0, completion.event.timestamp - userMessage.timestamp),
+      activity,
+      id: `work:${userMessage.messageId}`,
+    });
+
+    for (
+      let candidateIndex = activityEndIndex;
+      candidateIndex <= completionIndex;
+      candidateIndex += 1
+    ) {
+      result.push(items[candidateIndex]);
+    }
+    index = completionIndex;
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

- group completed turns into the prompt, an expandable worked-duration disclosure, and the final response
- preserve intermediate messages, tool calls, task activity, artifacts, and compaction markers within the expandable trajectory
- keep active and partial-history turns expanded
- render the "Worked for" label at the same `text-sm` size as timeline item text

## Testing

- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx src/components/session-timeline-scroll.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `git diff --check`