### PR TITLE
Expand child sessions in the session sidebar by default

### DIFF
--- a/packages/web/src/components/sidebar/child-sessions-section.test.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.test.tsx
@@ -21,9 +21,8 @@ vi.mock("next/link", () => ({
 }));
 
 describe("ChildSessionsSection", () => {
-  it("keeps sub-tasks collapsed until opened", async () => {
+  it("shows child sessions expanded by default", async () => {
     const sessionId = "parent-session";
-    const user = userEvent.setup();
     render(
       <SWRConfig
         value={{
@@ -53,18 +52,13 @@ describe("ChildSessionsSection", () => {
       </SWRConfig>
     );
 
-    const toggle = await screen.findByRole("button", { name: "Sub-tasks" });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(toggle).toHaveAttribute("aria-controls");
-    expect(screen.queryByRole("link", { name: /Child session/ })).not.toBeInTheDocument();
-
-    await user.click(toggle);
-
+    const toggle = await screen.findByRole("button", { name: "Child sessions" });
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-controls");
     expect(screen.getByRole("link", { name: /Child session/ })).toBeInTheDocument();
   });
 
-  it("collapses sub-tasks when navigating to another session", async () => {
+  it("shows child sessions expanded when navigating to another session", async () => {
     const user = userEvent.setup();
     const swrConfig = {
       fallback: Object.fromEntries(
@@ -96,9 +90,9 @@ describe("ChildSessionsSection", () => {
         <ChildSessionsSection sessionId="parent-a" />
       </SWRConfig>
     );
-    const toggle = await screen.findByRole("button", { name: "Sub-tasks" });
+    const toggle = await screen.findByRole("button", { name: "Child sessions" });
     await user.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
 
     rerender(
       <SWRConfig value={swrConfig}>
@@ -106,16 +100,15 @@ describe("ChildSessionsSection", () => {
       </SWRConfig>
     );
 
-    expect(await screen.findByRole("button", { name: "Sub-tasks" })).toHaveAttribute(
+    expect(await screen.findByRole("button", { name: "Child sessions" })).toHaveAttribute(
       "aria-expanded",
-      "false"
+      "true"
     );
-    expect(screen.queryByRole("link", { name: /Child parent-b/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Child parent-b/ })).toBeInTheDocument();
   });
 
   it("renders a child's pull request state icon", async () => {
     const sessionId = "parent-session";
-    const user = userEvent.setup();
     render(
       <SWRConfig
         value={{
@@ -151,8 +144,6 @@ describe("ChildSessionsSection", () => {
         <ChildSessionsSection sessionId={sessionId} />
       </SWRConfig>
     );
-
-    await user.click(await screen.findByRole("button", { name: "Sub-tasks" }));
 
     const childLink = (await screen.findByText("Child session")).closest("a");
     expect(childLink).toBeInTheDocument();

--- a/packages/web/src/components/sidebar/child-sessions-section.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.tsx
@@ -46,7 +46,7 @@ export function ChildSessionsSection({ sessionId }: ChildSessionsSectionProps) {
   if (!children?.length) return null;
 
   return (
-    <CollapsibleSection key={sessionId} title="Sub-tasks" defaultOpen={false}>
+    <CollapsibleSection key={sessionId} title="Child sessions">
       <div className="space-y-2">
         {children.map((child) => {
           const prDisplay = pullRequestSummaryDisplay(child.pullRequestSummary);


### PR DESCRIPTION
## Summary

- rename the right-hand session sidebar section from "Sub-tasks" to "Child sessions"
- restore the section's expanded-by-default behavior
- update component tests for the copy and expansion state

## Testing

- `npm test -w @open-inspect/web -- src/components/sidebar/child-sessions-section.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/7b35bf20eb9b7e79e6c93d05bcc0e8d9)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the sidebar section from “Sub-tasks” to “Child sessions.”
  * Child sessions are now expanded by default, making available session links immediately visible.
  * Newly created child sessions remain visible in the expanded section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->