### PR TITLE
fix: address timeline grouping review comments

### DIFF
--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -356,6 +356,52 @@ describe("completed turn activity", () => {
     expect(screen.getByRole("button", { name: "Worked for 5s" })).toBeInTheDocument();
     expect(screen.getByText("Finished.")).toBeInTheDocument();
   });
+
+  it("does not collapse across a queued prompt before the running turn completes", () => {
+    render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          { ...event(), messageId: "message-1", content: "First prompt", timestamp: 10 },
+          {
+            type: "token",
+            messageId: "message-1",
+            content: "Working on the first prompt.",
+            sandboxId: "sandbox-1",
+            timestamp: 11,
+          },
+          { ...event(), messageId: "message-2", content: "Second prompt", timestamp: 12 },
+          {
+            type: "execution_complete",
+            messageId: "message-1",
+            success: true,
+            sandboxId: "sandbox-1",
+            timestamp: 13,
+          },
+          {
+            type: "token",
+            messageId: "message-2",
+            content: "Finished the second prompt.",
+            sandboxId: "sandbox-1",
+            timestamp: 14,
+          },
+          {
+            type: "execution_complete",
+            messageId: "message-2",
+            success: true,
+            sandboxId: "sandbox-1",
+            timestamp: 15,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("First prompt")).toBeInTheDocument();
+    expect(screen.getByText("Second prompt")).toBeInTheDocument();
+    expect(screen.getByText("Working on the first prompt.")).toBeInTheDocument();
+    expect(screen.getByText("Finished the second prompt.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Worked for/i })).not.toBeInTheDocument();
+  });
 });
 
 describe("tool call groups", () => {

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -234,7 +234,7 @@ export function SessionTimeline({
     item.type === "work_group" ? (
       <SessionWorkGroup
         key={item.id}
-        durationSeconds={item.durationSeconds}
+        durationMs={item.durationMs}
         isExpanded={expandedWorkGroups.has(item.messageId)}
         onToggle={() => toggleWorkGroup(item.messageId)}
       >

--- a/packages/web/src/components/session-work-group.tsx
+++ b/packages/web/src/components/session-work-group.tsx
@@ -3,8 +3,8 @@
 import type { ReactNode } from "react";
 import { ChevronRightIcon } from "@/components/ui/icons";
 
-function formatDuration(durationSeconds: number): string {
-  const totalSeconds = Math.round(durationSeconds);
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.round(durationMs / 1000);
   if (totalSeconds < 1) return "less than a second";
 
   const hours = Math.floor(totalSeconds / 3600);
@@ -16,17 +16,17 @@ function formatDuration(durationSeconds: number): string {
 }
 
 export function SessionWorkGroup({
-  durationSeconds,
+  durationMs,
   isExpanded,
   onToggle,
   children,
 }: {
-  durationSeconds: number;
+  durationMs: number;
   isExpanded: boolean;
   onToggle: () => void;
   children: ReactNode;
 }) {
-  const label = `Worked for ${formatDuration(durationSeconds)}`;
+  const label = `Worked for ${formatDuration(durationMs)}`;
 
   return (
     <div className="border-b border-border-muted py-1">

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -16,7 +16,7 @@ export type SessionTimelineItem =
   | {
       type: "work_group";
       messageId: string;
-      durationSeconds: number;
+      durationMs: number;
       activity: TimelineItem[];
       id: string;
     };
@@ -156,26 +156,6 @@ export function buildTimelineItems(events: SandboxEvent[]): TimelineItem[] {
   return items;
 }
 
-function isVisibleActivity(item: TimelineItem): boolean {
-  if (item.type !== "single") return true;
-
-  const event = item.event;
-  switch (event.type) {
-    case "token":
-      return Boolean(event.content);
-    case "tool_result":
-      return Boolean(event.error);
-    case "git_sync":
-    case "artifact":
-    case "error":
-    case "warning":
-    case "context_compacted":
-      return true;
-    default:
-      return false;
-  }
-}
-
 /**
  * Collapses completed turn activity while leaving in-flight and partial-history
  * events in their existing flat presentation.
@@ -204,6 +184,20 @@ export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimeli
       continue;
     }
 
+    const crossesTurnBoundary = items
+      .slice(index + 1, completionIndex)
+      .some(
+        (candidate) =>
+          candidate.type === "single" &&
+          (candidate.event.type === "user_message" ||
+            (candidate.event.type === "execution_complete" &&
+              candidate.event.messageId !== userMessage.messageId))
+      );
+    if (crossesTurnBoundary) {
+      result.push(item);
+      continue;
+    }
+
     let finalOutputIndex = -1;
     for (let candidateIndex = index + 1; candidateIndex < completionIndex; candidateIndex += 1) {
       const candidate = items[candidateIndex];
@@ -217,14 +211,14 @@ export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimeli
     }
 
     const activityEndIndex = finalOutputIndex >= 0 ? finalOutputIndex : completionIndex;
-    const activity = items.slice(index + 1, activityEndIndex).filter(isVisibleActivity);
+    const activity = items.slice(index + 1, activityEndIndex);
     result.push(item);
     const completion = items[completionIndex];
     if (completion.type !== "single" || completion.event.type !== "execution_complete") continue;
     result.push({
       type: "work_group",
       messageId: userMessage.messageId,
-      durationSeconds: Math.max(0, completion.event.timestamp - userMessage.timestamp),
+      durationMs: Math.max(0, completion.event.timestamp - userMessage.timestamp) * 1000,
       activity,
       id: `work:${userMessage.messageId}`,
     });

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -176,24 +176,14 @@ export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimeli
       (candidate, candidateIndex) =>
         candidateIndex > index &&
         candidate.type === "single" &&
-        candidate.event.type === "execution_complete" &&
-        candidate.event.messageId === userMessage.messageId
+        (candidate.event.type === "user_message" || candidate.event.type === "execution_complete")
     );
-    if (completionIndex < 0) {
-      result.push(item);
-      continue;
-    }
-
-    const crossesTurnBoundary = items
-      .slice(index + 1, completionIndex)
-      .some(
-        (candidate) =>
-          candidate.type === "single" &&
-          (candidate.event.type === "user_message" ||
-            (candidate.event.type === "execution_complete" &&
-              candidate.event.messageId !== userMessage.messageId))
-      );
-    if (crossesTurnBoundary) {
+    const completion = items[completionIndex];
+    if (
+      completion?.type !== "single" ||
+      completion.event.type !== "execution_complete" ||
+      completion.event.messageId !== userMessage.messageId
+    ) {
       result.push(item);
       continue;
     }
@@ -213,8 +203,6 @@ export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimeli
     const activityEndIndex = finalOutputIndex >= 0 ? finalOutputIndex : completionIndex;
     const activity = items.slice(index + 1, activityEndIndex);
     result.push(item);
-    const completion = items[completionIndex];
-    if (completion.type !== "single" || completion.event.type !== "execution_complete") continue;
     result.push({
       type: "work_group",
       messageId: userMessage.messageId,


### PR DESCRIPTION
## Summary

- prevent completed timeline work groups from consuming later queued prompts or crossing completion boundaries
- preserve the full activity slice and rely on the existing event renderer as the canonical visibility boundary
- use milliseconds for the TypeScript work-group duration contract, converting second-based event timestamps at the builder boundary
- add regression coverage for a queued second prompt arriving before the first turn completes

## Context

This follows up on the post-merge review comments left on #1400. All three comments were still applicable to the merged implementation.

## Testing

- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx src/components/session-timeline-scroll.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `git diff --check -- packages/web/src/lib/timeline-items.ts packages/web/src/components/session-timeline.tsx packages/web/src/components/session-work-group.tsx packages/web/src/components/session-timeline.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9079c58412dc22b06b2b9c43b3eaea2d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timelines so activity from separate queued prompts is displayed in the correct work sections.
  * Prevented activity from being incorrectly merged across user messages or completed executions.
  * Improved work-duration labels by preserving accurate timing and rounding only when displayed.

* **Tests**
  * Added regression coverage for activity across multiple queued prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->