### PR TITLE
fix: center integration row chevrons

### DIFF
--- a/packages/web/src/components/settings/integrations-settings.tsx
+++ b/packages/web/src/components/settings/integrations-settings.tsx
@@ -24,7 +24,7 @@ export function IntegrationsSettings() {
                   <p className="text-sm font-medium">{integration.name}</p>
                   <p className="text-xs mt-1">{integration.description}</p>
                 </div>
-                <ChevronRightIcon className="w-4 h-4 mt-0.5 text-muted-foreground" />
+                <ChevronRightIcon className="w-4 h-4 shrink-0 self-center text-muted-foreground" />
               </Link>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- vertically center each right chevron within its integration settings row
- prevent the icon from shrinking when integration descriptions are long
- preserve the existing top-aligned text layout

## Root cause
The row uses `items-start` for its two-line text content, which also top-aligned the 16px chevron. A 2px top margin attempted to compensate, but could not center the icon against the approximately 40px text block.

## Verification
- `npm test -w @open-inspect/web -- --run src/components/settings/integrations-settings.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --quiet`

## Visual verification
A local browser capture was attempted at 1200x800, but the settings page was blocked by missing local authentication configuration (`Authentication is temporarily unavailable`). Artifact ID: `38654e4b45d328aebec451605ee52c99`.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/14626466a648711bab6a682967fd00a2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the integration settings list by keeping chevron icons at a consistent size and vertically aligning them within each link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->