### PR TITLE
feat(sandbox): add E2B prebuilt-image (snapshot) support

### DIFF
--- a/packages/control-plane/src/image-builds/e2b-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/e2b-adapter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import type { E2BSandboxProvider } from "../sandbox/providers/e2b-provider";
+import { E2BImageBuildAdapter } from "./e2b-adapter";
+import { resolveImageBuildProviderSessionTimeoutSeconds } from "./timeouts";
+import type { ImageBuildPlan } from "./types";
+
+function createProvider(): E2BSandboxProvider {
+  return {
+    triggerImageBuild: vi.fn(async () => undefined),
+    takeSnapshot: vi.fn(async () => ({ success: true, imageId: "snap-abc:default" })),
+    deleteSandbox: vi.fn(async () => undefined),
+    deleteProviderImage: vi.fn(async () => undefined),
+  } as unknown as E2BSandboxProvider;
+}
+
+function createPlan(): ImageBuildPlan {
+  return {
+    buildId: "build-1",
+    scope: { kind: "repo", id: "acme/repo" },
+    repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
+    repositoriesFingerprint: "fp-1",
+    callbackUrl: "https://worker.test/image-builds/build-complete",
+    failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+    callbackToken: "callback-token",
+    cloneAuth: { type: "credential_helper", token: "clone-token" },
+    buildTimeoutMs: 1_800_001,
+    userEnvVars: { FOO: "bar" },
+    correlation: { request_id: "request-1", trace_id: "trace-1" },
+  };
+}
+
+describe("E2BImageBuildAdapter", () => {
+  it("starts builds through the E2B provider capability", async () => {
+    const provider = createProvider();
+    const adapter = new E2BImageBuildAdapter(provider);
+    const bindProviderSession = vi.fn();
+
+    await adapter.startBuild(createPlan(), { bindProviderSession });
+
+    expect(provider.triggerImageBuild).toHaveBeenCalledWith({
+      scopeKind: "repo",
+      scopeId: "acme/repo",
+      buildId: "build-1",
+      repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
+      callbackUrl: "https://worker.test/image-builds/build-complete",
+      failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+      callbackToken: "callback-token",
+      cloneToken: "clone-token",
+      buildExecutionTimeoutSeconds: 1801,
+      providerSessionTimeoutSeconds: resolveImageBuildProviderSessionTimeoutSeconds(1_800_001),
+      userEnvVars: { FOO: "bar" },
+      onProviderSessionCreated: bindProviderSession,
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("snapshots the completed build sandbox", async () => {
+    const provider = createProvider();
+    const adapter = new E2BImageBuildAdapter(provider);
+
+    const result = await adapter.finalizeSuccessfulBuild({
+      buildId: "build-1",
+      providerSessionId: "e2b-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    expect(result).toEqual({
+      providerImageId: "snap-abc:default",
+      providerSessionId: "e2b-session-1",
+    });
+    expect(provider.takeSnapshot).toHaveBeenCalledWith({
+      providerObjectId: "e2b-session-1",
+      sessionId: "build-1",
+      reason: "environment_image_build",
+      correlation: { request_id: "request-1", trace_id: "trace-1", sandbox_id: "e2b-session-1" },
+    });
+  });
+
+  it("fails the build when the snapshot returns no image id", async () => {
+    const provider = createProvider();
+    vi.mocked(provider.takeSnapshot).mockResolvedValueOnce({ success: false, error: "boom" });
+    const adapter = new E2BImageBuildAdapter(provider);
+
+    await expect(
+      adapter.finalizeSuccessfulBuild({
+        buildId: "build-1",
+        providerSessionId: "e2b-session-1",
+        correlation: { request_id: "request-1", trace_id: "trace-1" },
+      })
+    ).rejects.toThrow(/boom/);
+  });
+
+  it("kills the build sandbox after a completed build", async () => {
+    const provider = createProvider();
+    const adapter = new E2BImageBuildAdapter(provider);
+
+    await adapter.cleanupCompletedBuild({
+      buildId: "build-1",
+      providerSessionId: "e2b-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("e2b-session-1");
+  });
+
+  it("kills the build sandbox on failed builds", async () => {
+    const provider = createProvider();
+    const adapter = new E2BImageBuildAdapter(provider);
+
+    await adapter.cleanupFailedBuild({
+      buildId: "build-1",
+      providerSessionId: "e2b-session-1",
+      errorMessage: "setup.sh failed",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("e2b-session-1");
+  });
+
+  it("deletes provider images through the E2B provider capability", async () => {
+    const provider = createProvider();
+    const adapter = new E2BImageBuildAdapter(provider);
+
+    await adapter.deleteImage({
+      image: { providerImageId: "snap-abc:default", providerSessionId: "ignored-session" },
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    expect(provider.deleteProviderImage).toHaveBeenCalledWith("snap-abc:default");
+  });
+});

--- a/packages/control-plane/src/image-builds/e2b-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/e2b-adapter.test.ts
@@ -7,7 +7,10 @@ import type { ImageBuildPlan } from "./types";
 function createProvider(): E2BSandboxProvider {
   return {
     triggerImageBuild: vi.fn(async () => undefined),
-    takeSnapshot: vi.fn(async () => ({ success: true, imageId: "snap-abc:default" })),
+    takePrebuiltImageSnapshot: vi.fn(async () => ({
+      success: true,
+      imageId: "snap-abc:default",
+    })),
     deleteSandbox: vi.fn(async () => undefined),
     deleteProviderImage: vi.fn(async () => undefined),
   } as unknown as E2BSandboxProvider;
@@ -68,7 +71,7 @@ describe("E2BImageBuildAdapter", () => {
       providerImageId: "snap-abc:default",
       providerSessionId: "e2b-session-1",
     });
-    expect(provider.takeSnapshot).toHaveBeenCalledWith({
+    expect(provider.takePrebuiltImageSnapshot).toHaveBeenCalledWith({
       providerObjectId: "e2b-session-1",
       sessionId: "build-1",
       reason: "environment_image_build",
@@ -78,7 +81,10 @@ describe("E2BImageBuildAdapter", () => {
 
   it("fails the build when the snapshot returns no image id", async () => {
     const provider = createProvider();
-    vi.mocked(provider.takeSnapshot).mockResolvedValueOnce({ success: false, error: "boom" });
+    vi.mocked(provider.takePrebuiltImageSnapshot).mockResolvedValueOnce({
+      success: false,
+      error: "boom",
+    });
     const adapter = new E2BImageBuildAdapter(provider);
 
     await expect(

--- a/packages/control-plane/src/image-builds/e2b-adapter.ts
+++ b/packages/control-plane/src/image-builds/e2b-adapter.ts
@@ -20,7 +20,8 @@ const MS_PER_SECOND = 1000;
  * build sandbox (E2B stop only pauses, which would leak the single-use box).
  *
  * Quiescing the build process before the snapshot is owned by the provider's
- * takeSnapshot (pause keepMemory:false → connect cold-boot → snapshot), so the
+ * takePrebuiltImageSnapshot (pause memory:false → connect cold-boot → snapshot),
+ * so the
  * adapter neither waits nor guesses when the build supervisor has exited.
  */
 export class E2BImageBuildAdapter implements ImageBuildAdapter {
@@ -49,7 +50,7 @@ export class E2BImageBuildAdapter implements ImageBuildAdapter {
   async finalizeSuccessfulBuild(
     input: FinalizeImageBuildInput
   ): Promise<ImageBuildProviderImageRef> {
-    const snapshot = await this.provider.takeSnapshot({
+    const snapshot = await this.provider.takePrebuiltImageSnapshot({
       providerObjectId: input.providerSessionId,
       sessionId: input.buildId,
       reason: "environment_image_build",

--- a/packages/control-plane/src/image-builds/e2b-adapter.ts
+++ b/packages/control-plane/src/image-builds/e2b-adapter.ts
@@ -1,0 +1,86 @@
+import type { E2BSandboxProvider } from "../sandbox/providers/e2b-provider";
+import type { ImageBuildProviderImageRef } from "./model";
+import type {
+  DeleteImageInput,
+  FailedImageBuildInput,
+  FinalizeImageBuildInput,
+  ImageBuildAdapter,
+  ImageBuildPlan,
+  ImageBuildStartCallbacks,
+} from "./types";
+import { resolveImageBuildProviderSessionTimeoutSeconds } from "./timeouts";
+
+const MS_PER_SECOND = 1000;
+
+/**
+ * E2B adapter for provider-session image builds.
+ *
+ * Builds run in a temporary E2B sandbox. On success, the adapter bakes that
+ * sandbox's filesystem into a reusable snapshot template; teardown kills the
+ * build sandbox (E2B stop only pauses, which would leak the single-use box).
+ *
+ * Quiescing the build process before the snapshot is owned by the provider's
+ * takeSnapshot (pause keepMemory:false → connect cold-boot → snapshot), so the
+ * adapter neither waits nor guesses when the build supervisor has exited.
+ */
+export class E2BImageBuildAdapter implements ImageBuildAdapter {
+  constructor(private readonly provider: E2BSandboxProvider) {}
+
+  async startBuild(plan: ImageBuildPlan, callbacks: ImageBuildStartCallbacks): Promise<void> {
+    await this.provider.triggerImageBuild({
+      scopeKind: plan.scope.kind,
+      scopeId: plan.scope.id,
+      repositories: plan.repositories,
+      buildId: plan.buildId,
+      callbackUrl: plan.callbackUrl,
+      failureCallbackUrl: plan.failureCallbackUrl,
+      callbackToken: plan.callbackToken,
+      userEnvVars: plan.userEnvVars,
+      cloneToken: plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.token : undefined,
+      buildExecutionTimeoutSeconds: Math.ceil(plan.buildTimeoutMs / MS_PER_SECOND),
+      providerSessionTimeoutSeconds: resolveImageBuildProviderSessionTimeoutSeconds(
+        plan.buildTimeoutMs
+      ),
+      onProviderSessionCreated: callbacks.bindProviderSession,
+      correlation: plan.correlation,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeImageBuildInput
+  ): Promise<ImageBuildProviderImageRef> {
+    const snapshot = await this.provider.takeSnapshot({
+      providerObjectId: input.providerSessionId,
+      sessionId: input.buildId,
+      reason: "environment_image_build",
+      correlation: {
+        ...input.correlation,
+        sandbox_id: input.providerSessionId,
+      },
+    });
+
+    if (!snapshot.success || !snapshot.imageId) {
+      throw new Error(snapshot.error || "E2B snapshot did not return an image id");
+    }
+
+    return {
+      providerImageId: snapshot.imageId,
+      providerSessionId: input.providerSessionId,
+    };
+  }
+
+  async cleanupCompletedBuild(input: FinalizeImageBuildInput): Promise<void> {
+    // The snapshot taken in finalizeSuccessfulBuild is a standalone template;
+    // it does not reference the build sandbox, so the box can be killed once
+    // the build is done. E2B stop only pauses, so delete rather than stop.
+    await this.provider.deleteSandbox(input.providerSessionId);
+  }
+
+  async cleanupFailedBuild(input: FailedImageBuildInput): Promise<void> {
+    await this.provider.deleteSandbox(input.providerSessionId);
+  }
+
+  async deleteImage(input: DeleteImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.image.providerImageId);
+  }
+}

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -20,9 +20,9 @@ import type {
 
 /**
  * Providers with image-build support: Modal images, Vercel snapshots,
- * OpenComputer checkpoints. Daytona has no image support.
+ * OpenComputer checkpoints, E2B snapshots. Daytona has no image support.
  */
-export type ImageBuildProvider = "modal" | "vercel" | "opencomputer";
+export type ImageBuildProvider = "modal" | "vercel" | "opencomputer" | "e2b";
 
 /**
  * What an image bakes. `id` is a lowercase `owner/name` pair for repo scopes

--- a/packages/control-plane/src/image-builds/provider-factory.ts
+++ b/packages/control-plane/src/image-builds/provider-factory.ts
@@ -1,5 +1,6 @@
 import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
 import type { Env } from "../types";
+import { E2BImageBuildAdapter } from "./e2b-adapter";
 import { ModalImageBuildAdapter } from "./modal-adapter";
 import type { ImageBuildProvider } from "./model";
 import { OpenComputerImageBuildAdapter } from "./opencomputer-adapter";
@@ -39,6 +40,8 @@ class EnvImageBuildAdapterFactory implements ImageBuildAdapterFactory {
             requireOpenComputerTemplate: operation === "start",
           })
         );
+      case "e2b":
+        return new E2BImageBuildAdapter(createSandboxProviderFromEnv(this.env, "e2b"));
     }
   }
 }

--- a/packages/control-plane/src/image-builds/provider-policy.ts
+++ b/packages/control-plane/src/image-builds/provider-policy.ts
@@ -13,6 +13,7 @@ const IMAGE_BUILD_PROVIDERS = {
   modal: true,
   vercel: true,
   opencomputer: true,
+  e2b: true,
 } satisfies Record<ImageBuildProvider, true>;
 
 export function getImageBuildsUnsupportedMessage(env: Env): string | null {
@@ -20,7 +21,7 @@ export function getImageBuildsUnsupportedMessage(env: Env): string | null {
     return null;
   }
 
-  return "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer";
+  return "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b";
 }
 
 export function resolveImageBuildProvider(value: string | undefined): ImageBuildProvider | null {

--- a/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
@@ -4,7 +4,6 @@ import {
   E2BNotFoundError,
   E2BConflictError,
   E2BApiError,
-  stripSnapshotTag,
   type E2BRestConfig,
 } from "./e2b-rest-client";
 
@@ -107,6 +106,13 @@ describe("E2BRestClient", () => {
     expect(JSON.parse(fetchSpy.mock.calls[0][1].body).secure).toBe(true);
   });
 
+  it("forwards outbound internet policy when requested", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(jsonResponse({ sandboxID: "sb-new", templateID: "tmpl-123" }));
+    await client.createSandbox({ templateID: "tmpl-123", allowInternetAccess: false });
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).allow_internet_access).toBe(false);
+  });
+
   it("writeSessionEnv sends the X-Access-Token header (never anonymous)", async () => {
     const client = new E2BRestClient(defaultConfig);
     fetchSpy.mockResolvedValue(new Response("[]", { status: 200 }));
@@ -118,10 +124,14 @@ describe("E2BRestClient", () => {
 
   it("connect + timeout endpoints", async () => {
     const client = new E2BRestClient(defaultConfig);
-    // Connect answers with the create-style Sandbox shape (no `state`); the
-    // command discards it rather than validating it as a sandbox detail.
-    fetchSpy.mockResolvedValue(jsonResponse({ sandboxID: "sb-1", templateID: "tmpl" }));
-    await expect(client.connectSandbox("sb-1", 3300)).resolves.toBeUndefined();
+    // Connect answers with the create-style Sandbox shape (no `state`), including
+    // the reissued envd access token secure sandboxes need after a cold boot.
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ sandboxID: "sb-1", templateID: "tmpl", envdAccessToken: "tok-fresh" })
+    );
+    await expect(client.connectSandbox("sb-1", 3300)).resolves.toEqual(
+      expect.objectContaining({ sandboxID: "sb-1", envdAccessToken: "tok-fresh" })
+    );
     expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({ timeout: 3300 });
 
     fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
@@ -171,6 +181,16 @@ describe("E2BRestClient", () => {
     await expect(client.getSandbox("x")).rejects.toMatchObject({
       body: '{"code":"bad_request"}',
     });
+  });
+
+  it("updates sandbox network policy", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+    await client.updateSandboxNetwork("sb-1", { allowInternetAccess: true });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.e2b.app/sandboxes/sb-1/network");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body)).toEqual({ allow_internet_access: true });
   });
 
   it("classifies 404/409/429 errors", async () => {
@@ -230,24 +250,12 @@ describe("E2BRestClient", () => {
     expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({ name: "my-snap" });
   });
 
-  it("deleteTemplate strips the snapshot tag and DELETEs the bare template id", async () => {
+  it("deleteTemplate passes the full snapshot id to E2B", async () => {
     const client = new E2BRestClient(defaultConfig);
     fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
     await client.deleteTemplate("snap-abc:default");
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe("https://api.e2b.app/templates/snap-abc");
+    expect(url).toBe("https://api.e2b.app/templates/snap-abc%3Adefault");
     expect(init.method).toBe("DELETE");
-  });
-});
-
-describe("stripSnapshotTag", () => {
-  it("removes a trailing build tag", () => {
-    expect(stripSnapshotTag("abc123:default")).toBe("abc123");
-    expect(stripSnapshotTag("team/my-snapshot:v2")).toBe("team/my-snapshot");
-  });
-
-  it("leaves ids without a tag untouched", () => {
-    expect(stripSnapshotTag("abc123")).toBe("abc123");
-    expect(stripSnapshotTag("team/my-snapshot")).toBe("team/my-snapshot");
   });
 });

--- a/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
@@ -4,6 +4,7 @@ import {
   E2BNotFoundError,
   E2BConflictError,
   E2BApiError,
+  stripSnapshotTag,
   type E2BRestConfig,
 } from "./e2b-rest-client";
 
@@ -197,5 +198,56 @@ describe("E2BRestClient", () => {
   it("getHostnameForPort is deterministic", () => {
     const client = new E2BRestClient(defaultConfig);
     expect(client.getHostnameForPort("abc", 8080)).toBe("https://8080-abc.e2b.app");
+  });
+
+  it("pauseSandbox sends no body by default but forwards memory:false for a disk-only pause", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+    await client.pauseSandbox("sb-1");
+    expect(fetchSpy.mock.calls[0][1].body).toBeUndefined();
+
+    await client.pauseSandbox("sb-1", { memory: false });
+    expect(JSON.parse(fetchSpy.mock.calls[1][1].body)).toEqual({ memory: false });
+  });
+
+  it("createSnapshot posts to the snapshots endpoint and returns the snapshot id", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ snapshotID: "snap-abc:default", names: ["team/snap:default"] }, 201)
+    );
+    const snapshot = await client.createSnapshot("sb-1");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.e2b.app/sandboxes/sb-1/snapshots");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({});
+    expect(snapshot.snapshotID).toBe("snap-abc:default");
+  });
+
+  it("createSnapshot forwards an optional name", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(jsonResponse({ snapshotID: "snap-x:default", names: [] }, 201));
+    await client.createSnapshot("sb-1", "my-snap");
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({ name: "my-snap" });
+  });
+
+  it("deleteTemplate strips the snapshot tag and DELETEs the bare template id", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+    await client.deleteTemplate("snap-abc:default");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.e2b.app/templates/snap-abc");
+    expect(init.method).toBe("DELETE");
+  });
+});
+
+describe("stripSnapshotTag", () => {
+  it("removes a trailing build tag", () => {
+    expect(stripSnapshotTag("abc123:default")).toBe("abc123");
+    expect(stripSnapshotTag("team/my-snapshot:v2")).toBe("team/my-snapshot");
+  });
+
+  it("leaves ids without a tag untouched", () => {
+    expect(stripSnapshotTag("abc123")).toBe("abc123");
+    expect(stripSnapshotTag("team/my-snapshot")).toBe("team/my-snapshot");
   });
 });

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -23,6 +23,10 @@ const TIMEOUT_KILL_MS = 30_000;
 const TIMEOUT_GET_MS = 15_000;
 const TIMEOUT_SETTTL_MS = 15_000;
 const TIMEOUT_WRITE_FILE_MS = 30_000;
+// A snapshot bakes the build sandbox's filesystem into a reusable template;
+// larger than the other calls because it copies the whole prebuilt filesystem.
+const TIMEOUT_SNAPSHOT_MS = 180_000;
+const TIMEOUT_DELETE_TEMPLATE_MS = 30_000;
 
 const e2bSandboxDetailSchema = z.object({
   sandboxID: z.string(),
@@ -55,6 +59,20 @@ const e2bErrorBodySchema = z.object({
 });
 
 export type E2BErrorBody = z.infer<typeof e2bErrorBodySchema>;
+
+/**
+ * Response of `POST /sandboxes/{id}/snapshots`. E2B bakes the sandbox's current
+ * filesystem and live process state into a reusable "snapshot template" whose
+ * id doubles as a `templateID`. The E2B launcher is deliberately snapshotted
+ * while waiting for fresh session env, so many sandboxes can spawn from one
+ * snapshot. `snapshotID` includes the build tag (e.g. `abc123:default`).
+ */
+const e2bSnapshotInfoSchema = z.object({
+  snapshotID: z.string(),
+  names: z.array(z.string()).default([]),
+});
+
+export type E2BSnapshotInfo = z.infer<typeof e2bSnapshotInfoSchema>;
 
 /** Default port envd listens on inside every sandbox. */
 const ENVD_PORT = 49983;
@@ -217,8 +235,20 @@ export class E2BRestClient {
     return this.requestJson("GET", `/sandboxes/${id}`, TIMEOUT_GET_MS, e2bSandboxDetailSchema);
   }
 
-  async pauseSandbox(id: string): Promise<void> {
-    await this.requestVoid("POST", `/sandboxes/${id}/pause`, TIMEOUT_PAUSE_MS);
+  /**
+   * Pause a sandbox. By default E2B persists filesystem + memory (a resumable
+   * freeze). Pass `{ memory: false }` for a filesystem-only pause: resuming it
+   * cold-boots (reboots) the sandbox from disk, dropping all process memory. The
+   * image-build path uses that to discard the build supervisor (and its secret
+   * env) before baking a reusable snapshot.
+   */
+  async pauseSandbox(id: string, opts?: { memory?: boolean }): Promise<void> {
+    await this.requestVoid(
+      "POST",
+      `/sandboxes/${id}/pause`,
+      TIMEOUT_PAUSE_MS,
+      opts?.memory === undefined ? undefined : { body: { memory: opts.memory } }
+    );
   }
 
   /**
@@ -243,6 +273,43 @@ export class E2BRestClient {
     await this.requestVoid("POST", `/sandboxes/${id}/timeout`, TIMEOUT_SETTTL_MS, {
       body: { timeout: timeoutSeconds },
     });
+  }
+
+  /**
+   * Bake the sandbox's current filesystem into a reusable snapshot template
+   * (`POST /sandboxes/{id}/snapshots`). The returned `snapshotID` is passed
+   * verbatim as `templateID` to {@link createSandbox} to spawn a prebuilt-image
+   * sandbox. Used by the image-build workflow after `.openinspect/setup.sh` has
+   * run once in the build sandbox.
+   */
+  async createSnapshot(id: string, name?: string): Promise<E2BSnapshotInfo> {
+    const startMs = Date.now();
+    try {
+      return await this.requestJson(
+        "POST",
+        `/sandboxes/${id}/snapshots`,
+        TIMEOUT_SNAPSHOT_MS,
+        e2bSnapshotInfoSchema,
+        { body: name ? { name } : {} }
+      );
+    } finally {
+      log.info("e2b.create_snapshot", { duration_ms: Date.now() - startMs, sandbox_id: id });
+    }
+  }
+
+  /**
+   * Delete a snapshot template (`DELETE /templates/{templateID}`). A snapshot id
+   * carries a build tag (`abc123:default`); the templates path takes the bare
+   * template id, so the tag is stripped. Used by the image-build reaper to
+   * reclaim superseded prebuilt images.
+   */
+  async deleteTemplate(templateId: string): Promise<void> {
+    const bareTemplateId = stripSnapshotTag(templateId);
+    await this.requestVoid(
+      "DELETE",
+      `/templates/${encodeURIComponent(bareTemplateId)}`,
+      TIMEOUT_DELETE_TEMPLATE_MS
+    );
   }
 
   getHostnameForPort(sandboxId: string, port: number, domain?: string | null): string {
@@ -355,6 +422,18 @@ export class E2BRestClient {
       clearTimeout(timeoutId);
     }
   }
+}
+
+/**
+ * Strip the build tag from a snapshot id for the templates delete path.
+ * `abc123:default` → `abc123`, `team/my-snapshot:v2` → `team/my-snapshot`.
+ * The tag is the final `:`-delimited segment (never contains a slash).
+ */
+export function stripSnapshotTag(snapshotId: string): string {
+  const lastColon = snapshotId.lastIndexOf(":");
+  if (lastColon === -1) return snapshotId;
+  const tag = snapshotId.slice(lastColon + 1);
+  return tag.includes("/") ? snapshotId : snapshotId.slice(0, lastColon);
 }
 
 export function createE2BRestClient(config: E2BRestConfig): E2BRestClient {

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -153,7 +153,7 @@ export class E2BRestClient {
             metadata: params.metadata,
             timeout: params.timeoutSeconds,
             secure: params.secure ?? false,
-        allow_internet_access: params.allowInternetAccess,
+            allow_internet_access: params.allowInternetAccess,
             autoPause: params.autoPause ?? false,
             autoResume: { enabled: params.autoResume ?? false },
           },
@@ -261,9 +261,9 @@ export class E2BRestClient {
    * Connect answers with the create-style `Sandbox` shape — `sandboxID`/`templateID`,
    * no `state`, which only `GET /sandboxes/{id}` returns. Callers re-read state
    * through getSandbox when they need it. The body is returned rather than
-   * discarded because a secure sandbox's envd access token is reissued on
-   * connect: a cold boot invalidates the create-time token, so the restore path
-   * needs the fresh one to write the per-session env.
+   * discarded because it carries the secure sandbox's current envd access token:
+   * the restore path connects a sandbox it did not create, so this is where it
+   * gets the token to write the per-session env with.
    */
   async connectSandbox(id: string, timeoutSeconds: number): Promise<E2BSandboxCreated> {
     return this.requestJson(

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -19,6 +19,7 @@ export interface E2BRestConfig {
 const TIMEOUT_CREATE_MS = 90_000;
 const TIMEOUT_CONNECT_MS = 60_000;
 const TIMEOUT_PAUSE_MS = 30_000;
+const TIMEOUT_NETWORK_UPDATE_MS = 15_000;
 const TIMEOUT_KILL_MS = 30_000;
 const TIMEOUT_GET_MS = 15_000;
 const TIMEOUT_SETTTL_MS = 15_000;
@@ -98,6 +99,8 @@ export interface E2BCreateSandboxParams {
    * envd accepts unauthenticated reads/writes of the uploaded session env.
    */
   secure?: boolean;
+  /** Whether the sandbox may make outbound internet requests. */
+  allowInternetAccess?: boolean;
 }
 
 export class E2BNotFoundError extends Error {
@@ -150,6 +153,7 @@ export class E2BRestClient {
             metadata: params.metadata,
             timeout: params.timeoutSeconds,
             secure: params.secure ?? false,
+        allow_internet_access: params.allowInternetAccess,
             autoPause: params.autoPause ?? false,
             autoResume: { enabled: params.autoResume ?? false },
           },
@@ -256,12 +260,30 @@ export class E2BRestClient {
    *
    * Connect answers with the create-style `Sandbox` shape — `sandboxID`/`templateID`,
    * no `state`, which only `GET /sandboxes/{id}` returns. Callers re-read state
-   * through getSandbox when they need it, so this is a command: the success body
-   * carries nothing we act on and is discarded.
+   * through getSandbox when they need it. The body is returned rather than
+   * discarded because a secure sandbox's envd access token is reissued on
+   * connect: a cold boot invalidates the create-time token, so the restore path
+   * needs the fresh one to write the per-session env.
    */
-  async connectSandbox(id: string, timeoutSeconds: number): Promise<void> {
-    await this.requestVoid("POST", `/sandboxes/${id}/connect`, TIMEOUT_CONNECT_MS, {
-      body: { timeout: timeoutSeconds },
+  async connectSandbox(id: string, timeoutSeconds: number): Promise<E2BSandboxCreated> {
+    return this.requestJson(
+      "POST",
+      `/sandboxes/${id}/connect`,
+      TIMEOUT_CONNECT_MS,
+      e2bSandboxCreatedSchema,
+      { body: { timeout: timeoutSeconds } }
+    );
+  }
+
+  /**
+   * Toggle a running sandbox's outbound internet access
+   * (`PUT /sandboxes/{id}/network`). Session restores boot with the network off
+   * so a snapshotted supervisor cannot act on stale credentials, then re-enable
+   * it once the process memory has been dropped.
+   */
+  async updateSandboxNetwork(id: string, options: { allowInternetAccess: boolean }): Promise<void> {
+    await this.requestVoid("PUT", `/sandboxes/${id}/network`, TIMEOUT_NETWORK_UPDATE_MS, {
+      body: { allow_internet_access: options.allowInternetAccess },
     });
   }
 
@@ -298,16 +320,14 @@ export class E2BRestClient {
   }
 
   /**
-   * Delete a snapshot template (`DELETE /templates/{templateID}`). A snapshot id
-   * carries a build tag (`abc123:default`); the templates path takes the bare
-   * template id, so the tag is stripped. Used by the image-build reaper to
-   * reclaim superseded prebuilt images.
+   * Delete a snapshot template (`DELETE /templates/{templateID}`). Snapshot ids,
+   * build tag included, are passed verbatim as the E2B API requires. Used by the
+   * image-build reaper to reclaim superseded prebuilt images.
    */
   async deleteTemplate(templateId: string): Promise<void> {
-    const bareTemplateId = stripSnapshotTag(templateId);
     await this.requestVoid(
       "DELETE",
-      `/templates/${encodeURIComponent(bareTemplateId)}`,
+      `/templates/${encodeURIComponent(templateId)}`,
       TIMEOUT_DELETE_TEMPLATE_MS
     );
   }
@@ -328,7 +348,7 @@ export class E2BRestClient {
    * `schema`, otherwise the call fails as an invalid response.
    */
   private requestJson<T>(
-    method: "GET" | "POST" | "DELETE",
+    method: "GET" | "POST" | "PUT" | "DELETE",
     path: string,
     timeoutMs: number,
     schema: z.ZodType<T>,
@@ -353,7 +373,7 @@ export class E2BRestClient {
    * can fail the call.
    */
   private requestVoid(
-    method: "GET" | "POST" | "DELETE",
+    method: "GET" | "POST" | "PUT" | "DELETE",
     path: string,
     timeoutMs: number,
     options?: { body?: unknown }
@@ -367,7 +387,7 @@ export class E2BRestClient {
    * abort raised there is translated like any other (see the catch below).
    */
   private async send<T>(
-    method: "GET" | "POST" | "DELETE",
+    method: "GET" | "POST" | "PUT" | "DELETE",
     path: string,
     timeoutMs: number,
     options: { body?: unknown } | undefined,
@@ -422,18 +442,6 @@ export class E2BRestClient {
       clearTimeout(timeoutId);
     }
   }
-}
-
-/**
- * Strip the build tag from a snapshot id for the templates delete path.
- * `abc123:default` → `abc123`, `team/my-snapshot:v2` → `team/my-snapshot`.
- * The tag is the final `:`-delimited segment (never contains a slash).
- */
-export function stripSnapshotTag(snapshotId: string): string {
-  const lastColon = snapshotId.lastIndexOf(":");
-  if (lastColon === -1) return snapshotId;
-  const tag = snapshotId.slice(lastColon + 1);
-  return tag.includes("/") ? snapshotId : snapshotId.slice(0, lastColon);
 }
 
 export function createE2BRestClient(config: E2BRestConfig): E2BRestClient {

--- a/packages/control-plane/src/sandbox/lifecycle/e2b-execution-complete-p1.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/e2b-execution-complete-p1.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test: the generic `execution_complete` snapshot path must not
+ * reboot a live E2B session.
+ *
+ * `sandbox-events.ts` calls `triggerSnapshot("execution_complete")` after every
+ * execution. The generic provider operation must create a resumable snapshot
+ * directly; the destructive pause(memory:false) → connect sequence is reserved
+ * for image-build baking.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { SandboxLifecycleManager, DEFAULT_LIFECYCLE_CONFIG } from "./manager";
+import { E2BSandboxProvider } from "../providers/e2b-provider";
+import type { E2BRestClient } from "../e2b-rest-client";
+
+function spyE2BClient() {
+  return {
+    config: { apiUrl: "https://api.e2b.app", apiKey: "k", templateId: "tmpl" },
+    pauseSandbox: vi.fn(async () => {}),
+    connectSandbox: vi.fn(async () => ({
+      sandboxID: "e2b-live-id",
+      templateID: "tmpl",
+      state: "running",
+    })),
+    createSnapshot: vi.fn(async () => ({ snapshotID: "snap-live:default", names: [] })),
+    killSandbox: vi.fn(async () => {}),
+    getHostnameForPort: vi.fn((id: string, port: number) => `https://${port}-${id}.e2b.app`),
+  } as unknown as E2BRestClient;
+}
+
+function stubbedManager(client: E2BRestClient) {
+  const provider = new E2BSandboxProvider(client, {
+    scmProvider: "github",
+    codeServerPasswordSecret: "secret",
+    sandboxTimeoutSeconds: 1800,
+    autoPause: true,
+  });
+
+  // Live session sandbox — actively serving a user (status "ready", real provider id).
+  const sandbox = { id: "sandbox-1", modal_object_id: "e2b-live-id", status: "ready" };
+  const storage = {
+    getSandbox: vi.fn(() => sandbox),
+    getSession: vi.fn(() => ({ id: "session-1", session_name: "session-1" })),
+    updateSandboxStatus: vi.fn((s: string) => {
+      sandbox.status = s;
+    }),
+    updateSandboxSnapshotImageId: vi.fn(),
+  };
+  const broadcaster = { broadcast: vi.fn() };
+
+  const manager = new SandboxLifecycleManager(
+    provider,
+    storage as never,
+    broadcaster as never,
+    { getSandboxWebSocket: () => null } as never,
+    { scheduleAlarm: vi.fn(async () => {}) } as never,
+    { generateId: () => "id-1" } as never,
+    {
+      ...DEFAULT_LIFECYCLE_CONFIG,
+      controlPlaneUrl: "https://cp.test",
+      model: "anthropic/claude",
+    } as never
+  );
+  return { manager, storage };
+}
+
+describe("execution_complete snapshot on a live E2B session", () => {
+  it("snapshots without pause(memory:false) or reconnecting", async () => {
+    const client = spyE2BClient();
+    const { manager } = stubbedManager(client);
+
+    // This is exactly what sandbox-events.ts fires after every prompt.
+    await manager.triggerSnapshot("execution_complete");
+
+    expect(client.pauseSandbox).not.toHaveBeenCalled();
+    expect(client.connectSandbox).not.toHaveBeenCalled();
+    expect(client.createSnapshot).toHaveBeenCalledWith("e2b-live-id");
+  });
+});

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -882,6 +882,30 @@ describe("SandboxLifecycleManager", () => {
       expect(provider.createSandbox).not.toHaveBeenCalled();
     });
 
+    it("falls back to a fresh spawn when restore capability is disabled", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const provider = createMockProvider({
+        capabilities: { supportsRestore: false },
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(createMockSession(), sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).not.toHaveBeenCalled();
+      expect(provider.createSandbox).toHaveBeenCalled();
+    });
+
     it("logs one terminal sandbox.restore event for success", async () => {
       const sandbox = createMockSandbox({
         status: "stopped",
@@ -1453,6 +1477,30 @@ describe("SandboxLifecycleManager", () => {
 
       // Should not crash, just skip
       expect(storage.calls).not.toContain("updateSandboxSnapshotImageId");
+    });
+
+    it("honors a disabled snapshot capability even when the method exists", async () => {
+      const takeSnapshot = vi.fn(async () => ({
+        success: true,
+        imageId: "should-not-be-used",
+      }));
+      const provider = createMockProvider({
+        capabilities: { supportsSnapshots: false },
+        takeSnapshot,
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(createMockSession(), createMockSandbox({ status: "ready" })),
+        createMockBroadcaster(),
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.triggerSnapshot("execution_complete");
+
+      expect(takeSnapshot).not.toHaveBeenCalled();
     });
 
     it("stores returned imageId", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -724,7 +724,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * Restore a sandbox from a filesystem snapshot.
    */
   private async restoreFromSnapshot(snapshotImageId: string): Promise<void> {
-    if (!this.provider.restoreFromSnapshot) {
+    if (!this.provider.capabilities.supportsRestore || !this.provider.restoreFromSnapshot) {
       this.log.info("Provider does not support restore, falling back to fresh spawn");
       // Fall back to fresh spawn
       await this.doSpawn();
@@ -964,7 +964,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * Trigger a filesystem snapshot of the sandbox.
    */
   async triggerSnapshot(reason: string): Promise<void> {
-    if (!this.provider.takeSnapshot) {
+    if (!this.provider.capabilities.supportsSnapshots || !this.provider.takeSnapshot) {
       this.log.debug("Provider does not support snapshots");
       return;
     }

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -38,6 +38,8 @@ function mockClient(overrides: Partial<E2BRestClient> = {}): E2BRestClient {
     connectSandbox: vi.fn(async (): Promise<void> => {}),
     killSandbox: vi.fn(async () => {}),
     setSandboxTimeout: vi.fn(async () => {}),
+    createSnapshot: vi.fn(async () => ({ snapshotID: "snap-abc:default", names: ["oi/snap"] })),
+    deleteTemplate: vi.fn(async () => {}),
     getHostnameForPort: vi.fn((id: string, port: number) => `https://${port}-${id}.e2b.app`),
     ...overrides,
   } as unknown as E2BRestClient;
@@ -405,5 +407,196 @@ describe("E2BSandboxProvider", () => {
       timeoutSeconds: 7200,
     });
     expect(client.setSandboxTimeout).toHaveBeenCalledWith("e2b-id", 7200);
+  });
+});
+
+describe("E2BSandboxProvider prebuilt images / snapshots", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("advertises snapshot + restore support", () => {
+    const provider = new E2BSandboxProvider(mockClient(), providerConfig);
+    expect(provider.capabilities.supportsSnapshots).toBe(true);
+    expect(provider.capabilities.supportsRestore).toBe(true);
+  });
+
+  it("createSandbox with no prebuilt image uses the base template and no repo-image markers", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).createSandbox(baseCreateConfig);
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ templateID: "tmpl" })
+    );
+    const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
+    expect(env).not.toHaveProperty("FROM_REPO_IMAGE");
+    expect(env).not.toHaveProperty("REPO_IMAGE_SHA");
+  });
+
+  it("createSandbox with a prebuilt image spawns from it and marks the boot", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).createSandbox({
+      ...baseCreateConfig,
+      prebuiltImageId: "snap-repo:default",
+      prebuiltImageSha: "abc123",
+    });
+    // The snapshot id is passed verbatim as the E2B templateID.
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ templateID: "snap-repo:default" })
+    );
+    const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
+    expect(env.FROM_REPO_IMAGE).toBe("true");
+    expect(env.REPO_IMAGE_SHA).toBe("abc123");
+  });
+
+  it("restoreFromSnapshot spawns from the snapshot id and sets RESTORED_FROM_SNAPSHOT", async () => {
+    const client = mockClient();
+    const result = await new E2BSandboxProvider(client, providerConfig).restoreFromSnapshot({
+      ...baseCreateConfig,
+      snapshotImageId: "snap-restore:default",
+    });
+    expect(result.success).toBe(true);
+    expect(result.providerObjectId).toBe("e2b-id");
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ templateID: "snap-restore:default" })
+    );
+    const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
+    expect(env.RESTORED_FROM_SNAPSHOT).toBe("true");
+  });
+
+  it("takeSnapshot sanitizes via pause(memory:false)+connect before createSnapshot", async () => {
+    const client = mockClient();
+    const provider = new E2BSandboxProvider(client, providerConfig);
+    const result = await provider.takeSnapshot({
+      providerObjectId: "build-sbx",
+      sessionId: "build-1",
+      reason: "environment_image_build",
+    });
+    // Drop process memory (build supervisor + secrets), then cold-boot, then bake.
+    expect(client.pauseSandbox).toHaveBeenCalledWith("build-sbx", { memory: false });
+    expect(client.connectSandbox).toHaveBeenCalledWith("build-sbx", expect.any(Number));
+    expect(client.createSnapshot).toHaveBeenCalledWith("build-sbx");
+    // Ordering: pause → connect → snapshot.
+    const pauseOrder = vi.mocked(client.pauseSandbox).mock.invocationCallOrder[0];
+    const connectOrder = vi.mocked(client.connectSandbox).mock.invocationCallOrder[0];
+    const snapOrder = vi.mocked(client.createSnapshot).mock.invocationCallOrder[0];
+    expect(pauseOrder).toBeLessThan(connectOrder);
+    expect(connectOrder).toBeLessThan(snapOrder);
+    expect(result).toEqual({ success: true, imageId: "snap-abc:default" });
+  });
+
+  it("takeSnapshot fails when the API returns no snapshot id", async () => {
+    const client = mockClient({
+      createSnapshot: vi.fn(async () => ({ snapshotID: "", names: [] })),
+    });
+    const result = await new E2BSandboxProvider(client, providerConfig).takeSnapshot({
+      providerObjectId: "build-sbx",
+      sessionId: "build-1",
+      reason: "environment_image_build",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("deleteProviderImage deletes the snapshot template and swallows a 404", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).deleteProviderImage("snap-x:default");
+    expect(client.deleteTemplate).toHaveBeenCalledWith("snap-x:default");
+
+    const gone = mockClient({
+      deleteTemplate: vi.fn(async () => {
+        throw new E2BNotFoundError("already gone");
+      }),
+    });
+    await expect(
+      new E2BSandboxProvider(gone, providerConfig).deleteProviderImage("snap-x:default")
+    ).resolves.toBeUndefined();
+  });
+
+  it("deleteSandbox kills the build sandbox and swallows a 404", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).deleteSandbox("build-sbx");
+    expect(client.killSandbox).toHaveBeenCalledWith("build-sbx");
+
+    const gone = mockClient({
+      killSandbox: vi.fn(async () => {
+        throw new E2BNotFoundError("already gone");
+      }),
+    });
+    await expect(
+      new E2BSandboxProvider(gone, providerConfig).deleteSandbox("build-sbx")
+    ).resolves.toBeUndefined();
+  });
+
+  it("triggerImageBuild boots a non-pausing build sandbox with build-mode env", async () => {
+    const client = mockClient();
+    const onProviderSessionCreated = vi.fn(async () => {});
+    await new E2BSandboxProvider(client, providerConfig).triggerImageBuild({
+      buildId: "build-1",
+      scopeKind: "environment",
+      scopeId: "env-1",
+      repositories: [
+        { repoOwner: "o", repoName: "r", baseBranch: "main" },
+        { repoOwner: "o2", repoName: "r2", baseBranch: "dev" },
+      ],
+      callbackUrl: "https://cp.test/cb",
+      failureCallbackUrl: "https://cp.test/cb/fail",
+      callbackToken: "cb-token",
+      cloneToken: "clone-token",
+      buildExecutionTimeoutSeconds: 1800,
+      providerSessionTimeoutSeconds: 2100,
+      onProviderSessionCreated,
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    // Build sandbox uses the base template and must not auto-pause (it idles
+    // awaiting the snapshot), and lives for the adapter-resolved session budget.
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateID: "tmpl",
+        autoPause: false,
+        secure: true,
+        timeoutSeconds: 2100,
+      })
+    );
+
+    // The provider session is bound (with the real sandbox id) before env delivery.
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("e2b-id");
+    const bindOrder = onProviderSessionCreated.mock.invocationCallOrder[0];
+    const writeOrder = vi.mocked(client.writeSessionEnv).mock.invocationCallOrder[0];
+    expect(bindOrder).toBeLessThan(writeOrder);
+
+    const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
+    expect(env.IMAGE_BUILD_MODE).toBe("true");
+    expect(env.SANDBOX_VERSION).toMatch(/^v\d+/);
+    expect(env.OI_REPO_IMAGE_PROVIDER_SESSION_ID).toBe("e2b-id");
+    expect(env.OI_REPO_IMAGE_BUILD_ID).toBe("build-1");
+    expect(env.OI_REPO_IMAGE_CALLBACK_URL).toBe("https://cp.test/cb");
+    expect(env.OI_REPO_IMAGE_FAILURE_CALLBACK_URL).toBe("https://cp.test/cb/fail");
+    expect(env.OI_REPO_IMAGE_CALLBACK_TOKEN).toBe("cb-token");
+    expect(env.OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS).toBe("1800");
+    expect(env.VCS_CLONE_TOKEN).toBe("clone-token");
+    const sessionConfig = JSON.parse(env.SESSION_CONFIG);
+    expect(sessionConfig.repositories).toHaveLength(2);
+  });
+
+  it("triggerImageBuild kills the sandbox if binding the session fails", async () => {
+    const client = mockClient();
+    const provider = new E2BSandboxProvider(client, providerConfig);
+    await expect(
+      provider.triggerImageBuild({
+        buildId: "build-1",
+        scopeKind: "environment",
+        scopeId: "env-1",
+        repositories: [{ repoOwner: "o", repoName: "r", baseBranch: "main" }],
+        callbackUrl: "https://cp.test/cb",
+        failureCallbackUrl: "https://cp.test/cb/fail",
+        callbackToken: "cb-token",
+        buildExecutionTimeoutSeconds: 1800,
+        providerSessionTimeoutSeconds: 2100,
+        onProviderSessionCreated: vi.fn(async () => {
+          throw new Error("bind failed");
+        }),
+        correlation: { request_id: "request-1", trace_id: "trace-1" },
+      })
+    ).rejects.toBeInstanceOf(SandboxProviderError);
+    expect(client.killSandbox).toHaveBeenCalledWith("e2b-id");
+    expect(client.writeSessionEnv).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -35,7 +35,12 @@ function mockClient(overrides: Partial<E2BRestClient> = {}): E2BRestClient {
       })
     ),
     pauseSandbox: vi.fn(async () => {}),
-    connectSandbox: vi.fn(async (): Promise<void> => {}),
+    connectSandbox: vi.fn(async () => ({
+      sandboxID: "e2b-id",
+      templateID: "tmpl",
+      envdAccessToken: "fresh-envd-token",
+    })),
+    updateSandboxNetwork: vi.fn(async () => {}),
     killSandbox: vi.fn(async () => {}),
     setSandboxTimeout: vi.fn(async () => {}),
     createSnapshot: vi.fn(async () => ({ snapshotID: "snap-abc:default", names: ["oi/snap"] })),
@@ -446,7 +451,7 @@ describe("E2BSandboxProvider prebuilt images / snapshots", () => {
     expect(env.REPO_IMAGE_SHA).toBe("abc123");
   });
 
-  it("restoreFromSnapshot spawns from the snapshot id and sets RESTORED_FROM_SNAPSHOT", async () => {
+  it("restoreFromSnapshot quarantines captured memory, cold-boots, then delivers fresh env", async () => {
     const client = mockClient();
     const result = await new E2BSandboxProvider(client, providerConfig).restoreFromSnapshot({
       ...baseCreateConfig,
@@ -455,25 +460,58 @@ describe("E2BSandboxProvider prebuilt images / snapshots", () => {
     expect(result.success).toBe(true);
     expect(result.providerObjectId).toBe("e2b-id");
     expect(client.createSandbox).toHaveBeenCalledWith(
-      expect.objectContaining({ templateID: "snap-restore:default" })
+      expect.objectContaining({
+        templateID: "snap-restore:default",
+        allowInternetAccess: false,
+        secure: true,
+      })
     );
+    expect(client.pauseSandbox).toHaveBeenCalledWith("e2b-id", { memory: false });
+    expect(client.connectSandbox).toHaveBeenCalledWith("e2b-id", 1800);
+    expect(client.updateSandboxNetwork).toHaveBeenCalledWith("e2b-id", {
+      allowInternetAccess: true,
+    });
     const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
     expect(env.RESTORED_FROM_SNAPSHOT).toBe("true");
+    expect(client.writeSessionEnv).toHaveBeenCalledWith(
+      "e2b-id",
+      expect.any(Object),
+      expect.objectContaining({ envdAccessToken: "fresh-envd-token" })
+    );
+    const pauseOrder = vi.mocked(client.pauseSandbox).mock.invocationCallOrder[0];
+    const connectOrder = vi.mocked(client.connectSandbox).mock.invocationCallOrder[0];
+    const networkOrder = vi.mocked(client.updateSandboxNetwork).mock.invocationCallOrder[0];
+    const envOrder = vi.mocked(client.writeSessionEnv).mock.invocationCallOrder[0];
+    expect(pauseOrder).toBeLessThan(connectOrder);
+    expect(connectOrder).toBeLessThan(networkOrder);
+    expect(networkOrder).toBeLessThan(envOrder);
   });
 
-  it("takeSnapshot sanitizes via pause(memory:false)+connect before createSnapshot", async () => {
+  it("takeSnapshot snapshots a live session without pausing or reconnecting it", async () => {
     const client = mockClient();
     const provider = new E2BSandboxProvider(client, providerConfig);
-    const result = await provider.takeSnapshot({
+    const liveResult = await provider.takeSnapshot({
+      providerObjectId: "build-sbx",
+      sessionId: "build-1",
+      reason: "execution_complete",
+    });
+    expect(client.pauseSandbox).not.toHaveBeenCalled();
+    expect(client.connectSandbox).not.toHaveBeenCalled();
+    expect(client.createSnapshot).toHaveBeenCalledWith("build-sbx");
+    expect(liveResult).toEqual({ success: true, imageId: "snap-abc:default" });
+  });
+
+  it("takePrebuiltImageSnapshot sanitizes via pause(memory:false)+connect before snapshot", async () => {
+    const client = mockClient();
+    const provider = new E2BSandboxProvider(client, providerConfig);
+    const result = await provider.takePrebuiltImageSnapshot({
       providerObjectId: "build-sbx",
       sessionId: "build-1",
       reason: "environment_image_build",
     });
-    // Drop process memory (build supervisor + secrets), then cold-boot, then bake.
     expect(client.pauseSandbox).toHaveBeenCalledWith("build-sbx", { memory: false });
     expect(client.connectSandbox).toHaveBeenCalledWith("build-sbx", expect.any(Number));
     expect(client.createSnapshot).toHaveBeenCalledWith("build-sbx");
-    // Ordering: pause → connect → snapshot.
     const pauseOrder = vi.mocked(client.pauseSandbox).mock.invocationCallOrder[0];
     const connectOrder = vi.mocked(client.connectSandbox).mock.invocationCallOrder[0];
     const snapOrder = vi.mocked(client.createSnapshot).mock.invocationCallOrder[0];

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -10,8 +10,9 @@
  * template's start command runs at build time.
  *
  * Prebuilt images (snapshots): the image-build workflow runs `.openinspect/setup.sh`
- * once in a build sandbox (triggerEnvironmentImageBuild), then bakes its filesystem
- * into a reusable snapshot template (takeSnapshot → `POST /sandboxes/{id}/snapshots`).
+ * once in a build sandbox (triggerImageBuild), then bakes its filesystem
+ * into a reusable snapshot template (takePrebuiltImageSnapshot →
+ * `POST /sandboxes/{id}/snapshots`).
  * The snapshot id doubles as a `templateID`, so a prebuilt/restored sandbox is just a
  * create with that id in place of the base template. The snapshot resumes oi-launch
  * in its env wait loop, where it reads the freshly written per-session env — so
@@ -154,29 +155,86 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
   }
 
+  /**
+   * Spawn a session from a session snapshot, which — unlike a prebuilt image —
+   * captures live process memory: the snapshotted supervisor would otherwise
+   * wake up holding the previous session's credentials. The sandbox is created
+   * with outbound networking off, its memory is dropped (pause memory:false)
+   * and cold-booted back into the template launcher, and only then is the
+   * network re-enabled and the fresh per-session env delivered.
+   */
   async restoreFromSnapshot(config: RestoreConfig): Promise<RestoreResult> {
+    let sandbox: E2BSandboxCreated | undefined;
     try {
-      const spawned = await this.spawnFromTemplate(config, config.snapshotImageId, {
+      const { envVars, codeServerPassword, vncPassword } = await this.buildRuntimeEnv(config, {
         RESTORED_FROM_SNAPSHOT: "true",
       });
+      const timeoutSeconds = config.timeoutSeconds ?? this.providerConfig.sandboxTimeoutSeconds;
+      sandbox = await this.client.createSandbox({
+        templateID: config.snapshotImageId,
+        metadata: this.buildMetadata(config),
+        timeoutSeconds,
+        autoPause: this.providerConfig.autoPause,
+        autoResume: false,
+        secure: true,
+        allowInternetAccess: false,
+      });
+
+      // Drop the captured process memory, then cold-boot the template launcher.
+      // connect reissues the envd token the cold boot invalidated.
+      await this.client.pauseSandbox(sandbox.sandboxID, { memory: false });
+      const connected = await this.client.connectSandbox(sandbox.sandboxID, timeoutSeconds);
+      await this.client.updateSandboxNetwork(sandbox.sandboxID, { allowInternetAccess: true });
+      await this.deliverSessionEnv(
+        {
+          sandboxID: connected.sandboxID,
+          templateID: connected.templateID,
+          domain: connected.domain ?? sandbox.domain,
+          envdAccessToken: connected.envdAccessToken,
+        },
+        envVars
+      );
+
+      const { codeServerUrl, vncUrl, tunnelUrls } = this.buildTunnelUrls(
+        connected.sandboxID,
+        config.codeServerEnabled,
+        config.vncEnabled,
+        config.sandboxSettings,
+        connected.domain ?? sandbox.domain
+      );
 
       return {
         success: true,
         sandboxId: config.sandboxId,
-        providerObjectId: spawned.providerObjectId,
-        codeServerUrl: spawned.codeServerUrl,
-        codeServerPassword: spawned.codeServerPassword,
-        vncAccess: createVncAccess(spawned.vncUrl, spawned.vncPassword),
-        tunnelUrls: spawned.tunnelUrls,
+        providerObjectId: connected.sandboxID,
+        codeServerUrl,
+        codeServerPassword,
+        vncAccess: createVncAccess(vncUrl, vncPassword),
+        tunnelUrls,
       };
     } catch (error) {
+      if (sandbox) {
+        await this.cleanupSandbox(sandbox.sandboxID, "e2b.restore_cleanup_kill_failed");
+      }
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to restore E2B sandbox from snapshot", error, "create");
     }
   }
 
   /**
-   * Bake the image-build sandbox into a reusable snapshot template, sanitized so
+   * Take a resumable snapshot of a live session without changing its runtime
+   * state. This is the generic lifecycle operation used after a prompt.
+   */
+  async takeSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
+    try {
+      return await this.createSnapshotResult(config.providerObjectId);
+    } catch (error) {
+      throw this.classifyError("Failed to snapshot E2B sandbox", error, "snapshot");
+    }
+  }
+
+  /**
+   * Bake an image-build sandbox into a reusable snapshot template, sanitized so
    * the image is a clean, quiescent cold boot rather than a frozen build process.
    *
    * A reusable E2B snapshot (`POST /sandboxes/{id}/snapshots`) captures live
@@ -190,7 +248,7 @@ export class E2BSandboxProvider implements SandboxProvider {
    * supervisor with their own per-session env (and never inherit build secrets in
    * memory).
    */
-  async takeSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
+  async takePrebuiltImageSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
     try {
       await this.client.pauseSandbox(config.providerObjectId, { memory: false });
       // Cold-boot from disk; connect returns once the template ready-check passes,
@@ -199,13 +257,9 @@ export class E2BSandboxProvider implements SandboxProvider {
       // No name: each build gets a distinct snapshot template. Superseded images
       // are reclaimed by the reaper via deleteProviderImage, so reusing a name
       // (which would reassign builds to one template) buys nothing.
-      const snapshot = await this.client.createSnapshot(config.providerObjectId);
-      if (!snapshot.snapshotID) {
-        return { success: false, error: "E2B snapshot did not return a snapshot id" };
-      }
-      return { success: true, imageId: snapshot.snapshotID };
+      return await this.createSnapshotResult(config.providerObjectId);
     } catch (error) {
-      throw this.classifyError("Failed to snapshot E2B sandbox", error, "snapshot");
+      throw this.classifyError("Failed to bake E2B image snapshot", error, "snapshot");
     }
   }
 
@@ -443,29 +497,11 @@ export class E2BSandboxProvider implements SandboxProvider {
     vncPassword?: string;
     tunnelUrls?: Record<string, string>;
   }> {
-    const codeServerPassword = config.codeServerEnabled
-      ? await deriveCodeServerPassword(
-          config.sandboxId,
-          this.providerConfig.sandboxAccessPasswordSecret
-        )
-      : undefined;
-    const vncPassword = config.vncEnabled
-      ? await deriveVncPassword(config.sandboxId, this.providerConfig.sandboxAccessPasswordSecret)
-      : undefined;
     const timeoutSeconds = config.timeoutSeconds ?? this.providerConfig.sandboxTimeoutSeconds;
-    const envVars = buildSandboxEnvVars(
-      { ...config, timeoutSeconds },
-      {
-        scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
-        codeServerPassword,
-        vncPassword,
-      }
+    const { envVars, codeServerPassword, vncPassword } = await this.buildRuntimeEnv(
+      config,
+      extraEnv
     );
-    // E2B sandboxes run as a non-root user and /run is a root-owned tmpfs, so
-    // the git credential helper can't create its default cache dir (/run/oi)
-    // and fails before brokering a token. Point it at a user-writable path.
-    envVars.OI_SCM_CRED_CACHE_DIR = "/tmp/oi";
-    Object.assign(envVars, extraEnv);
 
     const sandbox = await this.client.createSandbox({
       templateID: templateId,
@@ -501,6 +537,64 @@ export class E2BSandboxProvider implements SandboxProvider {
       vncPassword,
       tunnelUrls,
     };
+  }
+
+  /**
+   * Assemble the per-session env (and the derived service passwords) shared by
+   * the create and restore paths.
+   */
+  private async buildRuntimeEnv(
+    config: CreateSandboxConfig | RestoreConfig,
+    extraEnv: Record<string, string>
+  ): Promise<{
+    envVars: Record<string, string>;
+    codeServerPassword?: string;
+    vncPassword?: string;
+  }> {
+    const codeServerPassword = config.codeServerEnabled
+      ? await deriveCodeServerPassword(
+          config.sandboxId,
+          this.providerConfig.sandboxAccessPasswordSecret
+        )
+      : undefined;
+    const vncPassword = config.vncEnabled
+      ? await deriveVncPassword(config.sandboxId, this.providerConfig.sandboxAccessPasswordSecret)
+      : undefined;
+    const timeoutSeconds = config.timeoutSeconds ?? this.providerConfig.sandboxTimeoutSeconds;
+    const envVars = buildSandboxEnvVars(
+      { ...config, timeoutSeconds },
+      {
+        scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
+        codeServerPassword,
+        vncPassword,
+      }
+    );
+    // E2B sandboxes run as a non-root user and /run is a root-owned tmpfs, so
+    // the git credential helper can't create its default cache dir (/run/oi)
+    // and fails before brokering a token. Point it at a user-writable path.
+    envVars.OI_SCM_CRED_CACHE_DIR = "/tmp/oi";
+    Object.assign(envVars, extraEnv);
+    return { envVars, codeServerPassword, vncPassword };
+  }
+
+  private async createSnapshotResult(providerObjectId: string): Promise<SnapshotResult> {
+    const snapshot = await this.client.createSnapshot(providerObjectId);
+    if (!snapshot.snapshotID) {
+      return { success: false, error: "E2B snapshot did not return a snapshot id" };
+    }
+    return { success: true, imageId: snapshot.snapshotID };
+  }
+
+  private async cleanupSandbox(sandboxId: string, event: string): Promise<void> {
+    try {
+      await this.client.killSandbox(sandboxId);
+    } catch (error) {
+      if (error instanceof E2BNotFoundError) return;
+      log.warn(event, {
+        sandbox_id: sandboxId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -69,7 +69,7 @@ export const DEFAULT_E2B_AUTO_PAUSE = true;
  * sync with the toolchain pinned in e2b.Dockerfile (OPENCODE_VERSION) and the
  * matching Vercel/OpenComputer constants.
  */
-export const E2B_SANDBOX_VERSION = "v54-opencode-1-17-18";
+export const E2B_SANDBOX_VERSION = "v57-vnc-opencode-1-18-11";
 
 /**
  * TTL for the brief cold-boot between the sanitizing pause and createSnapshot
@@ -77,18 +77,6 @@ export const E2B_SANDBOX_VERSION = "v54-opencode-1-17-18";
  * sandbox is killed immediately afterwards.
  */
 const SNAPSHOT_CONNECT_TIMEOUT_SECONDS = 300;
-
-const REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
-  "OI_REPO_IMAGE_BUILD_ID",
-  "OI_REPO_IMAGE_CALLBACK_URL",
-  "OI_REPO_IMAGE_CALLBACK_TOKEN",
-  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
-] as const;
-const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
-  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
-  "OI_REPO_IMAGE_CALLBACK_SECRET",
-] as const;
 
 export interface E2BProviderConfig {
   scmProvider: SourceControlProviderName;

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -8,19 +8,31 @@
  * disabled so resume stays control-plane-driven (connectSandbox) and stray traffic can't
  * wake a paused box. Per-session env is delivered via an envd file write because the
  * template's start command runs at build time.
+ *
+ * Prebuilt images (snapshots): the image-build workflow runs `.openinspect/setup.sh`
+ * once in a build sandbox (triggerEnvironmentImageBuild), then bakes its filesystem
+ * into a reusable snapshot template (takeSnapshot → `POST /sandboxes/{id}/snapshots`).
+ * The snapshot id doubles as a `templateID`, so a prebuilt/restored sandbox is just a
+ * create with that id in place of the base template. The snapshot resumes oi-launch
+ * in its env wait loop, where it reads the freshly written per-session env — so
+ * prebuilt boots reuse the baked filesystem while still getting fresh session config.
  */
 
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { createLogger } from "../../logger";
 import {
+  buildImageBuildCallbackEnv,
+  buildImageBuildEnvVars,
+  IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY,
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   deriveVncPassword,
+  imageBuildSandboxIdentity,
   scmCloneIdentity,
 } from "../sandbox-env";
 import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
 import type { SourceControlProviderName } from "../../source-control";
-import type { E2BRestClient, E2BSandboxDetail } from "../e2b-rest-client";
+import type { E2BRestClient, E2BSandboxCreated, E2BSandboxDetail } from "../e2b-rest-client";
 import { E2BApiError, E2BConflictError, E2BNotFoundError } from "../e2b-rest-client";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
@@ -28,10 +40,15 @@ import {
   createVncAccess,
   type CreateSandboxConfig,
   type CreateSandboxResult,
+  type ImageBuildProviderTriggerConfig,
+  type RestoreConfig,
+  type RestoreResult,
   type ResumeConfig,
   type ResumeResult,
   type SandboxProvider,
   type SandboxProviderCapabilities,
+  type SnapshotConfig,
+  type SnapshotResult,
   type StopConfig,
   type StopResult,
 } from "../provider";
@@ -42,6 +59,35 @@ const log = createLogger("e2b-provider");
 export const DEFAULT_E2B_SANDBOX_TIMEOUT_SECONDS = DEFAULT_SANDBOX_TIMEOUT_SECONDS;
 /** Default to a recoverable stop: pause on TTL (not kill), so it stays resumable. */
 export const DEFAULT_E2B_AUTO_PAUSE = true;
+
+/**
+ * Runtime version baked into the E2B template, reported by build sandboxes so
+ * spawn-time selection can gate on the compatibility floor
+ * (MIN_COMPATIBLE_RUNTIME_VERSION). E2B does not propagate the Dockerfile's
+ * SANDBOX_VERSION to the runtime process, so builds get it here instead. Keep in
+ * sync with the toolchain pinned in e2b.Dockerfile (OPENCODE_VERSION) and the
+ * matching Vercel/OpenComputer constants.
+ */
+export const E2B_SANDBOX_VERSION = "v54-opencode-1-17-18";
+
+/**
+ * TTL for the brief cold-boot between the sanitizing pause and createSnapshot
+ * during an image build. Only needs to outlive the snapshot call; the build
+ * sandbox is killed immediately afterwards.
+ */
+const SNAPSHOT_CONNECT_TIMEOUT_SECONDS = 300;
+
+const REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
+  "OI_REPO_IMAGE_BUILD_ID",
+  "OI_REPO_IMAGE_CALLBACK_URL",
+  "OI_REPO_IMAGE_CALLBACK_TOKEN",
+  "OI_REPO_IMAGE_FAILURE_CALLBACK_URL",
+] as const;
+const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
+  "OI_REPO_IMAGE_CALLBACK_SECRET",
+] as const;
 
 export interface E2BProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -55,6 +101,8 @@ export interface E2BProviderConfig {
   autoPause: boolean;
 }
 
+type E2BOperation = "create" | "resume" | "stop" | "snapshot" | "delete";
+
 export class E2BSandboxProvider implements SandboxProvider {
   readonly name = "e2b";
 
@@ -66,8 +114,8 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   readonly capabilities: SandboxProviderCapabilities = {
     supportsSandboxTimeout: true,
-    supportsSnapshots: false,
-    supportsRestore: false,
+    supportsSnapshots: true,
+    supportsRestore: true,
     // Stop is a resumable pause; the manager treats it as provider-managed state.
     supportsPersistentResume: true,
     supportsExplicitStop: true,
@@ -80,97 +128,84 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   async createSandbox(config: CreateSandboxConfig): Promise<CreateSandboxResult> {
     try {
-      const codeServerPassword = config.codeServerEnabled
-        ? await deriveCodeServerPassword(
-            config.sandboxId,
-            this.providerConfig.sandboxAccessPasswordSecret
-          )
-        : undefined;
-      const vncPassword = config.vncEnabled
-        ? await deriveVncPassword(config.sandboxId, this.providerConfig.sandboxAccessPasswordSecret)
-        : undefined;
-      const timeoutSeconds = config.timeoutSeconds ?? this.providerConfig.sandboxTimeoutSeconds;
-      const envVars = buildSandboxEnvVars(
-        { ...config, timeoutSeconds },
-        {
-          scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
-          codeServerPassword,
-          vncPassword,
-        }
-      );
-      // E2B sandboxes run as a non-root user and /run is a root-owned tmpfs, so
-      // the git credential helper can't create its default cache dir (/run/oi)
-      // and fails before brokering a token. Point it at a user-writable path.
-      envVars.OI_SCM_CRED_CACHE_DIR = "/tmp/oi";
-      const metadata = this.buildMetadata(config);
-      const sandbox = await this.client.createSandbox({
-        templateID: this.client.config.templateId,
-        metadata,
-        timeoutSeconds,
-        autoPause: this.providerConfig.autoPause,
-        // Require secure envd access: the per-session env we upload carries
-        // SANDBOX_AUTH_TOKEN + user secrets, so envd must reject writes lacking the
-        // returned access token (otherwise the upload is anonymous over the public host).
-        secure: true,
-        // Deliberately NOT auto-resume: resume is control-plane-driven (resumeSandbox →
-        // connectSandbox). Provider-side auto-resume would wake a paused sandbox from
-        // stray inbound traffic, outside the DO state machine.
-        autoResume: false,
-      });
-
-      try {
-        // Deliver per-session env to the supervisor. E2B's template start command
-        // runs once at build and never sees create-time env vars, so the launcher
-        // (oi-launch.py) waits for this file and execs the supervisor with it.
-        const envdAccessToken = sandbox.envdAccessToken;
-        if (!envdAccessToken) {
-          // secure:true always returns a token, so a missing one is systemic (secure
-          // unsupported / API change), not intermittent — classify permanent to trip the
-          // circuit breaker rather than looping create→kill. Fail closed: the env write
-          // (SANDBOX_AUTH_TOKEN + secrets) never happens; the catch below kills the sandbox.
-          throw new SandboxProviderError(
-            "E2B create did not return an envd access token (secure access required)",
-            "permanent"
-          );
-        }
-        await this.client.writeSessionEnv(sandbox.sandboxID, envVars, {
-          domain: sandbox.domain,
-          envdAccessToken,
-        });
-      } catch (error) {
-        // The sandbox exists but will never get its session env — kill it rather
-        // than leak a running launcher-only sandbox until its TTL.
-        try {
-          await this.client.killSandbox(sandbox.sandboxID);
-        } catch (killError) {
-          log.warn("e2b.cleanup_kill_failed", {
-            sandbox_id: sandbox.sandboxID,
-            error: killError instanceof Error ? killError.message : String(killError),
-          });
-        }
-        throw error;
+      // A prebuilt image id is an E2B snapshot template id — spawn from it instead
+      // of the base template and mark the boot so the runtime skips setup.sh (it
+      // ran at build time). Otherwise fall back to the base template.
+      const extraEnv: Record<string, string> = {};
+      if (config.prebuiltImageId) {
+        extraEnv.FROM_REPO_IMAGE = "true";
+        extraEnv.REPO_IMAGE_SHA = config.prebuiltImageSha ?? "";
       }
-
-      const { codeServerUrl, vncUrl, tunnelUrls } = this.buildTunnelUrls(
-        sandbox.sandboxID,
-        config.codeServerEnabled,
-        config.vncEnabled,
-        config.sandboxSettings,
-        sandbox.domain
-      );
+      const templateId = config.prebuiltImageId || this.client.config.templateId;
+      const spawned = await this.spawnFromTemplate(config, templateId, extraEnv);
 
       return {
         sandboxId: config.sandboxId,
-        providerObjectId: sandbox.sandboxID,
+        providerObjectId: spawned.providerObjectId,
         status: "running",
-        createdAt: Date.now(),
-        codeServerUrl,
-        codeServerPassword,
-        vncAccess: createVncAccess(vncUrl, vncPassword),
-        tunnelUrls,
+        createdAt: spawned.createdAt,
+        codeServerUrl: spawned.codeServerUrl,
+        codeServerPassword: spawned.codeServerPassword,
+        vncAccess: createVncAccess(spawned.vncUrl, spawned.vncPassword),
+        tunnelUrls: spawned.tunnelUrls,
       };
     } catch (error) {
       throw this.classifyError("Failed to create E2B sandbox", error, "create");
+    }
+  }
+
+  async restoreFromSnapshot(config: RestoreConfig): Promise<RestoreResult> {
+    try {
+      const spawned = await this.spawnFromTemplate(config, config.snapshotImageId, {
+        RESTORED_FROM_SNAPSHOT: "true",
+      });
+
+      return {
+        success: true,
+        sandboxId: config.sandboxId,
+        providerObjectId: spawned.providerObjectId,
+        codeServerUrl: spawned.codeServerUrl,
+        codeServerPassword: spawned.codeServerPassword,
+        vncAccess: createVncAccess(spawned.vncUrl, spawned.vncPassword),
+        tunnelUrls: spawned.tunnelUrls,
+      };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to restore E2B sandbox from snapshot", error, "create");
+    }
+  }
+
+  /**
+   * Bake the image-build sandbox into a reusable snapshot template, sanitized so
+   * the image is a clean, quiescent cold boot rather than a frozen build process.
+   *
+   * A reusable E2B snapshot (`POST /sandboxes/{id}/snapshots`) captures live
+   * process memory, so snapshotting the running build sandbox directly would (a)
+   * bake the build supervisor and its secret env into every image and (b) resume
+   * that stale process on spawn instead of a fresh launcher. To avoid both, we
+   * first `pause(keepMemory:false)` — which drops all memory and persists only
+   * the filesystem — then `connect`, which cold-boots the sandbox from disk,
+   * re-running the launcher fresh in its env-wait state. The snapshot then
+   * captures that clean state, so sandboxes spawned from it start a fresh
+   * supervisor with their own per-session env (and never inherit build secrets in
+   * memory).
+   */
+  async takeSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
+    try {
+      await this.client.pauseSandbox(config.providerObjectId, { memory: false });
+      // Cold-boot from disk; connect returns once the template ready-check passes,
+      // i.e. once the launcher is back up and waiting — no readiness guesswork.
+      await this.client.connectSandbox(config.providerObjectId, SNAPSHOT_CONNECT_TIMEOUT_SECONDS);
+      // No name: each build gets a distinct snapshot template. Superseded images
+      // are reclaimed by the reaper via deleteProviderImage, so reusing a name
+      // (which would reassign builds to one template) buys nothing.
+      const snapshot = await this.client.createSnapshot(config.providerObjectId);
+      if (!snapshot.snapshotID) {
+        return { success: false, error: "E2B snapshot did not return a snapshot id" };
+      }
+      return { success: true, imageId: snapshot.snapshotID };
+    } catch (error) {
+      throw this.classifyError("Failed to snapshot E2B sandbox", error, "snapshot");
     }
   }
 
@@ -279,7 +314,236 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
   }
 
-  private buildMetadata(config: CreateSandboxConfig): Record<string, string> {
+  /**
+   * Permanently kill a sandbox. Used to tear down the ephemeral image-build
+   * sandbox once its filesystem has been snapshotted: stopSandbox only pauses
+   * (correct for idle sessions) and would leak the single-use build sandbox
+   * until its TTL. Idempotent — a missing sandbox is treated as already gone.
+   */
+  async deleteSandbox(providerObjectId: string): Promise<void> {
+    try {
+      await this.client.killSandbox(providerObjectId);
+    } catch (error) {
+      if (error instanceof E2BNotFoundError) return;
+      throw this.classifyError("Failed to delete E2B sandbox", error, "stop");
+    }
+  }
+
+  /**
+   * Trigger an E2B environment-image build. A build sandbox boots from the base
+   * template, clones every repository and runs `.openinspect/setup.sh` once (the
+   * SESSION_CONFIG carries the repository list), reports completion via the
+   * repo-image callback, then idles awaiting the snapshot taken by takeSnapshot.
+   * The build sandbox does not auto-pause: its filesystem is snapshotted in place.
+   */
+  async triggerImageBuild(config: ImageBuildProviderTriggerConfig): Promise<void> {
+    const identity = imageBuildSandboxIdentity(config, Date.now());
+
+    let sandboxId: string | undefined;
+    try {
+      const sandbox = await this.client.createSandbox({
+        templateID: this.client.config.templateId,
+        metadata: identity.labels,
+        timeoutSeconds: config.providerSessionTimeoutSeconds,
+        // The build sandbox must stay alive so takeSnapshot can bake its
+        // filesystem; never auto-pause/resume it.
+        autoPause: false,
+        secure: true,
+        autoResume: false,
+      });
+      sandboxId = sandbox.sandboxID;
+
+      // Register the build sandbox before delivering env, so the workflow has
+      // bound the provider session before the supervisor can run setup and fire
+      // the build-complete callback (which is rejected until the session is bound).
+      await config.onProviderSessionCreated(sandbox.sandboxID);
+
+      // E2B has no per-create entrypoint launch, so the whole build env — including
+      // the callback contract — is delivered in the single session-env file
+      // oi-launch reads, rather than baked at create time.
+      const envVars = buildImageBuildEnvVars({
+        sandboxId: identity.sandboxId,
+        repositories: config.repositories,
+        scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
+        cloneToken: config.cloneToken,
+        baseEnvVars: config.userEnvVars,
+      });
+      Object.assign(
+        envVars,
+        {
+          SANDBOX_VERSION: E2B_SANDBOX_VERSION,
+          // See the createSandbox path: /run is a root-owned tmpfs in E2B, so the
+          // git credential helper needs a user-writable cache dir.
+          OI_SCM_CRED_CACHE_DIR: "/tmp/oi",
+          [IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY]: String(config.buildExecutionTimeoutSeconds),
+        },
+        buildImageBuildCallbackEnv({
+          buildId: config.buildId,
+          callbackUrl: config.callbackUrl,
+          failureCallbackUrl: config.failureCallbackUrl,
+          token: config.callbackToken,
+          providerSessionId: sandbox.sandboxID,
+        })
+      );
+      await this.deliverSessionEnv(sandbox, envVars);
+
+      log.info("e2b.image_build_triggered", {
+        build_id: config.buildId,
+        scope_kind: config.scopeKind,
+        scope_id: config.scopeId,
+        sandbox_id: sandbox.sandboxID,
+        request_id: config.correlation.request_id,
+        trace_id: config.correlation.trace_id,
+      });
+    } catch (error) {
+      // deliverSessionEnv kills on write failure; this covers a create-time or
+      // onProviderSessionCreated failure that leaves the sandbox running.
+      if (sandboxId) {
+        try {
+          await this.client.killSandbox(sandboxId);
+        } catch (killError) {
+          if (!(killError instanceof E2BNotFoundError)) {
+            log.warn("e2b.build_cleanup_kill_failed", {
+              sandbox_id: sandboxId,
+              error: killError instanceof Error ? killError.message : String(killError),
+            });
+          }
+        }
+      }
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to trigger E2B image build", error, "create");
+    }
+  }
+
+  async deleteProviderImage(providerImageId: string): Promise<void> {
+    try {
+      await this.client.deleteTemplate(providerImageId);
+    } catch (error) {
+      if (error instanceof E2BNotFoundError) return;
+      throw this.classifyError("Failed to delete E2B snapshot", error, "delete");
+    }
+  }
+
+  /**
+   * Create a runtime sandbox from `templateId` (the base template, a prebuilt
+   * snapshot, or a restore snapshot) and deliver the per-session env. Shared by
+   * createSandbox and restoreFromSnapshot; `extraEnv` carries the boot-mode
+   * marker each path sets.
+   */
+  private async spawnFromTemplate(
+    config: CreateSandboxConfig | RestoreConfig,
+    templateId: string,
+    extraEnv: Record<string, string>
+  ): Promise<{
+    providerObjectId: string;
+    createdAt: number;
+    codeServerUrl?: string;
+    codeServerPassword?: string;
+    vncUrl?: string;
+    vncPassword?: string;
+    tunnelUrls?: Record<string, string>;
+  }> {
+    const codeServerPassword = config.codeServerEnabled
+      ? await deriveCodeServerPassword(
+          config.sandboxId,
+          this.providerConfig.sandboxAccessPasswordSecret
+        )
+      : undefined;
+    const vncPassword = config.vncEnabled
+      ? await deriveVncPassword(config.sandboxId, this.providerConfig.sandboxAccessPasswordSecret)
+      : undefined;
+    const timeoutSeconds = config.timeoutSeconds ?? this.providerConfig.sandboxTimeoutSeconds;
+    const envVars = buildSandboxEnvVars(
+      { ...config, timeoutSeconds },
+      {
+        scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
+        codeServerPassword,
+        vncPassword,
+      }
+    );
+    // E2B sandboxes run as a non-root user and /run is a root-owned tmpfs, so
+    // the git credential helper can't create its default cache dir (/run/oi)
+    // and fails before brokering a token. Point it at a user-writable path.
+    envVars.OI_SCM_CRED_CACHE_DIR = "/tmp/oi";
+    Object.assign(envVars, extraEnv);
+
+    const sandbox = await this.client.createSandbox({
+      templateID: templateId,
+      metadata: this.buildMetadata(config),
+      timeoutSeconds,
+      autoPause: this.providerConfig.autoPause,
+      // Require secure envd access: the per-session env we upload carries
+      // SANDBOX_AUTH_TOKEN + user secrets, so envd must reject writes lacking the
+      // returned access token (otherwise the upload is anonymous over the public host).
+      secure: true,
+      // Deliberately NOT auto-resume: resume is control-plane-driven (resumeSandbox →
+      // connectSandbox). Provider-side auto-resume would wake a paused sandbox from
+      // stray inbound traffic, outside the DO state machine.
+      autoResume: false,
+    });
+
+    await this.deliverSessionEnv(sandbox, envVars);
+
+    const { codeServerUrl, vncUrl, tunnelUrls } = this.buildTunnelUrls(
+      sandbox.sandboxID,
+      config.codeServerEnabled,
+      config.vncEnabled,
+      config.sandboxSettings,
+      sandbox.domain
+    );
+
+    return {
+      providerObjectId: sandbox.sandboxID,
+      createdAt: Date.now(),
+      codeServerUrl,
+      codeServerPassword,
+      vncUrl,
+      vncPassword,
+      tunnelUrls,
+    };
+  }
+
+  /**
+   * Deliver the per-session env to the supervisor via envd. E2B's template start
+   * command runs once at build and never sees create-time env vars, so the
+   * launcher (oi-launch.py) waits for this file and starts the supervisor with it.
+   * On failure the sandbox exists but will never get its env — kill it rather
+   * than leak a running launcher-only sandbox until its TTL.
+   */
+  private async deliverSessionEnv(
+    sandbox: E2BSandboxCreated,
+    envVars: Record<string, string>
+  ): Promise<void> {
+    try {
+      const envdAccessToken = sandbox.envdAccessToken;
+      if (!envdAccessToken) {
+        // secure:true always returns a token, so a missing one is systemic (secure
+        // unsupported / API change), not intermittent — classify permanent to trip the
+        // circuit breaker rather than looping create→kill. Fail closed: the env write
+        // (SANDBOX_AUTH_TOKEN + secrets) never happens; the catch below kills the sandbox.
+        throw new SandboxProviderError(
+          "E2B create did not return an envd access token (secure access required)",
+          "permanent"
+        );
+      }
+      await this.client.writeSessionEnv(sandbox.sandboxID, envVars, {
+        domain: sandbox.domain,
+        envdAccessToken,
+      });
+    } catch (error) {
+      try {
+        await this.client.killSandbox(sandbox.sandboxID);
+      } catch (killError) {
+        log.warn("e2b.cleanup_kill_failed", {
+          sandbox_id: sandbox.sandboxID,
+          error: killError instanceof Error ? killError.message : String(killError),
+        });
+      }
+      throw error;
+    }
+  }
+
+  private buildMetadata(config: CreateSandboxConfig | RestoreConfig): Record<string, string> {
     const metadata: Record<string, string> = {
       openinspect_framework: "open-inspect",
       openinspect_session_id: config.sessionId,
@@ -331,7 +595,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   private classifyError(
     message: string,
     error: unknown,
-    operation: "create" | "resume" | "stop"
+    operation: E2BOperation
   ): SandboxProviderError {
     // Already classified (e.g. the secure-access guard) — don't double-wrap and lose its message.
     if (error instanceof SandboxProviderError) return error;

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -169,7 +169,7 @@ export class E2BSandboxProvider implements SandboxProvider {
       });
 
       // Drop the captured process memory, then cold-boot the template launcher.
-      // connect reissues the envd token the cold boot invalidated.
+      // connect reports the sandbox's current envd token, which the env write below uses.
       await this.client.pauseSandbox(sandbox.sandboxID, { memory: false });
       const connected = await this.client.connectSandbox(sandbox.sandboxID, timeoutSeconds);
       await this.client.updateSandboxNetwork(sandbox.sandboxID, { allowInternetAccess: true });

--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -76,12 +76,16 @@ RUN printf '%s\n' '#!/bin/sh' 'exec python3 -m sandbox_runtime.credentials.git_c
 # Build-time env only. E2B does NOT propagate Docker ENV to the runtime process,
 # so the start command (build-template.py) re-exports PYTHONPATH / NODE_PATH;
 # control-plane-injected vars (CONTROL_PLANE_URL, etc.) arrive via E2B envVars.
+# SANDBOX_VERSION must parse as v<N> (>= MIN_COMPATIBLE_RUNTIME_VERSION) so
+# prebuilt images built from this template clear the spawn-time floor. Keep it in
+# sync with E2B_SANDBOX_VERSION in control-plane e2b-provider.ts and the pinned
+# OPENCODE_VERSION above.
 ENV HOME=/root \
     NODE_ENV=development \
     PATH=/usr/local/bin:/usr/bin:/bin \
     PYTHONPATH=/app \
     NODE_PATH=/usr/lib/node_modules \
-    SANDBOX_VERSION=e2b-v3-vnc
+    SANDBOX_VERSION=v57-vnc-opencode-1-18-11
 
 # NOTE: file staging (sandbox_runtime, oi-launch.py), WORKDIR, and the start/ready
 # commands are applied by build-template.py via the E2B Template SDK

--- a/packages/e2b-infra/oi-launch.py
+++ b/packages/e2b-infra/oi-launch.py
@@ -12,12 +12,13 @@ supervisor with the merged environment — so the supervisor starts fresh per
 session regardless of E2B's snapshot/resume model.
 
 On pause/resume the supervisor process itself is frozen/thawed by E2B, so this
-launcher only runs for a fresh spawn.
+launcher only runs for a fresh spawn (including a prebuilt-image spawn, whose
+snapshot was cold-booted back into this env-wait state — see the E2B provider's
+takeSnapshot).
 """
 
 import json
 import os
-import sys
 import time
 
 SESSION_ENV_PATH = "/tmp/oi-session.env"
@@ -69,6 +70,17 @@ def main() -> None:
                 else:
                     _log("session env is not a JSON object — retrying")
         time.sleep(POLL_INTERVAL_SECONDS)
+
+    # Delete the consumed env file before exec. An image-build sandbox is baked
+    # into a reusable snapshot; if this file survived on disk, a sandbox cold-
+    # booted from that snapshot would read the *build's* stale env (build mode,
+    # build callbacks) before the control plane wrote the new session env. The
+    # image build additionally sanitizes via pause(keepMemory:false)+connect, but
+    # removing the file here keeps the snapshot filesystem clean regardless.
+    try:
+        os.remove(SESSION_ENV_PATH)
+    except OSError as e:
+        _log(f"could not remove session env file (continuing): {e}")
 
     env = {**os.environ, **STATIC_ENV}
     for k, v in session_env.items():

--- a/packages/web/src/app/api/environments/[id]/images/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/route.ts
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json(
       {
         error:
-          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b",
       },
       { status: 501 }
     );

--- a/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
@@ -14,7 +14,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     return NextResponse.json(
       {
         error:
-          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b",
       },
       { status: 501 }
     );

--- a/packages/web/src/app/api/image-builds/repo/[owner]/[name]/toggle/route.ts
+++ b/packages/web/src/app/api/image-builds/repo/[owner]/[name]/toggle/route.ts
@@ -17,7 +17,7 @@ export async function PUT(
     return NextResponse.json(
       {
         error:
-          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b",
       },
       { status: 501 }
     );

--- a/packages/web/src/app/api/image-builds/repo/[owner]/[name]/trigger/route.ts
+++ b/packages/web/src/app/api/image-builds/repo/[owner]/[name]/trigger/route.ts
@@ -17,7 +17,7 @@ export async function POST(
     return NextResponse.json(
       {
         error:
-          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b",
       },
       { status: 501 }
     );

--- a/packages/web/src/app/api/image-builds/route.ts
+++ b/packages/web/src/app/api/image-builds/route.ts
@@ -24,7 +24,7 @@ export async function GET() {
     return NextResponse.json(
       {
         error:
-          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+          "Image builds are only available when SANDBOX_PROVIDER=modal, vercel, opencomputer, or e2b",
       },
       { status: 501 }
     );

--- a/packages/web/src/components/settings/environment-form.tsx
+++ b/packages/web/src/components/settings/environment-form.tsx
@@ -235,7 +235,7 @@ export function EnvironmentForm({
         ) : (
           <p className="text-xs text-muted-foreground">
             Prebuilt images are only available when <code>SANDBOX_PROVIDER=modal</code>,{" "}
-            <code>vercel</code>, or <code>opencomputer</code>.
+            <code>vercel</code>, <code>opencomputer</code>, or <code>e2b</code>.
           </p>
         )}
       </div>

--- a/packages/web/src/lib/sandbox-provider.test.ts
+++ b/packages/web/src/lib/sandbox-provider.test.ts
@@ -63,6 +63,16 @@ describe("sandbox-provider", () => {
     expect(supportsRepoImages()).toBe(true);
   });
 
+  it("supports e2b with repo images", async () => {
+    delete process.env.NEXT_PUBLIC_SANDBOX_PROVIDER;
+    process.env.SANDBOX_PROVIDER = "e2b";
+
+    const { getPublicSandboxProvider, supportsRepoImages } = await loadProvider();
+
+    expect(getPublicSandboxProvider()).toBe("e2b");
+    expect(supportsRepoImages()).toBe(true);
+  });
+
   it("throws for unsupported providers", async () => {
     process.env.NEXT_PUBLIC_SANDBOX_PROVIDER = "fly";
 

--- a/packages/web/src/lib/sandbox-provider.ts
+++ b/packages/web/src/lib/sandbox-provider.ts
@@ -26,5 +26,10 @@ export function getPublicSandboxProvider(): PublicSandboxProvider {
 
 export function supportsRepoImages(): boolean {
   const provider = getPublicSandboxProvider();
-  return provider === "modal" || provider === "vercel" || provider === "opencomputer";
+  return (
+    provider === "modal" ||
+    provider === "vercel" ||
+    provider === "opencomputer" ||
+    provider === "e2b"
+  );
 }


### PR DESCRIPTION
Adds prebuilt-image (snapshot) support to the E2B sandbox provider, so E2B sessions can boot from an image built once by `.openinspect/setup.sh` instead of re-running setup on every spawn — the same capability Modal, Vercel and OpenComputer already have.

Follows on from #1008, which added the E2B provider itself.

## How it works

An E2B snapshot template id doubles as a `templateID`, so a prebuilt spawn is just a create with that id in place of the base template. The image-build workflow runs setup once in a build sandbox, then bakes its filesystem into a reusable snapshot.

Baking needs care, because a reusable E2B snapshot captures live process memory. Snapshotting the running build sandbox directly would bake the build supervisor and its secret env into every image, and resume that stale process on spawn instead of a fresh launcher. So `takePrebuiltImageSnapshot` first does `pause(memory: false)` — which drops all memory and persists only the filesystem — then `connect`, which cold-boots from disk and re-runs the launcher into its env-wait state. The snapshot captures that clean state, so sandboxes spawned from it start a fresh supervisor with their own per-session env.

Sessions restored from a *session* snapshot get the inverse treatment: that snapshot deliberately preserves process memory, so the captured supervisor would wake holding the previous session's credentials. `restoreFromSnapshot` creates the sandbox with outbound networking off, drops the captured memory, cold-boots, and only then re-enables the network and delivers fresh session env.

The generic `takeSnapshot` used by the lifecycle manager after a prompt is left alone — it snapshots a live session in place, without pausing or reconnecting it.

## Integration

E2B registers as an image-build provider (`provider-policy`, `provider-factory`, `E2BImageBuildAdapter`) using the shared provider-session lifecycle and `buildImageBuildEnvVars` / `buildImageBuildCallbackEnv` helpers, so no E2B-specific plumbing enters the workflow. The web layer adds `e2b` to the prebuilt-image capability checks.

`E2B_SANDBOX_VERSION` and the template's `SANDBOX_VERSION` are bumped to `v57-vnc-opencode-1-18-11`, matching the Vercel/OpenComputer constants and the image's pinned opencode. This is required, not cosmetic: the previous value parsed below `MIN_COMPATIBLE_RUNTIME_VERSION`, which would have made spawn-time selection reject every E2B prebuilt image. **The E2B template needs a rebuild when this deploys.**

## Testing

Unit tests cover the adapter, the REST client, the provider paths and the lifecycle interaction. Beyond those, the template was rebuilt and the changed API surface was exercised against live E2B:

- `PUT /sandboxes/{id}/network` behaves as used by the restore path
- `DELETE /templates/{id}` accepts a tagged snapshot id (`abc:default`) verbatim — E2B strips the tag server-side
- `pause(memory: false)` → `connect` cold-boots and returns the envd access token the post-boot env write needs
- a snapshot id spawns as a `templateID`; `takeSnapshot` leaves a live session `running`; `restoreFromSnapshot` completes its quarantine sequence and boots

Not covered by automation: the bridge ↔ control-plane WebSocket path, which needs a running control plane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added E2B support for sandbox image builds, prebuilt images, snapshots, and snapshot restoration.
  * Added provider image creation and cleanup for completed or failed builds.
  * Added configurable internet access and network updates for E2B sandboxes.
  * Preserved refreshed access credentials when reconnecting to sandboxes.
* **Bug Fixes**
  * Unsupported snapshot and restore operations now safely fall back or skip when unavailable.
  * Improved cleanup and handling of missing resources during sandbox and image operations.
* **Infrastructure**
  * Updated the E2B runtime image and startup behavior for restored prebuilt environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->