### PR TITLE
fix: anchor timeline absolute descendants inside the scroller

### DIFF
--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -148,6 +148,32 @@ describe("timeline auto-scrolling", () => {
     expect(timeline.scrollTop).toBe(300);
   });
 
+  it("anchors absolutely-positioned descendants inside the timeline scroller", () => {
+    // A thinking task renders a `position: absolute` sr-only live-status span.
+    // The scroller must be its containing block (`relative`): otherwise the
+    // span anchors to the document, escapes every ancestor overflow clip, and
+    // stretches the page by the timeline's content height — scrolling the
+    // whole layout while sub-tasks stream.
+    const task = toolEvent("task", "task-call", 1, { status: "running" });
+    const { container } = render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          task,
+          toolEvent("Read", "child-call", 2, { isSubtask: true, taskCallId: "task-call" }),
+        ]}
+      />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    expect(timeline).toHaveClass("relative");
+
+    const statusSpan = container.querySelector('[role="status"]');
+    expect(statusSpan).toBeInTheDocument();
+    const containingBlock = statusSpan?.closest(".relative, .absolute, .fixed, .sticky") ?? null;
+    expect(containingBlock).not.toBeNull();
+    expect(timeline.contains(containingBlock)).toBe(true);
+  });
+
   it("follows processing indicator height changes before passive effects", () => {
     const events: SandboxEvent[] = [
       {

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -248,7 +248,11 @@ export function SessionTimeline({
     <div
       ref={scrollContainerRef}
       onScroll={handleScroll}
-      className="h-full overflow-y-auto overflow-x-hidden p-3 sm:p-4"
+      // `relative` makes this scroller the containing block for
+      // absolutely-positioned descendants (e.g. sr-only live-status spans in
+      // task rows). Without it they anchor to the document, escape every
+      // ancestor overflow clip, and grow the page itself.
+      className="relative h-full overflow-y-auto overflow-x-hidden p-3 sm:p-4"
     >
       <div className="w-full min-w-0 max-w-3xl mx-auto space-y-2">
         <div ref={topSentinelRef} className="h-1" />


### PR DESCRIPTION
## Summary

One-word layout fix: add `relative` to the session timeline scroll container so it is the **containing block** for absolutely-positioned descendants, plus a structural regression test.

## Symptom

While sub-agent tasks are running, the page itself becomes scrollable: you can scroll past the application bounds and the entire layout (header, sidebar, everything) moves. The moment the tasks finish, the symptom disappears. Long task activity makes it dramatically worse.

## Root cause

`TaskActivityItem` renders a screen-reader live status while a task is running:

```tsx
<span role="status" className="sr-only">Task in progress</span>
```

Tailwind's `sr-only` is `position: absolute`. **No ancestor in the session layout chain is positioned**, so the span's containing block is the initial containing block — the document. That has two consequences:

1. It escapes every `overflow: clip` / `overflow: hidden` barrier between the timeline and `<body>` (overflow clipping does not apply to absolutely-positioned descendants whose containing block is outside the clipper).
2. It is laid out at its static position measured in the timeline's **content** flow, and does not move with the timeline's `scrollTop` (the scroller is not its containing block).

With a long session, the running task's row sits thousands of pixels down the timeline content — so the span lands thousands of pixels down the **document**, giving `<html>` real scrollable overflow. Wheel input over the timeline chains into the document once the timeline hits bottom, scrolling the whole layout. When the task completes the span unmounts and the overflow collapses, which is why the bug is transient and only reproduces while tasks are thinking.

This is why the previous containment passes (#1340, #1362, #1396) never caught it: they hardened the overflow/height chain, which absolute-to-ICB content bypasses entirely, and the jsdom tests cannot observe real layout.

## Evidence

Measured live against the deployed app (CDP attached to Chrome) during a parallel sub-task run:

- `html.scrollHeight` grew to **7004px** against a 1464px viewport while `scrollTop` was still 0 — real document overflow, growing +32px per streamed row (each new row pushes the running task's static position down).
- 7004 ≈ the running task's y-position in the 7049px timeline content — independent of the timeline's scroll offset.
- The only absolutely-positioned elements in timeline content are this span (running tasks only) and the screenshot-card play overlay (already contained by a `relative` parent).

Reproduced locally in headless Chrome with a 150-row history before a running task:

| | page scrollHeight / clientHeight | page scrollTop after wheeling past timeline bottom |
|---|---|---|
| before fix | 4895 / 813 | **4082** (layout scrolls away) |
| after fix | 813 / 813 | 0 |

After the fix, a 10,000px expanded task activity stays fully inside the timeline scroller across every configuration (base, terminal open, changes open, narrow viewport, streaming) — no nested scrollbar or activity height cap needed; expand/collapse behaves like a normal disclosure.

## Changes

- `session-timeline.tsx`: `relative` on the timeline scroll container, with a comment explaining the invariant.
- `session-timeline-scroll.test.tsx`: regression test asserting the scroller is the containing block for the running-task status span.

## Testing

- `npm test -w @open-inspect/web -- src/components/session-timeline-scroll.test.tsx src/components/session-timeline.test.tsx src/components/task-activity-item.test.tsx src/components/session-desktop-layout.test.tsx` (37 passed)
- `npm run typecheck -w @open-inspect/web`
- ESLint on changed files
- Headless-Chrome layout verification described above (real browser, real components, fabricated events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live-status elements in the session timeline so they remain properly contained within the scroll area during sub-task streaming.
* **Tests**
  * Added regression coverage to verify correct timeline scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->