### PR TITLE
fix: contain mobile session workspace width

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -267,7 +267,7 @@ export default function SessionPage() {
   }, [focusDetailsTrigger, isBelowLg]);
 
   const sessionWorkspace = (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-clip">
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip">
       <div className="min-h-0 min-w-0 flex-1 overflow-clip">
         <PanelGroup orientation="vertical" id="session-terminal" style={{ overflow: "clip" }}>
           <Panel

--- a/packages/web/src/lib/session-workspace-layout.test.ts
+++ b/packages/web/src/lib/session-workspace-layout.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sessionPagePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../app/(app)/session/[id]/page.tsx"
+);
+
+describe("session workspace layout", () => {
+  it("allows the mobile workspace to shrink around long timeline content", () => {
+    const source = readFileSync(sessionPagePath, "utf8");
+
+    expect(source).toContain(
+      'className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip"'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow the mobile session workspace flex item to shrink to the viewport width
- prevent long assistant responses, inline code, and URLs from widening the workspace and clipping the prompt composer
- add regression coverage for the required `min-w-0` layout boundary

## Root Cause
The mobile session workspace was a direct flex child with the default `min-width: auto`. Long timeline content could therefore establish an intrinsic width wider than the viewport. The timeline's horizontal clipping then hid the excess, including the right side of the composer contained in the same workspace.

## Verification
- `npm test -w @open-inspect/web -- src/lib/session-workspace-layout.test.ts src/components/session-timeline.test.tsx src/components/session-desktop-layout.test.tsx`
- `npx eslint 'packages/web/src/app/(app)/session/[id]/page.tsx' packages/web/src/lib/session-workspace-layout.test.ts`
- `npx prettier --check 'packages/web/src/app/(app)/session/[id]/page.tsx' packages/web/src/lib/session-workspace-layout.test.ts`
- `npm run typecheck -w @open-inspect/web`
- `git diff HEAD^..HEAD --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e319a30e05ddddf576af796d5a8516ae)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session workspace layout behavior to prevent horizontal overflow, especially when viewing long timeline content on mobile devices.

* **Tests**
  * Added coverage to verify the workspace maintains the required responsive layout constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->