### PR TITLE
feat(bots): let the Slack and Linear classifiers run on OpenAI, and bound the request

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -100,7 +100,10 @@ jobs:
 
       - name: Terraform Tests
         id: test
-        run: terraform test -filter=tests/auth_provider_configuration.tftest.hcl
+        run: |
+          terraform test \
+            -filter=tests/auth_provider_configuration.tftest.hcl \
+            -filter=tests/classifier_provider.tftest.hcl
         working-directory: ${{ env.TF_WORKING_DIR }}
 
       - name: Post Validation Results
@@ -225,6 +228,8 @@ jobs:
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
+          TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
           TF_VAR_provider_accounts_encryption_key: ${{ secrets.PROVIDER_ACCOUNTS_ENCRYPTION_KEY }}
@@ -396,6 +401,8 @@ jobs:
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
+          TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
           TF_VAR_provider_accounts_encryption_key: ${{ secrets.PROVIDER_ACCOUNTS_ENCRYPTION_KEY }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -211,6 +211,9 @@ jobs:
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
+          TF_VAR_classification_anthropic_api_key: ${{ secrets.CLASSIFICATION_ANTHROPIC_API_KEY }}
+          TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
           TF_VAR_nextauth_secret: ${{ secrets.NEXTAUTH_SECRET }}
@@ -365,6 +368,9 @@ jobs:
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
+          TF_VAR_classification_anthropic_api_key: ${{ secrets.CLASSIFICATION_ANTHROPIC_API_KEY }}
+          TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
           TF_VAR_nextauth_secret: ${{ secrets.NEXTAUTH_SECRET }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -212,7 +212,6 @@ jobs:
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
-          TF_VAR_classification_anthropic_api_key: ${{ secrets.CLASSIFICATION_ANTHROPIC_API_KEY }}
           TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}
@@ -369,7 +368,6 @@ jobs:
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
-          TF_VAR_classification_anthropic_api_key: ${{ secrets.CLASSIFICATION_ANTHROPIC_API_KEY }}
           TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_token_encryption_key: ${{ secrets.TOKEN_ENCRYPTION_KEY }}
           TF_VAR_repo_secrets_encryption_key: ${{ secrets.REPO_SECRETS_ENCRYPTION_KEY }}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -563,6 +563,12 @@ linear_webhook_secret  = ""          # From Step 4b (required if enabled)
 # API Keys
 anthropic_api_key = "sk-ant-..."
 
+# Slack/Linear classifier provider, chosen by classification_model.
+# An OpenAI model requires classification_openai_api_key. An Anthropic model
+# needs no new value — it is served by anthropic_api_key above.
+# classification_model = "claude-haiku-4-5"   # e.g. "gpt-5.4-mini" to classify on OpenAI
+classification_openai_api_key = ""   # Required when classification_model is an OpenAI id
+
 # Security Secrets (from Step 5)
 token_encryption_key          = "your-generated-value"
 repo_secrets_encryption_key   = "your-generated-value"
@@ -968,6 +974,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `LINEAR_CLIENT_SECRET`             | Linear OAuth application client secret (required if Linear enabled)                         |
 | `LINEAR_WEBHOOK_SECRET`            | Linear webhook signing secret (required if Linear enabled)                                  |
 | `ANTHROPIC_API_KEY`                | Anthropic API key                                                                           |
+| `CLASSIFICATION_OPENAI_API_KEY`    | Classifier OpenAI key (required when `classification_model` is an OpenAI id)                |
 | `OPENAI_API_KEY`                   | Optional OpenAI API key used when a session selects API-key authentication                  |
 | `XAI_API_KEY`                      | Optional xAI API key used when a session selects API-key authentication                     |
 | `DEEPSEEK_API_KEY`                 | DeepSeek API key (optional, required only for DeepSeek models)                              |
@@ -986,6 +993,12 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `GH_BOT_USERNAME`                  | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
 | `APP_NAME`                         | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
 | `APP_ICON_URL`                     | Optional URL to a custom logo/favicon (default: built-in icon)                              |
+
+`CLASSIFICATION_MODEL` is an optional Actions **variable**, not a secret — add it under Settings →
+Secrets and variables → Actions → _Variables_ to point the Slack/Linear classifiers at a different
+model (for example `gpt-5.4-mini`). Leave it unset to keep the Terraform default. An OpenAI value
+also requires the `CLASSIFICATION_OPENAI_API_KEY` secret; an Anthropic value is served by
+`ANTHROPIC_API_KEY`.
 
 When enabling or upgrading the Linear bot, also enable **Client credentials tokens** on the OAuth
 application in **Linear Settings → API → Applications**. This provider-side setting is not managed

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -565,11 +565,9 @@ anthropic_api_key = "sk-ant-..."
 
 # Slack/Linear classifier provider, chosen by classification_model.
 # An OpenAI model requires classification_openai_api_key. An Anthropic model
-# needs no new value: classification_anthropic_api_key is an optional override
-# and falls back to anthropic_api_key above.
+# needs no new value — it is served by anthropic_api_key above.
 # classification_model = "claude-haiku-4-5"   # e.g. "gpt-5.4-mini" to classify on OpenAI
-classification_anthropic_api_key = ""   # Optional override; blank uses anthropic_api_key
-classification_openai_api_key    = ""   # Required when classification_model is an OpenAI id
+classification_openai_api_key = ""   # Required when classification_model is an OpenAI id
 
 # Security Secrets (from Step 5)
 token_encryption_key          = "your-generated-value"
@@ -930,67 +928,72 @@ Enable automatic deployments when you push to main by adding GitHub Secrets.
 
 Go to your fork's Settings → Secrets and variables → Actions, and add:
 
-| Secret Name                        | Value                                                                                       |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`             | Your Cloudflare API token                                                                   |
-| `CLOUDFLARE_ACCOUNT_ID`            | Your Cloudflare account ID                                                                  |
-| `CLOUDFLARE_WORKER_SUBDOMAIN`      | Your workers.dev subdomain                                                                  |
-| `DEPLOYMENT_NAME`                  | Your deployment name                                                                        |
-| `R2_ACCESS_KEY_ID`                 | R2 access key ID                                                                            |
-| `R2_SECRET_ACCESS_KEY`             | R2 secret access key                                                                        |
-| `WEB_PLATFORM`                     | `vercel` or `cloudflare`                                                                    |
-| `VERCEL_API_TOKEN`                 | Vercel API token _(only if `web_platform = "vercel"`)_                                      |
-| `VERCEL_TEAM_ID`                   | Vercel team/account ID _(only if `web_platform = "vercel"`)_                                |
-| `VERCEL_PROJECT_ID`                | Vercel project ID _(only if `web_platform = "vercel"`)_                                     |
-| `MODAL_TOKEN_ID`                   | Modal token ID                                                                              |
-| `MODAL_TOKEN_SECRET`               | Modal token secret                                                                          |
-| `MODAL_WORKSPACE`                  | Modal workspace name                                                                        |
-| `MODAL_ENVIRONMENT`                | Modal environment name (defaults to `main`)                                                 |
-| `MODAL_ENVIRONMENT_WEB_SUFFIX`     | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
-| `SANDBOX_PROVIDER`                 | `modal`, `daytona`, or `vercel`                                                             |
-| `DAYTONA_API_URL`                  | Daytona API URL _(only if `sandbox_provider = "daytona"`)_                                  |
-| `DAYTONA_API_KEY`                  | Daytona API key _(only if `sandbox_provider = "daytona"`)_                                  |
-| `DAYTONA_BASE_SNAPSHOT`            | Daytona base snapshot name _(only if `sandbox_provider = "daytona"`)_                       |
-| `DAYTONA_TARGET`                   | Optional Daytona target name                                                                |
-| `VERCEL_SANDBOX_TOKEN`             | Vercel API token _(only if `sandbox_provider = "vercel"`)_                                  |
-| `VERCEL_SANDBOX_PROJECT_ID`        | Vercel project ID for sandbox sessions _(only if `sandbox_provider = "vercel"`)_            |
-| `VERCEL_SANDBOX_TEAM_ID`           | Optional Vercel team/account ID for sandbox sessions                                        |
-| `VERCEL_BASE_SNAPSHOT_ID`          | Optional manual Vercel base-runtime snapshot; skips Terraform-managed snapshot builds       |
-| `VERCEL_SANDBOX_RUNTIME`           | Optional Vercel Sandbox runtime (defaults to `node24`)                                      |
-| `VERCEL_SNAPSHOT_EXPIRATION_MS`    | Optional Vercel runtime snapshot expiration in milliseconds (`0` means no expiration)       |
-| `VERCEL_SANDBOX_API_BASE_URL`      | Optional advanced Vercel Sandbox API base URL override                                      |
-| `GH_OAUTH_CLIENT_ID`               | Optional GitHub sign-in client ID; set with `GH_OAUTH_CLIENT_SECRET`                        |
-| `GH_OAUTH_CLIENT_SECRET`           | Optional GitHub sign-in client secret; set with `GH_OAUTH_CLIENT_ID`                        |
-| `GOOGLE_CLIENT_ID`                 | Optional Google sign-in client ID; set with `GOOGLE_CLIENT_SECRET`                          |
-| `GOOGLE_CLIENT_SECRET`             | Optional Google sign-in client secret; set with `GOOGLE_CLIENT_ID`                          |
-| `GH_APP_ID`                        | Required GitHub App repository-access ID                                                    |
-| `GH_APP_PRIVATE_KEY`               | Required GitHub App repository-access private key (PKCS#8 format)                           |
-| `GH_APP_INSTALLATION_ID`           | Required GitHub App repository-access installation ID                                       |
-| `ENABLE_SLACK_BOT`                 | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
-| `SLACK_BOT_TOKEN`                  | Slack bot token (required if enabled)                                                       |
-| `SLACK_SIGNING_SECRET`             | Slack signing secret (required if enabled)                                                  |
-| `ENABLE_LINEAR_BOT`                | `true` to deploy Linear bot, `false` to skip (default: `false`)                             |
-| `LINEAR_CLIENT_ID`                 | Linear OAuth application client ID (required if Linear enabled)                             |
-| `LINEAR_CLIENT_SECRET`             | Linear OAuth application client secret (required if Linear enabled)                         |
-| `LINEAR_WEBHOOK_SECRET`            | Linear webhook signing secret (required if Linear enabled)                                  |
-| `ANTHROPIC_API_KEY`                | Anthropic API key                                                                           |
-| `CLASSIFICATION_OPENAI_API_KEY`    | Classifier OpenAI key (required when classification_model is an OpenAI id)                  |
-| `CLASSIFICATION_ANTHROPIC_API_KEY` | Classifier Anthropic key (optional; falls back to `ANTHROPIC_API_KEY`)                      |
-| `DEEPSEEK_API_KEY`                 | DeepSeek API key (optional, required only for DeepSeek models)                              |
-| `TOKEN_ENCRYPTION_KEY`             | Generated encryption key (OAuth tokens)                                                     |
-| `REPO_SECRETS_ENCRYPTION_KEY`      | Generated encryption key (repo secrets)                                                     |
-| `MODAL_API_SECRET`                 | Generated Modal API secret                                                                  |
-| `NEXTAUTH_SECRET`                  | Generated browser-auth secret (legacy Actions secret name)                                  |
-| `ALLOWED_USERS`                    | Comma-separated GitHub usernames (or empty for all users)                                   |
-| `ALLOWED_EMAIL_DOMAINS`            | Comma-separated email domains (or empty for all domains)                                    |
-| `ALLOWED_EMAILS`                   | Comma-separated exact email addresses (for individual users on shared domains)              |
-| `ALLOWED_GITHUB_ORGS`              | Comma-separated GitHub orgs whose active members can sign in                                |
-| `ENABLE_DURABLE_OBJECT_BINDINGS`   | Optional Terraform CI flag for Durable Object phase 1 (defaults to `true`)                  |
-| `ENABLE_GITHUB_BOT`                | `true` to deploy GitHub bot worker (or empty to skip)                                       |
-| `GH_WEBHOOK_SECRET`                | GitHub webhook secret (required if GitHub bot enabled)                                      |
-| `GH_BOT_USERNAME`                  | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
-| `APP_NAME`                         | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
-| `APP_ICON_URL`                     | Optional URL to a custom logo/favicon (default: built-in icon)                              |
+| Secret Name                      | Value                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`           | Your Cloudflare API token                                                                   |
+| `CLOUDFLARE_ACCOUNT_ID`          | Your Cloudflare account ID                                                                  |
+| `CLOUDFLARE_WORKER_SUBDOMAIN`    | Your workers.dev subdomain                                                                  |
+| `DEPLOYMENT_NAME`                | Your deployment name                                                                        |
+| `R2_ACCESS_KEY_ID`               | R2 access key ID                                                                            |
+| `R2_SECRET_ACCESS_KEY`           | R2 secret access key                                                                        |
+| `WEB_PLATFORM`                   | `vercel` or `cloudflare`                                                                    |
+| `VERCEL_API_TOKEN`               | Vercel API token _(only if `web_platform = "vercel"`)_                                      |
+| `VERCEL_TEAM_ID`                 | Vercel team/account ID _(only if `web_platform = "vercel"`)_                                |
+| `VERCEL_PROJECT_ID`              | Vercel project ID _(only if `web_platform = "vercel"`)_                                     |
+| `MODAL_TOKEN_ID`                 | Modal token ID                                                                              |
+| `MODAL_TOKEN_SECRET`             | Modal token secret                                                                          |
+| `MODAL_WORKSPACE`                | Modal workspace name                                                                        |
+| `MODAL_ENVIRONMENT`              | Modal environment name (defaults to `main`)                                                 |
+| `MODAL_ENVIRONMENT_WEB_SUFFIX`   | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
+| `SANDBOX_PROVIDER`               | `modal`, `daytona`, or `vercel`                                                             |
+| `DAYTONA_API_URL`                | Daytona API URL _(only if `sandbox_provider = "daytona"`)_                                  |
+| `DAYTONA_API_KEY`                | Daytona API key _(only if `sandbox_provider = "daytona"`)_                                  |
+| `DAYTONA_BASE_SNAPSHOT`          | Daytona base snapshot name _(only if `sandbox_provider = "daytona"`)_                       |
+| `DAYTONA_TARGET`                 | Optional Daytona target name                                                                |
+| `VERCEL_SANDBOX_TOKEN`           | Vercel API token _(only if `sandbox_provider = "vercel"`)_                                  |
+| `VERCEL_SANDBOX_PROJECT_ID`      | Vercel project ID for sandbox sessions _(only if `sandbox_provider = "vercel"`)_            |
+| `VERCEL_SANDBOX_TEAM_ID`         | Optional Vercel team/account ID for sandbox sessions                                        |
+| `VERCEL_BASE_SNAPSHOT_ID`        | Optional manual Vercel base-runtime snapshot; skips Terraform-managed snapshot builds       |
+| `VERCEL_SANDBOX_RUNTIME`         | Optional Vercel Sandbox runtime (defaults to `node24`)                                      |
+| `VERCEL_SNAPSHOT_EXPIRATION_MS`  | Optional Vercel runtime snapshot expiration in milliseconds (`0` means no expiration)       |
+| `VERCEL_SANDBOX_API_BASE_URL`    | Optional advanced Vercel Sandbox API base URL override                                      |
+| `GH_OAUTH_CLIENT_ID`             | Optional GitHub sign-in client ID; set with `GH_OAUTH_CLIENT_SECRET`                        |
+| `GH_OAUTH_CLIENT_SECRET`         | Optional GitHub sign-in client secret; set with `GH_OAUTH_CLIENT_ID`                        |
+| `GOOGLE_CLIENT_ID`               | Optional Google sign-in client ID; set with `GOOGLE_CLIENT_SECRET`                          |
+| `GOOGLE_CLIENT_SECRET`           | Optional Google sign-in client secret; set with `GOOGLE_CLIENT_ID`                          |
+| `GH_APP_ID`                      | Required GitHub App repository-access ID                                                    |
+| `GH_APP_PRIVATE_KEY`             | Required GitHub App repository-access private key (PKCS#8 format)                           |
+| `GH_APP_INSTALLATION_ID`         | Required GitHub App repository-access installation ID                                       |
+| `ENABLE_SLACK_BOT`               | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
+| `SLACK_BOT_TOKEN`                | Slack bot token (required if enabled)                                                       |
+| `SLACK_SIGNING_SECRET`           | Slack signing secret (required if enabled)                                                  |
+| `ENABLE_LINEAR_BOT`              | `true` to deploy Linear bot, `false` to skip (default: `false`)                             |
+| `LINEAR_CLIENT_ID`               | Linear OAuth application client ID (required if Linear enabled)                             |
+| `LINEAR_CLIENT_SECRET`           | Linear OAuth application client secret (required if Linear enabled)                         |
+| `LINEAR_WEBHOOK_SECRET`          | Linear webhook signing secret (required if Linear enabled)                                  |
+| `ANTHROPIC_API_KEY`              | Anthropic API key                                                                           |
+| `CLASSIFICATION_OPENAI_API_KEY`  | Classifier OpenAI key (required when `classification_model` is an OpenAI id)                |
+| `DEEPSEEK_API_KEY`               | DeepSeek API key (optional, required only for DeepSeek models)                              |
+| `TOKEN_ENCRYPTION_KEY`           | Generated encryption key (OAuth tokens)                                                     |
+| `REPO_SECRETS_ENCRYPTION_KEY`    | Generated encryption key (repo secrets)                                                     |
+| `MODAL_API_SECRET`               | Generated Modal API secret                                                                  |
+| `NEXTAUTH_SECRET`                | Generated browser-auth secret (legacy Actions secret name)                                  |
+| `ALLOWED_USERS`                  | Comma-separated GitHub usernames (or empty for all users)                                   |
+| `ALLOWED_EMAIL_DOMAINS`          | Comma-separated email domains (or empty for all domains)                                    |
+| `ALLOWED_EMAILS`                 | Comma-separated exact email addresses (for individual users on shared domains)              |
+| `ALLOWED_GITHUB_ORGS`            | Comma-separated GitHub orgs whose active members can sign in                                |
+| `ENABLE_DURABLE_OBJECT_BINDINGS` | Optional Terraform CI flag for Durable Object phase 1 (defaults to `true`)                  |
+| `ENABLE_GITHUB_BOT`              | `true` to deploy GitHub bot worker (or empty to skip)                                       |
+| `GH_WEBHOOK_SECRET`              | GitHub webhook secret (required if GitHub bot enabled)                                      |
+| `GH_BOT_USERNAME`                | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
+| `APP_NAME`                       | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
+| `APP_ICON_URL`                   | Optional URL to a custom logo/favicon (default: built-in icon)                              |
+
+`CLASSIFICATION_MODEL` is an optional Actions **variable**, not a secret — add it under Settings →
+Secrets and variables → Actions → _Variables_ to point the Slack/Linear classifiers at a different
+model (for example `gpt-5.4-mini`). Leave it unset to keep the Terraform default. An OpenAI value
+also requires the `CLASSIFICATION_OPENAI_API_KEY` secret; an Anthropic value is served by
+`ANTHROPIC_API_KEY`.
 
 When enabling or upgrading the Linear bot, also enable **Client credentials tokens** on the OAuth
 application in **Linear Settings → API → Applications**. This provider-side setting is not managed

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -563,6 +563,14 @@ linear_webhook_secret  = ""          # From Step 4b (required if enabled)
 # API Keys
 anthropic_api_key = "sk-ant-..."
 
+# Slack/Linear classifier provider, chosen by classification_model.
+# An OpenAI model requires classification_openai_api_key. An Anthropic model
+# needs no new value: classification_anthropic_api_key is an optional override
+# and falls back to anthropic_api_key above.
+# classification_model = "claude-haiku-4-5"   # e.g. "gpt-5.4-mini" to classify on OpenAI
+classification_anthropic_api_key = ""   # Optional override; blank uses anthropic_api_key
+classification_openai_api_key    = ""   # Required when classification_model is an OpenAI id
+
 # Security Secrets (from Step 5)
 token_encryption_key          = "your-generated-value"
 repo_secrets_encryption_key   = "your-generated-value"
@@ -922,65 +930,67 @@ Enable automatic deployments when you push to main by adding GitHub Secrets.
 
 Go to your fork's Settings → Secrets and variables → Actions, and add:
 
-| Secret Name                      | Value                                                                                       |
-| -------------------------------- | ------------------------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`           | Your Cloudflare API token                                                                   |
-| `CLOUDFLARE_ACCOUNT_ID`          | Your Cloudflare account ID                                                                  |
-| `CLOUDFLARE_WORKER_SUBDOMAIN`    | Your workers.dev subdomain                                                                  |
-| `DEPLOYMENT_NAME`                | Your deployment name                                                                        |
-| `R2_ACCESS_KEY_ID`               | R2 access key ID                                                                            |
-| `R2_SECRET_ACCESS_KEY`           | R2 secret access key                                                                        |
-| `WEB_PLATFORM`                   | `vercel` or `cloudflare`                                                                    |
-| `VERCEL_API_TOKEN`               | Vercel API token _(only if `web_platform = "vercel"`)_                                      |
-| `VERCEL_TEAM_ID`                 | Vercel team/account ID _(only if `web_platform = "vercel"`)_                                |
-| `VERCEL_PROJECT_ID`              | Vercel project ID _(only if `web_platform = "vercel"`)_                                     |
-| `MODAL_TOKEN_ID`                 | Modal token ID                                                                              |
-| `MODAL_TOKEN_SECRET`             | Modal token secret                                                                          |
-| `MODAL_WORKSPACE`                | Modal workspace name                                                                        |
-| `MODAL_ENVIRONMENT`              | Modal environment name (defaults to `main`)                                                 |
-| `MODAL_ENVIRONMENT_WEB_SUFFIX`   | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
-| `SANDBOX_PROVIDER`               | `modal`, `daytona`, or `vercel`                                                             |
-| `DAYTONA_API_URL`                | Daytona API URL _(only if `sandbox_provider = "daytona"`)_                                  |
-| `DAYTONA_API_KEY`                | Daytona API key _(only if `sandbox_provider = "daytona"`)_                                  |
-| `DAYTONA_BASE_SNAPSHOT`          | Daytona base snapshot name _(only if `sandbox_provider = "daytona"`)_                       |
-| `DAYTONA_TARGET`                 | Optional Daytona target name                                                                |
-| `VERCEL_SANDBOX_TOKEN`           | Vercel API token _(only if `sandbox_provider = "vercel"`)_                                  |
-| `VERCEL_SANDBOX_PROJECT_ID`      | Vercel project ID for sandbox sessions _(only if `sandbox_provider = "vercel"`)_            |
-| `VERCEL_SANDBOX_TEAM_ID`         | Optional Vercel team/account ID for sandbox sessions                                        |
-| `VERCEL_BASE_SNAPSHOT_ID`        | Optional manual Vercel base-runtime snapshot; skips Terraform-managed snapshot builds       |
-| `VERCEL_SANDBOX_RUNTIME`         | Optional Vercel Sandbox runtime (defaults to `node24`)                                      |
-| `VERCEL_SNAPSHOT_EXPIRATION_MS`  | Optional Vercel runtime snapshot expiration in milliseconds (`0` means no expiration)       |
-| `VERCEL_SANDBOX_API_BASE_URL`    | Optional advanced Vercel Sandbox API base URL override                                      |
-| `GH_OAUTH_CLIENT_ID`             | Optional GitHub sign-in client ID; set with `GH_OAUTH_CLIENT_SECRET`                        |
-| `GH_OAUTH_CLIENT_SECRET`         | Optional GitHub sign-in client secret; set with `GH_OAUTH_CLIENT_ID`                        |
-| `GOOGLE_CLIENT_ID`               | Optional Google sign-in client ID; set with `GOOGLE_CLIENT_SECRET`                          |
-| `GOOGLE_CLIENT_SECRET`           | Optional Google sign-in client secret; set with `GOOGLE_CLIENT_ID`                          |
-| `GH_APP_ID`                      | Required GitHub App repository-access ID                                                    |
-| `GH_APP_PRIVATE_KEY`             | Required GitHub App repository-access private key (PKCS#8 format)                           |
-| `GH_APP_INSTALLATION_ID`         | Required GitHub App repository-access installation ID                                       |
-| `ENABLE_SLACK_BOT`               | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
-| `SLACK_BOT_TOKEN`                | Slack bot token (required if enabled)                                                       |
-| `SLACK_SIGNING_SECRET`           | Slack signing secret (required if enabled)                                                  |
-| `ENABLE_LINEAR_BOT`              | `true` to deploy Linear bot, `false` to skip (default: `false`)                             |
-| `LINEAR_CLIENT_ID`               | Linear OAuth application client ID (required if Linear enabled)                             |
-| `LINEAR_CLIENT_SECRET`           | Linear OAuth application client secret (required if Linear enabled)                         |
-| `LINEAR_WEBHOOK_SECRET`          | Linear webhook signing secret (required if Linear enabled)                                  |
-| `ANTHROPIC_API_KEY`              | Anthropic API key                                                                           |
-| `DEEPSEEK_API_KEY`               | DeepSeek API key (optional, required only for DeepSeek models)                              |
-| `TOKEN_ENCRYPTION_KEY`           | Generated encryption key (OAuth tokens)                                                     |
-| `REPO_SECRETS_ENCRYPTION_KEY`    | Generated encryption key (repo secrets)                                                     |
-| `MODAL_API_SECRET`               | Generated Modal API secret                                                                  |
-| `NEXTAUTH_SECRET`                | Generated browser-auth secret (legacy Actions secret name)                                  |
-| `ALLOWED_USERS`                  | Comma-separated GitHub usernames (or empty for all users)                                   |
-| `ALLOWED_EMAIL_DOMAINS`          | Comma-separated email domains (or empty for all domains)                                    |
-| `ALLOWED_EMAILS`                 | Comma-separated exact email addresses (for individual users on shared domains)              |
-| `ALLOWED_GITHUB_ORGS`            | Comma-separated GitHub orgs whose active members can sign in                                |
-| `ENABLE_DURABLE_OBJECT_BINDINGS` | Optional Terraform CI flag for Durable Object phase 1 (defaults to `true`)                  |
-| `ENABLE_GITHUB_BOT`              | `true` to deploy GitHub bot worker (or empty to skip)                                       |
-| `GH_WEBHOOK_SECRET`              | GitHub webhook secret (required if GitHub bot enabled)                                      |
-| `GH_BOT_USERNAME`                | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
-| `APP_NAME`                       | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
-| `APP_ICON_URL`                   | Optional URL to a custom logo/favicon (default: built-in icon)                              |
+| Secret Name                        | Value                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`             | Your Cloudflare API token                                                                   |
+| `CLOUDFLARE_ACCOUNT_ID`            | Your Cloudflare account ID                                                                  |
+| `CLOUDFLARE_WORKER_SUBDOMAIN`      | Your workers.dev subdomain                                                                  |
+| `DEPLOYMENT_NAME`                  | Your deployment name                                                                        |
+| `R2_ACCESS_KEY_ID`                 | R2 access key ID                                                                            |
+| `R2_SECRET_ACCESS_KEY`             | R2 secret access key                                                                        |
+| `WEB_PLATFORM`                     | `vercel` or `cloudflare`                                                                    |
+| `VERCEL_API_TOKEN`                 | Vercel API token _(only if `web_platform = "vercel"`)_                                      |
+| `VERCEL_TEAM_ID`                   | Vercel team/account ID _(only if `web_platform = "vercel"`)_                                |
+| `VERCEL_PROJECT_ID`                | Vercel project ID _(only if `web_platform = "vercel"`)_                                     |
+| `MODAL_TOKEN_ID`                   | Modal token ID                                                                              |
+| `MODAL_TOKEN_SECRET`               | Modal token secret                                                                          |
+| `MODAL_WORKSPACE`                  | Modal workspace name                                                                        |
+| `MODAL_ENVIRONMENT`                | Modal environment name (defaults to `main`)                                                 |
+| `MODAL_ENVIRONMENT_WEB_SUFFIX`     | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
+| `SANDBOX_PROVIDER`                 | `modal`, `daytona`, or `vercel`                                                             |
+| `DAYTONA_API_URL`                  | Daytona API URL _(only if `sandbox_provider = "daytona"`)_                                  |
+| `DAYTONA_API_KEY`                  | Daytona API key _(only if `sandbox_provider = "daytona"`)_                                  |
+| `DAYTONA_BASE_SNAPSHOT`            | Daytona base snapshot name _(only if `sandbox_provider = "daytona"`)_                       |
+| `DAYTONA_TARGET`                   | Optional Daytona target name                                                                |
+| `VERCEL_SANDBOX_TOKEN`             | Vercel API token _(only if `sandbox_provider = "vercel"`)_                                  |
+| `VERCEL_SANDBOX_PROJECT_ID`        | Vercel project ID for sandbox sessions _(only if `sandbox_provider = "vercel"`)_            |
+| `VERCEL_SANDBOX_TEAM_ID`           | Optional Vercel team/account ID for sandbox sessions                                        |
+| `VERCEL_BASE_SNAPSHOT_ID`          | Optional manual Vercel base-runtime snapshot; skips Terraform-managed snapshot builds       |
+| `VERCEL_SANDBOX_RUNTIME`           | Optional Vercel Sandbox runtime (defaults to `node24`)                                      |
+| `VERCEL_SNAPSHOT_EXPIRATION_MS`    | Optional Vercel runtime snapshot expiration in milliseconds (`0` means no expiration)       |
+| `VERCEL_SANDBOX_API_BASE_URL`      | Optional advanced Vercel Sandbox API base URL override                                      |
+| `GH_OAUTH_CLIENT_ID`               | Optional GitHub sign-in client ID; set with `GH_OAUTH_CLIENT_SECRET`                        |
+| `GH_OAUTH_CLIENT_SECRET`           | Optional GitHub sign-in client secret; set with `GH_OAUTH_CLIENT_ID`                        |
+| `GOOGLE_CLIENT_ID`                 | Optional Google sign-in client ID; set with `GOOGLE_CLIENT_SECRET`                          |
+| `GOOGLE_CLIENT_SECRET`             | Optional Google sign-in client secret; set with `GOOGLE_CLIENT_ID`                          |
+| `GH_APP_ID`                        | Required GitHub App repository-access ID                                                    |
+| `GH_APP_PRIVATE_KEY`               | Required GitHub App repository-access private key (PKCS#8 format)                           |
+| `GH_APP_INSTALLATION_ID`           | Required GitHub App repository-access installation ID                                       |
+| `ENABLE_SLACK_BOT`                 | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
+| `SLACK_BOT_TOKEN`                  | Slack bot token (required if enabled)                                                       |
+| `SLACK_SIGNING_SECRET`             | Slack signing secret (required if enabled)                                                  |
+| `ENABLE_LINEAR_BOT`                | `true` to deploy Linear bot, `false` to skip (default: `false`)                             |
+| `LINEAR_CLIENT_ID`                 | Linear OAuth application client ID (required if Linear enabled)                             |
+| `LINEAR_CLIENT_SECRET`             | Linear OAuth application client secret (required if Linear enabled)                         |
+| `LINEAR_WEBHOOK_SECRET`            | Linear webhook signing secret (required if Linear enabled)                                  |
+| `ANTHROPIC_API_KEY`                | Anthropic API key                                                                           |
+| `CLASSIFICATION_OPENAI_API_KEY`    | Classifier OpenAI key (required when classification_model is an OpenAI id)                  |
+| `CLASSIFICATION_ANTHROPIC_API_KEY` | Classifier Anthropic key (optional; falls back to `ANTHROPIC_API_KEY`)                      |
+| `DEEPSEEK_API_KEY`                 | DeepSeek API key (optional, required only for DeepSeek models)                              |
+| `TOKEN_ENCRYPTION_KEY`             | Generated encryption key (OAuth tokens)                                                     |
+| `REPO_SECRETS_ENCRYPTION_KEY`      | Generated encryption key (repo secrets)                                                     |
+| `MODAL_API_SECRET`                 | Generated Modal API secret                                                                  |
+| `NEXTAUTH_SECRET`                  | Generated browser-auth secret (legacy Actions secret name)                                  |
+| `ALLOWED_USERS`                    | Comma-separated GitHub usernames (or empty for all users)                                   |
+| `ALLOWED_EMAIL_DOMAINS`            | Comma-separated email domains (or empty for all domains)                                    |
+| `ALLOWED_EMAILS`                   | Comma-separated exact email addresses (for individual users on shared domains)              |
+| `ALLOWED_GITHUB_ORGS`              | Comma-separated GitHub orgs whose active members can sign in                                |
+| `ENABLE_DURABLE_OBJECT_BINDINGS`   | Optional Terraform CI flag for Durable Object phase 1 (defaults to `true`)                  |
+| `ENABLE_GITHUB_BOT`                | `true` to deploy GitHub bot worker (or empty to skip)                                       |
+| `GH_WEBHOOK_SECRET`                | GitHub webhook secret (required if GitHub bot enabled)                                      |
+| `GH_BOT_USERNAME`                  | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
+| `APP_NAME`                         | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
+| `APP_ICON_URL`                     | Optional URL to a custom logo/favicon (default: built-in icon)                              |
 
 When enabling or upgrading the Linear bot, also enable **Client credentials tokens** on the OAuth
 application in **Linear Settings → API → Applications**. This provider-side setting is not managed

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -68,7 +68,8 @@ linear_webhook_secret = "your-webhook-signing-secret"
 
 The worker also requires these secrets (set via `wrangler secret put` or Terraform):
 
-- **`ANTHROPIC_API_KEY`** — used by the LLM classifier for repo resolution fallback
+- Exactly one classifier credential selected by `CLASSIFICATION_MODEL`: **`ANTHROPIC_API_KEY`** for
+  an Anthropic model (the default), or **`OPENAI_API_KEY`** for an OpenAI model
 - **`SERVICE_AUTH_SECRET`** — per-service sig1 signing secret; also verifies CP callbacks
 
 Then `terraform apply`.
@@ -175,8 +176,9 @@ When an issue is triggered, the agent resolves the session target using a 5-step
    in the trigger comment or clarification reply
 4. **Linear's `issueRepositorySuggestions` API** — Linear's built-in repo suggestion (>= 70%
    confidence)
-5. **LLM classifier** — uses Claude Haiku to classify based on issue content, labels, and available
-   repo descriptions. Asks the user to clarify if confidence is low.
+5. **LLM classifier** — uses the model selected by `CLASSIFICATION_MODEL` (Anthropic by default) to
+   classify based on issue content, labels, and available repo descriptions. Asks the user to
+   clarify if confidence is low.
 
 Environment sessions clone the environment's full repository set; integration settings (model,
 enabled-repos allowlist) resolve from the environment's primary repository until environment-level

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -1,40 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { anthropicMessagesResponseSchema, classifyRepo, classifyToolInputSchema } from "./index";
 import {
-  anthropicMessagesResponseSchema,
-  CLASSIFIER_REQUEST_TIMEOUT_MS,
-  classifyRepo,
-  classifyToolInputSchema,
-} from "./index";
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+} from "@open-inspect/shared/classification";
+import { clearReposLocalCache } from "./repos";
 import { createFakeKV, makeLinearBotEnv } from "../test-helpers";
-
-const { getAvailableRepos, buildRepoDescriptions } = vi.hoisted(() => ({
-  getAvailableRepos: vi.fn(),
-  buildRepoDescriptions: vi.fn(),
-}));
-
-vi.mock("./repos", () => ({ getAvailableRepos, buildRepoDescriptions }));
-
-const repos: RepoConfig[] = ["api", "web"].map((name) => ({
-  id: `acme/${name}`,
-  owner: "acme",
-  name,
-  fullName: `acme/${name}`,
-  displayName: name,
-  description: `${name} repository`,
-  defaultBranch: "main",
-  private: true,
-}));
-
-beforeEach(() => {
-  getAvailableRepos.mockResolvedValue(repos);
-  buildRepoDescriptions.mockResolvedValue("- acme/api\n- acme/web");
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-});
+import type { Env } from "../types";
 
 describe("anthropicMessagesResponseSchema", () => {
   it("parses a response with the consumed tool block fields", () => {
@@ -99,10 +71,168 @@ describe("classifyToolInputSchema", () => {
   });
 });
 
-describe("classifyRepo", () => {
+describe("classifyRepo provider dispatch", () => {
+  const traceId = "trace-classify";
+
+  function twoRepoControlPlane(): Fetcher {
+    return {
+      fetch: vi.fn(async () =>
+        Response.json({
+          repos: [
+            {
+              id: 1,
+              owner: "acme",
+              name: "alpha",
+              fullName: "acme/alpha",
+              description: "Alpha service",
+              private: false,
+              defaultBranch: "main",
+              archived: false,
+              language: "TypeScript",
+              metadata: {},
+            },
+            {
+              id: 2,
+              owner: "acme",
+              name: "beta",
+              fullName: "acme/beta",
+              description: "Beta service",
+              private: false,
+              defaultBranch: "main",
+              archived: false,
+              language: "TypeScript",
+              metadata: {},
+            },
+          ],
+          cached: false,
+          cachedAt: "2026-08-02T00:00:00.000Z",
+        })
+      ),
+    } as unknown as Fetcher;
+  }
+
+  function classify(env: Env) {
+    return classifyRepo(
+      env,
+      "Fix the login bug",
+      "Users cannot log in",
+      ["bug"],
+      "Core",
+      "Platform",
+      "PLAT",
+      undefined,
+      traceId
+    );
+  }
+
+  function anthropicToolResponse(repoId: string) {
+    return vi.fn<typeof fetch>(async () =>
+      Response.json({
+        content: [
+          {
+            type: "tool_use",
+            name: "classify_repository",
+            input: { repoId, confidence: "high", reasoning: "Matches", alternatives: [] },
+          },
+        ],
+      })
+    );
+  }
+
+  beforeEach(() => {
+    clearReposLocalCache();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends a spec-compliant OpenAI request when CLASSIFICATION_MODEL selects an OpenAI model", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "openai/gpt-5.4-mini",
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                repoId: "acme/alpha",
+                confidence: "high",
+                reasoning: "Matches",
+                alternatives: [],
+              }),
+            },
+          },
+        ],
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.repo?.id).toBe("acme/alpha");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(init!.headers).toMatchObject({ Authorization: "Bearer openai-key" });
+
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe("gpt-5.4-mini");
+    // gpt-5-family models reject an explicit temperature with HTTP 400.
+    expect(body).not.toHaveProperty("temperature");
+    expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
+    expect(body).not.toHaveProperty("max_tokens");
+    expect(body.response_format.type).toBe("json_schema");
+    expect(body.response_format.json_schema.strict).toBe(true);
+    const schema = body.response_format.json_schema.schema;
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.required).toEqual(["repoId", "confidence", "reasoning", "alternatives"]);
+    expect(schema.properties.repoId.type).toEqual(["string", "null"]);
+  });
+
+  it("degrades to a clarification result with alternatives on a non-2xx OpenAI response", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "gpt-5.4-mini",
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("server exploded", { status: 500 }))
+    );
+
+    const result = await classify(env);
+
+    expect(result.needsClarification).toBe(true);
+    expect(result.repo).toBeNull();
+    expect(result.alternatives?.length).toBeGreaterThan(0);
+  });
+
+  it("bounds every classification request with the shared timeout signal", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() });
+
+    const fakeSignal = {} as AbortSignal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(fakeSignal);
+    const fetchMock = anthropicToolResponse("acme/alpha");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await classify(env);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init!.signal).toBe(fakeSignal);
+
+    timeoutSpy.mockRestore();
+  });
+
   it("falls back to clarification when the classifier request times out", async () => {
     const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
     vi.stubGlobal(
       "fetch",
       vi.fn(async (_input, init) => {
@@ -112,25 +242,80 @@ describe("classifyRepo", () => {
     );
     const { kv } = createFakeKV();
 
-    const result = await classifyRepo(
-      makeLinearBotEnv(kv),
-      "Update service",
-      null,
-      [],
-      null,
-      "Engineering",
-      "ENG",
-      null
-    );
+    const result = await classify(makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() }));
 
-    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFIER_REQUEST_TIMEOUT_MS);
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       repo: null,
       confidence: "low",
-      reasoning:
-        "Could not classify repository automatically. Please reply with the repository name (e.g., `owner/repo`).",
-      alternatives: repos,
       needsClarification: true,
     });
+    expect(result.alternatives).toHaveLength(2);
   });
+
+  it("fires the Anthropic default path when CLASSIFICATION_MODEL is unset", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() });
+    expect(env.CLASSIFICATION_MODEL).toBeUndefined();
+
+    const fetchMock = anthropicToolResponse("acme/beta");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.repo?.id).toBe("acme/beta");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+    expect(init!.headers).toMatchObject({ "x-api-key": "anthropic-key" });
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe("claude-haiku-4-5");
+  });
+
+  it("degrades rather than throwing on an unrecognised classification model prefix", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "mistral/mistral-large",
+    });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.needsClarification).toBe(true);
+    expect(result.repo).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      binding: "OPENAI_API_KEY",
+      model: "gpt-5.4-mini",
+      overrides: { OPENAI_API_KEY: undefined },
+    },
+    {
+      binding: "ANTHROPIC_API_KEY",
+      model: "claude-haiku-4-5",
+      overrides: { ANTHROPIC_API_KEY: undefined },
+    },
+  ])(
+    "degrades without calling out when $model is selected but $binding is unbound",
+    async ({ model, overrides }) => {
+      const { kv } = createFakeKV();
+      const env = makeLinearBotEnv(kv, {
+        CONTROL_PLANE: twoRepoControlPlane(),
+        CLASSIFICATION_MODEL: model,
+        ...overrides,
+      });
+
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await classify(env);
+
+      expect(result.needsClarification).toBe(true);
+      expect(result.repo).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -1,11 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  anthropicMessagesResponseSchema,
-  classifyRepo,
-  classifyToolInputSchema,
-  CLASSIFICATION_REQUEST_TIMEOUT_MS,
-  openaiChatCompletionResponseSchema,
-} from "./index";
+import { anthropicMessagesResponseSchema, classifyRepo, classifyToolInputSchema } from "./index";
+import { CLASSIFICATION_REQUEST_TIMEOUT_MS } from "@open-inspect/shared/classification";
 import { clearReposLocalCache } from "./repos";
 import { createFakeKV, makeLinearBotEnv } from "../test-helpers";
 import type { Env } from "../types";
@@ -68,22 +63,6 @@ describe("classifyToolInputSchema", () => {
       confidence: "certain",
       reasoning: "Invalid confidence value.",
     });
-
-    expect(parsed.success).toBe(false);
-  });
-});
-
-describe("openaiChatCompletionResponseSchema", () => {
-  it("parses a response with the consumed message fields", () => {
-    const parsed = openaiChatCompletionResponseSchema.safeParse({
-      choices: [{ message: { content: "{}", refusal: null } }],
-    });
-
-    expect(parsed.success).toBe(true);
-  });
-
-  it("rejects a response without choices", () => {
-    const parsed = openaiChatCompletionResponseSchema.safeParse({});
 
     expect(parsed.success).toBe(false);
   });
@@ -198,7 +177,8 @@ describe("classifyRepo provider dispatch", () => {
 
     const body = JSON.parse(init!.body as string);
     expect(body.model).toBe("gpt-5.4-mini");
-    expect(body.temperature).toBe(0);
+    // gpt-5-family models reject an explicit temperature with HTTP 400.
+    expect(body).not.toHaveProperty("temperature");
     expect(body.max_completion_tokens).toBe(2000);
     expect(body).not.toHaveProperty("max_tokens");
     expect(body.response_format.type).toBe("json_schema");
@@ -281,4 +261,36 @@ describe("classifyRepo provider dispatch", () => {
     expect(result.repo).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      binding: "OPENAI_API_KEY",
+      model: "gpt-5.4-mini",
+      overrides: { OPENAI_API_KEY: undefined },
+    },
+    {
+      binding: "ANTHROPIC_API_KEY",
+      model: "claude-haiku-4-5",
+      overrides: { ANTHROPIC_API_KEY: undefined },
+    },
+  ])(
+    "degrades without calling out when $model is selected but $binding is unbound",
+    async ({ model, overrides }) => {
+      const { kv } = createFakeKV();
+      const env = makeLinearBotEnv(kv, {
+        CONTROL_PLANE: twoRepoControlPlane(),
+        CLASSIFICATION_MODEL: model,
+        ...overrides,
+      });
+
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await classify(env);
+
+      expect(result.needsClarification).toBe(true);
+      expect(result.repo).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { anthropicMessagesResponseSchema, classifyRepo, classifyToolInputSchema } from "./index";
-import { CLASSIFICATION_REQUEST_TIMEOUT_MS } from "@open-inspect/shared/classification";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+} from "@open-inspect/shared/classification";
 import { clearReposLocalCache } from "./repos";
 import { createFakeKV, makeLinearBotEnv } from "../test-helpers";
 import type { Env } from "../types";
@@ -179,7 +182,7 @@ describe("classifyRepo provider dispatch", () => {
     expect(body.model).toBe("gpt-5.4-mini");
     // gpt-5-family models reject an explicit temperature with HTTP 400.
     expect(body).not.toHaveProperty("temperature");
-    expect(body.max_completion_tokens).toBe(2000);
+    expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
     expect(body).not.toHaveProperty("max_tokens");
     expect(body.response_format.type).toBe("json_schema");
     expect(body.response_format.json_schema.strict).toBe(true);

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -1,40 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   anthropicMessagesResponseSchema,
-  CLASSIFIER_REQUEST_TIMEOUT_MS,
   classifyRepo,
   classifyToolInputSchema,
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  openaiChatCompletionResponseSchema,
 } from "./index";
+import { clearReposLocalCache } from "./repos";
 import { createFakeKV, makeLinearBotEnv } from "../test-helpers";
-
-const { getAvailableRepos, buildRepoDescriptions } = vi.hoisted(() => ({
-  getAvailableRepos: vi.fn(),
-  buildRepoDescriptions: vi.fn(),
-}));
-
-vi.mock("./repos", () => ({ getAvailableRepos, buildRepoDescriptions }));
-
-const repos: RepoConfig[] = ["api", "web"].map((name) => ({
-  id: `acme/${name}`,
-  owner: "acme",
-  name,
-  fullName: `acme/${name}`,
-  displayName: name,
-  description: `${name} repository`,
-  defaultBranch: "main",
-  private: true,
-}));
-
-beforeEach(() => {
-  getAvailableRepos.mockResolvedValue(repos);
-  buildRepoDescriptions.mockResolvedValue("- acme/api\n- acme/web");
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-});
+import type { Env } from "../types";
 
 describe("anthropicMessagesResponseSchema", () => {
   it("parses a response with the consumed tool block fields", () => {
@@ -99,38 +73,212 @@ describe("classifyToolInputSchema", () => {
   });
 });
 
-describe("classifyRepo", () => {
-  it("falls back to clarification when the classifier request times out", async () => {
-    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input, init) => {
-        expect(init?.signal).toBe(timeoutSignal);
-        throw timeoutSignal.reason;
+describe("openaiChatCompletionResponseSchema", () => {
+  it("parses a response with the consumed message fields", () => {
+    const parsed = openaiChatCompletionResponseSchema.safeParse({
+      choices: [{ message: { content: "{}", refusal: null } }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a response without choices", () => {
+    const parsed = openaiChatCompletionResponseSchema.safeParse({});
+
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("classifyRepo provider dispatch", () => {
+  const traceId = "trace-classify";
+
+  function twoRepoControlPlane(): Fetcher {
+    return {
+      fetch: vi.fn(async () =>
+        Response.json({
+          repos: [
+            {
+              id: 1,
+              owner: "acme",
+              name: "alpha",
+              fullName: "acme/alpha",
+              description: "Alpha service",
+              private: false,
+              defaultBranch: "main",
+              archived: false,
+              language: "TypeScript",
+              metadata: {},
+            },
+            {
+              id: 2,
+              owner: "acme",
+              name: "beta",
+              fullName: "acme/beta",
+              description: "Beta service",
+              private: false,
+              defaultBranch: "main",
+              archived: false,
+              language: "TypeScript",
+              metadata: {},
+            },
+          ],
+          cached: false,
+          cachedAt: "2026-08-02T00:00:00.000Z",
+        })
+      ),
+    } as unknown as Fetcher;
+  }
+
+  function classify(env: Env) {
+    return classifyRepo(
+      env,
+      "Fix the login bug",
+      "Users cannot log in",
+      ["bug"],
+      "Core",
+      "Platform",
+      "PLAT",
+      undefined,
+      traceId
+    );
+  }
+
+  function anthropicToolResponse(repoId: string) {
+    return vi.fn<typeof fetch>(async () =>
+      Response.json({
+        content: [
+          {
+            type: "tool_use",
+            name: "classify_repository",
+            input: { repoId, confidence: "high", reasoning: "Matches", alternatives: [] },
+          },
+        ],
       })
     );
-    const { kv } = createFakeKV();
+  }
 
-    const result = await classifyRepo(
-      makeLinearBotEnv(kv),
-      "Update service",
-      null,
-      [],
-      null,
-      "Engineering",
-      "ENG",
-      null
+  beforeEach(() => {
+    clearReposLocalCache();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends a spec-compliant OpenAI request when CLASSIFICATION_MODEL selects an OpenAI model", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "openai/gpt-5.4-mini",
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                repoId: "acme/alpha",
+                confidence: "high",
+                reasoning: "Matches",
+                alternatives: [],
+              }),
+            },
+          },
+        ],
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.repo?.id).toBe("acme/alpha");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(init!.headers).toMatchObject({ Authorization: "Bearer openai-key" });
+
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe("gpt-5.4-mini");
+    expect(body.temperature).toBe(0);
+    expect(body.max_completion_tokens).toBe(2000);
+    expect(body).not.toHaveProperty("max_tokens");
+    expect(body.response_format.type).toBe("json_schema");
+    expect(body.response_format.json_schema.strict).toBe(true);
+    const schema = body.response_format.json_schema.schema;
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.required).toEqual(["repoId", "confidence", "reasoning", "alternatives"]);
+    expect(schema.properties.repoId.type).toEqual(["string", "null"]);
+  });
+
+  it("degrades to a clarification result with alternatives on a non-2xx OpenAI response", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "gpt-5.4-mini",
+      OPENAI_API_KEY: "openai-key",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("server exploded", { status: 500 }))
     );
 
-    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFIER_REQUEST_TIMEOUT_MS);
-    expect(result).toEqual({
-      repo: null,
-      confidence: "low",
-      reasoning:
-        "Could not classify repository automatically. Please reply with the repository name (e.g., `owner/repo`).",
-      alternatives: repos,
-      needsClarification: true,
+    const result = await classify(env);
+
+    expect(result.needsClarification).toBe(true);
+    expect(result.repo).toBeNull();
+    expect(result.alternatives?.length).toBeGreaterThan(0);
+  });
+
+  it("bounds every classification request with the shared timeout signal", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() });
+
+    const fakeSignal = {} as AbortSignal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(fakeSignal);
+    const fetchMock = anthropicToolResponse("acme/alpha");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await classify(env);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init!.signal).toBe(fakeSignal);
+
+    timeoutSpy.mockRestore();
+  });
+
+  it("fires the Anthropic default path when CLASSIFICATION_MODEL is unset", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() });
+    expect(env.CLASSIFICATION_MODEL).toBeUndefined();
+
+    const fetchMock = anthropicToolResponse("acme/beta");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.repo?.id).toBe("acme/beta");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+    expect(init!.headers).toMatchObject({ "x-api-key": "anthropic-key" });
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe("claude-haiku-4-5");
+  });
+
+  it("degrades rather than throwing on an unrecognised classification model prefix", async () => {
+    const { kv } = createFakeKV();
+    const env = makeLinearBotEnv(kv, {
+      CONTROL_PLANE: twoRepoControlPlane(),
+      CLASSIFICATION_MODEL: "mistral/mistral-large",
     });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await classify(env);
+
+    expect(result.needsClarification).toBe(true);
+    expect(result.repo).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -230,6 +230,28 @@ describe("classifyRepo provider dispatch", () => {
     timeoutSpy.mockRestore();
   });
 
+  it("falls back to clarification when the classifier request times out", async () => {
+    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        expect(init?.signal).toBe(timeoutSignal);
+        throw timeoutSignal.reason;
+      })
+    );
+    const { kv } = createFakeKV();
+
+    const result = await classify(makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() }));
+
+    expect(result).toMatchObject({
+      repo: null,
+      confidence: "low",
+      needsClarification: true,
+    });
+    expect(result.alternatives).toHaveLength(2);
+  });
+
   it("fires the Anthropic default path when CLASSIFICATION_MODEL is unset", async () => {
     const { kv } = createFakeKV();
     const env = makeLinearBotEnv(kv, { CONTROL_PLANE: twoRepoControlPlane() });

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -9,13 +9,19 @@ import type {
 } from "@open-inspect/shared/types/repository-catalog";
 import type { Env } from "../types";
 import { z } from "zod";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  callOpenAIStructured,
+  requireClassificationProviderKey,
+  resolveClassificationProvider,
+} from "@open-inspect/shared/classification";
 import { getAvailableRepos, buildRepoDescriptions } from "./repos";
 import { createLogger } from "../logger";
 
 const log = createLogger("classifier");
 
 const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
-export const CLASSIFIER_REQUEST_TIMEOUT_MS = 10_000;
 
 export const classifyToolInputSchema = z.object({
   repoId: z.string().nullable(),
@@ -35,6 +41,45 @@ export const anthropicMessagesResponseSchema = z.object({
     })
   ),
 });
+
+/**
+ * JSON schema for the classification result, shared by the Anthropic tool
+ * definition and the OpenAI strict structured-output schema.
+ *
+ * Anthropic's tool `input_schema` omits `additionalProperties`, so it stays a
+ * base schema here and the OpenAI side spreads the flag on: `strict: true`
+ * requires it, and keeping it off the base leaves the Anthropic request bytes
+ * unchanged.
+ */
+const classifyRepoJsonSchema = {
+  type: "object",
+  properties: {
+    repoId: {
+      type: ["string", "null"],
+      description: "Repository ID (owner/name) if confident, otherwise null.",
+    },
+    confidence: {
+      type: "string",
+      enum: ["high", "medium", "low"],
+    },
+    reasoning: {
+      type: "string",
+      description: "Brief explanation.",
+    },
+    alternatives: {
+      type: "array",
+      items: { type: "string" },
+      description: "Alternative repo IDs when not confident.",
+    },
+  },
+  required: ["repoId", "confidence", "reasoning", "alternatives"],
+} as const;
+
+/** OpenAI's strict structured-output mode requires `additionalProperties: false`. */
+const classifyRepoStrictJsonSchema = {
+  ...classifyRepoJsonSchema,
+  additionalProperties: false,
+} as const;
 
 /**
  * Build classification prompt from Linear issue context.
@@ -86,13 +131,17 @@ Consider:
 5. Project name associations
 6. Label associations
 
-Return your decision by calling the ${CLASSIFY_REPO_TOOL_NAME} tool.`;
+Return your decision with the fields repoId, confidence, reasoning, and alternatives.`;
 }
 
 /**
  * Call Anthropic API directly (no SDK — Workers can't use CJS imports).
  */
-async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyToolInput> {
+async function callAnthropic(
+  apiKey: string,
+  prompt: string,
+  model: string
+): Promise<ClassifyToolInput> {
   const response = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
@@ -101,42 +150,20 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
-      model: "claude-haiku-4-5",
+      model,
       max_tokens: 500,
       temperature: 0,
       tools: [
         {
           name: CLASSIFY_REPO_TOOL_NAME,
           description: "Classify which repository an issue belongs to.",
-          input_schema: {
-            type: "object" as const,
-            properties: {
-              repoId: {
-                type: ["string", "null"],
-                description: "Repository ID (owner/name) if confident, otherwise null.",
-              },
-              confidence: {
-                type: "string",
-                enum: ["high", "medium", "low"],
-              },
-              reasoning: {
-                type: "string",
-                description: "Brief explanation.",
-              },
-              alternatives: {
-                type: "array",
-                items: { type: "string" },
-                description: "Alternative repo IDs when not confident.",
-              },
-            },
-            required: ["repoId", "confidence", "reasoning", "alternatives"],
-          },
+          input_schema: classifyRepoJsonSchema,
         },
       ],
       tool_choice: { type: "tool", name: CLASSIFY_REPO_TOOL_NAME },
       messages: [{ role: "user", content: prompt }],
     }),
-    signal: AbortSignal.timeout(CLASSIFIER_REQUEST_TIMEOUT_MS),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -155,6 +182,27 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
 
   const input = classifyToolInputSchema.safeParse(toolBlock.input);
   if (!input.success) throw new Error("Malformed Anthropic tool input");
+
+  return input.data;
+}
+
+/**
+ * Call the OpenAI Chat Completions API with strict JSON-schema structured
+ * output, matching the same {@link classifyToolInputSchema} shape the
+ * Anthropic tool call produces.
+ */
+async function callOpenAI(
+  apiKey: string,
+  prompt: string,
+  model: string
+): Promise<ClassifyToolInput> {
+  const parsed = await callOpenAIStructured(apiKey, model, prompt, {
+    name: CLASSIFY_REPO_TOOL_NAME,
+    schema: classifyRepoStrictJsonSchema,
+  });
+
+  const input = classifyToolInputSchema.safeParse(parsed);
+  if (!input.success) throw new Error("Malformed OpenAI tool input");
 
   return input.data;
 }
@@ -206,7 +254,21 @@ export async function classifyRepo(
       traceId
     );
 
-    const result = await callAnthropic(env.ANTHROPIC_API_KEY, prompt);
+    const modelId = env.CLASSIFICATION_MODEL || DEFAULT_CLASSIFICATION_MODEL;
+    const { provider, model } = resolveClassificationProvider(modelId);
+
+    const result: ClassifyToolInput =
+      provider === "anthropic"
+        ? await callAnthropic(
+            requireClassificationProviderKey(env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY", modelId),
+            prompt,
+            model
+          )
+        : await callOpenAI(
+            requireClassificationProviderKey(env.OPENAI_API_KEY, "OPENAI_API_KEY", modelId),
+            prompt,
+            model
+          );
 
     let matchedRepo: RepoConfig | null = null;
     if (result.repoId) {

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -21,7 +21,6 @@ import { createLogger } from "../logger";
 const log = createLogger("classifier");
 
 const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
-export const CLASSIFIER_REQUEST_TIMEOUT_MS = 10_000;
 
 export const classifyToolInputSchema = z.object({
   repoId: z.string().nullable(),
@@ -163,7 +162,7 @@ async function callAnthropic(
       tool_choice: { type: "tool", name: CLASSIFY_REPO_TOOL_NAME },
       messages: [{ role: "user", content: prompt }],
     }),
-    signal: AbortSignal.timeout(CLASSIFIER_REQUEST_TIMEOUT_MS),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -17,6 +17,11 @@ const log = createLogger("classifier");
 const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
 export const CLASSIFIER_REQUEST_TIMEOUT_MS = 10_000;
 
+/** Bound on every classification request (Anthropic or OpenAI). */
+export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
+
+const DEFAULT_CLASSIFICATION_MODEL = "claude-haiku-4-5";
+
 export const classifyToolInputSchema = z.object({
   repoId: z.string().nullable(),
   confidence: z.enum(["high", "medium", "low"]),
@@ -35,6 +40,67 @@ export const anthropicMessagesResponseSchema = z.object({
     })
   ),
 });
+
+export const openaiChatCompletionResponseSchema = z.object({
+  choices: z.array(
+    z.object({
+      message: z.object({
+        content: z.string().nullable(),
+        refusal: z.string().nullable().optional(),
+      }),
+    })
+  ),
+});
+
+type ClassificationProvider = "anthropic" | "openai";
+
+/**
+ * Resolve which provider serves a classification model id, stripping any
+ * `anthropic/`/`openai/` prefix so callers send the bare id to the provider.
+ */
+function resolveClassificationProvider(modelId: string): {
+  provider: ClassificationProvider;
+  model: string;
+} {
+  if (modelId.startsWith("anthropic/")) {
+    return { provider: "anthropic", model: modelId.slice("anthropic/".length) };
+  }
+  if (modelId.startsWith("openai/")) {
+    return { provider: "openai", model: modelId.slice("openai/".length) };
+  }
+  if (modelId.startsWith("claude-")) return { provider: "anthropic", model: modelId };
+  if (modelId.startsWith("gpt-")) return { provider: "openai", model: modelId };
+  throw new Error(`Unrecognized classification model id: ${modelId}`);
+}
+
+/**
+ * JSON schema for the classification result, shared by the Anthropic tool
+ * definition and the OpenAI strict structured-output schema.
+ */
+const classifyRepoJsonSchema = {
+  type: "object",
+  properties: {
+    repoId: {
+      type: ["string", "null"],
+      description: "Repository ID (owner/name) if confident, otherwise null.",
+    },
+    confidence: {
+      type: "string",
+      enum: ["high", "medium", "low"],
+    },
+    reasoning: {
+      type: "string",
+      description: "Brief explanation.",
+    },
+    alternatives: {
+      type: "array",
+      items: { type: "string" },
+      description: "Alternative repo IDs when not confident.",
+    },
+  },
+  required: ["repoId", "confidence", "reasoning", "alternatives"],
+  additionalProperties: false,
+} as const;
 
 /**
  * Build classification prompt from Linear issue context.
@@ -86,13 +152,17 @@ Consider:
 5. Project name associations
 6. Label associations
 
-Return your decision by calling the ${CLASSIFY_REPO_TOOL_NAME} tool.`;
+Return your decision with the fields repoId, confidence, reasoning, and alternatives.`;
 }
 
 /**
  * Call Anthropic API directly (no SDK — Workers can't use CJS imports).
  */
-async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyToolInput> {
+async function callAnthropic(
+  apiKey: string,
+  prompt: string,
+  model: string
+): Promise<ClassifyToolInput> {
   const response = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
@@ -101,7 +171,7 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
-      model: "claude-haiku-4-5",
+      model,
       max_tokens: 500,
       temperature: 0,
       tools: [
@@ -160,6 +230,65 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
 }
 
 /**
+ * Call the OpenAI Chat Completions API with strict JSON-schema structured
+ * output, matching the same {@link classifyToolInputSchema} shape the
+ * Anthropic tool call produces.
+ */
+async function callOpenAI(
+  apiKey: string,
+  prompt: string,
+  model: string
+): Promise<ClassifyToolInput> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_completion_tokens: 2000,
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: CLASSIFY_REPO_TOOL_NAME,
+          strict: true,
+          schema: classifyRepoJsonSchema,
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const errText = (await response.text()).slice(0, 500);
+    throw new Error(`OpenAI API error ${response.status}: ${errText}`);
+  }
+
+  const data = openaiChatCompletionResponseSchema.safeParse(await response.json());
+  if (!data.success) throw new Error("Malformed OpenAI response");
+
+  const message = data.data.choices[0]?.message;
+  if (!message) throw new Error("No choices in OpenAI response");
+  if (message.refusal) throw new Error(`OpenAI refused to classify: ${message.refusal}`);
+  if (!message.content) throw new Error("Empty OpenAI response content");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message.content);
+  } catch {
+    throw new Error("Failed to parse OpenAI response content as JSON");
+  }
+
+  const input = classifyToolInputSchema.safeParse(parsed);
+  if (!input.success) throw new Error("Malformed OpenAI tool input");
+
+  return input.data;
+}
+
+/**
  * Classify which repository a Linear issue belongs to.
  */
 export async function classifyRepo(
@@ -206,7 +335,18 @@ export async function classifyRepo(
       traceId
     );
 
-    const result = await callAnthropic(env.ANTHROPIC_API_KEY, prompt);
+    const modelId = env.CLASSIFICATION_MODEL || DEFAULT_CLASSIFICATION_MODEL;
+    const { provider, model } = resolveClassificationProvider(modelId);
+
+    let result: ClassifyToolInput;
+    if (provider === "anthropic") {
+      result = await callAnthropic(env.ANTHROPIC_API_KEY, prompt, model);
+    } else {
+      if (!env.OPENAI_API_KEY) {
+        throw new Error(`Classification model "${modelId}" requires OPENAI_API_KEY to be set`);
+      }
+      result = await callOpenAI(env.OPENAI_API_KEY, prompt, model);
+    }
 
     let matchedRepo: RepoConfig | null = null;
     if (result.repoId) {

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -9,6 +9,12 @@ import type {
 } from "@open-inspect/shared/types/repository-catalog";
 import type { Env } from "../types";
 import { z } from "zod";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  callOpenAIStructured,
+  resolveClassificationProvider,
+} from "@open-inspect/shared/classification";
 import { getAvailableRepos, buildRepoDescriptions } from "./repos";
 import { createLogger } from "../logger";
 
@@ -16,11 +22,6 @@ const log = createLogger("classifier");
 
 const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
 export const CLASSIFIER_REQUEST_TIMEOUT_MS = 10_000;
-
-/** Bound on every classification request (Anthropic or OpenAI). */
-export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
-
-const DEFAULT_CLASSIFICATION_MODEL = "claude-haiku-4-5";
 
 export const classifyToolInputSchema = z.object({
   repoId: z.string().nullable(),
@@ -41,41 +42,14 @@ export const anthropicMessagesResponseSchema = z.object({
   ),
 });
 
-export const openaiChatCompletionResponseSchema = z.object({
-  choices: z.array(
-    z.object({
-      message: z.object({
-        content: z.string().nullable(),
-        refusal: z.string().nullable().optional(),
-      }),
-    })
-  ),
-});
-
-type ClassificationProvider = "anthropic" | "openai";
-
-/**
- * Resolve which provider serves a classification model id, stripping any
- * `anthropic/`/`openai/` prefix so callers send the bare id to the provider.
- */
-function resolveClassificationProvider(modelId: string): {
-  provider: ClassificationProvider;
-  model: string;
-} {
-  if (modelId.startsWith("anthropic/")) {
-    return { provider: "anthropic", model: modelId.slice("anthropic/".length) };
-  }
-  if (modelId.startsWith("openai/")) {
-    return { provider: "openai", model: modelId.slice("openai/".length) };
-  }
-  if (modelId.startsWith("claude-")) return { provider: "anthropic", model: modelId };
-  if (modelId.startsWith("gpt-")) return { provider: "openai", model: modelId };
-  throw new Error(`Unrecognized classification model id: ${modelId}`);
-}
-
 /**
  * JSON schema for the classification result, shared by the Anthropic tool
  * definition and the OpenAI strict structured-output schema.
+ *
+ * Anthropic's tool `input_schema` omits `additionalProperties`, so it stays a
+ * base schema here and the OpenAI side spreads the flag on: `strict: true`
+ * requires it, and keeping it off the base leaves the Anthropic request bytes
+ * unchanged.
  */
 const classifyRepoJsonSchema = {
   type: "object",
@@ -99,6 +73,11 @@ const classifyRepoJsonSchema = {
     },
   },
   required: ["repoId", "confidence", "reasoning", "alternatives"],
+} as const;
+
+/** OpenAI's strict structured-output mode requires `additionalProperties: false`. */
+const classifyRepoStrictJsonSchema = {
+  ...classifyRepoJsonSchema,
   additionalProperties: false,
 } as const;
 
@@ -178,29 +157,7 @@ async function callAnthropic(
         {
           name: CLASSIFY_REPO_TOOL_NAME,
           description: "Classify which repository an issue belongs to.",
-          input_schema: {
-            type: "object" as const,
-            properties: {
-              repoId: {
-                type: ["string", "null"],
-                description: "Repository ID (owner/name) if confident, otherwise null.",
-              },
-              confidence: {
-                type: "string",
-                enum: ["high", "medium", "low"],
-              },
-              reasoning: {
-                type: "string",
-                description: "Brief explanation.",
-              },
-              alternatives: {
-                type: "array",
-                items: { type: "string" },
-                description: "Alternative repo IDs when not confident.",
-              },
-            },
-            required: ["repoId", "confidence", "reasoning", "alternatives"],
-          },
+          input_schema: classifyRepoJsonSchema,
         },
       ],
       tool_choice: { type: "tool", name: CLASSIFY_REPO_TOOL_NAME },
@@ -239,53 +196,34 @@ async function callOpenAI(
   prompt: string,
   model: string
 ): Promise<ClassifyToolInput> {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model,
-      temperature: 0,
-      max_completion_tokens: 2000,
-      messages: [{ role: "user", content: prompt }],
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: CLASSIFY_REPO_TOOL_NAME,
-          strict: true,
-          schema: classifyRepoJsonSchema,
-        },
-      },
-    }),
-    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  const parsed = await callOpenAIStructured(apiKey, model, prompt, {
+    name: CLASSIFY_REPO_TOOL_NAME,
+    schema: classifyRepoStrictJsonSchema,
   });
-
-  if (!response.ok) {
-    const errText = (await response.text()).slice(0, 500);
-    throw new Error(`OpenAI API error ${response.status}: ${errText}`);
-  }
-
-  const data = openaiChatCompletionResponseSchema.safeParse(await response.json());
-  if (!data.success) throw new Error("Malformed OpenAI response");
-
-  const message = data.data.choices[0]?.message;
-  if (!message) throw new Error("No choices in OpenAI response");
-  if (message.refusal) throw new Error(`OpenAI refused to classify: ${message.refusal}`);
-  if (!message.content) throw new Error("Empty OpenAI response content");
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(message.content);
-  } catch {
-    throw new Error("Failed to parse OpenAI response content as JSON");
-  }
 
   const input = classifyToolInputSchema.safeParse(parsed);
   if (!input.success) throw new Error("Malformed OpenAI tool input");
 
   return input.data;
+}
+
+/**
+ * Read the provider credential the resolved classification model needs.
+ *
+ * Only the selected provider's key is bound to the Worker, so a model id that
+ * points at the unbound provider is a deployment misconfiguration — fail with
+ * that, rather than sending a request with an empty credential and reporting
+ * the provider's 401.
+ */
+function requireProviderKey(
+  key: string | undefined,
+  binding: "ANTHROPIC_API_KEY" | "OPENAI_API_KEY",
+  modelId: string
+): string {
+  if (!key) {
+    throw new Error(`Classification model "${modelId}" requires ${binding} to be set`);
+  }
+  return key;
 }
 
 /**
@@ -338,15 +276,18 @@ export async function classifyRepo(
     const modelId = env.CLASSIFICATION_MODEL || DEFAULT_CLASSIFICATION_MODEL;
     const { provider, model } = resolveClassificationProvider(modelId);
 
-    let result: ClassifyToolInput;
-    if (provider === "anthropic") {
-      result = await callAnthropic(env.ANTHROPIC_API_KEY, prompt, model);
-    } else {
-      if (!env.OPENAI_API_KEY) {
-        throw new Error(`Classification model "${modelId}" requires OPENAI_API_KEY to be set`);
-      }
-      result = await callOpenAI(env.OPENAI_API_KEY, prompt, model);
-    }
+    const result: ClassifyToolInput =
+      provider === "anthropic"
+        ? await callAnthropic(
+            requireProviderKey(env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY", modelId),
+            prompt,
+            model
+          )
+        : await callOpenAI(
+            requireProviderKey(env.OPENAI_API_KEY, "OPENAI_API_KEY", modelId),
+            prompt,
+            model
+          );
 
     let matchedRepo: RepoConfig | null = null;
     if (result.repoId) {

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -32,7 +32,14 @@ export interface Env {
   // Secrets
   LINEAR_WEBHOOK_SECRET: string;
   LINEAR_API_KEY?: string; // kept for backward compat / fallback
-  ANTHROPIC_API_KEY: string;
+  /**
+   * Classifier provider credentials. The deployment binds exactly the one
+   * `CLASSIFICATION_MODEL` selects, so each is optional on its own and the
+   * classifier guards the branch it needs.
+   */
+  ANTHROPIC_API_KEY?: string;
+  CLASSIFICATION_MODEL?: string; // Optional override; defaults to DEFAULT_CLASSIFICATION_MODEL
+  OPENAI_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;
 }

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -33,6 +33,8 @@ export interface Env {
   LINEAR_WEBHOOK_SECRET: string;
   LINEAR_API_KEY?: string; // kept for backward compat / fallback
   ANTHROPIC_API_KEY: string;
+  CLASSIFICATION_MODEL?: string; // Optional override, e.g. "gpt-5.4-mini"; defaults to Anthropic claude-haiku-4-5
+  OPENAI_API_KEY?: string; // Only required when CLASSIFICATION_MODEL selects an OpenAI model
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;
 }

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -32,9 +32,14 @@ export interface Env {
   // Secrets
   LINEAR_WEBHOOK_SECRET: string;
   LINEAR_API_KEY?: string; // kept for backward compat / fallback
-  ANTHROPIC_API_KEY: string;
-  CLASSIFICATION_MODEL?: string; // Optional override, e.g. "gpt-5.4-mini"; defaults to Anthropic claude-haiku-4-5
-  OPENAI_API_KEY?: string; // Only required when CLASSIFICATION_MODEL selects an OpenAI model
+  /**
+   * Classifier provider credentials. The deployment binds exactly the one
+   * `CLASSIFICATION_MODEL` selects, so each is optional on its own and the
+   * classifier guards the branch it needs.
+   */
+  ANTHROPIC_API_KEY?: string;
+  CLASSIFICATION_MODEL?: string; // Optional override; defaults to DEFAULT_CLASSIFICATION_MODEL
+  OPENAI_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,6 +22,10 @@
       "import": "./dist/models.js",
       "types": "./dist/models.d.ts"
     },
+    "./classification": {
+      "import": "./dist/classification.js",
+      "types": "./dist/classification.d.ts"
+    },
     "./logger": {
       "import": "./dist/logger.js",
       "types": "./dist/logger.d.ts"

--- a/packages/shared/src/classification.test.ts
+++ b/packages/shared/src/classification.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+  callOpenAIStructured,
+  openAiChatCompletionEnvelopeSchema,
+  resolveClassificationProvider,
+} from "./classification";
+
+const SCHEMA = {
+  name: "classify",
+  schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+};
+
+describe("resolveClassificationProvider", () => {
+  it.each([
+    ["anthropic/claude-haiku-4-5", "anthropic", "claude-haiku-4-5"],
+    ["claude-haiku-4-5", "anthropic", "claude-haiku-4-5"],
+    ["openai/gpt-5.4-mini", "openai", "gpt-5.4-mini"],
+    ["gpt-5.4-mini", "openai", "gpt-5.4-mini"],
+  ])("routes %s to %s and strips the prefix", (modelId, provider, model) => {
+    expect(resolveClassificationProvider(modelId)).toEqual({ provider, model });
+  });
+
+  it("routes the default model to Anthropic", () => {
+    expect(resolveClassificationProvider(DEFAULT_CLASSIFICATION_MODEL).provider).toBe("anthropic");
+  });
+
+  it("throws on an unrecognised id rather than silently defaulting to Anthropic", () => {
+    expect(() => resolveClassificationProvider("mistral/mistral-large")).toThrow(
+      /Unrecognized classification model/
+    );
+  });
+});
+
+describe("openAiChatCompletionEnvelopeSchema", () => {
+  it("parses a response with the consumed message fields", () => {
+    const parsed = openAiChatCompletionEnvelopeSchema.safeParse({
+      choices: [{ message: { content: "{}", refusal: null } }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a response without choices", () => {
+    expect(openAiChatCompletionEnvelopeSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("callOpenAIStructured", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch(impl: typeof fetch) {
+    const fetchMock = vi.fn(impl);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("sends a strict structured-output request with no temperature", async () => {
+    const fetchMock = stubFetch(async () =>
+      Response.json({ choices: [{ message: { content: '{"ok":true}' } }] })
+    );
+
+    const result = await callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA);
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(init!.headers).toMatchObject({ Authorization: "Bearer sk-test" });
+
+    const body = JSON.parse(init!.body as string);
+    // gpt-5-family models reject an explicit temperature with HTTP 400.
+    expect(body).not.toHaveProperty("temperature");
+    expect(body.model).toBe("gpt-5.4-mini");
+    expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
+    expect(body.response_format).toEqual({
+      type: "json_schema",
+      json_schema: { name: SCHEMA.name, strict: true, schema: SCHEMA.schema },
+    });
+  });
+
+  it("bounds the request with the shared timeout signal", async () => {
+    const fakeSignal = {} as AbortSignal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(fakeSignal);
+    const fetchMock = stubFetch(async () =>
+      Response.json({ choices: [{ message: { content: "{}" } }] })
+    );
+
+    await callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+    expect(fetchMock.mock.calls[0][1]!.signal).toBe(fakeSignal);
+    timeoutSpy.mockRestore();
+  });
+
+  it.each([
+    {
+      label: "an empty choices array",
+      respond: () => Response.json({ choices: [] }),
+      message: /No choices in OpenAI response/,
+    },
+    {
+      label: "a non-2xx response",
+      respond: () => new Response("server exploded", { status: 500 }),
+      message: /OpenAI API error 500: server exploded/,
+    },
+    {
+      label: "a malformed envelope",
+      respond: () => Response.json({ nope: true }),
+      message: /Malformed OpenAI response/,
+    },
+    {
+      label: "a refusal",
+      respond: () => Response.json({ choices: [{ message: { content: null, refusal: "no" } }] }),
+      message: /OpenAI refused to classify: no/,
+    },
+    {
+      label: "empty content",
+      respond: () => Response.json({ choices: [{ message: { content: null } }] }),
+      message: /Empty OpenAI response content/,
+    },
+    {
+      label: "non-JSON content",
+      respond: () => Response.json({ choices: [{ message: { content: "not json" } }] }),
+      message: /Failed to parse OpenAI response content as JSON/,
+    },
+  ])("throws on $label", async ({ respond, message }) => {
+    stubFetch(async () => respond());
+
+    await expect(callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA)).rejects.toThrow(
+      message
+    );
+  });
+
+  it("truncates a long error body", async () => {
+    stubFetch(async () => new Response("x".repeat(2000), { status: 400 }));
+
+    await expect(callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA)).rejects.toThrow(
+      `OpenAI API error 400: ${"x".repeat(500)}`
+    );
+  });
+});

--- a/packages/shared/src/classification.test.ts
+++ b/packages/shared/src/classification.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+  callOpenAIStructured,
+  openAiChatCompletionEnvelopeSchema,
+  resolveClassificationProvider,
+} from "./classification";
+
+const SCHEMA = {
+  name: "classify",
+  schema: { type: "object", properties: {}, required: [], additionalProperties: false },
+};
+
+describe("resolveClassificationProvider", () => {
+  it.each([
+    ["anthropic/claude-haiku-4-5", "anthropic", "claude-haiku-4-5"],
+    ["claude-haiku-4-5", "anthropic", "claude-haiku-4-5"],
+    ["openai/gpt-5.4-mini", "openai", "gpt-5.4-mini"],
+    ["gpt-5.4-mini", "openai", "gpt-5.4-mini"],
+  ])("routes %s to %s and strips the prefix", (modelId, provider, model) => {
+    expect(resolveClassificationProvider(modelId)).toEqual({ provider, model });
+  });
+
+  it("routes the default model to Anthropic", () => {
+    expect(resolveClassificationProvider(DEFAULT_CLASSIFICATION_MODEL).provider).toBe("anthropic");
+  });
+
+  it("throws on an unrecognised id rather than silently defaulting to Anthropic", () => {
+    expect(() => resolveClassificationProvider("mistral/mistral-large")).toThrow(
+      /Unrecognized classification model/
+    );
+  });
+});
+
+describe("openAiChatCompletionEnvelopeSchema", () => {
+  it("parses a response with the consumed message fields", () => {
+    const parsed = openAiChatCompletionEnvelopeSchema.safeParse({
+      choices: [{ message: { content: "{}", refusal: null } }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a response without choices", () => {
+    expect(openAiChatCompletionEnvelopeSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("callOpenAIStructured", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch(impl: typeof fetch) {
+    const fetchMock = vi.fn(impl);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("sends a strict structured-output request with no temperature", async () => {
+    const fetchMock = stubFetch(async () =>
+      Response.json({ choices: [{ message: { content: '{"ok":true}' } }] })
+    );
+
+    const result = await callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA);
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(init!.headers).toMatchObject({ Authorization: "Bearer sk-test" });
+
+    const body = JSON.parse(init!.body as string);
+    // gpt-5-family models reject an explicit temperature with HTTP 400.
+    expect(body).not.toHaveProperty("temperature");
+    expect(body.model).toBe("gpt-5.4-mini");
+    expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
+    expect(body.response_format).toEqual({
+      type: "json_schema",
+      json_schema: { name: SCHEMA.name, strict: true, schema: SCHEMA.schema },
+    });
+  });
+
+  it("bounds the request with the shared timeout signal", async () => {
+    const fakeSignal = {} as AbortSignal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(fakeSignal);
+    const fetchMock = stubFetch(async () =>
+      Response.json({ choices: [{ message: { content: "{}" } }] })
+    );
+
+    await callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+    expect(fetchMock.mock.calls[0][1]!.signal).toBe(fakeSignal);
+    timeoutSpy.mockRestore();
+  });
+
+  it.each([
+    {
+      label: "a non-2xx response",
+      respond: () => new Response("server exploded", { status: 500 }),
+      message: /OpenAI API error 500: server exploded/,
+    },
+    {
+      label: "a malformed envelope",
+      respond: () => Response.json({ nope: true }),
+      message: /Malformed OpenAI response/,
+    },
+    {
+      label: "a refusal",
+      respond: () => Response.json({ choices: [{ message: { content: null, refusal: "no" } }] }),
+      message: /OpenAI refused to classify: no/,
+    },
+    {
+      label: "empty content",
+      respond: () => Response.json({ choices: [{ message: { content: null } }] }),
+      message: /Empty OpenAI response content/,
+    },
+    {
+      label: "non-JSON content",
+      respond: () => Response.json({ choices: [{ message: { content: "not json" } }] }),
+      message: /Failed to parse OpenAI response content as JSON/,
+    },
+  ])("throws on $label", async ({ respond, message }) => {
+    stubFetch(async () => respond());
+
+    await expect(callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA)).rejects.toThrow(
+      message
+    );
+  });
+
+  it("truncates a long error body", async () => {
+    stubFetch(async () => new Response("x".repeat(2000), { status: 400 }));
+
+    await expect(callOpenAIStructured("sk-test", "gpt-5.4-mini", "prompt", SCHEMA)).rejects.toThrow(
+      `OpenAI API error 400: ${"x".repeat(500)}`
+    );
+  });
+});

--- a/packages/shared/src/classification.test.ts
+++ b/packages/shared/src/classification.test.ts
@@ -96,6 +96,11 @@ describe("callOpenAIStructured", () => {
 
   it.each([
     {
+      label: "an empty choices array",
+      respond: () => Response.json({ choices: [] }),
+      message: /No choices in OpenAI response/,
+    },
+    {
       label: "a non-2xx response",
       respond: () => new Response("server exploded", { status: 500 }),
       message: /OpenAI API error 500: server exploded/,

--- a/packages/shared/src/classification.ts
+++ b/packages/shared/src/classification.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared plumbing for the Slack and Linear bots' target classifiers.
+ *
+ * Both bots pick a classification provider from the model id alone and, on the
+ * OpenAI path, speak the same strict structured-output dialect of the Chat
+ * Completions API. Only that provider-selection and transport layer lives here;
+ * each bot keeps its own response validation, prompt, and Anthropic transport.
+ */
+
+import { z } from "zod";
+
+/** Provider serving a classification request. */
+export type ClassificationProvider = "anthropic" | "openai";
+
+/**
+ * Model the classifiers use when a deployment sets no override.
+ */
+export const DEFAULT_CLASSIFICATION_MODEL = "claude-haiku-4-5";
+
+/**
+ * Bound on a single classification request to either provider, so a stalled
+ * model call can't hang message handling indefinitely.
+ */
+export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Cap on an OpenAI classification response.
+ *
+ * Four times the Anthropic tool-call budget because gpt-5-family reasoning
+ * tokens are billed inside `max_completion_tokens`: a tighter cap can be spent
+ * on reasoning before the structured JSON is emitted, truncating the response.
+ */
+export const OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS = 2000;
+
+/**
+ * Resolve which provider serves a classification model id, and the bare id to
+ * send that provider (any `anthropic/`/`openai/` prefix stripped).
+ *
+ * There is no separate provider env var — the model id alone selects the
+ * provider, so `CLASSIFICATION_MODEL=gpt-5.4-mini` routes to OpenAI while the
+ * default {@link DEFAULT_CLASSIFICATION_MODEL} keeps routing to Anthropic.
+ *
+ * Unlike `extractProviderAndModel` in `./models`, an unrecognized id throws
+ * rather than silently falling back to Anthropic: a typo'd classifier model
+ * should fail the request loudly, not bill the wrong provider.
+ */
+export function resolveClassificationProvider(modelId: string): {
+  provider: ClassificationProvider;
+  model: string;
+} {
+  if (modelId.startsWith("anthropic/")) {
+    return { provider: "anthropic", model: modelId.slice("anthropic/".length) };
+  }
+  if (modelId.startsWith("openai/")) {
+    return { provider: "openai", model: modelId.slice("openai/".length) };
+  }
+  if (modelId.startsWith("claude-")) {
+    return { provider: "anthropic", model: modelId };
+  }
+  if (modelId.startsWith("gpt-")) {
+    return { provider: "openai", model: modelId };
+  }
+  throw new Error(`Unrecognized classification model: ${modelId}`);
+}
+
+/**
+ * Read the provider credential required by a resolved classification model.
+ *
+ * Only the selected provider's key is bound to each classifier Worker. Fail
+ * before the outbound request when the binding and model selection disagree,
+ * rather than reporting the provider's authentication error.
+ */
+export function requireClassificationProviderKey(
+  key: string | undefined,
+  binding: "ANTHROPIC_API_KEY" | "OPENAI_API_KEY",
+  modelId: string
+): string {
+  if (!key) {
+    throw new Error(`Classification model "${modelId}" requires ${binding} to be set`);
+  }
+  return key;
+}
+
+/**
+ * Envelope of an OpenAI Chat Completions response, validated before the
+ * structured payload inside it is handed to a caller's own schema.
+ */
+export const openAiChatCompletionEnvelopeSchema = z.object({
+  choices: z.array(
+    z.object({
+      message: z.object({
+        content: z.string().nullable(),
+        refusal: z.string().nullable().optional(),
+      }),
+    })
+  ),
+});
+
+/**
+ * Call OpenAI's Chat Completions API in strict structured-output mode and
+ * return the parsed JSON payload.
+ *
+ * The result is deliberately `unknown`: each bot validates it against its own
+ * schema, so this transport stays free of any one bot's result shape.
+ *
+ * No `temperature` is sent — gpt-5-family models accept only the default and
+ * reject an explicit value with HTTP 400 `unsupported_value`.
+ */
+export async function callOpenAIStructured(
+  apiKey: string,
+  model: string,
+  prompt: string,
+  schema: { name: string; schema: unknown }
+): Promise<unknown> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      max_completion_tokens: OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: schema.name,
+          strict: true,
+          schema: schema.schema,
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 500);
+    throw new Error(`OpenAI API error ${response.status}: ${body}`);
+  }
+
+  const envelope = openAiChatCompletionEnvelopeSchema.safeParse(await response.json());
+  if (!envelope.success) {
+    throw new Error("Malformed OpenAI response");
+  }
+
+  const message = envelope.data.choices[0]?.message;
+  if (!message) {
+    throw new Error("No choices in OpenAI response");
+  }
+  if (message.refusal) {
+    throw new Error(`OpenAI refused to classify: ${message.refusal}`);
+  }
+  if (!message.content) {
+    throw new Error("Empty OpenAI response content");
+  }
+
+  try {
+    return JSON.parse(message.content);
+  } catch {
+    throw new Error("Failed to parse OpenAI response content as JSON");
+  }
+}

--- a/packages/shared/src/classification.ts
+++ b/packages/shared/src/classification.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared plumbing for the Slack and Linear bots' target classifiers.
+ *
+ * Both bots pick a classification provider from the model id alone and, on the
+ * OpenAI path, speak the same strict structured-output dialect of the Chat
+ * Completions API. Only that provider-selection and transport layer lives here;
+ * each bot keeps its own response validation, prompt, and Anthropic transport.
+ */
+
+import { z } from "zod";
+
+/** Provider serving a classification request. */
+export type ClassificationProvider = "anthropic" | "openai";
+
+/**
+ * Model the classifiers use when a deployment sets no override.
+ */
+export const DEFAULT_CLASSIFICATION_MODEL = "claude-haiku-4-5";
+
+/**
+ * Bound on a single classification request to either provider, so a stalled
+ * model call can't hang message handling indefinitely.
+ */
+export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Cap on an OpenAI classification response.
+ *
+ * Four times the Anthropic tool-call budget because gpt-5-family reasoning
+ * tokens are billed inside `max_completion_tokens`: a tighter cap can be spent
+ * on reasoning before the structured JSON is emitted, truncating the response.
+ */
+export const OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS = 2000;
+
+/**
+ * Resolve which provider serves a classification model id, and the bare id to
+ * send that provider (any `anthropic/`/`openai/` prefix stripped).
+ *
+ * There is no separate provider env var — the model id alone selects the
+ * provider, so `CLASSIFICATION_MODEL=gpt-5.4-mini` routes to OpenAI while the
+ * default {@link DEFAULT_CLASSIFICATION_MODEL} keeps routing to Anthropic.
+ *
+ * Unlike `extractProviderAndModel` in `./models`, an unrecognized id throws
+ * rather than silently falling back to Anthropic: a typo'd classifier model
+ * should fail the request loudly, not bill the wrong provider.
+ */
+export function resolveClassificationProvider(modelId: string): {
+  provider: ClassificationProvider;
+  model: string;
+} {
+  if (modelId.startsWith("anthropic/")) {
+    return { provider: "anthropic", model: modelId.slice("anthropic/".length) };
+  }
+  if (modelId.startsWith("openai/")) {
+    return { provider: "openai", model: modelId.slice("openai/".length) };
+  }
+  if (modelId.startsWith("claude-")) {
+    return { provider: "anthropic", model: modelId };
+  }
+  if (modelId.startsWith("gpt-")) {
+    return { provider: "openai", model: modelId };
+  }
+  throw new Error(`Unrecognized classification model: ${modelId}`);
+}
+
+/**
+ * Envelope of an OpenAI Chat Completions response, validated before the
+ * structured payload inside it is handed to a caller's own schema.
+ */
+export const openAiChatCompletionEnvelopeSchema = z.object({
+  choices: z.array(
+    z.object({
+      message: z.object({
+        content: z.string().nullable(),
+        refusal: z.string().nullable().optional(),
+      }),
+    })
+  ),
+});
+
+/**
+ * Call OpenAI's Chat Completions API in strict structured-output mode and
+ * return the parsed JSON payload.
+ *
+ * The result is deliberately `unknown`: each bot validates it against its own
+ * schema, so this transport stays free of any one bot's result shape.
+ *
+ * No `temperature` is sent — gpt-5-family models accept only the default and
+ * reject an explicit value with HTTP 400 `unsupported_value`.
+ */
+export async function callOpenAIStructured(
+  apiKey: string,
+  model: string,
+  prompt: string,
+  schema: { name: string; schema: unknown }
+): Promise<unknown> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      max_completion_tokens: OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: schema.name,
+          strict: true,
+          schema: schema.schema,
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 500);
+    throw new Error(`OpenAI API error ${response.status}: ${body}`);
+  }
+
+  const envelope = openAiChatCompletionEnvelopeSchema.safeParse(await response.json());
+  if (!envelope.success) {
+    throw new Error("Malformed OpenAI response");
+  }
+
+  const message = envelope.data.choices[0]?.message;
+  if (!message) {
+    throw new Error("No choices in OpenAI response");
+  }
+  if (message.refusal) {
+    throw new Error(`OpenAI refused to classify: ${message.refusal}`);
+  }
+  if (!message.content) {
+    throw new Error("Empty OpenAI response content");
+  }
+
+  try {
+    return JSON.parse(message.content);
+  } catch {
+    throw new Error("Failed to parse OpenAI response content as JSON");
+  }
+}

--- a/packages/shared/src/classification.ts
+++ b/packages/shared/src/classification.ts
@@ -21,7 +21,7 @@ export const DEFAULT_CLASSIFICATION_MODEL = "claude-haiku-4-5";
  * Bound on a single classification request to either provider, so a stalled
  * model call can't hang message handling indefinitely.
  */
-export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
+export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * Cap on an OpenAI classification response.

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Environment } from "@open-inspect/shared/types/environments";
 import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import type { Env } from "../types";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+} from "@open-inspect/shared/classification";
 
 const {
   mockMessagesCreate,
@@ -139,7 +143,8 @@ describe("RepoClassifier", () => {
           name: "classify_target",
         }),
         tools: [expect.objectContaining({ name: "classify_target" })],
-      })
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     const prompt = mockMessagesCreate.mock.calls[0][0].messages[0].content as string;
     expect(prompt).toContain("## Available Repositories\n- acme/prod\n- acme/web");
@@ -670,5 +675,160 @@ describe("RepoClassifier", () => {
 
       expect(result.reasoning).toBe("Mentions &lt;!channel&gt; &amp; the web app.");
     });
+  });
+
+  describe("provider selection", () => {
+    // These tests stub the global fetch; restore it so anything added after
+    // this block doesn't inherit a stale stub.
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function openAiEnv(overrides: Partial<Env> = {}): Env {
+      return {
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "gpt-5.4-mini",
+        OPENAI_API_KEY: "test-openai-key",
+        ...overrides,
+      } as Env;
+    }
+
+    function openAiFetchResponse(content: Record<string, unknown>, status = 200): Response {
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: JSON.stringify(content) } }] }),
+        { status }
+      );
+    }
+
+    it("sends the OpenAI chat-completions contract for a gpt-* model", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        openAiFetchResponse({
+          targetId: "acme/prod",
+          confidence: "high",
+          reasoning: "Mentions prod.",
+          alternatives: [],
+        })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const classifier = new RepoClassifier(openAiEnv());
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(classifiedRepoFullName(result)).toBe("acme/prod");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.openai.com/v1/chat/completions");
+      expect(init.headers).toMatchObject({
+        Authorization: "Bearer test-openai-key",
+        "Content-Type": "application/json",
+      });
+
+      const body = JSON.parse(init.body as string);
+      // The bare model id — no "openai/" prefix reaches the wire.
+      expect(body.model).toBe("gpt-5.4-mini");
+      // gpt-5-family models accept only the default temperature and reject an
+      // explicit value with HTTP 400 `unsupported_value`.
+      expect(body).not.toHaveProperty("temperature");
+      expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
+      // gpt-5.x rejects `max_tokens` outright ("Unsupported parameter").
+      expect(body).not.toHaveProperty("max_tokens");
+
+      const jsonSchema = body.response_format.json_schema;
+      expect(jsonSchema.name).toBe("classify_target");
+      expect(jsonSchema.strict).toBe(true);
+      expect(jsonSchema.schema.additionalProperties).toBe(false);
+      expect(jsonSchema.schema.required).toEqual([
+        "targetId",
+        "confidence",
+        "reasoning",
+        "alternatives",
+      ]);
+      expect(jsonSchema.schema.properties.targetId.type).toEqual(["string", "null"]);
+    });
+
+    it("degrades to the picker on a non-2xx OpenAI response", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response("rate limited", { status: 429 }))
+      );
+
+      const classifier = new RepoClassifier(openAiEnv());
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.confidence).toBe("low");
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+    });
+
+    it("bounds the Anthropic classification request with a timeout and degrades to the picker when it fires", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      mockMessagesCreate.mockRejectedValue(
+        Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" })
+      );
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+      expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+      const [, options] = mockMessagesCreate.mock.calls[0] as [unknown, { signal?: unknown }];
+      // Identity, not just shape: attaching some other signal would pass an
+      // instanceof check while leaving the request effectively unbounded.
+      expect(options?.signal).toBe(timeoutSpy.mock.results[0]?.value);
+    });
+
+    it("degrades to the picker for an unrecognized model prefix without calling either provider", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const classifier = new RepoClassifier({
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "mistral-large-latest",
+      } as Env);
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        binding: "OPENAI_API_KEY",
+        model: "gpt-5.4-mini",
+        overrides: { OPENAI_API_KEY: undefined },
+      },
+      {
+        binding: "ANTHROPIC_API_KEY",
+        model: "claude-haiku-4-5",
+        overrides: { ANTHROPIC_API_KEY: undefined },
+      },
+    ])(
+      "degrades to the picker without calling out when $model is selected but $binding is unbound",
+      async ({ model, overrides }) => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+
+        const classifier = new RepoClassifier({
+          ...TEST_ENV,
+          CLASSIFICATION_MODEL: model,
+          ...overrides,
+        } as Env);
+        const result = await classifier.classify("please fix prod slack alerts");
+
+        expect(result.target).toBeNull();
+        expect(result.needsClarification).toBe(true);
+        expect(result.reasoning).toContain("structured model output");
+        expect(mockMessagesCreate).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    );
   });
 });

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Environment } from "@open-inspect/shared/types/environments";
 import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import type { Env } from "../types";
-import { CLASSIFICATION_REQUEST_TIMEOUT_MS } from "@open-inspect/shared/classification";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS,
+} from "@open-inspect/shared/classification";
 
 const {
   mockMessagesCreate,
@@ -728,7 +731,7 @@ describe("RepoClassifier", () => {
       // gpt-5-family models accept only the default temperature and reject an
       // explicit value with HTTP 400 `unsupported_value`.
       expect(body).not.toHaveProperty("temperature");
-      expect(body.max_completion_tokens).toBe(2000);
+      expect(body.max_completion_tokens).toBe(OPENAI_CLASSIFICATION_MAX_COMPLETION_TOKENS);
       // gpt-5.x rejects `max_tokens` outright ("Unsupported parameter").
       expect(body).not.toHaveProperty("max_tokens");
 

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Environment } from "@open-inspect/shared/types/environments";
 import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
 import type { Env } from "../types";
+import { CLASSIFICATION_REQUEST_TIMEOUT_MS } from "@open-inspect/shared/classification";
 
 const {
   mockMessagesCreate,
@@ -43,7 +44,7 @@ vi.mock("./environments", async (importOriginal) => ({
   getEnvironmentById: vi.fn(),
 }));
 
-import { CLASSIFICATION_REQUEST_TIMEOUT_MS, RepoClassifier } from "./index";
+import { RepoClassifier } from "./index";
 
 const TEST_REPOS: RepoConfig[] = [
   {
@@ -674,6 +675,12 @@ describe("RepoClassifier", () => {
   });
 
   describe("provider selection", () => {
+    // These tests stub the global fetch; restore it so anything added after
+    // this block doesn't inherit a stale stub.
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     function openAiEnv(overrides: Partial<Env> = {}): Env {
       return {
         ...TEST_ENV,
@@ -718,7 +725,9 @@ describe("RepoClassifier", () => {
       const body = JSON.parse(init.body as string);
       // The bare model id — no "openai/" prefix reaches the wire.
       expect(body.model).toBe("gpt-5.4-mini");
-      expect(body.temperature).toBe(0);
+      // gpt-5-family models accept only the default temperature and reject an
+      // explicit value with HTTP 400 `unsupported_value`.
+      expect(body).not.toHaveProperty("temperature");
       expect(body.max_completion_tokens).toBe(2000);
       // gpt-5.x rejects `max_tokens` outright ("Unsupported parameter").
       expect(body).not.toHaveProperty("max_tokens");
@@ -786,5 +795,37 @@ describe("RepoClassifier", () => {
       expect(mockMessagesCreate).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it.each([
+      {
+        binding: "OPENAI_API_KEY",
+        model: "gpt-5.4-mini",
+        overrides: { OPENAI_API_KEY: undefined },
+      },
+      {
+        binding: "ANTHROPIC_API_KEY",
+        model: "claude-haiku-4-5",
+        overrides: { ANTHROPIC_API_KEY: undefined },
+      },
+    ])(
+      "degrades to the picker without calling out when $model is selected but $binding is unbound",
+      async ({ model, overrides }) => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+
+        const classifier = new RepoClassifier({
+          ...TEST_ENV,
+          CLASSIFICATION_MODEL: model,
+          ...overrides,
+        } as Env);
+        const result = await classifier.classify("please fix prod slack alerts");
+
+        expect(result.target).toBeNull();
+        expect(result.needsClarification).toBe(true);
+        expect(result.reasoning).toContain("structured model output");
+        expect(mockMessagesCreate).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    );
   });
 });

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -43,7 +43,7 @@ vi.mock("./environments", async (importOriginal) => ({
   getEnvironmentById: vi.fn(),
 }));
 
-import { RepoClassifier } from "./index";
+import { CLASSIFICATION_REQUEST_TIMEOUT_MS, RepoClassifier } from "./index";
 
 const TEST_REPOS: RepoConfig[] = [
   {
@@ -139,7 +139,8 @@ describe("RepoClassifier", () => {
           name: "classify_target",
         }),
         tools: [expect.objectContaining({ name: "classify_target" })],
-      })
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     const prompt = mockMessagesCreate.mock.calls[0][0].messages[0].content as string;
     expect(prompt).toContain("## Available Repositories\n- acme/prod\n- acme/web");
@@ -669,6 +670,121 @@ describe("RepoClassifier", () => {
       const result = await classifier.classify("web app issue");
 
       expect(result.reasoning).toBe("Mentions &lt;!channel&gt; &amp; the web app.");
+    });
+  });
+
+  describe("provider selection", () => {
+    function openAiEnv(overrides: Partial<Env> = {}): Env {
+      return {
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "gpt-5.4-mini",
+        OPENAI_API_KEY: "test-openai-key",
+        ...overrides,
+      } as Env;
+    }
+
+    function openAiFetchResponse(content: Record<string, unknown>, status = 200): Response {
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: JSON.stringify(content) } }] }),
+        { status }
+      );
+    }
+
+    it("sends the OpenAI chat-completions contract for a gpt-* model", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        openAiFetchResponse({
+          targetId: "acme/prod",
+          confidence: "high",
+          reasoning: "Mentions prod.",
+          alternatives: [],
+        })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const classifier = new RepoClassifier(openAiEnv());
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(classifiedRepoFullName(result)).toBe("acme/prod");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.openai.com/v1/chat/completions");
+      expect(init.headers).toMatchObject({
+        Authorization: "Bearer test-openai-key",
+        "Content-Type": "application/json",
+      });
+
+      const body = JSON.parse(init.body as string);
+      // The bare model id — no "openai/" prefix reaches the wire.
+      expect(body.model).toBe("gpt-5.4-mini");
+      expect(body.temperature).toBe(0);
+      expect(body.max_completion_tokens).toBe(2000);
+      // gpt-5.x rejects `max_tokens` outright ("Unsupported parameter").
+      expect(body).not.toHaveProperty("max_tokens");
+
+      const jsonSchema = body.response_format.json_schema;
+      expect(jsonSchema.name).toBe("classify_target");
+      expect(jsonSchema.strict).toBe(true);
+      expect(jsonSchema.schema.additionalProperties).toBe(false);
+      expect(jsonSchema.schema.required).toEqual([
+        "targetId",
+        "confidence",
+        "reasoning",
+        "alternatives",
+      ]);
+      expect(jsonSchema.schema.properties.targetId.type).toEqual(["string", "null"]);
+    });
+
+    it("degrades to the picker on a non-2xx OpenAI response", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response("rate limited", { status: 429 }))
+      );
+
+      const classifier = new RepoClassifier(openAiEnv());
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.confidence).toBe("low");
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+    });
+
+    it("bounds the Anthropic classification request with a timeout and degrades to the picker when it fires", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      mockMessagesCreate.mockRejectedValue(
+        Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" })
+      );
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+      expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFICATION_REQUEST_TIMEOUT_MS);
+      const [, options] = mockMessagesCreate.mock.calls[0] as [unknown, { signal?: unknown }];
+      // Identity, not just shape: attaching some other signal would pass an
+      // instanceof check while leaving the request effectively unbounded.
+      expect(options?.signal).toBe(timeoutSpy.mock.results[0]?.value);
+    });
+
+    it("degrades to the picker for an unrecognized model prefix without calling either provider", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const classifier = new RepoClassifier({
+        ...TEST_ENV,
+        CLASSIFICATION_MODEL: "mistral-large-latest",
+      } as Env);
+      const result = await classifier.classify("please fix prod slack alerts");
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.reasoning).toContain("structured model output");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -14,6 +14,13 @@ import { loadTargetCatalog, type TargetCatalog } from "./catalog";
 import { matchTargetId, resolveChannelTargets, resolveRoutingRuleTargets } from "./routing";
 import { escapeMrkdwnText } from "@open-inspect/shared/slack";
 import type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  callOpenAIStructured,
+  requireClassificationProviderKey,
+  resolveClassificationProvider,
+} from "@open-inspect/shared/classification";
 import { targetId, targetLabel, targetValue, type SlackSessionTarget } from "../targets";
 import { createLogger } from "../logger";
 
@@ -116,7 +123,7 @@ Consider:
 
 ## Response Format
 
-Return your decision by calling the ${CLASSIFY_TARGET_TOOL_NAME} tool with:
+Respond with a JSON object with these fields:
 - targetId: a repository "owner/name", an environment id ("env_…"), or null if unclear
 - confidence: "high" | "medium" | "low"
 - reasoning: brief explanation
@@ -192,17 +199,68 @@ function extractStructuredResponse(response: Anthropic.Messages.Message): LLMRes
 }
 
 /**
+ * Call OpenAI's Chat Completions API with strict JSON-schema structured
+ * output, then funnel the parsed object through the same
+ * {@link normalizeModelResponse} validation as the Anthropic tool-use path.
+ *
+ * The Anthropic tool's `input_schema` already carries
+ * `additionalProperties: false`, which is what OpenAI's `strict` mode requires,
+ * so both providers are driven from that one declaration.
+ */
+async function callOpenAI(apiKey: string, model: string, prompt: string): Promise<LLMResponse> {
+  const parsed = await callOpenAIStructured(apiKey, model, prompt, {
+    name: CLASSIFY_TARGET_TOOL_NAME,
+    schema: CLASSIFY_TARGET_TOOL.input_schema,
+  });
+
+  return normalizeModelResponse(parsed);
+}
+
+/**
  * Repository classifier class.
  */
 export class RepoClassifier {
-  private client: Anthropic;
+  private anthropicClient: Anthropic | null = null;
   private env: Env;
 
   constructor(env: Env) {
     this.env = env;
-    this.client = new Anthropic({
-      apiKey: env.ANTHROPIC_API_KEY,
-    });
+  }
+
+  /**
+   * Lazily construct the Anthropic client so an OpenAI-configured deployment
+   * (no `ANTHROPIC_API_KEY`) never reaches `new Anthropic({ apiKey: undefined })`.
+   */
+  private getAnthropicClient(apiKey: string): Anthropic {
+    if (!this.anthropicClient) {
+      this.anthropicClient = new Anthropic({ apiKey });
+    }
+    return this.anthropicClient;
+  }
+
+  /**
+   * Call Anthropic's Messages API with the classification tool, then funnel the
+   * tool input through the same {@link normalizeModelResponse} validation as
+   * the OpenAI structured-output path.
+   */
+  private async callAnthropic(apiKey: string, model: string, prompt: string): Promise<LLMResponse> {
+    const response = await this.getAnthropicClient(apiKey).messages.create(
+      {
+        model,
+        max_tokens: 500,
+        temperature: 0,
+        tools: [CLASSIFY_TARGET_TOOL],
+        tool_choice: {
+          type: "tool",
+          name: CLASSIFY_TARGET_TOOL_NAME,
+          disable_parallel_tool_use: true,
+        },
+        messages: [{ role: "user", content: prompt }],
+      },
+      { signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS) }
+    );
+
+    return extractStructuredResponse(response);
   }
 
   /**
@@ -352,26 +410,25 @@ export class RepoClassifier {
     // Use LLM for classification
     try {
       const prompt = buildClassificationPrompt(message, catalog, context);
+      const modelId = this.env.CLASSIFICATION_MODEL || DEFAULT_CLASSIFICATION_MODEL;
+      const { provider, model } = resolveClassificationProvider(modelId);
 
-      const response = await this.client.messages.create({
-        model: this.env.CLASSIFICATION_MODEL || "claude-haiku-4-5",
-        max_tokens: 500,
-        temperature: 0,
-        tools: [CLASSIFY_TARGET_TOOL],
-        tool_choice: {
-          type: "tool",
-          name: CLASSIFY_TARGET_TOOL_NAME,
-          disable_parallel_tool_use: true,
-        },
-        messages: [
-          {
-            role: "user",
-            content: prompt,
-          },
-        ],
-      });
-
-      const llmResult = extractStructuredResponse(response);
+      const llmResult =
+        provider === "anthropic"
+          ? await this.callAnthropic(
+              requireClassificationProviderKey(
+                this.env.ANTHROPIC_API_KEY,
+                "ANTHROPIC_API_KEY",
+                modelId
+              ),
+              model,
+              prompt
+            )
+          : await callOpenAI(
+              requireClassificationProviderKey(this.env.OPENAI_API_KEY, "OPENAI_API_KEY", modelId),
+              model,
+              prompt
+            );
 
       const matchedTarget = llmResult.targetId ? matchTargetId(llmResult.targetId, catalog) : null;
 

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -21,6 +21,12 @@ const log = createLogger("classifier");
 const CLASSIFY_TARGET_TOOL_NAME = "classify_target";
 const CONFIDENCE_LEVELS: ClassificationResult["confidence"][] = ["high", "medium", "low"];
 
+/**
+ * Bound on the classification request to either provider, so a stalled model
+ * call can't hang message handling indefinitely.
+ */
+export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
+
 const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
   name: CLASSIFY_TARGET_TOOL_NAME,
   description:
@@ -53,6 +59,69 @@ const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
     additionalProperties: false,
   },
 };
+
+/**
+ * Plain JSON Schema mirror of {@link CLASSIFY_TARGET_TOOL}'s input shape, used
+ * for OpenAI's strict structured-output mode (`response_format.json_schema`).
+ * Kept in sync with the Anthropic tool's `input_schema` by hand — the two
+ * provider SDKs use incompatible schema types, so there's no single shared
+ * declaration to derive both from.
+ */
+const CLASSIFY_TARGET_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    targetId: {
+      type: ["string", "null"],
+      description:
+        'A repository "owner/name" or an environment id ("env_…") if confident enough to choose one, otherwise null.',
+    },
+    confidence: {
+      type: "string",
+      enum: CONFIDENCE_LEVELS,
+    },
+    reasoning: {
+      type: "string",
+      description: "Brief explanation of classification decision.",
+    },
+    alternatives: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Alternative repository fullNames / environment ids when confidence is not high.",
+    },
+  },
+  required: ["targetId", "confidence", "reasoning", "alternatives"],
+  additionalProperties: false,
+} as const;
+
+type ClassificationProvider = "anthropic" | "openai";
+
+/**
+ * Resolve which provider serves a classification model id, and the bare id to
+ * send that provider (any `anthropic/`/`openai/` prefix stripped).
+ *
+ * There is no separate provider env var — the model id alone selects the
+ * provider, so `CLASSIFICATION_MODEL=gpt-5.4-mini` routes to OpenAI while the
+ * default `claude-haiku-4-5` keeps routing to Anthropic.
+ */
+function resolveClassificationProvider(model: string): {
+  provider: ClassificationProvider;
+  model: string;
+} {
+  if (model.startsWith("anthropic/")) {
+    return { provider: "anthropic", model: model.slice("anthropic/".length) };
+  }
+  if (model.startsWith("openai/")) {
+    return { provider: "openai", model: model.slice("openai/".length) };
+  }
+  if (model.startsWith("claude-")) {
+    return { provider: "anthropic", model };
+  }
+  if (model.startsWith("gpt-")) {
+    return { provider: "openai", model };
+  }
+  throw new Error(`Unrecognized classification model: ${model}`);
+}
 
 /**
  * Build the classification prompt for the LLM over the target catalog.
@@ -116,7 +185,7 @@ Consider:
 
 ## Response Format
 
-Return your decision by calling the ${CLASSIFY_TARGET_TOOL_NAME} tool with:
+Respond with a JSON object with these fields:
 - targetId: a repository "owner/name", an environment id ("env_…"), or null if unclear
 - confidence: "high" | "medium" | "low"
 - reasoning: brief explanation
@@ -192,17 +261,88 @@ function extractStructuredResponse(response: Anthropic.Messages.Message): LLMRes
 }
 
 /**
+ * Call OpenAI's Chat Completions API with strict JSON-schema structured
+ * output, then funnel the parsed object through the same
+ * {@link normalizeModelResponse} validation as the Anthropic tool-use path.
+ */
+async function callOpenAI(apiKey: string, model: string, prompt: string): Promise<LLMResponse> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_completion_tokens: 2000,
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: CLASSIFY_TARGET_TOOL_NAME,
+          strict: true,
+          schema: CLASSIFY_TARGET_JSON_SCHEMA,
+        },
+      },
+    }),
+    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `OpenAI classification request failed (${response.status}): ${body.slice(0, 500)}`
+    );
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string | null; refusal?: string | null } }>;
+  };
+
+  const message = payload.choices?.[0]?.message;
+  if (message?.refusal) {
+    throw new Error(`OpenAI classification refused: ${message.refusal}`);
+  }
+
+  if (!message?.content) {
+    throw new Error("OpenAI classification response had no content");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message.content);
+  } catch (e) {
+    throw new Error(
+      `OpenAI classification response was not valid JSON: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+
+  return normalizeModelResponse(parsed);
+}
+
+/**
  * Repository classifier class.
  */
 export class RepoClassifier {
-  private client: Anthropic;
+  private anthropicClient: Anthropic | null = null;
   private env: Env;
 
   constructor(env: Env) {
     this.env = env;
-    this.client = new Anthropic({
-      apiKey: env.ANTHROPIC_API_KEY,
-    });
+  }
+
+  /**
+   * Lazily construct the Anthropic client so an OpenAI-configured deployment
+   * (no `ANTHROPIC_API_KEY`) never reaches `new Anthropic({ apiKey: undefined })`.
+   */
+  private getAnthropicClient(): Anthropic {
+    if (!this.anthropicClient) {
+      this.anthropicClient = new Anthropic({
+        apiKey: this.env.ANTHROPIC_API_KEY,
+      });
+    }
+    return this.anthropicClient;
   }
 
   /**
@@ -352,26 +492,35 @@ export class RepoClassifier {
     // Use LLM for classification
     try {
       const prompt = buildClassificationPrompt(message, catalog, context);
+      const { provider, model } = resolveClassificationProvider(
+        this.env.CLASSIFICATION_MODEL || "claude-haiku-4-5"
+      );
 
-      const response = await this.client.messages.create({
-        model: this.env.CLASSIFICATION_MODEL || "claude-haiku-4-5",
-        max_tokens: 500,
-        temperature: 0,
-        tools: [CLASSIFY_TARGET_TOOL],
-        tool_choice: {
-          type: "tool",
-          name: CLASSIFY_TARGET_TOOL_NAME,
-          disable_parallel_tool_use: true,
-        },
-        messages: [
-          {
-            role: "user",
-            content: prompt,
-          },
-        ],
-      });
-
-      const llmResult = extractStructuredResponse(response);
+      const llmResult =
+        provider === "anthropic"
+          ? extractStructuredResponse(
+              await this.getAnthropicClient().messages.create(
+                {
+                  model,
+                  max_tokens: 500,
+                  temperature: 0,
+                  tools: [CLASSIFY_TARGET_TOOL],
+                  tool_choice: {
+                    type: "tool",
+                    name: CLASSIFY_TARGET_TOOL_NAME,
+                    disable_parallel_tool_use: true,
+                  },
+                  messages: [
+                    {
+                      role: "user",
+                      content: prompt,
+                    },
+                  ],
+                },
+                { signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS) }
+              )
+            )
+          : await callOpenAI(this.env.OPENAI_API_KEY ?? "", model, prompt);
 
       const matchedTarget = llmResult.targetId ? matchTargetId(llmResult.targetId, catalog) : null;
 

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -14,18 +14,18 @@ import { loadTargetCatalog, type TargetCatalog } from "./catalog";
 import { matchTargetId, resolveChannelTargets, resolveRoutingRuleTargets } from "./routing";
 import { escapeMrkdwnText } from "@open-inspect/shared/slack";
 import type { ConfidenceLevel } from "@open-inspect/shared/types/repository-catalog";
+import {
+  CLASSIFICATION_REQUEST_TIMEOUT_MS,
+  DEFAULT_CLASSIFICATION_MODEL,
+  callOpenAIStructured,
+  resolveClassificationProvider,
+} from "@open-inspect/shared/classification";
 import { targetId, targetLabel, targetValue, type SlackSessionTarget } from "../targets";
 import { createLogger } from "../logger";
 
 const log = createLogger("classifier");
 const CLASSIFY_TARGET_TOOL_NAME = "classify_target";
 const CONFIDENCE_LEVELS: ClassificationResult["confidence"][] = ["high", "medium", "low"];
-
-/**
- * Bound on the classification request to either provider, so a stalled model
- * call can't hang message handling indefinitely.
- */
-export const CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000;
 
 const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
   name: CLASSIFY_TARGET_TOOL_NAME,
@@ -59,69 +59,6 @@ const CLASSIFY_TARGET_TOOL: Anthropic.Messages.Tool = {
     additionalProperties: false,
   },
 };
-
-/**
- * Plain JSON Schema mirror of {@link CLASSIFY_TARGET_TOOL}'s input shape, used
- * for OpenAI's strict structured-output mode (`response_format.json_schema`).
- * Kept in sync with the Anthropic tool's `input_schema` by hand — the two
- * provider SDKs use incompatible schema types, so there's no single shared
- * declaration to derive both from.
- */
-const CLASSIFY_TARGET_JSON_SCHEMA = {
-  type: "object",
-  properties: {
-    targetId: {
-      type: ["string", "null"],
-      description:
-        'A repository "owner/name" or an environment id ("env_…") if confident enough to choose one, otherwise null.',
-    },
-    confidence: {
-      type: "string",
-      enum: CONFIDENCE_LEVELS,
-    },
-    reasoning: {
-      type: "string",
-      description: "Brief explanation of classification decision.",
-    },
-    alternatives: {
-      type: "array",
-      items: { type: "string" },
-      description:
-        "Alternative repository fullNames / environment ids when confidence is not high.",
-    },
-  },
-  required: ["targetId", "confidence", "reasoning", "alternatives"],
-  additionalProperties: false,
-} as const;
-
-type ClassificationProvider = "anthropic" | "openai";
-
-/**
- * Resolve which provider serves a classification model id, and the bare id to
- * send that provider (any `anthropic/`/`openai/` prefix stripped).
- *
- * There is no separate provider env var — the model id alone selects the
- * provider, so `CLASSIFICATION_MODEL=gpt-5.4-mini` routes to OpenAI while the
- * default `claude-haiku-4-5` keeps routing to Anthropic.
- */
-function resolveClassificationProvider(model: string): {
-  provider: ClassificationProvider;
-  model: string;
-} {
-  if (model.startsWith("anthropic/")) {
-    return { provider: "anthropic", model: model.slice("anthropic/".length) };
-  }
-  if (model.startsWith("openai/")) {
-    return { provider: "openai", model: model.slice("openai/".length) };
-  }
-  if (model.startsWith("claude-")) {
-    return { provider: "anthropic", model };
-  }
-  if (model.startsWith("gpt-")) {
-    return { provider: "openai", model };
-  }
-  throw new Error(`Unrecognized classification model: ${model}`);
-}
 
 /**
  * Build the classification prompt for the LLM over the target catalog.
@@ -264,61 +201,37 @@ function extractStructuredResponse(response: Anthropic.Messages.Message): LLMRes
  * Call OpenAI's Chat Completions API with strict JSON-schema structured
  * output, then funnel the parsed object through the same
  * {@link normalizeModelResponse} validation as the Anthropic tool-use path.
+ *
+ * The Anthropic tool's `input_schema` already carries
+ * `additionalProperties: false`, which is what OpenAI's `strict` mode requires,
+ * so both providers are driven from that one declaration.
  */
 async function callOpenAI(apiKey: string, model: string, prompt: string): Promise<LLMResponse> {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model,
-      temperature: 0,
-      max_completion_tokens: 2000,
-      messages: [{ role: "user", content: prompt }],
-      response_format: {
-        type: "json_schema",
-        json_schema: {
-          name: CLASSIFY_TARGET_TOOL_NAME,
-          strict: true,
-          schema: CLASSIFY_TARGET_JSON_SCHEMA,
-        },
-      },
-    }),
-    signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS),
+  const parsed = await callOpenAIStructured(apiKey, model, prompt, {
+    name: CLASSIFY_TARGET_TOOL_NAME,
+    schema: CLASSIFY_TARGET_TOOL.input_schema,
   });
 
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(
-      `OpenAI classification request failed (${response.status}): ${body.slice(0, 500)}`
-    );
-  }
-
-  const payload = (await response.json()) as {
-    choices?: Array<{ message?: { content?: string | null; refusal?: string | null } }>;
-  };
-
-  const message = payload.choices?.[0]?.message;
-  if (message?.refusal) {
-    throw new Error(`OpenAI classification refused: ${message.refusal}`);
-  }
-
-  if (!message?.content) {
-    throw new Error("OpenAI classification response had no content");
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(message.content);
-  } catch (e) {
-    throw new Error(
-      `OpenAI classification response was not valid JSON: ${e instanceof Error ? e.message : String(e)}`
-    );
-  }
-
   return normalizeModelResponse(parsed);
+}
+
+/**
+ * Read the provider credential the resolved classification model needs.
+ *
+ * Only the selected provider's key is bound to the Worker, so a model id that
+ * points at the unbound provider is a deployment misconfiguration — fail with
+ * that, rather than sending a request with an empty credential and reporting
+ * the provider's 401.
+ */
+function requireProviderKey(
+  key: string | undefined,
+  binding: "ANTHROPIC_API_KEY" | "OPENAI_API_KEY",
+  modelId: string
+): string {
+  if (!key) {
+    throw new Error(`Classification model "${modelId}" requires ${binding} to be set`);
+  }
+  return key;
 }
 
 /**
@@ -336,13 +249,36 @@ export class RepoClassifier {
    * Lazily construct the Anthropic client so an OpenAI-configured deployment
    * (no `ANTHROPIC_API_KEY`) never reaches `new Anthropic({ apiKey: undefined })`.
    */
-  private getAnthropicClient(): Anthropic {
+  private getAnthropicClient(apiKey: string): Anthropic {
     if (!this.anthropicClient) {
-      this.anthropicClient = new Anthropic({
-        apiKey: this.env.ANTHROPIC_API_KEY,
-      });
+      this.anthropicClient = new Anthropic({ apiKey });
     }
     return this.anthropicClient;
+  }
+
+  /**
+   * Call Anthropic's Messages API with the classification tool, then funnel the
+   * tool input through the same {@link normalizeModelResponse} validation as
+   * the OpenAI structured-output path.
+   */
+  private async callAnthropic(apiKey: string, model: string, prompt: string): Promise<LLMResponse> {
+    const response = await this.getAnthropicClient(apiKey).messages.create(
+      {
+        model,
+        max_tokens: 500,
+        temperature: 0,
+        tools: [CLASSIFY_TARGET_TOOL],
+        tool_choice: {
+          type: "tool",
+          name: CLASSIFY_TARGET_TOOL_NAME,
+          disable_parallel_tool_use: true,
+        },
+        messages: [{ role: "user", content: prompt }],
+      },
+      { signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS) }
+    );
+
+    return extractStructuredResponse(response);
   }
 
   /**
@@ -492,35 +428,21 @@ export class RepoClassifier {
     // Use LLM for classification
     try {
       const prompt = buildClassificationPrompt(message, catalog, context);
-      const { provider, model } = resolveClassificationProvider(
-        this.env.CLASSIFICATION_MODEL || "claude-haiku-4-5"
-      );
+      const modelId = this.env.CLASSIFICATION_MODEL || DEFAULT_CLASSIFICATION_MODEL;
+      const { provider, model } = resolveClassificationProvider(modelId);
 
       const llmResult =
         provider === "anthropic"
-          ? extractStructuredResponse(
-              await this.getAnthropicClient().messages.create(
-                {
-                  model,
-                  max_tokens: 500,
-                  temperature: 0,
-                  tools: [CLASSIFY_TARGET_TOOL],
-                  tool_choice: {
-                    type: "tool",
-                    name: CLASSIFY_TARGET_TOOL_NAME,
-                    disable_parallel_tool_use: true,
-                  },
-                  messages: [
-                    {
-                      role: "user",
-                      content: prompt,
-                    },
-                  ],
-                },
-                { signal: AbortSignal.timeout(CLASSIFICATION_REQUEST_TIMEOUT_MS) }
-              )
+          ? await this.callAnthropic(
+              requireProviderKey(this.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY", modelId),
+              model,
+              prompt
             )
-          : await callOpenAI(this.env.OPENAI_API_KEY ?? "", model, prompt);
+          : await callOpenAI(
+              requireProviderKey(this.env.OPENAI_API_KEY, "OPENAI_API_KEY", modelId),
+              model,
+              prompt
+            );
 
       const matchedTarget = llmResult.targetId ? matchTargetId(llmResult.targetId, catalog) : null;
 

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -40,7 +40,13 @@ export interface Env {
   SLACK_BOT_TOKEN: string;
   SLACK_SIGNING_SECRET: string;
   SLACK_APP_TOKEN?: string;
-  ANTHROPIC_API_KEY: string;
+  /**
+   * Classifier provider credentials. The deployment binds exactly the one
+   * `CLASSIFICATION_MODEL` selects, so each is optional on its own and the
+   * classifier guards the branch it needs.
+   */
+  ANTHROPIC_API_KEY?: string;
+  OPENAI_API_KEY?: string;
   CONTROL_PLANE_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -40,7 +40,12 @@ export interface Env {
   SLACK_BOT_TOKEN: string;
   SLACK_SIGNING_SECRET: string;
   SLACK_APP_TOKEN?: string;
-  ANTHROPIC_API_KEY: string;
+  /**
+   * Classifier provider credentials. The deployment binds exactly the one
+   * `CLASSIFICATION_MODEL` selects, so each is optional on its own and the
+   * classifier guards the branch it needs.
+   */
+  ANTHROPIC_API_KEY?: string;
   OPENAI_API_KEY?: string;
   CONTROL_PLANE_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -41,6 +41,7 @@ export interface Env {
   SLACK_SIGNING_SECRET: string;
   SLACK_APP_TOKEN?: string;
   ANTHROPIC_API_KEY: string;
+  OPENAI_API_KEY?: string;
   CONTROL_PLANE_API_KEY?: string;
   SERVICE_AUTH_SECRET?: string; // Per-service sig1 signing secret; also verifies CP callbacks
   LOG_LEVEL?: string;

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -269,6 +269,7 @@ LINEAR_WEBHOOK_SECRET
 
 # API Keys
 ANTHROPIC_API_KEY
+CLASSIFICATION_OPENAI_API_KEY # Required when classification_model is an OpenAI model and the Slack or Linear bot is enabled
 
 # Security Secrets
 TOKEN_ENCRYPTION_KEY

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -261,6 +261,8 @@ LINEAR_WEBHOOK_SECRET
 
 # API Keys
 ANTHROPIC_API_KEY
+CLASSIFICATION_OPENAI_API_KEY # Required when classification_model is an OpenAI model
+CLASSIFICATION_ANTHROPIC_API_KEY # Optional; falls back to ANTHROPIC_API_KEY
 
 # Security Secrets
 TOKEN_ENCRYPTION_KEY

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -262,7 +262,6 @@ LINEAR_WEBHOOK_SECRET
 # API Keys
 ANTHROPIC_API_KEY
 CLASSIFICATION_OPENAI_API_KEY # Required when classification_model is an OpenAI model
-CLASSIFICATION_ANTHROPIC_API_KEY # Optional; falls back to ANTHROPIC_API_KEY
 
 # Security Secrets
 TOKEN_ENCRYPTION_KEY

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -261,7 +261,7 @@ LINEAR_WEBHOOK_SECRET
 
 # API Keys
 ANTHROPIC_API_KEY
-CLASSIFICATION_OPENAI_API_KEY # Required when classification_model is an OpenAI model
+CLASSIFICATION_OPENAI_API_KEY # Required when classification_model is an OpenAI model and the Slack or Linear bot is enabled
 
 # Security Secrets
 TOKEN_ENCRYPTION_KEY

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -42,6 +42,22 @@ locals {
     local.web_custom_domain_zone_id != ""
   )
 
+  # The bots derive their classifier's provider from the model id, so the
+  # deployment binds exactly one provider credential to them: an Anthropic model
+  # gets ANTHROPIC_API_KEY, an OpenAI model gets OPENAI_API_KEY. This is scoped
+  # to the classifier — var.anthropic_api_key is still what Claude coding
+  # sessions and the opencomputer control-plane path use.
+  classifier_uses_openai = (
+    startswith(var.classification_model, "openai/") ||
+    startswith(var.classification_model, "gpt-")
+  )
+
+  # Exactly one provider binding for the classifier bots.
+  classifier_secret_bindings = (local.classifier_uses_openai
+    ? [{ name = "OPENAI_API_KEY", value = var.classification_openai_api_key }]
+    : [{ name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key }]
+  )
+
   # Host the Cloudflare web Worker is served from: custom domain when configured,
   # otherwise its default workers.dev hostname.
   web_cloudflare_host = (local.web_custom_domain_enabled

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -52,18 +52,10 @@ locals {
     startswith(var.classification_model, "gpt-")
   )
 
-  # A blank classifier-specific Anthropic key falls back to the deployment-wide
-  # one, so deployments predating these variables need no new value.
-  classification_anthropic_api_key = (
-    trimspace(var.classification_anthropic_api_key) != ""
-    ? var.classification_anthropic_api_key
-    : var.anthropic_api_key
-  )
-
   # Exactly one provider binding for the classifier bots.
   classifier_secret_bindings = (local.classifier_uses_openai
     ? [{ name = "OPENAI_API_KEY", value = var.classification_openai_api_key }]
-    : [{ name = "ANTHROPIC_API_KEY", value = local.classification_anthropic_api_key }]
+    : [{ name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key }]
   )
 
   # Host the Cloudflare web Worker is served from: custom domain when configured,

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -42,6 +42,30 @@ locals {
     local.web_custom_domain_zone_id != ""
   )
 
+  # The bots derive their classifier's provider from the model id, so the
+  # deployment binds exactly one provider credential to them: an Anthropic model
+  # gets ANTHROPIC_API_KEY, an OpenAI model gets OPENAI_API_KEY. This is scoped
+  # to the classifier — var.anthropic_api_key is still what Claude coding
+  # sessions and the opencomputer control-plane path use.
+  classifier_uses_openai = (
+    startswith(var.classification_model, "openai/") ||
+    startswith(var.classification_model, "gpt-")
+  )
+
+  # A blank classifier-specific Anthropic key falls back to the deployment-wide
+  # one, so deployments predating these variables need no new value.
+  classification_anthropic_api_key = (
+    trimspace(var.classification_anthropic_api_key) != ""
+    ? var.classification_anthropic_api_key
+    : var.anthropic_api_key
+  )
+
+  # Exactly one provider binding for the classifier bots.
+  classifier_secret_bindings = (local.classifier_uses_openai
+    ? [{ name = "OPENAI_API_KEY", value = var.classification_openai_api_key }]
+    : [{ name = "ANTHROPIC_API_KEY", value = local.classification_anthropic_api_key }]
+  )
+
   # Host the Cloudflare web Worker is served from: custom domain when configured,
   # otherwise its default workers.dev hostname.
   web_cloudflare_host = (local.web_custom_domain_enabled

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -222,6 +222,18 @@ linear_webhook_secret = ""   # Webhook Signing Secret from the application confi
 # From: https://console.anthropic.com/
 anthropic_api_key = ""
 
+# OpenAI credential for the Slack/Linear bot classifiers. Required when
+# classification_model names an OpenAI model AND at least one of the Slack or
+# Linear bots is enabled; an Anthropic classifier model is served by
+# anthropic_api_key above.
+# From: https://platform.openai.com/api-keys
+classification_openai_api_key = ""
+
+# Model backing the Slack/Linear bot classifiers. A "claude-"/"anthropic/" id is
+# served by anthropic_api_key; a "gpt-"/"openai/" id by
+# classification_openai_api_key.
+# classification_model = "claude-haiku-4-5"
+
 # =============================================================================
 # Security Secrets
 # =============================================================================

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -222,15 +222,14 @@ linear_webhook_secret = ""   # Webhook Signing Secret from the application confi
 # From: https://console.anthropic.com/
 anthropic_api_key = ""
 
-# Classifier credentials for the Slack/Linear bots. Only the provider that
-# classification_model selects is required; the other can stay blank.
-# A blank classification_anthropic_api_key falls back to anthropic_api_key.
+# OpenAI credential for the Slack/Linear bot classifiers. Required only when
+# classification_model names an OpenAI model; an Anthropic classifier model is
+# served by anthropic_api_key above.
 # From: https://platform.openai.com/api-keys
-classification_openai_api_key    = ""
-classification_anthropic_api_key = ""
+classification_openai_api_key = ""
 
 # Model backing the Slack/Linear bot classifiers. A "claude-"/"anthropic/" id is
-# served by classification_anthropic_api_key; a "gpt-"/"openai/" id by
+# served by anthropic_api_key; a "gpt-"/"openai/" id by
 # classification_openai_api_key.
 # classification_model = "claude-haiku-4-5"
 

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -222,6 +222,18 @@ linear_webhook_secret = ""   # Webhook Signing Secret from the application confi
 # From: https://console.anthropic.com/
 anthropic_api_key = ""
 
+# Classifier credentials for the Slack/Linear bots. Only the provider that
+# classification_model selects is required; the other can stay blank.
+# A blank classification_anthropic_api_key falls back to anthropic_api_key.
+# From: https://platform.openai.com/api-keys
+classification_openai_api_key    = ""
+classification_anthropic_api_key = ""
+
+# Model backing the Slack/Linear bot classifiers. A "claude-"/"anthropic/" id is
+# served by classification_anthropic_api_key; a "gpt-"/"openai/" id by
+# classification_openai_api_key.
+# classification_model = "claude-haiku-4-5"
+
 # =============================================================================
 # Security Secrets
 # =============================================================================

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -222,9 +222,10 @@ linear_webhook_secret = ""   # Webhook Signing Secret from the application confi
 # From: https://console.anthropic.com/
 anthropic_api_key = ""
 
-# OpenAI credential for the Slack/Linear bot classifiers. Required only when
-# classification_model names an OpenAI model; an Anthropic classifier model is
-# served by anthropic_api_key above.
+# OpenAI credential for the Slack/Linear bot classifiers. Required when
+# classification_model names an OpenAI model AND at least one of the Slack or
+# Linear bots is enabled; an Anthropic classifier model is served by
+# anthropic_api_key above.
 # From: https://platform.openai.com/api-keys
 classification_openai_api_key = ""
 

--- a/terraform/environments/production/tests/classifier_provider.tftest.hcl
+++ b/terraform/environments/production/tests/classifier_provider.tftest.hcl
@@ -1,0 +1,253 @@
+mock_provider "cloudflare" {}
+mock_provider "external" {
+  mock_data "external" {
+    defaults = {
+      result = {
+        hash = "test-source-hash"
+      }
+    }
+  }
+}
+mock_provider "local" {}
+mock_provider "null" {}
+mock_provider "random" {}
+mock_provider "vercel" {}
+
+variables {
+  cloudflare_api_token        = "test-cloudflare-token"
+  cloudflare_account_id       = "test-account"
+  cloudflare_worker_subdomain = "test-account"
+  github_app_id               = "1"
+  github_app_private_key      = "test-private-key"
+  github_app_installation_id  = "1"
+  anthropic_api_key           = "test-anthropic-key"
+  token_encryption_key        = "test-token-key"
+  repo_secrets_encryption_key = "test-repo-key"
+  nextauth_secret             = "test-browser-auth-secret-with-32-characters"
+  deployment_name             = "classifier-provider-test"
+
+  modal_token_id     = "test-modal-token-id"
+  modal_token_secret = "test-modal-token-secret"
+  modal_workspace    = "test-workspace"
+  modal_api_secret   = "test-modal-api-secret"
+
+  web_platform      = "cloudflare"
+  project_root      = "../../../"
+  enable_github_bot = false
+
+  # Both classifier-bearing bots are deployed so their bindings can be asserted.
+  enable_slack_bot     = true
+  slack_bot_token      = "xoxb-test"
+  slack_signing_secret = "test-signing-secret"
+
+  enable_linear_bot     = true
+  linear_client_id      = "test-linear-client-id"
+  linear_client_secret  = "test-linear-client-secret"
+  linear_webhook_secret = "test-linear-webhook-secret"
+  linear_api_key        = "test-linear-api-key"
+
+  github_client_id     = "github-id"
+  github_client_secret = "github-secret"
+  allowed_users        = "octocat"
+}
+
+# The default must stay identical to a pre-feature deployment: the Anthropic key
+# bound, and no OpenAI key binding introduced at all.
+run "anthropic_classifier_by_default" {
+  command = plan
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "The default classification model must resolve to Anthropic."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.slack_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An Anthropic-classifier deployment must bind only the Anthropic key on the Slack bot."
+  }
+
+  assert {
+    condition = (
+      contains(module.linear_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.linear_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An Anthropic-classifier deployment must bind only the Anthropic key on the Linear bot."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL") &&
+      contains(module.linear_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL")
+    )
+    error_message = "Both classifier bots must receive the configured classification model."
+  }
+
+  # Backwards compatibility: an Anthropic classifier reuses the deployment-wide
+  # key, so an existing deployment needs no new variable.
+  assert {
+    condition = (
+      one([for b in local.classifier_secret_bindings : b.value]) == var.anthropic_api_key
+    )
+    error_message = "An Anthropic classifier must bind the deployment-wide anthropic_api_key."
+  }
+}
+
+run "openai_classifier_binds_openai_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  assert {
+    condition     = local.classifier_uses_openai
+    error_message = "A bare gpt- classification model must resolve to OpenAI."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].secret_binding_names, "OPENAI_API_KEY") &&
+      contains(module.linear_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An OpenAI-classifier deployment must bind the OpenAI key on both classifier bots."
+  }
+
+  # Exactly one provider credential reaches the classifier bots.
+  assert {
+    condition = (
+      !contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.linear_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
+    )
+    error_message = "An OpenAI-classifier deployment must not bind an Anthropic key it never uses."
+  }
+}
+
+run "prefixed_openai_model_resolves_to_openai" {
+  command = plan
+
+  variables {
+    classification_model          = "openai/gpt-5.4-mini"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  assert {
+    condition     = local.classifier_uses_openai
+    error_message = "An openai/-prefixed classification model must resolve to OpenAI."
+  }
+}
+
+run "prefixed_anthropic_model_resolves_to_anthropic" {
+  command = plan
+
+  variables {
+    classification_model = "anthropic/claude-haiku-4-5"
+  }
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "An anthropic/-prefixed classification model must resolve to Anthropic."
+  }
+}
+
+# CI renders an unset secret as an empty string, so this must fail at plan time
+# rather than deploying a classifier with no usable credential.
+run "openai_classifier_requires_openai_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = ""
+  }
+
+  expect_failures = [var.classification_openai_api_key]
+}
+
+# No classifier is deployed, so an unused OpenAI credential must not be demanded.
+run "openai_model_without_bots_needs_no_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = ""
+    enable_slack_bot              = false
+    enable_linear_bot             = false
+  }
+
+  assert {
+    condition     = length(module.slack_bot_worker) == 0 && length(module.linear_bot_worker) == 0
+    error_message = "Neither classifier bot should be deployed in this configuration."
+  }
+}
+
+run "rejects_unknown_classifier_provider" {
+  command = plan
+
+  variables {
+    classification_model = "llama-3-70b"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+# An unset CI variable renders as an empty string. The workflow supplies an
+# explicit fallback, and this asserts the configuration also refuses to treat a
+# blank override as "use the default" — it fails loudly instead.
+run "rejects_blank_classification_model" {
+  command = plan
+
+  variables {
+    classification_model = ""
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+# A prefix with no model id after it satisfies startswith but names nothing —
+# the bots' resolver would accept it and send it to the provider verbatim.
+run "rejects_a_bare_provider_prefix" {
+  command = plan
+
+  variables {
+    classification_model = "claude-"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "rejects_a_bare_openai_namespace" {
+  command = plan
+
+  variables {
+    classification_model          = "openai/"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "rejects_whitespace_after_a_prefix" {
+  command = plan
+
+  variables {
+    classification_model = "anthropic/   "
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "accepts_a_prefixed_model_with_one_character" {
+  command = plan
+
+  variables {
+    classification_model = "claude-x"
+  }
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "A minimal claude- id must still resolve to Anthropic."
+  }
+}

--- a/terraform/environments/production/tests/classifier_provider.tftest.hcl
+++ b/terraform/environments/production/tests/classifier_provider.tftest.hcl
@@ -84,6 +84,15 @@ run "anthropic_classifier_by_default" {
     )
     error_message = "Both classifier bots must receive the configured classification model."
   }
+
+  # Backwards compatibility: an Anthropic classifier reuses the deployment-wide
+  # key, so an existing deployment needs no new variable.
+  assert {
+    condition = (
+      one([for b in local.classifier_secret_bindings : b.value]) == var.anthropic_api_key
+    )
+    error_message = "An Anthropic classifier must bind the deployment-wide anthropic_api_key."
+  }
 }
 
 run "openai_classifier_binds_openai_key" {

--- a/terraform/environments/production/tests/classifier_provider.tftest.hcl
+++ b/terraform/environments/production/tests/classifier_provider.tftest.hcl
@@ -1,0 +1,198 @@
+mock_provider "cloudflare" {}
+mock_provider "external" {
+  mock_data "external" {
+    defaults = {
+      result = {
+        hash = "test-source-hash"
+      }
+    }
+  }
+}
+mock_provider "local" {}
+mock_provider "null" {}
+mock_provider "random" {}
+mock_provider "vercel" {}
+
+variables {
+  cloudflare_api_token        = "test-cloudflare-token"
+  cloudflare_account_id       = "test-account"
+  cloudflare_worker_subdomain = "test-account"
+  github_app_id               = "1"
+  github_app_private_key      = "test-private-key"
+  github_app_installation_id  = "1"
+  anthropic_api_key           = "test-anthropic-key"
+  token_encryption_key        = "test-token-key"
+  repo_secrets_encryption_key = "test-repo-key"
+  nextauth_secret             = "test-browser-auth-secret-with-32-characters"
+  deployment_name             = "classifier-provider-test"
+
+  modal_token_id     = "test-modal-token-id"
+  modal_token_secret = "test-modal-token-secret"
+  modal_workspace    = "test-workspace"
+  modal_api_secret   = "test-modal-api-secret"
+
+  web_platform      = "cloudflare"
+  project_root      = "../../../"
+  enable_github_bot = false
+
+  # Both classifier-bearing bots are deployed so their bindings can be asserted.
+  enable_slack_bot     = true
+  slack_bot_token      = "xoxb-test"
+  slack_signing_secret = "test-signing-secret"
+
+  enable_linear_bot     = true
+  linear_client_id      = "test-linear-client-id"
+  linear_client_secret  = "test-linear-client-secret"
+  linear_webhook_secret = "test-linear-webhook-secret"
+  linear_api_key        = "test-linear-api-key"
+
+  github_client_id     = "github-id"
+  github_client_secret = "github-secret"
+  allowed_users        = "octocat"
+}
+
+# The default must stay identical to a pre-feature deployment: the Anthropic key
+# bound, and no OpenAI key binding introduced at all.
+run "anthropic_classifier_by_default" {
+  command = plan
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "The default classification model must resolve to Anthropic."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.slack_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An Anthropic-classifier deployment must bind only the Anthropic key on the Slack bot."
+  }
+
+  assert {
+    condition = (
+      contains(module.linear_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.linear_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An Anthropic-classifier deployment must bind only the Anthropic key on the Linear bot."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL") &&
+      contains(module.linear_bot_worker[0].plain_text_binding_names, "CLASSIFICATION_MODEL")
+    )
+    error_message = "Both classifier bots must receive the configured classification model."
+  }
+}
+
+run "openai_classifier_binds_openai_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  assert {
+    condition     = local.classifier_uses_openai
+    error_message = "A bare gpt- classification model must resolve to OpenAI."
+  }
+
+  assert {
+    condition = (
+      contains(module.slack_bot_worker[0].secret_binding_names, "OPENAI_API_KEY") &&
+      contains(module.linear_bot_worker[0].secret_binding_names, "OPENAI_API_KEY")
+    )
+    error_message = "An OpenAI-classifier deployment must bind the OpenAI key on both classifier bots."
+  }
+
+  # Exactly one provider credential reaches the classifier bots.
+  assert {
+    condition = (
+      !contains(module.slack_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY") &&
+      !contains(module.linear_bot_worker[0].secret_binding_names, "ANTHROPIC_API_KEY")
+    )
+    error_message = "An OpenAI-classifier deployment must not bind an Anthropic key it never uses."
+  }
+}
+
+run "prefixed_openai_model_resolves_to_openai" {
+  command = plan
+
+  variables {
+    classification_model          = "openai/gpt-5.4-mini"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  assert {
+    condition     = local.classifier_uses_openai
+    error_message = "An openai/-prefixed classification model must resolve to OpenAI."
+  }
+}
+
+run "prefixed_anthropic_model_resolves_to_anthropic" {
+  command = plan
+
+  variables {
+    classification_model = "anthropic/claude-haiku-4-5"
+  }
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "An anthropic/-prefixed classification model must resolve to Anthropic."
+  }
+}
+
+# CI renders an unset secret as an empty string, so this must fail at plan time
+# rather than deploying a classifier with no usable credential.
+run "openai_classifier_requires_openai_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = ""
+  }
+
+  expect_failures = [var.classification_openai_api_key]
+}
+
+# No classifier is deployed, so an unused OpenAI credential must not be demanded.
+run "openai_model_without_bots_needs_no_key" {
+  command = plan
+
+  variables {
+    classification_model          = "gpt-5.4-mini"
+    classification_openai_api_key = ""
+    enable_slack_bot              = false
+    enable_linear_bot             = false
+  }
+
+  assert {
+    condition     = length(module.slack_bot_worker) == 0 && length(module.linear_bot_worker) == 0
+    error_message = "Neither classifier bot should be deployed in this configuration."
+  }
+}
+
+run "rejects_unknown_classifier_provider" {
+  command = plan
+
+  variables {
+    classification_model = "llama-3-70b"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+# An unset CI variable renders as an empty string. The workflow supplies an
+# explicit fallback, and this asserts the configuration also refuses to treat a
+# blank override as "use the default" — it fails loudly instead.
+run "rejects_blank_classification_model" {
+  command = plan
+
+  variables {
+    classification_model = ""
+  }
+
+  expect_failures = [var.classification_model]
+}

--- a/terraform/environments/production/tests/classifier_provider.tftest.hcl
+++ b/terraform/environments/production/tests/classifier_provider.tftest.hcl
@@ -205,3 +205,49 @@ run "rejects_blank_classification_model" {
 
   expect_failures = [var.classification_model]
 }
+
+# A prefix with no model id after it satisfies startswith but names nothing —
+# the bots' resolver would accept it and send it to the provider verbatim.
+run "rejects_a_bare_provider_prefix" {
+  command = plan
+
+  variables {
+    classification_model = "claude-"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "rejects_a_bare_openai_namespace" {
+  command = plan
+
+  variables {
+    classification_model          = "openai/"
+    classification_openai_api_key = "test-openai-key"
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "rejects_whitespace_after_a_prefix" {
+  command = plan
+
+  variables {
+    classification_model = "anthropic/   "
+  }
+
+  expect_failures = [var.classification_model]
+}
+
+run "accepts_a_prefixed_model_with_one_character" {
+  command = plan
+
+  variables {
+    classification_model = "claude-x"
+  }
+
+  assert {
+    condition     = !local.classifier_uses_openai
+    error_message = "A minimal claude- id must still resolve to Anthropic."
+  }
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -303,6 +303,45 @@ variable "anthropic_api_key" {
   }
 }
 
+variable "classification_model" {
+  description = "Model backing the Slack and Linear bots' target classifiers. An \"anthropic/\"-prefixed or bare \"claude-\" id is served by anthropic_api_key; an \"openai/\"-prefixed or bare \"gpt-\" id is served by classification_openai_api_key."
+  type        = string
+  default     = "claude-haiku-4-5"
+  nullable    = false
+
+  # Each prefix must be followed by an actual model id: a bare "claude-" or
+  # "openai/" satisfies startswith but names no model, and would reach the bots
+  # as a value their resolver accepts and then sends to the provider verbatim.
+  validation {
+    condition = anytrue([
+      for prefix in ["anthropic/", "claude-", "openai/", "gpt-"] :
+      startswith(var.classification_model, prefix) &&
+      trimspace(substr(var.classification_model, length(prefix), -1)) != ""
+    ])
+    error_message = "classification_model must be an Anthropic id (\"anthropic/...\" or \"claude-...\") or an OpenAI id (\"openai/...\" or \"gpt-...\"), naming a model after the prefix."
+  }
+}
+
+variable "classification_openai_api_key" {
+  description = "OpenAI API key used specifically by the Slack and Linear bot classifiers. Required when classification_model is an OpenAI model and the Slack or Linear bot is enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+  nullable    = false
+
+  # Fail closed once a deployed classifier is pointed at OpenAI: CI renders an
+  # unset secret as an empty string, which would otherwise deploy a
+  # credential-less classifier that rejects every message.
+  validation {
+    condition = (
+      (var.enable_slack_bot == false && var.enable_linear_bot == false) ||
+      !(startswith(var.classification_model, "openai/") || startswith(var.classification_model, "gpt-")) ||
+      trimspace(var.classification_openai_api_key) != ""
+    )
+    error_message = "classification_openai_api_key must be non-blank when the Slack or Linear bot is enabled and classification_model is an OpenAI model."
+  }
+}
+
 # =============================================================================
 # Security Secrets
 # =============================================================================

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -307,23 +307,27 @@ variable "classification_model" {
   description = "Model backing the Slack and Linear bots' target classifiers. An \"anthropic/\"-prefixed or bare \"claude-\" id is served by anthropic_api_key; an \"openai/\"-prefixed or bare \"gpt-\" id is served by classification_openai_api_key."
   type        = string
   default     = "claude-haiku-4-5"
+  nullable    = false
 
+  # Each prefix must be followed by an actual model id: a bare "claude-" or
+  # "openai/" satisfies startswith but names no model, and would reach the bots
+  # as a value their resolver accepts and then sends to the provider verbatim.
   validation {
-    condition = (
-      startswith(var.classification_model, "anthropic/") ||
-      startswith(var.classification_model, "claude-") ||
-      startswith(var.classification_model, "openai/") ||
-      startswith(var.classification_model, "gpt-")
-    )
-    error_message = "classification_model must be an Anthropic id (\"anthropic/...\" or \"claude-...\") or an OpenAI id (\"openai/...\" or \"gpt-...\")."
+    condition = anytrue([
+      for prefix in ["anthropic/", "claude-", "openai/", "gpt-"] :
+      startswith(var.classification_model, prefix) &&
+      trimspace(substr(var.classification_model, length(prefix), -1)) != ""
+    ])
+    error_message = "classification_model must be an Anthropic id (\"anthropic/...\" or \"claude-...\") or an OpenAI id (\"openai/...\" or \"gpt-...\"), naming a model after the prefix."
   }
 }
 
 variable "classification_openai_api_key" {
-  description = "OpenAI API key used specifically by the Slack and Linear bot classifiers. Required when classification_model is an OpenAI model and a classifier bot is enabled."
+  description = "OpenAI API key used specifically by the Slack and Linear bot classifiers. Required when classification_model is an OpenAI model and the Slack or Linear bot is enabled."
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 
   # Fail closed once a deployed classifier is pointed at OpenAI: CI renders an
   # unset secret as an empty string, which would otherwise deploy a

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -304,7 +304,7 @@ variable "anthropic_api_key" {
 }
 
 variable "classification_model" {
-  description = "Model backing the Slack and Linear bots' target classifiers. An \"anthropic/\"-prefixed or bare \"claude-\" id is served by classification_anthropic_api_key; an \"openai/\"-prefixed or bare \"gpt-\" id is served by classification_openai_api_key."
+  description = "Model backing the Slack and Linear bots' target classifiers. An \"anthropic/\"-prefixed or bare \"claude-\" id is served by anthropic_api_key; an \"openai/\"-prefixed or bare \"gpt-\" id is served by classification_openai_api_key."
   type        = string
   default     = "claude-haiku-4-5"
 
@@ -316,24 +316,6 @@ variable "classification_model" {
       startswith(var.classification_model, "gpt-")
     )
     error_message = "classification_model must be an Anthropic id (\"anthropic/...\" or \"claude-...\") or an OpenAI id (\"openai/...\" or \"gpt-...\")."
-  }
-}
-
-variable "classification_anthropic_api_key" {
-  description = "Anthropic API key used specifically by the Slack and Linear bot classifiers. Defaults to anthropic_api_key when blank, so existing deployments need no new value."
-  type        = string
-  sensitive   = true
-  default     = ""
-
-  validation {
-    condition = (
-      (var.enable_slack_bot == false && var.enable_linear_bot == false) ||
-      startswith(var.classification_model, "openai/") ||
-      startswith(var.classification_model, "gpt-") ||
-      trimspace(var.classification_anthropic_api_key) != "" ||
-      trimspace(var.anthropic_api_key) != ""
-    )
-    error_message = "An Anthropic classification_model needs a key: set classification_anthropic_api_key, or rely on anthropic_api_key."
   }
 }
 

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -303,6 +303,59 @@ variable "anthropic_api_key" {
   }
 }
 
+variable "classification_model" {
+  description = "Model backing the Slack and Linear bots' target classifiers. An \"anthropic/\"-prefixed or bare \"claude-\" id is served by classification_anthropic_api_key; an \"openai/\"-prefixed or bare \"gpt-\" id is served by classification_openai_api_key."
+  type        = string
+  default     = "claude-haiku-4-5"
+
+  validation {
+    condition = (
+      startswith(var.classification_model, "anthropic/") ||
+      startswith(var.classification_model, "claude-") ||
+      startswith(var.classification_model, "openai/") ||
+      startswith(var.classification_model, "gpt-")
+    )
+    error_message = "classification_model must be an Anthropic id (\"anthropic/...\" or \"claude-...\") or an OpenAI id (\"openai/...\" or \"gpt-...\")."
+  }
+}
+
+variable "classification_anthropic_api_key" {
+  description = "Anthropic API key used specifically by the Slack and Linear bot classifiers. Defaults to anthropic_api_key when blank, so existing deployments need no new value."
+  type        = string
+  sensitive   = true
+  default     = ""
+
+  validation {
+    condition = (
+      (var.enable_slack_bot == false && var.enable_linear_bot == false) ||
+      startswith(var.classification_model, "openai/") ||
+      startswith(var.classification_model, "gpt-") ||
+      trimspace(var.classification_anthropic_api_key) != "" ||
+      trimspace(var.anthropic_api_key) != ""
+    )
+    error_message = "An Anthropic classification_model needs a key: set classification_anthropic_api_key, or rely on anthropic_api_key."
+  }
+}
+
+variable "classification_openai_api_key" {
+  description = "OpenAI API key used specifically by the Slack and Linear bot classifiers. Required when classification_model is an OpenAI model and a classifier bot is enabled."
+  type        = string
+  sensitive   = true
+  default     = ""
+
+  # Fail closed once a deployed classifier is pointed at OpenAI: CI renders an
+  # unset secret as an empty string, which would otherwise deploy a
+  # credential-less classifier that rejects every message.
+  validation {
+    condition = (
+      (var.enable_slack_bot == false && var.enable_linear_bot == false) ||
+      !(startswith(var.classification_model, "openai/") || startswith(var.classification_model, "gpt-")) ||
+      trimspace(var.classification_openai_api_key) != ""
+    )
+    error_message = "classification_openai_api_key must be non-blank when the Slack or Linear bot is enabled and classification_model is an OpenAI model."
+  }
+}
+
 # =============================================================================
 # Security Secrets
 # =============================================================================

--- a/terraform/environments/production/workers-linear.tf
+++ b/terraform/environments/production/workers-linear.tf
@@ -47,17 +47,20 @@ module "linear_bot_worker" {
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "claude-sonnet-4-6" },
+    { name = "CLASSIFICATION_MODEL", value = var.classification_model },
     { name = "LINEAR_CLIENT_ID", value = var.linear_client_id },
     { name = "WORKER_URL", value = "https://open-inspect-linear-bot-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev" },
   ]
 
-  secrets = [
-    { name = "LINEAR_WEBHOOK_SECRET", value = var.linear_webhook_secret },
-    { name = "LINEAR_CLIENT_SECRET", value = var.linear_client_secret },
-    { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_linear_bot.result },
-    { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
-    { name = "LINEAR_API_KEY", value = var.linear_api_key },
-  ]
+  secrets = concat(
+    [
+      { name = "LINEAR_WEBHOOK_SECRET", value = var.linear_webhook_secret },
+      { name = "LINEAR_CLIENT_SECRET", value = var.linear_client_secret },
+      { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_linear_bot.result },
+      { name = "LINEAR_API_KEY", value = var.linear_api_key },
+    ],
+    local.classifier_secret_bindings
+  )
 
   compatibility_date  = "2024-09-23"
   compatibility_flags = ["nodejs_compat"]

--- a/terraform/environments/production/workers-slack.tf
+++ b/terraform/environments/production/workers-slack.tf
@@ -70,18 +70,20 @@ module "slack_bot_worker" {
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "claude-haiku-4-5" },
-    { name = "CLASSIFICATION_MODEL", value = "claude-haiku-4-5" },
+    { name = "CLASSIFICATION_MODEL", value = var.classification_model },
     # Kill switch for Slack channel-message triggers; the bot only ingests/
     # forwards channel messages when this is exactly "true" (dark by default).
     { name = "SLACK_TRIGGERS_ENABLED", value = var.slack_triggers_enabled ? "true" : "false" },
   ]
 
-  secrets = [
-    { name = "SLACK_BOT_TOKEN", value = var.slack_bot_token },
-    { name = "SLACK_SIGNING_SECRET", value = var.slack_signing_secret },
-    { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
-    { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_slack_bot.result },
-  ]
+  secrets = concat(
+    [
+      { name = "SLACK_BOT_TOKEN", value = var.slack_bot_token },
+      { name = "SLACK_SIGNING_SECRET", value = var.slack_signing_secret },
+      { name = "SERVICE_AUTH_SECRET", value = random_password.service_auth_secret_slack_bot.result },
+    ],
+    local.classifier_secret_bindings
+  )
 
   compatibility_date  = "2024-09-23"
   compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Problem

The Slack and Linear bots classify each inbound message to decide which repository or environment a coding session should target. Both classifiers are pinned to Anthropic:

- `packages/slack-bot/src/classifier/index.ts` builds an Anthropic client and forces a `classify_target` tool call.
- `packages/linear-bot/src/classifier/index.ts` calls `api.anthropic.com/v1/messages` directly and **hardcodes** `claude-haiku-4-5` with no env override at all.

Two consequences:

1. **Single-provider coupling.** An Anthropic outage, rate limit, or billing lapse degrades routing on every deployment, with no way to point the classifier elsewhere — even for deployments whose coding agents already run OpenAI models. We hit exactly this: an Anthropic billing lapse dropped both bots to "pick a target yourself" until it was noticed.
2. **Unbounded requests.** Neither classifier passes an abort signal, so a stalled or queued provider request holds the Slack thread / Linear webhook open until the platform kills the invocation. The classifiers already fail soft to a target picker, so a *fast* failure is cheap — it was the unbounded wait that hurt.

## What this does

Lets an operator pick the classifier's provider, requires **only that provider's** credential, and binds exactly one provider key to the bots.

| `classification_model` | Provider | Credential required |
|---|---|---|
| `anthropic/<x>` or bare `claude-*` (default) | Anthropic, existing tool-calling request | `classification_anthropic_api_key`, falling back to `anthropic_api_key` |
| `openai/<x>` or bare `gpt-*` | OpenAI Chat Completions, strict `json_schema` | `classification_openai_api_key` |

The prefix rule reuses the convention already encoded in `normalizeModelId`/`MODEL_CATALOG` in `packages/shared/src/models.ts`, so there is no second setting that can disagree with the model id. The bare id is sent to the provider. An unrecognised prefix throws into each classifier's existing `catch`, which already degrades to asking the user to pick — no new failure mode.

Both providers funnel through the existing validators (`normalizeModelResponse` in slack-bot, `classifyToolInputSchema` in linear-bot), so the downstream contract is untouched.

`CLASSIFICATION_REQUEST_TIMEOUT_MS = 15_000` now bounds **both** providers, following the existing convention (`REPOS_FETCH_TIMEOUT_MS`, `OUTBOUND_REQUEST_TIMEOUT_MS`): milliseconds in the name, defined once, and asserted in tests by identity of the signal object rather than just its shape.

### Scope of the credential choice — please read

This is deliberately **classifier-scoped**, not a deployment-wide provider switch. `anthropic_api_key` is left exactly as it is on `main` (`nullable = false`, non-blank validation) because it has consumers unrelated to classification: the Modal sandbox's `llm-api-keys` secret (`modal.tf`) that Claude coding sessions use, and the opencomputer control-plane path. The diff to `variables.tf` is purely additive — it does not touch that variable.

So: choosing the OpenAI classifier means you supply `classification_openai_api_key` and the bots receive **only** that key. It does not make the deployment OpenAI-only, and this PR makes no claim to. Making sandbox provider credentials uniformly optional is a separate, larger change tied to the default coding model, and I have not attempted it here.

## Backward compatibility

**Nothing changes for an existing deployment that sets no new value.**

- `classification_model` defaults to `claude-haiku-4-5` — today's value.
- `classification_anthropic_api_key` defaults to blank and falls back to `anthropic_api_key`, so existing deployments keep working untouched.
- The Anthropic request body is unchanged; the timeout is passed as `messages.create(body, { signal })`, so the body itself is untouched.
- `ANTHROPIC_API_KEY` stays required, the `@anthropic-ai/sdk` dependency stays, `CLASSIFY_TARGET_TOOL` stays.
- No Claude entries removed anywhere — `packages/linear-bot/src/model-resolution.ts` (`MODEL_LABEL_MAP`) is untouched, so `model:opus`-style Linear labels keep working.
- Anthropic-classifier deployments keep exactly the bot secret bindings they had; no empty secret is introduced and no worker version churns from this change.
- The Anthropic SDK client is now constructed lazily, so an OpenAI-configured deployment never reaches `new Anthropic({ apiKey: undefined })`.

The Linear bot gains a `CLASSIFICATION_MODEL` binding it never had; its default makes the previously hardcoded `claude-haiku-4-5` explicit, so the effective model is unchanged.

## Configuration

```hcl
# Default — Anthropic, using the key you already supply
# classification_model = "claude-haiku-4-5"

# Or classify on OpenAI; the bots then receive only this key
classification_model          = "gpt-5.4-mini"
classification_openai_api_key = "sk-proj-..."
```

Each provider's key is validated non-blank **when that provider is selected and a classifier bot is enabled** — so an OpenAI deployment is never asked for an Anthropic classifier key, a deployment running neither bot is never asked for either, and a selected provider can't ship credential-less. That last guard matters because GitHub Actions renders an unset secret as an empty string, which would otherwise plan and apply cleanly and leave a classifier rejecting every message. For the same reason the workflow maps the model with an explicit fallback (`${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}`, matching the existing `ENABLE_SLACK_BOT || 'true'` pattern), and the configuration additionally refuses a blank override rather than silently treating it as "use the default".

## Verification

Terraform (`terraform test`, mock providers) — **18 passed, 0 failed**, including a new `tests/classifier_provider.tftest.hcl` whose 8 runs cover every branch:

- Anthropic default binds `ANTHROPIC_API_KEY` and **no** `OPENAI_API_KEY` on both bots (the backward-compatibility guarantee, asserted rather than assumed)
- OpenAI model binds `OPENAI_API_KEY` and **no** `ANTHROPIC_API_KEY` — exactly one provider credential reaches the bots, asserted in both polarities
- `gpt-5.4-mini` and `openai/gpt-5.4-mini` both resolve to OpenAI; `anthropic/claude-haiku-4-5` resolves to Anthropic
- OpenAI model with a blank key → plan **fails**
- OpenAI model with both bots disabled and a blank key → plan **succeeds**
- unknown provider prefix → plan **fails**; blank model → plan **fails**

The pre-existing `anthropic_api_key_blank` guard in `tests/auth_provider_configuration.tftest.hcl` still passes unchanged. `terraform fmt -check -recursive` clean; `terraform validate` success.

TypeScript: `npm run typecheck` exit 0; `eslint --max-warnings 0` clean on both changed packages.

Unit suites (clean upstream-main baseline → this branch): slack-bot 421 → **425**, linear-bot 223 → **230**; unchanged elsewhere: shared **601**, github-bot **130**, control-plane **2518**, web **956**. Control-plane integration (workerd + real D1): **778 passed**.

New tests per bot cover: the OpenAI request contract (`max_completion_tokens` present, `max_tokens` absent, `temperature: 0`, `strict: true`, bare model id, `additionalProperties: false`, all fields `required`, nullable id typed `["string","null"]`), non-2xx degrading to the picker, the timeout signal being the exact `AbortSignal.timeout` object, the Anthropic default path still firing when nothing is set, and an unrecognised prefix degrading without calling either provider.

## Notes for reviewers

- **`max_completion_tokens` is required and `max_tokens` is rejected** by the gpt-5 family (`Unsupported parameter: 'max_tokens' is not supported with this model`) — verified against the live API, and pinned by a test in each bot so it cannot regress silently.
- Each bot implements its own small OpenAI request function rather than sharing one: two call sites with different schemas, and it keeps each Worker self-contained. Happy to extract into `packages/shared` if you would prefer that.
- The provider is derived from the model id rather than a separate `CLASSIFICATION_PROVIDER` variable, to avoid a setting that can disagree with the model. If you would rather support OpenAI-compatible gateways (Azure, OpenRouter, proxies) whose ids are not `gpt-*`, an explicit provider override is the natural follow-up — happy to add it here or later.
- `classification_anthropic_api_key` exists mainly so the two providers are symmetric and the classifier's credential is separable from the sandbox's. If you would rather the Anthropic classifier just always read `anthropic_api_key` and drop that variable, that is a one-line simplification — say which you prefer.
- The `docs/GETTING_STARTED.md` diff looks larger than it is: adding `CLASSIFICATION_ANTHROPIC_API_KEY` widened the Actions-secret table's first column, so Prettier (which your `lint-staged` runs on Markdown) realigned every row. `git diff -w` on that file shows only the six sample lines, the two new table rows, and the widened separator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable classification model selection for Slack and Linear bots.
  * Added OpenAI and Anthropic classification support with provider-specific credentials.
  * Added structured response validation and 15-second request timeouts.
  * Added graceful handling for unsupported models, provider errors, and missing credentials.

* **Documentation**
  * Updated setup and deployment guidance for models and API keys.

* **Tests**
  * Expanded coverage for provider selection, validation, timeouts, credentials, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->