### PR TITLE
fix: exclude github-bot sessions from the Mine session filter

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import { SessionIndexStore } from "./session-index";
 import type { SessionEntry } from "./session-index";
 
@@ -12,7 +13,7 @@ type SessionRow = {
   base_branch: string | null;
   status: string;
   parent_session_id: string | null;
-  spawn_source: "user" | "agent" | "automation";
+  spawn_source: SpawnSource;
   spawn_depth: number;
   automation_id: string | null;
   automation_run_id: string | null;
@@ -388,7 +389,10 @@ class FakeD1Database {
 
       if (conditions.includes("automation_id IS NULL")) {
         rows = rows.filter(
-          (row) => row.automation_id === null && row.spawn_source !== "automation"
+          (row) =>
+            row.automation_id === null &&
+            row.spawn_source !== "automation" &&
+            row.spawn_source !== "github-bot"
         );
       }
 
@@ -664,6 +668,36 @@ describe("SessionIndexStore", () => {
 
       expect(result.sessions.map((session) => session.id)).toEqual(["manual-new", "manual-old"]);
       expect(result.hasMore).toBe(false);
+    });
+
+    it("excludes github-bot sessions from lineage-filtered lists even when created by the user", async () => {
+      await store.create(
+        makeSession({ id: "web", spawnSource: "user", userId: "alice", updatedAt: 4000 })
+      );
+      await store.create(
+        makeSession({
+          id: "auto-review",
+          spawnSource: "github-bot",
+          userId: "alice",
+          updatedAt: 3000,
+        })
+      );
+      await store.create(
+        makeSession({ id: "slack", spawnSource: "slack-bot", userId: "alice", updatedAt: 2000 })
+      );
+
+      const filtered = await store.list({
+        excludeAutomationLineage: true,
+        createdByUserIds: ["alice"],
+      });
+      expect(filtered.sessions.map((session) => session.id)).toEqual(["web", "slack"]);
+
+      const unfiltered = await store.list({ createdByUserIds: ["alice"] });
+      expect(unfiltered.sessions.map((session) => session.id)).toEqual([
+        "web",
+        "auto-review",
+        "slack",
+      ]);
     });
 
     it("trims and lowercases repo filters", async () => {

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -353,7 +353,11 @@ export class SessionIndexStore {
     }
 
     if (excludeAutomationLineage) {
-      conditions.push("automation_id IS NULL AND spawn_source != 'automation'");
+      // The "Mine" view excludes sessions no human initiated in the app.
+      // github-bot sessions are attributed to the webhook sender (the verified
+      // actor), but auto reviews and review-request handling are bot-initiated,
+      // so they are lineage-excluded alongside automation runs.
+      conditions.push("automation_id IS NULL AND spawn_source NOT IN ('automation', 'github-bot')");
     }
 
     // Repo filters match against the membership table so a session is found

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -755,4 +755,45 @@ describe("D1 SessionIndexStore", () => {
 
     expect(result.sessions.map((session) => session.id)).toEqual(["manual-session"]);
   });
+
+  it("excludes github-bot sessions attributed to the user from lineage-filtered lists", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+    const baseSession = {
+      title: null,
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: "main",
+      status: "completed" as const,
+      userId: "user-1",
+      createdAt: now,
+    };
+
+    await store.create({
+      ...baseSession,
+      id: "auto-review",
+      spawnSource: "github-bot",
+      updatedAt: now,
+    });
+    await store.create({
+      ...baseSession,
+      id: "manual-session",
+      spawnSource: "user",
+      updatedAt: now - 1,
+    });
+
+    const filtered = await store.list({
+      createdByUserIds: ["user-1"],
+      excludeAutomationLineage: true,
+    });
+    expect(filtered.sessions.map((session) => session.id)).toEqual(["manual-session"]);
+
+    const unfiltered = await store.list({ createdByUserIds: ["user-1"] });
+    expect(unfiltered.sessions.map((session) => session.id)).toEqual([
+      "auto-review",
+      "manual-session",
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

The sidebar **Mine** tab shows sessions created by the GitHub bot's automated PR reviews (auto-review-on-open and review-requested). These are bot-initiated, but they satisfy both Mine conditions:

- The github-bot asserts the webhook sender as the verified actor (`actor: github:<sender.id>`), and for auto reviews the sender is the PR author — so the session's `user_id` resolves to the same canonical user as the author's web login.
- The lineage exclusion only filtered `spawn_source = 'automation'` (and `automation_id`), so `spawn_source = 'github-bot'` rows passed straight through.

The result is a Mine tab polluted with automated review sessions the user never started.

## Fix

Broaden the lineage exclusion in `SessionIndexStore.list()`:

```sql
automation_id IS NULL AND spawn_source NOT IN ('automation', 'github-bot')
```

`excludeAutomationLineage` has exactly one production caller — the sidebar Mine filter — so this changes only the Mine tab. "All" still shows every session. No web, schema, bot, or migration changes; the fix applies to historical rows immediately.

**Semantics:** Mine = sessions a human initiated in the app (plus their agent children). Deliberate `@mention` sessions also leave Mine — the sessions table can't distinguish them from auto reviews (all four github-bot triggers write identical rows), and their interaction surface is the PR thread; they remain under "All". Slack/Linear bot sessions are unaffected (always human-initiated).

Deliberately **not** re-attributing automated reviews to a bot user: `user_id` drives SCM enrichment (which credentials review sandboxes run under), and sender attribution is a deliberate identity-enforcement invariant.

## Testing

- Unit: new case in `session-index.test.ts` (github-bot rows excluded under the flag, included without it; slack-bot rows unaffected) — fake D1 lineage emulation updated to mirror the new SQL. 45/45 pass; full control-plane unit suite 2519/2519.
- Integration (workerd + real D1): new case in `d1-session-index.test.ts`. 32/32 pass.
- `npm run typecheck -w @open-inspect/control-plane` clean; prettier + eslint clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation-lineage filtering to exclude sessions created by automation and GitHub bots.
  * Preserved sessions created by other user-associated bots and unfiltered session results.

* **Tests**
  * Added coverage confirming the updated filtering behavior in unit and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->