### PR TITLE
chore: configure Knip runtime entries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -31,9 +31,31 @@
     "packages/opencomputer-infra": {
       "project": ["src/**/*.ts"]
     },
+    "packages/sandbox-runtime": {
+      "entry": [
+        "src/sandbox_runtime/bin/upload-media.js",
+        "src/sandbox_runtime/plugins/codex-auth-plugin.js",
+        "src/sandbox_runtime/plugins/inspect-plugin.js",
+        "src/sandbox_runtime/plugins/xai-auth-plugin.js",
+        "src/sandbox_runtime/tools/cancel-child.js",
+        "src/sandbox_runtime/tools/get-child-status.js",
+        "src/sandbox_runtime/tools/send-child-prompt.js",
+        "src/sandbox_runtime/tools/slack-notify.js",
+        "src/sandbox_runtime/tools/spawn-child.js",
+        "src/sandbox_runtime/ttyd_proxy/server.ts"
+      ]
+    },
     "packages/web": {
       "next": true,
-      "entry": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+      "entry": [
+        "open-next.config.ts",
+        "public/hljs-themes/atom-one-dark.css",
+        "public/hljs-themes/atom-one-light.css",
+        "public/hljs-themes/github-dark.css",
+        "public/hljs-themes/github.css",
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx"
+      ],
       "project": ["src/**/*.{ts,tsx,css}"]
     }
   }


### PR DESCRIPTION
## Summary

- register sandbox runtime JavaScript/TypeScript files that Python or OpenCode copies, discovers, or executes dynamically as Knip entries
- register the OpenNext config and dynamically URL-referenced highlight theme CSS files as web entries
- preserve existing root entries and Knip/plugin defaults without broad ignore patterns
- leave the four unreferenced control-plane barrel files visible for later dead-code cleanup

## Rationale

These files are runtime or convention entry points, but static import analysis cannot discover their consumers. Explicit workspace-scoped `entry` declarations remove only those known unused-file false positives while keeping unused exports, types, dependencies, binaries, duplicates, unresolved imports, and genuinely dead files reportable.

The sandbox runtime is added as a Knip-only workspace because it is a Python package and is not listed in the root npm workspaces. No broad `project` override is added there. The web workspace keeps its existing `project` scope; CSS assets are listed as explicit entries because they are selected dynamically by public URL.

## Validation

- `npx --yes knip@6.32.2 --config /tmp/opencode/knip-zero.json --include files --reporter json --no-exit-code`
  - confirmed all 18 known false positives in the zero-config baseline
- `npm run knip -- --include files --reporter json --no-exit-code`
  - confirmed all 18 known false positives are removed
  - retained `packages/control-plane/src/realtime/index.ts`
  - retained `packages/control-plane/src/scheduler/index.ts`
  - retained `packages/control-plane/src/session/index.ts`
  - retained `packages/control-plane/src/sandbox/index.ts`
  - also retained two unrelated manually invoked build scripts outside this PR's requested scope
- `npm run knip -- --reporter json --no-exit-code`
  - confirmed existing export/type findings remain reportable
- `npx knip --config knip.json --include files --reporter compact --treat-config-hints-as-errors --no-exit-code`
- `npx prettier --check knip.json`
- `git diff --check`


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/af3773f6c57249bae2617849e5ae6c68)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a sandbox runtime workspace.
  * Updated web application entry-point coverage to include deployment configuration and syntax-highlighting styles.
  * Retained existing test entry points for project analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->