### PR TITLE
refactor: trim unused exports

### DIFF
--- a/packages/control-plane/src/auth/authenticate.ts
+++ b/packages/control-plane/src/auth/authenticate.ts
@@ -20,7 +20,7 @@ import type { Env } from "../types";
 
 const logger = createLogger("auth");
 
-export { isAuthError, type AuthError, type AuthResult } from "./result";
+export { isAuthError, type AuthResult } from "./result";
 export { SERVICE_REQUEST_MAX_BODY_BYTES } from "./service/request-authenticator";
 
 export interface AuthenticationRequirement {

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 import { base64UrlEncode } from "./encoding";
 
 /** Timeout for individual GitHub API requests (ms). */
-export const GITHUB_FETCH_TIMEOUT_MS = 60_000;
+const GITHUB_FETCH_TIMEOUT_MS = 60_000;
 
 /** Cache installation tokens for this duration at most (ms). */
 export const INSTALLATION_TOKEN_CACHE_MAX_AGE_MS = 50 * 60 * 1000;
@@ -26,7 +26,7 @@ export const INSTALLATION_TOKEN_CACHE_MAX_AGE_MS = 50 * 60 * 1000;
 export const INSTALLATION_TOKEN_MIN_REMAINING_MS = 5 * 60 * 1000;
 
 /** Upper bound for KV cache TTL (seconds). */
-export const INSTALLATION_TOKEN_CACHE_MAX_TTL_SECONDS = 3600;
+const INSTALLATION_TOKEN_CACHE_MAX_TTL_SECONDS = 3600;
 
 const INSTALLATION_TOKEN_CACHE_KEY_PREFIX = "github:installation-token:v1";
 
@@ -73,7 +73,7 @@ export function fetchWithTimeout(
 }
 
 /** Per-page timing record returned from listInstallationRepositories. */
-export interface GitHubPageTiming {
+interface GitHubPageTiming {
   page: number;
   fetchMs: number;
   repoCount: number;
@@ -205,7 +205,7 @@ async function importPrivateKeyCached(pem: string): Promise<CryptoKey> {
  * @param privateKey - PEM-encoded private key
  * @returns Signed JWT valid for 10 minutes
  */
-export async function generateAppJwt(appId: string, privateKey: string): Promise<string> {
+async function generateAppJwt(appId: string, privateKey: string): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
 
   // JWT header

--- a/packages/control-plane/src/auth/github.test.ts
+++ b/packages/control-plane/src/auth/github.test.ts
@@ -8,7 +8,6 @@ describe("github auth", () => {
   const config: GitHubOAuthConfig = {
     clientId: "client-id",
     clientSecret: "client-secret",
-    encryptionKey: "unused",
   };
 
   afterEach(() => {

--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -2,39 +2,12 @@
  * GitHub authentication utilities.
  */
 
-import { formatGitHubNoreplyEmail } from "@open-inspect/shared/types/github-identity";
-import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import { z } from "zod";
-import { decryptToken, encryptToken } from "./crypto";
-import { githubTokenResponseSchema, type GitHubUser, type GitHubTokenResponse } from "../types";
+import { githubTokenResponseSchema, type GitHubTokenResponse } from "../types";
 
 const githubOAuthErrorSchema = z.object({
   error: z.string().optional(),
   error_description: z.string().optional(),
-});
-
-/**
- * The `/user` fields this service depends on. `id` and `login` are the identity
- * keys and are validated strictly — a malformed 200 (e.g. no `id`) must fail
- * closed rather than mint a subject on the literal string "undefined". Display
- * fields are lenient (absent → null) so a valid-but-partial response still
- * resolves an identity.
- */
-const githubUserSchema = z.object({
-  id: z.number(),
-  login: z.string().min(1),
-  name: z
-    .string()
-    .nullish()
-    .transform((value) => value ?? null),
-  email: z
-    .string()
-    .nullish()
-    .transform((value) => value ?? null),
-  avatar_url: z
-    .string()
-    .nullish()
-    .transform((value) => value ?? ""),
 });
 
 async function parseGitHubTokenResponse(response: Response): Promise<GitHubTokenResponse> {
@@ -59,16 +32,6 @@ export interface GitHubOAuthConfig {
   clientId: string;
   clientSecret: string;
   encryptionKey: string;
-}
-
-/**
- * GitHub token with metadata.
- */
-export interface StoredGitHubToken {
-  accessTokenEncrypted: string;
-  refreshTokenEncrypted: string | null;
-  expiresAt: number | null;
-  scope: string;
 }
 
 /**
@@ -116,178 +79,4 @@ export async function refreshAccessToken(
   });
 
   return parseGitHubTokenResponse(response);
-}
-
-/** Error from a GitHub API call, carrying the HTTP status for callers that map it. */
-export class GitHubUserApiError extends Error {
-  constructor(readonly status: number) {
-    super(`GitHub API error: ${status}`);
-    this.name = "GitHubUserApiError";
-  }
-}
-
-/**
- * Get current user info from GitHub.
- *
- * @throws {GitHubUserApiError} on non-2xx responses, with `status` set.
- * @throws {Error} on a 2xx response whose body is not a valid user — fail
- * closed rather than let a malformed identity through.
- */
-export async function getGitHubUser(
-  accessToken: string,
-  userAgent: string = DEFAULT_APP_NAME,
-  signal?: AbortSignal
-): Promise<GitHubUser> {
-  const response = await fetch("https://api.github.com/user", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github.v3+json",
-      "User-Agent": userAgent,
-    },
-    signal,
-  });
-
-  if (!response.ok) {
-    throw new GitHubUserApiError(response.status);
-  }
-
-  const parsed = githubUserSchema.safeParse(await response.json().catch(() => null));
-  if (!parsed.success) {
-    throw new Error("Malformed GitHub user response");
-  }
-  return parsed.data;
-}
-
-const githubUserEmailsSchema = z.array(
-  z.object({
-    email: z.string().min(1),
-    primary: z.boolean(),
-    verified: z.boolean(),
-  })
-);
-
-/**
- * Get user's email addresses from GitHub.
- *
- * @throws {GitHubUserApiError} on non-2xx responses, with `status` set — most
- * often 403 when the GitHub App is missing the "Email addresses" permission,
- * or 404 when an OAuth token lacks the email scope.
- * @throws {Error} on a 2xx response whose body is not a valid email list —
- * email evidence is an identity-linking key, so a malformed body must fail
- * closed, never read as "no email".
- */
-export async function getGitHubUserEmails(
-  accessToken: string,
-  userAgent: string = DEFAULT_APP_NAME,
-  signal?: AbortSignal
-): Promise<Array<{ email: string; primary: boolean; verified: boolean }>> {
-  const response = await fetch("https://api.github.com/user/emails", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github.v3+json",
-      "User-Agent": userAgent,
-    },
-    signal,
-  });
-
-  if (!response.ok) {
-    throw new GitHubUserApiError(response.status);
-  }
-
-  const parsed = githubUserEmailsSchema.safeParse(await response.json().catch(() => null));
-  if (!parsed.success) {
-    throw new Error("Malformed GitHub user emails response");
-  }
-  return parsed.data;
-}
-
-/**
- * Store encrypted GitHub tokens.
- */
-export async function encryptGitHubTokens(
-  tokens: GitHubTokenResponse,
-  encryptionKey: string
-): Promise<StoredGitHubToken> {
-  const accessTokenEncrypted = await encryptToken(tokens.access_token, encryptionKey);
-
-  const refreshTokenEncrypted = tokens.refresh_token
-    ? await encryptToken(tokens.refresh_token, encryptionKey)
-    : null;
-
-  const expiresAt = tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null;
-
-  return {
-    accessTokenEncrypted,
-    refreshTokenEncrypted,
-    expiresAt,
-    scope: tokens.scope,
-  };
-}
-
-/**
- * Get valid access token, refreshing if necessary.
- */
-export async function getValidAccessToken(
-  stored: StoredGitHubToken,
-  config: GitHubOAuthConfig
-): Promise<{ accessToken: string; refreshed: boolean; newStored?: StoredGitHubToken }> {
-  const now = Date.now();
-  const bufferMs = 5 * 60 * 1000; // 5 minutes
-
-  // Check if token needs refresh
-  if (stored.expiresAt && stored.expiresAt - now < bufferMs) {
-    if (!stored.refreshTokenEncrypted) {
-      throw new Error("Token expired and no refresh token available");
-    }
-
-    const refreshToken = await decryptToken(stored.refreshTokenEncrypted, config.encryptionKey);
-
-    const newTokens = await refreshAccessToken(refreshToken, config);
-    const newStored = await encryptGitHubTokens(newTokens, config.encryptionKey);
-
-    return {
-      accessToken: newTokens.access_token,
-      refreshed: true,
-      newStored,
-    };
-  }
-
-  // Token is still valid
-  const accessToken = await decryptToken(stored.accessTokenEncrypted, config.encryptionKey);
-
-  return {
-    accessToken,
-    refreshed: false,
-  };
-}
-
-/**
- * Generate noreply email for users with private email.
- */
-export function generateNoreplyEmail(githubUser: GitHubUser): string {
-  return formatGitHubNoreplyEmail(githubUser);
-}
-
-/**
- * Get best email for git commit attribution.
- */
-export function getCommitEmail(
-  githubUser: GitHubUser,
-  emails?: Array<{ email: string; primary: boolean; verified: boolean }>
-): string {
-  // Use public email if available
-  if (githubUser.email) {
-    return githubUser.email;
-  }
-
-  // Use primary verified email from list
-  if (emails) {
-    const primary = emails.find((e) => e.primary && e.verified);
-    if (primary) {
-      return primary.email;
-    }
-  }
-
-  // Fall back to noreply
-  return generateNoreplyEmail(githubUser);
 }

--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -31,7 +31,6 @@ async function parseGitHubTokenResponse(response: Response): Promise<GitHubToken
 export interface GitHubOAuthConfig {
   clientId: string;
   clientSecret: string;
-  encryptionKey: string;
 }
 
 /**

--- a/packages/control-plane/src/auth/identity-enforcement.ts
+++ b/packages/control-plane/src/auth/identity-enforcement.ts
@@ -95,7 +95,7 @@ export interface DerivedIdentity {
  * `applyIdentityEnforcement` gate; the type says so, sparing call sites a
  * null check the gate already performed.
  */
-export type EnforcedIdentity<R extends IdentityRoute> = R extends RequiresUserRoute
+type EnforcedIdentity<R extends IdentityRoute> = R extends RequiresUserRoute
   ? DerivedIdentity & { participantUserId: string }
   : DerivedIdentity;
 

--- a/packages/control-plane/src/auth/openai-token-broker.ts
+++ b/packages/control-plane/src/auth/openai-token-broker.ts
@@ -18,7 +18,7 @@ type OpenAITokenState =
 
 export type OpenAIToken = { accessToken: string; expiresIn?: number; accountId?: string };
 
-export class OpenAITokenBrokerError extends Error {}
+class OpenAITokenBrokerError extends Error {}
 export class OpenAITokenNotConfiguredError extends OpenAITokenBrokerError {}
 export class OpenAITokenStorageError extends OpenAITokenBrokerError {}
 export class OpenAITokenUnauthorizedError extends OpenAITokenBrokerError {}

--- a/packages/control-plane/src/auth/openai.ts
+++ b/packages/control-plane/src/auth/openai.ts
@@ -8,7 +8,7 @@ const OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
-export const openAITokenResponseSchema = z.object({
+const openAITokenResponseSchema = z.object({
   id_token: z.string(),
   access_token: z.string(),
   refresh_token: z.string(),

--- a/packages/control-plane/src/auth/principal.ts
+++ b/packages/control-plane/src/auth/principal.ts
@@ -10,7 +10,7 @@
 import type { ServiceName } from "@open-inspect/shared/service-auth";
 
 /** Actor namespaces bots may assert (`slack:U123` etc.). */
-export const ACTOR_NAMESPACES = ["slack", "github", "linear"] as const;
+const ACTOR_NAMESPACES = ["slack", "github", "linear"] as const;
 export type ActorNamespace = (typeof ACTOR_NAMESPACES)[number];
 
 export function isActorNamespace(value: string): value is ActorNamespace {

--- a/packages/control-plane/src/auth/user/providers/github-profile.ts
+++ b/packages/control-plane/src/auth/user/providers/github-profile.ts
@@ -2,7 +2,7 @@ import type { AdmissionPolicy, GitHubAdmissionEvidence } from "../admission-poli
 import type { ProviderProfile, ProviderTokens } from "../provider-profile";
 import { OAuthProviderError, type VerifiedProviderIdentity } from "./types";
 
-export interface GitHubIdentityResolver {
+interface GitHubIdentityResolver {
   resolveIdentity(accessToken: string): Promise<VerifiedProviderIdentity<"github">>;
 }
 

--- a/packages/control-plane/src/auth/xai.ts
+++ b/packages/control-plane/src/auth/xai.ts
@@ -4,7 +4,7 @@ const XAI_TOKEN_URL = "https://auth.x.ai/oauth2/token";
 const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 const XAI_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
-export const xaiTokenResponseSchema = z.object({
+const xaiTokenResponseSchema = z.object({
   access_token: z.string().min(1),
   refresh_token: z.string().optional(),
   expires_in: z.number().int().positive().optional(),

--- a/packages/control-plane/src/automation/repository.ts
+++ b/packages/control-plane/src/automation/repository.ts
@@ -3,7 +3,7 @@ import type { Env } from "../types";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
 
 /** A repository resolved for one firing: access checked, branch defaulted. */
-export interface ResolvedAutomationRepository {
+interface ResolvedAutomationRepository {
   repoOwner: string;
   repoName: string;
   // Access-checked at resolution, so always present (unlike the stored

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -125,7 +125,7 @@ export interface InvocationRunAggregate {
 
 // ─── Mappers ─────────────────────────────────────────────────────────────────
 
-export function toAutomationRepository(row: AutomationRepositoryRow): AutomationRepository {
+function toAutomationRepository(row: AutomationRepositoryRow): AutomationRepository {
   return {
     repoOwner: row.repo_owner,
     repoName: row.repo_name,
@@ -199,7 +199,7 @@ export function toAutomationRun(row: EnrichedRunRow): AutomationRun {
 // backfilled skip rows), no failure ⇒ completed, no success ⇒ failed,
 // otherwise partial_failed.
 
-export const DERIVED_INVOCATION_STATUS_SQL = `CASE
+const DERIVED_INVOCATION_STATUS_SQL = `CASE
   WHEN COUNT(r.id) = 0 THEN 'skipped'
   WHEN SUM(CASE WHEN r.status IN ('starting', 'running') THEN 1 ELSE 0 END) > 0 THEN
     CASE
@@ -213,7 +213,7 @@ export const DERIVED_INVOCATION_STATUS_SQL = `CASE
 END`;
 
 /** Derived completion time: latest child completion once all children are terminal. */
-export const DERIVED_INVOCATION_COMPLETED_AT_SQL = `CASE
+const DERIVED_INVOCATION_COMPLETED_AT_SQL = `CASE
   WHEN COUNT(r.id) = 0 THEN NULL
   WHEN SUM(CASE WHEN r.status IN ('starting', 'running') THEN 1 ELSE 0 END) > 0 THEN NULL
   ELSE MAX(r.completed_at)
@@ -243,7 +243,7 @@ export function deriveInvocationStatus(counts: {
   return "partial_failed";
 }
 
-export function toAutomationInvocation(
+function toAutomationInvocation(
   row: AutomationInvocationRow & { derived_status: string; derived_completed_at: number | null },
   runs: AutomationRun[]
 ): AutomationInvocation {

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -37,7 +37,7 @@ export type EnvironmentRepositoryInsert = Pick<
   "position" | "repo_owner" | "repo_name" | "repo_id" | "base_branch"
 >;
 
-export function toEnvironmentRepository(row: EnvironmentRepositoryRow): EnvironmentRepository {
+function toEnvironmentRepository(row: EnvironmentRepositoryRow): EnvironmentRepository {
   return {
     repoOwner: row.repo_owner,
     repoName: row.repo_name,

--- a/packages/control-plane/src/db/instrumented-d1.ts
+++ b/packages/control-plane/src/db/instrumented-d1.ts
@@ -17,7 +17,7 @@ import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
 // ---------------------------------------------------------------------------
 
 /** Record of a single D1 query execution. */
-export interface D1QueryRecord {
+interface D1QueryRecord {
   /** Wall-clock time in ms (includes network round-trip from Worker to D1 primary). */
   query_ms: number;
   /** Engine-reported server-side execution time in ms (from meta.duration). */

--- a/packages/control-plane/src/db/secrets-validation.ts
+++ b/packages/control-plane/src/db/secrets-validation.ts
@@ -1,10 +1,10 @@
-export const VALID_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const VALID_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export const MAX_KEY_LENGTH = 256;
 export const MAX_VALUE_SIZE = 16384;
 export const MAX_TOTAL_VALUE_SIZE = 65536;
 export const MAX_SECRETS_PER_SCOPE = 50;
 
-export const RESERVED_KEYS = new Set([
+const RESERVED_KEYS = new Set([
   "PYTHONUNBUFFERED",
   "SANDBOX_ID",
   "CONTROL_PLANE_URL",
@@ -72,7 +72,7 @@ export interface SecretSourceAttribution {
 }
 
 /** A key defined by more than one source; the higher-precedence source wins. */
-export interface SecretKeyCollision {
+interface SecretKeyCollision {
   key: string;
   /** Label of the source whose value is used. */
   winner: string;

--- a/packages/control-plane/src/db/sql-database.ts
+++ b/packages/control-plane/src/db/sql-database.ts
@@ -20,7 +20,7 @@
  * a load-bearing sync contract, and is intentionally not covered by this port.
  */
 
-export interface SqlResultMeta {
+interface SqlResultMeta {
   /**
    * Rows written by the statement. Required, not optional: ~38 store call
    * sites gate correctness on it (CAS conflict detection, guarded lifecycle

--- a/packages/control-plane/src/db/user-merge.ts
+++ b/packages/control-plane/src/db/user-merge.ts
@@ -57,7 +57,7 @@ export interface UserMergeOptions {
   readonly dryRun?: boolean;
 }
 
-export interface UserMergeCounts {
+interface UserMergeCounts {
   identitiesDeduped: number;
   identitiesRepointed: number;
   readStatesDeduped: number;

--- a/packages/control-plane/src/image-builds/callback-auth.ts
+++ b/packages/control-plane/src/image-builds/callback-auth.ts
@@ -13,7 +13,7 @@ import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { Env } from "../types";
 
 export const IMAGE_BUILD_CALLBACK_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
-export const IMAGE_BUILD_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+const IMAGE_BUILD_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
 
 export function generateImageBuildCallbackToken(): string {
   const bytes = new Uint8Array(32);

--- a/packages/control-plane/src/image-builds/finalizer.ts
+++ b/packages/control-plane/src/image-builds/finalizer.ts
@@ -13,7 +13,7 @@ import { parseRepositoryShasJson } from "./provenance";
 export { ImageBuildFinalizationAttemptError } from "./finalization-error";
 
 /** Lease exceeds the provider deadline so overlapping creation attempts cannot run. */
-export const IMAGE_BUILD_FINALIZATION_LEASE_MS = 6 * 60 * 1000;
+const IMAGE_BUILD_FINALIZATION_LEASE_MS = 6 * 60 * 1000;
 
 /** Hard deadline for one provider snapshot or checkpoint attempt. */
 export const IMAGE_BUILD_PROVIDER_ATTEMPT_MS = 5 * 60 * 1000;

--- a/packages/control-plane/src/media.ts
+++ b/packages/control-plane/src/media.ts
@@ -11,8 +11,8 @@ export const SCREENSHOT_MAX_BYTES = 10 * 1024 * 1024;
 export const SCREENSHOT_UPLOAD_LIMIT_PER_SESSION = 100;
 export const VIDEO_MAX_BYTES = 100 * 1024 * 1024;
 export const VIDEO_UPLOAD_LIMIT_PER_SESSION = 20;
-export const VIDEO_MAX_DURATION_MS = 90_000;
-export const VIDEO_TIMESTAMP_TOLERANCE_MS = 1_000;
+const VIDEO_MAX_DURATION_MS = 90_000;
+const VIDEO_TIMESTAMP_TOLERANCE_MS = 1_000;
 
 // Allows multipart boundaries and headers while rejecting oversized requests
 // before request.formData() buffers them when Content-Length is available.

--- a/packages/control-plane/src/realtime/events.ts
+++ b/packages/control-plane/src/realtime/events.ts
@@ -2,9 +2,6 @@
  * Real-time event utilities.
  */
 
-import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
-import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
-
 /**
  * Event categories for filtering.
  */
@@ -33,35 +30,6 @@ export function getEventCategory(eventType: string): EventCategory {
     default:
       return "system";
   }
-}
-
-/**
- * Create a server message from sandbox event.
- */
-export function createSandboxEventMessage(event: SandboxEvent): ServerMessage {
-  return {
-    type: "sandbox_event",
-    event,
-  };
-}
-
-/**
- * Create error message.
- */
-export function createErrorMessage(code: string, message: string): ServerMessage {
-  return {
-    type: "error",
-    code,
-    message,
-  };
-}
-
-/**
- * Determine if event should be broadcast to clients.
- */
-export function shouldBroadcastEvent(_eventType: string): boolean {
-  // Always broadcast to clients
-  return true;
 }
 
 /**

--- a/packages/control-plane/src/realtime/index.ts
+++ b/packages/control-plane/src/realtime/index.ts
@@ -2,11 +2,4 @@
  * Realtime module exports.
  */
 
-export {
-  getEventCategory,
-  createSandboxEventMessage,
-  createErrorMessage,
-  shouldBroadcastEvent,
-  TokenAggregator,
-  type EventCategory,
-} from "./events";
+export { getEventCategory, TokenAggregator, type EventCategory } from "./events";

--- a/packages/control-plane/src/routes/session-media-stream.ts
+++ b/packages/control-plane/src/routes/session-media-stream.ts
@@ -12,8 +12,6 @@ import {
 import { getSessionArtifactFromRuntime } from "./session-media-artifacts";
 import { error, parsePattern, type Route } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";
-export { parseByteRangeHeader } from "./requests/byte-range";
-
 const logger = createLogger("router:session-media");
 
 function getMediaMimeType(

--- a/packages/control-plane/src/routes/session-route.ts
+++ b/packages/control-plane/src/routes/session-route.ts
@@ -14,7 +14,7 @@ export type SessionRouteHandler = (
   ctx: SessionRouteContext
 ) => Promise<Response>;
 
-export function withSessionRuntime(handler: SessionRouteHandler): Route["handler"] {
+function withSessionRuntime(handler: SessionRouteHandler): Route["handler"] {
   return (request, env, match, ctx) =>
     handler(request, env, match, {
       ...ctx,

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -64,7 +64,7 @@ const DEFAULT_SANDBOX_DOMAIN = "e2b.app";
  * Path the per-session env file is written to. The template launcher
  * (packages/e2b-infra/oi-launch.py) polls this exact path — keep them in sync.
  */
-export const SESSION_ENV_PATH = "/tmp/oi-session.env";
+const SESSION_ENV_PATH = "/tmp/oi-session.env";
 
 export interface E2BCreateSandboxParams {
   templateID: string;

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -20,11 +20,7 @@ import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
  * through to their own checks (e.g. token comparison) instead of locking out
  * every sandbox.
  */
-export const DEAD_SANDBOX_STATUSES: ReadonlySet<SandboxStatus> = new Set([
-  "stopped",
-  "stale",
-  "failed",
-]);
+const DEAD_SANDBOX_STATUSES: ReadonlySet<SandboxStatus> = new Set(["stopped", "stale", "failed"]);
 
 export function isDeadSandboxStatus(status: SandboxStatus): boolean {
   return DEAD_SANDBOX_STATUSES.has(status);

--- a/packages/control-plane/src/sandbox/lifecycle/image-selection.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/image-selection.ts
@@ -67,7 +67,7 @@ export interface SelectedImageBuild {
   runtimeVersion: string;
 }
 
-export type ImageBuildMissReason =
+type ImageBuildMissReason =
   | "no_ready_image"
   | "missing_artifact"
   | "runtime_below_floor"

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -63,7 +63,7 @@ const TERMINAL_TOKEN_TTL_SECONDS = 86400;
 /**
  * Sandbox state with circuit breaker info (subset of full SandboxRow).
  */
-export interface SandboxCircuitBreakerInfo {
+interface SandboxCircuitBreakerInfo {
   status: string;
   created_at: number;
   modal_object_id: string | null;

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -99,7 +99,7 @@ export function toRepositoryConfigPayload(
 }
 
 /** `SESSION_CONFIG` env var carrying the serialized {@link SessionConfigPayload}. */
-export const SESSION_CONFIG_ENV_VAR = "SESSION_CONFIG";
+const SESSION_CONFIG_ENV_VAR = "SESSION_CONFIG";
 /** Build-mode marker checked as `=== "true"` by the runtime entrypoint. */
 export const IMAGE_BUILD_MODE_ENV_VAR = "IMAGE_BUILD_MODE";
 export const IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_KEY = "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS";

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -6,7 +6,7 @@ import {
   type SandboxSettings,
 } from "@open-inspect/shared/types/integrations";
 
-export type InvalidSandboxSettingsBehavior = "throw" | "omit";
+type InvalidSandboxSettingsBehavior = "throw" | "omit";
 
 export interface NormalizeSandboxSettingsOptions {
   invalid?: InvalidSandboxSettingsBehavior;

--- a/packages/control-plane/src/session/event-cursor.ts
+++ b/packages/control-plane/src/session/event-cursor.ts
@@ -7,7 +7,7 @@ export interface EventTimelineCursor {
   sequence?: number;
 }
 
-export interface LegacyEventCursor {
+interface LegacyEventCursor {
   kind: "legacy";
   createdAt: number;
 }

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -28,7 +28,7 @@ const MAX_TRAJECTORY_EVENT_LIMIT = 1000;
 const NOISY_RECENT_EVENT_TYPES = new Set(["token", "heartbeat", "step_start", "step_finish"]);
 const CHILD_SUMMARY_INCLUDE_VALUES = new Set<string>(CHILD_SESSION_DETAIL_INCLUDES);
 
-export interface ChildSummaryOptions {
+interface ChildSummaryOptions {
   includeFinalResponse: boolean;
   includeTrajectory: boolean;
   trajectoryLimit: number;

--- a/packages/control-plane/src/session/index.ts
+++ b/packages/control-plane/src/session/index.ts
@@ -7,7 +7,6 @@ export { SessionWebSocketManagerImpl } from "./websocket-manager";
 export type {
   SessionWebSocketManager,
   ParsedTags,
-  WsKind,
   WebSocketManagerConfig,
 } from "./websocket-manager";
 export { initSchema, SCHEMA_SQL, applyMigrations, MIGRATIONS } from "./schema";

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -10,7 +10,6 @@ import { resolveSessionOAuthSecretScope } from "./session-target-secrets";
 import type { SessionRow } from "./types";
 
 export {
-  OpenAITokenBrokerError,
   OpenAITokenNotConfiguredError,
   OpenAITokenStorageError,
   OpenAITokenUnauthorizedError,

--- a/packages/control-plane/src/session/participant-service.ts
+++ b/packages/control-plane/src/session/participant-service.ts
@@ -226,7 +226,6 @@ export class ParticipantService {
       const newTokens = await refreshAccessToken(d1Tokens.refreshToken, {
         clientId: this.env.GITHUB_CLIENT_ID,
         clientSecret: this.env.GITHUB_CLIENT_SECRET,
-        encryptionKey: this.env.TOKEN_ENCRYPTION_KEY,
       });
 
       const newAccessToken = newTokens.access_token;
@@ -360,7 +359,6 @@ export class ParticipantService {
       const newTokens = await refreshAccessToken(refreshToken, {
         clientId: this.env.GITHUB_CLIENT_ID,
         clientSecret: this.env.GITHUB_CLIENT_SECRET,
-        encryptionKey: this.env.TOKEN_ENCRYPTION_KEY,
       });
 
       const newAccessTokenEncrypted = await encryptToken(

--- a/packages/control-plane/src/session/pull-request-refresh.ts
+++ b/packages/control-plane/src/session/pull-request-refresh.ts
@@ -29,7 +29,7 @@ export interface PullRequestRefreshRepository {
 }
 
 /** A per-artifact problem from a refresh pass; the caller decides logging. */
-export interface PullRequestRefreshFailure {
+interface PullRequestRefreshFailure {
   artifactId: string;
   reason: "not_refreshable" | "provider_read_failed" | "record_write_failed";
   prNumber?: number;

--- a/packages/control-plane/src/session/runtime-client.ts
+++ b/packages/control-plane/src/session/runtime-client.ts
@@ -11,7 +11,7 @@ export interface SessionRuntimeClient {
   ): Promise<Response>;
 }
 
-export class CloudflareSessionRuntimeClient implements SessionRuntimeClient {
+class CloudflareSessionRuntimeClient implements SessionRuntimeClient {
   constructor(
     private readonly env: Env,
     private readonly ctx: CorrelationContext

--- a/packages/control-plane/src/session/session-attachment-protocol.ts
+++ b/packages/control-plane/src/session/session-attachment-protocol.ts
@@ -7,7 +7,7 @@ import { SESSION_ATTACHMENT_IMAGE_MAX_BYTES } from "../media";
 
 const objectKeySchema = z.string().min(1).max(1024);
 
-export const recordAttachmentCommandSchema = z
+const recordAttachmentCommandSchema = z
   .object({
     action: z.literal("record"),
     attachmentId: sessionAttachmentIdSchema,
@@ -16,7 +16,7 @@ export const recordAttachmentCommandSchema = z
   })
   .strict();
 
-export const completeAttachmentCleanupCommandSchema = z
+const completeAttachmentCleanupCommandSchema = z
   .object({
     action: z.literal("complete_cleanup"),
     cleanupClaimedAt: z.number().int().nonnegative(),

--- a/packages/control-plane/src/session/spawn-context.ts
+++ b/packages/control-plane/src/session/spawn-context.ts
@@ -12,7 +12,7 @@ const sandboxTimeoutMsSchema = z.number().refine(isValidSandboxTimeoutMs);
  * repository requires spawnContext.repositories, a named fast-follow (design
  * §13.13), not a v1 promise.
  */
-export const promptAuthorSchema = z.object({
+const promptAuthorSchema = z.object({
   userId: z.string(),
   canonicalUserId: z.string().nullable().optional(),
   scmUserId: z.string().nullable(),

--- a/packages/control-plane/src/session/title.ts
+++ b/packages/control-plane/src/session/title.ts
@@ -2,7 +2,7 @@ export interface SessionTitleUpdateOptions {
   onlyIfUnset?: boolean;
 }
 
-export type SessionTitleUpdateErrorReason = "invalid" | "not_found" | "already_set";
+type SessionTitleUpdateErrorReason = "invalid" | "not_found" | "already_set";
 
 export type SessionTitleValidationResult =
   | { ok: true; title: string }

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -170,7 +170,7 @@ export interface SandboxRow {
 
 // Command types for sandbox communication
 
-export interface PromptCommand {
+interface PromptCommand {
   type: "prompt";
   messageId: string;
   content: string;
@@ -183,29 +183,29 @@ export interface PromptCommand {
   attachments?: ResolvedSessionAttachment[];
 }
 
-export interface StopCommand {
+interface StopCommand {
   type: "stop";
 }
 
-export interface SnapshotCommand {
+interface SnapshotCommand {
   type: "snapshot";
 }
 
-export interface ShutdownCommand {
+interface ShutdownCommand {
   type: "shutdown";
 }
 
-export interface AckCommand {
+interface AckCommand {
   type: "ack";
   ackId: string;
 }
 
-export interface PushCommand {
+interface PushCommand {
   type: "push";
   pushSpec: GitPushSpec;
 }
 
-export interface RefreshDiffCommand {
+interface RefreshDiffCommand {
   type: "refresh_diff";
 }
 

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -14,9 +14,6 @@ import type { SessionRepository, WsClientMappingResult } from "./repository";
 // Types
 // ---------------------------------------------------------------------------
 
-/** The two kinds of WebSocket connections the DO manages. */
-export type WsKind = "client" | "sandbox";
-
 /** Result of parsing a WebSocket's Cloudflare hibernation tags. */
 export type ParsedTags =
   | { kind: "sandbox"; sandboxId?: string }

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -29,7 +29,7 @@ import type { GitLabProviderConfig } from "./types";
 import { USER_AGENT } from "./constants";
 
 /** GitLab API base URL. */
-export const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+const GITLAB_API_BASE = "https://gitlab.com/api/v4";
 
 /** Default per_page for paginated GitLab API requests (GitLab API maximum). */
 const PER_PAGE = 100;

--- a/packages/control-plane/src/source-control/providers/index.ts
+++ b/packages/control-plane/src/source-control/providers/index.ts
@@ -9,15 +9,10 @@ import { createGitLabProvider } from "./gitlab-provider";
 import type { GitHubProviderConfig, GitLabProviderConfig } from "./types";
 
 // Types
-export type { GitHubProviderConfig, GitLabProviderConfig } from "./types";
-
-// Constants
-export { USER_AGENT, GITHUB_API_BASE } from "./constants";
-export { GITLAB_API_BASE } from "./gitlab-provider";
+export type { GitHubProviderConfig } from "./types";
 
 // Providers
 export { GitHubSourceControlProvider, createGitHubProvider } from "./github-provider";
-export { GitLabSourceControlProvider, createGitLabProvider } from "./gitlab-provider";
 
 /**
  * Factory configuration for selecting a source control provider.

--- a/packages/control-plane/src/storage/object-storage.ts
+++ b/packages/control-plane/src/storage/object-storage.ts
@@ -2,11 +2,11 @@ import type { Env } from "../types";
 
 type ObjectStoragePutValue = ArrayBuffer | ArrayBufferView | ReadableStream | string;
 
-export type ObjectStoragePutOptions = {
+type ObjectStoragePutOptions = {
   contentType?: string;
 };
 
-export type ObjectStorageRange = {
+type ObjectStorageRange = {
   offset: number;
   length: number;
 };
@@ -17,7 +17,7 @@ export type ObjectStorageMetadata = {
   writeHttpMetadata(headers: Headers): void;
 };
 
-export type ObjectStorageObject = ObjectStorageMetadata & {
+type ObjectStorageObject = ObjectStorageMetadata & {
   body: ReadableStream;
 };
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -2,7 +2,6 @@
  * Type definitions for Open-Inspect Control Plane.
  */
 
-import type { SessionStatus } from "@open-inspect/shared/types/sessions";
 import { z } from "zod";
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
 
@@ -121,36 +120,6 @@ export interface ClientInfo {
   clientId: string;
   ws: WebSocket;
   lastFetchHistoryAt?: number;
-}
-
-export interface SessionResponse {
-  id: string;
-  title: string | null;
-  repoOwner: string;
-  repoName: string;
-  baseBranch: string;
-  branchName: string | null;
-  baseSha: string | null;
-  currentSha: string | null;
-  opencodeSessionId: string | null;
-  status: SessionStatus;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface ListSessionsResponse {
-  sessions: SessionResponse[];
-  total: number;
-  hasMore: boolean;
-}
-
-// GitHub OAuth types
-export interface GitHubUser {
-  id: number;
-  login: string;
-  name: string | null;
-  email: string | null;
-  avatar_url: string;
 }
 
 export const githubTokenResponseSchema = z.object({

--- a/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
+++ b/packages/control-plane/src/webhooks/pull-request-lifecycle.ts
@@ -36,7 +36,7 @@ export interface SessionArtifactSummary {
 }
 
 /** The slice of session-index state the processor needs. */
-export interface PullRequestLifecycleSessions {
+interface PullRequestLifecycleSessions {
   /** Primary-repo identity for the legacy identity-less-artifact convention. */
   get(id: string): Promise<{ repoOwner: string | null; repoName: string | null } | null>;
   isRepositoryAssociated(sessionId: string, repoOwner: string, repoName: string): Promise<boolean>;

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -23,7 +23,7 @@ export const classifyToolInputSchema = z.object({
   alternatives: z.array(z.string()),
 });
 
-export type ClassifyToolInput = z.infer<typeof classifyToolInputSchema>;
+type ClassifyToolInput = z.infer<typeof classifyToolInputSchema>;
 
 export const anthropicMessagesResponseSchema = z.object({
   content: z.array(

--- a/packages/linear-bot/src/logger.ts
+++ b/packages/linear-bot/src/logger.ts
@@ -9,7 +9,6 @@ import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shar
 import type { Logger } from "@open-inspect/shared/logger";
 export type { Logger } from "@open-inspect/shared/logger";
 export type { LogLevel } from "@open-inspect/shared/logger";
-export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "linear-bot";
 

--- a/packages/linear-bot/src/plan.ts
+++ b/packages/linear-bot/src/plan.ts
@@ -2,7 +2,7 @@
  * Agent plan step types and factory used by both the webhook handler and callbacks.
  */
 
-export type PlanStepStatus = "pending" | "inProgress" | "completed" | "canceled";
+type PlanStepStatus = "pending" | "inProgress" | "completed" | "canceled";
 
 export interface PlanStep {
   content: string;

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -43,24 +43,20 @@ export interface Env {
  * A single repo configuration with an optional label filter.
  * Used for static team→repo mapping (legacy/override).
  */
-export const staticRepoConfigSchema = z.object({
+const staticRepoConfigSchema = z.object({
   owner: z.string(),
   name: z.string(),
   label: z.string().optional(),
 });
 
-export type StaticRepoConfig = z.infer<typeof staticRepoConfigSchema>;
-
 /**
  * An environment target with an optional label filter. References the stable
  * `env_…` id, not the rename-able display name.
  */
-export const staticEnvironmentConfigSchema = z.object({
+const staticEnvironmentConfigSchema = z.object({
   environmentId: z.string(),
   label: z.string().optional(),
 });
-
-export type StaticEnvironmentConfig = z.infer<typeof staticEnvironmentConfigSchema>;
 
 /**
  * A mapping entry: a repository or a saved environment. Targets unify instead
@@ -73,10 +69,7 @@ export type StaticEnvironmentConfig = z.infer<typeof staticEnvironmentConfigSche
  * that entry pointed at the same target — validating stored config may reject
  * an entry, but it must never quietly re-point a working one somewhere else.
  */
-export const staticTargetConfigSchema = z.union([
-  staticEnvironmentConfigSchema,
-  staticRepoConfigSchema,
-]);
+const staticTargetConfigSchema = z.union([staticEnvironmentConfigSchema, staticRepoConfigSchema]);
 
 export type StaticTargetConfig = z.infer<typeof staticTargetConfigSchema>;
 
@@ -164,7 +157,7 @@ const linearCommentSchema = z.object({
   user: z.object({ name: z.string() }).nullable().optional(),
 });
 
-export const linearIssueDetailsSchema = z
+const linearIssueDetailsSchema = z
   .object({
     id: z.string(),
     identifier: z.string(),

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -22,8 +22,6 @@ export {
   completeLinearOAuthInstallation,
   getClientCredentialsTokenOrThrow,
   LinearAuthError,
-  type LinearAuthFailure,
-  type LinearAuthFailureReason,
 } from "./linear-credentials";
 
 const log = createLogger("linear-client");

--- a/packages/linear-bot/src/utils/linear-credential-schemas.ts
+++ b/packages/linear-bot/src/utils/linear-credential-schemas.ts
@@ -16,10 +16,6 @@ export const linearClientCredentialsTokenResponseSchema = z.object({
   scope: responseScopeSchema.optional(),
 });
 
-export type LinearClientCredentialsTokenResponse = z.infer<
-  typeof linearClientCredentialsTokenResponseSchema
->;
-
 export const linearOAuthErrorResponseSchema = z.object({
   error: z
     .string()

--- a/packages/linear-bot/src/utils/linear-credentials.ts
+++ b/packages/linear-bot/src/utils/linear-credentials.ts
@@ -17,12 +17,7 @@ import {
 } from "./linear-oauth";
 import type { StoredLinearClientCredentialsToken } from "./linear-credential-schemas";
 
-export {
-  LINEAR_CLIENT_CREDENTIALS_SCOPE,
-  LinearAuthError,
-  type LinearAuthFailure,
-  type LinearAuthFailureReason,
-} from "./linear-oauth";
+export { LINEAR_CLIENT_CREDENTIALS_SCOPE, LinearAuthError } from "./linear-oauth";
 
 const log = createLogger("linear-credentials");
 const credentialIssuanceByIdentity = new Map<string, Promise<string>>();

--- a/packages/shared/src/triggers/github/index.ts
+++ b/packages/shared/src/triggers/github/index.ts
@@ -5,7 +5,6 @@
 import type { TriggerSourceDefinition } from "../types";
 import { GITHUB_WEBHOOK_EVENT_CATALOG } from "./webhook-types";
 
-export type { GitHubAutomationEvent } from "../types";
 export { normalizeGitHubEvent } from "./normalizer";
 export { GITHUB_WEBHOOK_EVENT_CATALOG } from "./webhook-types";
 

--- a/packages/shared/src/triggers/sentry/index.ts
+++ b/packages/shared/src/triggers/sentry/index.ts
@@ -4,7 +4,6 @@
 
 import type { TriggerSourceDefinition } from "../types";
 
-export type { SentryAutomationEvent } from "../types";
 export type {
   SentryIssueAlertPayload,
   SentryIssueWebhookPayload,

--- a/packages/shared/src/triggers/slack/index.ts
+++ b/packages/shared/src/triggers/slack/index.ts
@@ -4,7 +4,6 @@
 
 import type { TriggerSourceDefinition } from "../types";
 
-export type { SlackAutomationEvent } from "../types";
 export {
   normalizeSlackEvent,
   buildSlackContextBlock,

--- a/packages/shared/src/triggers/testing.ts
+++ b/packages/shared/src/triggers/testing.ts
@@ -14,7 +14,6 @@ import type {
 import { matchesConditions } from "./conditions";
 import type { TriggerCondition } from "./types";
 import { conditionRegistry } from "./registry";
-import type { Automation } from "../types/automations";
 
 type EventForSource<S extends AutomationEventSource> = Extract<AutomationEvent, { source: S }>;
 
@@ -103,34 +102,4 @@ export function assertConditionMatch(
       `Expected condition ${condition.type}/${condition.operator} to ${expected ? "match" : "not match"}, but got ${result}`
     );
   }
-}
-
-/**
- * Build a minimal trigger automation for testing.
- */
-export function makeTriggerAutomation(overrides?: Partial<Automation>): Automation {
-  return {
-    id: "auto-test",
-    name: "Test Automation",
-    repositories: [
-      { repoOwner: "test-owner", repoName: "test-repo", repoId: 1, baseBranch: "main" },
-    ],
-    instructions: "Test instructions",
-    triggerType: "sentry",
-    scheduleCron: null,
-    scheduleTz: "UTC",
-    model: "anthropic/claude-sonnet-4-6",
-    reasoningEffort: null,
-    enabled: true,
-    nextRunAt: null,
-    consecutiveFailures: 0,
-    createdBy: "test-user",
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-    deletedAt: null,
-    eventType: "issue.created",
-    triggerConfig: { conditions: [] },
-    environmentIds: [],
-    ...overrides,
-  };
 }

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -263,8 +263,6 @@ export const automationEventSchema = z.discriminatedUnion("source", [
   }),
 ]);
 
-export type ParsedAutomationEvent = z.infer<typeof automationEventSchema>;
-
 // ─── Trigger Source Definition ────────────────────────────────────────────────
 
 export interface TriggerSourceDefinition {

--- a/packages/shared/src/triggers/webhook/index.ts
+++ b/packages/shared/src/triggers/webhook/index.ts
@@ -4,7 +4,6 @@
 
 import type { TriggerSourceDefinition } from "../types";
 
-export type { WebhookAutomationEvent } from "../types";
 export { conditions as webhookConditions } from "./conditions";
 export { normalizeWebhookEvent, resolveJsonPath, evaluateJsonPathFilter } from "./normalizer";
 export { buildWebhookContextBlock } from "./context";

--- a/packages/slack-bot/src/app-home/index.ts
+++ b/packages/slack-bot/src/app-home/index.ts
@@ -1,4 +1,3 @@
-export { getRepoBranchSuggestionOptions, handleAppHomeInteractionRoute } from "./interactions";
+export { handleAppHomeInteractionRoute } from "./interactions";
 export { publishAppHome } from "./publisher";
 export { buildAppHomeIntroText, buildAppHomeView } from "./view";
-export type { AppHomeViewState } from "./view";

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -73,7 +73,7 @@ const APP_HOME_BLOCK_ACTIONS: Record<string, AppHomeBlockActionHandler> = {
   [CLEAR_BRANCH_PREFERENCE_ACTION_ID]: { handle: handleClearBranchPreference },
 };
 
-export async function getRepoBranchSuggestionOptions(
+async function getRepoBranchSuggestionOptions(
   env: Env,
   userId: string,
   query: string | undefined,

--- a/packages/slack-bot/src/branch-preferences.ts
+++ b/packages/slack-bot/src/branch-preferences.ts
@@ -11,7 +11,7 @@ export const BRANCH_INPUT_ACTION_ID = "branch_value";
 export const REPO_BRANCH_SELECTOR_ACTION_ID = "select_repo_branch_override";
 export const CLEAR_REPO_BRANCH_ACTION_ID = "clear_repo_branch_override";
 
-export const INVALID_BRANCH_ERROR = "Enter a valid Git branch name.";
+const INVALID_BRANCH_ERROR = "Enter a valid Git branch name.";
 
 const BRANCH_NAME_SPECIAL_CHARS_REGEX = /[\s~^:?*[\\]/;
 
@@ -154,7 +154,7 @@ function hasControlCharacters(value: string): boolean {
   });
 }
 
-export function getBranchValidationError(branch: string): string | undefined {
+function getBranchValidationError(branch: string): string | undefined {
   if (branch.startsWith("-")) {
     return INVALID_BRANCH_ERROR;
   }

--- a/packages/slack-bot/src/logger.ts
+++ b/packages/slack-bot/src/logger.ts
@@ -9,7 +9,6 @@ import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shar
 import type { Logger } from "@open-inspect/shared/logger";
 export type { Logger } from "@open-inspect/shared/logger";
 export type { LogLevel } from "@open-inspect/shared/logger";
-export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "slack-bot";
 

--- a/packages/slack-bot/src/slack-blocks.ts
+++ b/packages/slack-bot/src/slack-blocks.ts
@@ -8,8 +8,8 @@
  */
 
 export type SlackPlainText = { type: "plain_text"; text: string };
-export type SlackMrkdwnText = { type: "mrkdwn"; text: string };
-export type SlackText = SlackPlainText | SlackMrkdwnText;
+type SlackMrkdwnText = { type: "mrkdwn"; text: string };
+type SlackText = SlackPlainText | SlackMrkdwnText;
 
 export type SlackSelectOption = {
   text: SlackPlainText;
@@ -22,7 +22,7 @@ export type SlackSelectOptionGroup = {
   options: SlackSelectOption[];
 };
 
-export type SlackConfirmation = {
+type SlackConfirmation = {
   title: SlackPlainText;
   text: SlackText;
   confirm: SlackPlainText;
@@ -54,17 +54,14 @@ export type SlackExternalSelectElement = {
   min_query_length: number;
 };
 
-export type SlackPlainTextInputElement = {
+type SlackPlainTextInputElement = {
   type: "plain_text_input";
   action_id: string;
   initial_value: string;
   placeholder: SlackPlainText;
 };
 
-export type SlackBlockElement =
-  | SlackButtonElement
-  | SlackStaticSelectElement
-  | SlackExternalSelectElement;
+type SlackBlockElement = SlackButtonElement | SlackStaticSelectElement | SlackExternalSelectElement;
 
 export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
 export type SlackSectionBlock = {

--- a/packages/slack-bot/src/slack-options.ts
+++ b/packages/slack-bot/src/slack-options.ts
@@ -1,10 +1,10 @@
 import type { SlackPlainText } from "./slack-blocks";
 
 /** Slack caps a select option's plain_text label/description at 75 characters. */
-export const SELECT_OPTION_TEXT_LIMIT = 75;
+const SELECT_OPTION_TEXT_LIMIT = 75;
 
 /** Truncate option text to Slack's per-option limit, with an ellipsis when cut. */
-export function truncateSelectOptionText(text: string): string {
+function truncateSelectOptionText(text: string): string {
   if (text.length <= SELECT_OPTION_TEXT_LIMIT) {
     return text;
   }

--- a/packages/slack-bot/src/thread-context.ts
+++ b/packages/slack-bot/src/thread-context.ts
@@ -25,12 +25,12 @@ const log = createLogger("thread-context");
  * rendered oldest-first. Bounded because an automation can wake on a reply deep
  * in a long thread and only the tail bears on it.
  */
-export const THREAD_CONTEXT_MESSAGE_LIMIT = 20;
+const THREAD_CONTEXT_MESSAGE_LIMIT = 20;
 
 /** Max characters kept per message. */
-export const THREAD_CONTEXT_MESSAGE_MAX_LENGTH = 1024;
+const THREAD_CONTEXT_MESSAGE_MAX_LENGTH = 1024;
 
-export type ThreadContextSpeaker =
+type ThreadContextSpeaker =
   | { kind: "self" }
   | { kind: "app"; id: string }
   | { kind: "user"; id: string; displayName: string }

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -75,8 +75,6 @@ export type { SlackSessionTarget } from "../targets";
 
 export type { SlackInteractionPayload } from "../interaction-payload";
 
-import type { SlackCallbackContext } from "@open-inspect/shared/types/session-api";
-
 /**
  * Thread-to-session mapping stored in KV for conversation continuity.
  */
@@ -96,30 +94,4 @@ export interface ThreadSession {
    * sees discussion that happened between invocations.
    */
   lastPromptTs?: string;
-}
-
-/**
- * Completion callback payload from control-plane.
- */
-export interface CompletionCallback {
-  sessionId: string;
-  messageId: string;
-  success: boolean;
-  error?: string;
-  timestamp: number;
-  signature: string;
-  context: SlackCallbackContext;
-}
-
-/**
- * Tool-call callback payload from control-plane.
- */
-export interface ToolCallCallback {
-  sessionId: string;
-  tool: string;
-  args: Record<string, unknown>;
-  callId: string;
-  timestamp: number;
-  signature: string;
-  context: SlackCallbackContext;
 }

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -192,7 +192,7 @@ export async function getResolvedUserPreferences(
   );
 }
 
-export async function saveUserPreferences(
+async function saveUserPreferences(
   env: Env,
   userId: string,
   preferences: UserPreferences,

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -68,7 +68,7 @@ interface UseSessionSocketReturn {
   loadOlderEvents: () => void;
 }
 
-export type QueuePromptResult =
+type QueuePromptResult =
   | { ok: true; clientRequestId: string; messageId: string; position: number | null }
   | {
       ok: false;

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -11,7 +11,7 @@ import { browserApiFetch } from "./browser-api-fetch";
 
 const BROWSER_AUTH_SESSION_PATH = "/api/auth/get-session";
 
-export type AuthSessionUser = BrowserAuthSessionUser;
+type AuthSessionUser = BrowserAuthSessionUser;
 
 export interface AuthSession {
   user: AuthSessionUser;

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -23,7 +23,7 @@ export type TemplateCategory =
  * required so every template is complete by construction — making these
  * invariants compile-time rather than test-only.
  */
-export type AutomationTemplatePrefill = Omit<
+type AutomationTemplatePrefill = Omit<
   Partial<AutomationFormValues>,
   "repositories" | "scheduleTz"
 > & {

--- a/packages/web/src/lib/browser-auth-session-contract.ts
+++ b/packages/web/src/lib/browser-auth-session-contract.ts
@@ -1,7 +1,7 @@
 import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { z } from "zod";
 
-export const browserAuthSessionUserSchema = z.object({
+const browserAuthSessionUserSchema = z.object({
   id: z.string().refine(isCanonicalUserId, "Browser session user id is not canonical"),
   name: z.string().nullable().optional(),
   email: z.string().nullable().optional(),

--- a/packages/web/src/lib/control-plane-query.ts
+++ b/packages/web/src/lib/control-plane-query.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CONTROL_PLANE_QUERY_PARAMS = ["status", "limit", "offset"] as const;
+const DEFAULT_CONTROL_PLANE_QUERY_PARAMS = ["status", "limit", "offset"] as const;
 
 export const SESSION_CONTROL_PLANE_QUERY_PARAMS = [
   ...DEFAULT_CONTROL_PLANE_QUERY_PARAMS,

--- a/packages/web/src/lib/control-plane-transport.ts
+++ b/packages/web/src/lib/control-plane-transport.ts
@@ -13,7 +13,7 @@
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("control-plane-transport");
-export const CONTROL_PLANE_FETCH_TIMEOUT_MS = 15_000;
+const CONTROL_PLANE_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * Get the control plane base URL (no trailing slash) from environment.

--- a/packages/web/src/lib/keyboard-shortcuts.ts
+++ b/packages/web/src/lib/keyboard-shortcuts.ts
@@ -11,7 +11,7 @@ function hasPrimaryModifier(event: KeyboardEvent) {
   return event.metaKey || event.ctrlKey;
 }
 
-export function isEditableElement(target: EventTarget | null) {
+function isEditableElement(target: EventTarget | null) {
   const HTMLElementCtor = typeof HTMLElement === "undefined" ? null : HTMLElement;
   if (!HTMLElementCtor || !(target instanceof HTMLElementCtor)) return false;
   if (target.isContentEditable) return true;

--- a/packages/web/src/lib/request-correlation.ts
+++ b/packages/web/src/lib/request-correlation.ts
@@ -11,7 +11,7 @@ export interface RequestCorrelation {
   requestId: string;
 }
 
-export function createTraceId(): string {
+function createTraceId(): string {
   return crypto.randomUUID();
 }
 
@@ -19,7 +19,7 @@ export function createRequestId(): string {
   return crypto.randomUUID().slice(0, REQUEST_ID_LENGTH);
 }
 
-export function isValidTraceId(value: string | null | undefined): value is string {
+function isValidTraceId(value: string | null | undefined): value is string {
   return Boolean(value && TRACE_ID_PATTERN.test(value));
 }
 

--- a/packages/web/src/lib/scm.ts
+++ b/packages/web/src/lib/scm.ts
@@ -6,7 +6,7 @@
  * defaulting to "github" for upstream compatibility.
  */
 
-export type ScmProvider = "github" | "gitlab" | "bitbucket";
+type ScmProvider = "github" | "gitlab" | "bitbucket";
 
 const BASE_URLS: Record<ScmProvider, string> = {
   github: "https://github.com",

--- a/packages/web/src/lib/server-auth-session.ts
+++ b/packages/web/src/lib/server-auth-session.ts
@@ -7,7 +7,7 @@ import {
 import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 import { serializeBrowserSessionCookies } from "./browser-session-cookie";
 
-export type ServerAuthUser = BrowserAuthSessionUser;
+type ServerAuthUser = BrowserAuthSessionUser;
 
 /**
  * App-owned session contract consumed by server-side BFF routes.

--- a/packages/web/src/lib/session-diffs.ts
+++ b/packages/web/src/lib/session-diffs.ts
@@ -23,7 +23,7 @@ export type ResolvedDiffSelection =
     }
   | { status: "missing"; revisionId: string };
 
-export type SessionDiffViewKind =
+type SessionDiffViewKind =
   | "hidden"
   | "loading"
   | "error"

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -4,7 +4,7 @@ import { formatRepoLabel } from "./repo-label";
 
 export const SESSIONS_PAGE_SIZE = 50;
 const COMMAND_MENU_SESSIONS_LIMIT = 100;
-export const SESSIONS_API_PATH = "/api/sessions";
+const SESSIONS_API_PATH = "/api/sessions";
 export const CURRENT_USER_CREATED_BY = "me";
 export const SIDEBAR_SESSIONS_KEY = buildSessionsPageKey({
   excludeStatus: "archived",

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -10,7 +10,7 @@ import type {
 import { toUiArtifact } from "./artifact-metadata";
 import { collapseReplayTokenEvents, toUiSandboxEvent } from "./event-log";
 
-export interface HistoryCursor {
+interface HistoryCursor {
   timestamp: number;
   id: string;
   sequence?: number;

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -2,7 +2,7 @@ import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME?.trim() || DEFAULT_APP_NAME;
 
-export const DEFAULT_FAVICON_URL = "/favicon.ico";
+const DEFAULT_FAVICON_URL = "/favicon.ico";
 
 export const APP_ICON_URL = process.env.NEXT_PUBLIC_APP_ICON_URL?.trim() || "";
 export const APP_FAVICON_URL = APP_ICON_URL || DEFAULT_FAVICON_URL;


### PR DESCRIPTION
## Summary

- make internally used declarations module-private across the control plane, web, Slack bot, and Linear bot
- remove proven-dead legacy helpers, types, and redundant barrel re-exports
- preserve shared package contracts, runtime-loaded contracts, and intentional shadcn/Radix design-system exports
- reduce Knip findings from 96 unused exports and 62 unused exported types to 23 exports and 0 types

## Verification

- `npm run build -w @open-inspect/shared`
- `npm run typecheck`
- `npm test -w @open-inspect/control-plane` (2518 tests)
- `npm test -w @open-inspect/web` (958 tests)
- `npm test -w @open-inspect/shared` (601 tests)
- `npm test -w @open-inspect/slack-bot` (421 tests)
- `npm test -w @open-inspect/linear-bot` (223 tests)
- ESLint on all changed package files
- `npx --yes knip@6.32.2 --reporter json`
- `git diff --check`

## Remaining Knip findings

The remaining 23 unused exports are intentionally retained standard shadcn/Radix compositional primitives in the web UI modules (`sheet`, `dropdown-menu`, `dialog`, `popover`, `select`, and `alert-dialog`).

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e58bf90fc7b1e829190d1765f8aadced)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the public interface by limiting access to internal helpers, constants, schemas, and implementation details.
  * Removed obsolete authentication, source-control, realtime messaging, and session utilities.
  * Preserved existing runtime behavior for supported functionality.
  * Retained the supported interfaces and types needed for integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->