### PR TITLE
feat: add desktop session details toggle

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -142,6 +142,7 @@ export default function SessionPage() {
   const isPhone = useMediaQuery("(max-width: 767px)");
 
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+  const [isDesktopDetailsOpen, setIsDesktopDetailsOpen] = useState(true);
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
   const actionsButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -175,6 +176,9 @@ export default function SessionPage() {
 
   const toggleDetails = useCallback(() => {
     setIsDetailsOpen((prev) => !prev);
+  }, []);
+  const toggleDesktopDetails = useCallback(() => {
+    setIsDesktopDetailsOpen((prev) => !prev);
   }, []);
   const openMobileDetails = useCallback(() => {
     setIsDetailsOpen(true);
@@ -352,9 +356,11 @@ export default function SessionPage() {
         connected={connected && ready}
         connecting={connecting || (connected && !ready)}
         isDetailsOpen={isDetailsOpen}
+        isDesktopDetailsOpen={isDesktopDetailsOpen}
         detailsButtonRef={detailsButtonRef}
         actionsButtonRef={actionsButtonRef}
         onToggleDetails={toggleDetails}
+        onToggleDesktopDetails={toggleDesktopDetails}
         onOpenMobileDetails={openMobileDetails}
         actions={{
           sessionId,
@@ -387,21 +393,23 @@ export default function SessionPage() {
           <SessionDesktopLayout
             workspace={sessionWorkspace}
             sidebar={
-              <SessionRightSidebar
-                sessionId={sessionId}
-                sessionState={sessionState}
-                participants={profiledParticipants}
-                presenceSynced={presenceSynced}
-                events={events}
-                artifacts={artifacts}
-                terminalOpen={terminalOpen}
-                onToggleTerminal={toggleTerminal}
-                onOpenMedia={setSelectedMediaArtifactId}
-                diffState={diffState}
-                diffLoading={diffLoading}
-                selectedDiff={selectedDiff}
-                onOpenDiff={openDiff}
-              />
+              isDesktopDetailsOpen ? (
+                <SessionRightSidebar
+                  sessionId={sessionId}
+                  sessionState={sessionState}
+                  participants={profiledParticipants}
+                  presenceSynced={presenceSynced}
+                  events={events}
+                  artifacts={artifacts}
+                  terminalOpen={terminalOpen}
+                  onToggleTerminal={toggleTerminal}
+                  onOpenMedia={setSelectedMediaArtifactId}
+                  diffState={diffState}
+                  diffLoading={diffLoading}
+                  selectedDiff={selectedDiff}
+                  onOpenDiff={openDiff}
+                />
+              ) : null
             }
             changes={
               resolvedDiff && diffState ? (

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -357,6 +357,7 @@ export default function SessionPage() {
         connecting={connecting || (connected && !ready)}
         isDetailsOpen={isDetailsOpen}
         isDesktopDetailsOpen={isDesktopDetailsOpen}
+        showDesktopDetailsToggle={!resolvedDiff}
         detailsButtonRef={detailsButtonRef}
         actionsButtonRef={actionsButtonRef}
         onToggleDetails={toggleDetails}
@@ -393,23 +394,22 @@ export default function SessionPage() {
           <SessionDesktopLayout
             workspace={sessionWorkspace}
             sidebar={
-              isDesktopDetailsOpen ? (
-                <SessionRightSidebar
-                  sessionId={sessionId}
-                  sessionState={sessionState}
-                  participants={profiledParticipants}
-                  presenceSynced={presenceSynced}
-                  events={events}
-                  artifacts={artifacts}
-                  terminalOpen={terminalOpen}
-                  onToggleTerminal={toggleTerminal}
-                  onOpenMedia={setSelectedMediaArtifactId}
-                  diffState={diffState}
-                  diffLoading={diffLoading}
-                  selectedDiff={selectedDiff}
-                  onOpenDiff={openDiff}
-                />
-              ) : null
+              <SessionRightSidebar
+                isOpen={isDesktopDetailsOpen && !resolvedDiff}
+                sessionId={sessionId}
+                sessionState={sessionState}
+                participants={profiledParticipants}
+                presenceSynced={presenceSynced}
+                events={events}
+                artifacts={artifacts}
+                terminalOpen={terminalOpen}
+                onToggleTerminal={toggleTerminal}
+                onOpenMedia={setSelectedMediaArtifactId}
+                diffState={diffState}
+                diffLoading={diffLoading}
+                selectedDiff={selectedDiff}
+                onOpenDiff={openDiff}
+              />
             }
             changes={
               resolvedDiff && diffState ? (

--- a/packages/web/src/components/session-desktop-layout.test.tsx
+++ b/packages/web/src/components/session-desktop-layout.test.tsx
@@ -45,6 +45,7 @@ describe("SessionDesktopLayout", () => {
 
     expect(screen.getByTestId("session-main")).toHaveAttribute("data-default-size", "45%");
     expect(screen.getByTestId("session-changes")).toHaveAttribute("data-default-size", "55%");
+    expect(screen.getByText("details")).toBeInTheDocument();
   });
 
   it("clips overflow on the real panel group and nested content wrapper", () => {
@@ -67,6 +68,8 @@ describe("SessionDesktopLayout", () => {
   it("keeps the session workspace mounted when the changes panel opens and closes", () => {
     const mounted = vi.fn();
     const unmounted = vi.fn();
+    const sidebarMounted = vi.fn();
+    const sidebarUnmounted = vi.fn();
 
     function Workspace() {
       useEffect(() => {
@@ -76,30 +79,32 @@ describe("SessionDesktopLayout", () => {
       return <div>timeline and terminal</div>;
     }
 
+    function Sidebar() {
+      useEffect(() => {
+        sidebarMounted();
+        return sidebarUnmounted;
+      }, []);
+      return <aside>details</aside>;
+    }
+
     const { rerender } = render(
-      <SessionDesktopLayout
-        workspace={<Workspace />}
-        sidebar={<aside>details</aside>}
-        changes={null}
-      />
+      <SessionDesktopLayout workspace={<Workspace />} sidebar={<Sidebar />} changes={null} />
     );
 
     rerender(
       <SessionDesktopLayout
         workspace={<Workspace />}
-        sidebar={<aside>details</aside>}
+        sidebar={<Sidebar />}
         changes={<aside>changes</aside>}
       />
     );
     rerender(
-      <SessionDesktopLayout
-        workspace={<Workspace />}
-        sidebar={<aside>details</aside>}
-        changes={null}
-      />
+      <SessionDesktopLayout workspace={<Workspace />} sidebar={<Sidebar />} changes={null} />
     );
 
     expect(mounted).toHaveBeenCalledTimes(1);
     expect(unmounted).not.toHaveBeenCalled();
+    expect(sidebarMounted).toHaveBeenCalledTimes(1);
+    expect(sidebarUnmounted).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/session-desktop-layout.tsx
+++ b/packages/web/src/components/session-desktop-layout.tsx
@@ -52,7 +52,7 @@ export function SessionDesktopLayout({
           </>
         )}
       </PanelGroup>
-      {!changes && sidebar}
+      {sidebar}
     </>
   );
 }

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -47,10 +47,14 @@ describe("SessionHeader", () => {
     );
 
     const hideButton = screen.getByRole("button", { name: "Hide session details" });
+    const connectedStatus = screen.getByText("Connected");
     expect(hideButton).toHaveClass("hidden", "lg:block");
     expect(hideButton).toHaveAttribute("aria-controls", "session-details-sidebar");
     expect(hideButton).toHaveAttribute("aria-expanded", "true");
     expect(hideButton.querySelector('line[x1="15"][x2="15"]')).toBeInTheDocument();
+    expect(
+      connectedStatus.compareDocumentPosition(hideButton) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     fireEvent.click(hideButton);
     expect(onToggleDesktopDetails).toHaveBeenCalledOnce();
 

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -50,6 +50,7 @@ describe("SessionHeader", () => {
     expect(hideButton).toHaveClass("hidden", "lg:block");
     expect(hideButton).toHaveAttribute("aria-controls", "session-details-sidebar");
     expect(hideButton).toHaveAttribute("aria-expanded", "true");
+    expect(hideButton.querySelector('line[x1="15"][x2="15"]')).toBeInTheDocument();
     fireEvent.click(hideButton);
     expect(onToggleDesktopDetails).toHaveBeenCalledOnce();
 

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -36,6 +36,7 @@ describe("SessionHeader", () => {
         connecting={false}
         isDetailsOpen={false}
         isDesktopDetailsOpen
+        showDesktopDetailsToggle
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}
@@ -66,6 +67,7 @@ describe("SessionHeader", () => {
         connecting={false}
         isDetailsOpen={false}
         isDesktopDetailsOpen={false}
+        showDesktopDetailsToggle
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}
@@ -82,6 +84,29 @@ describe("SessionHeader", () => {
     );
   });
 
+  it("hides the desktop details toggle while changes own the right-hand surface", () => {
+    render(
+      <SessionHeader
+        sessionState={null}
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Review changes" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        isDesktopDetailsOpen
+        showDesktopDetailsToggle={false}
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={vi.fn()}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Hide session details" })).not.toBeInTheDocument();
+  });
+
   it("renders no-repository fallback data as loaded while socket state is absent", () => {
     render(
       <SessionHeader
@@ -91,6 +116,7 @@ describe("SessionHeader", () => {
         connecting={true}
         isDetailsOpen={false}
         isDesktopDetailsOpen
+        showDesktopDetailsToggle
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}
@@ -117,6 +143,7 @@ describe("SessionHeader", () => {
         connecting={false}
         isDetailsOpen={false}
         isDesktopDetailsOpen
+        showDesktopDetailsToggle
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={onToggleDetails}

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -26,6 +26,57 @@ const actions: SessionActionProps = {
 };
 
 describe("SessionHeader", () => {
+  it("lets desktop users hide and show the session details sidebar", () => {
+    const onToggleDesktopDetails = vi.fn();
+    const { rerender } = render(
+      <SessionHeader
+        sessionState={null}
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Desktop details" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        isDesktopDetailsOpen
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={onToggleDesktopDetails}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    const hideButton = screen.getByRole("button", { name: "Hide session details" });
+    expect(hideButton).toHaveClass("hidden", "lg:block");
+    expect(hideButton).toHaveAttribute("aria-controls", "session-details-sidebar");
+    expect(hideButton).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(hideButton);
+    expect(onToggleDesktopDetails).toHaveBeenCalledOnce();
+
+    rerender(
+      <SessionHeader
+        sessionState={null}
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Desktop details" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        isDesktopDetailsOpen={false}
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={onToggleDesktopDetails}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Show session details" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
   it("renders no-repository fallback data as loaded while socket state is absent", () => {
     render(
       <SessionHeader
@@ -34,9 +85,11 @@ describe("SessionHeader", () => {
         connected={false}
         connecting={true}
         isDetailsOpen={false}
+        isDesktopDetailsOpen
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={vi.fn()}
         onOpenMobileDetails={vi.fn()}
         actions={actions}
         renameSession={vi.fn()}
@@ -58,9 +111,11 @@ describe("SessionHeader", () => {
         connected
         connecting={false}
         isDetailsOpen={false}
+        isDesktopDetailsOpen
         detailsButtonRef={createRef<HTMLButtonElement>()}
         actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={onToggleDetails}
+        onToggleDesktopDetails={vi.fn()}
         onOpenMobileDetails={onOpenMobileDetails}
         actions={actions}
         renameSession={vi.fn()}

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -159,16 +159,6 @@ export function SessionHeader({
         </div>
         <div className="flex items-center gap-4">
           <button
-            type="button"
-            onClick={onToggleDesktopDetails}
-            className="hidden rounded p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground lg:block"
-            aria-label={isDesktopDetailsOpen ? "Hide session details" : "Show session details"}
-            aria-controls="session-details-sidebar"
-            aria-expanded={isDesktopDetailsOpen}
-          >
-            <RightSidebarIcon className="h-4 w-4" />
-          </button>
-          <button
             ref={detailsButtonRef}
             type="button"
             onClick={onToggleDetails}
@@ -199,6 +189,16 @@ export function SessionHeader({
               dashboardUrl={sessionState?.sandboxDashboardUrl}
             />
           </div>
+          <button
+            type="button"
+            onClick={onToggleDesktopDetails}
+            className="hidden rounded p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground lg:block"
+            aria-label={isDesktopDetailsOpen ? "Hide session details" : "Show session details"}
+            aria-controls="session-details-sidebar"
+            aria-expanded={isDesktopDetailsOpen}
+          >
+            <RightSidebarIcon className="h-4 w-4" />
+          </button>
         </div>
       </div>
     </header>

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -6,6 +6,7 @@ import { MobileSessionActions } from "@/components/mobile-session-actions";
 import type { SessionActionProps } from "@/components/session-actions";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
 import { formatRepoLabel } from "@/lib/repo-label";
+import { SidebarIcon } from "@/components/ui/icons";
 
 type SessionSocketState = ReturnType<typeof useSessionSocket>;
 
@@ -31,9 +32,11 @@ export type SessionHeaderProps = {
   connected: boolean;
   connecting: boolean;
   isDetailsOpen: boolean;
+  isDesktopDetailsOpen: boolean;
   detailsButtonRef: RefObject<HTMLButtonElement | null>;
   actionsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
+  onToggleDesktopDetails: () => void;
   onOpenMobileDetails: () => void;
   actions: SessionActionProps;
   renameSession: (title: string) => Promise<boolean | undefined>;
@@ -45,9 +48,11 @@ export function SessionHeader({
   connected,
   connecting,
   isDetailsOpen,
+  isDesktopDetailsOpen,
   detailsButtonRef,
   actionsButtonRef,
   onToggleDetails,
+  onToggleDesktopDetails,
   onOpenMobileDetails,
   actions,
   renameSession,
@@ -153,6 +158,16 @@ export function SessionHeader({
           </div>
         </div>
         <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={onToggleDesktopDetails}
+            className="hidden rounded p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground lg:block"
+            aria-label={isDesktopDetailsOpen ? "Hide session details" : "Show session details"}
+            aria-controls="session-details-sidebar"
+            aria-expanded={isDesktopDetailsOpen}
+          >
+            <SidebarIcon className="h-4 w-4" />
+          </button>
           <button
             ref={detailsButtonRef}
             type="button"

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -6,7 +6,7 @@ import { MobileSessionActions } from "@/components/mobile-session-actions";
 import type { SessionActionProps } from "@/components/session-actions";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
 import { formatRepoLabel } from "@/lib/repo-label";
-import { SidebarIcon } from "@/components/ui/icons";
+import { RightSidebarIcon } from "@/components/ui/icons";
 
 type SessionSocketState = ReturnType<typeof useSessionSocket>;
 
@@ -166,7 +166,7 @@ export function SessionHeader({
             aria-controls="session-details-sidebar"
             aria-expanded={isDesktopDetailsOpen}
           >
-            <SidebarIcon className="h-4 w-4" />
+            <RightSidebarIcon className="h-4 w-4" />
           </button>
           <button
             ref={detailsButtonRef}

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -33,6 +33,7 @@ export type SessionHeaderProps = {
   connecting: boolean;
   isDetailsOpen: boolean;
   isDesktopDetailsOpen: boolean;
+  showDesktopDetailsToggle: boolean;
   detailsButtonRef: RefObject<HTMLButtonElement | null>;
   actionsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
@@ -49,6 +50,7 @@ export function SessionHeader({
   connecting,
   isDetailsOpen,
   isDesktopDetailsOpen,
+  showDesktopDetailsToggle,
   detailsButtonRef,
   actionsButtonRef,
   onToggleDetails,
@@ -189,16 +191,18 @@ export function SessionHeader({
               dashboardUrl={sessionState?.sandboxDashboardUrl}
             />
           </div>
-          <button
-            type="button"
-            onClick={onToggleDesktopDetails}
-            className="hidden rounded p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground lg:block"
-            aria-label={isDesktopDetailsOpen ? "Hide session details" : "Show session details"}
-            aria-controls="session-details-sidebar"
-            aria-expanded={isDesktopDetailsOpen}
-          >
-            <RightSidebarIcon className="h-4 w-4" />
-          </button>
+          {showDesktopDetailsToggle && (
+            <button
+              type="button"
+              onClick={onToggleDesktopDetails}
+              className="hidden rounded p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground lg:block"
+              aria-label={isDesktopDetailsOpen ? "Hide session details" : "Show session details"}
+              aria-controls="session-details-sidebar"
+              aria-expanded={isDesktopDetailsOpen}
+            >
+              <RightSidebarIcon className="h-4 w-4" />
+            </button>
+          )}
         </div>
       </div>
     </header>

--- a/packages/web/src/components/session-right-sidebar.test.tsx
+++ b/packages/web/src/components/session-right-sidebar.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionRightSidebar } from "./session-right-sidebar";
+
+vi.mock("swr", () => ({ default: () => ({ data: undefined }) }));
+
+afterEach(cleanup);
+
+describe("SessionRightSidebar", () => {
+  it("keeps its ARIA target mounted when closed", () => {
+    render(
+      <SessionRightSidebar
+        isOpen={false}
+        sessionId="session-1"
+        sessionState={null}
+        participants={[]}
+        presenceSynced={false}
+        events={[]}
+        artifacts={[]}
+        onOpenMedia={vi.fn()}
+      />
+    );
+
+    const sidebar = document.getElementById("session-details-sidebar");
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar).toHaveClass("hidden");
+    expect(sidebar).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByText("details")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -284,7 +284,10 @@ export function SessionRightSidebar({
   onOpenDiff,
 }: SessionRightSidebarProps) {
   return (
-    <aside className="hidden w-80 shrink-0 overflow-y-auto border-l border-border-muted lg:block">
+    <aside
+      id="session-details-sidebar"
+      className="hidden w-80 shrink-0 overflow-y-auto border-l border-border-muted lg:block"
+    >
       <SessionRightSidebarContent
         sessionId={sessionId}
         sessionState={sessionState}

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -26,6 +26,7 @@ import { deriveSessionDiffView } from "@/lib/session-diffs";
 import { DiffRetryNotice } from "@/components/diff-retry-notice";
 
 interface SessionRightSidebarProps {
+  isOpen?: boolean;
   sessionId: string;
   sessionState: SessionState | null;
   participants: ParticipantPresence[];
@@ -269,6 +270,7 @@ export function SessionRightSidebarContent({
 }
 
 export function SessionRightSidebar({
+  isOpen = true,
   sessionId,
   sessionState,
   participants,
@@ -286,7 +288,12 @@ export function SessionRightSidebar({
   return (
     <aside
       id="session-details-sidebar"
-      className="hidden w-80 shrink-0 overflow-y-auto border-l border-border-muted lg:block"
+      aria-hidden={!isOpen}
+      className={
+        isOpen
+          ? "hidden w-80 shrink-0 overflow-y-auto border-l border-border-muted lg:block"
+          : "hidden"
+      }
     >
       <SessionRightSidebarContent
         sessionId={sessionId}

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -22,6 +22,23 @@ export function SidebarIcon({ className }: IconProps) {
   );
 }
 
+export function RightSidebarIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="15" y1="3" x2="15" y2="21" />
+    </svg>
+  );
+}
+
 export function BackIcon({ className }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
## Summary
- add a desktop-only control to hide and restore the right-hand session details sidebar
- keep desktop sidebar state independent from the existing tablet and phone details overlay
- expose accessible state through descriptive labels, `aria-expanded`, and `aria-controls`
- add TDD coverage for both open and closed toggle states

## Testing
- `npm test -w @open-inspect/web -- --run src/components/session-header.test.tsx src/components/session-desktop-layout.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx eslint "packages/web/src/app/(app)/session/[id]/page.tsx" packages/web/src/components/session-header.tsx packages/web/src/components/session-header.test.tsx packages/web/src/components/session-right-sidebar.tsx`
- `npx prettier --check "packages/web/src/app/(app)/session/[id]/page.tsx" packages/web/src/components/session-header.tsx packages/web/src/components/session-header.test.tsx packages/web/src/components/session-right-sidebar.tsx`
- full web suite: 957 tests passed; two ESLint-boundary tests timed out under parallel load, then both passed when rerun independently (`7/7` and `5/5`)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/7f69f81c9093503a9fcd23aea5605a93)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop toggle for showing or hiding session details.
  * Added accessible labels and state indicators for the sidebar toggle.
  * Mobile session-details behavior remains unchanged.

* **Bug Fixes**
  * Improved desktop sidebar visibility handling and layout updates.

* **Tests**
  * Added coverage for sidebar toggling, accessibility attributes, button states, and sidebar placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->