### PR TITLE
Normalize responsive spacing on Automations and Analytics

### DIFF
--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -68,7 +68,7 @@ export default function AnalyticsPage() {
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="relative z-10 mx-auto max-w-7xl space-y-6">
           <div className="relative overflow-hidden rounded-xl border border-border-muted bg-card px-5 py-5 sm:px-6 sm:py-6">
             <div className="pointer-events-none absolute inset-y-0 right-0 w-1/3 bg-[linear-gradient(135deg,var(--accent-muted),transparent)] opacity-70" />
@@ -79,7 +79,7 @@ export default function AnalyticsPage() {
                   Usage analytics
                 </div>
                 <div>
-                  <h1 className="text-3xl font-semibold text-foreground">Analytics</h1>
+                  <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">Analytics</h1>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
                     Usage metrics across sessions, repositories, and users. PR counts currently
                     reflect pull requests created through the platform&apos;s built-in flow, and

--- a/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
@@ -83,9 +83,11 @@ export default function EditAutomationPage({ params }: { params: Promise<{ id: s
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="max-w-2xl mx-auto">
-          <h1 className="text-3xl font-semibold text-foreground mb-6">Edit Automation</h1>
+          <h1 className="mb-6 text-2xl font-semibold text-foreground sm:text-3xl">
+            Edit Automation
+          </h1>
 
           {error && (
             <ErrorBanner className="mb-4" role="alert">

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -113,7 +113,7 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="max-w-3xl mx-auto">
           {actionError && (
             <ErrorBanner className="mb-4" role="alert">
@@ -125,7 +125,9 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
           <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <div className="flex flex-wrap items-center gap-2">
-                <h1 className="text-3xl font-semibold text-foreground">{automation.name}</h1>
+                <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">
+                  {automation.name}
+                </h1>
                 <AutomationStatusBadge automation={automation} />
               </div>
               <p className="text-sm text-muted-foreground mt-1">

--- a/packages/web/src/app/(app)/automations/new/page.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.tsx
@@ -84,9 +84,11 @@ function NewAutomationContent() {
           </header>
         )}
 
-        <div className="flex-1 overflow-y-auto p-8">
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
           <div className="max-w-2xl mx-auto">
-            <h1 className="text-3xl font-semibold text-foreground mb-2">Automation Created</h1>
+            <h1 className="mb-2 text-2xl font-semibold text-foreground sm:text-3xl">
+              Automation Created
+            </h1>
             {webhookResult.sentryWebhookUrl ? (
               <>
                 <p className="text-sm text-muted-foreground mb-6">
@@ -139,9 +141,11 @@ function NewAutomationContent() {
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="max-w-2xl mx-auto">
-          <h1 className="text-3xl font-semibold text-foreground mb-6">Create Automation</h1>
+          <h1 className="mb-6 text-2xl font-semibold text-foreground sm:text-3xl">
+            Create Automation
+          </h1>
 
           {error && (
             <ErrorBanner className="mb-4" role="alert">

--- a/packages/web/src/app/(app)/automations/page.tsx
+++ b/packages/web/src/app/(app)/automations/page.tsx
@@ -45,10 +45,10 @@ export default function AutomationsPage() {
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="max-w-3xl mx-auto">
           <div className="flex items-center justify-between mb-6">
-            <h1 className="text-3xl font-semibold text-foreground">Automations</h1>
+            <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">Automations</h1>
             <div className="flex items-center gap-2">
               <Button variant="outline" size="sm" asChild>
                 <Link href="/automations/templates">Browse templates</Link>

--- a/packages/web/src/app/(app)/automations/templates/page.tsx
+++ b/packages/web/src/app/(app)/automations/templates/page.tsx
@@ -25,10 +25,12 @@ export default function AutomationTemplatesPage() {
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-8">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
         <div className="max-w-3xl mx-auto">
           <div className="mb-6">
-            <h1 className="text-3xl font-semibold text-foreground">Automation templates</h1>
+            <h1 className="text-2xl font-semibold text-foreground sm:text-3xl">
+              Automation templates
+            </h1>
             <p className="mt-1.5 text-sm text-muted-foreground">
               Start from a pre-built idea instead of a blank form. Pick a template, choose a
               repository, and create.


### PR DESCRIPTION
## Summary
- use responsive page padding across Analytics and all Automations routes
- scale page-level headings from `text-2xl` on mobile to `text-3xl` on larger screens
- cover create, post-create, templates, detail, and edit Automation states

## Verification
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npm test -w @open-inspect/web -- --run 'src/app/(app)/analytics/page.test.tsx' 'src/app/(app)/automations/new/page.test.tsx'`
- Prettier check on all changed files

## Visual verification
- Not captured because no configured local web server was running in the workspace.

Closes COL-29

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/70bf9a7ca0d23ec4bda89c2dcb57e718)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across Analytics and Automations pages.
  * Adjusted page spacing to provide a better experience on mobile, tablet, and desktop screens.
  * Updated headings with responsive typography that scales appropriately across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->