### PR TITLE
fix: persist desktop session details sidebar preference

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/components/session-desktop-layout";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { useBrowserLayoutStorage } from "@/hooks/use-browser-layout-storage";
+import { usePersistedBoolean } from "@/hooks/use-persisted-boolean";
 import { focusSessionDetailsTrigger } from "@/lib/session-details-focus";
 import { useSessionParticipantProfiles } from "@/hooks/use-session-participant-profiles";
 import {
@@ -68,6 +69,7 @@ import { useSessionSnapshot } from "./session-snapshot-provider";
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
 const TERMINAL_VISIBLE_STORAGE_KEY = "terminal-visible";
+const DESKTOP_DETAILS_OPEN_STORAGE_KEY = "session-details-open";
 
 export default function SessionPage() {
   const initialSnapshot = useSessionSnapshot();
@@ -142,31 +144,20 @@ export default function SessionPage() {
   const isPhone = useMediaQuery("(max-width: 767px)");
 
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-  const [isDesktopDetailsOpen, setIsDesktopDetailsOpen] = useState(true);
+  const { value: isDesktopDetailsOpen, toggle: toggleDesktopDetails } = usePersistedBoolean(
+    DESKTOP_DETAILS_OPEN_STORAGE_KEY,
+    true
+  );
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
   const actionsButtonRef = useRef<HTMLButtonElement>(null);
 
   // Terminal panel state. Starts closed so the server and the client render the
   // same markup, then adopts the stored preference after hydration.
-  const [terminalOpen, setTerminalOpen] = useState(false);
-  useEffect(() => {
-    try {
-      setTerminalOpen(localStorage.getItem(TERMINAL_VISIBLE_STORAGE_KEY) === "true");
-    } catch {
-      // Storage is optional; the terminal stays closed when it is unavailable.
-    }
-  }, []);
-  const applyTerminalOpen = useCallback((next: boolean) => {
-    setTerminalOpen(next);
-    try {
-      localStorage.setItem(TERMINAL_VISIBLE_STORAGE_KEY, String(next));
-    } catch {
-      // Continue with the in-memory preference when storage is unavailable.
-    }
-  }, []);
-  const toggleTerminal = useCallback(() => {
-    applyTerminalOpen(!terminalOpen);
-  }, [applyTerminalOpen, terminalOpen]);
+  const {
+    value: terminalOpen,
+    setValue: applyTerminalOpen,
+    toggle: toggleTerminal,
+  } = usePersistedBoolean(TERMINAL_VISIBLE_STORAGE_KEY, false);
   const closeTerminal = useCallback(() => {
     applyTerminalOpen(false);
   }, [applyTerminalOpen]);
@@ -176,9 +167,6 @@ export default function SessionPage() {
 
   const toggleDetails = useCallback(() => {
     setIsDetailsOpen((prev) => !prev);
-  }, []);
-  const toggleDesktopDetails = useCallback(() => {
-    setIsDesktopDetailsOpen((prev) => !prev);
   }, []);
   const openMobileDetails = useCallback(() => {
     setIsDetailsOpen(true);

--- a/packages/web/src/hooks/use-persisted-boolean.test.tsx
+++ b/packages/web/src/hooks/use-persisted-boolean.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePersistedBoolean } from "./use-persisted-boolean";
+
+const STORAGE_KEY = "test-persisted-boolean";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("usePersistedBoolean", () => {
+  it("restores a stored preference after mount", async () => {
+    localStorage.setItem(STORAGE_KEY, "false");
+    const { result } = renderHook(() => usePersistedBoolean(STORAGE_KEY, true));
+
+    await waitFor(() => expect(result.current.value).toBe(false));
+  });
+
+  it("keeps the default when nothing is stored", () => {
+    const { result } = renderHook(() => usePersistedBoolean(STORAGE_KEY, true));
+
+    expect(result.current.value).toBe(true);
+  });
+
+  it("persists toggles and explicit updates", async () => {
+    const { result } = renderHook(() => usePersistedBoolean(STORAGE_KEY, true));
+
+    act(() => result.current.toggle());
+    expect(result.current.value).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("false");
+
+    act(() => result.current.setValue(true));
+    expect(result.current.value).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("keeps working when localStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+
+    const { result } = renderHook(() => usePersistedBoolean(STORAGE_KEY, true));
+
+    act(() => result.current.toggle());
+    expect(result.current.value).toBe(false);
+  });
+});

--- a/packages/web/src/hooks/use-persisted-boolean.ts
+++ b/packages/web/src/hooks/use-persisted-boolean.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Boolean preference that hydrates from localStorage after mount so SSR and the
+ * first client paint stay aligned, then persists subsequent updates.
+ */
+export function usePersistedBoolean(storageKey: string, defaultValue: boolean) {
+  const [value, setValueState] = useState(defaultValue);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored === "true" || stored === "false") {
+        setValueState(stored === "true");
+      }
+    } catch {
+      // Storage is optional; keep the default when unavailable.
+    }
+  }, [storageKey]);
+
+  const setValue = useCallback(
+    (next: boolean) => {
+      setValueState(next);
+      try {
+        localStorage.setItem(storageKey, String(next));
+      } catch {
+        // Continue with the in-memory preference when storage is unavailable.
+      }
+    },
+    [storageKey]
+  );
+
+  const toggle = useCallback(() => {
+    setValueState((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(storageKey, String(next));
+      } catch {
+        // Continue with the in-memory preference when storage is unavailable.
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  return { value, setValue, toggle };
+}


### PR DESCRIPTION
## Summary
- The desktop right-hand session details toggle (`isDesktopDetailsOpen`) was in-memory only, so closing it did not survive reload, unlike the left sidebar and terminal preferences.
- Added `usePersistedBoolean` to hydrate boolean UI prefs from `localStorage` after mount and write updates back.
- Wired the desktop details sidebar to `session-details-open`, and moved the existing terminal preference onto the same helper.

## Testing
- `npm test -w @open-inspect/web -- --run src/hooks/use-persisted-boolean.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx eslint packages/web/src/hooks/use-persisted-boolean.ts packages/web/src/hooks/use-persisted-boolean.test.tsx "packages/web/src/app/(app)/session/[id]/page.tsx"`
- `npx prettier --check` on the touched files

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f47fe4b0a2e88ecd7050e9eeda1244a6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session page preferences for desktop details and terminal visibility now persist across visits.
  * Preferences safely retain their in-memory state when browser storage is unavailable.

* **Bug Fixes**
  * Improved preference initialization and restoration from previously saved settings.

* **Tests**
  * Added coverage for restoring, updating, toggling, default behavior, and storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->