### PR TITLE
fix: persist session details sidebar state

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -52,6 +52,7 @@ import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { useBrowserLayoutStorage } from "@/hooks/use-browser-layout-storage";
 import { focusSessionDetailsTrigger } from "@/lib/session-details-focus";
 import { useSessionParticipantProfiles } from "@/hooks/use-session-participant-profiles";
+import { useSessionDetailsSidebar } from "@/hooks/use-session-details-sidebar";
 import {
   promptRequestSignature,
   resolvePromptRequestIdentity,
@@ -142,7 +143,7 @@ export default function SessionPage() {
   const isPhone = useMediaQuery("(max-width: 767px)");
 
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-  const [isDesktopDetailsOpen, setIsDesktopDetailsOpen] = useState(true);
+  const { isOpen: isDesktopDetailsOpen, toggle: toggleDesktopDetails } = useSessionDetailsSidebar();
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
   const actionsButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -176,9 +177,6 @@ export default function SessionPage() {
 
   const toggleDetails = useCallback(() => {
     setIsDetailsOpen((prev) => !prev);
-  }, []);
-  const toggleDesktopDetails = useCallback(() => {
-    setIsDesktopDetailsOpen((prev) => !prev);
   }, []);
   const openMobileDetails = useCallback(() => {
     setIsDetailsOpen(true);

--- a/packages/web/src/hooks/use-session-details-sidebar.test.tsx
+++ b/packages/web/src/hooks/use-session-details-sidebar.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSessionDetailsSidebar } from "./use-session-details-sidebar";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe("useSessionDetailsSidebar", () => {
+  it("opens the sidebar by default", () => {
+    const { result } = renderHook(() => useSessionDetailsSidebar());
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("persists and restores the closed preference", async () => {
+    const firstRender = renderHook(() => useSessionDetailsSidebar());
+
+    act(() => firstRender.result.current.toggle());
+
+    expect(firstRender.result.current.isOpen).toBe(false);
+    expect(localStorage.getItem("open-inspect-session-details-sidebar-open")).toBe("false");
+    firstRender.unmount();
+
+    const secondRender = renderHook(() => useSessionDetailsSidebar());
+
+    await waitFor(() => expect(secondRender.result.current.isOpen).toBe(false));
+  });
+
+  it("keeps working when browser storage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage unavailable");
+    });
+    const { result } = renderHook(() => useSessionDetailsSidebar());
+
+    act(() => result.current.toggle());
+
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/packages/web/src/hooks/use-session-details-sidebar.test.tsx
+++ b/packages/web/src/hooks/use-session-details-sidebar.test.tsx
@@ -29,6 +29,18 @@ describe("useSessionDetailsSidebar", () => {
     await waitFor(() => expect(secondRender.result.current.isOpen).toBe(false));
   });
 
+  it("applies multiple queued toggles in order", () => {
+    const { result } = renderHook(() => useSessionDetailsSidebar());
+
+    act(() => {
+      result.current.toggle();
+      result.current.toggle();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(localStorage.getItem("open-inspect-session-details-sidebar-open")).toBe("true");
+  });
+
   it("keeps working when browser storage is unavailable", () => {
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("Storage unavailable");

--- a/packages/web/src/hooks/use-session-details-sidebar.ts
+++ b/packages/web/src/hooks/use-session-details-sidebar.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY = "open-inspect-session-details-sidebar-open";
+
+export function useSessionDetailsSidebar() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY);
+      if (stored === "true" || stored === "false") {
+        setIsOpen(stored === "true");
+      }
+    } catch {
+      // Storage is optional; the sidebar remains open when it is unavailable.
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    const next = !isOpen;
+    setIsOpen(next);
+    try {
+      localStorage.setItem(SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY, String(next));
+    } catch {
+      // Continue with the in-memory preference when storage is unavailable.
+    }
+  }, [isOpen]);
+
+  return { isOpen, toggle };
+}

--- a/packages/web/src/hooks/use-session-details-sidebar.ts
+++ b/packages/web/src/hooks/use-session-details-sidebar.ts
@@ -2,10 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+export const DEFAULT_SESSION_DETAILS_SIDEBAR_OPEN = true;
 const SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY = "open-inspect-session-details-sidebar-open";
 
 export function useSessionDetailsSidebar() {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(DEFAULT_SESSION_DETAILS_SIDEBAR_OPEN);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     try {
@@ -14,19 +16,23 @@ export function useSessionDetailsSidebar() {
         setIsOpen(stored === "true");
       }
     } catch {
-      // Storage is optional; the sidebar remains open when it is unavailable.
+      // Storage is optional; the sidebar keeps DEFAULT_SESSION_DETAILS_SIDEBAR_OPEN.
     }
+    setIsHydrated(true);
   }, []);
 
-  const toggle = useCallback(() => {
-    const next = !isOpen;
-    setIsOpen(next);
+  useEffect(() => {
+    if (!isHydrated) return;
     try {
-      localStorage.setItem(SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY, String(next));
+      localStorage.setItem(SESSION_DETAILS_SIDEBAR_OPEN_STORAGE_KEY, String(isOpen));
     } catch {
       // Continue with the in-memory preference when storage is unavailable.
     }
-  }, [isOpen]);
+  }, [isHydrated, isOpen]);
+
+  const toggle = useCallback(() => {
+    setIsOpen((previous) => !previous);
+  }, []);
 
   return { isOpen, toggle };
 }


### PR DESCRIPTION
## Summary
- persist the desktop session details sidebar open/closed preference in browser storage
- restore the preference after hydration while preserving the existing open-by-default behavior
- keep sidebar toggling functional when browser storage is unavailable
- add hook coverage for default, persisted closed, and unavailable-storage behavior

## Testing
- `npm test -w @open-inspect/web -- --run src/hooks/use-session-details-sidebar.test.tsx src/components/session-header.test.tsx src/components/session-right-sidebar.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx eslint "packages/web/src/hooks/use-session-details-sidebar.ts" "packages/web/src/hooks/use-session-details-sidebar.test.tsx" "packages/web/src/app/(app)/session/[id]/page.tsx"`
- `npx prettier --check "packages/web/src/hooks/use-session-details-sidebar.ts" "packages/web/src/hooks/use-session-details-sidebar.test.tsx" "packages/web/src/app/(app)/session/[id]/page.tsx"`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ec1a5c94aed4994ae8d2a06c6b27d069)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent session details-sidebar preferences, restoring the sidebar’s open or closed state across visits.
  * Added a desktop toggle for showing or hiding session details.
  * Sidebar preferences now load reliably when returning to a session.

* **Bug Fixes**
  * Sidebar controls continue working when browser storage is unavailable or fails.

* **Tests**
  * Added coverage for default behavior, preference persistence, restoration, toggle handling, cleanup, and storage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->