### PR TITLE
feat: remove queued prompts from sessions

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1291,13 +1291,14 @@ export class SessionDO extends DurableObject<Env> {
     try {
       const data = this.parseWebSocketMessage(message, "client", clientMessageSchema);
       if (!data) {
-        const invalidPrompt = this.readInvalidPrompt(message);
+        const invalidRequest = this.readInvalidCorrelatedRequest(message);
         this.safeSend(ws, {
           type: "error",
-          code: invalidPrompt ? "INVALID_PROMPT" : "INVALID_MESSAGE",
-          message: invalidPrompt ? "Invalid prompt" : "Failed to process message",
-          ...(invalidPrompt?.clientRequestId
-            ? { clientRequestId: invalidPrompt.clientRequestId }
+          code: invalidRequest?.type === "prompt" ? "INVALID_PROMPT" : "INVALID_MESSAGE",
+          message:
+            invalidRequest?.type === "prompt" ? "Invalid prompt" : "Failed to process message",
+          ...(invalidRequest?.clientRequestId
+            ? { clientRequestId: invalidRequest.clientRequestId }
             : {}),
         });
         return;
@@ -1319,6 +1320,10 @@ export class SessionDO extends DurableObject<Env> {
       switch (data.type) {
         case "prompt":
           await this.handlePromptMessage(ws, client, data);
+          break;
+
+        case "cancel_prompt":
+          await this.messageQueue.cancelQueuedPrompt(ws, data);
           break;
 
         case "stop":
@@ -1377,14 +1382,18 @@ export class SessionDO extends DurableObject<Env> {
     return result.data;
   }
 
-  private readInvalidPrompt(message: string): { clientRequestId?: string } | null {
+  private readInvalidCorrelatedRequest(
+    message: string
+  ): { type: "prompt" | "cancel_prompt"; clientRequestId?: string } | null {
     try {
       const raw = JSON.parse(message) as unknown;
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
       const candidate = raw as Record<string, unknown>;
-      if (candidate.type !== "prompt") return null;
+      if (candidate.type !== "prompt" && candidate.type !== "cancel_prompt") return null;
       const clientRequestId = clientRequestIdSchema.safeParse(candidate.clientRequestId);
-      return clientRequestId.success ? { clientRequestId: clientRequestId.data } : {};
+      return clientRequestId.success
+        ? { type: candidate.type, clientRequestId: clientRequestId.data }
+        : { type: candidate.type };
     } catch {
       return null;
     }

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -130,6 +130,7 @@ function buildQueue() {
     createEvent: vi.fn(),
     getPendingOrProcessingCount: vi.fn(() => 1),
     getMessageByClientRequestId: vi.fn(() => null as MessageRow | null),
+    cancelPendingMessage: vi.fn(() => false),
     getUnfinishedMessagePosition: vi.fn((): number | null => 1),
     listUnfinishedMessages: vi.fn((): MessageRow[] => []),
     listPromptQueue: vi.fn(() => []),
@@ -183,6 +184,7 @@ function buildQueue() {
   const sessionStatus = {
     transition: vi.fn(async (_status: string) => true),
     reconcileAfterExecution: vi.fn(async (_success: boolean) => {}),
+    reconcileAfterQueueRemoval: vi.fn(async () => {}),
   };
   const sandboxLifecycle = {
     spawnSandbox: vi.fn(async () => {}),
@@ -231,6 +233,56 @@ function buildQueue() {
 }
 
 describe("SessionMessageQueue", () => {
+  it("cancels a pending prompt and confirms it to the requester", async () => {
+    const h = buildQueue();
+    h.repository.cancelPendingMessage.mockReturnValue(true);
+    const ws = {} as WebSocket;
+
+    await h.queue.cancelQueuedPrompt(ws, {
+      messageId: "msg-1",
+      clientRequestId: "request-1",
+    });
+
+    expect(h.repository.cancelPendingMessage).toHaveBeenCalledWith("msg-1");
+    expect(h.wsManager.send).toHaveBeenCalledWith(ws, {
+      type: "prompt_cancelled",
+      clientRequestId: "request-1",
+      messageId: "msg-1",
+    });
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "prompt_queue_updated", promptQueue: [] });
+    expect(h.sessionStatus.reconcileAfterQueueRemoval).toHaveBeenCalledOnce();
+  });
+
+  it("rejects cancellation after a prompt leaves pending state", async () => {
+    const h = buildQueue();
+    const ws = {} as WebSocket;
+
+    await h.queue.cancelQueuedPrompt(ws, {
+      messageId: "msg-1",
+      clientRequestId: "request-1",
+    });
+
+    expect(h.wsManager.send).toHaveBeenCalledWith(ws, {
+      type: "error",
+      code: "PROMPT_NOT_CANCELLABLE",
+      message: "This prompt is no longer pending and cannot be removed",
+      clientRequestId: "request-1",
+    });
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("reconciles session status after removing a prompt", async () => {
+    const h = buildQueue();
+    h.repository.cancelPendingMessage.mockReturnValue(true);
+
+    await h.queue.cancelQueuedPrompt({} as WebSocket, {
+      messageId: "msg-1",
+      clientRequestId: "request-1",
+    });
+
+    expect(h.sessionStatus.reconcileAfterQueueRemoval).toHaveBeenCalledOnce();
+  });
+
   it("spawns sandbox when queue has work but no sandbox socket", async () => {
     const h = buildQueue();
     h.repository.getNextPendingMessage.mockReturnValue(createMessage());

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -250,6 +250,34 @@ export class SessionMessageQueue {
     await this.processMessageQueue();
   }
 
+  async cancelQueuedPrompt(
+    ws: WebSocket,
+    data: { messageId: string; clientRequestId: string }
+  ): Promise<void> {
+    if (!this.repository.cancelPendingMessage(data.messageId)) {
+      this.wsManager.send(ws, {
+        type: "error",
+        code: "PROMPT_NOT_CANCELLABLE",
+        message: "This prompt is no longer pending and cannot be removed",
+        clientRequestId: data.clientRequestId,
+      });
+      return;
+    }
+
+    this.wsManager.send(ws, {
+      type: "prompt_cancelled",
+      clientRequestId: data.clientRequestId,
+      messageId: data.messageId,
+    });
+    this.broadcastPromptQueue();
+    this.log.info("prompt.cancelled", {
+      event: "prompt.cancelled",
+      message_id: data.messageId,
+    });
+
+    await this.sessionStatus.reconcileAfterQueueRemoval();
+  }
+
   async processMessageQueue(): Promise<void> {
     const currentSession = this.repository.getSession();
     if (!currentSession || !isPromptableSessionStatus(currentSession.status)) {

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -748,7 +748,7 @@ describe("SessionRepository", () => {
       ]);
 
       expect(repo.listPromptQueue()).toEqual([
-        { messageId: "msg-legacy", content: "continue", status: "pending" },
+        { messageId: "msg-legacy", content: "continue", status: "pending", canCancel: true },
       ]);
     });
   });
@@ -823,6 +823,50 @@ describe("SessionRepository", () => {
       expect(() => repo.createMessageWithAttachments(message, ["up-1", "up-2"])).toThrow(
         AttachmentClaimConflictError
       );
+      expect(mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe("cancelPendingMessage", () => {
+    const statusQuery = `SELECT status, source, callback_context FROM messages WHERE id = ?`;
+
+    it("atomically releases attachments and deletes a pending message", () => {
+      mock.setData(statusQuery, [{ status: "pending", source: "web", callback_context: null }]);
+      mock.setDefaultRowsWritten(1);
+
+      expect(repo.cancelPendingMessage("msg-1")).toBe(true);
+
+      expect(transactionSyncCalls).toBe(1);
+      expect(mock.calls[1]).toMatchObject({
+        query: expect.stringContaining("UPDATE attachments SET message_id = NULL"),
+        params: ["msg-1"],
+      });
+      expect(mock.calls[2]).toMatchObject({
+        query: expect.stringContaining("DELETE FROM messages"),
+        params: ["msg-1"],
+      });
+    });
+
+    it("does not change a processing message", () => {
+      mock.setData(statusQuery, [{ status: "processing", source: "web", callback_context: null }]);
+
+      expect(repo.cancelPendingMessage("msg-1")).toBe(false);
+      expect(mock.calls).toHaveLength(1);
+    });
+
+    it("does not delete a non-web prompt that may require a callback", () => {
+      mock.setData(statusQuery, [{ status: "pending", source: "linear", callback_context: null }]);
+
+      expect(repo.cancelPendingMessage("msg-1")).toBe(false);
+      expect(mock.calls).toHaveLength(1);
+    });
+
+    it("does not delete a prompt with a completion callback", () => {
+      mock.setData(statusQuery, [
+        { status: "pending", source: "web", callback_context: '{"channel":"C1"}' },
+      ]);
+
+      expect(repo.cancelPendingMessage("msg-1")).toBe(false);
       expect(mock.calls).toHaveLength(1);
     });
   });

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -751,6 +751,33 @@ describe("SessionRepository", () => {
         { messageId: "msg-legacy", content: "continue", status: "pending", canCancel: true },
       ]);
     });
+
+    it("does not mark processing prompts as cancellable", () => {
+      vi.spyOn(repo, "listUnfinishedMessages").mockReturnValue([
+        {
+          id: "msg-running",
+          author_id: "part-1",
+          content: "running",
+          source: "web",
+          model: null,
+          reasoning_effort: null,
+          attachments: null,
+          callback_context: null,
+          client_request_id: null,
+          request_fingerprint: null,
+          status: "processing",
+          error_message: null,
+          stop_confirmation_deadline: null,
+          created_at: 1000,
+          started_at: 1100,
+          completed_at: null,
+        },
+      ]);
+
+      expect(repo.listPromptQueue()).toEqual([
+        { messageId: "msg-running", content: "running", status: "processing", canCancel: false },
+      ]);
+    });
   });
 
   describe("createMessage", () => {

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -748,34 +748,7 @@ describe("SessionRepository", () => {
       ]);
 
       expect(repo.listPromptQueue()).toEqual([
-        { messageId: "msg-legacy", content: "continue", status: "pending", canCancel: true },
-      ]);
-    });
-
-    it("does not mark processing prompts as cancellable", () => {
-      vi.spyOn(repo, "listUnfinishedMessages").mockReturnValue([
-        {
-          id: "msg-running",
-          author_id: "part-1",
-          content: "running",
-          source: "web",
-          model: null,
-          reasoning_effort: null,
-          attachments: null,
-          callback_context: null,
-          client_request_id: null,
-          request_fingerprint: null,
-          status: "processing",
-          error_message: null,
-          stop_confirmation_deadline: null,
-          created_at: 1000,
-          started_at: 1100,
-          completed_at: null,
-        },
-      ]);
-
-      expect(repo.listPromptQueue()).toEqual([
-        { messageId: "msg-running", content: "running", status: "processing", canCancel: false },
+        { messageId: "msg-legacy", content: "continue", status: "pending" },
       ]);
     });
   });

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -277,7 +277,10 @@ export class SessionRepository {
   constructor(
     private readonly sql: SqlStorage,
     private readonly transactionSync: TransactionSync,
-    private readonly attachments: Pick<SessionAttachmentRepository, "claimForMessage">
+    private readonly attachments: Pick<
+      SessionAttachmentRepository,
+      "claimForMessage" | "releaseForMessage"
+    >
   ) {}
 
   private rows<T>(result: SqlResult): T[] {
@@ -877,7 +880,39 @@ export class SessionRepository {
       messageId: message.id,
       content: message.content,
       status: message.status as "pending" | "processing",
+      canCancel: message.source === "web" && message.callback_context === null,
     }));
+  }
+
+  cancelPendingMessage(messageId: string): boolean {
+    return this.transactionSync(() => {
+      const result = this.sql.exec(
+        `SELECT status, source, callback_context FROM messages WHERE id = ?`,
+        messageId
+      );
+      const message = (
+        result.toArray() as Array<{
+          status: MessageStatus;
+          source: string;
+          callback_context: string | null;
+        }>
+      )[0];
+      if (
+        message?.status !== "pending" ||
+        message.source !== "web" ||
+        message.callback_context !== null
+      ) {
+        return false;
+      }
+
+      this.attachments.releaseForMessage(messageId);
+      const deleted = this.sql.exec(
+        `DELETE FROM messages WHERE id = ? AND status = 'pending'`,
+        messageId
+      );
+      deleted.toArray();
+      return deleted.rowsWritten === 1;
+    });
   }
 
   getMessageCallbackContext(

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -880,7 +880,10 @@ export class SessionRepository {
       messageId: message.id,
       content: message.content,
       status: message.status as "pending" | "processing",
-      canCancel: message.source === "web" && message.callback_context === null,
+      canCancel:
+        message.status === "pending" &&
+        message.source === "web" &&
+        message.callback_context === null,
     }));
   }
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -880,10 +880,6 @@ export class SessionRepository {
       messageId: message.id,
       content: message.content,
       status: message.status as "pending" | "processing",
-      canCancel:
-        message.status === "pending" &&
-        message.source === "web" &&
-        message.callback_context === null,
     }));
   }
 

--- a/packages/control-plane/src/session/session-attachment-repository.ts
+++ b/packages/control-plane/src/session/session-attachment-repository.ts
@@ -69,6 +69,10 @@ export class SessionAttachmentRepository {
     }
   }
 
+  releaseForMessage(messageId: string): void {
+    this.sql.exec(`UPDATE attachments SET message_id = NULL WHERE message_id = ?`, messageId);
+  }
+
   /** Claim stale records without losing ownership before fallible object deletion. */
   claimStale(
     cutoff: number,

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -3,7 +3,7 @@ import { SessionStatusService } from "./session-status-service";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import type { Logger } from "../logger";
 import type { SessionIndexStore } from "../db/session-index";
-import type { SessionRow, ArtifactRow } from "./types";
+import type { SessionRow, ArtifactRow, MessageRow } from "./types";
 import type { SessionRepository } from "./repository";
 import type { SessionMessenger } from "./messenger";
 
@@ -44,6 +44,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
     getSession: vi.fn(() => session),
     updateSessionStatus: vi.fn(),
     getPendingOrProcessingCount: vi.fn(() => 0),
+    getLatestTerminalMessage: vi.fn(() => null as MessageRow | null),
     getMessageCount: vi.fn(() => 3),
     getActiveDurationMs: vi.fn(() => 4500),
     listArtifacts: vi.fn(
@@ -285,6 +286,35 @@ describe("SessionStatusService.reconcileAfterExecution", () => {
     await h.service.reconcileAfterExecution(false);
 
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "failed" });
+  });
+});
+
+describe("SessionStatusService.reconcileAfterQueueRemoval", () => {
+  it("preserves the latest failed execution outcome", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+    h.repository.getLatestTerminalMessage.mockReturnValue({ status: "failed" } as MessageRow);
+
+    await h.service.reconcileAfterQueueRemoval();
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "failed" });
+  });
+
+  it("completes when no failed terminal message remains", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+    h.repository.getLatestTerminalMessage.mockReturnValue({ status: "completed" } as MessageRow);
+
+    await h.service.reconcileAfterQueueRemoval();
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
+  });
+
+  it("does not transition while other work remains", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+    h.repository.getPendingOrProcessingCount.mockReturnValue(1);
+
+    await h.service.reconcileAfterQueueRemoval();
+
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -308,6 +308,14 @@ describe("SessionStatusService.reconcileAfterQueueRemoval", () => {
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
   });
 
+  it("returns to created when no prompt has executed", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+
+    await h.service.reconcileAfterQueueRemoval();
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "created" });
+  });
+
   it("does not transition while other work remains", async () => {
     const h = harness({ session: createSession({ status: "active" }) });
     h.repository.getPendingOrProcessingCount.mockReturnValue(1);

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -110,6 +110,12 @@ export class SessionStatusService {
     await this.transition(nextStatus);
   }
 
+  async reconcileAfterQueueRemoval(): Promise<void> {
+    if (this.repository.getPendingOrProcessingCount() > 0) return;
+    const latestMessage = this.repository.getLatestTerminalMessage();
+    await this.transition(latestMessage?.status === "failed" ? "failed" : "completed");
+  }
+
   /**
    * Fire-and-forget notification to the parent session so its connected
    * clients can refresh the child-sessions list in real time.

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -113,7 +113,12 @@ export class SessionStatusService {
   async reconcileAfterQueueRemoval(): Promise<void> {
     if (this.repository.getPendingOrProcessingCount() > 0) return;
     const latestMessage = this.repository.getLatestTerminalMessage();
-    await this.transition(latestMessage?.status === "failed" ? "failed" : "completed");
+    const nextStatus: SessionStatus = latestMessage
+      ? latestMessage.status === "failed"
+        ? "failed"
+        : "completed"
+      : "created";
+    await this.transition(nextStatus);
   }
 
   /**

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -798,10 +798,10 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     );
     const { ws, messages } = await openClientWs(name, { subscribe: true });
     const subscribed = messages.find((message) => message.type === "subscribed") as {
-      promptQueue: Array<{ messageId: string; canCancel?: boolean }>;
+      promptQueue: Array<{ messageId: string }>;
     };
     expect(subscribed.promptQueue).toContainEqual(
-      expect.objectContaining({ messageId: "message-linear", canCancel: false })
+      expect.objectContaining({ messageId: "message-linear" })
     );
     const clientRequestId = crypto.randomUUID();
     const rejected = collectMessages(ws, {

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -607,6 +607,190 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
+  it("cancels a pending prompt, releases attachments, broadcasts, and frees its slot", async () => {
+    const name = `ws-client-cancel-prompt-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    const [{ id: participantId }] = await queryDO<{ id: string }>(
+      stub,
+      "SELECT id FROM participants LIMIT 1"
+    );
+    const now = Date.now();
+    for (let index = 0; index < MAX_UNFINISHED_PROMPTS; index++) {
+      await seedMessage(stub, {
+        id: `message-${index}`,
+        authorId: participantId,
+        content: `Prompt ${index}`,
+        source: "web",
+        status: "pending",
+        createdAt: now + index,
+      });
+    }
+    await queryDO(
+      stub,
+      `INSERT INTO attachments
+         (id, mime_type, size_bytes, object_key, message_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      "attachment-1",
+      "image/png",
+      100,
+      "sessions/test/attachment-1",
+      "message-0",
+      now
+    );
+
+    const watcher = await openClientWs(name, { subscribe: true, userId: "watcher" });
+    const requester = await openClientWs(name, { subscribe: true, userId: "requester" });
+    const clientRequestId = crypto.randomUUID();
+    const requesterMessages = collectMessages(requester.ws, {
+      until: (message) => message.type === "prompt_cancelled",
+      timeoutMs: 2000,
+    });
+    const watcherMessages = collectMessages(watcher.ws, {
+      until: (message) =>
+        message.type === "prompt_queue_updated" &&
+        !(message.promptQueue as Array<{ messageId: string }>).some(
+          (item) => item.messageId === "message-0"
+        ),
+      timeoutMs: 2000,
+    });
+
+    requester.ws.send(
+      JSON.stringify({ type: "cancel_prompt", messageId: "message-0", clientRequestId })
+    );
+
+    expect(
+      (await requesterMessages).find((message) => message.type === "prompt_cancelled")
+    ).toMatchObject({ clientRequestId, messageId: "message-0" });
+    const queueUpdate = (await watcherMessages).find(
+      (message) => message.type === "prompt_queue_updated"
+    ) as { promptQueue: Array<{ messageId: string }> };
+    expect(queueUpdate.promptQueue.map((item) => item.messageId)).not.toContain("message-0");
+    expect(await queryDO(stub, "SELECT id FROM messages WHERE id = ?", "message-0")).toEqual([]);
+    expect(
+      await queryDO(stub, "SELECT message_id FROM attachments WHERE id = ?", "attachment-1")
+    ).toEqual([{ message_id: null }]);
+
+    const enqueueRequestId = crypto.randomUUID();
+    const enqueued = collectMessages(requester.ws, {
+      until: (message) => message.type === "prompt_queued",
+      timeoutMs: 2000,
+    });
+    requester.ws.send(
+      JSON.stringify({
+        type: "prompt",
+        clientRequestId: enqueueRequestId,
+        content: "Replacement prompt",
+      })
+    );
+    expect((await enqueued).find((message) => message.type === "prompt_queued")).toMatchObject({
+      clientRequestId: enqueueRequestId,
+    });
+
+    requester.ws.close();
+    watcher.ws.close();
+  });
+
+  it("rejects cancellation when the prompt is already processing", async () => {
+    const name = `ws-client-cancel-processing-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    const [{ id: participantId }] = await queryDO<{ id: string }>(
+      stub,
+      "SELECT id FROM participants LIMIT 1"
+    );
+    await seedMessage(stub, {
+      id: "message-processing",
+      authorId: participantId,
+      content: "Already running",
+      source: "web",
+      status: "processing",
+      createdAt: Date.now(),
+      startedAt: Date.now(),
+    });
+    const { ws } = await openClientWs(name, { subscribe: true });
+    const clientRequestId = crypto.randomUUID();
+    const rejected = collectMessages(ws, {
+      until: (message) => message.type === "error",
+      timeoutMs: 2000,
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "cancel_prompt",
+        messageId: "message-processing",
+        clientRequestId,
+      })
+    );
+
+    expect((await rejected).find((message) => message.type === "error")).toMatchObject({
+      code: "PROMPT_NOT_CANCELLABLE",
+      clientRequestId,
+    });
+    expect(
+      await queryDO<{ status: string }>(
+        stub,
+        "SELECT status FROM messages WHERE id = ?",
+        "message-processing"
+      )
+    ).toEqual([{ status: "processing" }]);
+    ws.close();
+  });
+
+  it("does not allow web clients to cancel integration-owned prompts", async () => {
+    const name = `ws-client-cancel-integration-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    const [{ id: participantId }] = await queryDO<{ id: string }>(
+      stub,
+      "SELECT id FROM participants LIMIT 1"
+    );
+    await seedMessage(stub, {
+      id: "message-linear",
+      authorId: participantId,
+      content: "Reply in Linear",
+      source: "linear",
+      status: "pending",
+      createdAt: Date.now(),
+    });
+    await queryDO(
+      stub,
+      "UPDATE messages SET source = 'web', callback_context = ? WHERE id = ?",
+      JSON.stringify({ channel: "C1", threadTs: "1.0" }),
+      "message-linear"
+    );
+    const { ws, messages } = await openClientWs(name, { subscribe: true });
+    const subscribed = messages.find((message) => message.type === "subscribed") as {
+      promptQueue: Array<{ messageId: string; canCancel?: boolean }>;
+    };
+    expect(subscribed.promptQueue).toContainEqual(
+      expect.objectContaining({ messageId: "message-linear", canCancel: false })
+    );
+    const clientRequestId = crypto.randomUUID();
+    const rejected = collectMessages(ws, {
+      until: (message) => message.type === "error",
+      timeoutMs: 2000,
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "cancel_prompt",
+        messageId: "message-linear",
+        clientRequestId,
+      })
+    );
+
+    expect((await rejected).find((message) => message.type === "error")).toMatchObject({
+      code: "PROMPT_NOT_CANCELLABLE",
+      clientRequestId,
+    });
+    expect(
+      await queryDO<{ status: string }>(
+        stub,
+        "SELECT status FROM messages WHERE id = ?",
+        "message-linear"
+      )
+    ).toEqual([{ status: "pending" }]);
+    ws.close();
+  });
+
   it.each([
     ["blank", "  \n"],
     ["oversized", "x".repeat(64_001)],

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -690,6 +690,46 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     watcher.ws.close();
   });
 
+  it("returns a session to created when its first prompt is removed before execution", async () => {
+    const name = `ws-client-cancel-first-prompt-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    const { ws } = await openClientWs(name, { subscribe: true });
+    const enqueueRequestId = crypto.randomUUID();
+    const enqueued = collectMessages(ws, {
+      until: (message) => message.type === "prompt_queued",
+      timeoutMs: 2000,
+    });
+    ws.send(
+      JSON.stringify({
+        type: "prompt",
+        clientRequestId: enqueueRequestId,
+        content: "Cancel before execution",
+      })
+    );
+    const queued = (await enqueued).find((message) => message.type === "prompt_queued") as {
+      messageId: string;
+    };
+    const cancelRequestId = crypto.randomUUID();
+    const cancelled = collectMessages(ws, {
+      until: (message) => message.type === "prompt_cancelled",
+      timeoutMs: 2000,
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "cancel_prompt",
+        messageId: queued.messageId,
+        clientRequestId: cancelRequestId,
+      })
+    );
+    await cancelled;
+
+    expect(await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1")).toEqual([
+      { status: "created" },
+    ]);
+    ws.close();
+  });
+
   it("rejects cancellation when the prompt is already processing", async () => {
     const name = `ws-client-cancel-processing-${Date.now()}`;
     const { stub } = await initNamedSession(name);

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -620,6 +620,23 @@ describe("boundary schemas", () => {
       );
     });
 
+    it("parses correlated queued prompt cancellation", () => {
+      expect(
+        clientMessageSchema.parse({
+          type: "cancel_prompt",
+          messageId: "message-1",
+          clientRequestId: "request-1",
+        })
+      ).toMatchObject({ messageId: "message-1", clientRequestId: "request-1" });
+      expect(
+        clientMessageSchema.safeParse({
+          type: "cancel_prompt",
+          messageId: "",
+          clientRequestId: "request-1",
+        }).success
+      ).toBe(false);
+    });
+
     it("rejects invalid prompt request correlation identifiers", () => {
       expect(
         clientMessageSchema.safeParse({ type: "prompt", content: "Continue", clientRequestId: "" })

--- a/packages/shared/src/types/server-messages.test.ts
+++ b/packages/shared/src/types/server-messages.test.ts
@@ -177,6 +177,13 @@ describe("session view contracts", () => {
       })
     ).toMatchObject({ position: null });
     expect(
+      serverMessageSchema.parse({
+        type: "prompt_cancelled",
+        clientRequestId: "request-cancel",
+        messageId: "message-1",
+      })
+    ).toMatchObject({ clientRequestId: "request-cancel", messageId: "message-1" });
+    expect(
       serverMessageSchema.safeParse({
         type: "prompt_queued",
         messageId: "message-1",

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -11,6 +11,7 @@ export const promptQueueItemSchema = z.object({
   messageId: z.string(),
   content: z.string(),
   status: z.enum(["pending", "processing"]),
+  canCancel: z.boolean().optional(),
 });
 export type PromptQueueItem = z.infer<typeof promptQueueItemSchema>;
 
@@ -130,6 +131,11 @@ const serverMessageUnionSchema = z.discriminatedUnion("type", [
     clientRequestId: clientRequestIdSchema,
     messageId: z.string(),
     position: z.number().int().positive().nullable(),
+  }),
+  z.object({
+    type: z.literal("prompt_cancelled"),
+    clientRequestId: clientRequestIdSchema,
+    messageId: z.string(),
   }),
   z.object({
     type: z.literal("prompt_queue_updated"),

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -11,7 +11,6 @@ export const promptQueueItemSchema = z.object({
   messageId: z.string(),
   content: z.string(),
   status: z.enum(["pending", "processing"]),
-  canCancel: z.boolean().optional(),
 });
 export type PromptQueueItem = z.infer<typeof promptQueueItemSchema>;
 

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -14,6 +14,11 @@ export const clientMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("prompt"),
     clientRequestId: clientRequestIdSchema,
   }),
+  z.object({
+    type: z.literal("cancel_prompt"),
+    messageId: z.string().min(1),
+    clientRequestId: clientRequestIdSchema,
+  }),
   z.object({ type: z.literal("stop") }),
   z.object({ type: z.literal("typing") }),
   z.object({

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -64,6 +64,7 @@ import {
   reconcileSessionReadState,
   SessionReadRequestError,
 } from "@/lib/session-read-state";
+import { restoreQueuedPrompt } from "@/lib/restore-queued-prompt";
 import { useSessionSnapshot } from "./session-snapshot-provider";
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
@@ -89,6 +90,7 @@ export default function SessionPage() {
     promptQueue,
     loadingHistory,
     sendPrompt,
+    cancelPrompt,
     stopExecution,
     sendTyping,
     reconnect,
@@ -121,9 +123,11 @@ export default function SessionPage() {
     inputRef,
     isSubmitting,
     submitError,
+    setSubmitError,
     handleSubmit,
     handleInputChange,
     handleKeyDown,
+    restorePrompt,
   } = usePromptInput(
     sessionId,
     sendPrompt,
@@ -132,6 +136,37 @@ export default function SessionPage() {
     reasoningEffort,
     loadingEnabledModels,
     sessionState?.status ?? "created"
+  );
+  const [cancellingPromptIds, setCancellingPromptIds] = useState<ReadonlySet<string>>(new Set());
+  const cancellingPromptIdsRef = useRef(new Set<string>());
+  const handleRemoveQueuedPrompt = useCallback(
+    async (messageId: string) => {
+      if (cancellingPromptIdsRef.current.has(messageId)) return;
+      const queuedPrompt = promptQueue.find((item) => item.messageId === messageId);
+      if (!queuedPrompt || queuedPrompt.status !== "pending") return;
+
+      cancellingPromptIdsRef.current.add(messageId);
+      setCancellingPromptIds(new Set(cancellingPromptIdsRef.current));
+      try {
+        const result = await cancelPrompt(messageId);
+        if (!result.ok) {
+          const message =
+            result.message ??
+            (result.reason === "timeout"
+              ? "Removing the queued prompt timed out"
+              : result.reason === "disconnected"
+                ? "Reconnect before removing a queued prompt"
+                : "The queued prompt could not be removed");
+          setSubmitError(message);
+          return;
+        }
+        restorePrompt(queuedPrompt.content);
+      } finally {
+        cancellingPromptIdsRef.current.delete(messageId);
+        setCancellingPromptIds(new Set(cancellingPromptIdsRef.current));
+      }
+    },
+    [cancelPrompt, promptQueue, restorePrompt, setSubmitError]
   );
 
   const [selectedMediaArtifactId, setSelectedMediaArtifactId] = useState<string | null>(null);
@@ -307,7 +342,11 @@ export default function SessionPage() {
           )}
         </PanelGroup>
       </div>
-      <QueuedPromptStack promptQueue={promptQueue} />
+      <QueuedPromptStack
+        promptQueue={promptQueue}
+        cancellingPromptIds={cancellingPromptIds}
+        onRemove={handleRemoveQueuedPrompt}
+      />
       <SessionPromptComposer
         session={{
           id: sessionId,
@@ -667,6 +706,7 @@ function usePromptInput(
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const sessionAttachments = useSessionAttachments();
+  const hasAttachments = sessionAttachments.hasAttachments;
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const submitInFlightRef = useRef(false);
@@ -674,6 +714,8 @@ function usePromptInput(
   const attachmentDraftSignature = sessionAttachments.attachments
     .map((attachment) => attachment.id)
     .join("\u0000");
+  const promptRef = useRef(prompt);
+  promptRef.current = prompt;
 
   const clearTypingTimeout = useCallback(() => {
     if (typingTimeoutRef.current) {
@@ -746,6 +788,7 @@ function usePromptInput(
       }
 
       retryRequestRef.current = null;
+      promptRef.current = "";
       setPrompt("");
       sessionAttachments.clearAttachments();
       // Revalidate sidebar so this session bubbles to the top
@@ -766,6 +809,7 @@ function usePromptInput(
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    promptRef.current = e.target.value;
     setPrompt(e.target.value);
     setSubmitError(null);
     retryRequestRef.current = null;
@@ -777,14 +821,31 @@ function usePromptInput(
     }, 300);
   };
 
+  const restorePrompt = useCallback(
+    (content: string) => {
+      const restored = restoreQueuedPrompt({
+        content,
+        currentPrompt: promptRef.current,
+        hasAttachments: hasAttachments(),
+        setPrompt,
+        input: inputRef.current,
+      });
+      if (restored) promptRef.current = content;
+      return restored;
+    },
+    [hasAttachments]
+  );
+
   return {
     prompt,
     sessionAttachments,
     inputRef,
     isSubmitting,
     submitError,
+    setSubmitError,
     handleSubmit,
     handleInputChange,
     handleKeyDown,
+    restorePrompt,
   };
 }

--- a/packages/web/src/components/queued-prompt-stack.test.tsx
+++ b/packages/web/src/components/queued-prompt-stack.test.tsx
@@ -18,8 +18,8 @@ describe("QueuedPromptStack", () => {
         onRemove={vi.fn()}
         promptQueue={[
           { messageId: "running", content: "Already running", status: "processing" },
-          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
-          { messageId: "later", content: "Run after that", status: "pending", canCancel: true },
+          { messageId: "next", content: "Run next", status: "pending" },
+          { messageId: "later", content: "Run after that", status: "pending" },
         ]}
       />
     );
@@ -48,9 +48,7 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[
-          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
-        ]}
+        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
         cancellingPromptIds={new Set(["next"])}
         onRemove={onRemove}
       />
@@ -66,9 +64,7 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[
-          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
-        ]}
+        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
         cancellingPromptIds={new Set()}
         onRemove={onRemove}
       />
@@ -78,7 +74,8 @@ describe("QueuedPromptStack", () => {
     expect(onRemove).toHaveBeenCalledWith("next");
   });
 
-  it("does not offer removal for prompts owned by callback integrations", () => {
+  it("offers removal for pending prompts whose eligibility is server-owned", () => {
+    const onRemove = vi.fn();
     render(
       <QueuedPromptStack
         promptQueue={[
@@ -86,28 +83,14 @@ describe("QueuedPromptStack", () => {
             messageId: "linear-prompt",
             content: "Reply in Linear",
             status: "pending",
-            canCancel: false,
           },
         ]}
         cancellingPromptIds={new Set()}
-        onRemove={vi.fn()}
+        onRemove={onRemove}
       />
     );
 
-    expect(screen.getByText("Reply in Linear")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Remove queued prompt/ })).not.toBeInTheDocument();
-  });
-
-  it("defaults missing cancellation capability closed", () => {
-    render(
-      <QueuedPromptStack
-        promptQueue={[{ messageId: "legacy", content: "Legacy prompt", status: "pending" }]}
-        cancellingPromptIds={new Set()}
-        onRemove={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText("Legacy prompt")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Remove queued prompt/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Remove queued prompt: Reply in Linear" }));
+    expect(onRemove).toHaveBeenCalledWith("linear-prompt");
   });
 });

--- a/packages/web/src/components/queued-prompt-stack.test.tsx
+++ b/packages/web/src/components/queued-prompt-stack.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QueuedPromptStack } from "./queued-prompt-stack";
 
 expect.extend(matchers);
@@ -14,6 +14,8 @@ describe("QueuedPromptStack", () => {
   it("renders only pending prompts in FIFO order", () => {
     render(
       <QueuedPromptStack
+        cancellingPromptIds={new Set()}
+        onRemove={vi.fn()}
         promptQueue={[
           { messageId: "running", content: "Already running", status: "processing" },
           { messageId: "next", content: "Run next", status: "pending" },
@@ -27,15 +29,68 @@ describe("QueuedPromptStack", () => {
       "Run next",
       "Run after that",
     ]);
+    expect(screen.getAllByRole("button", { name: /Remove queued prompt:/ })).toHaveLength(2);
   });
 
   it("does not render when the queue has no pending prompts", () => {
     const { container } = render(
       <QueuedPromptStack
+        cancellingPromptIds={new Set()}
+        onRemove={vi.fn()}
         promptQueue={[{ messageId: "running", content: "Already running", status: "processing" }]}
       />
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("removes the selected prompt and disables duplicate removal", () => {
+    const onRemove = vi.fn();
+    render(
+      <QueuedPromptStack
+        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        cancellingPromptIds={new Set(["next"])}
+        onRemove={onRemove}
+      />
+    );
+
+    const remove = screen.getByRole("button", { name: "Remove queued prompt: Run next" });
+    expect(remove).toBeDisabled();
+    fireEvent.click(remove);
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it("passes the queued message id to the remove callback", () => {
+    const onRemove = vi.fn();
+    render(
+      <QueuedPromptStack
+        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        cancellingPromptIds={new Set()}
+        onRemove={onRemove}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove queued prompt: Run next" }));
+    expect(onRemove).toHaveBeenCalledWith("next");
+  });
+
+  it("does not offer removal for prompts owned by callback integrations", () => {
+    render(
+      <QueuedPromptStack
+        promptQueue={[
+          {
+            messageId: "linear-prompt",
+            content: "Reply in Linear",
+            status: "pending",
+            canCancel: false,
+          },
+        ]}
+        cancellingPromptIds={new Set()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Reply in Linear")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove queued prompt/ })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/queued-prompt-stack.test.tsx
+++ b/packages/web/src/components/queued-prompt-stack.test.tsx
@@ -18,8 +18,8 @@ describe("QueuedPromptStack", () => {
         onRemove={vi.fn()}
         promptQueue={[
           { messageId: "running", content: "Already running", status: "processing" },
-          { messageId: "next", content: "Run next", status: "pending" },
-          { messageId: "later", content: "Run after that", status: "pending" },
+          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
+          { messageId: "later", content: "Run after that", status: "pending", canCancel: true },
         ]}
       />
     );
@@ -48,7 +48,9 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        promptQueue={[
+          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
+        ]}
         cancellingPromptIds={new Set(["next"])}
         onRemove={onRemove}
       />
@@ -64,7 +66,9 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        promptQueue={[
+          { messageId: "next", content: "Run next", status: "pending", canCancel: true },
+        ]}
         cancellingPromptIds={new Set()}
         onRemove={onRemove}
       />
@@ -91,6 +95,19 @@ describe("QueuedPromptStack", () => {
     );
 
     expect(screen.getByText("Reply in Linear")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove queued prompt/ })).not.toBeInTheDocument();
+  });
+
+  it("defaults missing cancellation capability closed", () => {
+    render(
+      <QueuedPromptStack
+        promptQueue={[{ messageId: "legacy", content: "Legacy prompt", status: "pending" }]}
+        cancellingPromptIds={new Set()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Legacy prompt")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Remove queued prompt/ })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/queued-prompt-stack.tsx
+++ b/packages/web/src/components/queued-prompt-stack.tsx
@@ -28,7 +28,7 @@ export function QueuedPromptStack({
               <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-secondary-foreground">
                 {prompt.content}
               </p>
-              {prompt.canCancel !== false && (
+              {prompt.canCancel === true && (
                 <button
                   type="button"
                   onClick={() => onRemove(prompt.messageId)}

--- a/packages/web/src/components/queued-prompt-stack.tsx
+++ b/packages/web/src/components/queued-prompt-stack.tsx
@@ -28,18 +28,16 @@ export function QueuedPromptStack({
               <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-secondary-foreground">
                 {prompt.content}
               </p>
-              {prompt.canCancel === true && (
-                <button
-                  type="button"
-                  onClick={() => onRemove(prompt.messageId)}
-                  disabled={cancellingPromptIds.has(prompt.messageId)}
-                  className="shrink-0 rounded p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50"
-                  aria-label={`Remove queued prompt: ${prompt.content}`}
-                  title="Remove queued prompt"
-                >
-                  <XIcon className="h-4 w-4" />
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => onRemove(prompt.messageId)}
+                disabled={cancellingPromptIds.has(prompt.messageId)}
+                className="shrink-0 rounded p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50"
+                aria-label={`Remove queued prompt: ${prompt.content}`}
+                title="Remove queued prompt"
+              >
+                <XIcon className="h-4 w-4" />
+              </button>
             </li>
           ))}
         </ol>

--- a/packages/web/src/components/queued-prompt-stack.tsx
+++ b/packages/web/src/components/queued-prompt-stack.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { ClockIcon } from "@/components/ui/icons";
+import { ClockIcon, XIcon } from "@/components/ui/icons";
 import type { PromptQueueItem } from "@open-inspect/shared/types/server-messages";
 
-export function QueuedPromptStack({ promptQueue }: { promptQueue: PromptQueueItem[] }) {
+export function QueuedPromptStack({
+  promptQueue,
+  cancellingPromptIds,
+  onRemove,
+}: {
+  promptQueue: PromptQueueItem[];
+  cancellingPromptIds: ReadonlySet<string>;
+  onRemove: (messageId: string) => void;
+}) {
   const pendingPrompts = promptQueue.filter((item) => item.status === "pending");
   if (pendingPrompts.length === 0) return null;
 
@@ -20,6 +28,18 @@ export function QueuedPromptStack({ promptQueue }: { promptQueue: PromptQueueIte
               <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-secondary-foreground">
                 {prompt.content}
               </p>
+              {prompt.canCancel !== false && (
+                <button
+                  type="button"
+                  onClick={() => onRemove(prompt.messageId)}
+                  disabled={cancellingPromptIds.has(prompt.messageId)}
+                  className="shrink-0 rounded p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-wait disabled:opacity-50"
+                  aria-label={`Remove queued prompt: ${prompt.content}`}
+                  title="Remove queued prompt"
+                >
+                  <XIcon className="h-4 w-4" />
+                </button>
+              )}
             </li>
           ))}
         </ol>

--- a/packages/web/src/hooks/use-session-attachments.ts
+++ b/packages/web/src/hooks/use-session-attachments.ts
@@ -143,6 +143,8 @@ export function useSessionAttachments() {
     setAttachments([]);
   }, []);
 
+  const hasAttachments = useCallback(() => attachmentsRef.current.length > 0, []);
+
   /**
    * Upload all pending attachments and return the references to send with the
    * prompt. Throws (with a user-readable message) if any upload fails; the
@@ -250,6 +252,7 @@ export function useSessionAttachments() {
     addFiles,
     removeAttachment,
     clearAttachments,
+    hasAttachments,
     uploadAll,
   };
 }

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -190,6 +190,81 @@ describe("useSessionSocket", () => {
     });
   });
 
+  it("keeps cancelPrompt pending until the matching server acknowledgement", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1", createSnapshot()));
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+    });
+
+    let cancellation!: ReturnType<typeof result.current.cancelPrompt>;
+    act(() => {
+      cancellation = result.current.cancelPrompt("message-1");
+    });
+    await waitFor(() => {
+      expect(socket.sentMessages).toContainEqual({
+        type: "cancel_prompt",
+        messageId: "message-1",
+        clientRequestId: "client-id",
+      });
+    });
+
+    let settled = false;
+    void cancellation.then(() => (settled = true));
+    act(() => {
+      socket.receive({
+        type: "prompt_cancelled",
+        clientRequestId: "another-request",
+        messageId: "message-1",
+      } as ServerMessage);
+      socket.receive({
+        type: "prompt_cancelled",
+        clientRequestId: "client-id",
+        messageId: "another-message",
+      } as ServerMessage);
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    act(() => {
+      socket.receive({
+        type: "prompt_cancelled",
+        clientRequestId: "client-id",
+        messageId: "message-1",
+      } as ServerMessage);
+    });
+    await expect(cancellation).resolves.toEqual({ ok: true, messageId: "message-1" });
+  });
+
+  it("returns a correlated cancellation race error without treating it as success", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1", createSnapshot()));
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+    });
+
+    const cancellation = result.current.cancelPrompt("message-1");
+    await waitFor(() => expect(socket.sentMessages).toHaveLength(2));
+    act(() => {
+      socket.receive({
+        type: "error",
+        code: "PROMPT_NOT_CANCELLABLE",
+        message: "This prompt is no longer pending and cannot be removed",
+        clientRequestId: "client-id",
+      } as ServerMessage);
+    });
+
+    await expect(cancellation).resolves.toEqual({
+      ok: false,
+      reason: "rejected",
+      message: "This prompt is no longer pending and cannot be removed",
+    });
+  });
+
   it("sends correlated prompts without feature negotiation", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1", createSnapshot()));
     await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -62,6 +62,7 @@ interface UseSessionSocketReturn {
     attachments?: SessionAttachmentReference[],
     clientRequestId?: string
   ) => Promise<QueuePromptResult>;
+  cancelPrompt: (messageId: string) => Promise<CancelPromptResult>;
   stopExecution: () => void;
   sendTyping: () => void;
   reconnect: () => void;
@@ -75,6 +76,10 @@ type QueuePromptResult =
       reason: "rejected" | "disconnected" | "timeout";
       message?: string;
     };
+
+type CancelPromptResult =
+  | { ok: true; messageId: string }
+  | { ok: false; reason: "rejected" | "disconnected" | "timeout"; message?: string };
 
 /**
  * Session view over a WebSocket connection, composed from four layers:
@@ -104,6 +109,16 @@ export function useSessionSocket(
     resolve: (result: QueuePromptResult) => void;
     timeout: ReturnType<typeof setTimeout>;
   } | null>(null);
+  const pendingCancellationsRef = useRef(
+    new Map<
+      string,
+      {
+        messageId: string;
+        resolve: (result: CancelPromptResult) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    >()
+  );
   const {
     sandboxAccess,
     clear: clearSandboxAccess,
@@ -125,6 +140,23 @@ export function useSessionSocket(
     pendingPromptRef.current = null;
     pending.resolve(result);
   }, []);
+
+  const settleCancellation = useCallback((clientRequestId: string, result: CancelPromptResult) => {
+    const pending = pendingCancellationsRef.current.get(clientRequestId);
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    pendingCancellationsRef.current.delete(clientRequestId);
+    pending.resolve(result);
+  }, []);
+
+  const settleAllCancellations = useCallback(
+    (result: CancelPromptResult) => {
+      for (const [clientRequestId] of pendingCancellationsRef.current) {
+        settleCancellation(clientRequestId, result);
+      }
+    },
+    [settleCancellation]
+  );
 
   useEffect(() => {
     subscribedRef.current = state.ready;
@@ -162,6 +194,13 @@ export function useSessionSocket(
         if (pending && message.clientRequestId === pending.clientRequestId) {
           settlePendingPrompt({ ok: false, reason: "rejected", message: message.message });
         }
+        if (message.clientRequestId) {
+          settleCancellation(message.clientRequestId, {
+            ok: false,
+            reason: "rejected",
+            message: message.message,
+          });
+        }
       } else if (message.type === "prompt_queued") {
         const pending = pendingPromptRef.current;
         if (pending && message.clientRequestId === pending.clientRequestId) {
@@ -170,6 +209,14 @@ export function useSessionSocket(
             clientRequestId: pending.clientRequestId,
             messageId: message.messageId,
             position: message.position,
+          });
+        }
+      } else if (message.type === "prompt_cancelled") {
+        const pendingCancellation = pendingCancellationsRef.current.get(message.clientRequestId);
+        if (pendingCancellation?.messageId === message.messageId) {
+          settleCancellation(message.clientRequestId, {
+            ok: true,
+            messageId: message.messageId,
           });
         }
       }
@@ -186,15 +233,16 @@ export function useSessionSocket(
         mutate(key);
       }
     },
-    [clearSandboxAccess, refreshSandboxAccess, sessionId, settlePendingPrompt]
+    [clearSandboxAccess, refreshSandboxAccess, sessionId, settleCancellation, settlePendingPrompt]
   );
 
   const handleClose = useCallback(() => {
     subscribedRef.current = false;
     settleSubscriptionWaiters(false);
     settlePendingPrompt({ ok: false, reason: "disconnected" });
+    settleAllCancellations({ ok: false, reason: "disconnected" });
     dispatch({ type: "socket_closed" });
-  }, [settlePendingPrompt, settleSubscriptionWaiters]);
+  }, [settleAllCancellations, settlePendingPrompt, settleSubscriptionWaiters]);
 
   const transport = useSessionTransport(sessionId, {
     onMessage: handleMessage,
@@ -211,8 +259,9 @@ export function useSessionSocket(
     () => () => {
       settleSubscriptionWaiters(false);
       settlePendingPrompt({ ok: false, reason: "disconnected" });
+      settleAllCancellations({ ok: false, reason: "disconnected" });
     },
-    [settlePendingPrompt, settleSubscriptionWaiters]
+    [settleAllCancellations, settlePendingPrompt, settleSubscriptionWaiters]
   );
 
   const waitForSubscription = useCallback((): Promise<boolean> => {
@@ -305,6 +354,24 @@ export function useSessionSocket(
     send({ type: "stop" });
   }, [isOpen, send]);
 
+  const cancelPrompt = useCallback(
+    async (messageId: string): Promise<CancelPromptResult> => {
+      if (!isOpen() || !(await waitForSubscription()) || !isOpen()) {
+        return { ok: false, reason: "disconnected" };
+      }
+
+      const clientRequestId = crypto.randomUUID();
+      return new Promise<CancelPromptResult>((resolve) => {
+        const timeout = setTimeout(() => {
+          settleCancellation(clientRequestId, { ok: false, reason: "timeout" });
+        }, PROMPT_ACK_TIMEOUT_MS);
+        pendingCancellationsRef.current.set(clientRequestId, { messageId, resolve, timeout });
+        send({ type: "cancel_prompt", messageId, clientRequestId });
+      });
+    },
+    [isOpen, send, settleCancellation, waitForSubscription]
+  );
+
   const sendTyping = useCallback(() => {
     if (!isOpen() || !subscribedRef.current) {
       return;
@@ -350,6 +417,7 @@ export function useSessionSocket(
     hasMoreHistory,
     loadingHistory,
     sendPrompt,
+    cancelPrompt,
     stopExecution,
     sendTyping,
     reconnect,

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -69,17 +69,22 @@ interface UseSessionSocketReturn {
   loadOlderEvents: () => void;
 }
 
+type CorrelatedRequestFailure = {
+  ok: false;
+  reason: "rejected" | "disconnected" | "timeout";
+  message?: string;
+};
+
 type QueuePromptResult =
   | { ok: true; clientRequestId: string; messageId: string; position: number | null }
-  | {
-      ok: false;
-      reason: "rejected" | "disconnected" | "timeout";
-      message?: string;
-    };
+  | CorrelatedRequestFailure;
 
-type CancelPromptResult =
-  | { ok: true; messageId: string }
-  | { ok: false; reason: "rejected" | "disconnected" | "timeout"; message?: string };
+type CancelPromptResult = { ok: true; messageId: string } | CorrelatedRequestFailure;
+
+interface PendingCorrelatedRequest {
+  settleSuccess: (message: ServerMessage) => boolean;
+  settleFailure: (failure: CorrelatedRequestFailure) => void;
+}
 
 /**
  * Session view over a WebSocket connection, composed from four layers:
@@ -104,21 +109,8 @@ export function useSessionSocket(
   // high frequency) don't re-render; the text is appended on completion.
   const pendingTextRef = useRef<PendingAssistantText | null>(null);
   const subscriptionWaitersRef = useRef(new Set<(subscribed: boolean) => void>());
-  const pendingPromptRef = useRef<{
-    clientRequestId: string;
-    resolve: (result: QueuePromptResult) => void;
-    timeout: ReturnType<typeof setTimeout>;
-  } | null>(null);
-  const pendingCancellationsRef = useRef(
-    new Map<
-      string,
-      {
-        messageId: string;
-        resolve: (result: CancelPromptResult) => void;
-        timeout: ReturnType<typeof setTimeout>;
-      }
-    >()
-  );
+  const pendingPromptRequestIdRef = useRef<string | null>(null);
+  const pendingRequestsRef = useRef(new Map<string, PendingCorrelatedRequest>());
   const {
     sandboxAccess,
     clear: clearSandboxAccess,
@@ -132,31 +124,45 @@ export function useSessionSocket(
     subscriptionWaitersRef.current.clear();
   }, []);
 
-  const settlePendingPrompt = useCallback((result: QueuePromptResult) => {
-    const pending = pendingPromptRef.current;
-    if (!pending) return;
+  const registerCorrelatedRequest = useCallback(
+    <T extends { ok: true }>(
+      clientRequestId: string,
+      resolve: (result: T | CorrelatedRequestFailure) => void,
+      successFromMessage: (message: ServerMessage) => T | null,
+      onSettled?: () => void
+    ) => {
+      let settled = false;
+      const finish = (result: T | CorrelatedRequestFailure) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        pendingRequestsRef.current.delete(clientRequestId);
+        onSettled?.();
+        resolve(result);
+      };
 
-    clearTimeout(pending.timeout);
-    pendingPromptRef.current = null;
-    pending.resolve(result);
-  }, []);
-
-  const settleCancellation = useCallback((clientRequestId: string, result: CancelPromptResult) => {
-    const pending = pendingCancellationsRef.current.get(clientRequestId);
-    if (!pending) return;
-    clearTimeout(pending.timeout);
-    pendingCancellationsRef.current.delete(clientRequestId);
-    pending.resolve(result);
-  }, []);
-
-  const settleAllCancellations = useCallback(
-    (result: CancelPromptResult) => {
-      for (const [clientRequestId] of pendingCancellationsRef.current) {
-        settleCancellation(clientRequestId, result);
-      }
+      const timeout = setTimeout(
+        () => finish({ ok: false, reason: "timeout" }),
+        PROMPT_ACK_TIMEOUT_MS
+      );
+      pendingRequestsRef.current.set(clientRequestId, {
+        settleSuccess: (message) => {
+          const result = successFromMessage(message);
+          if (!result) return false;
+          finish(result);
+          return true;
+        },
+        settleFailure: finish,
+      });
     },
-    [settleCancellation]
+    []
   );
+
+  const settleAllCorrelatedRequests = useCallback((failure: CorrelatedRequestFailure) => {
+    for (const pending of [...pendingRequestsRef.current.values()]) {
+      pending.settleFailure(failure);
+    }
+  }, []);
 
   useEffect(() => {
     subscribedRef.current = state.ready;
@@ -190,35 +196,15 @@ export function useSessionSocket(
         console.error("Sandbox error:", message.error);
       } else if (message.type === "error") {
         console.error("Session error:", message);
-        const pending = pendingPromptRef.current;
-        if (pending && message.clientRequestId === pending.clientRequestId) {
-          settlePendingPrompt({ ok: false, reason: "rejected", message: message.message });
-        }
         if (message.clientRequestId) {
-          settleCancellation(message.clientRequestId, {
+          pendingRequestsRef.current.get(message.clientRequestId)?.settleFailure({
             ok: false,
             reason: "rejected",
             message: message.message,
           });
         }
-      } else if (message.type === "prompt_queued") {
-        const pending = pendingPromptRef.current;
-        if (pending && message.clientRequestId === pending.clientRequestId) {
-          settlePendingPrompt({
-            ok: true,
-            clientRequestId: pending.clientRequestId,
-            messageId: message.messageId,
-            position: message.position,
-          });
-        }
-      } else if (message.type === "prompt_cancelled") {
-        const pendingCancellation = pendingCancellationsRef.current.get(message.clientRequestId);
-        if (pendingCancellation?.messageId === message.messageId) {
-          settleCancellation(message.clientRequestId, {
-            ok: true,
-            messageId: message.messageId,
-          });
-        }
+      } else if (message.type === "prompt_queued" || message.type === "prompt_cancelled") {
+        pendingRequestsRef.current.get(message.clientRequestId)?.settleSuccess(message);
       }
 
       const clearsSandboxAccess =
@@ -233,16 +219,15 @@ export function useSessionSocket(
         mutate(key);
       }
     },
-    [clearSandboxAccess, refreshSandboxAccess, sessionId, settleCancellation, settlePendingPrompt]
+    [clearSandboxAccess, refreshSandboxAccess, sessionId]
   );
 
   const handleClose = useCallback(() => {
     subscribedRef.current = false;
     settleSubscriptionWaiters(false);
-    settlePendingPrompt({ ok: false, reason: "disconnected" });
-    settleAllCancellations({ ok: false, reason: "disconnected" });
+    settleAllCorrelatedRequests({ ok: false, reason: "disconnected" });
     dispatch({ type: "socket_closed" });
-  }, [settleAllCancellations, settlePendingPrompt, settleSubscriptionWaiters]);
+  }, [settleAllCorrelatedRequests, settleSubscriptionWaiters]);
 
   const transport = useSessionTransport(sessionId, {
     onMessage: handleMessage,
@@ -258,10 +243,9 @@ export function useSessionSocket(
   useEffect(
     () => () => {
       settleSubscriptionWaiters(false);
-      settlePendingPrompt({ ok: false, reason: "disconnected" });
-      settleAllCancellations({ ok: false, reason: "disconnected" });
+      settleAllCorrelatedRequests({ ok: false, reason: "disconnected" });
     },
-    [settleAllCancellations, settlePendingPrompt, settleSubscriptionWaiters]
+    [settleAllCorrelatedRequests, settleSubscriptionWaiters]
   );
 
   const waitForSubscription = useCallback((): Promise<boolean> => {
@@ -295,7 +279,7 @@ export function useSessionSocket(
         return { ok: false, reason: "disconnected" };
       }
 
-      if (pendingPromptRef.current) {
+      if (pendingPromptRequestIdRef.current) {
         console.error("A prompt is already waiting for acknowledgement");
         return { ok: false, reason: "rejected", message: "A prompt is awaiting confirmation" };
       }
@@ -305,7 +289,7 @@ export function useSessionSocket(
         return { ok: false, reason: "disconnected" };
       }
 
-      if (pendingPromptRef.current) {
+      if (pendingPromptRequestIdRef.current) {
         console.error("A prompt is already waiting for acknowledgement");
         return { ok: false, reason: "rejected", message: "A prompt is awaiting confirmation" };
       }
@@ -323,10 +307,25 @@ export function useSessionSocket(
 
       const clientRequestId = requestedClientRequestId ?? crypto.randomUUID();
       return new Promise<QueuePromptResult>((resolve) => {
-        const timeout = setTimeout(() => {
-          settlePendingPrompt({ ok: false, reason: "timeout" });
-        }, PROMPT_ACK_TIMEOUT_MS);
-        pendingPromptRef.current = { clientRequestId, resolve, timeout };
+        pendingPromptRequestIdRef.current = clientRequestId;
+        registerCorrelatedRequest<Extract<QueuePromptResult, { ok: true }>>(
+          clientRequestId,
+          resolve,
+          (message) =>
+            message.type === "prompt_queued"
+              ? {
+                  ok: true,
+                  clientRequestId,
+                  messageId: message.messageId,
+                  position: message.position,
+                }
+              : null,
+          () => {
+            if (pendingPromptRequestIdRef.current === clientRequestId) {
+              pendingPromptRequestIdRef.current = null;
+            }
+          }
+        );
 
         send({
           type: "prompt",
@@ -338,7 +337,7 @@ export function useSessionSocket(
         });
       });
     },
-    [isOpen, send, settlePendingPrompt, waitForSubscription]
+    [isOpen, registerCorrelatedRequest, send, waitForSubscription]
   );
 
   const stopExecution = useCallback(() => {
@@ -362,14 +361,18 @@ export function useSessionSocket(
 
       const clientRequestId = crypto.randomUUID();
       return new Promise<CancelPromptResult>((resolve) => {
-        const timeout = setTimeout(() => {
-          settleCancellation(clientRequestId, { ok: false, reason: "timeout" });
-        }, PROMPT_ACK_TIMEOUT_MS);
-        pendingCancellationsRef.current.set(clientRequestId, { messageId, resolve, timeout });
+        registerCorrelatedRequest<Extract<CancelPromptResult, { ok: true }>>(
+          clientRequestId,
+          resolve,
+          (message) =>
+            message.type === "prompt_cancelled" && message.messageId === messageId
+              ? { ok: true, messageId }
+              : null
+        );
         send({ type: "cancel_prompt", messageId, clientRequestId });
       });
     },
-    [isOpen, send, settleCancellation, waitForSubscription]
+    [isOpen, registerCorrelatedRequest, send, waitForSubscription]
   );
 
   const sendTyping = useCallback(() => {

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -135,13 +135,13 @@ export function useSessionSocket(
       const finish = (result: T | CorrelatedRequestFailure) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timeout);
+        clearTimeout(ackTimeoutId);
         pendingRequestsRef.current.delete(clientRequestId);
         onSettled?.();
         resolve(result);
       };
 
-      const timeout = setTimeout(
+      const ackTimeoutId = setTimeout(
         () => finish({ ok: false, reason: "timeout" }),
         PROMPT_ACK_TIMEOUT_MS
       );

--- a/packages/web/src/lib/restore-queued-prompt.test.ts
+++ b/packages/web/src/lib/restore-queued-prompt.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { restoreQueuedPrompt } from "./restore-queued-prompt";
+
+describe("restoreQueuedPrompt", () => {
+  it("restores and focuses a removed prompt when the composer is empty", () => {
+    const input = document.createElement("textarea");
+    const focus = vi.spyOn(input, "focus");
+    const setPrompt = vi.fn();
+
+    expect(
+      restoreQueuedPrompt({
+        content: "Revise this",
+        currentPrompt: "  ",
+        hasAttachments: false,
+        setPrompt,
+        input,
+      })
+    ).toBe(true);
+    expect(setPrompt).toHaveBeenCalledWith("Revise this");
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { currentPrompt: "New draft", hasAttachments: false },
+    { currentPrompt: "", hasAttachments: true },
+  ])("does not overwrite composer content", ({ currentPrompt, hasAttachments }) => {
+    const input = document.createElement("textarea");
+    const focus = vi.spyOn(input, "focus");
+    const setPrompt = vi.fn();
+
+    expect(
+      restoreQueuedPrompt({
+        content: "Removed prompt",
+        currentPrompt,
+        hasAttachments,
+        setPrompt,
+        input,
+      })
+    ).toBe(false);
+    expect(setPrompt).not.toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/lib/restore-queued-prompt.ts
+++ b/packages/web/src/lib/restore-queued-prompt.ts
@@ -1,0 +1,18 @@
+export function restoreQueuedPrompt({
+  content,
+  currentPrompt,
+  hasAttachments,
+  setPrompt,
+  input,
+}: {
+  content: string;
+  currentPrompt: string;
+  hasAttachments: boolean;
+  setPrompt: (prompt: string) => void;
+  input: HTMLTextAreaElement | null;
+}): boolean {
+  if (currentPrompt.trim().length > 0 || hasAttachments) return false;
+  setPrompt(content);
+  input?.focus();
+  return true;
+}

--- a/packages/web/src/lib/session-socket/reducer.test.ts
+++ b/packages/web/src/lib/session-socket/reducer.test.ts
@@ -175,6 +175,21 @@ describe("sessionSocketReducer", () => {
     expect(state.promptQueue).toEqual(queue);
   });
 
+  it("waits for the authoritative queue update after cancellation acknowledgement", () => {
+    const initial = subscribedState({
+      promptQueue: [{ messageId: "message-2", content: "Next", status: "pending" }],
+    });
+    const state = reduce(
+      initial,
+      serverMessage({
+        type: "prompt_cancelled",
+        clientRequestId: "request-1",
+        messageId: "message-2",
+      })
+    );
+    expect(state.promptQueue).toEqual(initial.promptQueue);
+  });
+
   describe("subscribed", () => {
     it("hydrates the authoritative projection", () => {
       const state = subscribedState({

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -288,7 +288,7 @@ function reduceServerMessage(
       // Reset loading state if a fetch_history request was rejected.
       return { ...state, loadingHistory: false };
 
-    // pong, prompt_queued, child_session_update, snapshot_saved,
+    // pong, prompt_queued, prompt_cancelled, child_session_update, snapshot_saved,
     // sandbox_restored, sandbox_warning: no view-state change.
     default:
       return state;


### PR DESCRIPTION
## Summary

- add a correlated `cancel_prompt` WebSocket command and `prompt_cancelled` acknowledgement
- atomically delete pending web prompts, release attachment claims, broadcast the authoritative queue, and free queue capacity
- reject prompts that are processing or carry integration callback context
- preserve completed/failed session status when removing the last queued prompt
- add per-item remove controls and restore removed text only after server confirmation when the latest composer has no text or attachments
- keep drafts untouched and surface a clear error when cancellation loses the dispatch race

## Testing

- `npm run typecheck`
- changed-file ESLint
- shared schema tests: 82 passed
- control-plane focused unit tests: 174 passed
- web focused tests: 74 passed
- control-plane WebSocket integration tests: 29 passed

## Notes

- attachment claims are released, but only prompt text is restored to the composer; model, reasoning effort, and attachments are intentionally not reconstructed
- all pending prompts expose Remove; integration/callback-owned prompts are rejected authoritatively by the server
- repository-wide `npm run lint` still reports pre-existing errors in `.opencode` helper scripts; all changed files lint clean
- visual browser verification was not available because the session page requires an authenticated control-plane backend

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/87b68893382772e1eace0413550e5a18)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel eligible queued prompts from the session page.
  * Added removal controls with loading states and clear feedback for unavailable, failed, timed-out, or disconnected cancellations.
  * Restores cancelled prompt text to the composer when it is empty and has no attachments.
  * Queued prompts now indicate whether they can be cancelled.
* **Bug Fixes**
  * Improved queue synchronization, attachment handling, and session status updates after cancellation.
  * Prevented cancellation of prompts that are already processing or otherwise ineligible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->