### PR TITLE
fix: align WebSocket recovery read model

### DIFF
--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -119,8 +119,8 @@ function createMockRepository() {
         participant_id: data.participantId,
         client_id: data.clientId,
         user_id: `user-${data.participantId}`,
+        canonical_user_id: null,
         scm_name: null,
-        auth_name: null,
         scm_login: null,
       });
     },
@@ -526,8 +526,8 @@ describe("SessionWebSocketManagerImpl", () => {
         participant_id: "part-1",
         client_id: "client-1",
         user_id: "user-1",
+        canonical_user_id: null,
         scm_name: "Test",
-        auth_name: null,
         scm_login: "testuser",
       };
       mockRepo.addMapping("ws-42", mapping);
@@ -585,8 +585,8 @@ describe("SessionWebSocketManagerImpl", () => {
         participant_id: "p-1",
         client_id: "c-1",
         user_id: "u-1",
+        canonical_user_id: null,
         scm_name: null,
-        auth_name: null,
         scm_login: null,
       });
 
@@ -706,8 +706,8 @@ describe("SessionWebSocketManagerImpl", () => {
         participant_id: "p-1",
         client_id: "c-1",
         user_id: "u-1",
+        canonical_user_id: null,
         scm_name: null,
-        auth_name: null,
         scm_login: null,
       });
 
@@ -744,8 +744,8 @@ describe("SessionWebSocketManagerImpl", () => {
         participant_id: "p-2",
         client_id: "c-2",
         user_id: "u-2",
+        canonical_user_id: null,
         scm_name: null,
-        auth_name: null,
         scm_login: null,
       });
 
@@ -807,8 +807,8 @@ describe("SessionWebSocketManagerImpl", () => {
         participant_id: "p-1",
         client_id: "c-1",
         user_id: "u-1",
+        canonical_user_id: null,
         scm_name: null,
-        auth_name: null,
         scm_login: null,
       });
 

--- a/packages/control-plane/src/session/ws-client-mapping-repository.test.ts
+++ b/packages/control-plane/src/session/ws-client-mapping-repository.test.ts
@@ -35,13 +35,27 @@ describe("WsClientMappingRepository", () => {
   });
 
   it("restores a mapping with joined participant data", () => {
-    mock.setRows([{ participant_id: "p-1", client_id: "client-1", user_id: "user-1" }]);
-    expect(repository.getWsClientMapping("ws-1")).toMatchObject({
+    mock.setRows([
+      {
+        participant_id: "p-1",
+        client_id: null,
+        user_id: "user-1",
+        canonical_user_id: null,
+        scm_name: "Test User",
+        scm_login: "test-user",
+      },
+    ]);
+    expect(repository.getWsClientMapping("ws-1")).toEqual({
       participant_id: "p-1",
-      client_id: "client-1",
+      client_id: null,
       user_id: "user-1",
+      canonical_user_id: null,
+      scm_name: "Test User",
+      scm_login: "test-user",
     });
     expect(mock.calls[0].query).toContain("JOIN participants");
+    expect(mock.calls[0].query).toContain("p.canonical_user_id");
+    expect(mock.calls[0].query).not.toContain("auth_name");
   });
 
   it("returns null for an unknown mapping", () => {

--- a/packages/control-plane/src/session/ws-client-mapping-repository.ts
+++ b/packages/control-plane/src/session/ws-client-mapping-repository.ts
@@ -1,48 +1,17 @@
+import { z } from "zod";
 import type { SqlStorage } from "./sql-storage";
 
 /** WS client mapping result for hibernation recovery. */
-export interface WsClientMappingResult {
-  participant_id: string;
-  client_id: string | null;
-  user_id: string;
-  canonical_user_id: string | null;
-  scm_name: string | null;
-  scm_login: string | null;
-}
+const wsClientMappingResultSchema = z.object({
+  participant_id: z.string(),
+  client_id: z.string().nullable(),
+  user_id: z.string(),
+  canonical_user_id: z.string().nullable(),
+  scm_name: z.string().nullable(),
+  scm_login: z.string().nullable(),
+});
 
-function isNullableString(value: unknown): value is string | null {
-  return value === null || typeof value === "string";
-}
-
-function parseWsClientMapping(row: unknown): WsClientMappingResult {
-  if (
-    row === null ||
-    typeof row !== "object" ||
-    !("participant_id" in row) ||
-    typeof row.participant_id !== "string" ||
-    !("client_id" in row) ||
-    !isNullableString(row.client_id) ||
-    !("user_id" in row) ||
-    typeof row.user_id !== "string" ||
-    !("canonical_user_id" in row) ||
-    !isNullableString(row.canonical_user_id) ||
-    !("scm_name" in row) ||
-    !isNullableString(row.scm_name) ||
-    !("scm_login" in row) ||
-    !isNullableString(row.scm_login)
-  ) {
-    throw new Error("Invalid WebSocket client mapping row");
-  }
-
-  return {
-    participant_id: row.participant_id,
-    client_id: row.client_id,
-    user_id: row.user_id,
-    canonical_user_id: row.canonical_user_id,
-    scm_name: row.scm_name,
-    scm_login: row.scm_login,
-  };
-}
+export type WsClientMappingResult = z.infer<typeof wsClientMappingResultSchema>;
 
 /** Data for a WS client mapping. */
 export interface WsClientMappingData {
@@ -78,7 +47,7 @@ export class WsClientMappingRepository {
       wsId
     );
     const row = result.toArray()[0];
-    return row === undefined ? null : parseWsClientMapping(row);
+    return row === undefined ? null : wsClientMappingResultSchema.parse(row);
   }
 
   hasWsClientMapping(wsId: string): boolean {

--- a/packages/control-plane/src/session/ws-client-mapping-repository.ts
+++ b/packages/control-plane/src/session/ws-client-mapping-repository.ts
@@ -3,13 +3,45 @@ import type { SqlStorage } from "./sql-storage";
 /** WS client mapping result for hibernation recovery. */
 export interface WsClientMappingResult {
   participant_id: string;
-  client_id: string;
+  client_id: string | null;
   user_id: string;
-  canonical_user_id?: string | null;
+  canonical_user_id: string | null;
   scm_name: string | null;
   scm_login: string | null;
-  /** Dormant legacy column may still be present on older mapping fixtures. */
-  auth_name?: string | null;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function parseWsClientMapping(row: unknown): WsClientMappingResult {
+  if (
+    row === null ||
+    typeof row !== "object" ||
+    !("participant_id" in row) ||
+    typeof row.participant_id !== "string" ||
+    !("client_id" in row) ||
+    !isNullableString(row.client_id) ||
+    !("user_id" in row) ||
+    typeof row.user_id !== "string" ||
+    !("canonical_user_id" in row) ||
+    !isNullableString(row.canonical_user_id) ||
+    !("scm_name" in row) ||
+    !isNullableString(row.scm_name) ||
+    !("scm_login" in row) ||
+    !isNullableString(row.scm_login)
+  ) {
+    throw new Error("Invalid WebSocket client mapping row");
+  }
+
+  return {
+    participant_id: row.participant_id,
+    client_id: row.client_id,
+    user_id: row.user_id,
+    canonical_user_id: row.canonical_user_id,
+    scm_name: row.scm_name,
+    scm_login: row.scm_login,
+  };
 }
 
 /** Data for a WS client mapping. */
@@ -45,7 +77,8 @@ export class WsClientMappingRepository {
        WHERE m.ws_id = ?`,
       wsId
     );
-    return (result.toArray() as WsClientMappingResult[])[0] ?? null;
+    const row = result.toArray()[0];
+    return row === undefined ? null : parseWsClientMapping(row);
   }
 
   hasWsClientMapping(wsId: string): boolean {


### PR DESCRIPTION
## Summary
- align `WsClientMappingResult` with the recovery query and SQLite schema
- model `client_id` as nullable and `canonical_user_id` as always projected but nullable
- remove the unprojected legacy `auth_name` field from the recovery contract
- validate projected rows instead of asserting the entire SQL result array
- update repository and WebSocket manager fixtures to enforce the exact contract

## Verification
- `npm test -w @open-inspect/control-plane -- --run src/session/ws-client-mapping-repository.test.ts src/session/websocket-manager.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/session/ws-client-mapping-repository.ts packages/control-plane/src/session/ws-client-mapping-repository.test.ts packages/control-plane/src/session/websocket-manager.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e6211ba2968f0ef28a781c23ea5ce3ab)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when restoring WebSocket sessions.
  * Added safer handling for missing or invalid connection and identity information.
  * Removed reliance on a legacy authentication value.

* **Tests**
  * Expanded coverage for connection recovery, message broadcasts, authentication timeouts, and session restoration.
  * Added validation to detect malformed session mapping data and prevent invalid information from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->