### PR TITLE
fix(control-plane): move the draft sweep to its own hourly cron

### DIFF
--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -9,6 +9,11 @@ import { createLogger } from "./logger";
 import type { Env } from "./types";
 import { consumeImageBuildFinalizations } from "./image-builds/finalization-consumer";
 import { IMAGE_BUILD_SCHEDULER_CRON, runImageBuildScheduler } from "./image-builds/scheduler";
+import {
+  ABANDONED_DRAFT_SWEEP_CRON,
+  AbandonedDraftSweep,
+  SessionDraftExpiryClient,
+} from "./session/abandoned-draft-sweep";
 import { createRequestMetrics, instrumentD1, type RequestMetrics } from "./db/instrumented-d1";
 import { SessionIndexStore } from "./db/session-index";
 import type { SqlDatabase } from "./db/sql-database";
@@ -50,6 +55,15 @@ export default {
         request_id: requestId,
         trace_id: requestId,
       });
+      return;
+    }
+    if (event.cron === ABANDONED_DRAFT_SWEEP_CRON) {
+      await new AbandonedDraftSweep(
+        // eslint-disable-next-line no-restricted-syntax -- scheduled composition root: the one cron env.DB read
+        new SessionIndexStore(env.DB),
+        new SessionDraftExpiryClient(env.SESSION),
+        logger
+      ).run(Date.now());
       return;
     }
     if (event.cron !== "* * * * *") {

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -48,8 +48,6 @@ import {
   type SlackCompletionContext,
 } from "./slack-completion";
 import { UserStore } from "../db/user-store";
-import { SessionIndexStore } from "../db/session-index";
-import { AbandonedDraftSweep, SessionDraftExpiryClient } from "../session/abandoned-draft-sweep";
 import { createRequestMetrics } from "../db/instrumented-d1";
 import { generateId } from "../auth/crypto";
 import { createLogger, parseLogLevel } from "../logger";
@@ -571,14 +569,7 @@ export class SchedulerDO extends DurableObject<Env> {
     // 1. Recovery sweep
     await this.recoverySweep(store);
 
-    // 2. Retire warm sessions that were never prompted.
-    await new AbandonedDraftSweep(
-      new SessionIndexStore(this.db),
-      new SessionDraftExpiryClient(this.env.SESSION),
-      this.log
-    ).run(now);
-
-    // 3. Process overdue automations, bounded by the per-tick child budget.
+    // 2. Process overdue automations, bounded by the per-tick child budget.
     const overdue = await store.getOverdueAutomations(now, MAX_PER_TICK);
     const [repositoriesByAutomation, environmentsByAutomation] = await Promise.all([
       store.getRepositoriesForAutomationIds(overdue.map((automation) => automation.id)),

--- a/packages/control-plane/src/session/abandoned-draft-sweep.test.ts
+++ b/packages/control-plane/src/session/abandoned-draft-sweep.test.ts
@@ -65,13 +65,14 @@ describe("AbandonedDraftSweep", () => {
     expect(result).toEqual({
       candidates: 2,
       archived: 2,
-      retained: 0,
+      notDraft: 0,
+      hasWork: 0,
       errored: 0,
       truncated: false,
     });
   });
 
-  it("counts sessions the durable object declines to expire", async () => {
+  it("separates the two reasons a session declines to expire", async () => {
     const sweep = new AbandonedDraftSweep(
       createIndex(["archived-one", "started-work", "queued-work"]),
       createClient({ "started-work": "not_draft", "queued-work": "has_work" }),
@@ -82,7 +83,15 @@ describe("AbandonedDraftSweep", () => {
 
     const result = await sweep.run(NOW);
 
-    expect(result).toMatchObject({ candidates: 3, archived: 1, retained: 2, errored: 0 });
+    // The split is the whole point: `not_draft` means a stale index that has now
+    // been repaired, `has_work` means a prompt that never dispatched.
+    expect(result).toMatchObject({
+      candidates: 3,
+      archived: 1,
+      notDraft: 1,
+      hasWork: 1,
+      errored: 0,
+    });
   });
 
   it("isolates a failing session from the rest of the batch", async () => {
@@ -134,7 +143,8 @@ describe("AbandonedDraftSweep", () => {
     expect(result).toEqual({
       candidates: 0,
       archived: 0,
-      retained: 0,
+      notDraft: 0,
+      hasWork: 0,
       errored: 0,
       truncated: false,
     });

--- a/packages/control-plane/src/session/abandoned-draft-sweep.ts
+++ b/packages/control-plane/src/session/abandoned-draft-sweep.ts
@@ -61,10 +61,21 @@ export interface DraftExpiryClient {
   expireDraft(sessionId: string): Promise<DraftExpiryOutcome>;
 }
 
+/**
+ * Own cron rather than the automation tick. Retention is measured in hours, so
+ * riding a per-minute tick meant ~1,440 queries a day to action a handful of
+ * rows — and shared that tick's subrequest budget with automation launches.
+ * Offset from IMAGE_BUILD_SCHEDULER_CRON so the two never fire together.
+ */
+export const ABANDONED_DRAFT_SWEEP_CRON = "23 * * * *";
+
 export interface AbandonedDraftSweepResult {
   candidates: number;
   archived: number;
-  retained: number;
+  /** Session had already left `created`; the index was stale and was repaired. */
+  notDraft: number;
+  /** Session still `created` but holds messages — a prompt that never dispatched. */
+  hasWork: number;
   errored: number;
   /** The query is capped, so a full batch means more remain for the next sweep. */
   truncated: boolean;
@@ -112,7 +123,8 @@ export class AbandonedDraftSweep {
     const empty: AbandonedDraftSweepResult = {
       candidates: 0,
       archived: 0,
-      retained: 0,
+      notDraft: 0,
+      hasWork: 0,
       errored: 0,
       truncated: false,
     };
@@ -137,7 +149,8 @@ export class AbandonedDraftSweep {
     const result: AbandonedDraftSweepResult = {
       candidates: candidates.length,
       archived: 0,
-      retained: 0,
+      notDraft: 0,
+      hasWork: 0,
       errored: 0,
       truncated: candidates.length === this.limit,
     };
@@ -152,8 +165,10 @@ export class AbandonedDraftSweep {
         });
       } else if (outcome.value === "archived") {
         result.archived += 1;
+      } else if (outcome.value === "not_draft") {
+        result.notDraft += 1;
       } else {
-        result.retained += 1;
+        result.hasWork += 1;
       }
     }
 

--- a/packages/control-plane/src/session/abandoned-draft-sweep.ts
+++ b/packages/control-plane/src/session/abandoned-draft-sweep.ts
@@ -172,9 +172,16 @@ export class AbandonedDraftSweep {
       }
     }
 
+    // Serialized field by field rather than spread: log fields are snake_case
+    // here, and these two share their names with the protocol outcomes.
     this.log.info("Abandoned draft sweep completed", {
       event: "scheduler.abandoned_draft_sweep",
-      ...result,
+      candidates: result.candidates,
+      archived: result.archived,
+      not_draft: result.notDraft,
+      has_work: result.hasWork,
+      errored: result.errored,
+      truncated: result.truncated,
     });
 
     return result;

--- a/packages/control-plane/test/integration/abandoned-draft-sweep.test.ts
+++ b/packages/control-plane/test/integration/abandoned-draft-sweep.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createExecutionContext, env } from "cloudflare:test";
+import worker from "../../src/index";
+import { SessionIndexStore } from "../../src/db/session-index";
+import { ABANDONED_DRAFT_SWEEP_CRON } from "../../src/session/abandoned-draft-sweep";
+import type { Env } from "../../src/types";
+import { cleanD1Tables } from "./cleanup";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+async function seedStaleDraft(id: string): Promise<void> {
+  await new SessionIndexStore(env.DB).create({
+    id,
+    title: id,
+    repoOwner: "acme",
+    repoName: "web-app",
+    model: "anthropic/claude-haiku-4-5",
+    reasoningEffort: null,
+    baseBranch: null,
+    status: "created",
+    createdAt: Date.now() - 48 * HOUR_MS,
+    updatedAt: Date.now() - 48 * HOUR_MS,
+  });
+}
+
+function createSchedulerNamespace() {
+  return {
+    idFromName: vi.fn(() => {
+      throw new Error("automation scheduler should not run");
+    }),
+  };
+}
+
+function createSessionNamespace(response: () => Response) {
+  return {
+    idFromName: vi.fn((name: string) => name),
+    get: vi.fn(() => ({ fetch: vi.fn(async () => response()) })),
+  };
+}
+
+describe("abandoned draft sweep cron routing", () => {
+  beforeEach(cleanD1Tables);
+
+  it("routes the draft-sweep cron to the sweep instead of the automation Durable Object", async () => {
+    await seedStaleDraft("stale-draft");
+    const schedulerNamespace = createSchedulerNamespace();
+    const sessionNamespace = createSessionNamespace(() =>
+      Response.json({ outcome: "archived", status: "archived" })
+    );
+
+    await worker.scheduled(
+      { cron: ABANDONED_DRAFT_SWEEP_CRON } as ScheduledEvent,
+      {
+        DB: env.DB,
+        SCHEDULER: schedulerNamespace,
+        SESSION: sessionNamespace,
+      } as unknown as Env,
+      createExecutionContext()
+    );
+
+    expect(schedulerNamespace.idFromName).not.toHaveBeenCalled();
+    // Proves the sweep actually ran rather than falling through to the
+    // unknown-trigger branch, which would leave the session untouched.
+    expect(sessionNamespace.idFromName).toHaveBeenCalledWith("stale-draft");
+  });
+
+  it("leaves the draft sweep alone on the automation tick", async () => {
+    await seedStaleDraft("stale-draft");
+    const schedulerNamespace = {
+      idFromName: vi.fn(() => "scheduler-id"),
+      get: vi.fn(() => ({ fetch: vi.fn(async () => Response.json({})) })),
+    };
+    const sessionNamespace = createSessionNamespace(() =>
+      Response.json({ outcome: "archived", status: "archived" })
+    );
+
+    await worker.scheduled(
+      { cron: "* * * * *" } as ScheduledEvent,
+      {
+        DB: env.DB,
+        SCHEDULER: schedulerNamespace,
+        SESSION: sessionNamespace,
+      } as unknown as Env,
+      createExecutionContext()
+    );
+
+    expect(schedulerNamespace.idFromName).toHaveBeenCalled();
+    expect(sessionNamespace.idFromName).not.toHaveBeenCalled();
+  });
+});

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -209,8 +209,9 @@ module "control_plane_worker" {
   migration_old_tag   = var.control_plane_migration_old_tag
   new_sqlite_classes  = var.control_plane_new_sqlite_classes
 
-  # The image-build schedule must match IMAGE_BUILD_SCHEDULER_CRON in scheduler.ts.
-  cron_triggers = ["* * * * *", "7,37 * * * *"]
+  # The image-build schedule must match IMAGE_BUILD_SCHEDULER_CRON in scheduler.ts,
+  # and the draft sweep ABANDONED_DRAFT_SWEEP_CRON in abandoned-draft-sweep.ts.
+  cron_triggers = ["* * * * *", "7,37 * * * *", "23 * * * *"]
 
   depends_on = [
     null_resource.control_plane_build,


### PR DESCRIPTION
Follow-up to #1420. Two problems, both visible in production right now.

## The sweep runs 1,440 times a day for an 8-hour TTL

I attached the sweep to the automation tick, which fires every minute. That tick's cadence exists for cron automations, which genuinely need minute granularity. Draft retention does not: `ABANDONED_DRAFT_TTL_MS` is 8h, so the sweep was querying D1 roughly 1,440 times a day to action one to three rows, and spending the automation tick's subrequest budget doing it.

This repo already has the right pattern — `IMAGE_BUILD_SCHEDULER_CRON = "7,37 * * * *"` is a maintenance job with its own cron expression, matched in `scheduled()`. `ABANDONED_DRAFT_SWEEP_CRON = "23 * * * *"` follows it, offset so the two never fire together. The sweep also gets its own invocation now, so it no longer competes with automation launches for subrequests.

## The sweep is stalled, and one counter can't say why

Production, every tick:

```
candidates: 50, archived: 0, retained: 50, errored: 0, truncated: true
```

`created` has gone 268 → 267 in ~20 minutes of running. The candidate query is oldest-first, so rows that can never be archived hold the head of the queue permanently and nothing behind them is ever reached.

`retained` collapses two very different situations:

- `not_draft` — the session already left `created`, so the index was stale and has now been repaired. Self-correcting; if this is the bulk, the repair added in #1420 is not landing and that is its own bug.
- `has_work` — the session is still `created` but holds messages: a prompt that was issued and never dispatched.

The second is a real defect we have independently observed, and it has no timeout today. `failStuckProcessingMessage()` and the alarm's execution timeout both act only on `processing` messages; the only exit for a `pending` message is an explicit user cancel. So a prompt queued against a sandbox that never connects waits indefinitely.

Splitting the counter is what lets us size that before choosing a fix, rather than guessing. Deliberately kept small — the follow-up will likely remove the distinction once the head-of-line problem is properly resolved.

## Not in this PR

The pending-dispatch timeout itself. Two things have to be settled first, and the counter split is what settles them:

1. Dormant durable objects have no alarms, so an alarm-based timeout would never reach the existing backlog. The sweep's visit is the only thing that wakes those sessions, so the rule has to run there too.
2. `failMessage()` projects a terminal message, and unread is `latest_terminal_message_completed_at >= viewer.created_at` with no read-state row. Failing the whole backlog at once would therefore mark every one of those sessions unread — recreating the inbox flood that #1418's sibling change just removed, from the other direction.

## Testing

- `npm test -w @open-inspect/control-plane` — 2555 passed (163 files)
- `npm run test:integration -w @open-inspect/control-plane` — 787 passed (65 files)
- `npm run typecheck` — clean across all packages; eslint + prettier clean
- `terraform fmt -check` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic hourly sweep to identify and expire abandoned drafts.
  * Scheduled the sweep to run at 23 minutes past every hour.
  * Improved draft handling by distinguishing non-draft sessions from sessions containing pending work.

* **Bug Fixes**
  * Prevented abandoned-draft processing from interfering with other scheduled tasks.
  * Improved cleanup and repair of stale session records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->