### PR TITLE
feat: add completed workflow run automations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Open-Inspect provides a hosted background coding agent that can:
 - Connect from anywhere — web UI, Slack, GitHub PRs, Linear issues, or webhooks
 - Enable multiplayer sessions where multiple people can collaborate in real time
 - Create PRs with proper commit attribution to the prompting user
-- Run scheduled or event-driven automations for cron jobs, GitHub events, Sentry alerts, and
-  webhooks
+- Run scheduled automations for cron jobs, or event-driven automations for GitHub events, Sentry
+  alerts, and webhooks
 - Spawn parallel sub-tasks that work in separate sandboxes simultaneously
 - Use your choice of AI model — Anthropic Claude, OpenAI Codex (via ChatGPT subscription), xAI Grok
   (via SuperGrok subscription), or OpenCode Zen
@@ -235,8 +235,8 @@ Schedule recurring tasks or react to external events — no human in the loop:
 
 - **Cron schedules** — Hourly, daily, weekly, monthly, or custom 5-field cron with timezone support
 - **Sentry alerts** — Auto-triage on new errors, regressions, or critical metric alerts
-- **GitHub workflow runs** — Start work when a named GitHub Actions workflow finishes with a
-  configured conclusion
+- **GitHub workflow runs** — Start work when a GitHub Actions workflow finishes, with optional
+  workflow-name and conclusion filters
 - **Inbound webhooks** — JSONPath condition filters to gate which payloads spawn sessions
 - **Multi-repo fan-out** — One scheduled automation can run across up to 10 repositories, opening a
   separate session and pull request for each

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Open-Inspect provides a hosted background coding agent that can:
 - Connect from anywhere — web UI, Slack, GitHub PRs, Linear issues, or webhooks
 - Enable multiplayer sessions where multiple people can collaborate in real time
 - Create PRs with proper commit attribution to the prompting user
-- Run on a schedule — cron jobs, Sentry alerts, and webhook-triggered automations
+- Run scheduled or event-driven automations for cron jobs, GitHub events, Sentry alerts, and
+  webhooks
 - Spawn parallel sub-tasks that work in separate sandboxes simultaneously
 - Use your choice of AI model — Anthropic Claude, OpenAI Codex (via ChatGPT subscription), xAI Grok
   (via SuperGrok subscription), or OpenCode Zen
@@ -234,6 +235,8 @@ Schedule recurring tasks or react to external events — no human in the loop:
 
 - **Cron schedules** — Hourly, daily, weekly, monthly, or custom 5-field cron with timezone support
 - **Sentry alerts** — Auto-triage on new errors, regressions, or critical metric alerts
+- **GitHub workflow runs** — Start work when a named GitHub Actions workflow finishes with a
+  configured conclusion
 - **Inbound webhooks** — JSONPath condition filters to gate which payloads spawn sessions
 - **Multi-repo fan-out** — One scheduled automation can run across up to 10 repositories, opening a
   separate session and pull request for each

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -239,6 +239,12 @@ number in its deduplication key, so it can admit each GitHub rerun once.
 **Conclusion** also works for completed check suites. **Check Conclusion** remains available for
 existing check-suite automations.
 
+Each event type offers only the conditions its payload can answer, so the choices change with the
+event you pick — pull requests offer branch, target branch, label, and actor; issues offer label and
+actor; comments offer actor. Changing the event type removes conditions the new one cannot answer,
+and the form says which. GitHub webhook payloads carry no file list, so path-pattern filtering is
+not offered for any GitHub event.
+
 ---
 
 ## Slack Message Triggers

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -228,7 +228,8 @@ App's read-only Actions permission and the **Workflow runs** event subscription.
 conditions to restrict it:
 
 - **Workflow Name** matches the workflow name exactly.
-- **Conclusion** matches `success`, `failure`, `neutral`, `cancelled`, or `timed_out`.
+- **Conclusion** matches `success`, `failure`, `neutral`, `cancelled`, `timed_out`,
+  `action_required`, `skipped`, `stale`, or `startup_failure`.
 
 All configured conditions must match. Open-Inspect includes the workflow name, conclusion, and run
 ID in the untrusted event context sent to the agent. When GitHub supplies them, the context also

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -12,7 +12,7 @@ Trigger types:
 | **Inbound Webhook** | Trigger from any system with an HTTP POST | Available          |
 | **Sentry Alert**    | Trigger from a Sentry Custom Integration  | Available          |
 | **Slack Message**   | Trigger on messages in watched channels   | Available (opt-in) |
-| **GitHub Event**    | Trigger on GitHub activity                | Planned            |
+| **GitHub Event**    | Trigger on GitHub activity                | Available          |
 | **Linear Event**    | Trigger on Linear activity                | Planned            |
 
 Common use cases include nightly dependency updates, reacting to deploy or incident events, triaging
@@ -30,7 +30,7 @@ Start by choosing a **Trigger Type**. The rest of the form adjusts based on that
 
 | Field                        | Description                                                                                                                                                                                                                                      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Trigger Type**             | How the automation starts: schedule, inbound webhook, Sentry alert, or Slack message.                                                                                                                                                            |
+| **Trigger Type**             | How the automation starts: schedule, inbound webhook, Sentry alert, GitHub event, or Slack message.                                                                                                                                              |
 | **Name**                     | A short label for the automation (max 200 characters). Appears in the automations list and in session titles prefixed with `[Auto]`.                                                                                                             |
 | **Repository Configuration** | Pick no repository, one repository, or (for scheduled automations) up to 10 repositories. Selecting several fans each firing out into one session per repository. Only repositories installed on the GitHub App are available.                   |
 | **Instructions**             | The prompt sent to the coding agent each time the automation fires (max 15,000 characters). Write this as you would a normal session prompt and reference the trigger context when useful. Multi-repo automations share one prompt across repos. |
@@ -42,7 +42,7 @@ Start by choosing a **Trigger Type**. The rest of the form adjusts based on that
 | **Branch**     | The base branch for each session (shown when exactly one repository is selected). Multi-repo selections use each repository's default branch. |
 | **Model**      | The AI model to use. Defaults to the system default model.                                                                                    |
 | **Reasoning**  | Optional reasoning level for models that support it.                                                                                          |
-| **Conditions** | Optional trigger filters for event-driven automations such as inbound webhooks and Sentry alerts.                                             |
+| **Conditions** | Optional trigger filters for event-driven automations such as inbound webhooks, GitHub events, and Sentry alerts.                             |
 
 ### Trigger-Specific Fields
 
@@ -51,6 +51,7 @@ Start by choosing a **Trigger Type**. The rest of the form adjusts based on that
 | **Schedule**        | **Schedule** and **Timezone**                                                                |
 | **Inbound Webhook** | No extra required fields                                                                     |
 | **Sentry Alert**    | **Event Type** and **Sentry Client Secret**                                                  |
+| **GitHub Event**    | **Event Type** and optional **Conditions**                                                   |
 | **Slack Message**   | **Conditions** (a Slack Channel condition is required; a Message Text condition is optional) |
 
 For non-schedule automations, schedule fields are not used.
@@ -211,6 +212,31 @@ concurrency protection.
 | `404`  | Automation not found or not a webhook automation |
 | `413`  | Payload too large                                |
 | `415`  | `Content-Type` was not `application/json`        |
+
+---
+
+## GitHub Event Triggers
+
+A **GitHub Event** automation starts a session when a supported webhook event arrives for its
+repository. Pick one repository and one event type. The GitHub App must subscribe to that event and
+have its required repository permission. See the
+[GitHub App setup](GETTING_STARTED.md#step-3-create-github-app) for the permission and webhook
+settings.
+
+**Workflow Run Completed** handles completed GitHub Actions workflow runs. It requires the GitHub
+App's read-only Actions permission and the **Workflow runs** event subscription. Use these
+conditions to restrict it:
+
+- **Workflow Name** matches the workflow name exactly.
+- **Conclusion** matches `success`, `failure`, `neutral`, `cancelled`, or `timed_out`.
+
+All configured conditions must match. Open-Inspect includes the workflow name, conclusion, and run
+ID in the untrusted event context sent to the agent. When GitHub supplies them, the context also
+includes the branch, commit SHA, workflow path, and run URL. Open-Inspect includes the attempt
+number in its deduplication key, so it can admit each GitHub rerun once.
+
+**Conclusion** also works for completed check suites. **Check Conclusion** remains available for
+existing check-suite automations.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -307,6 +307,7 @@ GitHub OAuth sign-in, but its client pair is optional when Google is the only si
    > identity for repository access.
 
 5. Set **Repository permissions**:
+   - Actions: **Read-only** _(required for GitHub workflow-run automations)_
    - Contents: **Read & Write**
    - Issues: **Read & Write** _(required if enabling GitHub bot)_
    - Pull requests: **Read & Write** _(also authorizes creating and applying labels to
@@ -779,6 +780,7 @@ Now that the GitHub bot worker is deployed, configure the GitHub App for webhook
    - **Pull requests**
    - **Issue comments**
    - **Pull request review comments**
+   - **Workflow runs** _(required for GitHub workflow-run automations)_
 5. Click **Save changes**
 
 ### Find Your Bot Username

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -777,6 +777,27 @@ describe("automation route handlers", () => {
       });
     });
 
+    it("rejects conditions that do not apply to the GitHub event type", async () => {
+      const response = await callRoute("POST", "/automations", {
+        body: {
+          name: "PR workflow filter",
+          instructions: "Review the pull request.",
+          triggerType: "github_event",
+          eventType: "pull_request.opened",
+          repositories: [{ repoOwner: "acme", repoName: "web-app" }],
+          triggerConfig: {
+            conditions: [{ type: "workflow_name", operator: "eq", value: "CI" }],
+          },
+        },
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Condition "workflow_name" does not apply to GitHub event pull_request.opened',
+      });
+      expect(mockStore.bindAutomationInsert).not.toHaveBeenCalled();
+    });
+
     it("stores the user principal's canonical id without consulting the user store", async () => {
       mockStore.getById.mockResolvedValue(sampleRow);
 
@@ -1021,6 +1042,29 @@ describe("automation route handlers", () => {
       await expect(response.json()).resolves.toEqual({
         error: "Cannot set triggerConfig on schedule automations",
       });
+    });
+
+    it("rejects an event type change that would leave incompatible conditions", async () => {
+      mockStore.getById.mockResolvedValue({
+        ...sampleRow,
+        trigger_type: "github_event",
+        schedule_cron: null,
+        schedule_tz: null,
+        event_type: "workflow_run.completed",
+        trigger_config: JSON.stringify({
+          conditions: [{ type: "workflow_name", operator: "eq", value: "CI" }],
+        }),
+      });
+
+      const response = await callRoute("PUT", "/automations/auto-1", {
+        body: { eventType: "pull_request.opened" },
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Condition "workflow_name" does not apply to GitHub event pull_request.opened',
+      });
+      expect(mockStore.bindAutomationUpdate).not.toHaveBeenCalled();
     });
 
     it("updates reasoning effort when valid for the selected model", async () => {

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -117,6 +117,17 @@ function parseTriggerConfig(value: unknown): ParseTriggerConfigResult {
   };
 }
 
+function getTriggerConditionError(
+  triggerType: AutomationTriggerType,
+  triggerConfig: TriggerConfig,
+  eventType?: string
+): string | null {
+  const source = TRIGGER_TYPE_TO_SOURCE[triggerType];
+  if (!source) return null;
+  const errors = validateConditions(triggerConfig.conditions, source, conditionRegistry, eventType);
+  return errors.length > 0 ? errors.join("; ") : null;
+}
+
 /** Warn if next run is more than 31 days away. */
 const FAR_FUTURE_THRESHOLD_MS = 31 * 24 * 60 * 60 * 1000;
 
@@ -545,18 +556,13 @@ async function handleCreateAutomation(
   }
 
   // Validate conditions
-  if (body.triggerConfig?.conditions) {
-    const source = TRIGGER_TYPE_TO_SOURCE[triggerType];
-    if (source) {
-      const conditionErrors = validateConditions(
-        body.triggerConfig.conditions,
-        source,
-        conditionRegistry
-      );
-      if (conditionErrors.length > 0) {
-        return error(conditionErrors.join("; "), 400);
-      }
-    }
+  if (body.triggerConfig) {
+    const conditionError = getTriggerConditionError(
+      triggerType,
+      body.triggerConfig,
+      body.eventType
+    );
+    if (conditionError) return error(conditionError, 400);
   }
 
   // Slack triggers require explicit scoping (at least one watched channel).
@@ -888,39 +894,42 @@ async function handleUpdateAutomation(
     updateFields.event_type = body.eventType;
   }
 
-  // Validate trigger config (conditions) — only for non-schedule types
-  if (body.triggerConfig !== undefined) {
-    if (body.triggerConfig === null) {
-      // A slack_event's trigger_config holds its required scoping (channel +
-      // text_match) and the watched-channel index is derived from it. Clearing
-      // it would leave the automation enabled but untriggerable, so reject null
-      // — pause or delete instead. (Other sources may clear conditions to a
-      // match-all, so null stays allowed for them.)
-      if (existing.trigger_type === "slack_event") {
-        return error(
-          "Cannot clear triggerConfig on slack_event automations; pause or delete instead",
-          400
-        );
-      }
-    } else {
-      if (existing.trigger_type === "slack_event") {
-        const slackError = validateSlackTriggerConfig(body.triggerConfig);
-        if (slackError) return error(slackError, 400);
-      }
-      if (body.triggerConfig.conditions) {
-        const source = TRIGGER_TYPE_TO_SOURCE[existing.trigger_type as AutomationTriggerType];
-        if (source) {
-          const conditionErrors = validateConditions(
-            body.triggerConfig.conditions,
-            source,
-            conditionRegistry
-          );
-          if (conditionErrors.length > 0) {
-            return error(conditionErrors.join("; "), 400);
-          }
-        }
-      }
+  let triggerConfigToValidate = body.triggerConfig;
+  if (
+    body.eventType !== undefined &&
+    triggerConfigToValidate === undefined &&
+    existing.trigger_config
+  ) {
+    // This column was written through parseTriggerConfig, so a failure here is a
+    // corrupt row, not user input — parseTriggerConfig's per-condition messages
+    // would have no one to help.
+    try {
+      triggerConfigToValidate = triggerConfigSchema.parse(JSON.parse(existing.trigger_config));
+    } catch {
+      return error("Stored triggerConfig is invalid", 500);
     }
+  }
+
+  // A slack_event's trigger_config holds its required channel scope. Clearing it
+  // would leave the automation enabled but untriggerable.
+  if (body.triggerConfig === null && existing.trigger_type === "slack_event") {
+    return error(
+      "Cannot clear triggerConfig on slack_event automations; pause or delete instead",
+      400
+    );
+  }
+  if (body.triggerConfig && existing.trigger_type === "slack_event") {
+    const slackError = validateSlackTriggerConfig(body.triggerConfig);
+    if (slackError) return error(slackError, 400);
+  }
+
+  if (triggerConfigToValidate) {
+    const conditionError = getTriggerConditionError(
+      existing.trigger_type as AutomationTriggerType,
+      triggerConfigToValidate,
+      body.eventType ?? existing.event_type ?? undefined
+    );
+    if (conditionError) return error(conditionError, 400);
   }
 
   // trigger_config is a single source-interpreted JSON blob (the conditions),

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -406,6 +406,58 @@ describe("POST /webhooks/github", () => {
       },
     });
   });
+
+  it("forwards a completed workflow run", async () => {
+    const body = JSON.stringify({
+      action: "completed",
+      repository: { owner: { login: "acme-org" }, name: "my-app" },
+      sender: { login: "github-actions[bot]" },
+      workflow_run: {
+        id: 123456789,
+        run_attempt: 1,
+        name: "CI",
+        conclusion: "failure",
+        head_branch: "main",
+        head_sha: "abc1234def5678",
+        path: ".github/workflows/ci.yml",
+        html_url: "https://github.com/acme-org/my-app/actions/runs/123456789",
+      },
+    });
+    const signature = await sign(SECRET, body);
+    const ctx = makeCtx();
+    const env = makeEnv();
+
+    const response = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": signature,
+          "X-GitHub-Event": "workflow_run",
+          "X-GitHub-Delivery": "delivery-workflow-run-123456789",
+        },
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const controlPlaneFetch = (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> })
+      .fetch;
+    expect(controlPlaneFetch).toHaveBeenCalledOnce();
+    const [url, init] = controlPlaneFetch.mock.calls[0];
+    expect(url).toBe("https://internal/internal/github-event");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      eventType: "workflow_run.completed",
+      repoOwner: "acme-org",
+      repoName: "my-app",
+      workflowName: "CI",
+      conclusion: "failure",
+      triggerKey: "workflow_run:123456789:1",
+    });
+  });
 });
 
 describe("GET /health", () => {

--- a/packages/shared/src/triggers/conditions.test.ts
+++ b/packages/shared/src/triggers/conditions.test.ts
@@ -130,6 +130,57 @@ describe("matchesConditions", () => {
       expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
     });
   });
+
+  describe("GitHub workflow_name", () => {
+    it("matches only the configured workflow", () => {
+      const event = buildMockEvent("github", { workflowName: "CI" });
+      const conditions = [{ type: "workflow_name" as const, operator: "eq" as const, value: "CI" }];
+
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
+      expect(
+        matchesConditions(
+          conditions,
+          buildMockEvent("github", { workflowName: "Deploy" }),
+          conditionRegistry
+        )
+      ).toBe(false);
+    });
+
+    it("does not match events without a workflow name", () => {
+      const conditions = [{ type: "workflow_name" as const, operator: "eq" as const, value: "CI" }];
+
+      expect(matchesConditions(conditions, buildMockEvent("github"), conditionRegistry)).toBe(
+        false
+      );
+    });
+  });
+
+  describe("GitHub conclusion", () => {
+    it("matches a workflow conclusion without using the check-suite field", () => {
+      const event = buildMockEvent("github", { conclusion: "failure" });
+      const conditions = [
+        { type: "conclusion" as const, operator: "eq" as const, value: "failure" },
+      ];
+
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
+      expect(
+        matchesConditions(
+          conditions,
+          buildMockEvent("github", { checkConclusion: "failure" }),
+          conditionRegistry
+        )
+      ).toBe(false);
+    });
+
+    it("keeps the check conclusion condition compatible", () => {
+      const event = buildMockEvent("github", { checkConclusion: "failure" });
+      const conditions = [
+        { type: "check_conclusion" as const, operator: "eq" as const, value: "failure" },
+      ];
+
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
+    });
+  });
 });
 
 describe("validateConditions", () => {

--- a/packages/shared/src/triggers/conditions.test.ts
+++ b/packages/shared/src/triggers/conditions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { matchesConditions, validateConditions } from "./conditions";
-import { conditionRegistry, GITHUB_CONCLUSIONS } from "./registry";
+import { conditionRegistry } from "./registry";
+import { GITHUB_CONCLUSIONS } from "./github";
 import { buildMockEvent } from "./testing";
 
 describe("matchesConditions", () => {
@@ -156,24 +157,17 @@ describe("matchesConditions", () => {
   });
 
   describe("GitHub conclusion", () => {
-    it("matches a workflow conclusion without using the check-suite field", () => {
+    it("matches the canonical conclusion field", () => {
       const event = buildMockEvent("github", { conclusion: "failure" });
       const conditions = [
         { type: "conclusion" as const, operator: "eq" as const, value: "failure" },
       ];
 
       expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
-      expect(
-        matchesConditions(
-          conditions,
-          buildMockEvent("github", { checkConclusion: "failure" }),
-          conditionRegistry
-        )
-      ).toBe(false);
     });
 
-    it("keeps the check conclusion condition compatible", () => {
-      const event = buildMockEvent("github", { checkConclusion: "failure" });
+    it("keeps the legacy check conclusion condition compatible with the canonical field", () => {
+      const event = buildMockEvent("github", { conclusion: "failure" });
       const conditions = [
         { type: "check_conclusion" as const, operator: "eq" as const, value: "failure" },
       ];
@@ -217,30 +211,99 @@ describe("validateConditions", () => {
     const errors = validateConditions(
       [{ type: "target_branch", operator: "glob_match", value: [] }],
       "github",
-      conditionRegistry
+      conditionRegistry,
+      "pull_request.opened"
     );
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("target branch");
   });
 
-  it("accepts target_branch for github triggers", () => {
+  it("accepts target_branch for pull request triggers", () => {
     const errors = validateConditions(
       [{ type: "target_branch", operator: "glob_match", value: ["stable", "main"] }],
       "github",
-      conditionRegistry
+      conditionRegistry,
+      "pull_request.opened"
     );
     expect(errors).toHaveLength(0);
   });
 
+  it("rejects GitHub conditions when no event type is known", () => {
+    expect(
+      validateConditions(
+        [{ type: "branch", operator: "glob_match", value: ["main"] }],
+        "github",
+        conditionRegistry
+      )
+    ).toEqual(['Condition "branch" requires a GitHub event type']);
+  });
+
+  it.each([
+    { type: "workflow_name" as const, value: "CI" },
+    { type: "conclusion" as const, value: "success" },
+    { type: "check_conclusion" as const, value: "success" },
+  ])("rejects $type for an incompatible GitHub event type", ({ type, value }) => {
+    const errors = validateConditions(
+      [{ type, operator: "eq", value }],
+      "github",
+      conditionRegistry,
+      "pull_request.opened"
+    );
+
+    expect(errors).toEqual([
+      `Condition "${type}" does not apply to GitHub event pull_request.opened`,
+    ]);
+  });
+
+  it("rejects fields absent from the event type's payload", () => {
+    expect(
+      validateConditions(
+        [{ type: "label", operator: "any_of", value: ["bug"] }],
+        "github",
+        conditionRegistry,
+        "workflow_run.completed"
+      )
+    ).toEqual(['Condition "label" does not apply to GitHub event workflow_run.completed']);
+  });
+
+  it("rejects path_glob outright — no source can supply a file list", () => {
+    expect(
+      validateConditions(
+        [{ type: "path_glob", operator: "any_match", value: ["src/**"] }],
+        "github",
+        conditionRegistry,
+        "pull_request.opened"
+      )
+    ).toEqual(['Condition "path_glob" does not apply to github triggers']);
+  });
+
+  it("accepts workflow_name only for workflow runs", () => {
+    expect(
+      validateConditions(
+        [{ type: "workflow_name", operator: "eq", value: "CI" }],
+        "github",
+        conditionRegistry,
+        "workflow_run.completed"
+      )
+    ).toHaveLength(0);
+  });
+
   it.each(GITHUB_CONCLUSIONS)("accepts the %s GitHub conclusion", (conclusion) => {
-    for (const type of ["conclusion", "check_conclusion"] as const) {
-      expect(
-        validateConditions(
-          [{ type, operator: "eq", value: conclusion }],
-          "github",
-          conditionRegistry
-        )
-      ).toHaveLength(0);
-    }
+    expect(
+      validateConditions(
+        [{ type: "conclusion", operator: "eq", value: conclusion }],
+        "github",
+        conditionRegistry,
+        "workflow_run.completed"
+      )
+    ).toHaveLength(0);
+    expect(
+      validateConditions(
+        [{ type: "check_conclusion", operator: "eq", value: conclusion }],
+        "github",
+        conditionRegistry,
+        "check_suite.completed"
+      )
+    ).toHaveLength(0);
   });
 });

--- a/packages/shared/src/triggers/conditions.test.ts
+++ b/packages/shared/src/triggers/conditions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { matchesConditions, validateConditions } from "./conditions";
-import { conditionRegistry } from "./registry";
+import { conditionRegistry, GITHUB_CONCLUSIONS } from "./registry";
 import { buildMockEvent } from "./testing";
 
 describe("matchesConditions", () => {
@@ -230,5 +230,17 @@ describe("validateConditions", () => {
       conditionRegistry
     );
     expect(errors).toHaveLength(0);
+  });
+
+  it.each(GITHUB_CONCLUSIONS)("accepts the %s GitHub conclusion", (conclusion) => {
+    for (const type of ["conclusion", "check_conclusion"] as const) {
+      expect(
+        validateConditions(
+          [{ type, operator: "eq", value: conclusion }],
+          "github",
+          conditionRegistry
+        )
+      ).toHaveLength(0);
+    }
   });
 });

--- a/packages/shared/src/triggers/conditions.ts
+++ b/packages/shared/src/triggers/conditions.ts
@@ -11,6 +11,7 @@ import type {
   ConditionType,
   TriggerCondition,
 } from "./types";
+import { isGitHubConditionSupported } from "./github/webhook-types";
 
 type ConditionOf<K extends ConditionType> = Extract<TriggerCondition, { type: K }>;
 
@@ -49,7 +50,8 @@ export function matchesConditions(
 export function validateConditions(
   conditions: TriggerCondition[],
   triggerSource: AutomationEventSource,
-  registry: ConditionRegistry
+  registry: ConditionRegistry,
+  eventType?: string
 ): string[] {
   const errors: string[] = [];
   for (const condition of conditions) {
@@ -57,6 +59,16 @@ export function validateConditions(
     if (!handler.appliesTo.includes(triggerSource)) {
       errors.push(`Condition "${condition.type}" does not apply to ${triggerSource} triggers`);
       continue;
+    }
+    if (triggerSource === "github") {
+      if (!eventType) {
+        errors.push(`Condition "${condition.type}" requires a GitHub event type`);
+        continue;
+      }
+      if (!isGitHubConditionSupported(eventType, condition.type)) {
+        errors.push(`Condition "${condition.type}" does not apply to GitHub event ${eventType}`);
+        continue;
+      }
     }
     const err = handler.validate(condition);
     if (err) errors.push(err);

--- a/packages/shared/src/triggers/github/conditions.ts
+++ b/packages/shared/src/triggers/github/conditions.ts
@@ -1,0 +1,99 @@
+/** GitHub-specific condition handlers and conclusion values. */
+
+import type { ConditionRegistry } from "../conditions";
+import { matchGlob } from "../glob";
+import type { AutomationEvent } from "../types";
+
+export const DEFAULT_GITHUB_CONCLUSION = "success" as const;
+
+export const GITHUB_CONCLUSIONS = [
+  DEFAULT_GITHUB_CONCLUSION,
+  "failure",
+  "neutral",
+  "cancelled",
+  "timed_out",
+  "action_required",
+  "skipped",
+  "stale",
+  "startup_failure",
+] as const;
+
+const githubConclusionSet: ReadonlySet<string> = new Set(GITHUB_CONCLUSIONS);
+
+function validateGitHubConclusion(condition: { value: string }): string | null {
+  return githubConclusionSet.has(condition.value) ? null : `Invalid conclusion: ${condition.value}`;
+}
+
+function evaluateGitHubConclusion(condition: { value: string }, event: AutomationEvent): boolean {
+  if (event.source !== "github") return true;
+  return event.conclusion === condition.value;
+}
+
+/** Match one branch name against a condition's exact list or glob patterns. */
+function matchesPatterns(
+  condition: { operator: string; value: string[] },
+  branch: string | undefined
+): boolean {
+  if (!branch) return false;
+  if (condition.operator === "exact") return condition.value.includes(branch);
+  return condition.value.some((pattern) => matchGlob(pattern, branch));
+}
+
+export const githubConditions = {
+  branch: {
+    appliesTo: ["github"] as const,
+    validate(condition) {
+      return condition.value.length === 0 ? "At least one branch pattern required" : null;
+    },
+    evaluate(condition, event) {
+      if (event.source !== "github") return true;
+      return matchesPatterns(condition, event.branch);
+    },
+  },
+  target_branch: {
+    appliesTo: ["github"] as const,
+    validate(condition) {
+      return condition.value.length === 0 ? "At least one target branch pattern required" : null;
+    },
+    evaluate(condition, event) {
+      if (event.source !== "github") return true;
+      return matchesPatterns(condition, event.targetBranch);
+    },
+  },
+  // No GitHub webhook payload carries a file list, so no normalizer ever sets
+  // `changedFiles` and no catalog entry offers this condition. The handler and
+  // its schema variant stay so persisted configs still parse; the empty
+  // `appliesTo` is what says no source can answer it.
+  path_glob: {
+    appliesTo: [] as const,
+    validate(condition) {
+      return condition.value.length === 0 ? "At least one path pattern required" : null;
+    },
+    evaluate(condition, event) {
+      if (event.source !== "github") return true;
+      const changedFiles = event.changedFiles;
+      if (!changedFiles?.length) return false;
+      return condition.value.some((glob) => changedFiles.some((file) => matchGlob(glob, file)));
+    },
+  },
+  conclusion: {
+    appliesTo: ["github"] as const,
+    validate: validateGitHubConclusion,
+    evaluate: evaluateGitHubConclusion,
+  },
+  check_conclusion: {
+    appliesTo: ["github"] as const,
+    validate: validateGitHubConclusion,
+    evaluate: evaluateGitHubConclusion,
+  },
+  workflow_name: {
+    appliesTo: ["github"] as const,
+    validate(condition) {
+      return condition.value.trim().length === 0 ? "Workflow name is required" : null;
+    },
+    evaluate(condition, event) {
+      if (event.source !== "github") return true;
+      return event.workflowName === condition.value;
+    },
+  },
+} satisfies Partial<ConditionRegistry>;

--- a/packages/shared/src/triggers/github/context.ts
+++ b/packages/shared/src/triggers/github/context.ts
@@ -208,6 +208,12 @@ export function buildCheckSuiteContextBlock(payload: CheckSuitePayload): string 
   return wrapUserContextTag(lines.join("\n"));
 }
 
+/**
+ * Build the context block for `workflow_run.completed`. The workflow name and
+ * run ID are required; a missing conclusion is rendered as unknown. The
+ * workflow path, branch, commit, and run URL are appended when GitHub supplies
+ * them.
+ */
 export function buildWorkflowRunContextBlock(payload: WorkflowRunPayload): string {
   const run = payload.workflow_run;
   const lines = [

--- a/packages/shared/src/triggers/github/context.ts
+++ b/packages/shared/src/triggers/github/context.ts
@@ -13,6 +13,7 @@ import type {
   IssuesPayload,
   PullRequestPayload,
   PullRequestReviewCommentPayload,
+  WorkflowRunPayload,
 } from "./webhook-types";
 
 const GITHUB_CONTEXT_CONSTANTS = {
@@ -203,6 +204,26 @@ export function buildCheckSuiteContextBlock(payload: CheckSuitePayload): string 
   if (prNumbers) {
     lines.push(`Pull Requests: ${prNumbers}`);
   }
+
+  return wrapUserContextTag(lines.join("\n"));
+}
+
+export function buildWorkflowRunContextBlock(payload: WorkflowRunPayload): string {
+  const run = payload.workflow_run;
+  const lines = [
+    GITHUB_EVENT_PREAMBLE,
+    "",
+    "Event: workflow_run.completed",
+    `Repository: ${getRepoFullName(payload)}`,
+    `Workflow: ${run.name}`,
+    `Run: ${run.id}`,
+    `Conclusion: ${run.conclusion ?? "unknown"}`,
+  ];
+
+  if (run.path) lines.push(`Workflow file: ${run.path}`);
+  if (run.head_branch) lines.push(`Branch: ${run.head_branch}`);
+  if (run.head_sha) lines.push(`Commit: ${run.head_sha.slice(0, 7)}`);
+  if (run.html_url) lines.push(`Run URL: ${run.html_url}`);
 
   return wrapUserContextTag(lines.join("\n"));
 }

--- a/packages/shared/src/triggers/github/index.ts
+++ b/packages/shared/src/triggers/github/index.ts
@@ -5,9 +5,13 @@
 import type { TriggerSourceDefinition } from "../types";
 import { GITHUB_WEBHOOK_EVENT_CATALOG } from "./webhook-types";
 
+export { githubConditions, DEFAULT_GITHUB_CONCLUSION, GITHUB_CONCLUSIONS } from "./conditions";
 export { normalizeGitHubEvent } from "./normalizer";
-export { GITHUB_WEBHOOK_EVENT_CATALOG } from "./webhook-types";
-
+export {
+  GITHUB_WEBHOOK_EVENT_CATALOG,
+  getGitHubEventConditionTypes,
+  isGitHubConditionSupported,
+} from "./webhook-types";
 export const githubSource: TriggerSourceDefinition = {
   source: "github",
   triggerType: "github_event",
@@ -21,13 +25,8 @@ export const githubSource: TriggerSourceDefinition = {
     description,
   })),
   supportedConditions: [
-    "branch",
-    "target_branch",
-    "label",
-    "path_glob",
-    "actor",
-    "conclusion",
-    "check_conclusion",
-    "workflow_name",
+    ...new Set(
+      GITHUB_WEBHOOK_EVENT_CATALOG.flatMap(({ supportedConditions }) => supportedConditions)
+    ),
   ],
 };

--- a/packages/shared/src/triggers/github/index.ts
+++ b/packages/shared/src/triggers/github/index.ts
@@ -26,6 +26,8 @@ export const githubSource: TriggerSourceDefinition = {
     "label",
     "path_glob",
     "actor",
+    "conclusion",
     "check_conclusion",
+    "workflow_name",
   ],
 };

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { normalizeGitHubEvent } from "./normalizer";
+import { GITHUB_WEBHOOK_EVENT_CATALOG } from "./webhook-types";
+import type { GitHubAutomationEvent } from "../types";
 
 // ─── Shared fixture data ───────────────────────────────────────────────────────
 
@@ -262,14 +264,14 @@ describe("normalizeGitHubEvent", () => {
   });
 
   describe("check_suite.completed", () => {
-    it("extracts checkConclusion and check suite id", () => {
+    it("extracts the canonical conclusion and check suite id", () => {
       const event = normalizeGitHubEvent("check_suite", checkSuiteCompletedPayload);
 
       expect(event).not.toBeNull();
       expect(event!.source).toBe("github");
       expect(event!.eventType).toBe("check_suite.completed");
       expect(event!.conclusion).toBe("failure");
-      expect(event!.checkConclusion).toBe("failure");
+      expect(event).not.toHaveProperty("checkConclusion");
       expect(event!.triggerKey).toBe("check_suite:77777");
       expect(event!.concurrencyKey).toBe("check_suite:77777");
       expect(event!.branch).toBe("feature/my-feature");
@@ -290,10 +292,10 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.repoName).toBe("my-app");
       expect(event!.workflowName).toBe("CI");
       expect(event!.conclusion).toBe("failure");
-      expect(event!.checkConclusion).toBeUndefined();
+      expect(event).not.toHaveProperty("checkConclusion");
       expect(event!.branch).toBe("main");
       expect(event!.triggerKey).toBe("workflow_run:123456789:1");
-      expect(event!.concurrencyKey).toBe("workflow:CI");
+      expect(event!.concurrencyKey).toBe("workflow_run:123456789");
       expect(event!.contextBlock).toContain("Run: 123456789");
       expect(event!.contextBlock).toContain(".github/workflows/ci.yml");
       expect(event!.meta).toMatchObject({
@@ -304,13 +306,24 @@ describe("normalizeGitHubEvent", () => {
       });
     });
 
-    it("uses the run attempt to distinguish workflow reruns", () => {
+    it("deduplicates attempts separately within one run concurrency scope", () => {
       const rerun = normalizeGitHubEvent("workflow_run", {
         ...workflowRunCompletedPayload,
         workflow_run: { ...workflowRunCompletedPayload.workflow_run, run_attempt: 2 },
       });
 
       expect(rerun?.triggerKey).toBe("workflow_run:123456789:2");
+      expect(rerun?.concurrencyKey).toBe("workflow_run:123456789");
+    });
+
+    it("admits different run ids with the same workflow name independently", () => {
+      const otherRun = normalizeGitHubEvent("workflow_run", {
+        ...workflowRunCompletedPayload,
+        workflow_run: { ...workflowRunCompletedPayload.workflow_run, id: 987654321 },
+      });
+
+      expect(otherRun?.triggerKey).toBe("workflow_run:987654321:1");
+      expect(otherRun?.concurrencyKey).toBe("workflow_run:987654321");
     });
   });
 
@@ -724,4 +737,64 @@ describe("typed pullRequest facts on pull_request events", () => {
       expect(parsed.pullRequest).toEqual(event!.pullRequest);
     }
   });
+});
+
+// ─── Catalog ↔ normalizer agreement ───────────────────────────────────────────
+//
+// The catalog tells the UI and the API which conditions an event type may use.
+// That promise is only worth anything if the normalizer actually fills the field
+// each condition reads. This suite normalizes one payload per catalog entry and
+// checks every condition the catalog offers against the fields that came out, so
+// the catalog can never promise a filter that could not match.
+//
+// One direction only: over-promising is the failure that reaches users, and
+// asserting the reverse would quietly require every fixture to be the fattest
+// payload GitHub can send.
+
+/** The normalized event field each GitHub condition reads. */
+const CONDITION_SOURCE_FIELD = {
+  branch: "branch",
+  target_branch: "targetBranch",
+  label: "labels",
+  path_glob: "changedFiles",
+  actor: "actor",
+  conclusion: "conclusion",
+  workflow_name: "workflowName",
+} as const satisfies Record<string, keyof GitHubAutomationEvent>;
+
+/** A payload per catalog event type. */
+const CATALOG_PAYLOADS: Record<string, [event: string, payload: Record<string, unknown>]> = {
+  "pull_request.opened": ["pull_request", pullRequestOpenedPayload],
+  "pull_request.synchronize": ["pull_request", pullRequestSynchronizePayload],
+  "pull_request.closed": ["pull_request", pullRequestClosedPayload],
+  "issue_comment.created": ["issue_comment", issueCommentPayload],
+  "pull_request_review_comment.created": ["pull_request_review_comment", reviewCommentPayload],
+  "check_suite.completed": ["check_suite", checkSuiteCompletedPayload],
+  "workflow_run.completed": ["workflow_run", workflowRunCompletedPayload],
+  // The shared opened fixture covers the unlabelled case; a catalog entry that
+  // promises `label` has to be checked against a payload that carries labels.
+  "issues.opened": [
+    "issues",
+    { ...issuesOpenedPayload, issue: { ...issuesOpenedPayload.issue, labels: [{ name: "bug" }] } },
+  ],
+  "issues.labeled": ["issues", issuesLabeledPayload],
+};
+
+describe("GITHUB_WEBHOOK_EVENT_CATALOG supportedConditions", () => {
+  it.each(GITHUB_WEBHOOK_EVENT_CATALOG.map((entry) => [`${entry.event}.${entry.action}`, entry]))(
+    "%s only offers conditions its normalizer can answer",
+    (eventType, entry) => {
+      const fixture = CATALOG_PAYLOADS[eventType];
+      expect(fixture, `no fixture for ${eventType}`).toBeDefined();
+
+      const event = normalizeGitHubEvent(fixture[0], fixture[1]);
+      expect(event).not.toBeNull();
+
+      const unanswerable = entry.supportedConditions.filter(
+        (conditionType) => event![CONDITION_SOURCE_FIELD[conditionType]] === undefined
+      );
+
+      expect(unanswerable).toEqual([]);
+    }
+  );
 });

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -91,6 +91,22 @@ const checkSuiteCompletedPayload = {
   },
 };
 
+const workflowRunCompletedPayload = {
+  action: "completed",
+  repository: repo,
+  sender,
+  workflow_run: {
+    id: 123456789,
+    run_attempt: 1,
+    name: "CI",
+    conclusion: "failure",
+    head_branch: "main",
+    head_sha: "abc1234def5678",
+    path: ".github/workflows/ci.yml",
+    html_url: "https://github.com/acme-org/my-app/actions/runs/123456789",
+  },
+};
+
 const issuesOpenedPayload = {
   action: "opened",
   repository: repo,
@@ -252,6 +268,7 @@ describe("normalizeGitHubEvent", () => {
       expect(event).not.toBeNull();
       expect(event!.source).toBe("github");
       expect(event!.eventType).toBe("check_suite.completed");
+      expect(event!.conclusion).toBe("failure");
       expect(event!.checkConclusion).toBe("failure");
       expect(event!.triggerKey).toBe("check_suite:77777");
       expect(event!.concurrencyKey).toBe("check_suite:77777");
@@ -260,6 +277,40 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.contextBlock).toContain("check_suite.completed");
       expect(event!.contextBlock).toContain("failure");
       expect(event!.meta).toMatchObject({ checkSuiteId: 77777, conclusion: "failure" });
+    });
+  });
+
+  describe("workflow_run.completed", () => {
+    it("normalizes a completed workflow run", () => {
+      const event = normalizeGitHubEvent("workflow_run", workflowRunCompletedPayload);
+
+      expect(event).not.toBeNull();
+      expect(event!.eventType).toBe("workflow_run.completed");
+      expect(event!.repoOwner).toBe("acme-org");
+      expect(event!.repoName).toBe("my-app");
+      expect(event!.workflowName).toBe("CI");
+      expect(event!.conclusion).toBe("failure");
+      expect(event!.checkConclusion).toBeUndefined();
+      expect(event!.branch).toBe("main");
+      expect(event!.triggerKey).toBe("workflow_run:123456789:1");
+      expect(event!.concurrencyKey).toBe("workflow:CI");
+      expect(event!.contextBlock).toContain("Run: 123456789");
+      expect(event!.contextBlock).toContain(".github/workflows/ci.yml");
+      expect(event!.meta).toMatchObject({
+        workflowRunId: 123456789,
+        workflowRunAttempt: 1,
+        workflowName: "CI",
+        conclusion: "failure",
+      });
+    });
+
+    it("uses the run attempt to distinguish workflow reruns", () => {
+      const rerun = normalizeGitHubEvent("workflow_run", {
+        ...workflowRunCompletedPayload,
+        workflow_run: { ...workflowRunCompletedPayload.workflow_run, run_attempt: 2 },
+      });
+
+      expect(rerun?.triggerKey).toBe("workflow_run:123456789:2");
     });
   });
 

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -9,6 +9,7 @@ import {
   buildIssueContextBlock,
   buildPullRequestContextBlock,
   buildReviewCommentContextBlock,
+  buildWorkflowRunContextBlock,
 } from "./context";
 import {
   GITHUB_WEBHOOK_EVENT_CATALOG,
@@ -17,12 +18,14 @@ import {
   issuesEventSchema,
   pullRequestEventSchema,
   pullRequestReviewCommentEventSchema,
+  workflowRunEventSchema,
   type CheckSuitePayload,
   type GitHubEventBase,
   type IssueCommentPayload,
   type IssuesPayload,
   type PullRequestPayload,
   type PullRequestReviewCommentPayload,
+  type WorkflowRunPayload,
 } from "./webhook-types";
 
 // ─── Supported event type map ─────────────────────────────────────────────────
@@ -101,6 +104,12 @@ export function normalizeGitHubEvent(
       const parsed = checkSuiteEventSchema.safeParse(payload);
       if (!parsed.success) return null;
       return normalizeCheckSuite(eventType, parsed.data);
+    }
+
+    case "workflow_run": {
+      const parsed = workflowRunEventSchema.safeParse(payload);
+      if (!parsed.success) return null;
+      return normalizeWorkflowRun(eventType, parsed.data);
     }
 
     case "issues": {
@@ -254,10 +263,39 @@ function normalizeCheckSuite(eventType: string, payload: CheckSuitePayload): Git
     repoName: getRepoName(payload),
     branch: checkSuite.head_branch ?? undefined,
     actor: getActor(payload),
+    conclusion,
     checkConclusion: conclusion,
     contextBlock: buildCheckSuiteContextBlock(payload),
     meta: {
       checkSuiteId: checkSuite.id,
+      conclusion,
+    },
+  };
+}
+
+function normalizeWorkflowRun(
+  eventType: string,
+  payload: WorkflowRunPayload
+): GitHubAutomationEvent {
+  const run = payload.workflow_run;
+  const conclusion = run.conclusion ?? undefined;
+
+  return {
+    source: "github",
+    eventType,
+    triggerKey: `workflow_run:${run.id}:${run.run_attempt}`,
+    concurrencyKey: `workflow:${run.name}`,
+    repoOwner: getRepoOwner(payload),
+    repoName: getRepoName(payload),
+    branch: run.head_branch ?? undefined,
+    actor: getActor(payload),
+    conclusion,
+    workflowName: run.name,
+    contextBlock: buildWorkflowRunContextBlock(payload),
+    meta: {
+      workflowRunId: run.id,
+      workflowRunAttempt: run.run_attempt,
+      workflowName: run.name,
       conclusion,
     },
   };

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -264,7 +264,6 @@ function normalizeCheckSuite(eventType: string, payload: CheckSuitePayload): Git
     branch: checkSuite.head_branch ?? undefined,
     actor: getActor(payload),
     conclusion,
-    checkConclusion: conclusion,
     contextBlock: buildCheckSuiteContextBlock(payload),
     meta: {
       checkSuiteId: checkSuite.id,
@@ -274,10 +273,8 @@ function normalizeCheckSuite(eventType: string, payload: CheckSuitePayload): Git
 }
 
 /**
- * Normalize `workflow_run.completed`. Including the attempt number in the
- * trigger key deduplicates each attempt independently. Grouping concurrency by
- * workflow name suppresses a new run while an invocation for that workflow is
- * still active.
+ * Normalize `workflow_run.completed`. The attempt number deduplicates each
+ * attempt independently, while the run id keeps all attempts in one concurrency scope.
  */
 function normalizeWorkflowRun(
   eventType: string,
@@ -290,7 +287,7 @@ function normalizeWorkflowRun(
     source: "github",
     eventType,
     triggerKey: `workflow_run:${run.id}:${run.run_attempt}`,
-    concurrencyKey: `workflow:${run.name}`,
+    concurrencyKey: `workflow_run:${run.id}`,
     repoOwner: getRepoOwner(payload),
     repoName: getRepoName(payload),
     branch: run.head_branch ?? undefined,

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -273,6 +273,12 @@ function normalizeCheckSuite(eventType: string, payload: CheckSuitePayload): Git
   };
 }
 
+/**
+ * Normalize `workflow_run.completed`. Including the attempt number in the
+ * trigger key deduplicates each attempt independently. Grouping concurrency by
+ * workflow name suppresses a new run while an invocation for that workflow is
+ * still active.
+ */
 function normalizeWorkflowRun(
   eventType: string,
   payload: WorkflowRunPayload

--- a/packages/shared/src/triggers/github/webhook-types.ts
+++ b/packages/shared/src/triggers/github/webhook-types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { WebhookEventMap } from "@octokit/webhooks-types";
+import type { ConditionType } from "../types";
 
 type GitHubWebhookEvent = Extract<keyof WebhookEventMap, string>;
 
@@ -10,6 +11,7 @@ type GitHubEventCatalogEntry<E extends GitHubWebhookEvent = GitHubWebhookEvent> 
   displayName: string;
   description: string;
   shortLabel: string;
+  supportedConditions: readonly ConditionType[];
 };
 
 export const GITHUB_WEBHOOK_EVENT_CATALOG = [
@@ -19,6 +21,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "PR Opened",
     description: "A pull request was opened",
     shortLabel: "PR opened",
+    supportedConditions: ["branch", "target_branch", "label", "actor"],
   },
   {
     event: "pull_request",
@@ -26,6 +29,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "PR Updated",
     description: "New commits pushed to a pull request",
     shortLabel: "PR updated",
+    supportedConditions: ["branch", "target_branch", "label", "actor"],
   },
   {
     event: "pull_request",
@@ -33,6 +37,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "PR Closed",
     description: "A pull request was closed or merged",
     shortLabel: "PR closed",
+    supportedConditions: ["branch", "target_branch", "label", "actor"],
   },
   {
     event: "issue_comment",
@@ -40,6 +45,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Issue Comment",
     description: "A comment was added to an issue or PR",
     shortLabel: "comment created",
+    supportedConditions: ["actor"],
   },
   {
     event: "pull_request_review_comment",
@@ -47,6 +53,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Review Comment",
     description: "A review comment was added to a pull request",
     shortLabel: "review comment created",
+    supportedConditions: ["branch", "target_branch", "actor"],
   },
   {
     event: "check_suite",
@@ -54,6 +61,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Check Suite Completed",
     description: "A CI check suite finished running",
     shortLabel: "CI completed",
+    supportedConditions: ["branch", "actor", "conclusion"],
   },
   {
     event: "workflow_run",
@@ -61,6 +69,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Workflow Run Completed",
     description: "A GitHub Actions workflow run finished",
     shortLabel: "workflow completed",
+    supportedConditions: ["branch", "actor", "conclusion", "workflow_name"],
   },
   {
     event: "issues",
@@ -68,6 +77,7 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Issue Opened",
     description: "A new issue was opened",
     shortLabel: "issue opened",
+    supportedConditions: ["label", "actor"],
   },
   {
     event: "issues",
@@ -75,9 +85,24 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     displayName: "Issue Labeled",
     description: "A label was added to an issue",
     shortLabel: "issue labeled",
+    supportedConditions: ["label", "actor"],
   },
 ] as const satisfies readonly GitHubEventCatalogEntry[];
 
+export function getGitHubEventConditionTypes(eventType: string): readonly ConditionType[] {
+  const entry = GITHUB_WEBHOOK_EVENT_CATALOG.find(
+    ({ event, action }) => `${event}.${action}` === eventType
+  );
+  return entry?.supportedConditions ?? [];
+}
+
+export function isGitHubConditionSupported(
+  eventType: string,
+  conditionType: ConditionType
+): boolean {
+  const preferredType = conditionType === "check_conclusion" ? "conclusion" : conditionType;
+  return getGitHubEventConditionTypes(eventType).includes(preferredType);
+}
 // ─── Webhook payload schemas ──────────────────────────────────────────────────
 //
 // Each schema is the single source of truth for one supported event: it produces

--- a/packages/shared/src/triggers/github/webhook-types.ts
+++ b/packages/shared/src/triggers/github/webhook-types.ts
@@ -56,6 +56,13 @@ export const GITHUB_WEBHOOK_EVENT_CATALOG = [
     shortLabel: "CI completed",
   },
   {
+    event: "workflow_run",
+    action: "completed",
+    displayName: "Workflow Run Completed",
+    description: "A GitHub Actions workflow run finished",
+    shortLabel: "workflow completed",
+  },
+  {
     event: "issues",
     action: "opened",
     displayName: "Issue Opened",
@@ -159,6 +166,17 @@ const checkSuiteObjectSchema = z.object({
   pull_requests: z.array(z.object({ number: z.number() })).optional(),
 });
 
+const workflowRunObjectSchema = z.object({
+  id: z.number(),
+  run_attempt: z.number().int().positive(),
+  name: z.string(),
+  conclusion: z.string().nullable().optional(),
+  head_branch: z.string().nullable().optional(),
+  head_sha: z.string().optional(),
+  path: z.string().optional(),
+  html_url: z.string().optional(),
+});
+
 // GitHub always includes the event's primary object (a pull_request event always
 // carries `pull_request`, an issue_comment always carries `issue` + `comment`,
 // etc.), so each is required — a payload missing it is malformed and fails the
@@ -181,6 +199,10 @@ export const checkSuiteEventSchema = baseEventSchema.extend({
   check_suite: checkSuiteObjectSchema,
 });
 
+export const workflowRunEventSchema = baseEventSchema.extend({
+  workflow_run: workflowRunObjectSchema,
+});
+
 export const issuesEventSchema = baseEventSchema.extend({
   issue: issueObjectSchema,
 });
@@ -191,4 +213,5 @@ export type PullRequestPayload = z.infer<typeof pullRequestEventSchema>;
 export type IssueCommentPayload = z.infer<typeof issueCommentEventSchema>;
 export type PullRequestReviewCommentPayload = z.infer<typeof pullRequestReviewCommentEventSchema>;
 export type CheckSuitePayload = z.infer<typeof checkSuiteEventSchema>;
+export type WorkflowRunPayload = z.infer<typeof workflowRunEventSchema>;
 export type IssuesPayload = z.infer<typeof issuesEventSchema>;

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -37,18 +37,22 @@ export type { ConditionHandler, ConditionRegistry } from "./conditions";
 export { matchesConditions, validateConditions } from "./conditions";
 
 // Registry
-export {
-  conditionRegistry,
-  triggerSources,
-  DEFAULT_GITHUB_CONCLUSION,
-  GITHUB_CONCLUSIONS,
-} from "./registry";
+export { conditionRegistry, triggerSources } from "./registry";
 
 // Glob utility
 export { matchGlob } from "./glob";
 
 // GitHub source module
-export { githubSource, normalizeGitHubEvent, GITHUB_WEBHOOK_EVENT_CATALOG } from "./github";
+export {
+  githubSource,
+  githubConditions,
+  normalizeGitHubEvent,
+  DEFAULT_GITHUB_CONCLUSION,
+  GITHUB_CONCLUSIONS,
+  GITHUB_WEBHOOK_EVENT_CATALOG,
+  getGitHubEventConditionTypes,
+  isGitHubConditionSupported,
+} from "./github";
 
 // Sentry source module
 export {

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -37,7 +37,7 @@ export type { ConditionHandler, ConditionRegistry } from "./conditions";
 export { matchesConditions, validateConditions } from "./conditions";
 
 // Registry
-export { conditionRegistry, triggerSources } from "./registry";
+export { conditionRegistry, triggerSources, GITHUB_CONCLUSIONS } from "./registry";
 
 // Glob utility
 export { matchGlob } from "./glob";

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -37,7 +37,12 @@ export type { ConditionHandler, ConditionRegistry } from "./conditions";
 export { matchesConditions, validateConditions } from "./conditions";
 
 // Registry
-export { conditionRegistry, triggerSources, GITHUB_CONCLUSIONS } from "./registry";
+export {
+  conditionRegistry,
+  triggerSources,
+  DEFAULT_GITHUB_CONCLUSION,
+  GITHUB_CONCLUSIONS,
+} from "./registry";
 
 // Glob utility
 export { matchGlob } from "./glob";

--- a/packages/shared/src/triggers/registry.ts
+++ b/packages/shared/src/triggers/registry.ts
@@ -9,14 +9,27 @@ import { webhookSource, webhookConditions } from "./webhook";
 import { githubSource } from "./github";
 import { slackSource, slackConditions } from "./slack";
 
-// GitHub and Linear condition handlers (stubs for Phase 2c).
-// These need to exist so that the ConditionRegistry is complete.
+// GitHub condition handlers and the reserved Linear handlers live here so the
+// ConditionRegistry remains complete across sources.
 import { matchGlob } from "./glob";
 import type { AutomationEvent } from "./types";
 
+export const GITHUB_CONCLUSIONS = [
+  "success",
+  "failure",
+  "neutral",
+  "cancelled",
+  "timed_out",
+] as const;
+
+const githubConclusionSet: ReadonlySet<string> = new Set(GITHUB_CONCLUSIONS);
+
+function validateGitHubConclusion(condition: { value: string }): string | null {
+  return githubConclusionSet.has(condition.value) ? null : `Invalid conclusion: ${condition.value}`;
+}
+
 /**
- * GitHub + Linear condition handlers defined here (cross-source).
- * Will move to source modules when those ship in Phase 2c.
+ * GitHub and Linear condition handlers defined here (cross-source).
  */
 const sharedConditions = {
   branch: {
@@ -84,16 +97,30 @@ const sharedConditions = {
         : c.value.every((v: string) => v.toLowerCase() !== lowerActor);
     },
   },
+  conclusion: {
+    appliesTo: ["github"] as const,
+    validate: validateGitHubConclusion,
+    evaluate(c: { value: string }, event: AutomationEvent) {
+      if (event.source !== "github") return true;
+      return event.conclusion === c.value;
+    },
+  },
   check_conclusion: {
     appliesTo: ["github"] as const,
-    validate(c: { value: string }) {
-      return ["success", "failure", "neutral", "cancelled", "timed_out"].includes(c.value)
-        ? null
-        : `Invalid conclusion: ${c.value}`;
-    },
+    validate: validateGitHubConclusion,
     evaluate(c: { value: string }, event: AutomationEvent) {
       if (event.source !== "github") return true;
       return event.checkConclusion === c.value;
+    },
+  },
+  workflow_name: {
+    appliesTo: ["github"] as const,
+    validate(c: { value: string }) {
+      return c.value.trim().length === 0 ? "Workflow name is required" : null;
+    },
+    evaluate(c: { value: string }, event: AutomationEvent) {
+      if (event.source !== "github") return true;
+      return event.workflowName === c.value;
     },
   },
   linear_status: {
@@ -120,7 +147,6 @@ export const conditionRegistry: ConditionRegistry = {
 
 /**
  * All registered trigger sources. The UI reads this for the trigger type selector.
- * Only Sentry and Webhook are active in Phase 2a/2b.
  */
 export const triggerSources: TriggerSourceDefinition[] = [
   sentrySource,

--- a/packages/shared/src/triggers/registry.ts
+++ b/packages/shared/src/triggers/registry.ts
@@ -6,62 +6,13 @@ import type { ConditionRegistry } from "./conditions";
 import type { TriggerSourceDefinition } from "./types";
 import { sentrySource, sentryConditions } from "./sentry";
 import { webhookSource, webhookConditions } from "./webhook";
-import { githubSource } from "./github";
+import { githubSource, githubConditions } from "./github";
 import { slackSource, slackConditions } from "./slack";
 
-// GitHub condition handlers and the reserved Linear handlers live here so the
-// ConditionRegistry remains complete across sources.
-import { matchGlob } from "./glob";
+// Cross-source and reserved Linear handlers remain here.
 import type { AutomationEvent } from "./types";
-
-export const DEFAULT_GITHUB_CONCLUSION = "success" as const;
-
-export const GITHUB_CONCLUSIONS = [
-  DEFAULT_GITHUB_CONCLUSION,
-  "failure",
-  "neutral",
-  "cancelled",
-  "timed_out",
-  "action_required",
-  "skipped",
-  "stale",
-  "startup_failure",
-] as const;
-
-const githubConclusionSet: ReadonlySet<string> = new Set(GITHUB_CONCLUSIONS);
-
-function validateGitHubConclusion(condition: { value: string }): string | null {
-  return githubConclusionSet.has(condition.value) ? null : `Invalid conclusion: ${condition.value}`;
-}
-
-/**
- * GitHub and Linear condition handlers defined here (cross-source).
- */
+/** Cross-source and reserved Linear condition handlers. */
 const sharedConditions = {
-  branch: {
-    appliesTo: ["github"] as const,
-    validate(c: { value: string[] }) {
-      return c.value.length === 0 ? "At least one branch pattern required" : null;
-    },
-    evaluate(c: { operator: string; value: string[] }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      if (!event.branch) return false;
-      if (c.operator === "exact") return c.value.includes(event.branch);
-      return c.value.some((pattern: string) => matchGlob(pattern, event.branch!));
-    },
-  },
-  target_branch: {
-    appliesTo: ["github"] as const,
-    validate(c: { value: string[] }) {
-      return c.value.length === 0 ? "At least one target branch pattern required" : null;
-    },
-    evaluate(c: { operator: string; value: string[] }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      if (!event.targetBranch) return false;
-      if (c.operator === "exact") return c.value.includes(event.targetBranch);
-      return c.value.some((pattern: string) => matchGlob(pattern, event.targetBranch!));
-    },
-  },
   label: {
     appliesTo: ["github", "linear"] as const,
     validate(c: { value: string[] }) {
@@ -76,19 +27,6 @@ const sharedConditions = {
       return c.operator === "any_of" ? hasOverlap : !hasOverlap;
     },
   },
-  path_glob: {
-    appliesTo: ["github"] as const,
-    validate(c: { value: string[] }) {
-      return c.value.length === 0 ? "At least one path pattern required" : null;
-    },
-    evaluate(c: { value: string[] }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      if (!event.changedFiles?.length) return false;
-      return c.value.some((glob: string) =>
-        event.changedFiles!.some((file: string) => matchGlob(glob, file))
-      );
-    },
-  },
   actor: {
     appliesTo: ["github", "linear"] as const,
     validate(c: { value: string[] }) {
@@ -101,32 +39,6 @@ const sharedConditions = {
       return c.operator === "include"
         ? c.value.some((v: string) => v.toLowerCase() === lowerActor)
         : c.value.every((v: string) => v.toLowerCase() !== lowerActor);
-    },
-  },
-  conclusion: {
-    appliesTo: ["github"] as const,
-    validate: validateGitHubConclusion,
-    evaluate(c: { value: string }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      return event.conclusion === c.value;
-    },
-  },
-  check_conclusion: {
-    appliesTo: ["github"] as const,
-    validate: validateGitHubConclusion,
-    evaluate(c: { value: string }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      return event.checkConclusion === c.value;
-    },
-  },
-  workflow_name: {
-    appliesTo: ["github"] as const,
-    validate(c: { value: string }) {
-      return c.value.trim().length === 0 ? "Workflow name is required" : null;
-    },
-    evaluate(c: { value: string }, event: AutomationEvent) {
-      if (event.source !== "github") return true;
-      return event.workflowName === c.value;
     },
   },
   linear_status: {
@@ -146,6 +58,7 @@ const sharedConditions = {
  */
 export const conditionRegistry: ConditionRegistry = {
   ...sharedConditions,
+  ...githubConditions,
   ...sentryConditions,
   ...webhookConditions,
   ...slackConditions,

--- a/packages/shared/src/triggers/registry.ts
+++ b/packages/shared/src/triggers/registry.ts
@@ -14,12 +14,18 @@ import { slackSource, slackConditions } from "./slack";
 import { matchGlob } from "./glob";
 import type { AutomationEvent } from "./types";
 
+export const DEFAULT_GITHUB_CONCLUSION = "success" as const;
+
 export const GITHUB_CONCLUSIONS = [
-  "success",
+  DEFAULT_GITHUB_CONCLUSION,
   "failure",
   "neutral",
   "cancelled",
   "timed_out",
+  "action_required",
+  "skipped",
+  "stale",
+  "startup_failure",
 ] as const;
 
 const githubConclusionSet: ReadonlySet<string> = new Set(GITHUB_CONCLUSIONS);

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -158,7 +158,6 @@ export const githubAutomationEventSchema = z.object({
   actor: z.string().optional(),
   changedFiles: z.array(z.string()).optional(),
   conclusion: z.string().optional(),
-  checkConclusion: z.string().optional(),
   workflowName: z.string().optional(),
   /** Present only on pull_request events. */
   pullRequest: z

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -64,7 +64,17 @@ const triggerConditionSchema = z.discriminatedUnion("type", [
     value: stringArrayConditionValueSchema,
   }),
   z.object({
+    type: z.literal("conclusion"),
+    operator: z.literal("eq"),
+    value: z.string(),
+  }),
+  z.object({
     type: z.literal("check_conclusion"),
+    operator: z.literal("eq"),
+    value: z.string(),
+  }),
+  z.object({
+    type: z.literal("workflow_name"),
     operator: z.literal("eq"),
     value: z.string(),
   }),
@@ -147,7 +157,9 @@ export const githubAutomationEventSchema = z.object({
   labels: z.array(z.string()).optional(),
   actor: z.string().optional(),
   changedFiles: z.array(z.string()).optional(),
+  conclusion: z.string().optional(),
   checkConclusion: z.string().optional(),
+  workflowName: z.string().optional(),
   /** Present only on pull_request events. */
   pullRequest: z
     .object({

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -290,6 +290,46 @@ describe("automation cron submission", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("drops conditions the newly picked event type cannot answer, and says which", () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={{
+          name: "CI watcher",
+          repositories: singleRepository,
+          model: "openai/gpt-5.4",
+          instructions: "Look at the failing workflow.",
+          triggerType: "github_event",
+          eventType: "workflow_run.completed",
+          triggerConfig: {
+            conditions: [{ type: "workflow_name", operator: "eq", value: "CI" }],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/Exact workflow name/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Event Type" }));
+    fireEvent.click(screen.getByRole("option", { name: /PR Opened/ }));
+
+    expect(screen.queryByPlaceholderText(/Exact workflow name/)).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Removed Workflow Name — not available for this event type."
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      eventType: "pull_request.opened",
+      triggerConfig: { conditions: [] },
+    });
+  });
+
   it("submits triggerConfig with empty conditions for non-schedule automations", () => {
     const onSubmit = vi.fn();
     const { container } = render(

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { isValidCron } from "@open-inspect/shared/cron";
 import {
   triggerSources,
+  isGitHubConditionSupported,
   TRIGGER_TYPE_TO_SOURCE,
   type AutomationTriggerType,
   type AutomationEventSource,
@@ -47,7 +48,7 @@ import {
 } from "@/components/ui/icons";
 import { CronPicker } from "./cron-picker";
 import { TriggerTypeSelector } from "./trigger-type-selector";
-import { ConditionBuilder } from "./condition-builder";
+import { ConditionBuilder, CONDITION_LABELS } from "./condition-builder";
 import { useAutomationTargets } from "./use-automation-targets";
 import { cn } from "@/lib/utils";
 import { NO_REPOSITORY_LABEL, formatRepositoriesLabel } from "@/lib/repo-label";
@@ -164,6 +165,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   const [conditions, setConditions] = useState<TriggerCondition[]>(
     initialValues?.triggerConfig?.conditions ?? []
   );
+  const [droppedConditions, setDroppedConditions] = useState<string[]>([]);
   const [sentryClientSecret, setSentryClientSecret] = useState("");
   const [providerSelections, setProviderSelections] = useState<ModelProviderSelections>(
     initialValues?.providerSelections ?? EMPTY_PROVIDER_SELECTIONS
@@ -852,6 +854,16 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             onValueChange={(value) => {
               setEventType(value);
               if (eventTypeError) setEventTypeError("");
+              // A GitHub event can only be filtered on the fields its payload
+              // carries, so conditions the new event cannot answer come off
+              // rather than being saved as filters that could never match. Say
+              // which — a filter vanishing without a word reads as a bug.
+              if (TRIGGER_TYPE_TO_SOURCE[triggerType] !== "github") return;
+              const kept = conditions.filter((condition) =>
+                isGitHubConditionSupported(value, condition.type)
+              );
+              setDroppedConditions(conditions.filter((c) => !kept.includes(c)).map((c) => c.type));
+              setConditions(kept);
             }}
           >
             <SelectTrigger id="automation-event-type" className="w-full">
@@ -908,11 +920,20 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             conditions={conditions}
             onChange={setConditions}
             triggerSource={TRIGGER_TYPE_TO_SOURCE[triggerType] as AutomationEventSource}
+            eventType={eventType || undefined}
           />
           <FieldDescription>
             Optional filters on incoming events. When you add conditions, every condition must pass
             before a run starts.
           </FieldDescription>
+          {droppedConditions.length > 0 && (
+            <FieldDescription>
+              <span role="status">
+                Removed {droppedConditions.map((t) => CONDITION_LABELS[t] || t).join(", ")} — not
+                available for this event type.
+              </span>
+            </FieldDescription>
+          )}
           {isSlack && !slackConditionsValid && (
             <p className="mt-1 text-xs text-destructive">
               Slack triggers require at least one Slack Channel condition.

--- a/packages/web/src/components/automations/condition-builder.test.tsx
+++ b/packages/web/src/components/automations/condition-builder.test.tsx
@@ -22,9 +22,14 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn();
 });
 
-function renderBuilder(conditions: TriggerCondition[]) {
+function renderBuilder(
+  conditions: TriggerCondition[],
+  triggerSource: "slack" | "github" = "slack"
+) {
   const onChange = vi.fn();
-  render(<ConditionBuilder conditions={conditions} onChange={onChange} triggerSource="slack" />);
+  render(
+    <ConditionBuilder conditions={conditions} onChange={onChange} triggerSource={triggerSource} />
+  );
   return onChange;
 }
 
@@ -92,5 +97,29 @@ describe("ConditionBuilder — slack editors", () => {
     renderBuilder([{ type: "slack_actor", operator: "include", value: [] }]);
     expect(screen.getByText("Slack User")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Add Slack user ID/)).toBeInTheDocument();
+  });
+});
+
+describe("ConditionBuilder — GitHub workflow editors", () => {
+  it("stores the exact workflow name", () => {
+    const onChange = renderBuilder(
+      [{ type: "workflow_name", operator: "eq", value: "" }],
+      "github"
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/Exact workflow name/), {
+      target: { value: "CI" },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { type: "workflow_name", operator: "eq", value: "CI" },
+    ]);
+  });
+
+  it("renders the workflow conclusion condition", () => {
+    renderBuilder([{ type: "conclusion", operator: "eq", value: "failure" }], "github");
+
+    expect(screen.getByText("Conclusion")).toBeInTheDocument();
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("failure");
   });
 });

--- a/packages/web/src/components/automations/condition-builder.test.tsx
+++ b/packages/web/src/components/automations/condition-builder.test.tsx
@@ -4,10 +4,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import type { TriggerCondition } from "@open-inspect/shared/triggers";
+import {
+  GITHUB_CONCLUSIONS,
+  type AutomationEventSource,
+  type TriggerCondition,
+} from "@open-inspect/shared/triggers";
 import { ConditionBuilder } from "./condition-builder";
 
 type ChannelListing = { id: string; name: string; isPrivate: boolean; isMember: boolean };
+const DEFAULT_TRIGGER_SOURCE = "slack" as const satisfies AutomationEventSource;
 // Mutable per-test channel listing; the hoisted use-slack-channels mock closes over it.
 let slackChannelsMock: { channels: ChannelListing[]; loading: boolean; error?: string };
 vi.mock("@/hooks/use-slack-channels", () => ({
@@ -24,7 +29,7 @@ beforeEach(() => {
 
 function renderBuilder(
   conditions: TriggerCondition[],
-  triggerSource: "slack" | "github" = "slack"
+  triggerSource: "slack" | "github" = DEFAULT_TRIGGER_SOURCE
 ) {
   const onChange = vi.fn();
   render(
@@ -116,10 +121,10 @@ describe("ConditionBuilder — GitHub workflow editors", () => {
     ]);
   });
 
-  it("renders the workflow conclusion condition", () => {
-    renderBuilder([{ type: "conclusion", operator: "eq", value: "failure" }], "github");
+  it.each(GITHUB_CONCLUSIONS)("renders the %s conclusion", (conclusion) => {
+    renderBuilder([{ type: "conclusion", operator: "eq", value: conclusion }], "github");
 
     expect(screen.getByText("Conclusion")).toBeInTheDocument();
-    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("failure");
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent(conclusion);
   });
 });

--- a/packages/web/src/components/automations/condition-builder.test.tsx
+++ b/packages/web/src/components/automations/condition-builder.test.tsx
@@ -12,7 +12,6 @@ import {
 import { ConditionBuilder } from "./condition-builder";
 
 type ChannelListing = { id: string; name: string; isPrivate: boolean; isMember: boolean };
-const DEFAULT_TRIGGER_SOURCE = "slack" as const satisfies AutomationEventSource;
 // Mutable per-test channel listing; the hoisted use-slack-channels mock closes over it.
 let slackChannelsMock: { channels: ChannelListing[]; loading: boolean; error?: string };
 vi.mock("@/hooks/use-slack-channels", () => ({
@@ -29,11 +28,17 @@ beforeEach(() => {
 
 function renderBuilder(
   conditions: TriggerCondition[],
-  triggerSource: "slack" | "github" = DEFAULT_TRIGGER_SOURCE
+  triggerSource: AutomationEventSource = "slack",
+  eventType?: string
 ) {
   const onChange = vi.fn();
   render(
-    <ConditionBuilder conditions={conditions} onChange={onChange} triggerSource={triggerSource} />
+    <ConditionBuilder
+      conditions={conditions}
+      onChange={onChange}
+      triggerSource={triggerSource}
+      eventType={eventType}
+    />
   );
   return onChange;
 }
@@ -109,7 +114,8 @@ describe("ConditionBuilder — GitHub workflow editors", () => {
   it("stores the exact workflow name", () => {
     const onChange = renderBuilder(
       [{ type: "workflow_name", operator: "eq", value: "" }],
-      "github"
+      "github",
+      "workflow_run.completed"
     );
 
     fireEvent.change(screen.getByPlaceholderText(/Exact workflow name/), {
@@ -122,9 +128,57 @@ describe("ConditionBuilder — GitHub workflow editors", () => {
   });
 
   it.each(GITHUB_CONCLUSIONS)("renders the %s conclusion", (conclusion) => {
-    renderBuilder([{ type: "conclusion", operator: "eq", value: conclusion }], "github");
+    renderBuilder(
+      [{ type: "conclusion", operator: "eq", value: conclusion }],
+      "github",
+      "workflow_run.completed"
+    );
 
     expect(screen.getByText("Conclusion")).toBeInTheDocument();
     expect(screen.getAllByRole("combobox")[0]).toHaveTextContent(conclusion);
+  });
+
+  it("offers workflow filters only for workflow run events", () => {
+    renderBuilder([], "github", "workflow_run.completed");
+
+    fireEvent.click(screen.getByText("Add condition..."));
+
+    expect(screen.getByText("Workflow Name")).toBeInTheDocument();
+    expect(screen.getByText("Conclusion")).toBeInTheDocument();
+    expect(screen.queryByText("Check Conclusion")).not.toBeInTheDocument();
+  });
+
+  it("does not offer workflow filters for pull request events", () => {
+    renderBuilder([], "github", "pull_request.opened");
+
+    fireEvent.click(screen.getByText("Add condition..."));
+
+    expect(screen.queryByText("Workflow Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Conclusion")).not.toBeInTheDocument();
+    expect(screen.queryByText("Check Conclusion")).not.toBeInTheDocument();
+    expect(screen.queryByText("Path Glob")).not.toBeInTheDocument();
+    expect(screen.getByText("Target branch")).toBeInTheDocument();
+  });
+
+  it("leaves a persisted condition the event type cannot answer for the user to remove", () => {
+    const onChange = renderBuilder(
+      [{ type: "path_glob", operator: "any_match", value: ["src/**"] }],
+      "github",
+      "pull_request.opened"
+    );
+
+    expect(screen.getByText("Path Glob")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps a persisted legacy check conclusion condition editable", () => {
+    const onChange = renderBuilder(
+      [{ type: "check_conclusion", operator: "eq", value: "failure" }],
+      "github",
+      "check_suite.completed"
+    );
+
+    expect(screen.getByText("Check Conclusion")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -6,7 +6,7 @@ import type {
   AutomationEventSource,
   JsonPathFilter,
 } from "@open-inspect/shared/triggers";
-import { conditionRegistry } from "@open-inspect/shared/triggers";
+import { conditionRegistry, GITHUB_CONCLUSIONS } from "@open-inspect/shared/triggers";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
@@ -35,7 +35,9 @@ const CONDITION_LABELS: Record<string, string> = {
   label: "Label",
   path_glob: "Path Glob",
   actor: "Actor",
+  conclusion: "Conclusion",
   check_conclusion: "Check Conclusion",
+  workflow_name: "Workflow Name",
   linear_status: "Linear Status",
   text_match: "Message Text",
   slack_channel: "Slack Channel",
@@ -45,13 +47,6 @@ const CONDITION_LABELS: Record<string, string> = {
 const TEXT_MATCH_MODES = ["contains", "exact", "regex"] as const;
 
 const SENTRY_LEVELS = ["warning", "error", "fatal"];
-const CHECK_CONCLUSION_OPTIONS = [
-  "success",
-  "failure",
-  "neutral",
-  "cancelled",
-  "timed_out",
-] as const;
 
 export function ConditionBuilder({ conditions, onChange, triggerSource }: ConditionBuilderProps) {
   // Get available condition types for this trigger source
@@ -90,12 +85,22 @@ export function ConditionBuilder({ conditions, onChange, triggerSource }: Condit
       case "actor":
         newCondition = { type: "actor", operator: "include", value: [] };
         break;
+      case "conclusion":
+        newCondition = {
+          type: "conclusion",
+          operator: "eq",
+          value: GITHUB_CONCLUSIONS[0],
+        };
+        break;
       case "check_conclusion":
         newCondition = {
           type: "check_conclusion",
           operator: "eq",
-          value: CHECK_CONCLUSION_OPTIONS[0],
+          value: GITHUB_CONCLUSIONS[0],
         };
+        break;
+      case "workflow_name":
+        newCondition = { type: "workflow_name", operator: "eq", value: "" };
         break;
       case "text_match":
         newCondition = { type: "text_match", operator: "contains", value: { pattern: "" } };
@@ -248,6 +253,7 @@ function ConditionEditor({
           />
         </div>
       );
+    case "conclusion":
     case "check_conclusion":
       return (
         <Select value={condition.value} onValueChange={(v) => onChange({ ...condition, value: v })}>
@@ -255,13 +261,23 @@ function ConditionEditor({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {CHECK_CONCLUSION_OPTIONS.map((option) => (
+            {GITHUB_CONCLUSIONS.map((option) => (
               <SelectItem key={option} value={option}>
                 {option}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
+      );
+    case "workflow_name":
+      return (
+        <Input
+          type="text"
+          value={condition.value}
+          onChange={(event) => onChange({ ...condition, value: event.target.value })}
+          placeholder="Exact workflow name, e.g. CI"
+          className="text-xs"
+        />
       );
     case "text_match": {
       const flags = condition.value.flags ?? "";

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -6,7 +6,11 @@ import type {
   AutomationEventSource,
   JsonPathFilter,
 } from "@open-inspect/shared/triggers";
-import { conditionRegistry, GITHUB_CONCLUSIONS } from "@open-inspect/shared/triggers";
+import {
+  conditionRegistry,
+  DEFAULT_GITHUB_CONCLUSION,
+  GITHUB_CONCLUSIONS,
+} from "@open-inspect/shared/triggers";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
@@ -89,14 +93,14 @@ export function ConditionBuilder({ conditions, onChange, triggerSource }: Condit
         newCondition = {
           type: "conclusion",
           operator: "eq",
-          value: GITHUB_CONCLUSIONS[0],
+          value: DEFAULT_GITHUB_CONCLUSION,
         };
         break;
       case "check_conclusion":
         newCondition = {
           type: "check_conclusion",
           operator: "eq",
-          value: GITHUB_CONCLUSIONS[0],
+          value: DEFAULT_GITHUB_CONCLUSION,
         };
         break;
       case "workflow_name":

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -10,6 +10,7 @@ import {
   conditionRegistry,
   DEFAULT_GITHUB_CONCLUSION,
   GITHUB_CONCLUSIONS,
+  getGitHubEventConditionTypes,
 } from "@open-inspect/shared/triggers";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -28,9 +29,10 @@ interface ConditionBuilderProps {
   conditions: TriggerCondition[];
   onChange: (conditions: TriggerCondition[]) => void;
   triggerSource: AutomationEventSource;
+  eventType?: string;
 }
 
-const CONDITION_LABELS: Record<string, string> = {
+export const CONDITION_LABELS: Record<string, string> = {
   sentry_project: "Sentry Project",
   sentry_level: "Error Level",
   jsonpath: "JSONPath Filter",
@@ -52,11 +54,20 @@ const TEXT_MATCH_MODES = ["contains", "exact", "regex"] as const;
 
 const SENTRY_LEVELS = ["warning", "error", "fatal"];
 
-export function ConditionBuilder({ conditions, onChange, triggerSource }: ConditionBuilderProps) {
-  // Get available condition types for this trigger source
-  const availableTypes = Object.entries(conditionRegistry)
-    .filter(([_, handler]) => handler.appliesTo.includes(triggerSource))
-    .map(([type]) => type);
+export function ConditionBuilder({
+  conditions,
+  onChange,
+  triggerSource,
+  eventType,
+}: ConditionBuilderProps) {
+  const availableTypes =
+    triggerSource === "github"
+      ? eventType
+        ? [...getGitHubEventConditionTypes(eventType)]
+        : []
+      : Object.entries(conditionRegistry)
+          .filter(([_, handler]) => handler.appliesTo.includes(triggerSource))
+          .map(([type]) => type);
 
   const addCondition = (type: string) => {
     let newCondition: TriggerCondition;
@@ -83,22 +94,12 @@ export function ConditionBuilder({ conditions, onChange, triggerSource }: Condit
       case "label":
         newCondition = { type: "label", operator: "any_of", value: [] };
         break;
-      case "path_glob":
-        newCondition = { type: "path_glob", operator: "any_match", value: [] };
-        break;
       case "actor":
         newCondition = { type: "actor", operator: "include", value: [] };
         break;
       case "conclusion":
         newCondition = {
           type: "conclusion",
-          operator: "eq",
-          value: DEFAULT_GITHUB_CONCLUSION,
-        };
-        break;
-      case "check_conclusion":
-        newCondition = {
-          type: "check_conclusion",
           operator: "eq",
           value: DEFAULT_GITHUB_CONCLUSION,
         };

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -111,13 +111,17 @@ describe("automation templates catalog", () => {
 
     if (t.prefill.triggerConfig?.conditions?.length) {
       const conditions = t.prefill.triggerConfig.conditions;
+      it("does not create new configs with legacy condition names", () => {
+        expect(conditions.every((condition) => condition.type !== "check_conclusion")).toBe(true);
+      });
       it("has trigger conditions valid for its source", () => {
         const source = TRIGGER_TYPE_TO_SOURCE[triggerType as AutomationTriggerType];
         expect(source).toBeDefined();
         const errors = validateConditions(
           conditions,
           source as NonNullable<typeof source>,
-          conditionRegistry
+          conditionRegistry,
+          t.prefill.eventType
         );
         expect(errors).toEqual([]);
       });

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -217,7 +217,7 @@ export const automationTemplates: AutomationTemplate[] = [
       eventType: "check_suite.completed",
       // Only fire on failed suites — avoids spawning a run on every green build.
       triggerConfig: {
-        conditions: [{ type: "check_conclusion", operator: "eq", value: "failure" }],
+        conditions: [{ type: "conclusion", operator: "eq", value: "failure" }],
       },
       instructions:
         "A CI check suite failed on this repository; the failing branch and commit are shown above.\n\n" +


### PR DESCRIPTION
Adds support for `workflow_run.completed` GitHub Event automations, including workflow-name and
conclusion filters, rerun-aware deduplication, UI controls, tests, and setup documentation.

## Review feedback addressed

**Conditions are now scoped per event type.** Previously every GitHub condition was offered for
every GitHub event, so `workflow_name = CI` could be saved on `pull_request.opened` and never
match. `GITHUB_WEBHOOK_EVENT_CATALOG` is now the canonical map from event type to supported
conditions; `eventType` is threaded through both the form and server-side `validateConditions`, and
switching event type drops conditions the new one cannot answer rather than leaving them behind.

**Workflow-run concurrency keys on the run, not the workflow name.** `concurrencyKey` is
`workflow_run:${run.id}`; `run_attempt` stays in the trigger key. Two runs of the same workflow no
longer collide, while reruns of one run still share a concurrency scope.

**One canonical `conclusion` field.** Check suites and workflow runs both populate `conclusion`;
the separate `checkConclusion` normalized field is gone. The GitHub condition handlers and
conclusion constants moved out of the cross-source registry into `triggers/github/conditions.ts`.

## Worth flagging

**Path-pattern filtering is no longer offered for GitHub events.** No GitHub webhook payload
carries a file list, so `changedFiles` was never populated and a `path_glob` condition could only
ever prevent an automation from firing. Making the catalog canonical surfaced this, so the handler
now declares an empty `appliesTo`. Its schema variant is kept so persisted configs still parse.
This was not part of the review feedback — flagging it because it removes a filter the UI
previously offered.

**`check_conclusion` is retained as a legacy alias.** It reads the canonical `conclusion` field for
persisted-config compatibility and is no longer offered for new automations. Collapsing it away
entirely would need either a D1 migration or canonicalization at the parse boundary — happy to do
that here if you would prefer it in this PR rather than a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub workflow-run completion automations.
  * Added workflow name and run conclusion filters, including success, failure, cancelled, and timed-out outcomes.
  * Added workflow-run details to automation event context.
  * Added event-specific GitHub condition filtering and configuration guidance for required permissions and webhook events.

* **Bug Fixes**
  * Improved validation for GitHub event conditions and conclusions.
  * Prevented duplicate processing when workflow runs are rerun.
  * Automatically removes incompatible conditions when changing event types.

* **Documentation**
  * Updated automation and setup documentation for GitHub event triggers and workflow-run automations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
