### PR TITLE
test(slack-bot): make the Starting-status assertions deterministic

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { Env } from "./types";
 import type * as SlackModule from "@open-inspect/shared/slack";
 
@@ -176,6 +176,30 @@ function createDeferred<T>() {
 
 async function flushWaitUntil(ctx: ReturnType<typeof makeCtx>, callIndex = 0): Promise<void> {
   await ctx.waitUntil.mock.calls[callIndex]?.[0];
+}
+
+/**
+ * Whether a promise has settled, decided by draining the microtask queue rather
+ * than by waiting on the clock.
+ *
+ * Racing against a `setTimeout` would make the answer depend on how loaded the
+ * machine is: a background chain that beats the timer on a dev laptop can lose
+ * on a CI runner, which is how these assertions became flaky. A promise blocked
+ * on an unresolved deferred can never settle no matter how many microtask turns
+ * elapse, so draining them answers the question deterministically.
+ */
+async function hasSettled(promise: Promise<unknown>): Promise<boolean> {
+  let settled = false;
+  void promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+  for (let i = 0; i < 50; i++) await Promise.resolve();
+  return settled;
 }
 
 function makeSessionEnv(
@@ -409,6 +433,14 @@ describe("POST /events", () => {
     clearLocalCache();
     mockVerifySlackSignature.mockResolvedValue(true);
     mockGetUserInfo.mockResolvedValue({ ok: false, error: "user_not_found" });
+  });
+
+  // Restore the global fetch spy even when a test throws before its own cleanup
+  // line. Without this, a failure part-way through a test left the spy installed
+  // and its in-flight Slack calls landing inside the next test, so one timing
+  // flake surfaced as an unrelated failure in a different describe block.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("publishes App Home when the home tab is opened", async () => {
@@ -1600,7 +1632,7 @@ describe("POST /events", () => {
   it("does not wait for Starting status before creating a session", async () => {
     const statusDeferred = createDeferred<Response>();
     const order: string[] = [];
-    const slackFetch = mockSlackFetch(order, { statusResponse: statusDeferred.promise });
+    mockSlackFetch(order, { statusResponse: statusDeferred.promise });
     const env = makeSessionEnv(order);
     const ctx = makeCtx();
 
@@ -1618,23 +1650,22 @@ describe("POST /events", () => {
     );
 
     expect(response.status).toBe(200);
-    const backgroundPromise = ctx.waitUntil.mock.calls[0]?.[0] as Promise<void>;
-    const backgroundOutcome = await Promise.race([
-      backgroundPromise.then(() => "complete"),
-      new Promise<string>((resolve) => setTimeout(() => resolve("blocked"), 25)),
-    ]);
 
-    expect(backgroundOutcome).toBe("complete");
+    // The status call is still blocked on an unresolved deferred. If session
+    // creation waited on it, this await could never return — so awaiting it
+    // directly proves the property, with vitest's own timeout as the failure
+    // mode rather than a hand-rolled stopwatch.
+    const backgroundPromise = ctx.waitUntil.mock.calls[0]?.[0] as Promise<void>;
+    await backgroundPromise;
+
     expect(order).toContain("session");
     expect(order).toContain("prompt");
     expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
 
+    // ...and the status work genuinely has not finished, so the completion above
+    // was not simply the status call racing ahead.
     const statusPromise = ctx.waitUntil.mock.calls[1]?.[0] as Promise<void>;
-    const statusOutcome = await Promise.race([
-      statusPromise.then(() => "complete"),
-      new Promise<string>((resolve) => setTimeout(() => resolve("pending"), 25)),
-    ]);
-    expect(statusOutcome).toBe("pending");
+    expect(await hasSettled(statusPromise)).toBe(false);
 
     statusDeferred.resolve(
       new Response(JSON.stringify({ ok: false, error: "missing_scope" }), {
@@ -1642,9 +1673,7 @@ describe("POST /events", () => {
         headers: { "Content-Type": "application/json" },
       })
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    slackFetch.mockRestore();
+    await statusPromise;
   });
 });
 


### PR DESCRIPTION
## Summary

Two tests in `packages/slack-bot/src/index.test.ts` race a background promise against a 25 ms `setTimeout` and assert the background work wins. That budget holds on a developer machine and loses on a loaded CI runner, producing `expected 'blocked' to be 'complete'` — the timer winning rather than anything being wrong with the code.

We hit this on a fork, where it failed three merge-gating pipelines in one day while passing 423/423 locally on every run. The same code is here, so it will surface for you too — the tests date from #646, and the work later added to that background path (parent→child follow-ups, unread indicators) is what pushed it past the budget.

## A second bug, independent of the flake

The failing test's cleanup — resolving its deferred and restoring the global `fetch` spy — sits on the **last lines of the test body**:

```js
statusDeferred.resolve(...);
await new Promise((resolve) => setTimeout(resolve, 0));
slackFetch.mockRestore();
```

When the race assertion throws, none of that runs. The spy stays installed with a Slack status call in flight, and that call lands inside the *next* test. On our fork the symptom was `sets Starting status for repo-selection starts before session creation` failing with a `channel_id: 'D123'` body in its array — the DM channel from the previous test, not the `C123` it sends. One timing flake, two reported failures in different `describe` blocks.

This pattern is not limited to the two tests here: there are ten-plus tests in this file ending in `slackFetch.mockRestore()`, and no `afterEach` anywhere in it. Any of them can poison its neighbours by failing early.

## The change

- The property under test — "session creation does not wait for the Slack status call" — needs no clock. With the status deferred left unresolved, awaiting the background promise proves it: a chain that *did* wait could never settle, and vitest's own timeout reports that.
- `hasSettled()` answers "has this settled yet" by draining the microtask queue instead of sleeping. A promise blocked on an unresolved deferred cannot settle however many turns elapse, so the answer no longer depends on machine load.
- Teardown moves to an `afterEach`, so a test that throws part-way can no longer leave a global spy installed for its neighbours.

I left the ten-plus trailing `mockRestore()` calls in place — they are now redundant but harmless, and removing them felt like a separate cleanup for you to decide on.

## Test plan

- [x] `npm test -w @open-inspect/slack-bot` on this branch: 417 passed, 4 failed
- [x] Same command on clean `main`: 417 passed, **the identical 4 failed** — those failures are pre-existing (attachment/file tests in `attachments.test.ts` and `index.test.ts`) and unrelated to this change, which is neutral on them
- [x] The two target tests pass: `-t "Starting status"` → 7 passed

## One caveat

I could not reproduce the flake locally even with all cores saturated — the CI slowness involved is cgroup throttling and I/O rather than raw contention. So the case rests on the CI error message, which is definitionally the timer winning, plus the fact that the fix removes the clock the assertion depended on. The cross-test-pollution half is demonstrable independently of any flake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Slack bot event test reliability and consistency.
  * Added deterministic handling for asynchronous operations.
  * Ensured test mocks are restored between event tests.
  * Strengthened coverage for concurrent starting-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->