### PR TITLE
fix: pin OpenCode past the message-ID wraparound

### DIFF
--- a/packages/control-plane/src/image-builds/rebuild-policy.test.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
+import type { ImageBuildProvider } from "./model";
 import { evaluateImageBuildRebuildPolicy } from "./rebuild-policy";
 import { COMPATIBLE_RUNTIME_VERSION } from "./test-helpers";
 
@@ -55,6 +56,30 @@ describe("evaluateImageBuildRebuildPolicy", () => {
     expect(
       evaluateImageBuildRebuildPolicy(unit, [row({ provider: "vercel" })], "modal")
     ).toMatchObject({ type: "rebuild", reason: "missing_image" });
+  });
+
+  it("rebuilds each provider's pre-wraparound image and keeps the shared new generation", () => {
+    const superseded: Array<[ImageBuildProvider, string]> = [
+      ["modal", "v58-image-build-stdin-launch-vnc"],
+      ["opencomputer", "v57-vnc-opencode-1-18-11"],
+      ["vercel", "v57-vnc-opencode-1-18-11"],
+    ];
+    for (const [provider, runtime_version] of superseded) {
+      expect(
+        evaluateImageBuildRebuildPolicy(unit, [row({ provider, runtime_version })], provider)
+      ).toMatchObject({ type: "rebuild", reason: "runtime_incompatible" });
+    }
+
+    const current: Array<[ImageBuildProvider, string]> = [
+      ["modal", "v59-opencode-1-18-18"],
+      ["opencomputer", "v59-vnc-opencode-1-18-18"],
+      ["vercel", "v59-vnc-opencode-1-18-18"],
+    ];
+    for (const [provider, runtime_version] of current) {
+      expect(
+        evaluateImageBuildRebuildPolicy(unit, [row({ provider, runtime_version })], provider).type
+      ).toBe("check_branches");
+    }
   });
 
   it("defers a compatible image to branch-head comparison", () => {

--- a/packages/control-plane/src/image-builds/rebuild-policy.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.ts
@@ -3,9 +3,12 @@ import { parseRuntimeVersionNumber, type ImageBuildProvider } from "./model";
 import { parseRepositoryShasJson, repositoryIdentityKey } from "./provenance";
 import type { EnabledScopeUnit } from "./scope";
 
-// v57 adds the VNC/noVNC toolchain. v56 remains safe to boot while the
-// scheduler converges prebuilt images in the background.
-const MIN_REBUILD_RUNTIME_VERSION = 57;
+// Runtime generations are one sequence shared by every image-build provider.
+// v59 carries OpenCode past its message-ID wraparound (see
+// packages/modal-infra/src/images/base.py); v57 added the VNC/noVNC toolchain.
+// MIN_COMPATIBLE_RUNTIME_VERSION remains safe to boot while the scheduler
+// converges prebuilt images in the background.
+export const MIN_REBUILD_RUNTIME_VERSION = 59;
 
 export type ImageBuildRebuildDecision =
   | { type: "skip"; reason: "building" }

--- a/packages/control-plane/src/image-builds/test-helpers.ts
+++ b/packages/control-plane/src/image-builds/test-helpers.ts
@@ -1,3 +1,5 @@
-import { MIN_COMPATIBLE_RUNTIME_VERSION } from "./model";
+import { MIN_REBUILD_RUNTIME_VERSION } from "./rebuild-policy";
 
-export const COMPATIBLE_RUNTIME_VERSION = `v${MIN_COMPATIBLE_RUNTIME_VERSION + 1}-test-runtime`;
+// A runtime the scheduler treats as current: at the rebuild floor, which is
+// itself at or above the boot-compatibility floor.
+export const COMPATIBLE_RUNTIME_VERSION = `v${MIN_REBUILD_RUNTIME_VERSION}-test-runtime`;

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -45,7 +45,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v57-vnc-opencode-1-18-11");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v58-vnc-opencode-1-18-18");
   });
 
   it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
@@ -55,7 +55,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     await client.runRuntimeForeground("sb-1", 60);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v57-vnc-opencode-1-18-11");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v58-vnc-opencode-1-18-18");
   });
 });
 

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -45,7 +45,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v58-vnc-opencode-1-18-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v59-vnc-opencode-1-18-18");
   });
 
   it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
@@ -55,7 +55,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     await client.runRuntimeForeground("sb-1", 60);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v58-vnc-opencode-1-18-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v59-vnc-opencode-1-18-18");
   });
 });
 

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -227,7 +227,7 @@ const RUNTIME_HOSTS_BOOTSTRAP =
 // runtime reports an empty version and the build-complete callback is rejected
 // (runtime-version floor check). Keep in sync with the value baked in
 // packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
-const OPENCOMPUTER_SANDBOX_VERSION = "v57-vnc-opencode-1-18-11";
+const OPENCOMPUTER_SANDBOX_VERSION = "v58-vnc-opencode-1-18-18";
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -227,7 +227,7 @@ const RUNTIME_HOSTS_BOOTSTRAP =
 // runtime reports an empty version and the build-complete callback is rejected
 // (runtime-version floor check). Keep in sync with the value baked in
 // packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
-const OPENCOMPUTER_SANDBOX_VERSION = "v58-vnc-opencode-1-18-18";
+const OPENCOMPUTER_SANDBOX_VERSION = "v59-vnc-opencode-1-18-18";
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -6,7 +6,7 @@
 
 export const VERCEL_PYTHON_BIN = "/usr/bin/python3.12";
 export const DEFAULT_VERCEL_RUNTIME = "node24";
-export const VERCEL_SANDBOX_VERSION = "v57-vnc-opencode-1-18-11";
+export const VERCEL_SANDBOX_VERSION = "v58-vnc-opencode-1-18-18";
 export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 
@@ -16,7 +16,7 @@ export function buildVercelBootstrapScript(params: { runtimeExtractDir?: string 
   return `
 set -euo pipefail
 
-OPENCODE_VERSION="1.18.11"
+OPENCODE_VERSION="1.18.18"
 CODE_SERVER_VERSION="4.109.5"
 AGENT_BROWSER_VERSION="0.21.2"
 TTYD_VERSION="1.7.7"

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -6,7 +6,7 @@
 
 export const VERCEL_PYTHON_BIN = "/usr/bin/python3.12";
 export const DEFAULT_VERCEL_RUNTIME = "node24";
-export const VERCEL_SANDBOX_VERSION = "v58-vnc-opencode-1-18-18";
+export const VERCEL_SANDBOX_VERSION = "v59-vnc-opencode-1-18-18";
 export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 

--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -10,11 +10,14 @@ from daytona import CreateSnapshotParams, Daytona, Image
 #
 # OpenCode restored `/event` stream context in 1.14.50 and fixed the remaining
 # eager-subscription race in 1.15.5. Keep the CLI and plugin on the same pin.
-OPENCODE_VERSION = "1.18.11"
+#
+# Never pin below 1.18.15 — see packages/modal-infra/src/images/base.py for why
+# (OpenCode's message-ID counter wraps and earlier releases order by ID string).
+OPENCODE_VERSION = "1.18.18"
 CODE_SERVER_VERSION = "4.109.5"
 AGENT_BROWSER_VERSION = "0.21.2"
 # Bump when changing image contents to invalidate the Daytona snapshot.
-SANDBOX_VERSION = "daytona-v5-vnc-opencode-1-18-11"
+SANDBOX_VERSION = "daytona-v6-vnc-opencode-1-18-18"
 
 
 def build_base_image(repo_root: Path) -> Image:

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -24,7 +24,14 @@ SANDBOX_RUNTIME_DIR = Path(sandbox_runtime.__file__).parent
 #
 # OpenCode restored `/event` stream context in 1.14.50 and fixed the remaining
 # eager-subscription race in 1.15.5. Keep the CLI and plugin on the same pin.
-OPENCODE_VERSION = "1.18.11"
+#
+# Never pin below 1.18.15: OpenCode's message-ID counter is a 48-bit truncation
+# of `Date.now() * 0x1000`, so it wraps roughly every 795 days (most recently
+# 2026-08-14) and IDs minted afterwards sort below every older one. Earlier
+# releases order the turn loop by comparing those IDs as strings, which makes
+# any session carrying pre-wraparound history exit the loop without calling the
+# model. 1.18.15 orders by message creation time instead.
+OPENCODE_VERSION = "1.18.18"
 
 # code-server version to install (pinned for reproducible images)
 CODE_SERVER_VERSION = "4.109.5"
@@ -37,8 +44,8 @@ TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
-# v58: run gated image builds with the VNC/noVNC desktop toolchain
-CACHE_BUSTER = "v58-image-build-stdin-launch-vnc"
+# v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
+CACHE_BUSTER = "v59-opencode-message-id-wraparound"
 
 # Base image with all development tools
 base_image = (

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -43,9 +43,12 @@ AGENT_BROWSER_VERSION = "0.21.2"
 TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
-# Cache buster - change this to force Modal image rebuild
+# Cache buster - change this to force Modal image rebuild.
+# The numeric generation is one sequence shared by every image-build provider,
+# and MIN_REBUILD_RUNTIME_VERSION gates which prebuilt images get rebuilt onto
+# it, so bump every provider's label together.
 # v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
-CACHE_BUSTER = "v59-opencode-message-id-wraparound"
+CACHE_BUSTER = "v59-opencode-1-18-18"
 
 # Base image with all development tools
 base_image = (

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -247,7 +247,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "v58-vnc-opencode-1-18-18",
+      SANDBOX_VERSION: "v59-vnc-opencode-1-18-18",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -3,7 +3,9 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { Image, Snapshots } from "@opencomputer/sdk/node";
 
-const OPENCODE_VERSION = "1.18.11";
+// Never pin below 1.18.15 — see packages/modal-infra/src/images/base.py for why
+// (OpenCode's message-ID counter wraps and earlier releases order by ID string).
+const OPENCODE_VERSION = "1.18.18";
 const CODE_SERVER_VERSION = "4.109.5";
 const PYTHON_VERSION = "3.12";
 const AGENT_BROWSER_VERSION = "0.21.2";
@@ -245,7 +247,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "v57-vnc-opencode-1-18-11",
+      SANDBOX_VERSION: "v58-vnc-opencode-1-18-18",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);


### PR DESCRIPTION
Refs #1429

## Problem

Prompting any session whose history predates **2026-08-14 11:19:55 UTC** fails immediately with
"Execution failed: OpenCode completed without emitting assistant output." OpenCode's turn loop exits
at step 0, before it ever calls the model:

```
loop          session.id=ses_… step=0    18:02:57.339
exiting loop  session.id=ses_…           18:02:57.363
```

Newly created sessions are unaffected. Nothing in this repo changed — the failure boundary is a
wall-clock instant, not a deploy.

## Root cause

OpenCode message IDs are `msg_<12 hex><14 base62>`, where the hex is `Date.now() * 0x1000 + counter`
truncated to **48 bits**. That counter overflows every 2^36 ms (795 days) — most recently at
2026-08-14 11:19:55 UTC. IDs flipped from `msg_ffff04f3…` to `msg_00170d4b…`, so every new ID now
sorts *below* everything created in the previous 795 days.

OpenCode ≤ 1.18.14 orders messages by comparing those IDs as strings: `MessageV2.latest()` picks the
newest user/assistant by max ID, and the loop exits on `lastUser.id < lastAssistant.id`. In a session
with pre-wraparound history the new prompt is never recognised as the latest user message, so the
loop evaluates the *old* (already finished) pair, the exit condition is trivially true, and it breaks
without calling the model.

Fixed upstream in **v1.18.15** (`fix(opencode): order legacy message loop by time`, `db581e47a`):
the exit condition became `lastAssistant.parentID === lastUser.id`, and `latest()` now orders by
`time.created`.

## Change

Bumps the OpenCode pin `1.18.11` → `1.18.18` across all four provider images, plus the
`SANDBOX_VERSION` labels that encode it and Modal's `CACHE_BUSTER` so the base image rebuilds.

1.18.15 is the floor; 1.18.18 is npm `latest` and adds only prompt-routing, compaction-wording and
retry-jitter fixes on top of it.

## Verification

- Checked the upstream source tag by tag: 1.18.11–1.18.14 compare ID strings, 1.18.15+ compare
  `parentID` / `time.created`.
- Reproduced the arithmetic — encoded prefix is `ffff04f38001` seven hours before the wraparound and
  `00170d4b8001` after it, so `lastUser.id < lastAssistant.id` is `True` exactly as observed.
- `prettier --check`, `eslint`, `ruff check` clean on the changed files.
- `vitest run opencomputer-rest-client` — 21 passed.

`npm run typecheck -w @open-inspect/control-plane` reports 3 pre-existing `@open-inspect/shared`
resolution errors in files this PR doesn't touch; identical on a clean tree (stale worktree
`node_modules`, not a real failure).

## Not covered here

`restore_from_snapshot()` boots `modal.Image.from_id(snapshot_image_id)` with no runtime-version
gate, and `updateSandboxSnapshotImageId()` never clears the id — so **sessions resuming from a
snapshot taken before this lands keep the old binary and stay broken.** Unbreaking those needs a
compatibility floor for session snapshots (like `MIN_COMPATIBLE_RUNTIME_VERSION` for prebuilt repo
images), which trades away uncommitted sandbox state and is tracked separately in #1429.

Next wraparound: **2028-10-17 20:04:31 UTC**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sandbox environments to OpenCode 1.18.18.
  * Improved message ordering reliability by requiring the minimum supported OpenCode version.
  * Updated runtime and image versions across supported sandbox providers.
  * Ensured older runtime images are rebuilt when needed while maintaining compatibility with current runtime generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->