### PR TITLE
fix: order compaction attribution by creation time

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
-from .opencode_identifier import OpenCodeIdentifier
-
 
 class AssistantMessageDisposition(Enum):
     REJECT = "reject"
@@ -19,6 +17,9 @@ class MessageAttribution:
     """Own message eligibility state for one prompt and its compaction chain."""
 
     prompt_user_message_id: str
+    # OpenCode stamps every message with `time.created` on the same clock, so
+    # this is the boundary the compaction fallback orders against.
+    prompt_started_epoch_ms: int
     _user_message_ids: set[str] = field(default_factory=set, init=False)
     _allowed_assistant_message_ids: set[str] = field(default_factory=set, init=False)
     _correlated_summary_ids: set[str] = field(default_factory=set, init=False)
@@ -53,7 +54,12 @@ class MessageAttribution:
         self._compaction_occurred = True
 
     def assistant_disposition(
-        self, message_id: str, parent_id: str, *, is_summary: bool
+        self,
+        message_id: str,
+        parent_id: str,
+        *,
+        is_summary: bool,
+        created_epoch_ms: int | None,
     ) -> AssistantMessageDisposition:
         parent_matches = self.parent_matches(parent_id)
         if is_summary:
@@ -67,14 +73,22 @@ class MessageAttribution:
         if (
             parent_matches
             or self.is_assistant_allowed(message_id)
-            or self._compaction_fallback_accepts(message_id)
+            or self._compaction_fallback_accepts(created_epoch_ms)
         ):
             self.allow_assistant(message_id)
             return AssistantMessageDisposition.OUTPUT
         return AssistantMessageDisposition.REJECT
 
-    def _compaction_fallback_accepts(self, message_id: str) -> bool:
-        """Claim only post-prompt messages after compaction rewrites the chain."""
-        return self._compaction_occurred and OpenCodeIdentifier.is_after(
-            message_id, self.prompt_user_message_id
-        )
+    def _compaction_fallback_accepts(self, created_epoch_ms: int | None) -> bool:
+        """Claim only post-prompt messages after compaction rewrites the chain.
+
+        Ordered by creation time rather than by message ID. OpenCode IDs encode
+        a 48-bit truncation of their creation time, so they stop sorting
+        monotonically every ~795 days; across such a rollover an earlier turn's
+        messages compare greater than this prompt's and would be replayed as
+        this turn's output. A message with no timestamp is rejected rather than
+        risk that replay.
+        """
+        if not self._compaction_occurred or created_epoch_ms is None:
+            return False
+        return created_epoch_ms >= self.prompt_started_epoch_ms

--- a/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/message_attribution.py
@@ -88,7 +88,14 @@ class MessageAttribution:
         messages compare greater than this prompt's and would be replayed as
         this turn's output. A message with no timestamp is rejected rather than
         risk that replay.
+
+        The comparison is strict because the boundary is truncated to whole
+        milliseconds: a prior turn's message created earlier within the
+        boundary millisecond would otherwise be claimed. Nothing this prompt
+        produces can share that millisecond — the boundary is taken before the
+        prompt is posted, and this fallback only runs after a compaction and a
+        model round trip.
         """
         if not self._compaction_occurred or created_epoch_ms is None:
             return False
-        return created_epoch_ms >= self.prompt_started_epoch_ms
+        return created_epoch_ms > self.prompt_started_epoch_ms

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
@@ -19,9 +19,10 @@ class OpenCodeIdentifier:
     - timestamp_hex: 12 hex chars encoding (timestamp_ms * 0x1000 + counter)
     - random_base62: 14 random base62 characters
 
-    IDs are monotonically increasing, ensuring new user messages always have
-    IDs greater than previous assistant messages (required for OpenCode's
-    prompt loop).
+    IDs increase monotonically only within a rollover window: the encoded value
+    is truncated to 48 bits, so it wraps roughly every 795 days and IDs minted
+    after a rollover sort BELOW every ID from the window before it. Never order
+    messages by comparing these IDs — order by their `time.created` instead.
 
     Note: Uses class-level state for monotonic generation. Safe for async code
     but NOT thread-safe.
@@ -59,11 +60,6 @@ class OpenCodeIdentifier:
         random_suffix = cls._random_base62(cls.RANDOM_LENGTH)
 
         return f"{prefix_str}_{timestamp_hex}{random_suffix}"
-
-    @staticmethod
-    def is_after(candidate: str, boundary: str) -> bool:
-        """Return whether an ascending ID was created after another ID."""
-        return candidate > boundary
 
     @classmethod
     def _random_base62(cls, length: int) -> str:

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -95,7 +95,12 @@ class _PromptState:
     pending_overflow_error: str | None = None
 
     def __post_init__(self) -> None:
-        self.attribution = MessageAttribution(self.opencode_message_id)
+        self.attribution = MessageAttribution(
+            self.opencode_message_id,
+            # start_time is captured before the prompt is posted, so nothing
+            # OpenCode creates for this prompt can predate it.
+            int(self.start_time * 1000),
+        )
 
 
 class _Disposition(Enum):
@@ -118,6 +123,17 @@ class _StreamStep:
 
     events: list[dict[str, Any]]
     disposition: _Disposition
+
+
+def _message_created_epoch_ms(info: dict[str, Any]) -> int | None:
+    """Read `time.created` off an OpenCode message, or None when it is absent."""
+    time_info = info.get("time")
+    if not isinstance(time_info, dict):
+        return None
+    created = time_info.get("created")
+    if isinstance(created, bool) or not isinstance(created, (int, float)):
+        return None
+    return int(created)
 
 
 class OpenCodePromptStream:
@@ -398,7 +414,10 @@ class OpenCodePromptStream:
             events: list[dict[str, Any]] = []
             if role == "assistant" and oc_msg_id:
                 disposition = state.attribution.assistant_disposition(
-                    oc_msg_id, parent_id, is_summary=is_compaction_summary
+                    oc_msg_id,
+                    parent_id,
+                    is_summary=is_compaction_summary,
+                    created_epoch_ms=_message_created_epoch_ms(info),
                 )
                 if disposition is not AssistantMessageDisposition.REJECT and info.get("error"):
                     error_event = self._parent_error_event_once(state, info["error"])
@@ -942,7 +961,10 @@ class OpenCodePromptStream:
 
                 is_compaction_summary = info.get("summary") is True
                 disposition = state.attribution.assistant_disposition(
-                    msg_id, parent_id, is_summary=is_compaction_summary
+                    msg_id,
+                    parent_id,
+                    is_summary=is_compaction_summary,
+                    created_epoch_ms=_message_created_epoch_ms(info),
                 )
                 if disposition is not AssistantMessageDisposition.OUTPUT:
                     continue

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import re
 import time
 from contextlib import AsyncExitStack
@@ -126,12 +127,19 @@ class _StreamStep:
 
 
 def _message_created_epoch_ms(info: dict[str, Any]) -> int | None:
-    """Read `time.created` off an OpenCode message, or None when it is absent."""
+    """Read `time.created` off an OpenCode message, or None when it is absent.
+
+    Non-finite values are treated as absent rather than converted: `int()`
+    raises on NaN and infinity, which would tear down the SSE loop over a
+    malformed payload.
+    """
     time_info = info.get("time")
     if not isinstance(time_info, dict):
         return None
     created = time_info.get("created")
     if isinstance(created, bool) or not isinstance(created, (int, float)):
+        return None
+    if not math.isfinite(created):
         return None
     return int(created)
 
@@ -183,9 +191,10 @@ class OpenCodePromptStream:
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream response from OpenCode using Server-Sent Events.
 
-        The ascending ID ensures our user message ID is lexicographically
-        greater than any previous assistant message IDs, preventing the early
-        exit condition in OpenCode's prompt loop (lastUser.id < lastAssistant.id).
+        Supplying our own user message ID is what makes attribution possible:
+        OpenCode stamps the assistant messages it generates for this prompt
+        with `parentID` pointing at it. The ID's ordering carries no meaning —
+        see OpenCodeIdentifier on why these IDs must never be compared.
         """
         opencode_message_id = OpenCodeIdentifier.ascending("message")
         request_body = self._build_prompt_request_body(

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -311,14 +311,24 @@ class TestOpenCodeIdentifier:
         ids = [OpenCodeIdentifier.ascending("message") for _ in range(100)]
         assert len(set(ids)) == 100  # All unique
 
-    def test_ascending_ids_increase_within_one_rollover_window(self):
+    def test_ascending_ids_increase_within_one_rollover_window(self, monkeypatch):
         """Consecutive IDs increase — but only inside a rollover window.
 
         The encoded value is truncated to 48 bits and wraps roughly every 795
         days, so this is not an ordering guarantee callers may rely on: nothing
-        may compare these IDs to order messages. It holds here because all
-        three are generated back to back.
+        may compare these IDs to order messages. The clock is pinned inside one
+        window so the assertion cannot straddle a rollover, and it ticks once so
+        both the same-millisecond counter and the millisecond advance are
+        covered.
         """
+        pinned_epoch_seconds = 1_754_000_000.0
+        next_millisecond = pinned_epoch_seconds + 0.5
+        ticks = iter([pinned_epoch_seconds, pinned_epoch_seconds, next_millisecond])
+        monkeypatch.setattr(
+            "sandbox_runtime.opencode_identifier.time.time",
+            lambda: next(ticks, next_millisecond),
+        )
+
         id1 = OpenCodeIdentifier.ascending("message")
         id2 = OpenCodeIdentifier.ascending("message")
         id3 = OpenCodeIdentifier.ascending("message")

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -311,8 +311,14 @@ class TestOpenCodeIdentifier:
         ids = [OpenCodeIdentifier.ascending("message") for _ in range(100)]
         assert len(set(ids)) == 100  # All unique
 
-    def test_ascending_ids_are_lexicographically_ordered(self):
-        """IDs generated later should be lexicographically greater."""
+    def test_ascending_ids_increase_within_one_rollover_window(self):
+        """Consecutive IDs increase — but only inside a rollover window.
+
+        The encoded value is truncated to 48 bits and wraps roughly every 795
+        days, so this is not an ordering guarantee callers may rely on: nothing
+        may compare these IDs to order messages. It holds here because all
+        three are generated back to back.
+        """
         id1 = OpenCodeIdentifier.ascending("message")
         id2 = OpenCodeIdentifier.ascending("message")
         id3 = OpenCodeIdentifier.ascending("message")

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -99,20 +99,29 @@ def create_sse_event(event_type: str, properties: dict) -> str:
     return f"data: {json.dumps(data)}\n\n"
 
 
+def created_after_prompt_start_ms() -> int:
+    """A message creation time comfortably after the boundary `_PromptState`
+    records when the stream starts, for post-compaction fixtures whose parentID
+    no longer matches the prompt's user message."""
+    return int(time.time() * 1000) + 60_000
+
+
 def make_prompt_state(
     message_id: str,
     opencode_message_id: str,
     *,
     cumulative_text: dict[str, str] | None = None,
     compaction_occurred: bool = False,
+    start_time: float = 0.0,
 ) -> _PromptState:
     """Per-prompt state as stream_prompt would build it, for direct
-    reconciliation calls."""
+    reconciliation calls. `start_time` is the boundary the compaction fallback
+    orders message creation times against."""
     state = _PromptState(
         opencode_session_id="oc-session-123",
         message_id=message_id,
         opencode_message_id=opencode_message_id,
-        start_time=0.0,
+        start_time=start_time,
     )
     if cumulative_text is not None:
         state.cumulative_text = cumulative_text
@@ -1090,6 +1099,7 @@ class TestFetchFinalMessageState:
                     "id": prior_assistant_id,
                     "role": "assistant",
                     "parentID": prior_user_id,
+                    "time": {"created": prompt_ts_ms - 60_000},
                 },
                 "parts": [{"id": "part-prior", "type": "text", "text": "Prior turn final report"}],
             },
@@ -1099,6 +1109,7 @@ class TestFetchFinalMessageState:
                     "role": "assistant",
                     "parentID": compaction_user_id,
                     "summary": True,
+                    "time": {"created": prompt_ts_ms + 1_000},
                 },
                 "parts": [{"id": "part-summary", "type": "text", "text": "Internal summary"}],
             },
@@ -1107,6 +1118,7 @@ class TestFetchFinalMessageState:
                     "id": continuation_id,
                     "role": "assistant",
                     "parentID": continue_user_id,
+                    "time": {"created": prompt_ts_ms + 2_000},
                 },
                 "parts": [
                     {
@@ -1129,6 +1141,7 @@ class TestFetchFinalMessageState:
             prompt_user_id,
             cumulative_text=cumulative_text,
             compaction_occurred=True,
+            start_time=prompt_ts_ms / 1000,
         )
         async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
             events.append(event)
@@ -2578,6 +2591,7 @@ class TestCompactionHandling:
                         "sessionID": "oc-session-123",
                         "parentID": "msg_compaction_user",
                         "summary": True,
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -2590,6 +2604,7 @@ class TestCompactionHandling:
                         "role": "assistant",
                         "sessionID": "oc-session-123",
                         "parentID": "msg_synthetic_continue",
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -2678,6 +2693,7 @@ class TestCompactionHandling:
                         "sessionID": "oc-session-123",
                         "parentID": "msg_compaction_user",
                         "summary": True,
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -2702,6 +2718,7 @@ class TestCompactionHandling:
                         "role": "assistant",
                         "sessionID": "oc-session-123",
                         "parentID": "msg_synthetic_continue",
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -2878,6 +2895,7 @@ class TestCompactionHandling:
                         "sessionID": "oc-session-123",
                         "parentID": "msg_compaction_user",
                         "summary": True,
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -2998,6 +3016,7 @@ class TestCompactionHandling:
                         "role": "assistant",
                         "sessionID": "oc-session-123",
                         "parentID": "msg_synthetic_continue",
+                        "time": {"created": created_after_prompt_start_ms()},
                     }
                 },
             ),
@@ -3024,6 +3043,8 @@ class TestCompactionHandling:
         bridge.opencode_session_id = "oc-session-123"
         wire_opencode_transport(bridge, AsyncMock())
 
+        prompt_ts_ms = 1_754_000_000_000
+
         # API returns: compaction summary + post-compaction response
         messages = [
             {
@@ -3032,6 +3053,7 @@ class TestCompactionHandling:
                     "role": "assistant",
                     "parentID": "msg_compaction_user",
                     "summary": True,
+                    "time": {"created": prompt_ts_ms + 1_000},
                 },
                 "parts": [
                     {"id": "summary-part", "type": "text", "text": "## Goal\nSummary..."},
@@ -3042,6 +3064,7 @@ class TestCompactionHandling:
                     "id": "oc-msg-post",
                     "role": "assistant",
                     "parentID": "msg_synthetic_continue",
+                    "time": {"created": prompt_ts_ms + 2_000},
                 },
                 "parts": [
                     {"id": "post-part", "type": "text", "text": "Here is the answer."},
@@ -3052,7 +3075,12 @@ class TestCompactionHandling:
         bridge.http_client.get = AsyncMock(return_value=MockResponse(200, messages))
 
         events = []
-        state = make_prompt_state("cp-msg-1", "msg_original_id", compaction_occurred=True)
+        state = make_prompt_state(
+            "cp-msg-1",
+            "msg_original_id",
+            compaction_occurred=True,
+            start_time=prompt_ts_ms / 1000,
+        )
         async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
             events.append(event)
 

--- a/packages/sandbox-runtime/tests/test_message_attribution.py
+++ b/packages/sandbox-runtime/tests/test_message_attribution.py
@@ -7,12 +7,24 @@ from tests.conftest import oc_message_id
 PROMPT_TS_MS = 1_754_000_000_000
 PROMPT_MESSAGE_ID = oc_message_id(PROMPT_TS_MS, 2, "p")
 
+# OpenCode truncates its encoded message IDs to 48 bits, so the encoding rolls
+# over every 2**36 ms and IDs minted after a rollover sort below every ID from
+# the window before it. This is the rollover that broke pre-existing sessions.
+ROLLOVER_TS_MS = 26 * 2**36
+ONE_HOUR_MS = 60 * 60 * 1000
+
+
+def _attribution(
+    message_id: str = PROMPT_MESSAGE_ID, started_epoch_ms: int = PROMPT_TS_MS
+) -> MessageAttribution:
+    return MessageAttribution(message_id, started_epoch_ms)
+
 
 def test_direct_parent_message_is_accepted_and_tracked():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution = _attribution()
 
     disposition = attribution.assistant_disposition(
-        "assistant-message", PROMPT_MESSAGE_ID, is_summary=False
+        "assistant-message", PROMPT_MESSAGE_ID, is_summary=False, created_epoch_ms=None
     )
 
     assert disposition is AssistantMessageDisposition.OUTPUT
@@ -20,21 +32,28 @@ def test_direct_parent_message_is_accepted_and_tracked():
 
 
 def test_discovered_user_message_can_parent_output():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution = _attribution()
     attribution.add_user_message("server-generated-user-message")
 
     disposition = attribution.assistant_disposition(
-        "assistant-message", "server-generated-user-message", is_summary=False
+        "assistant-message",
+        "server-generated-user-message",
+        is_summary=False,
+        created_epoch_ms=None,
     )
 
     assert disposition is AssistantMessageDisposition.OUTPUT
 
 
 def test_correlated_summary_is_error_only_and_remains_correlated():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution = _attribution()
 
-    first = attribution.assistant_disposition("summary-message", PROMPT_MESSAGE_ID, is_summary=True)
-    repeated = attribution.assistant_disposition("summary-message", "", is_summary=False)
+    first = attribution.assistant_disposition(
+        "summary-message", PROMPT_MESSAGE_ID, is_summary=True, created_epoch_ms=PROMPT_TS_MS
+    )
+    repeated = attribution.assistant_disposition(
+        "summary-message", "", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+    )
 
     assert first is AssistantMessageDisposition.ERROR_ONLY
     assert repeated is AssistantMessageDisposition.ERROR_ONLY
@@ -42,43 +61,89 @@ def test_correlated_summary_is_error_only_and_remains_correlated():
 
 
 def test_tracked_message_is_accepted_during_reconciliation():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
+    attribution = _attribution()
     attribution.allow_assistant("assistant-message")
 
     disposition = attribution.assistant_disposition(
-        "assistant-message", "unknown-parent", is_summary=False
+        "assistant-message", "unknown-parent", is_summary=False, created_epoch_ms=None
     )
 
     assert disposition is AssistantMessageDisposition.OUTPUT
 
 
-def test_compaction_fallback_only_accepts_messages_after_prompt_boundary():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
-    before_prompt = oc_message_id(PROMPT_TS_MS, 1, "b")
-    after_prompt = oc_message_id(PROMPT_TS_MS, 3, "a")
+def test_compaction_fallback_only_accepts_messages_created_after_the_prompt():
+    attribution = _attribution()
 
     assert (
-        attribution.assistant_disposition(after_prompt, "unknown", is_summary=False)
+        attribution.assistant_disposition(
+            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+        )
         is AssistantMessageDisposition.REJECT
     )
 
     attribution.mark_compacted()
 
     assert (
-        attribution.assistant_disposition(before_prompt, "unknown", is_summary=False)
+        attribution.assistant_disposition(
+            "before-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS - 1
+        )
         is AssistantMessageDisposition.REJECT
     )
     assert (
-        attribution.assistant_disposition(after_prompt, "unknown", is_summary=False)
+        attribution.assistant_disposition(
+            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+        )
         is AssistantMessageDisposition.OUTPUT
     )
 
 
-def test_compaction_summary_is_never_accepted_as_output():
-    attribution = MessageAttribution(PROMPT_MESSAGE_ID)
-    attribution.mark_compacted()
-    after_prompt = oc_message_id(PROMPT_TS_MS, 3, "s")
+def test_compaction_fallback_ignores_id_order_across_a_rollover():
+    """An earlier turn's message outranks ours by ID after a rollover."""
+    prompt_ts_ms = ROLLOVER_TS_MS + ONE_HOUR_MS
+    stale_ts_ms = ROLLOVER_TS_MS - ONE_HOUR_MS
+    prompt_message_id = oc_message_id(prompt_ts_ms, 2, "p")
+    stale_message_id = oc_message_id(stale_ts_ms, 1, "s")
+    fresh_message_id = oc_message_id(prompt_ts_ms, 3, "f")
 
-    disposition = attribution.assistant_disposition(after_prompt, "unknown", is_summary=True)
+    # Guards the premise: ordering by ID would claim the earlier turn's message
+    # and drop ours, which is exactly backwards.
+    assert stale_message_id > prompt_message_id
+    assert fresh_message_id < stale_message_id
+
+    attribution = _attribution(prompt_message_id, prompt_ts_ms)
+    attribution.mark_compacted()
+
+    assert (
+        attribution.assistant_disposition(
+            stale_message_id, "unknown", is_summary=False, created_epoch_ms=stale_ts_ms
+        )
+        is AssistantMessageDisposition.REJECT
+    )
+    assert (
+        attribution.assistant_disposition(
+            fresh_message_id, "unknown", is_summary=False, created_epoch_ms=prompt_ts_ms
+        )
+        is AssistantMessageDisposition.OUTPUT
+    )
+
+
+def test_compaction_fallback_rejects_a_message_without_a_creation_time():
+    attribution = _attribution()
+    attribution.mark_compacted()
+
+    disposition = attribution.assistant_disposition(
+        "untimed-message", "unknown", is_summary=False, created_epoch_ms=None
+    )
+
+    assert disposition is AssistantMessageDisposition.REJECT
+
+
+def test_compaction_summary_is_never_accepted_as_output():
+    attribution = _attribution()
+    attribution.mark_compacted()
+
+    disposition = attribution.assistant_disposition(
+        "summary-message", "unknown", is_summary=True, created_epoch_ms=PROMPT_TS_MS
+    )
 
     assert disposition is AssistantMessageDisposition.REJECT

--- a/packages/sandbox-runtime/tests/test_message_attribution.py
+++ b/packages/sandbox-runtime/tests/test_message_attribution.py
@@ -76,7 +76,7 @@ def test_compaction_fallback_only_accepts_messages_created_after_the_prompt():
 
     assert (
         attribution.assistant_disposition(
-            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS + 1
         )
         is AssistantMessageDisposition.REJECT
     )
@@ -91,10 +91,24 @@ def test_compaction_fallback_only_accepts_messages_created_after_the_prompt():
     )
     assert (
         attribution.assistant_disposition(
-            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+            "after-prompt", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS + 1
         )
         is AssistantMessageDisposition.OUTPUT
     )
+
+
+def test_compaction_fallback_rejects_the_boundary_millisecond():
+    """The boundary is truncated to whole milliseconds, so a prior turn's
+    message created earlier within it must not be claimed. Nothing this prompt
+    produces shares that millisecond."""
+    attribution = _attribution()
+    attribution.mark_compacted()
+
+    disposition = attribution.assistant_disposition(
+        "same-millisecond", "unknown", is_summary=False, created_epoch_ms=PROMPT_TS_MS
+    )
+
+    assert disposition is AssistantMessageDisposition.REJECT
 
 
 def test_compaction_fallback_ignores_id_order_across_a_rollover():
@@ -121,7 +135,7 @@ def test_compaction_fallback_ignores_id_order_across_a_rollover():
     )
     assert (
         attribution.assistant_disposition(
-            fresh_message_id, "unknown", is_summary=False, created_epoch_ms=prompt_ts_ms
+            fresh_message_id, "unknown", is_summary=False, created_epoch_ms=prompt_ts_ms + 1
         )
         is AssistantMessageDisposition.OUTPUT
     )

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -15,6 +15,7 @@ from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
 from sandbox_runtime.prompt_stream import (
     OpenCodePromptStream,
     _Disposition,
+    _message_created_epoch_ms,
     _PromptState,
 )
 from tests.conftest import oc_message_id
@@ -55,6 +56,19 @@ def make_state(
 
 def sse(event_type: str, properties: dict) -> dict:
     return {"type": event_type, "properties": properties}
+
+
+def test_message_created_epoch_ms_treats_unusable_values_as_absent():
+    """Anything int() would reject must read as absent: raising here would tear
+    down the SSE loop over one malformed message."""
+    assert _message_created_epoch_ms({"time": {"created": PROMPT_TS_MS}}) == PROMPT_TS_MS
+    assert _message_created_epoch_ms({}) is None
+    assert _message_created_epoch_ms({"time": None}) is None
+    assert _message_created_epoch_ms({"time": {}}) is None
+    assert _message_created_epoch_ms({"time": {"created": "1754000000000"}}) is None
+    assert _message_created_epoch_ms({"time": {"created": True}}) is None
+    assert _message_created_epoch_ms({"time": {"created": float("nan")}}) is None
+    assert _message_created_epoch_ms({"time": {"created": float("inf")}}) is None
 
 
 def test_oc_message_id_matches_real_generator_format():
@@ -757,18 +771,18 @@ class TestApplySseEventDispositions:
         ]
 
     def test_post_compaction_millisecond_boundary(self):
-        """The boundary is the prompt's start millisecond: a message created one
-        millisecond earlier is rejected, one created in that same millisecond is
-        accepted."""
-        before_boundary_id = oc_message_id(PROMPT_TS_MS - 1, 1, "s")
-        at_boundary_id = oc_message_id(PROMPT_TS_MS, 3, "t")
+        """The boundary is the prompt's start millisecond and the comparison is
+        strict: a message created in that same millisecond is rejected, because
+        a prior turn could have produced it earlier within that millisecond."""
+        at_boundary_id = oc_message_id(PROMPT_TS_MS, 1, "s")
+        after_boundary_id = oc_message_id(PROMPT_TS_MS + 1, 3, "t")
         stream = make_stream()
         state = make_state(PROMPT_MESSAGE_ID)
         stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
 
         for oc_msg_id, created in (
-            (before_boundary_id, PROMPT_TS_MS - 1),
             (at_boundary_id, PROMPT_TS_MS),
+            (after_boundary_id, PROMPT_TS_MS + 1),
         ):
             stream._apply_sse_event(
                 state,
@@ -786,8 +800,8 @@ class TestApplySseEventDispositions:
                 ),
             )
 
-        assert not state.attribution.is_assistant_allowed(before_boundary_id)
-        assert state.attribution.is_assistant_allowed(at_boundary_id)
+        assert not state.attribution.is_assistant_allowed(at_boundary_id)
+        assert state.attribution.is_assistant_allowed(after_boundary_id)
 
     def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
         prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -6,7 +6,6 @@ the synchronous per-event translator (`_apply_sse_event`) dispositions and
 the cross-prompt session-title dedupe, which are directly testable now.
 """
 
-import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,12 +39,16 @@ def make_stream() -> OpenCodePromptStream:
     )
 
 
-def make_state(opencode_message_id: str = "msg_test") -> _PromptState:
+def make_state(
+    opencode_message_id: str = "msg_test", start_time: float = PROMPT_TS_MS / 1000
+) -> _PromptState:
+    """Anchor the prompt boundary to PROMPT_TS_MS so fixture creation times and
+    fixture IDs describe the same instant."""
     state = _PromptState(
         opencode_session_id=PARENT_SESSION_ID,
         message_id="cp-msg-1",
         opencode_message_id=opencode_message_id,
-        start_time=time.time(),
+        start_time=start_time,
     )
     return state
 
@@ -662,9 +665,9 @@ class TestApplySseEventDispositions:
         assert step.events == []
 
     def test_post_compaction_prior_prompt_message_is_not_accepted(self):
-        """The compaction fallback must not claim messages that predate the
-        prompt (IDs below the prompt's user message): forwarding them would
-        replay prior turns' text as current output."""
+        """The compaction fallback must not claim messages created before the
+        prompt: forwarding them would replay prior turns' text as current
+        output."""
         prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")
         prior_user_id = oc_message_id(PROMPT_TS_MS - 61_000, 1, "u")
         stream = make_stream()
@@ -696,6 +699,7 @@ class TestApplySseEventDispositions:
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
                         "parentID": prior_user_id,
+                        "time": {"created": PROMPT_TS_MS - 60_000},
                     }
                 },
             ),
@@ -722,6 +726,7 @@ class TestApplySseEventDispositions:
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
                         "parentID": continue_user_id,
+                        "time": {"created": PROMPT_TS_MS + 5_000},
                     }
                 },
             ),
@@ -751,17 +756,20 @@ class TestApplySseEventDispositions:
             }
         ]
 
-    def test_post_compaction_same_timestamp_counter_boundary(self):
-        """Within one millisecond the encoded counter decides ordering: an
-        assistant ID one counter tick below the prompt's user message is
-        rejected, one tick above is accepted."""
-        same_ms_below_id = oc_message_id(PROMPT_TS_MS, 1, "s")
-        same_ms_above_id = oc_message_id(PROMPT_TS_MS, 3, "t")
+    def test_post_compaction_millisecond_boundary(self):
+        """The boundary is the prompt's start millisecond: a message created one
+        millisecond earlier is rejected, one created in that same millisecond is
+        accepted."""
+        before_boundary_id = oc_message_id(PROMPT_TS_MS - 1, 1, "s")
+        at_boundary_id = oc_message_id(PROMPT_TS_MS, 3, "t")
         stream = make_stream()
         state = make_state(PROMPT_MESSAGE_ID)
         stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
 
-        for oc_msg_id in (same_ms_below_id, same_ms_above_id):
+        for oc_msg_id, created in (
+            (before_boundary_id, PROMPT_TS_MS - 1),
+            (at_boundary_id, PROMPT_TS_MS),
+        ):
             stream._apply_sse_event(
                 state,
                 sse(
@@ -772,13 +780,14 @@ class TestApplySseEventDispositions:
                             "role": "assistant",
                             "sessionID": PARENT_SESSION_ID,
                             "parentID": oc_message_id(PROMPT_TS_MS, 0, "w"),
+                            "time": {"created": created},
                         }
                     },
                 ),
             )
 
-        assert not state.attribution.is_assistant_allowed(same_ms_below_id)
-        assert state.attribution.is_assistant_allowed(same_ms_above_id)
+        assert not state.attribution.is_assistant_allowed(before_boundary_id)
+        assert state.attribution.is_assistant_allowed(at_boundary_id)
 
     def test_post_compaction_error_on_prior_prompt_message_is_ignored(self):
         prior_assistant_id = oc_message_id(PROMPT_TS_MS - 60_000, 1, "q")
@@ -796,6 +805,7 @@ class TestApplySseEventDispositions:
                         "role": "assistant",
                         "sessionID": PARENT_SESSION_ID,
                         "parentID": oc_message_id(PROMPT_TS_MS - 61_000, 1, "u"),
+                        "time": {"created": PROMPT_TS_MS - 60_000},
                         "error": {"name": "SomeError", "data": {"message": "Old failure"}},
                     }
                 },


### PR DESCRIPTION
Refs #1429. Follow-up to #1430, which fixed the OpenCode side of the message-ID rollover but left
the bridge's own ID comparison in place.

## Problem

When OpenCode compacts a session it rewrites the parent chain, so assistant messages stop pointing at
the prompt's user message. `MessageAttribution` falls back to claiming anything that came "after" the
prompt — and it decided that by comparing OpenCode message IDs as strings:

```python
return self._compaction_occurred and OpenCodeIdentifier.is_after(
    message_id, self.prompt_user_message_id
)
```

Those IDs encode a 48-bit truncation of `Date.now() * 0x1000`, so the encoding rolls over roughly
every 795 days (most recently 2026-08-14 11:19:55 UTC). Across a rollover the comparison inverts:
an earlier turn's messages sort *above* this prompt's user message and get claimed, while this
prompt's own messages sort below. In a session with pre-rollover history, a compaction would replay
a previous turn's final text as the current turn's output — the failure #1385 was meant to close.

## Change

Order by creation time instead. `MessageAttribution` now takes the prompt's start as
`prompt_started_epoch_ms` and `assistant_disposition` takes each message's `created_epoch_ms`, read
off the `time.created` OpenCode stamps on every message it persists. Both call sites — the live SSE
translator and the final-state reconciliation — pass it through.

A message with no timestamp is rejected rather than accepted: silently surfacing an earlier turn's
output is worse than dropping a message OpenCode never dated, and in practice OpenCode always dates
them.

`OpenCodeIdentifier.is_after` had no other caller and is deleted, so the wrap-unsafe comparison can't
be reused. The class docstring claimed these IDs are monotonically increasing; it now says they are
monotonic only within a rollover window and must never be used for ordering.

## Tests

- New: an earlier turn's message that outranks the prompt by ID across a rollover is rejected, and
  this prompt's lower-sorting message is accepted. The test asserts the inverted ID ordering first,
  so it fails against the old comparison rather than passing vacuously.
- New: a message with no `time.created` is rejected after compaction.
- `test_post_compaction_same_timestamp_counter_boundary` tested counter-tick ordering *within* a
  millisecond, which was purely an ID-comparison property. Replaced with
  `test_post_compaction_millisecond_boundary`, which pins the same boundary precision in the new
  ordering: one millisecond before the prompt is rejected, the prompt's own millisecond is accepted.
- Compaction fixtures across `test_prompt_stream.py` and `test_bridge_sse.py` now carry
  `time.created`, and their prompt boundaries are anchored to the same instant as their fixture IDs
  instead of `time.time()` / `0.0`.

## Verification

- `pytest tests/test_message_attribution.py tests/test_prompt_stream.py tests/test_bridge_sse.py
  tests/test_bridge_message_tracking.py` — 125 passed.
- `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy` on the three changed modules —
  all clean.
- Full `pytest tests/` locally: 62 failed / 511 passed, byte-identical failure set to the clean-tree
  baseline (62 failed / 509 passed) — an ambient-env dependency problem in this checkout, not a
  regression. The +2 is this PR's new tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved assistant message attribution after context compaction by using creation timestamps.
  - Prevented older, timestamp-less, summary, or pre-prompt messages from being incorrectly attributed.
  - Corrected ordering behavior when message identifiers roll over, ensuring messages are evaluated chronologically.

- **Tests**
  - Added coverage for prompt boundaries, compaction filtering, missing or malformed timestamps, strict timing boundaries, and identifier rollover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->