### PR TITLE
feat: add Claude Sonnet 5, Grok 4.6, Kimi K3, and GLM 5.3 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## August 14, 2026
+
+**Claude Sonnet 5 and Grok 4.6.** Adds `anthropic/claude-sonnet-5` to the model picker and
+integrations with adaptive thinking and reasoning efforts from low through max, and `xai/grok-4.6`
+to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts.
+
 ## August 9, 2026
 
 **Browser-based sandbox desktops.** Opt in to a full VNC desktop for sessions, available from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 integrations with adaptive thinking and reasoning efforts from low through max, and `xai/grok-4.6`
 to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts.
 
+**Kimi K3 and GLM 5.3.** Adds `opencode/kimi-k3` to the opt-in OpenCode Zen catalog and
+`zai-coding-plan/glm-5.3` to the opt-in Z.AI Coding Plan catalog.
+
 ## August 9, 2026
 
 **Browser-based sandbox desktops.** Opt in to a full VNC desktop for sessions, available from the

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider         | Models                                                            |
-| ---------------- | ----------------------------------------------------------------- |
-| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
-| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                      |
-| xAI / SuperGrok  | Grok models (opt-in)                                              |
-| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)     |
-| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                  |
+| Provider         | Models                                                              |
+| ---------------- | ------------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
+| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                        |
+| xAI / SuperGrok  | Grok models (opt-in)                                                |
+| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)       |
+| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                    |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Choose the AI model that fits your task, with per-session reasoning effort contr
 | Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
 | OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                        |
 | xAI / SuperGrok  | Grok models (opt-in)                                                |
-| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)       |
-| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                    |
+| OpenCode Zen     | Kimi K2.5/K2.6/K3, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)    |
+| Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -12,7 +12,8 @@ managed xAI OAuth credentials; Z.AI Coding Plan requires `ZHIPU_API_KEY`; DeepSe
 | ----------------------------- | ----------------- | ---------------------------------- | ----------------------------- | -------------- |
 | `anthropic/claude-haiku-4-5`  | Claude Haiku 4.5  | Fast and efficient                 | high, max                     | max            |
 | `anthropic/claude-sonnet-4-5` | Claude Sonnet 4.5 | Balanced performance               | high, max                     | max            |
-| `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 | Latest balanced, fast coding       | low, medium, high, max        | high           |
+| `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 | Balanced, fast coding              | low, medium, high, max        | high           |
+| `anthropic/claude-sonnet-5`   | Claude Sonnet 5   | Latest Sonnet, adaptive thinking   | low, medium, high, xhigh, max | high           |
 | `anthropic/claude-opus-4-5`   | Claude Opus 4.5   | Most capable                       | high, max                     | max            |
 | `anthropic/claude-opus-4-6`   | Claude Opus 4.6   | Most capable, adaptive thinking    | low, medium, high, max        | high           |
 | `anthropic/claude-opus-4-7`   | Claude Opus 4.7   | Most capable, adaptive thinking    | low, medium, high, xhigh, max | high           |
@@ -42,7 +43,8 @@ Grok models require a SuperGrok OAuth refresh token and are disabled by default.
 
 | Model ID             | Display name   | Description                                     | Reasoning efforts | Default effort |
 | -------------------- | -------------- | ----------------------------------------------- | ----------------- | -------------- |
-| `xai/grok-4.5`       | Grok 4.5       | Latest Grok for chat, coding, and agentic tools | low, medium, high | high           |
+| `xai/grok-4.5`       | Grok 4.5       | Grok for chat, coding, and agentic tools        | low, medium, high | high           |
+| `xai/grok-4.6`       | Grok 4.6       | Latest Grok for chat, coding, and agentic tools | low, medium, high | high           |
 | `xai/grok-build-0.1` | Grok Build 0.1 | Coding model for SuperGrok subscribers          | Not configurable  | N/A            |
 
 ## OpenCode Zen

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -53,6 +53,7 @@ Grok models require a SuperGrok OAuth refresh token and are disabled by default.
 | ----------------------- | ------------ | ------------- | ----------------- | -------------- |
 | `opencode/kimi-k2.5`    | Kimi K2.5    | Moonshot AI   | Not supported     | N/A            |
 | `opencode/kimi-k2.6`    | Kimi K2.6    | Moonshot AI   | Not supported     | N/A            |
+| `opencode/kimi-k3`      | Kimi K3      | Moonshot AI   | Not supported     | N/A            |
 | `opencode/minimax-m2.5` | MiniMax M2.5 | MiniMax       | Not supported     | N/A            |
 | `opencode/qwen3.7-max`  | Qwen3.7 Max  | Alibaba Cloud | Not supported     | N/A            |
 | `opencode/glm-5`        | GLM 5        | Z.ai 744B MoE | Not supported     | N/A            |
@@ -65,6 +66,7 @@ Z.AI Coding Plan models require `ZHIPU_API_KEY` as a global or repository secret
 | Model ID                  | Display name | Description      | Reasoning efforts | Default effort |
 | ------------------------- | ------------ | ---------------- | ----------------- | -------------- |
 | `zai-coding-plan/glm-5.2` | GLM 5.2      | Z.AI Coding Plan | Not supported     | N/A            |
+| `zai-coding-plan/glm-5.3` | GLM 5.3      | Z.AI Coding Plan | Not supported     | N/A            |
 
 ## DeepSeek
 

--- a/docs/GROK_MODELS.md
+++ b/docs/GROK_MODELS.md
@@ -13,6 +13,7 @@ the durable OAuth refresh token and gives each sandbox only a short-lived access
 | Model ID             | Display name   | Reasoning efforts | Default effort |
 | -------------------- | -------------- | ----------------- | -------------- |
 | `xai/grok-4.5`       | Grok 4.5       | low, medium, high | high           |
+| `xai/grok-4.6`       | Grok 4.6       | low, medium, high | high           |
 | `xai/grok-build-0.1` | Grok Build 0.1 | Not configurable  | N/A            |
 
 Grok Build performs reasoning internally but does not accept a configurable reasoning effort.
@@ -68,7 +69,7 @@ only, then fall back to global. A secondary repository cannot become the token r
 ### Step 3: Enable and Select Grok
 
 1. Open **Settings > Models**.
-2. Enable **Grok 4.5** or **Grok Build 0.1** under **xAI / SuperGrok**.
+2. Enable **Grok 4.6**, **Grok 4.5**, or **Grok Build 0.1** under **xAI / SuperGrok**.
 3. Create a new session or restart an existing sandbox.
 4. Select the enabled Grok model and the desired reasoning effort.
 
@@ -113,8 +114,8 @@ Before production rollout, run a staging session with an eligible SuperGrok acco
 
 ### Grok does not appear in the model selector
 
-Enable **Grok 4.5** or **Grok Build 0.1** under **Settings > Models**. The xAI group is opt-in and
-is not part of the default enabled model set.
+Enable **Grok 4.6**, **Grok 4.5**, or **Grok Build 0.1** under **Settings > Models**. The xAI group
+is opt-in and is not part of the default enabled model set.
 
 ### `XAI_OAUTH_REFRESH_TOKEN not configured`
 
@@ -127,7 +128,7 @@ sandbox after changing secrets.
 The refresh token was revoked, expired, or already rotated elsewhere. Repeat the local OpenCode
 login and replace `XAI_OAUTH_REFRESH_TOKEN` in the same secret scope.
 
-### `Model not found: xai/grok-4.5` or `xai/grok-build-0.1`
+### `Model not found: xai/grok-4.6`, `xai/grok-4.5`, or `xai/grok-build-0.1`
 
 Rebuild the sandbox image so it includes the xAI auth proxy plugin and confirm the deployment uses
 OpenCode 1.17.18 or newer.

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -161,7 +161,7 @@ On any Linear issue:
 - Assign the issue to `OpenInspect` → agent picks it up
 - Agent status is visible directly in Linear (thinking, working, done)
 - Add a `model:<name>` label to override the model (e.g., `model:opus`, `model:sonnet`,
-  `model:opus-5`, `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
+  `model:opus-5`, `model:sonnet-5`, `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
 
 ## Repo Resolution
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -118,6 +118,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:opus-5" }])).toBe("anthropic/claude-opus-5");
   });
 
+  it("returns Sonnet 5 for model:sonnet-5 label", () => {
+    expect(extractModelFromLabels([{ name: "model:sonnet-5" }])).toBe("anthropic/claude-sonnet-5");
+  });
+
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();
   });

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -38,6 +38,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "opus-4-7": "anthropic/claude-opus-4-7",
   "opus-4-8": "anthropic/claude-opus-4-8",
   "opus-5": "anthropic/claude-opus-5",
+  "sonnet-5": "anthropic/claude-sonnet-5",
   fable: "anthropic/claude-fable-5",
   "fable-5": "anthropic/claude-fable-5",
   "gpt-5.4": "openai/gpt-5.4",

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -53,6 +53,7 @@ ANTHROPIC_ADAPTIVE_THINKING_MODELS: Final[frozenset[str]] = frozenset(
         "claude-opus-4-8",
         "claude-opus-5",
         "claude-sonnet-4-6",
+        "claude-sonnet-5",
     }
 )
 ANTHROPIC_ADAPTIVE_EFFORTS: Final[frozenset[str]] = frozenset(

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -287,6 +287,23 @@ class TestBuildPromptRequestBody:
             "outputConfig": {"effort": "high"},
         }
 
+    def test_with_sonnet_5_adaptive_thinking(self, bridge: AgentBridge):
+        """Sonnet 5 should use adaptive thinking instead of manual budgets."""
+        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+            "Hello",
+            "anthropic/claude-sonnet-5",
+            reasoning_effort="xhigh",
+        )
+
+        assert body["model"] == {
+            "providerID": "anthropic",
+            "modelID": "claude-sonnet-5",
+            "options": {
+                "thinking": {"type": "adaptive"},
+                "outputConfig": {"effort": "xhigh"},
+            },
+        }
+
     def test_with_xai_reasoning_effort(self, bridge: AgentBridge):
         body = bridge._ensure_prompt_stream()._build_prompt_request_body(
             "Hello",
@@ -296,6 +313,16 @@ class TestBuildPromptRequestBody:
 
         assert body["variant"] == "high"
         assert "options" not in body["model"]
+
+    def test_with_grok_4_6_reasoning_effort(self, bridge: AgentBridge):
+        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+            "Hello",
+            "xai/grok-4.6",
+            reasoning_effort="medium",
+        )
+
+        assert body["variant"] == "medium"
+        assert body["model"] == {"providerID": "xai", "modelID": "grok-4.6"}
 
 
 class TestOpenCodeIdentifier:

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -22,6 +22,7 @@ const ANTHROPIC_MODELS = [
   "anthropic/claude-haiku-4-5",
   "anthropic/claude-sonnet-4-5",
   "anthropic/claude-sonnet-4-6",
+  "anthropic/claude-sonnet-5",
   "anthropic/claude-opus-4-5",
   "anthropic/claude-opus-4-6",
   "anthropic/claude-opus-4-7",
@@ -40,7 +41,7 @@ const OPENAI_MODELS = [
   "openai/gpt-5.3-codex-spark",
 ] as const;
 
-const XAI_MODELS = ["xai/grok-4.5", "xai/grok-build-0.1"] as const;
+const XAI_MODELS = ["xai/grok-4.5", "xai/grok-4.6", "xai/grok-build-0.1"] as const;
 
 const ZEN_MODELS = [
   "opencode/kimi-k2.5",
@@ -249,6 +250,7 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("anthropic/claude-haiku-4-5")).toBe("max");
     expect(getDefaultReasoningEffort("anthropic/claude-sonnet-4-6")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-opus-4-8")).toBe("high");
+    expect(getDefaultReasoningEffort("anthropic/claude-sonnet-5")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-opus-5")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-fable-5")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
@@ -265,6 +267,10 @@ describe("model utilities", () => {
     });
     expect(getReasoningConfig("anthropic/claude-sonnet-4-6")).toEqual({
       efforts: ["low", "medium", "high", "max"],
+      default: "high",
+    });
+    expect(getReasoningConfig("anthropic/claude-sonnet-5")).toEqual({
+      efforts: ["low", "medium", "high", "xhigh", "max"],
       default: "high",
     });
     expect(getReasoningConfig("anthropic/claude-opus-4-8")).toEqual({
@@ -291,6 +297,10 @@ describe("model utilities", () => {
       efforts: ["low", "medium", "high", "xhigh"],
       default: "high",
     });
+    expect(getReasoningConfig("xai/grok-4.6")).toEqual({
+      efforts: ["low", "medium", "high"],
+      default: "high",
+    });
     expect(getReasoningConfig("xai/grok-build-0.1")).toBeUndefined();
     expect(getReasoningConfig("deepseek/deepseek-v4-flash")).toBeUndefined();
   });
@@ -300,6 +310,7 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("anthropic/claude-sonnet-4-5", "low")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "none")).toBe(false);
+    expect(isValidReasoningEffort("anthropic/claude-sonnet-5", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-5", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-5", "none")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-fable-5", "max")).toBe(true);
@@ -308,6 +319,8 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.6-luna", "max")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
+    expect(isValidReasoningEffort("xai/grok-4.6", "high")).toBe(true);
+    expect(isValidReasoningEffort("xai/grok-4.6", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "high")).toBe(false);
     expect(isValidReasoningEffort("xai/grok-build-0.1", "xhigh")).toBe(false);
     expect(isValidReasoningEffort("deepseek/deepseek-v4-pro", "high")).toBe(false);

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -46,6 +46,7 @@ const XAI_MODELS = ["xai/grok-4.5", "xai/grok-4.6", "xai/grok-build-0.1"] as con
 const ZEN_MODELS = [
   "opencode/kimi-k2.5",
   "opencode/kimi-k2.6",
+  "opencode/kimi-k3",
   "opencode/minimax-m2.5",
   "opencode/qwen3.7-max",
   "opencode/glm-5",
@@ -53,7 +54,7 @@ const ZEN_MODELS = [
 ] as const;
 
 const DEEPSEEK_MODELS = ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"] as const;
-const ZAI_CODING_PLAN_MODELS = ["zai-coding-plan/glm-5.2"] as const;
+const ZAI_CODING_PLAN_MODELS = ["zai-coding-plan/glm-5.2", "zai-coding-plan/glm-5.3"] as const;
 
 describe("model utilities", () => {
   it("derives every public model view from the authoritative catalog", () => {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -59,9 +59,18 @@ export const MODEL_CATALOG = [
       {
         id: "anthropic/claude-sonnet-4-6",
         name: "Claude Sonnet 4.6",
-        description: "Latest balanced, fast coding",
+        description: "Balanced, fast coding",
         default: true,
         reasoning: { efforts: ["low", "medium", "high", "max"], default: "high" },
+      },
+      {
+        id: "anthropic/claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        description: "Latest Sonnet, adaptive thinking",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
       },
       {
         id: "anthropic/claude-opus-4-5",
@@ -195,6 +204,12 @@ export const MODEL_CATALOG = [
       {
         id: "xai/grok-4.5",
         name: "Grok 4.5",
+        description: "Grok for chat, coding, and agentic tools",
+        reasoning: { efforts: ["low", "medium", "high"], default: "high" },
+      },
+      {
+        id: "xai/grok-4.6",
+        name: "Grok 4.6",
         description: "Latest Grok for chat, coding, and agentic tools",
         reasoning: { efforts: ["low", "medium", "high"], default: "high" },
       },

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -191,6 +191,7 @@ export const MODEL_CATALOG = [
     models: [
       { id: "opencode/kimi-k2.5", name: "Kimi K2.5", description: "Moonshot AI" },
       { id: "opencode/kimi-k2.6", name: "Kimi K2.6", description: "Moonshot AI" },
+      { id: "opencode/kimi-k3", name: "Kimi K3", description: "Moonshot AI" },
       { id: "opencode/minimax-m2.5", name: "MiniMax M2.5", description: "MiniMax" },
       { id: "opencode/qwen3.7-max", name: "Qwen3.7 Max", description: "Alibaba Cloud" },
       { id: "opencode/glm-5", name: "GLM 5", description: "Z.ai 744B MoE" },
@@ -223,7 +224,10 @@ export const MODEL_CATALOG = [
   {
     category: "Z.AI Coding Plan",
     enabledByDefault: false,
-    models: [{ id: "zai-coding-plan/glm-5.2", name: "GLM 5.2", description: "Z.AI Coding Plan" }],
+    models: [
+      { id: "zai-coding-plan/glm-5.2", name: "GLM 5.2", description: "Z.AI Coding Plan" },
+      { id: "zai-coding-plan/glm-5.3", name: "GLM 5.3", description: "Z.AI Coding Plan" },
+    ],
   },
   {
     category: "DeepSeek",


### PR DESCRIPTION
## Summary

- add `anthropic/claude-sonnet-5` to the Anthropic catalog with adaptive thinking and low-through-max
  reasoning efforts (default `high`)
- route Sonnet 5 through `ANTHROPIC_ADAPTIVE_THINKING_MODELS` so it sends `thinking: {type: adaptive}`
  + `outputConfig.effort` instead of the manual `budgetTokens` path, which Sonnet 5 rejects
- add `xai/grok-4.6` to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts
  (default `high`), matching Grok 4.5
- add `opencode/kimi-k3` to the opt-in OpenCode Zen catalog
- add `zai-coding-plan/glm-5.3` to the opt-in Z.AI Coding Plan catalog
- support the `model:sonnet-5` Linear label
- move the "Latest" wording from Sonnet 4.6 to Sonnet 5 and from Grok 4.5 to Grok 4.6 so the picker
  descriptions stay accurate
- update shared, sandbox-runtime, linear-bot, and documentation coverage

The default model is unchanged (`anthropic/claude-sonnet-4-6`), and every group other than Anthropic
and OpenAI stays disabled by default. No new credentials are required: Kimi K3 uses the existing
OpenCode Zen key and GLM 5.3 the existing `ZHIPU_API_KEY`.

## Upstream verification

Confirmed against OpenCode's model metadata (models.dev):

- `anthropic/claude-sonnet-5` uses provider model ID `claude-sonnet-5`, 1M context / 128K output,
  and supports reasoning. Per Anthropic's migration guide, manual extended thinking
  (`budget_tokens`) returns a 400 on Sonnet 5 and `effort` supports low/medium/high/xhigh/max with
  `high` as the default — hence the adaptive-thinking routing and effort list.
- `xai/grok-4.6` uses provider model ID `grok-4.6` and, like Grok 4.5, exposes low, medium, and high
  effort variants. The xAI auth proxy preserves OpenCode's provider models and only injects Grok
  Build, so no plugin change is needed.
- `opencode/kimi-k3` is present on the OpenCode Zen provider (`opencode.ai/zen/v1`), 1M context /
  128K output. Like the other Zen entries it gets no reasoning config, since
  `_build_prompt_request_body` only maps reasoning effort for the anthropic, openai, and xai
  providers.
- `zai-coding-plan/glm-5.3` is present on the Z.AI Coding Plan provider, 1M context / 128K output,
  and follows the existing GLM 5.2 entry.

Two models that might be expected here are deliberately absent: GLM 5.3 and Qwen 3.8 Max are **not**
carried by the OpenCode Zen provider (Zen's GLM line stops at 5.2 and its newest Qwen is
`qwen3.6-plus`), so GLM 5.3 is added via Z.AI Coding Plan instead and Qwen 3.8 Max is left out. The
DeepSeek group already lists that provider's newest models (`deepseek-v4-flash`, `deepseek-v4-pro`).

## Test plan

- [x] `npm run build -w @open-inspect/shared`
- [x] `npm test -w @open-inspect/shared` (616 tests passed)
- [x] `npm test -w @open-inspect/linear-bot` (224 tests passed)
- [x] `npm test -w @open-inspect/control-plane` (2552 tests passed)
- [x] `npm test -w @open-inspect/web` (981 tests passed)
- [x] `PYTHONPATH="$PWD/src" uv run --extra dev pytest tests/test_bridge_message_tracking.py`
      (26 tests passed)
- [x] `npm run typecheck`
- [x] Prettier check and Ruff check/format on changed files
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Sonnet 5 with adaptive thinking and configurable reasoning effort.
  * Added Grok 4.6 with low, medium, and high reasoning options.
  * Added Kimi K3 and GLM 5.3 to their respective opt-in model catalogs.
  * Added `model:sonnet-5` as a supported model-label override.
* **Documentation**
  * Updated model availability tables, setup instructions, and troubleshooting guidance.
* **Tests**
  * Added coverage for model selection, reasoning configuration, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->