### PR TITLE
docs: update changelog for recent improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
-## August 14, 2026
+## August 15, 2026
 
 **Claude Sonnet 5 and Grok 4.6.** Adds `anthropic/claude-sonnet-5` to the model picker and
 integrations with adaptive thinking and reasoning efforts from low through max, and `xai/grok-4.6`
@@ -10,6 +10,48 @@ to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts.
 
 **Kimi K3 and GLM 5.3.** Adds `opencode/kimi-k3` to the opt-in OpenCode Zen catalog and
 `zai-coding-plan/glm-5.3` to the opt-in Z.AI Coding Plan catalog.
+
+**Cancel queued prompts.** Pending web prompts can now be removed before they start processing,
+freeing queue capacity and restoring the removed text to an empty composer after server
+confirmation.
+
+## August 14, 2026
+
+**OpenCode runtime upgraded to 1.18.18.** All sandbox providers now use a release that fixes a
+message-ID wraparound which prevented older sessions from recognizing new prompts after August 14.
+
+**Automatic abandoned-draft cleanup.** Warmed sessions that never receive a prompt are archived
+after an eight-hour grace period, while active drafts and sessions with messages or queued work are
+left untouched.
+
+**More adaptable session controls.** Desktop users can hide the session details sidebar, with the
+preference preserved across visits. Mobile headers now show separate connection and sandbox states,
+including lifecycle details and provider-dashboard access when available.
+
+**Search and paginate automations.** The automation list now supports URL-backed name search and
+stable cursor pagination, with responsive rows and distinct empty, no-results, and error states.
+
+## August 13, 2026
+
+**Cleaner, more responsive session timelines.** Completed turns collapse intermediate activity
+behind a “Worked for” disclosure while keeping the prompt and final response visible. Long text and
+expanded tool details now wrap or scroll within mobile layouts without widening the page.
+
+## August 12, 2026
+
+**Queue web follow-up prompts.** Submit up to ten follow-ups while a session is processing, with
+durable FIFO ordering, state synchronized across tabs and reloads, and idempotent retries that avoid
+duplicate work.
+
+**Correct child-session attribution.** Child sessions and parent-to-child follow-ups now use the
+active prompt author's identity and SCM credentials instead of always inheriting the parent session
+owner, including prompts started from bot integrations.
+
+## August 11, 2026
+
+**Clear Slack speaker attribution.** Slack-started sessions and follow-ups now label the current
+message with the sender's display name and stable Slack ID, preserving who gave an instruction in
+multi-person threads and across repository clarification.
 
 ## August 9, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ confirmation.
 
 ## August 14, 2026
 
-**OpenCode runtime upgraded to 1.18.18.** All sandbox providers now use a release that fixes a
-message-ID wraparound which prevented older sessions from recognizing new prompts after August 14.
+**OpenCode runtime upgraded to 1.18.18.** Newly built images across all sandbox providers now use a
+release that fixes a message-ID wraparound which prevented older sessions from recognizing new
+prompts after August 14. Sessions restored from pre-upgrade snapshots retain their existing runtime.
 
 **Automatic abandoned-draft cleanup.** Warmed sessions that never receive a prompt are archived
-after an eight-hour grace period, while active drafts and sessions with messages or queued work are
-left untouched.
+after an eight-hour grace period, while sessions that have started work or contain messages or
+queued prompts are left untouched.
 
 **More adaptable session controls.** Desktop users can hide the session details sidebar, with the
 preference preserved across visits. Mobile headers now show separate connection and sandbox states,


### PR DESCRIPTION
## Summary

- add concise changelog entries for notable improvements merged from August 11 through August 15
- cover queued prompt controls, session and automation UX, attribution, abandoned-draft cleanup, and the OpenCode runtime upgrade
- group each entry by its UTC merge date and move the latest model additions to August 15

## Validation

- `npx prettier --check CHANGELOG.md`
- `git diff --check -- CHANGELOG.md`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/7ee677da7d7ad72bd212e49a2626d148)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cancelling queued web prompts.
  * Improved automation search and pagination.
  * Added timeline and follow-up prompt enhancements.
  * Improved child-session and Slack speaker attribution.

* **Bug Fixes**
  * Improved runtime behavior, draft cleanup, and session controls.

* **Documentation**
  * Updated the changelog with August 15, 2026 release details and the latest August 14 improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->