### PR TITLE
refactor: extract EventRepository

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -63,6 +63,7 @@ import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
 import { ArtifactRepository } from "./artifact-repository";
+import { EventRepository } from "./event-repository";
 import { ParticipantRepository } from "./participant-repository";
 import { WsClientMappingRepository } from "./ws-client-mapping-repository";
 import { resolveParticipantName } from "./participant-name";
@@ -170,6 +171,7 @@ export class SessionDO extends DurableObject<Env> {
   private repository: SessionRepository;
   private attachmentRepository: SessionAttachmentRepository;
   private artifactRepository: ArtifactRepository;
+  private eventRepository: EventRepository;
   private participantRepository: ParticipantRepository;
   private wsClientMappingRepository: WsClientMappingRepository;
   private initialized = false;
@@ -283,12 +285,16 @@ export class SessionDO extends DurableObject<Env> {
     this.sql = ctx.storage.sql;
     this.attachmentRepository = new SessionAttachmentRepository(this.sql);
     this.artifactRepository = new ArtifactRepository(this.sql);
+    this.eventRepository = new EventRepository(this.sql, (closure) =>
+      ctx.storage.transactionSync(closure)
+    );
     this.participantRepository = new ParticipantRepository(this.sql);
     this.wsClientMappingRepository = new WsClientMappingRepository(this.sql);
     this.repository = new SessionRepository(
       this.sql,
       (closure) => ctx.storage.transactionSync(closure),
-      this.attachmentRepository
+      this.attachmentRepository,
+      this.eventRepository
     );
     this.log = createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL));
     // Note: session_id context is set in ensureInitialized() once DB is ready
@@ -470,6 +476,7 @@ export class SessionDO extends DurableObject<Env> {
     if (!this._messageService) {
       this._messageService = new MessageService({
         repository: this.repository,
+        eventRepository: this.eventRepository,
         artifactRepository: this.artifactRepository,
         messageQueue: this.messageQueue,
         stopExecution: () => this.stopExecution(),
@@ -482,7 +489,7 @@ export class SessionDO extends DurableObject<Env> {
 
   private get eventStream(): SessionEventStream {
     if (!this._eventStream) {
-      this._eventStream = new SessionEventStream(this.repository);
+      this._eventStream = new SessionEventStream(this.eventRepository);
     }
 
     return this._eventStream;
@@ -502,6 +509,7 @@ export class SessionDO extends DurableObject<Env> {
     if (!this._childSessionsHandler) {
       this._childSessionsHandler = createChildSessionsHandler({
         repository: this.repository,
+        eventRepository: this.eventRepository,
         participantRepository: this.participantRepository,
         artifactRepository: this.artifactRepository,
         getSession: () => this.getSession(),
@@ -520,6 +528,7 @@ export class SessionDO extends DurableObject<Env> {
     if (!this._sandboxHandler) {
       this._sandboxHandler = createSandboxHandler({
         repository: this.repository,
+        eventRepository: this.eventRepository,
         participantRepository: this.participantRepository,
         artifactRepository: this.artifactRepository,
         processSandboxEvent: (event) => this.processSandboxEvent(event),
@@ -728,6 +737,7 @@ export class SessionDO extends DurableObject<Env> {
         this.ctx,
         () => this.log,
         this.repository,
+        this.eventRepository,
         this.artifactRepository,
         this.callbackService,
         this.wsManager,

--- a/packages/control-plane/src/session/event-repository.test.ts
+++ b/packages/control-plane/src/session/event-repository.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { EventRepository } from "./event-repository";
+import type { SqlResult, SqlStorage } from "./sql-storage";
+
+function createMockSql() {
+  const calls: Array<{ query: string; params: unknown[] }> = [];
+  const rowsByQuery = new Map<string, unknown[]>();
+  const sql: SqlStorage = {
+    exec(query: string, ...params: unknown[]): SqlResult {
+      calls.push({ query, params });
+      return {
+        toArray: () => rowsByQuery.get(query) ?? [],
+        one: () => null,
+        rowsWritten: 0,
+      };
+    },
+  };
+  return {
+    sql,
+    calls,
+    setRows(query: string, rows: unknown[]) {
+      rowsByQuery.set(query, rows);
+    },
+  };
+}
+
+describe("EventRepository", () => {
+  let mock: ReturnType<typeof createMockSql>;
+  let repository: EventRepository;
+  let transactionSyncCalls: number;
+
+  beforeEach(() => {
+    mock = createMockSql();
+    transactionSyncCalls = 0;
+    repository = new EventRepository(mock.sql, (closure) => {
+      transactionSyncCalls += 1;
+      return closure();
+    });
+  });
+
+  describe("createEvent", () => {
+    it("stores event with all fields", () => {
+      repository.createEvent({
+        id: "evt-1",
+        type: "tool_call",
+        data: '{"tool":"read"}',
+        messageId: "msg-1",
+        createdAt: 1000,
+      });
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].query).toContain("INSERT INTO events");
+      expect(mock.calls[0].params).toEqual([
+        "evt-1",
+        "tool_call",
+        '{"tool":"read"}',
+        "msg-1",
+        1000,
+      ]);
+    });
+  });
+
+  describe("createContextCompactionEvent", () => {
+    it("atomically seals the current token and inserts the compaction marker", () => {
+      repository.createContextCompactionEvent({
+        id: "compaction-1",
+        type: "context_compacted",
+        data: '{"type":"context_compacted"}',
+        messageId: "msg-1",
+        createdAt: 1000,
+      });
+
+      expect(transactionSyncCalls).toBe(1);
+      expect(mock.calls).toHaveLength(2);
+      expect(mock.calls[0].query).toContain("UPDATE events SET id = ? WHERE id = ?");
+      expect(mock.calls[0].params).toEqual(["token:msg-1:compaction-1", "token:msg-1"]);
+      expect(mock.calls[1].query).toContain("INSERT INTO events");
+      expect(mock.calls[1].params).toEqual([
+        "compaction-1",
+        "context_compacted",
+        '{"type":"context_compacted"}',
+        "msg-1",
+        1000,
+      ]);
+    });
+  });
+
+  describe("upsertTokenEvent", () => {
+    it("upserts token events by deterministic message key", () => {
+      const event = {
+        type: "token" as const,
+        content: "partial response",
+        messageId: "msg-1",
+        sandboxId: "sb-1",
+        timestamp: 1,
+      };
+
+      repository.upsertTokenEvent("msg-1", event, 1000);
+
+      expect(mock.calls[0].query).toContain("ON CONFLICT(id) DO UPDATE SET");
+      expect(mock.calls[0].params).toEqual([
+        "token:msg-1",
+        "token",
+        JSON.stringify(event),
+        "msg-1",
+        1000,
+      ]);
+    });
+
+    it("reuses the same deterministic ID across updates", () => {
+      const firstEvent = {
+        type: "token" as const,
+        content: "first",
+        messageId: "msg-1",
+        sandboxId: "sb-1",
+        timestamp: 1,
+      };
+      const secondEvent = { ...firstEvent, content: "second", timestamp: 2 };
+
+      repository.upsertTokenEvent("msg-1", firstEvent, 1000);
+      repository.upsertTokenEvent("msg-1", secondEvent, 2000);
+
+      expect(mock.calls[0].params[0]).toBe("token:msg-1");
+      expect(mock.calls[1].params[0]).toBe("token:msg-1");
+      expect(mock.calls[1].params[2]).toBe(JSON.stringify(secondEvent));
+      expect(mock.calls[1].params[4]).toBe(2000);
+    });
+  });
+
+  describe("upsertToolCallEvent", () => {
+    it("scopes child call IDs and preserves the first event position on updates", () => {
+      const event = {
+        type: "tool_call" as const,
+        tool: "bash",
+        args: { command: "npm test" },
+        callId: "call-1",
+        status: "running",
+        messageId: "msg-1",
+        sandboxId: "sb-1",
+        timestamp: 1,
+        isSubtask: true,
+        childSessionId: "child-1",
+        taskCallId: "task-1",
+      };
+
+      repository.upsertToolCallEvent("msg-1", event, 1000);
+
+      expect(mock.calls[0].query).toContain("ON CONFLICT(id) DO UPDATE SET");
+      expect(mock.calls[0].query).not.toContain("created_at = excluded.created_at");
+      expect(mock.calls[0].params).toEqual([
+        'tool_call:["msg-1","child-1","call-1"]',
+        "tool_call",
+        JSON.stringify(event),
+        "msg-1",
+        1000,
+      ]);
+    });
+
+    it("uses a different identity for a parent call with the same call ID", () => {
+      const event = {
+        type: "tool_call" as const,
+        tool: "bash",
+        args: {},
+        callId: "call-1",
+        messageId: "msg-1",
+        sandboxId: "sb-1",
+        timestamp: 1,
+      };
+
+      repository.upsertToolCallEvent("msg-1", event, 1000);
+      expect(mock.calls[0].params[0]).toBe('tool_call:["msg-1","parent","call-1"]');
+    });
+  });
+
+  describe("upsertExecutionCompleteEvent", () => {
+    it("upserts completion events by message ID", () => {
+      const event = {
+        type: "execution_complete" as const,
+        messageId: "msg-1",
+        sandboxId: "sb-1",
+        success: true,
+        timestamp: 1,
+      };
+
+      repository.upsertExecutionCompleteEvent("msg-1", event, 1000);
+
+      expect(mock.calls[0].params).toEqual([
+        "execution_complete:msg-1",
+        "execution_complete",
+        JSON.stringify(event),
+        "msg-1",
+        1000,
+      ]);
+    });
+  });
+
+  describe("listEventPage", () => {
+    it("returns in deterministic descending order", () => {
+      repository.listEventPage({ limit: 50 });
+      expect(mock.calls[0].query).toContain("ORDER BY created_at DESC, timeline_sequence DESC");
+    });
+
+    it("filters by type", () => {
+      repository.listEventPage({ limit: 50, type: "tool_call" });
+      expect(mock.calls[0].query).toContain("type = ?");
+      expect(mock.calls[0].params).toContain("tool_call");
+    });
+
+    it("filters by messageId", () => {
+      repository.listEventPage({ limit: 50, messageId: "msg-1" });
+      expect(mock.calls[0].query).toContain("message_id = ?");
+      expect(mock.calls[0].params).toContain("msg-1");
+    });
+
+    it("keeps legacy timestamp cursors for pagination", () => {
+      repository.listEventPage({ limit: 50, cursor: { kind: "legacy", createdAt: 5000 } });
+      expect(mock.calls[0].query).toContain("created_at < ?");
+      expect(mock.calls[0].params).toContain(5000);
+    });
+
+    it("uses composite cursors for stable pagination across tied timestamps", () => {
+      repository.listEventPage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+      });
+      expect(mock.calls[0].query).toContain("((created_at < ?) OR (created_at = ? AND id < ?))");
+      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
+    });
+
+    it("returns hasMore and trims overflow", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
+      mock.setRows(query, [
+        { id: "e3", created_at: 5000, type: "token", data: "{}" },
+        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
+        { id: "e1", created_at: 3000, type: "token", data: "{}" },
+      ]);
+
+      const result = repository.listEventPage({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.events.map((event) => event.id)).toEqual(["e3", "e2"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
+    });
+  });
+
+  describe("getEventTimelinePage", () => {
+    it("queries the first timeline page with deterministic descending storage order", () => {
+      repository.getEventTimelinePage({ limit: 50 });
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual([51]);
+    });
+
+    it("queries timeline pages after a composite cursor", () => {
+      repository.getEventTimelinePage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+      });
+
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events WHERE ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
+    });
+
+    it("queries after a composite cursor and excludes event types", () => {
+      repository.getEventTimelinePage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+      });
+
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events WHERE type NOT IN (?) AND ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual(["heartbeat", 5000, 5000, "cursor-id", 51]);
+    });
+
+    it("returns ascending events and preserves the descending page cursor", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
+      mock.setRows(query, [
+        { id: "e3", created_at: 5000, type: "token", data: "{}" },
+        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
+        { id: "e1", created_at: 3000, type: "token", data: "{}" },
+      ]);
+
+      const result = repository.getEventTimelinePage({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.events.map((event) => event.id)).toEqual(["e2", "e3"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
+    });
+
+    it("returns hasMore=false when a timeline page fits within the limit", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
+      mock.setRows(query, [
+        { id: "e2", created_at: 4000, type: "token", data: "{}" },
+        { id: "e1", created_at: 3000, type: "tool_call", data: "{}" },
+      ]);
+
+      const result = repository.getEventTimelinePage({ limit: 50 });
+
+      expect(result.hasMore).toBe(false);
+      expect(result.events.map((event) => event.id)).toEqual(["e1", "e2"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 3000, id: "e1" });
+    });
+  });
+});

--- a/packages/control-plane/src/session/event-repository.ts
+++ b/packages/control-plane/src/session/event-repository.ts
@@ -1,0 +1,187 @@
+import { toolCallIdentityKey } from "@open-inspect/shared/types/sandbox-events";
+import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import {
+  eventTimelineCursorFromRow,
+  type EventListCursor,
+  type EventTimelineCursor,
+} from "./event-cursor";
+import type { SqlStorage, TransactionSync } from "./sql-storage";
+import type { EventRow } from "./types";
+
+type TokenEvent = Extract<SandboxEvent, { type: "token" }>;
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
+type UpsertableEventType = TokenEvent["type"] | ExecutionCompleteEvent["type"];
+
+const NEXT_TIMELINE_SEQUENCE_SQL = "(SELECT COALESCE(MAX(timeline_sequence), 0) + 1 FROM events)";
+
+/**
+ * Data for creating an event. Type is open because sandboxes emit additional
+ * event types beyond the shared EventType union.
+ */
+export interface CreateEventData {
+  id: string;
+  type: string;
+  data: string;
+  messageId: string | null;
+  createdAt: number;
+}
+
+export interface ListEventPageOptions {
+  cursor?: EventListCursor | null;
+  limit: number;
+  type?: string | null;
+  messageId?: string | null;
+}
+
+export interface ListEventTimelinePageOptions {
+  cursor?: EventTimelineCursor | null;
+  excludeTypes?: string[];
+  limit: number;
+}
+
+export interface EventPage {
+  events: EventRow[];
+  hasMore: boolean;
+  nextCursor: EventTimelineCursor | null;
+}
+
+interface QueryEventPageOptions extends ListEventPageOptions {
+  excludeTypes?: string[];
+}
+
+/** Persistence for events scoped to one session. */
+export class EventRepository {
+  constructor(
+    private readonly sql: SqlStorage,
+    private readonly transactionSync: TransactionSync
+  ) {}
+
+  createEvent(data: CreateEventData): void {
+    this.sql.exec(
+      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
+       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})`,
+      data.id,
+      data.type,
+      data.data,
+      data.messageId,
+      data.createdAt
+    );
+  }
+
+  createContextCompactionEvent(data: CreateEventData & { messageId: string }): void {
+    this.transactionSync(() => {
+      this.sql.exec(
+        `UPDATE events SET id = ? WHERE id = ?`,
+        `token:${data.messageId}:${data.id}`,
+        `token:${data.messageId}`
+      );
+      this.createEvent(data);
+    });
+  }
+
+  private upsertEventByMessageId<TType extends UpsertableEventType>(
+    type: TType,
+    messageId: string,
+    event: Extract<SandboxEvent, { type: TType }>,
+    createdAt: number
+  ): void {
+    const id = `${type}:${messageId}`;
+    this.sql.exec(
+      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
+       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})
+       ON CONFLICT(id) DO UPDATE SET
+         data = excluded.data,
+         message_id = excluded.message_id,
+         created_at = excluded.created_at`,
+      id,
+      type,
+      JSON.stringify(event),
+      messageId,
+      createdAt
+    );
+  }
+
+  upsertTokenEvent(messageId: string, event: TokenEvent, createdAt: number): void {
+    this.upsertEventByMessageId("token", messageId, event, createdAt);
+  }
+
+  upsertToolCallEvent(messageId: string, event: ToolCallEvent, createdAt: number): void {
+    const id = `tool_call:${toolCallIdentityKey(event)}`;
+    this.sql.exec(
+      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
+       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})
+       ON CONFLICT(id) DO UPDATE SET
+         data = excluded.data,
+         message_id = excluded.message_id`,
+      id,
+      event.type,
+      JSON.stringify(event),
+      messageId,
+      createdAt
+    );
+  }
+
+  upsertExecutionCompleteEvent(
+    messageId: string,
+    event: ExecutionCompleteEvent,
+    createdAt: number
+  ): void {
+    this.upsertEventByMessageId("execution_complete", messageId, event, createdAt);
+  }
+
+  listEventPage(options: ListEventPageOptions): EventPage {
+    return this.queryEventPage(options);
+  }
+
+  getEventTimelinePage(options: ListEventTimelinePageOptions): EventPage {
+    const page = this.queryEventPage(options);
+    return { ...page, events: [...page.events].reverse() };
+  }
+
+  private queryEventPage(options: QueryEventPageOptions): EventPage {
+    let query = `SELECT * FROM events`;
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (options.type) {
+      conditions.push(`type = ?`);
+      params.push(options.type);
+    }
+    if (options.messageId) {
+      conditions.push(`message_id = ?`);
+      params.push(options.messageId);
+    }
+    if (options.excludeTypes?.length) {
+      conditions.push(`type NOT IN (${options.excludeTypes.map(() => "?").join(", ")})`);
+      params.push(...options.excludeTypes);
+    }
+
+    const cursor = options.cursor;
+    if (cursor?.kind === "timeline") {
+      if (cursor.sequence !== undefined) {
+        conditions.push(`((created_at < ?) OR (created_at = ? AND timeline_sequence < ?))`);
+        params.push(cursor.createdAt, cursor.createdAt, cursor.sequence);
+      } else {
+        conditions.push(`((created_at < ?) OR (created_at = ? AND id < ?))`);
+        params.push(cursor.createdAt, cursor.createdAt, cursor.id);
+      }
+    } else if (cursor?.kind === "legacy") {
+      conditions.push(`created_at < ?`);
+      params.push(cursor.createdAt);
+    }
+
+    if (conditions.length > 0) query += ` WHERE ${conditions.join(" AND ")}`;
+
+    const tieBreaker =
+      cursor?.kind === "timeline" && cursor.sequence === undefined ? "id" : "timeline_sequence";
+    query += ` ORDER BY created_at DESC, ${tieBreaker} DESC LIMIT ?`;
+    params.push(options.limit + 1);
+
+    const rows = this.sql.exec(query, ...params).toArray() as EventRow[];
+    const hasMore = rows.length > options.limit;
+    const events = hasMore ? rows.slice(0, options.limit) : rows;
+    const nextCursor = events.length ? eventTimelineCursorFromRow(events[events.length - 1]) : null;
+    return { events, hasMore, nextCursor };
+  }
+}

--- a/packages/control-plane/src/session/event-stream.test.ts
+++ b/packages/control-plane/src/session/event-stream.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  DEFAULT_REPLAY_LIMIT,
-  SessionEventStream,
-  type SessionEventStreamRepository,
-} from "./event-stream";
+import { DEFAULT_REPLAY_LIMIT, SessionEventStream } from "./event-stream";
+import type { EventRepository } from "./event-repository";
 import type { EventRow } from "./types";
 
 function createStream() {
   const repository = {
     getEventTimelinePage: vi.fn(),
     listEventPage: vi.fn(),
-  } as unknown as SessionEventStreamRepository;
+  } as unknown as EventRepository;
 
   return {
     stream: new SessionEventStream(repository),

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -6,7 +6,7 @@ import {
   type EventTimelineCursor,
 } from "./event-cursor";
 import type { EventRow } from "./types";
-import type { SessionRepository } from "./repository";
+import type { EventRepository } from "./event-repository";
 import {
   sessionTimelineEventSchema,
   type ServerMessage,
@@ -27,11 +27,6 @@ export type SessionTimeline = NonNullable<
 >;
 export type SessionHistoryPage = Omit<Extract<ServerMessage, { type: "history_page" }>, "type">;
 
-export type SessionEventStreamRepository = Pick<
-  SessionRepository,
-  "getEventTimelinePage" | "listEventPage"
->;
-
 export interface SessionEventListRequest {
   cursor: EventListCursor | null;
   limit: number;
@@ -40,7 +35,7 @@ export interface SessionEventListRequest {
 }
 
 export class SessionEventStream {
-  constructor(private readonly repository: SessionEventStreamRepository) {}
+  constructor(private readonly repository: EventRepository) {}
 
   getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionTimeline {
     const page = this.repository.getEventTimelinePage({

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../types";
 import type { ArtifactRepository } from "../../artifact-repository";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { EventRepository } from "../../event-repository";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
@@ -169,6 +170,7 @@ function createHandler() {
 
   const handler = createChildSessionsHandler({
     repository,
+    eventRepository: repository as unknown as EventRepository,
     participantRepository: repository as unknown as ParticipantRepository,
     artifactRepository: artifactRepository as unknown as ArtifactRepository,
     getSession,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -10,6 +10,7 @@ import {
 } from "../../message-queue";
 import type { SessionRepository } from "../../repository";
 import type { ArtifactRepository } from "../../artifact-repository";
+import type { EventRepository } from "../../event-repository";
 import type { ParticipantRepository } from "../../participant-repository";
 import type { MessageService } from "../../services/message.service";
 import type { SpawnContext } from "../../spawn-context";
@@ -27,12 +28,9 @@ import {
 export interface ChildSessionsHandlerDeps {
   repository: Pick<
     SessionRepository,
-    | "listEventPage"
-    | "getLatestTerminalMessage"
-    | "getEventTimelinePage"
-    | "getPendingOrProcessingCount"
-    | "getProcessingMessageAuthor"
+    "getLatestTerminalMessage" | "getPendingOrProcessingCount" | "getProcessingMessageAuthor"
   >;
+  eventRepository: EventRepository;
   participantRepository: ParticipantRepository;
   artifactRepository: ArtifactRepository;
   getSession: () => SessionRow | null;
@@ -155,7 +153,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       const options = parsedOptions.options;
       const sandbox = deps.getSandbox();
       const artifacts = deps.artifactRepository.listArtifacts();
-      const recentEventRows = deps.repository.listEventPage({
+      const recentEventRows = deps.eventRepository.listEventPage({
         limit: RECENT_EVENT_FETCH_LIMIT,
       }).events;
       let finalResponse: ChildSummaryFinalResponseInput | undefined;
@@ -164,13 +162,13 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       if (options.includeFinalResponse) {
         const terminalMessage = deps.repository.getLatestTerminalMessage();
         const collectedEvents = terminalMessage
-          ? collectFinalResponseEventRows(deps.repository, terminalMessage.id)
+          ? collectFinalResponseEventRows(deps.eventRepository, terminalMessage.id)
           : { eventRows: [], eventLimitReached: false };
         finalResponse = { message: terminalMessage, ...collectedEvents };
       }
 
       if (options.includeTrajectory) {
-        const page = deps.repository.getEventTimelinePage({
+        const page = deps.eventRepository.getEventTimelinePage({
           limit: options.trajectoryLimit,
           cursor: options.trajectoryCursor ?? undefined,
         });

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -10,6 +10,7 @@ import type { SandboxRow, SessionRow } from "../../types";
 import { createSandboxHandler } from "./sandbox.handler";
 import type { ArtifactRepository } from "../../artifact-repository";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { EventRepository } from "../../event-repository";
 
 function createHandler() {
   const repository = {
@@ -41,6 +42,7 @@ function createHandler() {
 
   const sandboxHandler = createSandboxHandler({
     repository,
+    eventRepository: repository as unknown as EventRepository,
     participantRepository: repository as unknown as ParticipantRepository,
     artifactRepository,
     processSandboxEvent,

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -19,6 +19,7 @@ import type { ScmCredentialsResult } from "../../scm-credentials-service";
 import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
 import type { ArtifactRepository } from "../../artifact-repository";
+import type { EventRepository } from "../../event-repository";
 import type { ParticipantRepository } from "../../participant-repository";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
@@ -36,7 +37,8 @@ const addParticipantRequestSchema = z.object({
 type AddParticipantRequest = z.infer<typeof addParticipantRequestSchema>;
 
 export interface SandboxHandlerDeps {
-  repository: Pick<SessionRepository, "createEvent" | "getProcessingMessage">;
+  repository: Pick<SessionRepository, "getProcessingMessage">;
+  eventRepository: EventRepository;
   participantRepository: ParticipantRepository;
   artifactRepository: ArtifactRepository;
   processSandboxEvent: (event: SandboxEvent) => Promise<void>;
@@ -143,7 +145,7 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         timestamp: timestampSeconds,
       };
 
-      deps.repository.createEvent({
+      deps.eventRepository.createEvent({
         id: deps.generateId(),
         type: event.type,
         data: JSON.stringify(event),

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { SessionRepository } from "./repository";
+import { EventRepository } from "./event-repository";
 import {
   AttachmentClaimConflictError,
   SessionAttachmentRepository,
@@ -82,7 +83,8 @@ describe("SessionRepository", () => {
         transactionSyncCalls += 1;
         return closure();
       },
-      new SessionAttachmentRepository(mock.sql)
+      new SessionAttachmentRepository(mock.sql),
+      new EventRepository(mock.sql, (closure) => closure())
     );
   });
 
@@ -344,7 +346,8 @@ describe("SessionRepository", () => {
           transactions += 1;
           return closure();
         },
-        new SessionAttachmentRepository(mock.sql)
+        new SessionAttachmentRepository(mock.sql),
+        new EventRepository(mock.sql, (closure) => closure())
       );
 
       repo.setSessionDiffBaselines([
@@ -667,7 +670,8 @@ describe("SessionRepository", () => {
           transactions += 1;
           return closure();
         },
-        new SessionAttachmentRepository(mock.sql)
+        new SessionAttachmentRepository(mock.sql),
+        new EventRepository(mock.sql, (closure) => closure())
       );
       mock.setDefaultRowsWritten(2);
 
@@ -905,270 +909,6 @@ describe("SessionRepository", () => {
         "ORDER BY COALESCE(completed_at, started_at, created_at) DESC"
       );
       expect(mock.calls[0].query).toContain("LIMIT 1");
-    });
-  });
-
-  // === EVENTS ===
-
-  describe("createEvent", () => {
-    it("stores event with all fields", () => {
-      repo.createEvent({
-        id: "evt-1",
-        type: "tool_call",
-        data: '{"tool":"read"}',
-        messageId: "msg-1",
-        createdAt: 1000,
-      });
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("INSERT INTO events");
-      expect(mock.calls[0].params).toEqual([
-        "evt-1",
-        "tool_call",
-        '{"tool":"read"}',
-        "msg-1",
-        1000,
-      ]);
-    });
-  });
-
-  describe("upsertTokenEvent", () => {
-    it("upserts token event by deterministic message key", () => {
-      const event = {
-        type: "token" as const,
-        content: "partial response",
-        messageId: "msg-1",
-        sandboxId: "sb-1",
-        timestamp: 1,
-      };
-
-      repo.upsertTokenEvent("msg-1", event, 1000);
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("INSERT INTO events");
-      expect(mock.calls[0].query).toContain("timeline_sequence");
-      expect(mock.calls[0].query).toContain("ON CONFLICT(id) DO UPDATE SET");
-      expect(mock.calls[0].params).toEqual([
-        "token:msg-1",
-        "token",
-        JSON.stringify(event),
-        "msg-1",
-        1000,
-      ]);
-    });
-
-    it("reuses the same deterministic ID across updates", () => {
-      const firstEvent = {
-        type: "token" as const,
-        content: "first",
-        messageId: "msg-1",
-        sandboxId: "sb-1",
-        timestamp: 1,
-      };
-      const secondEvent = {
-        ...firstEvent,
-        content: "second",
-        timestamp: 2,
-      };
-
-      repo.upsertTokenEvent("msg-1", firstEvent, 1000);
-      repo.upsertTokenEvent("msg-1", secondEvent, 2000);
-
-      expect(mock.calls.length).toBe(2);
-      expect(mock.calls[0].params[0]).toBe("token:msg-1");
-      expect(mock.calls[1].params[0]).toBe("token:msg-1");
-      expect(mock.calls[1].params[1]).toBe("token");
-      expect(mock.calls[1].params[2]).toBe(JSON.stringify(secondEvent));
-      expect(mock.calls[1].params[4]).toBe(2000);
-    });
-  });
-
-  describe("createContextCompactionEvent", () => {
-    it("atomically seals the current token and inserts the compaction marker", () => {
-      repo.createContextCompactionEvent({
-        id: "compaction-1",
-        type: "context_compacted",
-        data: '{"type":"context_compacted"}',
-        messageId: "msg-1",
-        createdAt: 1000,
-      });
-
-      expect(transactionSyncCalls).toBe(1);
-      expect(mock.calls).toHaveLength(2);
-      expect(mock.calls[0].query).toContain("UPDATE events SET id = ? WHERE id = ?");
-      expect(mock.calls[0].params).toEqual(["token:msg-1:compaction-1", "token:msg-1"]);
-      expect(mock.calls[1].query).toContain("INSERT INTO events");
-      expect(mock.calls[1].params).toEqual([
-        "compaction-1",
-        "context_compacted",
-        '{"type":"context_compacted"}',
-        "msg-1",
-        1000,
-      ]);
-    });
-  });
-
-  describe("upsertToolCallEvent", () => {
-    it("scopes child call IDs and preserves the first event position on updates", () => {
-      const event = {
-        type: "tool_call" as const,
-        tool: "bash",
-        args: { command: "npm test" },
-        callId: "call-1",
-        status: "running",
-        messageId: "msg-1",
-        sandboxId: "sb-1",
-        timestamp: 1,
-        isSubtask: true,
-        childSessionId: "child-1",
-        taskCallId: "task-1",
-      };
-
-      repo.upsertToolCallEvent("msg-1", event, 1000);
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("ON CONFLICT(id) DO UPDATE SET");
-      expect(mock.calls[0].query).not.toContain("created_at = excluded.created_at");
-      expect(mock.calls[0].params).toEqual([
-        'tool_call:["msg-1","child-1","call-1"]',
-        "tool_call",
-        JSON.stringify(event),
-        "msg-1",
-        1000,
-      ]);
-    });
-
-    it("uses a different identity for a parent call with the same call ID", () => {
-      const event = {
-        type: "tool_call" as const,
-        tool: "bash",
-        args: {},
-        callId: "call-1",
-        messageId: "msg-1",
-        sandboxId: "sb-1",
-        timestamp: 1,
-      };
-
-      repo.upsertToolCallEvent("msg-1", event, 1000);
-
-      expect(mock.calls[0].params[0]).toBe('tool_call:["msg-1","parent","call-1"]');
-    });
-  });
-
-  describe("listEventPage", () => {
-    it("returns in deterministic descending order", () => {
-      repo.listEventPage({ limit: 50 });
-      expect(mock.calls[0].query).toContain("ORDER BY created_at DESC, timeline_sequence DESC");
-    });
-
-    it("filters by type", () => {
-      repo.listEventPage({ limit: 50, type: "tool_call" });
-      expect(mock.calls[0].query).toContain("type = ?");
-      expect(mock.calls[0].params).toContain("tool_call");
-    });
-
-    it("filters by messageId", () => {
-      repo.listEventPage({ limit: 50, messageId: "msg-1" });
-      expect(mock.calls[0].query).toContain("message_id = ?");
-      expect(mock.calls[0].params).toContain("msg-1");
-    });
-
-    it("keeps legacy timestamp cursors for pagination", () => {
-      repo.listEventPage({ limit: 50, cursor: { kind: "legacy", createdAt: 5000 } });
-      expect(mock.calls[0].query).toContain("created_at < ?");
-      expect(mock.calls[0].params).toContain(5000);
-    });
-
-    it("uses composite cursors for stable pagination across tied timestamps", () => {
-      repo.listEventPage({
-        limit: 50,
-        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
-      });
-      expect(mock.calls[0].query).toContain("((created_at < ?) OR (created_at = ? AND id < ?))");
-      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
-    });
-
-    it("returns hasMore and trims overflow", () => {
-      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
-      mock.setData(query, [
-        { id: "e3", created_at: 5000, type: "token", data: "{}" },
-        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
-        { id: "e1", created_at: 3000, type: "token", data: "{}" },
-      ]);
-
-      const result = repo.listEventPage({ limit: 2 });
-
-      expect(result.hasMore).toBe(true);
-      expect(result.events.map((event) => event.id)).toEqual(["e3", "e2"]);
-      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
-    });
-  });
-
-  describe("getEventTimelinePage", () => {
-    it("queries the first timeline page with deterministic descending storage order", () => {
-      repo.getEventTimelinePage({ limit: 50 });
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toBe(
-        "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?"
-      );
-      expect(mock.calls[0].params).toEqual([51]);
-    });
-
-    it("queries timeline pages after a composite cursor", () => {
-      repo.getEventTimelinePage({
-        limit: 50,
-        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
-      });
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toBe(
-        "SELECT * FROM events WHERE ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
-      );
-      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
-    });
-
-    it("can exclude event types while using the same timeline pager", () => {
-      repo.getEventTimelinePage({
-        limit: 50,
-        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
-        excludeTypes: ["heartbeat"],
-      });
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toBe(
-        "SELECT * FROM events WHERE type NOT IN (?) AND ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
-      );
-      expect(mock.calls[0].params).toEqual(["heartbeat", 5000, 5000, "cursor-id", 51]);
-    });
-
-    it("returns hasMore=false when a timeline page fits within the limit", () => {
-      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
-      mock.setData(query, [
-        { id: "e2", created_at: 4000, type: "token", data: "{}" },
-        { id: "e1", created_at: 3000, type: "tool_call", data: "{}" },
-      ]);
-
-      const result = repo.getEventTimelinePage({ limit: 50 });
-
-      expect(result.hasMore).toBe(false);
-      expect(result.events.map((event) => event.id)).toEqual(["e1", "e2"]);
-      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 3000, id: "e1" });
-    });
-
-    it("returns hasMore=true and trims overflow when a timeline page exceeds the limit", () => {
-      const query = "SELECT * FROM events ORDER BY created_at DESC, timeline_sequence DESC LIMIT ?";
-      mock.setData(query, [
-        { id: "e3", created_at: 5000, type: "token", data: "{}" },
-        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
-        { id: "e1", created_at: 3000, type: "token", data: "{}" },
-      ]);
-
-      const result = repo.getEventTimelinePage({ limit: 2 });
-
-      expect(result.hasMore).toBe(true);
-      expect(result.events.map((event) => event.id)).toEqual(["e2", "e3"]);
-      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
     });
   });
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -6,8 +6,7 @@
  * coordinated here when they also create or update core session records.
  */
 
-import type { SessionRow, MessageRow, EventRow, SandboxRow, SessionRepositoryRow } from "./types";
-import { toolCallIdentityKey } from "@open-inspect/shared/types/sandbox-events";
+import type { SessionRow, MessageRow, SandboxRow, SessionRepositoryRow } from "./types";
 import type { GitSyncStatus, SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import type {
   SessionStatus,
@@ -17,20 +16,12 @@ import type {
   SpawnSource,
 } from "@open-inspect/shared/types/sessions";
 import type { PromptQueueItem } from "@open-inspect/shared/types/server-messages";
-import {
-  eventTimelineCursorFromRow,
-  type EventListCursor,
-  type EventTimelineCursor,
-} from "./event-cursor";
+import type { CreateEventData, EventRepository } from "./event-repository";
 import { buildSessionRepositories, type SessionRepositoryEntry } from "./repository-target";
 import type { SessionAttachmentRepository } from "./session-attachment-repository";
 import type { SqlResult, SqlStorage, TransactionSync } from "./sql-storage";
 
-type TokenEvent = Extract<SandboxEvent, { type: "token" }>;
-type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
-type UpsertableEventType = TokenEvent["type"] | ExecutionCompleteEvent["type"];
-const NEXT_TIMELINE_SEQUENCE_SQL = "(SELECT COALESCE(MAX(timeline_sequence), 0) + 1 FROM events)";
 export const STOP_CONFIRMATION_TIMEOUT_MS = 15_000;
 
 /**
@@ -122,45 +113,6 @@ export interface CreateMessageData {
 }
 
 /**
- * Data for creating an event.
- * Note: type is string because sandbox sends additional event types
- * beyond those defined in EventType (e.g., 'heartbeat', 'execution_complete').
- */
-export interface CreateEventData {
-  id: string;
-  type: string;
-  data: string;
-  messageId: string | null;
-  createdAt: number;
-}
-
-/**
- * Options for listing event pages.
- */
-export interface ListEventPageOptions {
-  cursor?: EventListCursor | null;
-  limit: number;
-  type?: string | null;
-  messageId?: string | null;
-}
-
-export interface ListEventTimelinePageOptions {
-  cursor?: EventTimelineCursor | null;
-  excludeTypes?: string[];
-  limit: number;
-}
-
-export interface EventPage {
-  events: EventRow[];
-  hasMore: boolean;
-  nextCursor: EventTimelineCursor | null;
-}
-
-interface QueryEventPageOptions extends ListEventPageOptions {
-  excludeTypes?: string[];
-}
-
-/**
  * Options for listing messages.
  */
 export interface ListMessagesOptions {
@@ -194,7 +146,8 @@ export class SessionRepository {
     private readonly attachments: Pick<
       SessionAttachmentRepository,
       "claimForMessage" | "releaseForMessage"
-    >
+    >,
+    private readonly eventRepository: EventRepository
   ) {}
 
   private rows<T>(result: SqlResult): T[] {
@@ -772,7 +725,7 @@ export class SessionRepository {
     this.transactionSync(() => {
       this.attachments.claimForMessage(data.id, attachmentIds);
       this.createMessage(data);
-      if (event) this.createEvent(event);
+      if (event) this.eventRepository.createEvent(event);
     });
   }
 
@@ -787,7 +740,7 @@ export class SessionRepository {
         startedAt,
         messageId
       );
-      this.createEvent({
+      this.eventRepository.createEvent({
         id: `user_message:${messageId}`,
         type: "user_message",
         data: JSON.stringify(userMessageEvent),
@@ -831,7 +784,7 @@ export class SessionRepository {
         event.success ? null : (event.error ?? null),
         event.messageId
       );
-      this.upsertEventByMessageId("execution_complete", event.messageId, event, completedAt);
+      this.eventRepository.upsertExecutionCompleteEvent(event.messageId, event, completedAt);
 
       return {
         messageId: event.messageId,
@@ -881,137 +834,6 @@ export class SessionRepository {
     );
     const rows = this.rows<MessageRow>(result);
     return rows[0] ?? null;
-  }
-
-  // === EVENTS ===
-
-  createEvent(data: CreateEventData): void {
-    this.sql.exec(
-      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
-       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})`,
-      data.id,
-      data.type,
-      data.data,
-      data.messageId,
-      data.createdAt
-    );
-  }
-
-  createContextCompactionEvent(data: CreateEventData & { messageId: string }): void {
-    this.transactionSync(() => {
-      this.sql.exec(
-        `UPDATE events SET id = ? WHERE id = ?`,
-        `token:${data.messageId}:${data.id}`,
-        `token:${data.messageId}`
-      );
-      this.createEvent(data);
-    });
-  }
-
-  private upsertEventByMessageId<TType extends UpsertableEventType>(
-    type: TType,
-    messageId: string,
-    event: Extract<SandboxEvent, { type: TType }>,
-    createdAt: number
-  ): void {
-    const id = `${type}:${messageId}`;
-    this.sql.exec(
-      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
-       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})
-       ON CONFLICT(id) DO UPDATE SET
-         data = excluded.data,
-         message_id = excluded.message_id,
-         created_at = excluded.created_at`,
-      id,
-      type,
-      JSON.stringify(event),
-      messageId,
-      createdAt
-    );
-  }
-
-  upsertTokenEvent(messageId: string, event: TokenEvent, createdAt: number): void {
-    this.upsertEventByMessageId("token", messageId, event, createdAt);
-  }
-
-  upsertToolCallEvent(messageId: string, event: ToolCallEvent, createdAt: number): void {
-    const id = `tool_call:${toolCallIdentityKey(event)}`;
-    this.sql.exec(
-      `INSERT INTO events (id, type, data, message_id, created_at, timeline_sequence)
-       VALUES (?, ?, ?, ?, ?, ${NEXT_TIMELINE_SEQUENCE_SQL})
-       ON CONFLICT(id) DO UPDATE SET
-         data = excluded.data,
-         message_id = excluded.message_id`,
-      id,
-      event.type,
-      JSON.stringify(event),
-      messageId,
-      createdAt
-    );
-  }
-
-  listEventPage(options: ListEventPageOptions): EventPage {
-    return this.queryEventPage(options);
-  }
-
-  getEventTimelinePage(options: ListEventTimelinePageOptions): EventPage {
-    const page = this.queryEventPage(options);
-    return {
-      ...page,
-      events: [...page.events].reverse(),
-    };
-  }
-
-  private queryEventPage(options: QueryEventPageOptions): EventPage {
-    let query = `SELECT * FROM events`;
-    const conditions: string[] = [];
-    const params: (string | number)[] = [];
-
-    if (options.type) {
-      conditions.push(`type = ?`);
-      params.push(options.type);
-    }
-
-    if (options.messageId) {
-      conditions.push(`message_id = ?`);
-      params.push(options.messageId);
-    }
-
-    if (options.excludeTypes?.length) {
-      conditions.push(`type NOT IN (${options.excludeTypes.map(() => "?").join(", ")})`);
-      params.push(...options.excludeTypes);
-    }
-
-    const cursor = options.cursor;
-    if (cursor?.kind === "timeline") {
-      if (cursor.sequence !== undefined) {
-        conditions.push(`((created_at < ?) OR (created_at = ? AND timeline_sequence < ?))`);
-        params.push(cursor.createdAt, cursor.createdAt, cursor.sequence);
-      } else {
-        conditions.push(`((created_at < ?) OR (created_at = ? AND id < ?))`);
-        params.push(cursor.createdAt, cursor.createdAt, cursor.id);
-      }
-    } else if (cursor?.kind === "legacy") {
-      conditions.push(`created_at < ?`);
-      params.push(cursor.createdAt);
-    }
-
-    if (conditions.length > 0) {
-      query += ` WHERE ${conditions.join(" AND ")}`;
-    }
-
-    const tieBreaker =
-      cursor?.kind === "timeline" && cursor.sequence === undefined ? "id" : "timeline_sequence";
-    query += ` ORDER BY created_at DESC, ${tieBreaker} DESC LIMIT ?`;
-    params.push(options.limit + 1);
-
-    const result = this.sql.exec(query, ...params);
-    const rows = this.rows<EventRow>(result);
-    const hasMore = rows.length > options.limit;
-    const pageEvents = hasMore ? rows.slice(0, options.limit) : rows;
-    const nextCursor =
-      pageEvents.length > 0 ? eventTimelineCursorFromRow(pageEvents[pageEvents.length - 1]) : null;
-    return { events: pageEvents, hasMore, nextCursor };
   }
 
   // === PR HELPERS ===

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -7,6 +7,7 @@ import type { CallbackNotificationService } from "./callback-notification-servic
 import type { SessionDiffService } from "./diffs/service";
 import type { SessionRepository } from "./repository";
 import type { ArtifactRepository } from "./artifact-repository";
+import type { EventRepository } from "./event-repository";
 import type { SessionStatusService } from "./session-status-service";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
@@ -82,6 +83,7 @@ function createProcessor() {
     { waitUntil } as unknown as DurableObjectState,
     () => log,
     repository as unknown as SessionRepository,
+    repository as unknown as EventRepository,
     artifactRepository,
     callbackService as unknown as CallbackNotificationService,
     wsManager as unknown as SessionWebSocketManager,

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -28,10 +28,6 @@ function createProcessor() {
   const repository = {
     updateSandboxHeartbeat: vi.fn(),
     getProcessingMessage,
-    upsertTokenEvent: vi.fn(),
-    createContextCompactionEvent: vi.fn(),
-    upsertToolCallEvent: vi.fn(),
-    createEvent: vi.fn(),
     addSessionCost: vi.fn(),
     recordMessageCompletion: vi.fn((event: { messageId: string }, completedAt: number) => {
       getProcessingMessage.mockReturnValue(null);
@@ -47,6 +43,12 @@ function createProcessor() {
     updateSandboxGitSyncStatus: vi.fn(),
     updateSessionCurrentSha: vi.fn(),
   };
+  const eventRepository = {
+    upsertTokenEvent: vi.fn(),
+    createContextCompactionEvent: vi.fn(),
+    upsertToolCallEvent: vi.fn(),
+    createEvent: vi.fn(),
+  } as unknown as EventRepository;
   const artifactRepository = { createArtifact: vi.fn() } as unknown as ArtifactRepository;
 
   const callbackService = {
@@ -83,7 +85,7 @@ function createProcessor() {
     { waitUntil } as unknown as DurableObjectState,
     () => log,
     repository as unknown as SessionRepository,
-    repository as unknown as EventRepository,
+    eventRepository,
     artifactRepository,
     callbackService as unknown as CallbackNotificationService,
     wsManager as unknown as SessionWebSocketManager,
@@ -103,6 +105,7 @@ function createProcessor() {
     processor,
     artifactRepository,
     repository,
+    eventRepository,
     wsManager,
     callbackService,
     broadcast,
@@ -187,7 +190,7 @@ describe("SessionSandboxEventProcessor", () => {
     expect(h.applySessionTitleUpdate).toHaveBeenCalledWith("Generated title", {
       onlyIfUnset: true,
     });
-    expect(h.repository.createEvent).not.toHaveBeenCalled();
+    expect(h.eventRepository.createEvent).not.toHaveBeenCalled();
     expect(h.broadcast).not.toHaveBeenCalled();
     expect(h.updateLastActivity).not.toHaveBeenCalled();
   });
@@ -217,7 +220,11 @@ describe("SessionSandboxEventProcessor", () => {
 
     await h.processor.processSandboxEvent(event);
 
-    expect(h.repository.upsertTokenEvent).toHaveBeenCalledWith("msg-1", event, expect.any(Number));
+    expect(h.eventRepository.upsertTokenEvent).toHaveBeenCalledWith(
+      "msg-1",
+      event,
+      expect.any(Number)
+    );
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_event", event });
   });
 
@@ -233,15 +240,15 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
     await h.processor.processSandboxEvent({ ...event, timestamp: 1001 });
 
-    expect(h.repository.createContextCompactionEvent).toHaveBeenCalledTimes(2);
-    expect(h.repository.createContextCompactionEvent).toHaveBeenNthCalledWith(1, {
+    expect(h.eventRepository.createContextCompactionEvent).toHaveBeenCalledTimes(2);
+    expect(h.eventRepository.createContextCompactionEvent).toHaveBeenNthCalledWith(1, {
       id: expect.any(String),
       type: "context_compacted",
       data: JSON.stringify(event),
       messageId: "msg-1",
       createdAt: expect.any(Number),
     });
-    expect(h.repository.createContextCompactionEvent).toHaveBeenNthCalledWith(2, {
+    expect(h.eventRepository.createContextCompactionEvent).toHaveBeenNthCalledWith(2, {
       id: expect.any(String),
       type: "context_compacted",
       data: JSON.stringify({ ...event, timestamp: 1001 }),
@@ -285,7 +292,7 @@ describe("SessionSandboxEventProcessor", () => {
       }),
       createdAt: expect.any(Number),
     });
-    expect(h.repository.createEvent).toHaveBeenCalledWith({
+    expect(h.eventRepository.createEvent).toHaveBeenCalledWith({
       id: expect.any(String),
       type: "artifact",
       data: expect.any(String),
@@ -332,7 +339,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
 
     expect(h.repository.addSessionCost).toHaveBeenCalledWith(0.0123, expect.any(Number));
-    expect(h.repository.createEvent).not.toHaveBeenCalled();
+    expect(h.eventRepository.createEvent).not.toHaveBeenCalled();
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_event", event });
   });
 
@@ -349,7 +356,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
 
     expect(h.repository.addSessionCost).not.toHaveBeenCalled();
-    expect(h.repository.createEvent).not.toHaveBeenCalled();
+    expect(h.eventRepository.createEvent).not.toHaveBeenCalled();
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_event", event });
   });
 
@@ -382,7 +389,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
 
     expect(h.repository.addSessionCost).not.toHaveBeenCalled();
-    expect(h.repository.createEvent).not.toHaveBeenCalled();
+    expect(h.eventRepository.createEvent).not.toHaveBeenCalled();
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_event", event });
   });
 
@@ -683,7 +690,7 @@ describe("SessionSandboxEventProcessor", () => {
       });
 
       expect(h.updateLastActivity).toHaveBeenCalledWith(expect.any(Number));
-      expect(h.repository.upsertToolCallEvent).toHaveBeenCalledWith(
+      expect(h.eventRepository.upsertToolCallEvent).toHaveBeenCalledWith(
         "msg-1",
         expect.objectContaining({ callId: "call-1", status: "running" }),
         expect.any(Number)

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -6,6 +6,7 @@ import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
 import { assertArtifactType } from "./artifacts";
 import type { SessionRepository } from "./repository";
 import type { ArtifactRepository } from "./artifact-repository";
+import type { EventRepository } from "./event-repository";
 import type { CallbackNotificationService } from "./callback-notification-service";
 import type { SessionDiffService } from "./diffs/service";
 import type { SessionMessenger } from "./messenger";
@@ -39,6 +40,7 @@ export class SessionSandboxEventProcessor {
     // capturing one by value at construction time.
     private readonly getLog: () => Logger,
     private readonly repository: SessionRepository,
+    private readonly eventRepository: EventRepository,
     private readonly artifactRepository: ArtifactRepository,
     private readonly callbackService: CallbackNotificationService,
     private readonly wsManager: SessionWebSocketManager,
@@ -124,7 +126,7 @@ export class SessionSandboxEventProcessor {
         metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
         createdAt: now,
       });
-      this.repository.createEvent({
+      this.eventRepository.createEvent({
         id: generateId(),
         type: event.type,
         data: JSON.stringify(augmentedEvent),
@@ -139,7 +141,7 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "token") {
       if (messageId) {
-        this.repository.upsertTokenEvent(messageId, event, now);
+        this.eventRepository.upsertTokenEvent(messageId, event, now);
       }
       this.messenger.broadcast({ type: "sandbox_event", event });
       return;
@@ -147,7 +149,7 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "context_compacted") {
       const eventId = generateId();
-      this.repository.createContextCompactionEvent({
+      this.eventRepository.createContextCompactionEvent({
         id: eventId,
         type: event.type,
         data: JSON.stringify(event),
@@ -175,7 +177,7 @@ export class SessionSandboxEventProcessor {
     if (event.type === "tool_call") {
       this.updateLastActivity(now);
       if (messageId) {
-        this.repository.upsertToolCallEvent(messageId, event, now);
+        this.eventRepository.upsertToolCallEvent(messageId, event, now);
       }
       this.messenger.broadcast({ type: "sandbox_event", event });
 
@@ -193,7 +195,7 @@ export class SessionSandboxEventProcessor {
     }
 
     if (event.type === "tool_result") {
-      this.repository.createEvent({
+      this.eventRepository.createEvent({
         id: generateId(),
         type: event.type,
         data: JSON.stringify(event),
@@ -265,7 +267,7 @@ export class SessionSandboxEventProcessor {
       return;
     }
 
-    this.repository.createEvent({
+    this.eventRepository.createEvent({
       id: generateId(),
       type: event.type,
       data: JSON.stringify(event),

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -3,13 +3,16 @@ import type { ArtifactRow, EventRow, MessageRow } from "../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 import type { ArtifactRepository } from "../artifact-repository";
+import type { EventRepository } from "../event-repository";
 import { MessageService } from "./message.service";
 
 function createService() {
   const repository = {
-    listEventPage: vi.fn(),
     listMessages: vi.fn(),
   } as unknown as SessionRepository;
+  const eventRepository = {
+    listEventPage: vi.fn(),
+  } as unknown as EventRepository;
   const artifactRepository = {
     listArtifacts: vi.fn(),
     getArtifactById: vi.fn(),
@@ -25,12 +28,14 @@ function createService() {
   return {
     service: new MessageService({
       repository,
+      eventRepository,
       artifactRepository,
       messageQueue,
       stopExecution,
       parseArtifactMetadata,
     }),
     repository,
+    eventRepository,
     artifactRepository,
     messageQueue,
     stopExecution,
@@ -69,13 +74,13 @@ describe("MessageService", () => {
   });
 
   it("paginates events with hasMore and cursor", () => {
-    const { service, repository } = createService();
+    const { service, eventRepository } = createService();
     const events: EventRow[] = [
       { id: "e3", type: "token", data: "{}", message_id: "m1", created_at: 3000 },
       { id: "e2", type: "token", data: "{}", message_id: "m1", created_at: 2000 },
       { id: "e1", type: "token", data: "{}", message_id: "m1", created_at: 1000 },
     ];
-    vi.mocked(repository.listEventPage).mockReturnValue({
+    vi.mocked(eventRepository.listEventPage).mockReturnValue({
       events: events.slice(0, 2),
       hasMore: true,
       nextCursor: { kind: "timeline", createdAt: 2000, id: "e2" },
@@ -93,7 +98,7 @@ describe("MessageService", () => {
       messageId: "m1",
       createdAt: 3000,
     });
-    expect(repository.listEventPage).toHaveBeenCalledWith({
+    expect(eventRepository.listEventPage).toHaveBeenCalledWith({
       cursor: null,
       limit: 2,
       type: "token",

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -4,6 +4,7 @@ import type { ListEventsResponse } from "@open-inspect/shared/types/sandbox-even
 import type { NormalizedArtifactResponse } from "../artifacts";
 import type { SessionRepository } from "../repository";
 import type { ArtifactRepository } from "../artifact-repository";
+import type { EventRepository } from "../event-repository";
 import type { SessionMessageQueue } from "../message-queue";
 import type { EnqueuePromptRequest } from "../enqueue-prompt-contract";
 import { SessionEventStream, type SessionEventListRequest } from "../event-stream";
@@ -19,6 +20,7 @@ export interface ListMessagesRequest {
 
 interface MessageServiceDeps {
   repository: SessionRepository;
+  eventRepository: EventRepository;
   artifactRepository: ArtifactRepository;
   messageQueue: SessionMessageQueue;
   stopExecution: () => Promise<void>;
@@ -31,7 +33,7 @@ export class MessageService {
   private readonly eventStream: SessionEventStream;
 
   constructor(private readonly deps: MessageServiceDeps) {
-    this.eventStream = new SessionEventStream(deps.repository);
+    this.eventStream = new SessionEventStream(deps.eventRepository);
   }
 
   enqueuePrompt(request: EnqueuePromptRequest): Promise<{ messageId: string; status: "queued" }> {

--- a/packages/control-plane/src/session/stop-execution.test.ts
+++ b/packages/control-plane/src/session/stop-execution.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { SessionRepository } from "./repository";
+import { EventRepository } from "./event-repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
 import type { SqlResult, SqlStorage } from "./sql-storage";
 
@@ -58,7 +59,8 @@ describe("Stop execution - repository interactions", () => {
     repo = new SessionRepository(
       mock.sql,
       (closure) => closure(),
-      new SessionAttachmentRepository(mock.sql)
+      new SessionAttachmentRepository(mock.sql),
+      new EventRepository(mock.sql, (closure) => closure())
     );
   });
 


### PR DESCRIPTION
## Summary

- extract all event-table persistence and event cursor types into `EventRepository`
- wire the focused repository through event streaming, sandbox event processing, API handlers, and child-session summaries
- preserve atomic message/event writes by delegating from existing message transactions to `EventRepository`
- move event repository unit coverage out of `repository.test.ts`

## Verification

- `npm test -w @open-inspect/control-plane` (166 files, 2,559 tests passed)
- `npm run lint -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `npm run test:integration -w @open-inspect/control-plane` (792/793 passed; one existing WebSocket hydration test hit its 5-second timeout)
- isolated retry of the timed-out integration test passed

Closes COL-34.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8597e0bb91f2e4af5d4333d42d40ac24)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated session activity management with event creation, updates, filtering, pagination, and timeline browsing.
  * Improved visibility and handling of context compaction, token usage, tool calls, execution results, sandbox activity, and child-session events.
* **Bug Fixes**
  * Improved consistency and ordering for event updates through atomic processing.
* **Tests**
  * Added comprehensive coverage for event persistence, filtering, cursors, ordering, pagination, and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->