### PR TITLE
Fix first-launch VNC password prompt

### DIFF
--- a/packages/web/src/components/sidebar/vnc-section.test.tsx
+++ b/packages/web/src/components/sidebar/vnc-section.test.tsx
@@ -22,6 +22,22 @@ describe("VncSection", () => {
     );
   });
 
+  it("waits for the password before linking the desktop", () => {
+    const { rerender } = render(
+      <VncSection url="https://desktop.example" password={null} sandboxStatus="ready" />
+    );
+
+    expect(screen.getByText("Desktop unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    rerender(<VncSection url="https://desktop.example" password="secret" sandboxStatus="ready" />);
+
+    expect(screen.getByRole("link", { name: "Open Desktop" })).toHaveAttribute(
+      "href",
+      "https://desktop.example/vnc.html?autoconnect=true&resize=scale#password=secret"
+    );
+  });
+
   it("does not link unsafe URLs or inactive sandboxes", () => {
     const { rerender } = render(
       <VncSection url="javascript:alert(1)" password="secret" sandboxStatus="ready" />

--- a/packages/web/src/lib/urls.test.ts
+++ b/packages/web/src/lib/urls.test.ts
@@ -60,10 +60,9 @@ describe("buildVncUrl", () => {
     );
   });
 
-  it("omits an absent password and rejects unsafe base URLs", () => {
-    expect(buildVncUrl("https://desktop.example", null)).toBe(
-      "https://desktop.example/vnc.html?autoconnect=true&resize=scale"
-    );
+  it("rejects missing passwords and unsafe base URLs", () => {
+    expect(buildVncUrl("https://desktop.example", null)).toBeNull();
+    expect(buildVncUrl("https://desktop.example", "")).toBeNull();
     expect(buildVncUrl("javascript:alert(1)", "secret")).toBeNull();
     expect(buildVncUrl("http://desktop.example", "secret")).toBeNull();
   });

--- a/packages/web/src/lib/urls.ts
+++ b/packages/web/src/lib/urls.ts
@@ -25,14 +25,14 @@ export function buildVncUrl(
   password: string | null | undefined
 ): string | null {
   const safeUrl = getSafeExternalUrl(url);
-  if (!safeUrl) return null;
+  if (!safeUrl || !password) return null;
 
   const parsed = new URL(safeUrl);
   parsed.pathname = `${parsed.pathname.replace(/\/?$/, "/")}vnc.html`;
   parsed.searchParams.set("autoconnect", "true");
   parsed.searchParams.set("resize", "scale");
   parsed.searchParams.delete("password");
-  parsed.hash = password ? new URLSearchParams({ password }).toString() : "";
+  parsed.hash = new URLSearchParams({ password }).toString();
   return parsed.toString();
 }
 


### PR DESCRIPTION
## Summary
- require VNC credentials before rendering an authenticated noVNC URL
- prevent the desktop link from opening while the separately fetched password is still loading
- add regression coverage for the URL helper and delayed-password UI flow

## Testing
- `npm test -w @open-inspect/web -- src/lib/urls.test.ts src/components/sidebar/vnc-section.test.tsx`
- `npm run lint -w @open-inspect/web -- src/lib/urls.ts src/lib/urls.test.ts src/components/sidebar/vnc-section.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- full web suite: 1000 tests passed; one unrelated ESLint-boundary test timed out under suite load and passed when rerun individually

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c5ae4eb0a811a3925df2d163110fb883)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VNC desktop connections now require a password before a connection link is generated.
  * Prevents creation of incomplete noVNC links when the password is missing or empty.
  * VNC desktops are correctly shown as unavailable until the required password is provided.

* **Tests**
  * Added coverage for password-dependent desktop availability and link generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->