### PR TITLE
fix(control-plane): stop unarchivable rows pinning the draft sweep

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -666,8 +666,9 @@ export class SessionIndexStore {
    *
    * `created` is the status a session holds until its first prompt is enqueued,
    * so a row still sitting there long after its last update was abandoned before
-   * any work started. Ordered oldest-first so a backlog drains deterministically
-   * across ticks rather than re-reading the same head each time.
+   * any work started. Ordered oldest-first, which drains a backlog only while
+   * every visited row leaves this set — see `archiveOrphanedDraft` and
+   * `repairStatus` for the two cases where that had to be made true.
    */
   async listAbandonedDraftSessionIds(staleBefore: number, limit: number): Promise<string[]> {
     const result = await this.db
@@ -681,6 +682,46 @@ export class SessionIndexStore {
       .all<{ id: string }>();
 
     return (result.results ?? []).map((row) => row.id);
+  }
+
+  /**
+   * Retire an index row whose Durable Object holds no session at all.
+   *
+   * A 404 from the expiry route is definitive rather than transient: there is no
+   * Durable Object state for this row to diverge from, so the index can be
+   * corrected on its own. Guarded on `created` so a row that acquired a real
+   * session between the sweep's read and this write is left alone.
+   */
+  async archiveOrphanedDraft(id: string): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        "UPDATE sessions SET status = 'archived', updated_at = ? WHERE id = ? AND status = 'created'"
+      )
+      .bind(Date.now(), id)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  /**
+   * Correct a status projection that drifted away from its Durable Object.
+   *
+   * Deliberately not `updateStatus`, which carries an `updated_at` and refuses
+   * writes that would move it backwards. That guard keeps concurrent transitions
+   * ordered, but it silently drops a repair: the Durable Object sends its own
+   * timestamp, which is behind D1's whenever `touchUpdatedAt` has run, so the
+   * write matches no rows and reports success as `false`. A repair asserts
+   * nothing about recency — the Durable Object is simply the authority on its
+   * own status — so only that column is written, leaving `updated_at` to keep
+   * meaning "last real activity".
+   */
+  async repairStatus(id: string, status: SessionStatus): Promise<boolean> {
+    const result = await this.db
+      .prepare("UPDATE sessions SET status = ? WHERE id = ? AND status != ?")
+      .bind(status, id, status)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async touchUpdatedAt(id: string): Promise<boolean> {

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -704,20 +704,20 @@ export class SessionIndexStore {
   }
 
   /**
-   * Correct a status projection that drifted away from its Durable Object.
+   * Correct a draft status projection that drifted away from its Durable Object.
    *
    * Deliberately not `updateStatus`, which carries an `updated_at` and refuses
    * writes that would move it backwards. That guard keeps concurrent transitions
    * ordered, but it silently drops a repair: the Durable Object sends its own
    * timestamp, which is behind D1's whenever `touchUpdatedAt` has run, so the
-   * write matches no rows and reports success as `false`. A repair asserts
-   * nothing about recency — the Durable Object is simply the authority on its
-   * own status — so only that column is written, leaving `updated_at` to keep
-   * meaning "last real activity".
+   * write matches no rows and reports success as `false`. This repair asserts
+   * only the stale shape the draft sweep selected: D1 still says `created`, and
+   * the Durable Object says otherwise. Only that status column is written,
+   * leaving `updated_at` to keep meaning "last real activity".
    */
   async repairStatus(id: string, status: SessionStatus): Promise<boolean> {
     const result = await this.db
-      .prepare("UPDATE sessions SET status = ? WHERE id = ? AND status != ?")
+      .prepare("UPDATE sessions SET status = ? WHERE id = ? AND status = 'created' AND status != ?")
       .bind(status, id, status)
       .run();
 

--- a/packages/control-plane/src/session/abandoned-draft-sweep.test.ts
+++ b/packages/control-plane/src/session/abandoned-draft-sweep.test.ts
@@ -4,7 +4,7 @@ import {
   SessionDraftExpiryClient,
   type AbandonedDraftIndex,
   type DraftExpiryClient,
-  type DraftExpiryOutcome,
+  type DraftSweepOutcome,
 } from "./abandoned-draft-sweep";
 import type { Logger } from "../logger";
 
@@ -20,18 +20,20 @@ function createLog(): Logger {
   } as unknown as Logger;
 }
 
-function createIndex(ids: string[] | Error): AbandonedDraftIndex {
+function createIndex(ids: string[] | Error, archiveError?: Error): AbandonedDraftIndex {
   return {
     listAbandonedDraftSessionIds: vi.fn(async () => {
       if (ids instanceof Error) throw ids;
       return ids;
     }),
+    archiveOrphanedDraft: vi.fn(async () => {
+      if (archiveError) throw archiveError;
+      return true;
+    }),
   };
 }
 
-function createClient(
-  outcomes: Record<string, DraftExpiryOutcome | Error> = {}
-): DraftExpiryClient {
+function createClient(outcomes: Record<string, DraftSweepOutcome | Error> = {}): DraftExpiryClient {
   return {
     expireDraft: vi.fn(async (sessionId: string) => {
       const outcome = outcomes[sessionId] ?? "archived";
@@ -67,6 +69,7 @@ describe("AbandonedDraftSweep", () => {
       archived: 2,
       notDraft: 0,
       hasWork: 0,
+      missing: 0,
       errored: 0,
       truncated: false,
     });
@@ -145,11 +148,104 @@ describe("AbandonedDraftSweep", () => {
       archived: 0,
       notDraft: 0,
       hasWork: 0,
+      missing: 0,
       errored: 0,
       truncated: false,
     });
     expect(client.expireDraft).not.toHaveBeenCalled();
     expect(log.error).toHaveBeenCalled();
+  });
+
+  // The sweep reads its batch oldest-first, so a row that declines without
+  // changing state is selected again on every run and nothing behind it is ever
+  // reached. These cover the two outcomes that used to leave a row untouched.
+  it("archives the index row itself when the durable object holds no session", async () => {
+    const index = createIndex(["orphan"]);
+    const sweep = new AbandonedDraftSweep(
+      index,
+      createClient({ orphan: "missing" }),
+      createLog(),
+      TTL_MS,
+      50
+    );
+
+    const result = await sweep.run(NOW);
+
+    // A 404 proves there is no durable object state to diverge from, so the
+    // index row can be retired directly.
+    expect(index.archiveOrphanedDraft).toHaveBeenCalledWith("orphan");
+    expect(result).toMatchObject({ candidates: 1, missing: 1, archived: 0, errored: 0 });
+  });
+
+  it("counts a failed orphan archive as errored without dropping the batch", async () => {
+    const index = createIndex(["orphan", "healthy"], new Error("d1 write failed"));
+    const sweep = new AbandonedDraftSweep(
+      index,
+      createClient({ orphan: "missing" }),
+      createLog(),
+      TTL_MS,
+      50
+    );
+
+    const result = await sweep.run(NOW);
+
+    expect(result).toMatchObject({ candidates: 2, archived: 1, missing: 0, errored: 1 });
+  });
+
+  it("raises an alarm when a full batch makes no progress at all", async () => {
+    // The signature of a wall: every candidate declined, so the next run reads
+    // exactly the same rows. This is the alert that was missing when the sweep
+    // spun for a day logging `truncated:true` at info.
+    const log = createLog();
+    const sweep = new AbandonedDraftSweep(
+      createIndex(["a", "b"]),
+      createClient({ a: new Error("unreachable"), b: new Error("unreachable") }),
+      log,
+      TTL_MS,
+      2
+    );
+
+    const result = await sweep.run(NOW);
+
+    expect(result).toMatchObject({ truncated: true, errored: 2 });
+    expect(log.error).toHaveBeenCalledWith(
+      "Abandoned draft sweep made no progress",
+      expect.objectContaining({ event: "scheduler.abandoned_draft_sweep_stalled" })
+    );
+  });
+
+  it("stays quiet when a full batch was repaired rather than archived", async () => {
+    // `not_draft` and `has_work` archive nothing, but both now leave `created`
+    // behind, so the next run reads different rows. That is progress, not a wall.
+    const log = createLog();
+    const sweep = new AbandonedDraftSweep(
+      createIndex(["a", "b"]),
+      createClient({ a: "not_draft", b: "has_work" }),
+      log,
+      TTL_MS,
+      2
+    );
+
+    const result = await sweep.run(NOW);
+
+    expect(result).toMatchObject({ truncated: true, archived: 0, notDraft: 1, hasWork: 1 });
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when a partial batch fails, since nothing is being starved", async () => {
+    const log = createLog();
+    const sweep = new AbandonedDraftSweep(
+      createIndex(["a"]),
+      createClient({ a: new Error("unreachable") }),
+      log,
+      TTL_MS,
+      50
+    );
+
+    const result = await sweep.run(NOW);
+
+    expect(result).toMatchObject({ truncated: false, errored: 1 });
+    expect(log.error).not.toHaveBeenCalled();
   });
 });
 
@@ -204,5 +300,16 @@ describe("SessionDraftExpiryClient", () => {
     );
 
     await expect(client.expireDraft("session-1")).rejects.toThrow(/status 500/);
+  });
+
+  it("reports a missing session rather than throwing, so the sweep can retire it", async () => {
+    // 404 is a definitive answer, not a transient failure: the durable object
+    // has no session at all. Throwing made it indistinguishable from an outage,
+    // and the row was left to be re-read on every subsequent sweep.
+    const client = new SessionDraftExpiryClient(
+      createSessions(Response.json({ error: "Session not found" }, { status: 404 }))
+    );
+
+    await expect(client.expireDraft("session-1")).resolves.toBe("missing");
   });
 });

--- a/packages/control-plane/src/session/abandoned-draft-sweep.ts
+++ b/packages/control-plane/src/session/abandoned-draft-sweep.ts
@@ -49,16 +49,24 @@ export const ABANDONED_DRAFT_EXPIRY_TIMEOUT_MS = 10_000;
 export const draftExpiryOutcomeSchema = z.enum(["archived", "not_draft", "has_work"]);
 export type DraftExpiryOutcome = z.infer<typeof draftExpiryOutcomeSchema>;
 
+/**
+ * What the sweep saw for one candidate. `missing` is not one of the protocol
+ * outcomes above: the Durable Object answered 404, so no session exists behind
+ * the index row at all.
+ */
+export type DraftSweepOutcome = DraftExpiryOutcome | "missing";
+
 const draftExpiryResponseSchema = z.object({ outcome: draftExpiryOutcomeSchema });
 
-/** The index read the sweep needs; `SessionIndexStore` satisfies it. */
+/** The index access the sweep needs; `SessionIndexStore` satisfies it. */
 export interface AbandonedDraftIndex {
   listAbandonedDraftSessionIds(staleBefore: number, limit: number): Promise<string[]>;
+  archiveOrphanedDraft(id: string): Promise<boolean>;
 }
 
 /** Asks one session to retire itself. */
 export interface DraftExpiryClient {
-  expireDraft(sessionId: string): Promise<DraftExpiryOutcome>;
+  expireDraft(sessionId: string): Promise<DraftSweepOutcome>;
 }
 
 /**
@@ -76,6 +84,8 @@ export interface AbandonedDraftSweepResult {
   notDraft: number;
   /** Session still `created` but holds messages — a prompt that never dispatched. */
   hasWork: number;
+  /** Index row with no Durable Object session behind it; retired in the index. */
+  missing: number;
   errored: number;
   /** The query is capped, so a full batch means more remain for the next sweep. */
   truncated: boolean;
@@ -85,12 +95,18 @@ export interface AbandonedDraftSweepResult {
 export class SessionDraftExpiryClient implements DraftExpiryClient {
   constructor(private readonly sessions: DurableObjectNamespace) {}
 
-  async expireDraft(sessionId: string): Promise<DraftExpiryOutcome> {
+  async expireDraft(sessionId: string): Promise<DraftSweepOutcome> {
     const stub = this.sessions.get(this.sessions.idFromName(sessionId));
     const response = await stub.fetch(buildSessionInternalUrl(SessionInternalPaths.expireDraft), {
       method: "POST",
       signal: AbortSignal.timeout(ABANDONED_DRAFT_EXPIRY_TIMEOUT_MS),
     });
+
+    // Reported rather than thrown: a 404 is a definitive answer about this row,
+    // so the sweep can retire it, where an error would have it retried forever.
+    if (response.status === 404) {
+      return "missing";
+    }
 
     if (!response.ok) {
       throw new Error(`Draft expiry failed with status ${response.status}`);
@@ -118,6 +134,11 @@ export class AbandonedDraftSweep {
    * Candidates come from the index, which may have been read before a prompt
    * arrived, so each session re-checks the invariant inside its own Durable
    * Object before transitioning.
+   *
+   * The batch is read oldest-first, which only drains while every visited row
+   * leaves the candidate set. Each outcome is therefore a state change: expired
+   * and repaired sessions leave `created` in the Durable Object, and a session
+   * that turns out not to exist is retired in the index here.
    */
   async run(now: number): Promise<AbandonedDraftSweepResult> {
     const empty: AbandonedDraftSweepResult = {
@@ -125,6 +146,7 @@ export class AbandonedDraftSweep {
       archived: 0,
       notDraft: 0,
       hasWork: 0,
+      missing: 0,
       errored: 0,
       truncated: false,
     };
@@ -143,7 +165,7 @@ export class AbandonedDraftSweep {
     if (candidates.length === 0) return empty;
 
     const outcomes = await Promise.allSettled(
-      candidates.map((sessionId) => this.client.expireDraft(sessionId))
+      candidates.map((sessionId) => this.expireOne(sessionId))
     );
 
     const result: AbandonedDraftSweepResult = {
@@ -151,6 +173,7 @@ export class AbandonedDraftSweep {
       archived: 0,
       notDraft: 0,
       hasWork: 0,
+      missing: 0,
       errored: 0,
       truncated: candidates.length === this.limit,
     };
@@ -167,23 +190,50 @@ export class AbandonedDraftSweep {
         result.archived += 1;
       } else if (outcome.value === "not_draft") {
         result.notDraft += 1;
-      } else {
+      } else if (outcome.value === "has_work") {
         result.hasWork += 1;
+      } else {
+        result.missing += 1;
       }
     }
 
     // Serialized field by field rather than spread: log fields are snake_case
-    // here, and these two share their names with the protocol outcomes.
+    // here, and several share their names with the protocol outcomes.
     this.log.info("Abandoned draft sweep completed", {
       event: "scheduler.abandoned_draft_sweep",
       candidates: result.candidates,
       archived: result.archived,
       not_draft: result.notDraft,
       has_work: result.hasWork,
+      missing: result.missing,
       errored: result.errored,
       truncated: result.truncated,
     });
 
+    // Only a failure leaves a row in place, so a full batch where nothing else
+    // happened means the next run reads exactly these rows again. Raised loudly
+    // because the symptom is otherwise indistinguishable from routine work: the
+    // sweep spun on the same 50 rows for a day logging `truncated` at info.
+    if (result.truncated && result.candidates === result.errored) {
+      this.log.error("Abandoned draft sweep made no progress", {
+        event: "scheduler.abandoned_draft_sweep_stalled",
+        candidates: result.candidates,
+        errored: result.errored,
+      });
+    }
+
     return result;
+  }
+
+  /**
+   * A missing session is retired here rather than by its Durable Object: there
+   * is no Durable Object to do it, which is exactly what the 404 established.
+   */
+  private async expireOne(sessionId: string): Promise<DraftSweepOutcome> {
+    const outcome = await this.client.expireDraft(sessionId);
+    if (outcome === "missing") {
+      await this.index.archiveOrphanedDraft(sessionId);
+    }
+    return outcome;
   }
 }

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -113,7 +113,12 @@ function createHandler() {
   const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const transition = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
   const repairIndexStatus = vi.fn<() => Promise<void>>();
-  const statusService = { transition, repairIndexStatus } as unknown as SessionStatusService;
+  const settleFromMessageState = vi.fn<() => Promise<SessionRow["status"]>>();
+  const statusService = {
+    transition,
+    repairIndexStatus,
+    settleFromMessageState,
+  } as unknown as SessionStatusService;
   const applySessionTitleUpdate = vi.fn((title: string) => ({ ok: true as const, title }));
   const cancelSession = vi.fn();
   const getSandboxSocket = vi.fn<() => WebSocket | null>();
@@ -168,6 +173,7 @@ function createHandler() {
     getParticipantByUserId,
     transition,
     repairIndexStatus,
+    settleFromMessageState,
     applySessionTitleUpdate,
     cancelSession,
     getSandboxSocket,
@@ -875,28 +881,31 @@ describe("createSessionLifecycleHandler", () => {
   // pin the head of the sweep's oldest-first batch forever, so the invariant
   // under test is that every one of these branches leaves `created` behind.
   it("settles a draft that still holds queued work", async () => {
-    const { handler, getSession, repository, transition } = createHandler();
+    const { handler, getSession, repository, transition, settleFromMessageState } = createHandler();
     getSession.mockReturnValue(createSession({ status: "created" }));
     repository.getPendingOrProcessingCount.mockReturnValue(1);
+    settleFromMessageState.mockResolvedValue("active");
 
     const response = await handler.expireDraft();
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ outcome: "has_work", status: "active" });
-    expect(transition).toHaveBeenCalledWith("active");
+    expect(settleFromMessageState).toHaveBeenCalled();
+    expect(transition).not.toHaveBeenCalledWith("archived");
   });
 
-  it("settles a draft whose messages have all finished", async () => {
-    const { handler, getSession, repository, transition } = createHandler();
+  it("settles a draft whose latest terminal message failed", async () => {
+    const { handler, getSession, repository, settleFromMessageState } = createHandler();
     getSession.mockReturnValue(createSession({ status: "created" }));
     repository.getMessageCount.mockReturnValue(2);
     repository.getPendingOrProcessingCount.mockReturnValue(0);
+    settleFromMessageState.mockResolvedValue("failed");
 
     const response = await handler.expireDraft();
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ outcome: "has_work", status: "completed" });
-    expect(transition).toHaveBeenCalledWith("completed");
+    expect(await response.json()).toEqual({ outcome: "has_work", status: "failed" });
+    expect(settleFromMessageState).toHaveBeenCalled();
   });
 
   it("never archives a draft that holds work", async () => {
@@ -909,6 +918,14 @@ describe("createSessionLifecycleHandler", () => {
     await handler.expireDraft();
 
     expect(transition).not.toHaveBeenCalledWith("archived");
+  });
+
+  it("reports failure when stale index repair fails", async () => {
+    const { handler, getSession, repairIndexStatus } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "archived" }));
+    repairIndexStatus.mockRejectedValue(new Error("d1 down"));
+
+    await expect(handler.expireDraft()).rejects.toThrow(/d1 down/);
   });
 
   it("does not expire a session that has left the draft status", async () => {

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -112,7 +112,8 @@ function createHandler() {
   const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
   const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const transition = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
-  const statusService = { transition } as unknown as SessionStatusService;
+  const repairIndexStatus = vi.fn<() => Promise<void>>();
+  const statusService = { transition, repairIndexStatus } as unknown as SessionStatusService;
   const applySessionTitleUpdate = vi.fn((title: string) => ({ ok: true as const, title }));
   const cancelSession = vi.fn();
   const getSandboxSocket = vi.fn<() => WebSocket | null>();
@@ -166,6 +167,7 @@ function createHandler() {
     getPublicSessionId,
     getParticipantByUserId,
     transition,
+    repairIndexStatus,
     applySessionTitleUpdate,
     cancelSession,
     getSandboxSocket,
@@ -867,19 +869,12 @@ describe("createSessionLifecycleHandler", () => {
     expect(transition).toHaveBeenCalledWith("archived");
   });
 
-  it("leaves a draft alone once it has a message", async () => {
-    const { handler, getSession, repository, transition } = createHandler();
-    getSession.mockReturnValue(createSession({ status: "created" }));
-    repository.getMessageCount.mockReturnValue(1);
-
-    const response = await handler.expireDraft();
-
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ outcome: "has_work", status: "created" });
-    expect(transition).not.toHaveBeenCalled();
-  });
-
-  it("leaves a draft alone once work is queued", async () => {
+  // `created` with messages is unreachable under current code: enqueuePromptCore
+  // inserts the message and transitions to `active` in the same durable object
+  // turn. Returning the session unchanged is what let legacy rows in that shape
+  // pin the head of the sweep's oldest-first batch forever, so the invariant
+  // under test is that every one of these branches leaves `created` behind.
+  it("settles a draft that still holds queued work", async () => {
     const { handler, getSession, repository, transition } = createHandler();
     getSession.mockReturnValue(createSession({ status: "created" }));
     repository.getPendingOrProcessingCount.mockReturnValue(1);
@@ -887,8 +882,33 @@ describe("createSessionLifecycleHandler", () => {
     const response = await handler.expireDraft();
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ outcome: "has_work", status: "created" });
-    expect(transition).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ outcome: "has_work", status: "active" });
+    expect(transition).toHaveBeenCalledWith("active");
+  });
+
+  it("settles a draft whose messages have all finished", async () => {
+    const { handler, getSession, repository, transition } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "created" }));
+    repository.getMessageCount.mockReturnValue(2);
+    repository.getPendingOrProcessingCount.mockReturnValue(0);
+
+    const response = await handler.expireDraft();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcome: "has_work", status: "completed" });
+    expect(transition).toHaveBeenCalledWith("completed");
+  });
+
+  it("never archives a draft that holds work", async () => {
+    // Archiving would discard a real queued request, and `archived` is not
+    // promptable, so the request could not even be resumed afterwards.
+    const { handler, getSession, repository, transition } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "created" }));
+    repository.getPendingOrProcessingCount.mockReturnValue(1);
+
+    await handler.expireDraft();
+
+    expect(transition).not.toHaveBeenCalledWith("archived");
   });
 
   it("does not expire a session that has left the draft status", async () => {
@@ -902,17 +922,20 @@ describe("createSessionLifecycleHandler", () => {
     expect(transition).not.toHaveBeenCalledWith("archived");
   });
 
-  it("repairs a stale index rather than re-selecting the session forever", async () => {
+  it("repairs a stale index without claiming new activity", async () => {
     // A session reaches this branch when the index still reads `created` while
-    // the durable object has moved on — the shape left behind by a swallowed D1
-    // projection failure. Re-projecting is what stops the sweep looping on it.
-    const { handler, getSession, transition } = createHandler();
+    // the durable object has moved on. Repairing through `transition` would send
+    // the durable object's own `updated_at`, which the index rejects whenever D1
+    // is the newer of the two — a silent no-op that leaves the row selectable
+    // forever. The repair projects status alone instead.
+    const { handler, getSession, transition, repairIndexStatus } = createHandler();
     getSession.mockReturnValue(createSession({ status: "archived" }));
 
     const response = await handler.expireDraft();
 
     expect(await response.json()).toEqual({ outcome: "not_draft", status: "archived" });
-    expect(transition).toHaveBeenCalledWith("archived");
+    expect(repairIndexStatus).toHaveBeenCalled();
+    expect(transition).not.toHaveBeenCalled();
   });
 
   it("returns 404 when expiring a missing session", async () => {

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -456,17 +456,27 @@ export function createSessionLifecycleHandler(
         // Reaching here means the index still reads `created` while this session
         // has moved on — which is exactly what happens when an earlier
         // transition's D1 projection failed (they are logged and swallowed).
-        // Re-projecting the current status repairs the mirror, so the row stops
-        // being selected instead of being retried every sweep forever.
-        await deps.statusService.transition(session.status);
+        // Repairing the mirror is what stops the row being selected instead of
+        // being retried every sweep forever.
+        await deps.statusService.repairIndexStatus();
         return Response.json({ outcome: "not_draft", status: session.status });
       }
 
-      if (
-        deps.messageRepository.getMessageCount() > 0 ||
-        deps.messageRepository.getPendingOrProcessingCount() > 0
-      )
-        return Response.json({ outcome: "has_work", status: session.status });
+      const pendingOrProcessing = deps.messageRepository.getPendingOrProcessingCount();
+      if (pendingOrProcessing > 0 || deps.messageRepository.getMessageCount() > 0) {
+        // A session holding messages while still `created` is a broken aggregate:
+        // enqueueing a prompt inserts the message and transitions to `active` in
+        // the same Durable Object turn, so current code cannot produce this. It
+        // survives only on rows predating that guarantee, and answering without
+        // changing anything is what let them pin the head of the sweep's
+        // oldest-first batch forever. Settle the status to what the messages say
+        // instead. A queued prompt is left for the dispatch timeout rather than
+        // archived: archiving discards a real request, and `archived` is not
+        // promptable, so the author could not resume it either.
+        const settled: SessionStatus = pendingOrProcessing > 0 ? "active" : "completed";
+        await deps.statusService.transition(settled);
+        return Response.json({ outcome: "has_work", status: settled });
+      }
 
       await deps.statusService.transition("archived");
 

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -462,8 +462,10 @@ export function createSessionLifecycleHandler(
         return Response.json({ outcome: "not_draft", status: session.status });
       }
 
-      const pendingOrProcessing = deps.messageRepository.getPendingOrProcessingCount();
-      if (pendingOrProcessing > 0 || deps.messageRepository.getMessageCount() > 0) {
+      if (
+        deps.messageRepository.getPendingOrProcessingCount() > 0 ||
+        deps.messageRepository.getMessageCount() > 0
+      ) {
         // A session holding messages while still `created` is a broken aggregate:
         // enqueueing a prompt inserts the message and transitions to `active` in
         // the same Durable Object turn, so current code cannot produce this. It
@@ -473,8 +475,7 @@ export function createSessionLifecycleHandler(
         // instead. A queued prompt is left for the dispatch timeout rather than
         // archived: archiving discards a real request, and `archived` is not
         // promptable, so the author could not resume it either.
-        const settled: SessionStatus = pendingOrProcessing > 0 ? "active" : "completed";
-        await deps.statusService.transition(settled);
+        const settled = await deps.statusService.settleFromMessageState();
         return Response.json({ outcome: "has_work", status: settled });
       }
 

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -64,6 +64,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
       ? null
       : {
           updateStatus: vi.fn(async () => true),
+          repairStatus: vi.fn(async () => true),
           finalizeChildAdmission: vi.fn(async () => {}),
           updateMetrics: vi.fn(async () => true),
         };
@@ -330,6 +331,61 @@ describe("SessionStatusService.reconcileAfterQueueRemoval", () => {
     await h.service.reconcileAfterQueueRemoval();
 
     expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionStatusService.repairIndexStatus", () => {
+  it("repairs a stale created index row", async () => {
+    const h = harness({ session: createSession({ status: "completed" }) });
+
+    await h.service.repairIndexStatus();
+
+    expect(h.sessionIndex!.repairStatus).toHaveBeenCalledWith("public-session-1", "completed");
+  });
+
+  it("logs and propagates repair failures", async () => {
+    const h = harness({ session: createSession({ status: "completed" }) });
+    const error = new Error("d1 down");
+    h.sessionIndex!.repairStatus.mockRejectedValue(error);
+
+    await expect(h.service.repairIndexStatus()).rejects.toThrow(error);
+
+    expect(h.log.error).toHaveBeenCalledWith(
+      "session_index.update_status.background_error",
+      expect.objectContaining({
+        session_id: "public-session-1",
+        status: "completed",
+        error,
+      })
+    );
+  });
+});
+
+describe("SessionStatusService.settleFromMessageState", () => {
+  it("activates when work is pending", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+    h.repository.getPendingOrProcessingCount.mockReturnValue(1);
+
+    await expect(h.service.settleFromMessageState()).resolves.toBe("active");
+
+    expect(h.repository.updateSessionStatus).toHaveBeenCalledWith(
+      "session-1",
+      "active",
+      expect.any(Number)
+    );
+  });
+
+  it("preserves failed as the latest terminal outcome", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+    h.repository.getLatestTerminalMessage.mockReturnValue({ status: "failed" } as MessageRow);
+
+    await expect(h.service.settleFromMessageState()).resolves.toBe("failed");
+
+    expect(h.repository.updateSessionStatus).toHaveBeenCalledWith(
+      "session-1",
+      "failed",
+      expect.any(Number)
+    );
   });
 });
 

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -88,7 +88,7 @@ export class SessionStatusService {
           session.updated_at,
           error
         );
-        return false;
+        throw error;
       });
 
     if (repaired && session.status === "active") {
@@ -147,13 +147,22 @@ export class SessionStatusService {
 
   async reconcileAfterQueueRemoval(): Promise<void> {
     if (this.messageRepository.getPendingOrProcessingCount() > 0) return;
-    const latestMessage = this.messageRepository.getLatestTerminalMessage();
-    const nextStatus: SessionStatus = latestMessage
-      ? latestMessage.status === "failed"
-        ? "failed"
-        : "completed"
-      : "created";
+    const nextStatus = this.getIdleStatusFromTerminalMessages();
     await this.transition(nextStatus);
+  }
+
+  async settleFromMessageState(): Promise<SessionStatus> {
+    const nextStatus: SessionStatus =
+      this.messageRepository.getPendingOrProcessingCount() > 0
+        ? "active"
+        : this.getIdleStatusFromTerminalMessages();
+    await this.transition(nextStatus);
+    return nextStatus;
+  }
+
+  private getIdleStatusFromTerminalMessages(): SessionStatus {
+    const latestMessage = this.messageRepository.getLatestTerminalMessage();
+    return latestMessage ? (latestMessage.status === "failed" ? "failed" : "completed") : "created";
   }
 
   /**

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -66,6 +66,37 @@ export class SessionStatusService {
   }
 
   /**
+   * Re-project this session's current status onto the index, for callers that
+   * already know the two disagree.
+   *
+   * A swallowed projection failure leaves D1 behind, and the stale row keeps
+   * being picked up by anything that scans on status. Unlike `transition`, this
+   * claims no new activity: the session did not do anything, its mirror was
+   * simply wrong, so `updated_at` is left alone.
+   */
+  async repairIndexStatus(): Promise<void> {
+    const session = this.repository.getSession();
+    if (!session || !this.sessionIndex) return;
+
+    const publicSessionId = this.getPublicSessionId(session);
+    const repaired = await this.sessionIndex
+      .repairStatus(publicSessionId, session.status)
+      .catch((error) => {
+        this.logSessionIndexStatusSyncError(
+          publicSessionId,
+          session.status,
+          session.updated_at,
+          error
+        );
+        return false;
+      });
+
+    if (repaired && session.status === "active") {
+      await this.sessionIndex.finalizeChildAdmission(publicSessionId);
+    }
+  }
+
+  /**
    * Atomically close the local aggregate before publishing cancellation.
    * The callback must be synchronous: no request may observe cancelled status
    * with unfinished messages, or accept work between those two mutations.

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -849,5 +849,92 @@ describe("D1 SessionIndexStore", () => {
 
       expect(ids).toEqual(["oldest", "middle"]);
     });
+
+    it("archives an orphaned draft so the batch advances past it", async () => {
+      // The end-to-end shape of the head-of-line bug. Reading oldest-first is
+      // only correct if a visited row leaves the candidate set; a row that could
+      // never be expired used to hold the head and starve everything behind it.
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+      const cutoff = now - 24 * HOUR_MS;
+
+      await seedSession(store, "orphan", "created", now - 72 * HOUR_MS);
+      await seedSession(store, "behind-it", "created", now - 48 * HOUR_MS);
+      expect(await store.listAbandonedDraftSessionIds(cutoff, 1)).toEqual(["orphan"]);
+
+      expect(await store.archiveOrphanedDraft("orphan")).toBe(true);
+
+      expect((await store.get("orphan"))!.status).toBe("archived");
+      expect(await store.listAbandonedDraftSessionIds(cutoff, 1)).toEqual(["behind-it"]);
+    });
+
+    it("refuses to archive a row that has left the draft status", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await seedSession(store, "started", "active", now - 48 * HOUR_MS);
+
+      expect(await store.archiveOrphanedDraft("started")).toBe(false);
+      expect((await store.get("started"))!.status).toBe("active");
+    });
+  });
+
+  describe("repairStatus", () => {
+    const HOUR_MS = 60 * 60 * 1000;
+
+    async function seedDraft(store: SessionIndexStore, id: string, updatedAt: number) {
+      await store.create({
+        id,
+        title: id,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        createdAt: updatedAt,
+        updatedAt,
+      });
+    }
+
+    it("projects a diverged status without claiming new activity", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const updatedAt = Date.now() - 48 * HOUR_MS;
+      await seedDraft(store, "diverged", updatedAt);
+
+      expect(await store.repairStatus("diverged", "completed")).toBe(true);
+
+      const session = await store.get("diverged");
+      expect(session!.status).toBe("completed");
+      // `updated_at` is user-visible recency, maintained by touchUpdatedAt on
+      // real activity. A repair is bookkeeping, so it must not reorder the list.
+      expect(session!.updatedAt).toBe(updatedAt);
+    });
+
+    it("lands even when the index is newer than the durable object", async () => {
+      // The regression this method exists for. updateStatus guards on
+      // `updated_at <= ?` to keep out-of-order async writes from winning, but a
+      // repair carries the durable object's own timestamp — which is older than
+      // D1 whenever touchUpdatedAt has run. The guard then drops the write and
+      // reports zero changes, leaving the row selectable forever.
+      const store = new SessionIndexStore(env.DB);
+      const durableObjectUpdatedAt = Date.now() - 48 * HOUR_MS;
+      await seedDraft(store, "index-ahead", durableObjectUpdatedAt);
+      await store.touchUpdatedAt("index-ahead");
+
+      expect(await store.updateStatus("index-ahead", "completed", durableObjectUpdatedAt)).toBe(
+        false
+      );
+
+      expect(await store.repairStatus("index-ahead", "completed")).toBe(true);
+      expect((await store.get("index-ahead"))!.status).toBe("completed");
+    });
+
+    it("reports no change when the index already agrees", async () => {
+      const store = new SessionIndexStore(env.DB);
+      await seedDraft(store, "agreed", Date.now() - 48 * HOUR_MS);
+
+      expect(await store.repairStatus("agreed", "created")).toBe(false);
+    });
   });
 });

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -936,5 +936,14 @@ describe("D1 SessionIndexStore", () => {
 
       expect(await store.repairStatus("agreed", "created")).toBe(false);
     });
+
+    it("does not overwrite a newer non-draft projection", async () => {
+      const store = new SessionIndexStore(env.DB);
+      await seedDraft(store, "advanced", Date.now() - 48 * HOUR_MS);
+      expect(await store.updateStatus("advanced", "active", Date.now())).toBe(true);
+
+      expect(await store.repairStatus("advanced", "completed")).toBe(false);
+      expect((await store.get("advanced"))!.status).toBe("active");
+    });
   });
 });

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -432,7 +432,7 @@ describe("DO internal sub-session routes", () => {
     async function seedMessage(
       stub: DurableObjectStub,
       id: string,
-      status: "pending" | "completed"
+      status: "pending" | "completed" | "failed"
     ): Promise<void> {
       const [{ id: participantId }] = await queryDO<{ id: string }>(
         stub,
@@ -478,6 +478,18 @@ describe("DO internal sub-session routes", () => {
       expect(await res.json()).toEqual({ outcome: "has_work", status: "completed" });
       const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1");
       expect(rows[0].status).toBe("completed");
+    });
+
+    it("settles a draft whose latest terminal message failed", async () => {
+      const { stub } = await initSession();
+      await seedMessage(stub, "msg-draft-4", "failed");
+
+      const res = await stub.fetch("http://internal/internal/expire-draft", { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ outcome: "has_work", status: "failed" });
+      const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1");
+      expect(rows[0].status).toBe("failed");
     });
 
     it("never archives a draft that holds work", async () => {

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -429,8 +429,11 @@ describe("DO internal sub-session routes", () => {
       expect(rows[0].status).toBe("active");
     });
 
-    it("spares a draft that has a message queued", async () => {
-      const { stub } = await initSession();
+    async function seedMessage(
+      stub: DurableObjectStub,
+      id: string,
+      status: "pending" | "completed"
+    ): Promise<void> {
       const [{ id: participantId }] = await queryDO<{ id: string }>(
         stub,
         "SELECT id FROM participants LIMIT 1"
@@ -439,20 +442,54 @@ describe("DO internal sub-session routes", () => {
         stub,
         `INSERT INTO messages (id, author_id, content, source, status, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        "msg-draft-1",
+        id,
         participantId,
         "Ship it",
         "web",
-        "pending",
+        status,
         100
       );
+    }
+
+    // Holding messages while still `created` is a broken aggregate — enqueueing
+    // inserts the message and transitions in one turn — so the session settles
+    // to what its messages say. Leaving `created` behind is the whole point: the
+    // sweep reads oldest-first, so a row that answers without changing anything
+    // is re-read every run and starves everything queued behind it.
+    it("settles a draft that has a message queued", async () => {
+      const { stub } = await initSession();
+      await seedMessage(stub, "msg-draft-1", "pending");
 
       const res = await stub.fetch("http://internal/internal/expire-draft", { method: "POST" });
 
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ outcome: "has_work", status: "created" });
+      expect(await res.json()).toEqual({ outcome: "has_work", status: "active" });
       const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1");
-      expect(rows[0].status).toBe("created");
+      expect(rows[0].status).toBe("active");
+    });
+
+    it("settles a draft whose messages have all finished", async () => {
+      const { stub } = await initSession();
+      await seedMessage(stub, "msg-draft-2", "completed");
+
+      const res = await stub.fetch("http://internal/internal/expire-draft", { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ outcome: "has_work", status: "completed" });
+      const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1");
+      expect(rows[0].status).toBe("completed");
+    });
+
+    it("never archives a draft that holds work", async () => {
+      // Archiving would discard a real queued request, and `archived` is not
+      // promptable, so the author could not resume it either.
+      const { stub } = await initSession();
+      await seedMessage(stub, "msg-draft-3", "pending");
+
+      await stub.fetch("http://internal/internal/expire-draft", { method: "POST" });
+
+      const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM session LIMIT 1");
+      expect(rows[0].status).not.toBe("archived");
     });
 
     it("is idempotent across repeated sweeps", async () => {


### PR DESCRIPTION
Follow-up to #1420 and #1425. The abandoned draft sweep has archived **zero**
rows in production since it shipped, while 266 sessions sat at `created`.

## What was happening

`listAbandonedDraftSessionIds` reads its batch oldest-first:

```sql
SELECT id FROM sessions
WHERE status = 'created' AND updated_at < ?
ORDER BY updated_at ASC LIMIT 50
```

That ordering only drains a backlog while every visited row leaves the candidate
set. Two of the four outcomes left the row exactly as they found it, so any row
that declined *permanently* held the head and starved everything queued behind
it. The production log said so every hour, at `info`:

```
candidates:50  archived:0  not_draft:0  has_work:50  errored:0  truncated:true
```

All 50 were the oldest sessions in the deployment, holding messages while their
durable object still said `created` — a state current code cannot produce, since
`enqueuePromptCore` inserts the message and transitions in the same turn. They
would have declined forever, and nothing behind them was ever reached.

## The change

Every outcome now moves the row out of the candidate set.

| Outcome | Before | After |
| --- | --- | --- |
| `archived` | leaves `created` | unchanged |
| `not_draft` | repair could silently no-op | status-only write that always lands |
| `has_work` | **returns unchanged** | settles to `active` / `completed` |
| 404 | **throws, retried forever** | reported as `missing`; index row retired |

**`has_work` settles the session.** A queued prompt goes to `active` and is left
for the dispatch timeout. It is deliberately not archived: that would discard a
real request, and `archived` is not promptable, so the author could not resume it
either.

**404 becomes `missing`.** A 404 is definitive rather than transient — there is
no durable object session behind the row. The sweep retires the index row
directly, which is divergence-free precisely because no durable object state
exists. These rows are real; some were found while bulk-archiving.

**`not_draft` repairs without claiming activity.** Repairing through `transition`
sent the durable object's own `updated_at`, and `updateStatus` guards on
`updated_at <= ?` to keep concurrent writes ordered. D1 is the newer of the two
whenever `touchUpdatedAt` has run, so the guard matched no rows and returned
`false` — discarded, unlogged. The new `repairStatus` writes status alone, so
`updated_at` keeps meaning "last real activity" and the repair cannot be dropped.

**A stalled sweep is now loud.** `truncated` with every candidate errored is the
one shape where the next run reads identical rows. It logs at `error` instead of
hiding in an `info` line.

## Tests

Written first; the nine that mattered failed against `main` before the fix.

- `abandoned-draft-sweep.test.ts` — `missing` routes to the index archive; a
  failed orphan archive is isolated as `errored`; the stall alarm fires on a full
  errored batch **and stays quiet when a full batch was repaired rather than
  archived**, which is what encodes "repair is progress"; 404 resolves to
  `missing` while 500 still throws.
- `do-internal-routes.test.ts` — against the real durable object: a draft with a
  queued message now ends at `active`, one whose messages finished ends at
  `completed`, and neither is ever archived.
- `d1-session-index.test.ts` — against real D1: `repairStatus` writes status
  without moving `updated_at` and lands even when the index is ahead of the
  durable object (the regression the method exists for); `archiveOrphanedDraft`
  refuses a row that left `created`, and after it runs the next batch read
  returns the row *behind* the orphan — the end-to-end proof the head advances.

2572 unit, 801 integration, typecheck and lint clean.

## Not in this PR

Settling a stalled draft to `active` hands it to the pending-dispatch timeout,
which still does not exist — a prompt whose sandbox never connected has no exit
but an explicit cancel. That is the follow-up, and it has to run inside this same
endpoint, since a dormant durable object has no alarm armed to run it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved abandoned-draft cleanup by archiving sessions whose runtime is missing.
  - Drafts with messages now transition to **active**, **completed**, or **failed** based on their work state.
  - Prevented drafts with queued or processing work from being archived.
  - Repaired stale session statuses without changing session recency.
  - Improved reporting for missing sessions, cleanup failures, and stalled batches.
- **Tests**
  - Expanded coverage for orphaned drafts, status repairs, partial failures, and lifecycle outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->