### PR TITLE
fix: interrupt supervisor restart backoff

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -92,8 +92,18 @@ class SandboxSupervisor:
                 if attempt > self.MAX_RESTARTS:
                     self.log.warn("vnc.max_restarts", restart_count=attempt)
                     return False
-                await asyncio.sleep(min(self.BACKOFF_BASE**attempt, self.BACKOFF_MAX))
+                if await self._wait_for_shutdown(min(self.BACKOFF_BASE**attempt, self.BACKOFF_MAX)):
+                    return False
         return False
+
+    async def _wait_for_shutdown(self, delay: float) -> bool:
+        if self.shutdown_event.is_set():
+            return True
+        try:
+            await asyncio.wait_for(self.shutdown_event.wait(), timeout=delay)
+        except TimeoutError:
+            return False
+        return True
 
     async def _handle_opencode_exit(self, restart_count: int) -> tuple[int, bool]:
         exit_code = self.opencode_server.exit_code()
@@ -118,7 +128,8 @@ class SandboxSupervisor:
             delay_s=round(delay, 1),
             restart_count=restart_count,
         )
-        await asyncio.sleep(delay)
+        if await self._wait_for_shutdown(delay):
+            return restart_count, True
         if self._repository_boot_result is None:
             raise RuntimeError("OpenCode restart requested before repository boot")
         await self.opencode_server.start(
@@ -154,7 +165,8 @@ class SandboxSupervisor:
             delay_s=round(delay, 1),
             restart_count=restart_count,
         )
-        await asyncio.sleep(delay)
+        if await self._wait_for_shutdown(delay):
+            return restart_count, True
         await self.agent_bridge.start()
         return restart_count, False
 
@@ -174,7 +186,8 @@ class SandboxSupervisor:
             await self.code_server.stop()
             return restart_count
 
-        await asyncio.sleep(min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX))
+        if await self._wait_for_shutdown(min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX)):
+            return restart_count
         try:
             if self._repository_boot_result is None:
                 raise RuntimeError("code-server restart requested before repository boot")
@@ -202,7 +215,8 @@ class SandboxSupervisor:
             self.log.warn("web_terminal.max_restarts", restart_count=restart_count)
             return restart_count
 
-        await asyncio.sleep(min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX))
+        if await self._wait_for_shutdown(min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX)):
+            return restart_count
         try:
             if self._repository_boot_result is None:
                 raise RuntimeError("terminal restart requested before repository boot")
@@ -250,9 +264,14 @@ class SandboxSupervisor:
             if should_stop:
                 break
             code_server_restarts = await self._handle_code_server_exit(code_server_restarts)
+            if self.shutdown_event.is_set():
+                break
             terminal_restarts = await self._handle_terminal_crash(terminal_restarts)
+            if self.shutdown_event.is_set():
+                break
             desktop_restarts = await self._handle_desktop_crash(desktop_restarts)
-            await asyncio.sleep(1.0)
+            if await self._wait_for_shutdown(1.0):
+                break
 
     def _image_build_execution_timeout_seconds(self) -> int | None:
         raw_timeout = os.environ.get(IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR)

--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -105,10 +105,10 @@ class SandboxSupervisor:
             return False
         return True
 
-    async def _handle_opencode_exit(self, restart_count: int) -> tuple[int, bool]:
+    async def _handle_opencode_exit(self, restart_count: int) -> int:
         exit_code = self.opencode_server.exit_code()
         if exit_code is None:
-            return restart_count, False
+            return restart_count
 
         restart_count += 1
         self.log.error(
@@ -120,7 +120,7 @@ class SandboxSupervisor:
             self.log.error("opencode.max_restarts", restart_count=restart_count)
             await self._report_fatal_error(f"OpenCode crashed {restart_count} times, giving up")
             self.shutdown_event.set()
-            return restart_count, True
+            return restart_count
 
         delay = min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX)
         self.log.info(
@@ -129,23 +129,23 @@ class SandboxSupervisor:
             restart_count=restart_count,
         )
         if await self._wait_for_shutdown(delay):
-            return restart_count, True
+            return restart_count
         if self._repository_boot_result is None:
             raise RuntimeError("OpenCode restart requested before repository boot")
         await self.opencode_server.start(
             self._repository_boot_result.repositories,
             self._repository_boot_result.workdir,
         )
-        return restart_count, False
+        return restart_count
 
-    async def _handle_bridge_exit(self, restart_count: int) -> tuple[int, bool]:
+    async def _handle_bridge_exit(self, restart_count: int) -> int:
         exit_code = self.agent_bridge.exit_code()
         if exit_code is None:
-            return restart_count, False
+            return restart_count
         if exit_code == 0:
             self.log.info("bridge.graceful_exit", exit_code=exit_code)
             self.shutdown_event.set()
-            return restart_count, True
+            return restart_count
 
         restart_count += 1
         self.log.error(
@@ -157,7 +157,7 @@ class SandboxSupervisor:
             self.log.error("bridge.max_restarts", restart_count=restart_count)
             await self._report_fatal_error(f"Bridge crashed {restart_count} times, giving up")
             self.shutdown_event.set()
-            return restart_count, True
+            return restart_count
 
         delay = min(self.BACKOFF_BASE**restart_count, self.BACKOFF_MAX)
         self.log.info(
@@ -166,9 +166,9 @@ class SandboxSupervisor:
             restart_count=restart_count,
         )
         if await self._wait_for_shutdown(delay):
-            return restart_count, True
+            return restart_count
         await self.agent_bridge.start()
-        return restart_count, False
+        return restart_count
 
     async def _handle_code_server_exit(self, restart_count: int) -> int:
         exit_code = self.code_server.exit_code()
@@ -257,11 +257,11 @@ class SandboxSupervisor:
         desktop_restarts = 0
 
         while not self.shutdown_event.is_set():
-            opencode_restarts, should_stop = await self._handle_opencode_exit(opencode_restarts)
-            if should_stop:
+            opencode_restarts = await self._handle_opencode_exit(opencode_restarts)
+            if self.shutdown_event.is_set():
                 break
-            bridge_restarts, should_stop = await self._handle_bridge_exit(bridge_restarts)
-            if should_stop:
+            bridge_restarts = await self._handle_bridge_exit(bridge_restarts)
+            if self.shutdown_event.is_set():
                 break
             code_server_restarts = await self._handle_code_server_exit(code_server_restarts)
             if self.shutdown_event.is_set():

--- a/packages/sandbox-runtime/tests/test_browser_desktop.py
+++ b/packages/sandbox-runtime/tests/test_browser_desktop.py
@@ -43,6 +43,11 @@ async def _yielding_sleep(_delay: float) -> None:
     await _ORIGINAL_ASYNCIO_SLEEP(0)
 
 
+async def _yielding_shutdown_wait(supervisor, _delay: float) -> bool:
+    await _ORIGINAL_ASYNCIO_SLEEP(0)
+    return supervisor.shutdown_event.is_set()
+
+
 class TestStartVnc:
     def test_configures_display_for_workload_processes(self):
         with patch.dict(
@@ -262,7 +267,7 @@ class TestVncLifecycle:
         supervisor.browser_desktop.start = AsyncMock(side_effect=[RuntimeError("not ready"), None])
         supervisor.browser_desktop.stop = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             assert await supervisor._start_desktop_with_retries()
 
         assert supervisor.browser_desktop.start.await_count == 2
@@ -282,7 +287,14 @@ class TestVncLifecycle:
         supervisor.browser_desktop.start = AsyncMock(side_effect=restart)
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=_yielding_sleep):
+        async def wait_for_shutdown(delay):
+            return await _yielding_shutdown_wait(supervisor, delay)
+
+        with patch.object(
+            supervisor,
+            "_wait_for_shutdown",
+            AsyncMock(side_effect=wait_for_shutdown),
+        ):
             await supervisor.monitor_processes()
 
         supervisor.browser_desktop.stop.assert_awaited_once()
@@ -305,7 +317,14 @@ class TestVncLifecycle:
         supervisor._start_desktop_with_retries = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=_yielding_sleep):
+        async def wait_for_shutdown(delay):
+            return await _yielding_shutdown_wait(supervisor, delay)
+
+        with patch.object(
+            supervisor,
+            "_wait_for_shutdown",
+            AsyncMock(side_effect=wait_for_shutdown),
+        ):
             await supervisor.monitor_processes()
 
         supervisor._start_desktop_with_retries.assert_not_awaited()
@@ -327,12 +346,31 @@ class TestVncLifecycle:
         supervisor.browser_desktop.start = AsyncMock(side_effect=restart)
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=_yielding_sleep):
+        async def wait_for_shutdown(delay):
+            return await _yielding_shutdown_wait(supervisor, delay)
+
+        with patch.object(
+            supervisor,
+            "_wait_for_shutdown",
+            AsyncMock(side_effect=wait_for_shutdown),
+        ):
             await supervisor.monitor_processes()
 
         assert supervisor.browser_desktop.start.await_count == 2
         assert supervisor.browser_desktop.stop.await_count == 2
         supervisor._report_fatal_error.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_initial_start_stops_retrying_when_shutdown_set_during_backoff(self):
+        supervisor = _make_lifecycle_supervisor()
+        supervisor.browser_desktop.start = AsyncMock(side_effect=RuntimeError("not ready"))
+        supervisor.browser_desktop.stop = AsyncMock()
+
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
+            assert not await supervisor._start_desktop_with_retries()
+
+        supervisor.browser_desktop.start.assert_awaited_once()
+        supervisor.browser_desktop.stop.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_cleanup_continues_when_a_process_exits_before_terminate(self, tmp_path):

--- a/packages/sandbox-runtime/tests/test_code_server_supervisor.py
+++ b/packages/sandbox-runtime/tests/test_code_server_supervisor.py
@@ -37,7 +37,7 @@ class TestCodeServerMonitorRestart:
         supervisor.code_server.start = AsyncMock(side_effect=restart_side_effect)
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         supervisor.code_server.start.assert_called_once()
@@ -51,15 +51,7 @@ class TestCodeServerMonitorRestart:
         supervisor.code_server.start = AsyncMock(
             side_effect=RuntimeError("code-server binary not found")
         )
-        iteration = 0
-
-        async def counting_sleep(_delay):
-            nonlocal iteration
-            iteration += 1
-            if iteration >= 2:
-                supervisor.shutdown_event.set()
-
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=counting_sleep):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(side_effect=[False, True])):
             await supervisor.monitor_processes()
 
         supervisor.code_server.start.assert_awaited_once()
@@ -72,15 +64,11 @@ class TestCodeServerMonitorRestart:
         supervisor.code_server._process = _fake_process(1)
         supervisor.code_server.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
-        sleep_count = 0
-
-        async def counting_sleep(_delay):
-            nonlocal sleep_count
-            sleep_count += 1
-            if sleep_count > supervisor.MAX_RESTARTS * 3:
-                supervisor.shutdown_event.set()
-
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=counting_sleep):
+        with patch.object(
+            supervisor,
+            "_wait_for_shutdown",
+            AsyncMock(side_effect=[False] * (supervisor.MAX_RESTARTS * 2) + [True]),
+        ):
             await supervisor.monitor_processes()
 
         assert supervisor.code_server.start.call_count == supervisor.MAX_RESTARTS
@@ -104,7 +92,7 @@ class TestTerminalMonitorRestart:
         supervisor.web_terminal.start = AsyncMock(side_effect=restart_side_effect)
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         supervisor.web_terminal.stop.assert_awaited_once()
@@ -120,15 +108,7 @@ class TestTerminalMonitorRestart:
             side_effect=lambda: setattr(supervisor.web_terminal, "_ttyd_process", None)
         )
         supervisor.web_terminal.start = AsyncMock(side_effect=RuntimeError("unavailable"))
-        iteration = 0
-
-        async def counting_sleep(_delay):
-            nonlocal iteration
-            iteration += 1
-            if iteration >= 2:
-                supervisor.shutdown_event.set()
-
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=counting_sleep):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(side_effect=[False, True])):
             await supervisor.monitor_processes()
 
         supervisor.web_terminal.start.assert_awaited_once()
@@ -148,9 +128,35 @@ class TestTerminalMonitorRestart:
 
         supervisor.web_terminal.stop = AsyncMock(side_effect=stop_terminal)
         supervisor._report_fatal_error = AsyncMock()
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         assert supervisor.web_terminal.start.await_count == supervisor.MAX_RESTARTS
         assert supervisor.web_terminal.stop.await_count == supervisor.MAX_RESTARTS + 1
         supervisor._report_fatal_error.assert_not_awaited()
+
+    async def test_code_server_shutdown_during_backoff_does_not_restart(self):
+        supervisor = _make_supervisor()
+        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.agent_bridge._process = _fake_process(None)
+        supervisor.code_server._process = _fake_process(1)
+        supervisor.code_server.start = AsyncMock()
+
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
+            await supervisor.monitor_processes()
+
+        supervisor.code_server.start.assert_not_called()
+
+    async def test_terminal_shutdown_during_backoff_does_not_restart(self):
+        supervisor = _make_supervisor()
+        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.agent_bridge._process = _fake_process(None)
+        supervisor.web_terminal._ttyd_process = _fake_process(1)
+        supervisor.web_terminal.stop = AsyncMock()
+        supervisor.web_terminal.start = AsyncMock()
+
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
+            await supervisor.monitor_processes()
+
+        supervisor.web_terminal.stop.assert_awaited_once()
+        supervisor.web_terminal.start.assert_not_called()

--- a/packages/sandbox-runtime/tests/test_supervisor_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_supervisor_lifecycle.py
@@ -130,7 +130,7 @@ async def test_bridge_restart_exhaustion_is_fatal(tmp_path, monkeypatch):
     supervisor, _repository, _opencode_server, agent_bridge, *_ = _supervisor(tmp_path, [])
     agent_bridge.exit_code.return_value = 1
     supervisor._report_fatal_error = AsyncMock()
-    monkeypatch.setattr("sandbox_runtime.supervisor.asyncio.sleep", AsyncMock())
+    monkeypatch.setattr(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False))
 
     await SandboxSupervisor.monitor_processes(supervisor)
 
@@ -146,11 +146,11 @@ async def test_code_server_restart_exhaustion_is_nonfatal(tmp_path, monkeypatch)
     code_server.exit_code.return_value = 1
     supervisor._report_fatal_error = AsyncMock()
 
-    async def no_delay(_seconds):
-        if code_server.stop.await_count > supervisor.MAX_RESTARTS:
-            supervisor.shutdown_event.set()
-
-    monkeypatch.setattr("sandbox_runtime.supervisor.asyncio.sleep", no_delay)
+    monkeypatch.setattr(
+        supervisor,
+        "_wait_for_shutdown",
+        AsyncMock(side_effect=[False] * supervisor.MAX_RESTARTS + [True]),
+    )
     await SandboxSupervisor.monitor_processes(supervisor)
 
     supervisor._report_fatal_error.assert_not_awaited()

--- a/packages/sandbox-runtime/tests/test_supervisor_monitor.py
+++ b/packages/sandbox-runtime/tests/test_supervisor_monitor.py
@@ -1,5 +1,6 @@
 """Tests for SandboxSupervisor.monitor_processes bridge restart logic."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sandbox_runtime.supervisor import SandboxSupervisor
@@ -169,6 +170,20 @@ class TestOpenCodeCrashRestart:
 
         with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
             await supervisor.monitor_processes()
+
+        supervisor.opencode_server.start.assert_not_called()
+        supervisor._report_fatal_error.assert_not_called()
+
+    async def test_real_shutdown_event_interrupts_opencode_backoff(self):
+        supervisor = _make_supervisor()
+        supervisor.opencode_server._opencode_process = _fake_process(returncode=1)
+        supervisor.opencode_server.start = AsyncMock()
+        supervisor._report_fatal_error = AsyncMock()
+
+        monitor_task = asyncio.create_task(supervisor.monitor_processes())
+        await asyncio.sleep(0)
+        supervisor.shutdown_event.set()
+        await asyncio.wait_for(monitor_task, timeout=0.5)
 
         supervisor.opencode_server.start.assert_not_called()
         supervisor._report_fatal_error.assert_not_called()

--- a/packages/sandbox-runtime/tests/test_supervisor_monitor.py
+++ b/packages/sandbox-runtime/tests/test_supervisor_monitor.py
@@ -70,7 +70,7 @@ class TestBridgeCrashRestart:
         supervisor.agent_bridge._process = _fake_process(returncode=1)
         supervisor.agent_bridge.start = AsyncMock(side_effect=restart_side_effect)
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         supervisor.agent_bridge.start.assert_called_once()
@@ -83,7 +83,7 @@ class TestBridgeCrashRestart:
         supervisor.agent_bridge.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         assert supervisor.shutdown_event.is_set()
@@ -103,7 +103,7 @@ class TestBridgeCrashRestart:
         supervisor.agent_bridge._process = _fake_process(returncode=-15)
         supervisor.agent_bridge.start = AsyncMock(side_effect=restart_side_effect)
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         supervisor.agent_bridge.start.assert_called_once()
@@ -122,10 +122,12 @@ class TestBridgeBackoffTiming:
         supervisor.agent_bridge._process = _fake_process(returncode=1)
         supervisor.agent_bridge.start = AsyncMock(side_effect=restart_side_effect)
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock) as sleep:
+        with patch.object(
+            supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)
+        ) as wait_for_shutdown:
             await supervisor.monitor_processes()
 
-        sleep.assert_any_call(supervisor.BACKOFF_BASE**1)
+        wait_for_shutdown.assert_any_await(supervisor.BACKOFF_BASE**1)
 
     async def test_backoff_is_capped_at_max(self):
         supervisor = _make_supervisor()
@@ -135,10 +137,11 @@ class TestBridgeBackoffTiming:
         supervisor._report_fatal_error = AsyncMock()
         sleep_delays = []
 
-        async def capture_sleep(delay):
+        async def capture_wait(delay):
             sleep_delays.append(delay)
+            return False
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", side_effect=capture_sleep):
+        with patch.object(supervisor, "_wait_for_shutdown", side_effect=capture_wait):
             await supervisor.monitor_processes()
 
         assert all(delay <= supervisor.BACKOFF_MAX for delay in sleep_delays)
@@ -151,12 +154,37 @@ class TestOpenCodeCrashRestart:
         supervisor.opencode_server.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
-        with patch("sandbox_runtime.supervisor.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
         assert supervisor.opencode_server.start.call_count == supervisor.MAX_RESTARTS
         supervisor._report_fatal_error.assert_called_once()
         assert "OpenCode crashed" in supervisor._report_fatal_error.call_args.args[0]
+
+    async def test_opencode_shutdown_during_backoff_does_not_restart(self):
+        supervisor = _make_supervisor()
+        supervisor.opencode_server._opencode_process = _fake_process(returncode=1)
+        supervisor.opencode_server.start = AsyncMock()
+        supervisor._report_fatal_error = AsyncMock()
+
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
+            await supervisor.monitor_processes()
+
+        supervisor.opencode_server.start.assert_not_called()
+        supervisor._report_fatal_error.assert_not_called()
+
+    async def test_bridge_shutdown_during_backoff_does_not_restart(self):
+        supervisor = _make_supervisor()
+        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.agent_bridge._process = _fake_process(returncode=1)
+        supervisor.agent_bridge.start = AsyncMock()
+        supervisor._report_fatal_error = AsyncMock()
+
+        with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
+            await supervisor.monitor_processes()
+
+        supervisor.agent_bridge.start.assert_not_called()
+        supervisor._report_fatal_error.assert_not_called()
 
 
 class TestFatalErrorReporting:


### PR DESCRIPTION
## Summary
- Add a shutdown-aware wait helper for supervisor restart backoff and monitor polling
- Skip service restarts when shutdown is requested during backoff
- Update focused supervisor tests and add coverage for shutdown during restart waits

## Stacking
- Follow-up to #1443. This branch is based on the #1443 refactor commit, so GitHub may show it as dependent until #1443 merges.

## Validation
- `PYTHONPATH=src uv run --extra dev pytest tests/test_supervisor_monitor.py tests/test_code_server_supervisor.py tests/test_browser_desktop.py tests/test_supervisor_lifecycle.py -q`
- `PYTHONPATH=src uv run --extra dev ruff check src/sandbox_runtime/supervisor.py tests/test_supervisor_monitor.py tests/test_code_server_supervisor.py tests/test_browser_desktop.py tests/test_supervisor_lifecycle.py`
- `PYTHONPATH=src uv run --extra dev ruff format --check src/sandbox_runtime/supervisor.py tests/test_supervisor_monitor.py tests/test_code_server_supervisor.py tests/test_browser_desktop.py tests/test_supervisor_lifecycle.py`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/7a060709247a5f9073c1708084ec3c74)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service restart handling during shutdown.
  - Shutdowns now interrupt retry and backoff delays promptly.
  - Prevented unnecessary restarts and fatal errors when services stop during shutdown.
  - Improved process monitoring responsiveness across desktop, bridge, code-server, terminal, and OpenCode services.

- **Tests**
  - Added coverage for shutdown behavior during service restart delays and monitoring cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->