### PR TITLE
refactor: retire SessionRepository

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -200,7 +200,7 @@ function normalizeRepoIdentifier(value: string | null | undefined): string | nul
   return trimmed ? trimmed.toLowerCase() : null;
 }
 
-function normalizeSessionRepository(session: SessionEntry): {
+function normalizeSessionRepositoryFields(session: SessionEntry): {
   repoOwner: string | null;
   repoName: string | null;
   baseBranch: string | null;
@@ -231,7 +231,7 @@ export class SessionIndexStore {
   }
 
   async create(session: SessionEntry): Promise<void> {
-    const repository = normalizeSessionRepository(session);
+    const repository = normalizeSessionRepositoryFields(session);
 
     const sessionStmt = this.db
       .prepare(

--- a/packages/control-plane/src/db/sql-database.ts
+++ b/packages/control-plane/src/db/sql-database.ts
@@ -16,7 +16,7 @@
  * exists exactly because wrapped statements cross into the raw db.batch()).
  *
  * Not to be confused with the session Durable Object's synchronous
- * `SqlStorage` (src/session/repository.ts) — that is a different engine with
+ * `SqlStorage` (src/session/sql-storage.ts) — that is a different engine with
  * a load-bearing sync contract, and is intentionally not covered by this port.
  */
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -518,7 +518,7 @@ export class SessionDO extends DurableObject<Env> {
   private get childSessionsHandler(): ChildSessionsHandler {
     if (!this._childSessionsHandler) {
       this._childSessionsHandler = createChildSessionsHandler({
-        repository: this.messageRepository,
+        messageRepository: this.messageRepository,
         eventRepository: this.eventRepository,
         participantRepository: this.participantRepository,
         artifactRepository: this.artifactRepository,
@@ -537,7 +537,7 @@ export class SessionDO extends DurableObject<Env> {
   private get sandboxHandler(): SandboxHandler {
     if (!this._sandboxHandler) {
       this._sandboxHandler = createSandboxHandler({
-        repository: this.messageRepository,
+        messageRepository: this.messageRepository,
         eventRepository: this.eventRepository,
         participantRepository: this.participantRepository,
         artifactRepository: this.artifactRepository,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -170,7 +170,7 @@ function createHandler() {
   const messageService = { enqueuePrompt };
 
   const handler = createChildSessionsHandler({
-    repository: repository as unknown as MessageRepository,
+    messageRepository: repository as unknown as MessageRepository,
     eventRepository: repository as unknown as EventRepository,
     participantRepository: repository as unknown as ParticipantRepository,
     artifactRepository: artifactRepository as unknown as ArtifactRepository,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -26,7 +26,7 @@ import {
 } from "./child-session-summary";
 
 export interface ChildSessionsHandlerDeps {
-  repository: MessageRepository;
+  messageRepository: MessageRepository;
   eventRepository: EventRepository;
   participantRepository: ParticipantRepository;
   artifactRepository: ArtifactRepository;
@@ -60,10 +60,10 @@ const childSessionUpdateBodySchema = z.object({
 });
 
 function resolvePromptAuthorParticipant(
-  repository: ChildSessionsHandlerDeps["repository"],
+  messageRepository: MessageRepository,
   participantRepository: ParticipantRepository
 ): ParticipantRow | Response {
-  const processingMessage = repository.getProcessingMessageAuthor();
+  const processingMessage = messageRepository.getProcessingMessageAuthor();
   if (!processingMessage) {
     return Response.json(
       { error: "No active prompt found. Child operations must be triggered by an active prompt." },
@@ -94,7 +94,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       }
 
       const promptAuthor = resolvePromptAuthorParticipant(
-        deps.repository,
+        deps.messageRepository,
         deps.participantRepository
       );
       if (promptAuthor instanceof Response) return promptAuthor;
@@ -132,7 +132,10 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
 
     getActivePromptAuthor(): Response {
       if (!deps.getSession()) return Response.json({ error: "Session not found" }, { status: 404 });
-      const author = resolvePromptAuthorParticipant(deps.repository, deps.participantRepository);
+      const author = resolvePromptAuthorParticipant(
+        deps.messageRepository,
+        deps.participantRepository
+      );
       return author instanceof Response ? author : Response.json(toActivePromptAuthor(author));
     },
 
@@ -157,7 +160,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       let trajectory: ChildSummaryTrajectoryInput | undefined;
 
       if (options.includeFinalResponse) {
-        const terminalMessage = deps.repository.getLatestTerminalMessage();
+        const terminalMessage = deps.messageRepository.getLatestTerminalMessage();
         const collectedEvents = terminalMessage
           ? collectFinalResponseEventRows(deps.eventRepository, terminalMessage.id)
           : { eventRows: [], eventLimitReached: false };
@@ -184,7 +187,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
           publicSessionId: deps.getPublicSessionId(session),
           artifacts,
           recentEventRows,
-          hasUnfinishedPrompt: deps.repository.getPendingOrProcessingCount() > 0,
+          hasUnfinishedPrompt: deps.messageRepository.getPendingOrProcessingCount() > 0,
           parseArtifactMetadata: deps.parseArtifactMetadata,
           finalResponse,
           trajectory,

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -75,7 +75,7 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 function createHandler() {
   const getSession = vi.fn<() => SessionRow | null>();
   let repositoryRows: SessionRepositoryRow[] = [];
-  // Mirrors SessionRepository.getSessionRepositories: members derive from the
+  // Mirrors SessionCoreRepository.getSessionRepositories: members derive from the
   // session scalars plus whatever rows the test seeds.
   const getSessionRepositories = vi.fn<() => SessionRepositoryEntry[]>(() => {
     const session = getSession();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -42,7 +42,7 @@ function createHandler() {
   } as unknown as Logger;
 
   const sandboxHandler = createSandboxHandler({
-    repository: repository as unknown as MessageRepository,
+    messageRepository: repository as unknown as MessageRepository,
     eventRepository: repository as unknown as EventRepository,
     participantRepository: repository as unknown as ParticipantRepository,
     artifactRepository,

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -37,7 +37,7 @@ const addParticipantRequestSchema = z.object({
 type AddParticipantRequest = z.infer<typeof addParticipantRequestSchema>;
 
 export interface SandboxHandlerDeps {
-  repository: MessageRepository;
+  messageRepository: MessageRepository;
   eventRepository: EventRepository;
   participantRepository: ParticipantRepository;
   artifactRepository: ArtifactRepository;
@@ -109,7 +109,7 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ error: "artifactId and objectKey are required" }, { status: 400 });
       }
 
-      const processingMessage = deps.repository.getProcessingMessage();
+      const processingMessage = deps.messageRepository.getProcessingMessage();
       if (!processingMessage) {
         return Response.json({ error: "No active prompt" }, { status: 409 });
       }

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -146,7 +146,7 @@ function createTestHarness(options: { scmSettings?: ScmSettings } = {}) {
 
   const repository: PullRequestRepository = {
     getSession: () => session,
-    // Mirrors SessionRepository.getSessionRepositories: members derive from the
+    // Mirrors SessionCoreRepository.getSessionRepositories: members derive from the
     // session scalars plus whatever rows the test seeds.
     getSessionRepositories: () =>
       session?.repo_owner && session.repo_name

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -1,2 +1,0 @@
-/** Transitional shell retained until the repository split is finalized. */
-export class SessionRepository {}


### PR DESCRIPTION
## Summary

- delete the empty `SessionRepository` transition shell
- wire sandbox and child-session handlers through explicitly named focused repositories
- remove stale `SessionRepository` references so the retirement acceptance search is clean
- keep the integration suite unmodified

## Verification

- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/session packages/control-plane/src/db/session-index.ts`
- `npm run build -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane` (2,566 tests)
- `npm run test:integration -w @open-inspect/control-plane -- --maxWorkers=4` (794 tests)

Closes COL-38.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/20be55f7ee3423e5a6b45cff83a8a5af)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal session, child-session, and sandbox message handling.
  * Removed an obsolete session repository component.
  * Updated related integrations, documentation, and test coverage for improved consistency.

* **Bug Fixes**
  * Preserved existing session indexing and handler behavior while improving consistency across session workflows.
  * No user-facing behavior changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->