### PR TITLE
test: isolate WebSocket dashboard URL hydration cases

### DIFF
--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -97,36 +97,17 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
-  it("subscribe hydrates dashboard URL when provider object id exists", async () => {
-    const dashboardUrl =
-      "https://modal.com/apps/test-workspace/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=provider-obj-123";
-    const cases = [
-      {
-        status: "connecting",
-        providerObjectId: "provider-obj-123",
-        expectedDashboardUrl: dashboardUrl,
-      },
-      {
-        status: "spawning",
-        providerObjectId: "provider-obj-123",
-        expectedDashboardUrl: dashboardUrl,
-      },
-      { status: "spawning", providerObjectId: null, expectedDashboardUrl: null },
-      { status: "stale", providerObjectId: "provider-obj-123", expectedDashboardUrl: dashboardUrl },
-      {
-        status: "stopped",
-        providerObjectId: "provider-obj-123",
-        expectedDashboardUrl: dashboardUrl,
-      },
-      {
-        status: "failed",
-        providerObjectId: "provider-obj-123",
-        expectedDashboardUrl: dashboardUrl,
-      },
-    ];
-
-    for (const [index, testCase] of cases.entries()) {
-      const name = `ws-client-dashboard-url-${testCase.status}-${testCase.providerObjectId ? "with-id" : "without-id"}-${Date.now()}-${index}`;
+  it.each([
+    { status: "connecting", providerObjectId: "provider-obj-123" },
+    { status: "spawning", providerObjectId: "provider-obj-123" },
+    { status: "spawning", providerObjectId: null },
+    { status: "stale", providerObjectId: "provider-obj-123" },
+    { status: "stopped", providerObjectId: "provider-obj-123" },
+    { status: "failed", providerObjectId: "provider-obj-123" },
+  ])(
+    "subscribe hydrates dashboard URL for $status sandbox with provider object id $providerObjectId",
+    async ({ status, providerObjectId }) => {
+      const name = `ws-client-dashboard-url-${status}-${providerObjectId ? "with-id" : "without-id"}-${Date.now()}`;
       const { stub } = await initNamedSession(name);
       // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env)
       // before forcing each status, otherwise it can race and overwrite the row.
@@ -136,20 +117,24 @@ describe("Client WebSocket (via SELF.fetch)", () => {
         `UPDATE sandbox
            SET status = ?, modal_object_id = ?
          WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
-        testCase.status,
-        testCase.providerObjectId
+        status,
+        providerObjectId
       );
 
       const { ws, messages } = await openClientWs(name, { subscribe: true });
       const subscribed = messages!.find((m) => m.type === "subscribed") as Record<string, unknown>;
       const state = subscribed.session as Record<string, unknown>;
 
-      expect(state.sandboxStatus).toBe(testCase.status);
-      expect(state.sandboxDashboardUrl).toBe(testCase.expectedDashboardUrl);
+      expect(state.sandboxStatus).toBe(status);
+      expect(state.sandboxDashboardUrl).toBe(
+        providerObjectId
+          ? "https://modal.com/apps/test-workspace/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=provider-obj-123"
+          : null
+      );
 
       ws.close();
     }
-  });
+  );
 
   it("subscribe with invalid token closes socket 4001", async () => {
     const name = `ws-client-badtoken-${Date.now()}`;


### PR DESCRIPTION
## Summary

- replace the serial six-case dashboard URL hydration loop with `it.each`
- give each sandbox lifecycle scenario independent reporting and Vitest timeout accounting
- preserve the existing end-to-end WebSocket subscription assertions for sandbox status and dashboard URL hydration

## Root cause

The original test performed six production-shaped session initializations, sandbox failure waits, database updates, and WebSocket subscriptions inside one test. Under integration-suite contention, that combined work could exhaust Vitest's default 5-second per-test deadline.

Production-shaped initialization always schedules `warmSandbox()` through the Durable Object context. Avoiding that attempt would require a test-only production hook or duplicating initialization with raw SQL, so this change retains the existing failure wait to prevent its status write from racing the seeded scenario. Isolating each case removes the shared deadline without changing production behavior, global timeouts, worker counts, or assertions. The URL formatter already has focused unit coverage for construction, missing inputs, and encoding.

## Verification

- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-client.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-client.test.ts -t "subscribe hydrates dashboard URL" --reporter=verbose`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/test/integration/websocket-client.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- --shard=1/2` (332 tests)
- `npm run test:integration -w @open-inspect/control-plane -- --shard=2/2` (467 tests)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/cca50f324e9aee402a694e5a48a56b84)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined dashboard URL subscription test coverage using parameterized scenarios.
  * Preserved validation across sandbox statuses and provider object ID combinations.
  * Continued verifying both sandbox status and dashboard URL results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->