### PR TITLE
fix: show skill name in tool calls

### DIFF
--- a/packages/web/src/lib/tool-formatters.test.ts
+++ b/packages/web/src/lib/tool-formatters.test.ts
@@ -47,6 +47,13 @@ describe("formatToolCall summaries", () => {
     expect(formatToolCall(toolCall("webfetch", { url })).summary).toBe(url);
   });
 
+  it("renders skill calls with the skill name", () => {
+    expect(formatToolCall(toolCall("skill", { name: "visual-verification" }))).toMatchObject({
+      toolName: "skill",
+      summary: '"visual-verification"',
+    });
+  });
+
   it("does not render full task prompts or unknown-tool arguments in collapsed summaries", () => {
     const prompt = "x".repeat(1_000);
     const args = { query: "y".repeat(1_000), limit: 10 };

--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -213,6 +213,16 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       };
     }
 
+    case "skill": {
+      const name = getStringArg(args, "name");
+      return {
+        toolName: "skill",
+        summary: name ? `"${name}"` : "",
+        icon: null,
+        getDetails: () => ({ args, output }),
+      };
+    }
+
     case "webfetch": {
       const url = getStringArg(args, "url");
       return {


### PR DESCRIPTION
## Summary
- add dedicated formatting for skill tool calls
- display the selected skill name instead of a generic argument count
- add a regression test for the collapsed skill label

## Testing
- `npm test -w @open-inspect/web -- --run src/lib/tool-formatters.test.ts`
- `npx prettier --check packages/web/src/lib/tool-formatters.ts packages/web/src/lib/tool-formatters.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/0326ce7ba1e3d575a32634beb1bb35f5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying skill tool calls with the skill name shown in quotes.
  * Preserves the original tool arguments and output in the call details.

* **Tests**
  * Added coverage verifying skill tool-call names and summaries are formatted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->