### PR TITLE
docs: add managed skills changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 
 ## August 15, 2026
 
+**Managed skills.** Create and edit reusable Agent Skills in Settings, assign them globally or to
+specific repositories and environments, and organize personal profiles. When starting a session,
+choose all applicable skills, none, or a profile; Open-Inspect pins and securely installs the exact
+revisions before the agent starts, while the session sidebar records each skill's revision and
+assignment source so existing sessions stay reproducible as the shared catalog changes.
+
 **Multiple pull requests per session.** The `create-pull-request` tool now opens one PR per head
 branch instead of one per repository: agents can create stacked PRs (each level passing the previous
 branch as `baseBranch`), open a fresh PR after the previous one merges, and calling the tool again


### PR DESCRIPTION
## Summary

- add a managed skills entry to the August 15, 2026 changelog
- highlight shared skill authoring, scoped assignments, personal profiles, and session-level selection
- document pinned revisions, secure installation, and session provenance visibility

## Verification

- `npx prettier --check CHANGELOG.md`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ee4af55cf411c8cac7684732f5af8a3c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for managed Agent Skills.
  * Documented skill creation and editing in Settings.
  * Added details on global or scoped assignment, profile organization, and session-time selection.
  * Documented pinned revision installation and revision/source tracking for reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->