### PR TITLE
fix: align grouped action icons with text

### DIFF
--- a/packages/web/src/components/tool-call-group.test.tsx
+++ b/packages/web/src/components/tool-call-group.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SandboxEvent } from "@/types/session";
+import { ToolCallGroup } from "./tool-call-group";
+
+afterEach(cleanup);
+
+describe("ToolCallGroup", () => {
+  it("aligns grouped action icons with the text", () => {
+    const events: Array<Extract<SandboxEvent, { type: "tool_call" }>> = [
+      {
+        type: "tool_call",
+        sandboxId: "sandbox-1",
+        messageId: "message-1",
+        callId: "call-1",
+        tool: "Bash",
+        args: { command: "pwd" },
+        timestamp: 1,
+      },
+      {
+        type: "tool_call",
+        sandboxId: "sandbox-1",
+        messageId: "message-2",
+        callId: "call-2",
+        tool: "Bash",
+        args: { command: "ls" },
+        timestamp: 2,
+      },
+    ];
+
+    render(
+      <ToolCallGroup
+        events={events}
+        isExpanded={false}
+        expandedToolCallIds={new Set()}
+        onToggleGroup={() => {}}
+        onToggleTool={() => {}}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /Bash 2 commands/ });
+    const icons = button.querySelectorAll("svg");
+
+    expect(icons).toHaveLength(2);
+    expect([...icons].every((icon) => icon.classList.contains("mt-[3px]"))).toBe(true);
+  });
+});

--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/icons";
 
 function ToolIcon({ toolName }: { toolName: string }) {
-  const iconClass = "w-3.5 h-3.5 shrink-0 text-secondary-foreground";
+  const iconClass = "mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground";
 
   switch (toolName) {
     case "Read":
@@ -69,7 +69,7 @@ export const ToolCallGroup = memo(
           className="-mx-2 flex w-full min-w-0 items-start gap-2 px-2 py-1 text-left text-sm transition-colors hover:bg-muted"
         >
           <ChevronRightIcon
-            className={`w-3.5 h-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
+            className={`mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground transition-transform duration-200 ${
               isExpanded ? "rotate-90" : ""
             }`}
           />


### PR DESCRIPTION
## Summary

- apply the existing 3px vertical icon offset to grouped action headers
- align both the disclosure chevron and tool icon with the action text
- add regression coverage for grouped Bash action icon alignment

## Testing

- `npm test -w @open-inspect/web -- --run src/components/tool-call-group.test.tsx src/components/tool-call-item.test.tsx src/components/task-activity-item.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx eslint src/components/tool-call-group.tsx src/components/tool-call-group.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ed4a0f9f00b182ef4bf6658df1fa70fc)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment of tool icons and expandable group chevrons for a more consistent appearance.

* **Tests**
  * Added coverage to verify grouped tool calls display the expected icons and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->