### PR TITLE
fix: validate normalized automation events at ingress

### DIFF
--- a/packages/control-plane/src/webhooks/automation-event.test.ts
+++ b/packages/control-plane/src/webhooks/automation-event.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { validateAutomationEventEnvelope } from "./automation-event";
+
+function makeSlackEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    source: "slack",
+    eventType: "message.posted",
+    triggerKey: "slack:msg:C1:1700000000.000200",
+    concurrencyKey: "slack:C1:1700000000.000100",
+    contextBlock: "A message was posted in #ops.",
+    meta: {},
+    channelId: "C1",
+    ts: "1700000000.000200",
+    actorUserId: "U1",
+    text: "please deploy the api",
+    ...overrides,
+  };
+}
+
+describe("validateAutomationEventEnvelope", () => {
+  it.each([
+    ["eventType", { nested: "value" }],
+    ["triggerKey", ["not", "a", "string"]],
+    ["concurrencyKey", { key: "value" }],
+    ["contextBlock", ["context"]],
+    ["meta", []],
+    ["channelId", { id: "C1" }],
+    ["ts", ["1700000000.000200"]],
+    ["actorUserId", { id: "U1" }],
+    ["text", ["deploy"]],
+  ])("rejects a non-protocol value for %s", async (field, value) => {
+    const result = validateAutomationEventEnvelope(makeSlackEvent({ [field]: value }), "slack");
+
+    expect(result.response?.status).toBe(400);
+    expect(await result.response?.text()).toContain(field);
+  });
+
+  it("returns a typed event without unknown envelope fields", () => {
+    const result = validateAutomationEventEnvelope(
+      makeSlackEvent({ untrustedAdditionalField: "discard me" }),
+      "slack"
+    );
+
+    expect(result.response).toBeUndefined();
+    expect(result.event).toEqual(makeSlackEvent());
+    expect(result.event?.source).toBe("slack");
+  });
+
+  it.each(["eventType", "triggerKey", "concurrencyKey", "channelId", "ts"])(
+    "rejects an empty required field for %s",
+    async (field) => {
+      const result = validateAutomationEventEnvelope(makeSlackEvent({ [field]: "" }), "slack");
+
+      expect(result.response?.status).toBe(400);
+      expect(await result.response?.text()).toContain(field);
+    }
+  );
+
+  it("rejects source-specific fields from a different event variant", async () => {
+    const result = validateAutomationEventEnvelope(
+      {
+        source: "github",
+        eventType: "pull_request.opened",
+        triggerKey: "github:pr:1",
+        concurrencyKey: "github:pr:1",
+        contextBlock: "A pull request was opened.",
+        meta: {},
+        repoOwner: { login: "acme" },
+        repoName: "api",
+      },
+      "github"
+    );
+
+    expect(result.response?.status).toBe(400);
+    expect(await result.response?.text()).toContain("repoOwner");
+  });
+});

--- a/packages/control-plane/src/webhooks/automation-event.test.ts
+++ b/packages/control-plane/src/webhooks/automation-event.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { validateAutomationEventEnvelope } from "./automation-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RequestContext } from "../routes/shared";
+import { logAutomationEventRejection, validateAutomationEventEnvelope } from "./automation-event";
 
 function makeSlackEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -73,5 +74,30 @@ describe("validateAutomationEventEnvelope", () => {
 
     expect(result.response?.status).toBe(400);
     expect(await result.response?.text()).toContain("repoOwner");
+  });
+});
+
+describe("logAutomationEventRejection", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("logs safe protocol and request correlation fields", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    logAutomationEventRejection(
+      makeSlackEvent({ eventType: "x".repeat(200), channelId: [] }),
+      "slack",
+      ["channelId"],
+      { request_id: "request-1", trace_id: "trace-1" } as RequestContext
+    );
+
+    const entry = JSON.parse(String(warn.mock.calls[0]?.[0])) as Record<string, unknown>;
+    expect(entry).toMatchObject({
+      event: "automation_event.ingress_rejected",
+      source: "slack",
+      event_type: "x".repeat(128),
+      issue_paths: ["channelId"],
+      request_id: "request-1",
+      trace_id: "trace-1",
+    });
   });
 });

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -9,48 +9,55 @@
  * named handler.
  */
 
-import type { AutomationEventSource } from "@open-inspect/shared/triggers";
+import {
+  automationEventSchema,
+  type AutomationEvent,
+  type AutomationEventSource,
+} from "@open-inspect/shared/triggers";
 import { requireEventPoster } from "../auth/identity-enforcement";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
 import type { Env } from "../types";
 
-export type AutomationEventEnvelopeResult =
-  | { event: Record<string, unknown>; response?: never }
+type AutomationEventForSource<S extends AutomationEventSource> = Extract<
+  AutomationEvent,
+  { source: S }
+>;
+
+export type AutomationEventEnvelopeResult<S extends AutomationEventSource> =
+  | { event: AutomationEventForSource<S>; response?: never }
   | { event?: never; response: Response };
 
 /**
- * Validate the normalized event envelope — source, then source-specific
- * fields, then the common dispatch keys every event must carry.
+ * Validate the source and the complete normalized event protocol.
  */
-export function validateAutomationEventEnvelope(
+export function validateAutomationEventEnvelope<S extends AutomationEventSource>(
   body: unknown,
-  source: AutomationEventSource,
-  validate: (event: Record<string, unknown>) => string | null
-): AutomationEventEnvelopeResult {
+  source: S
+): AutomationEventEnvelopeResult<S> {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return { response: error("Invalid event: body must be a JSON object", 400) };
   }
-  const event = body as Record<string, unknown>;
-  if (event.source !== source) {
+  if ((body as Record<string, unknown>).source !== source) {
     return { response: error(`Invalid event: source must be '${source}'`, 400) };
   }
-  const fieldError = validate(event);
-  if (fieldError) {
-    return { response: error(fieldError, 400) };
+
+  const parsed = automationEventSchema.safeParse(body);
+  if (!parsed.success) {
+    const invalidFields = [
+      ...new Set(parsed.error.issues.map((issue) => issue.path.join(".") || "body")),
+    ].join(", ");
+    return { response: error(`Invalid event: ${invalidFields}`, 400) };
   }
-  if (!event.eventType || !event.triggerKey || !event.concurrencyKey) {
-    return {
-      response: error("Invalid event: eventType, triggerKey, and concurrencyKey are required", 400),
-    };
-  }
-  return { event };
+
+  // The source equality check above narrows the discriminated union at runtime.
+  return { event: parsed.data as AutomationEventForSource<S> };
 }
 
 /** Forward a validated event to the singleton SchedulerDO for matching. */
 export async function forwardAutomationEventToScheduler(
   env: Env,
-  event: Record<string, unknown>
+  event: AutomationEvent
 ): Promise<Response> {
   if (!env.SCHEDULER) {
     return error("Scheduler not configured", 503);
@@ -81,8 +88,6 @@ export async function forwardAutomationEventToScheduler(
 export function createAutomationEventRoute(opts: {
   path: string;
   source: AutomationEventSource;
-  /** Validate source-specific required fields. Returns an error message, or null when valid. */
-  validate: (event: Record<string, unknown>) => string | null;
 }): Route {
   async function handler(
     request: Request,
@@ -100,7 +105,7 @@ export function createAutomationEventRoute(opts: {
       return error("Invalid JSON", 400);
     }
 
-    const validated = validateAutomationEventEnvelope(body, opts.source, opts.validate);
+    const validated = validateAutomationEventEnvelope(body, opts.source);
     if (validated.response) return validated.response;
 
     return forwardAutomationEventToScheduler(env, validated.event);

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -15,6 +15,7 @@ import {
   type AutomationEventSource,
 } from "@open-inspect/shared/triggers";
 import { requireEventPoster } from "../auth/identity-enforcement";
+import { createLogger } from "../logger";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
 import type { Env } from "../types";
@@ -24,9 +25,40 @@ type AutomationEventForSource<S extends AutomationEventSource> = Extract<
   { source: S }
 >;
 
+const logger = createLogger("webhook:automation-event");
+
 export type AutomationEventEnvelopeResult<S extends AutomationEventSource> =
   | { event: AutomationEventForSource<S>; response?: never }
-  | { event?: never; response: Response };
+  | { event?: never; response: Response; issuePaths: string[] };
+
+function hasAutomationEventSource<S extends AutomationEventSource>(
+  event: AutomationEvent,
+  source: S
+): event is AutomationEventForSource<S> {
+  return event.source === source;
+}
+
+export function logAutomationEventRejection(
+  body: unknown,
+  source: AutomationEventSource,
+  issuePaths: string[],
+  ctx: RequestContext
+): void {
+  const rawEventType =
+    typeof body === "object" && body !== null && !Array.isArray(body)
+      ? (body as Record<string, unknown>).eventType
+      : undefined;
+  const eventType = typeof rawEventType === "string" ? rawEventType.slice(0, 128) : undefined;
+
+  logger.warn("Normalized automation event rejected", {
+    event: "automation_event.ingress_rejected",
+    source,
+    event_type: eventType,
+    issue_paths: issuePaths,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+}
 
 /**
  * Validate the source and the complete normalized event protocol.
@@ -36,22 +68,36 @@ export function validateAutomationEventEnvelope<S extends AutomationEventSource>
   source: S
 ): AutomationEventEnvelopeResult<S> {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
-    return { response: error("Invalid event: body must be a JSON object", 400) };
+    return {
+      response: error("Invalid event: body must be a JSON object", 400),
+      issuePaths: ["body"],
+    };
   }
   if ((body as Record<string, unknown>).source !== source) {
-    return { response: error(`Invalid event: source must be '${source}'`, 400) };
+    return {
+      response: error(`Invalid event: source must be '${source}'`, 400),
+      issuePaths: ["source"],
+    };
   }
 
   const parsed = automationEventSchema.safeParse(body);
   if (!parsed.success) {
-    const invalidFields = [
+    const issuePaths = [
       ...new Set(parsed.error.issues.map((issue) => issue.path.join(".") || "body")),
-    ].join(", ");
-    return { response: error(`Invalid event: ${invalidFields}`, 400) };
+    ];
+    return {
+      response: error(`Invalid event: ${issuePaths.join(", ")}`, 400),
+      issuePaths,
+    };
   }
 
-  // The source equality check above narrows the discriminated union at runtime.
-  return { event: parsed.data as AutomationEventForSource<S> };
+  if (!hasAutomationEventSource(parsed.data, source)) {
+    return {
+      response: error(`Invalid event: source must be '${source}'`, 400),
+      issuePaths: ["source"],
+    };
+  }
+  return { event: parsed.data };
 }
 
 /** Forward a validated event to the singleton SchedulerDO for matching. */
@@ -102,11 +148,15 @@ export function createAutomationEventRoute(opts: {
     try {
       body = await request.json();
     } catch {
+      logAutomationEventRejection(undefined, opts.source, ["body"], ctx);
       return error("Invalid JSON", 400);
     }
 
     const validated = validateAutomationEventEnvelope(body, opts.source);
-    if (validated.response) return validated.response;
+    if (validated.response) {
+      logAutomationEventRejection(body, opts.source, validated.issuePaths, ctx);
+      return validated.response;
+    }
 
     return forwardAutomationEventToScheduler(env, validated.event);
   }

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -6,7 +6,7 @@
  * background and is additive: its failure never affects automation matching.
  */
 
-import { automationEventSchema } from "@open-inspect/shared/triggers";
+import type { GitHubAutomationEvent } from "@open-inspect/shared/triggers";
 import { SessionIndexStore } from "../db/session-index";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { createLogger, parseLogLevel } from "../logger";
@@ -26,19 +26,13 @@ import {
   type SessionArtifactSummary,
 } from "./pull-request-lifecycle";
 
-function validateGitHubEvent(event: Record<string, unknown>): string | null {
-  return !event.repoOwner || !event.repoName
-    ? "Invalid event: repoOwner and repoName are required"
-    : null;
-}
-
 /**
  * Best-effort PR lifecycle tracking for one normalized event. Runs in
  * waitUntil off the request path; every failure is logged and swallowed.
  */
 async function trackPullRequestLifecycle(
   env: Env,
-  rawEvent: Record<string, unknown>,
+  event: GitHubAutomationEvent,
   ctx: RequestContext
 ): Promise<void> {
   const log = createLogger(
@@ -49,21 +43,7 @@ async function trackPullRequestLifecycle(
   try {
     if (!env.SESSION) return;
 
-    const parsed = automationEventSchema.safeParse(rawEvent);
-    if (!parsed.success) {
-      // Distinguish schema drift from the benign "not a PR event" skip: if
-      // the bot and control plane ever disagree on the envelope shape, PR
-      // tracking would otherwise go dark with zero signal.
-      if (typeof rawEvent.eventType === "string" && rawEvent.eventType.startsWith("pull_request")) {
-        log.warn("pull_request_lifecycle.envelope_parse_failed", {
-          event_type: rawEvent.eventType,
-          issues: parsed.error.issues.slice(0, 5).map((issue) => issue.path.join(".")),
-        });
-      }
-      return;
-    }
-    if (parsed.data.source !== "github" || !parsed.data.pullRequest) return;
-    const event = parsed.data;
+    if (!event.pullRequest) return;
 
     const sessionRuntime = createSessionRuntimeClient(env, ctx);
     const deps: PullRequestLifecycleDeps = {
@@ -129,7 +109,7 @@ async function handleGitHubAutomationEvent(
     return error("Invalid JSON", 400);
   }
 
-  const validated = validateAutomationEventEnvelope(body, "github", validateGitHubEvent);
+  const validated = validateAutomationEventEnvelope(body, "github");
   if (validated.response) return validated.response;
 
   const lifecycleWork = trackPullRequestLifecycle(env, validated.event, ctx);

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -18,6 +18,7 @@ import { error, parsePattern } from "../routes/shared";
 import { requireEventPoster } from "../auth/identity-enforcement";
 import {
   forwardAutomationEventToScheduler,
+  logAutomationEventRejection,
   validateAutomationEventEnvelope,
 } from "./automation-event";
 import {
@@ -106,11 +107,15 @@ async function handleGitHubAutomationEvent(
   try {
     body = await request.json();
   } catch {
+    logAutomationEventRejection(undefined, "github", ["body"], ctx);
     return error("Invalid JSON", 400);
   }
 
   const validated = validateAutomationEventEnvelope(body, "github");
-  if (validated.response) return validated.response;
+  if (validated.response) {
+    logAutomationEventRejection(body, "github", validated.issuePaths, ctx);
+    return validated.response;
+  }
 
   const lifecycleWork = trackPullRequestLifecycle(env, validated.event, ctx);
   if (ctx.executionCtx) {

--- a/packages/control-plane/src/webhooks/slack.ts
+++ b/packages/control-plane/src/webhooks/slack.ts
@@ -14,6 +14,4 @@ import { createAutomationEventRoute } from "./automation-event";
 export const slackAutomationEventRoute = createAutomationEventRoute({
   path: "/internal/slack-event",
   source: "slack",
-  validate: (event) =>
-    !event.channelId || !event.ts ? "Invalid event: channelId and ts are required" : null,
 });

--- a/packages/control-plane/test/integration/webhooks-slack.test.ts
+++ b/packages/control-plane/test/integration/webhooks-slack.test.ts
@@ -147,6 +147,19 @@ describe("POST /internal/slack-event (integration)", () => {
     expect(res.status).toBe(400);
   });
 
+  it.each([
+    ["eventType", { type: "message.posted" }],
+    ["triggerKey", ["slack:msg:C1:1"]],
+    ["concurrencyKey", { key: "slack:C1:1" }],
+    ["channelId", ["C1"]],
+    ["ts", { value: "1700000000.000200" }],
+  ])("returns 400 when %s is not a string", async (field, value) => {
+    const res = await postEvent(makeSlackEventBody({ [field]: value }));
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain(field);
+  });
+
   it("forwards a valid event to the scheduler and returns trigger counts", async () => {
     const id = await seedSlackAutomation();
     const body = makeSlackEventBody({ text: "please deploy the api" });

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -21,7 +21,16 @@ export type {
   TextMatchValue,
   TriggerConfig,
 } from "./types";
-export { TRIGGER_TYPE_TO_SOURCE, automationEventSchema, triggerConfigSchema } from "./types";
+export {
+  TRIGGER_TYPE_TO_SOURCE,
+  automationEventSchema,
+  githubAutomationEventSchema,
+  linearAutomationEventSchema,
+  sentryAutomationEventSchema,
+  webhookAutomationEventSchema,
+  slackAutomationEventSchema,
+  triggerConfigSchema,
+} from "./types";
 
 // Condition system
 export type { ConditionHandler, ConditionRegistry } from "./conditions";

--- a/packages/shared/src/triggers/sentry/conditions.test.ts
+++ b/packages/shared/src/triggers/sentry/conditions.test.ts
@@ -21,6 +21,15 @@ describe("sentry conditions", () => {
       );
     });
 
+    it("does not match metric alerts without a project", () => {
+      const event = buildMockEvent("sentry", { sentryProject: undefined });
+      assertConditionMatch(
+        { type: "sentry_project", operator: "any_of", value: ["acme-backend"] },
+        event,
+        false
+      );
+    });
+
     it("passes through for non-sentry events", () => {
       const event = buildMockEvent("github");
       assertConditionMatch(

--- a/packages/shared/src/triggers/sentry/conditions.ts
+++ b/packages/shared/src/triggers/sentry/conditions.ts
@@ -12,7 +12,7 @@ export const conditions = {
     },
     evaluate(c, event) {
       if (event.source !== "sentry") return true;
-      return c.value.includes(event.sentryProject);
+      return event.sentryProject !== undefined && c.value.includes(event.sentryProject);
     },
   },
   sentry_level: {

--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { sentryAutomationEventSchema } from "../types";
 import { normalizeSentryEvent } from "./normalizer";
 
 const issueAlertPayload = {
@@ -165,6 +166,30 @@ describe("normalizeSentryEvent", () => {
     expect(event.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");
     expect(event.concurrencyKey).toBe("sentry_metric:789");
     expect(event.meta.alertRuleId).toBe("789");
+  });
+
+  it("produces schema-valid metric alert events without a project", () => {
+    const metricPayload = {
+      action: "critical",
+      data: {
+        metric_alert: {
+          id: 456,
+          title: "Error rate > 5%",
+          alert_rule: { id: 789, name: "High error rate" },
+          date_started: "2026-03-23T14:30:00Z",
+          current_trigger: { label: "critical" },
+        },
+        description_text: "Error rate exceeded 5%",
+        description_title: "Metric Alert",
+        web_url: "https://sentry.io/alerts/456/",
+      },
+    };
+    const event = expectNormalized(
+      normalizeSentryEvent(metricPayload, "automation-1", "metric_alert")
+    );
+
+    expect(event.sentryProject).toBeUndefined();
+    expect(sentryAutomationEventSchema.safeParse(event).success).toBe(true);
   });
 
   it("returns unsupported_action for non-critical metric alerts", () => {

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -130,7 +130,6 @@ export function normalizeSentryEvent(
           eventType: "metric_alert.critical",
           triggerKey,
           concurrencyKey,
-          sentryProject: "",
           sentryLevel: "critical",
           contextBlock: buildSentryMetricContextBlock(p),
           meta: {

--- a/packages/shared/src/triggers/types.test.ts
+++ b/packages/shared/src/triggers/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { automationEventSchema } from "./types";
+import { automationEventSchema, githubAutomationEventSchema } from "./types";
 
 describe("automationEventSchema", () => {
   it("parses a valid Slack automation event", () => {
@@ -49,6 +49,21 @@ describe("automationEventSchema", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("exports source-specific schemas", () => {
+    const result = githubAutomationEventSchema.safeParse({
+      source: "github",
+      eventType: "pull_request.opened",
+      triggerKey: "github:pr:1",
+      concurrencyKey: "github:pr:1",
+      contextBlock: "A pull request was opened.",
+      meta: {},
+      repoOwner: "acme",
+      repoName: "web-app",
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("rejects optional arrays with non-string values", () => {

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -256,76 +256,86 @@ export type AutomationEvent =
   | SlackAutomationEvent;
 
 const baseAutomationEventSchema = {
-  eventType: z.string(),
-  triggerKey: z.string(),
-  concurrencyKey: z.string(),
+  eventType: z.string().min(1),
+  triggerKey: z.string().min(1),
+  concurrencyKey: z.string().min(1),
   contextBlock: z.string(),
   meta: z.record(z.string(), z.unknown()),
 };
 
+export const githubAutomationEventSchema = z.object({
+  ...baseAutomationEventSchema,
+  source: z.literal("github"),
+  repoOwner: z.string().min(1),
+  repoName: z.string().min(1),
+  branch: z.string().optional(),
+  targetBranch: z.string().optional(),
+  labels: z.array(z.string()).optional(),
+  actor: z.string().optional(),
+  changedFiles: z.array(z.string()).optional(),
+  checkConclusion: z.string().optional(),
+  pullRequest: z
+    .object({
+      number: z.number(),
+      state: z.enum(["open", "closed"]).optional(),
+      draft: z.boolean().optional(),
+      merged: z.boolean().optional(),
+      headSha: z.string().optional(),
+      isCrossRepository: z.boolean().optional(),
+      url: z.string().optional(),
+      repositoryExternalId: z.string().optional(),
+      providerCreatedAt: z.number().optional(),
+      providerUpdatedAt: z.number().optional(),
+      mergedAt: z.number().optional(),
+      closedAt: z.number().optional(),
+    })
+    .optional(),
+}) satisfies z.ZodType<GitHubAutomationEvent>;
+
+export const linearAutomationEventSchema = z.object({
+  ...baseAutomationEventSchema,
+  source: z.literal("linear"),
+  repoOwner: z.string().min(1),
+  repoName: z.string().min(1),
+  actor: z.string().optional(),
+  labels: z.array(z.string()).optional(),
+  linearStatus: z.string().optional(),
+}) satisfies z.ZodType<LinearAutomationEvent>;
+
+export const sentryAutomationEventSchema = z.object({
+  ...baseAutomationEventSchema,
+  source: z.literal("sentry"),
+  automationId: z.string().min(1),
+  sentryProject: z.string().min(1),
+  sentryLevel: z.string().min(1),
+  culpritFile: z.string().optional(),
+}) satisfies z.ZodType<SentryAutomationEvent>;
+
+export const webhookAutomationEventSchema = z.object({
+  ...baseAutomationEventSchema,
+  source: z.literal("webhook"),
+  automationId: z.string().min(1),
+  body: z.unknown(),
+}) satisfies z.ZodType<WebhookAutomationEvent>;
+
+export const slackAutomationEventSchema = z.object({
+  ...baseAutomationEventSchema,
+  source: z.literal("slack"),
+  channelId: z.string().min(1),
+  channelName: z.string().optional(),
+  permalink: z.string().optional(),
+  threadTs: z.string().optional(),
+  ts: z.string().min(1),
+  actorUserId: z.string().min(1),
+  text: z.string(),
+}) satisfies z.ZodType<SlackAutomationEvent>;
+
 export const automationEventSchema = z.discriminatedUnion("source", [
-  z.object({
-    ...baseAutomationEventSchema,
-    source: z.literal("github"),
-    repoOwner: z.string(),
-    repoName: z.string(),
-    branch: z.string().optional(),
-    targetBranch: z.string().optional(),
-    labels: z.array(z.string()).optional(),
-    actor: z.string().optional(),
-    changedFiles: z.array(z.string()).optional(),
-    checkConclusion: z.string().optional(),
-    pullRequest: z
-      .object({
-        number: z.number(),
-        state: z.enum(["open", "closed"]).optional(),
-        draft: z.boolean().optional(),
-        merged: z.boolean().optional(),
-        headSha: z.string().optional(),
-        isCrossRepository: z.boolean().optional(),
-        url: z.string().optional(),
-        repositoryExternalId: z.string().optional(),
-        providerCreatedAt: z.number().optional(),
-        providerUpdatedAt: z.number().optional(),
-        mergedAt: z.number().optional(),
-        closedAt: z.number().optional(),
-      })
-      .optional(),
-  }),
-  z.object({
-    ...baseAutomationEventSchema,
-    source: z.literal("linear"),
-    repoOwner: z.string(),
-    repoName: z.string(),
-    actor: z.string().optional(),
-    labels: z.array(z.string()).optional(),
-    linearStatus: z.string().optional(),
-  }),
-  z.object({
-    ...baseAutomationEventSchema,
-    source: z.literal("sentry"),
-    automationId: z.string(),
-    sentryProject: z.string(),
-    sentryLevel: z.string(),
-    culpritFile: z.string().optional(),
-  }),
-  z.object({
-    ...baseAutomationEventSchema,
-    source: z.literal("webhook"),
-    automationId: z.string(),
-    body: z.unknown(),
-  }),
-  z.object({
-    ...baseAutomationEventSchema,
-    source: z.literal("slack"),
-    channelId: z.string(),
-    channelName: z.string().optional(),
-    permalink: z.string().optional(),
-    threadTs: z.string().optional(),
-    ts: z.string(),
-    actorUserId: z.string(),
-    text: z.string(),
-  }),
+  githubAutomationEventSchema,
+  linearAutomationEventSchema,
+  sentryAutomationEventSchema,
+  webhookAutomationEventSchema,
+  slackAutomationEventSchema,
 ]);
 
 // ─── Trigger Source Definition ────────────────────────────────────────────────

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -120,146 +120,18 @@ export const triggerConfigSchema = z.object({
 
 export type TriggerConfig = z.infer<typeof triggerConfigSchema>;
 
-// ─── Event Sources ────────────────────────────────────────────────────────────
-
-export type AutomationEventSource = "github" | "linear" | "sentry" | "webhook" | "slack";
-
-/**
- * Maps AutomationTriggerType → AutomationEventSource.
- * Used by control-plane validation and web UI condition builders.
- */
-export const TRIGGER_TYPE_TO_SOURCE: Partial<Record<AutomationTriggerType, AutomationEventSource>> =
-  {
-    github_event: "github",
-    linear_event: "linear",
-    sentry: "sentry",
-    webhook: "webhook",
-    slack_event: "slack",
-  };
-
-// ─── Base Event ───────────────────────────────────────────────────────────────
-
-interface BaseAutomationEvent {
-  /** Dot-delimited event type (e.g., "pull_request.opened", "issue.created"). */
-  eventType: string;
-
-  /** Trigger key for dedup and concurrency (e.g., "pr:42", "sentry_issue:12345"). */
-  triggerKey: string;
-
-  /** Concurrency key — the stable prefix of triggerKey for concurrency scoping. */
-  concurrencyKey: string;
-
-  /** Human-readable context block prepended to automation instructions. */
-  contextBlock: string;
-
-  /** Raw event metadata for logging/debugging. Not used for matching. */
-  meta: Record<string, unknown>;
-}
-
-// ─── Source-Specific Variants ─────────────────────────────────────────────────
-
-/**
- * Typed pull-request facts carried on pull_request events. Every field beyond
- * the number is optional and reflects only what the webhook payload actually
- * said — consumers fall back to a provider read when a field is absent.
- */
-export interface GitHubPullRequestEventFacts {
-  number: number;
-  /** Raw provider state; merged-vs-closed is disambiguated by `merged`. */
-  state?: "open" | "closed";
-  draft?: boolean;
-  merged?: boolean;
-  headSha?: string;
-  /**
-   * True when the head branch lives in a different repository than the base
-   * (fork PR). Undefined when the payload lacks repo identity to compare.
-   */
-  isCrossRepository?: boolean;
-  /** Web URL of the pull request (html_url). */
-  url?: string;
-  /**
-   * Stable id of the repository the PR lives in (the base repo) — the
-   * canonical PR-record identity used for webhook correlation.
-   */
-  repositoryExternalId?: string;
-  /** Provider's created_at (epoch ms) — analytics cohort bucketing. */
-  providerCreatedAt?: number;
-  /** Provider's updated_at (epoch ms) — the monotonic write guard source. */
-  providerUpdatedAt?: number;
-  /** Provider's merged_at (epoch ms); only meaningful when merged. */
-  mergedAt?: number;
-  /** Provider's closed_at (epoch ms); only meaningful when not open. */
-  closedAt?: number;
-}
-
-export interface GitHubAutomationEvent extends BaseAutomationEvent {
-  source: "github";
-  repoOwner: string;
-  repoName: string;
-  /** Pull request head ref when the event is tied to a PR (source branch). */
-  branch?: string;
-  /** Pull request base ref when the event is tied to a PR (merge target branch). */
-  targetBranch?: string;
-  labels?: string[];
-  actor?: string;
-  changedFiles?: string[];
-  checkConclusion?: string;
-  /** Present only on pull_request events. */
-  pullRequest?: GitHubPullRequestEventFacts;
-}
-
-export interface LinearAutomationEvent extends BaseAutomationEvent {
-  source: "linear";
-  repoOwner: string;
-  repoName: string;
-  actor?: string;
-  labels?: string[];
-  linearStatus?: string;
-}
-
-export interface SentryAutomationEvent extends BaseAutomationEvent {
-  source: "sentry";
-  automationId: string;
-  sentryProject: string;
-  sentryLevel: string;
-  culpritFile?: string;
-}
-
-export interface WebhookAutomationEvent extends BaseAutomationEvent {
-  source: "webhook";
-  automationId: string;
-  body: unknown;
-}
-
-export interface SlackAutomationEvent extends BaseAutomationEvent {
-  source: "slack";
-  channelId: string;
-  channelName?: string;
-  /** Permalink to the triggering message, when Slack returned one. */
-  permalink?: string;
-  /** Parent thread ts when the message is a thread reply. */
-  threadTs?: string;
-  /** The message's own ts (the triggering message). */
-  ts: string;
-  actorUserId: string;
-  /** Message text — bot-mention token stripped and length-capped. */
-  text: string;
-}
-
-// ─── Discriminated Union ──────────────────────────────────────────────────────
-
-export type AutomationEvent =
-  | GitHubAutomationEvent
-  | LinearAutomationEvent
-  | SentryAutomationEvent
-  | WebhookAutomationEvent
-  | SlackAutomationEvent;
+// ─── Automation Events ────────────────────────────────────────────────────────
 
 const baseAutomationEventSchema = {
+  /** Dot-delimited event type (e.g., "pull_request.opened", "issue.created"). */
   eventType: z.string().min(1),
+  /** Trigger key for dedup and concurrency (e.g., "pr:42", "sentry_issue:12345"). */
   triggerKey: z.string().min(1),
+  /** Stable prefix of triggerKey used for concurrency scoping. */
   concurrencyKey: z.string().min(1),
+  /** Human-readable context prepended to automation instructions. */
   contextBlock: z.string(),
+  /** Raw event metadata for logging/debugging. Not used for matching. */
   meta: z.record(z.string(), z.unknown()),
 };
 
@@ -268,12 +140,15 @@ export const githubAutomationEventSchema = z.object({
   source: z.literal("github"),
   repoOwner: z.string().min(1),
   repoName: z.string().min(1),
+  /** Pull request head ref when the event is tied to a PR. */
   branch: z.string().optional(),
+  /** Pull request base ref when the event is tied to a PR. */
   targetBranch: z.string().optional(),
   labels: z.array(z.string()).optional(),
   actor: z.string().optional(),
   changedFiles: z.array(z.string()).optional(),
   checkConclusion: z.string().optional(),
+  /** Present only on pull_request events. */
   pullRequest: z
     .object({
       number: z.number(),
@@ -290,7 +165,7 @@ export const githubAutomationEventSchema = z.object({
       closedAt: z.number().optional(),
     })
     .optional(),
-}) satisfies z.ZodType<GitHubAutomationEvent>;
+});
 
 export const linearAutomationEventSchema = z.object({
   ...baseAutomationEventSchema,
@@ -300,35 +175,40 @@ export const linearAutomationEventSchema = z.object({
   actor: z.string().optional(),
   labels: z.array(z.string()).optional(),
   linearStatus: z.string().optional(),
-}) satisfies z.ZodType<LinearAutomationEvent>;
+});
 
 export const sentryAutomationEventSchema = z.object({
   ...baseAutomationEventSchema,
   source: z.literal("sentry"),
   automationId: z.string().min(1),
-  sentryProject: z.string().min(1),
+  /** Metric alerts do not identify a single project. */
+  sentryProject: z.string().min(1).optional(),
   sentryLevel: z.string().min(1),
   culpritFile: z.string().optional(),
-}) satisfies z.ZodType<SentryAutomationEvent>;
+});
 
 export const webhookAutomationEventSchema = z.object({
   ...baseAutomationEventSchema,
   source: z.literal("webhook"),
   automationId: z.string().min(1),
   body: z.unknown(),
-}) satisfies z.ZodType<WebhookAutomationEvent>;
+});
 
 export const slackAutomationEventSchema = z.object({
   ...baseAutomationEventSchema,
   source: z.literal("slack"),
   channelId: z.string().min(1),
   channelName: z.string().optional(),
+  /** Permalink to the triggering message, when Slack returned one. */
   permalink: z.string().optional(),
+  /** Parent thread ts when the message is a thread reply. */
   threadTs: z.string().optional(),
+  /** The triggering message's own ts. */
   ts: z.string().min(1),
   actorUserId: z.string().min(1),
+  /** Bot-mention token stripped and length-capped. */
   text: z.string(),
-}) satisfies z.ZodType<SlackAutomationEvent>;
+});
 
 export const automationEventSchema = z.discriminatedUnion("source", [
   githubAutomationEventSchema,
@@ -337,6 +217,28 @@ export const automationEventSchema = z.discriminatedUnion("source", [
   webhookAutomationEventSchema,
   slackAutomationEventSchema,
 ]);
+
+export type AutomationEvent = z.infer<typeof automationEventSchema>;
+export type AutomationEventSource = AutomationEvent["source"];
+export type GitHubAutomationEvent = z.infer<typeof githubAutomationEventSchema>;
+export type GitHubPullRequestEventFacts = NonNullable<GitHubAutomationEvent["pullRequest"]>;
+export type LinearAutomationEvent = z.infer<typeof linearAutomationEventSchema>;
+export type SentryAutomationEvent = z.infer<typeof sentryAutomationEventSchema>;
+export type WebhookAutomationEvent = z.infer<typeof webhookAutomationEventSchema>;
+export type SlackAutomationEvent = z.infer<typeof slackAutomationEventSchema>;
+
+/**
+ * Maps AutomationTriggerType → AutomationEventSource.
+ * Used by control-plane validation and web UI condition builders.
+ */
+export const TRIGGER_TYPE_TO_SOURCE: Partial<Record<AutomationTriggerType, AutomationEventSource>> =
+  {
+    github_event: "github",
+    linear_event: "linear",
+    sentry: "sentry",
+    webhook: "webhook",
+    slack_event: "slack",
+  };
 
 // ─── Trigger Source Definition ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- export source-specific Zod schemas and compose them into the shared discriminated automation event schema
- parse and normalize internal automation events once at control-plane ingress before scheduler forwarding
- pass concrete typed GitHub events to PR lifecycle processing instead of reparsing open records
- reject malformed object/array values and empty required dispatch keys, while dropping unknown envelope fields

## Testing
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/control-plane`
- `npm test -w @open-inspect/shared -- --run src/triggers/types.test.ts`
- `npm test -w @open-inspect/control-plane -- --run src/webhooks/automation-event.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/webhooks-slack.test.ts test/integration/webhooks-github-pr-lifecycle.test.ts`

Closes COL-41.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/308757fe0622e55a6ea1f2e7785f1c6e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automation events from GitHub, Slack, Linear, Sentry, and webhook integrations now enforce consistent field and source-specific validation.
  * Invalid types, empty identifiers, missing required values, and incompatible fields return clearer HTTP 400 errors.
  * Sentry metric alerts without a project are accepted while remaining excluded from project-specific conditions.
  * Rejected webhook requests now provide safer, more informative diagnostic details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->