### PR TITLE
fix: validate MCP server request bodies

### DIFF
--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import type { ValidatedCreateMcpServerInput } from "@open-inspect/shared/types/integrations";
 import { McpServerStore, McpServerValidationError } from "./mcp-servers";
 
 // ─── Fake D1 helpers ────────────────────────────────────────────────────────
@@ -180,23 +181,34 @@ describe("McpServerStore", () => {
     it("throws McpServerValidationError for local server without command", async () => {
       const { db } = createFakeD1();
       const store = new McpServerStore(db);
-      await expect(store.create({ name: "test", type: "local", enabled: true })).rejects.toThrow(
-        McpServerValidationError
-      );
+      const invalid = {
+        name: "test",
+        type: "local",
+        enabled: true,
+      } as unknown as ValidatedCreateMcpServerInput;
+      await expect(store.create(invalid)).rejects.toThrow(McpServerValidationError);
     });
 
     it("throws McpServerValidationError for remote server without url", async () => {
       const { db } = createFakeD1({ firstResult: remoteRow });
       const store = new McpServerStore(db);
-      await expect(store.create({ name: "test", type: "remote", enabled: true })).rejects.toThrow(
-        McpServerValidationError
-      );
+      const invalid = {
+        name: "test",
+        type: "remote",
+        enabled: true,
+      } as unknown as ValidatedCreateMcpServerInput;
+      await expect(store.create(invalid)).rejects.toThrow(McpServerValidationError);
     });
 
     it("throws McpServerValidationError (not generic Error) so routes can return 400", async () => {
       const { db } = createFakeD1();
       const store = new McpServerStore(db);
-      const err = await store.create({ name: "x", type: "local", enabled: true }).catch((e) => e);
+      const invalid = {
+        name: "x",
+        type: "local",
+        enabled: true,
+      } as unknown as ValidatedCreateMcpServerInput;
+      const err = await store.create(invalid).catch((e) => e);
       expect(err).toBeInstanceOf(McpServerValidationError);
       expect(err).toBeInstanceOf(Error);
     });

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -69,8 +69,8 @@ function rowToConfig(row: McpServerRow, payload: Record<string, string>): McpSer
     id: row.id,
     name: row.name,
     type: row.type as "local" | "remote",
-    command: safeJsonParseCommand(row.command),
-    url: row.url ?? undefined,
+    command: row.type === "local" ? safeJsonParseCommand(row.command) : undefined,
+    url: row.type === "remote" ? (row.url ?? undefined) : undefined,
     ...envOrHeaders,
     repoScopes: parseRepoScopes(row.repo_scope),
     enabled: row.enabled === 1,
@@ -83,8 +83,8 @@ function rowToMetadata(row: McpServerRow): McpServerMetadata {
     id: row.id,
     name: row.name,
     type: row.type as "local" | "remote",
-    command: safeJsonParseCommand(row.command),
-    url: row.url ?? undefined,
+    command: row.type === "local" ? safeJsonParseCommand(row.command) : undefined,
+    url: row.type === "remote" ? (row.url ?? undefined) : undefined,
     hasEnv: row.type === "local" && hasCredentials,
     hasHeaders: row.type === "remote" && hasCredentials,
     repoScopes: parseRepoScopes(row.repo_scope),
@@ -258,8 +258,8 @@ export class McpServerStore {
         .bind(
           patch.name ?? row.name,
           mergedType,
-          mergedCommand ? JSON.stringify(mergedCommand) : null,
-          mergedUrl ?? null,
+          mergedType === "local" && mergedCommand ? JSON.stringify(mergedCommand) : null,
+          mergedType === "remote" ? (mergedUrl ?? null) : null,
           encryptedEnv,
           patch.repoScopes !== undefined
             ? patch.repoScopes?.length

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -1,4 +1,9 @@
-import type { McpServerConfig, McpServerMetadata } from "@open-inspect/shared/types/integrations";
+import type {
+  CreateMcpServerInput,
+  McpServerConfig,
+  McpServerMetadata,
+  UpdateMcpServerInput,
+} from "@open-inspect/shared/types/integrations";
 import { encryptToken, decryptToken } from "../auth/crypto";
 import { createLogger } from "../logger";
 import { isUniqueConstraintError } from "./errors";
@@ -147,7 +152,7 @@ export class McpServerStore {
     return row ? rowToMetadata(row) : null;
   }
 
-  async create(config: Omit<McpServerConfig, "id">): Promise<McpServerMetadata> {
+  async create(config: CreateMcpServerInput): Promise<McpServerMetadata> {
     const id = generateId();
     const now = Date.now();
 
@@ -197,15 +202,7 @@ export class McpServerStore {
     return created;
   }
 
-  async update(
-    id: string,
-    patch: Partial<
-      Pick<
-        McpServerConfig,
-        "name" | "type" | "command" | "url" | "env" | "headers" | "repoScopes" | "enabled"
-      >
-    >
-  ): Promise<McpServerMetadata | null> {
+  async update(id: string, patch: UpdateMcpServerInput): Promise<McpServerMetadata | null> {
     const row = await this.db
       .prepare("SELECT * FROM mcp_servers WHERE id = ?")
       .bind(id)

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -1,8 +1,8 @@
 import type {
-  CreateMcpServerInput,
   McpServerConfig,
   McpServerMetadata,
-  UpdateMcpServerInput,
+  ValidatedCreateMcpServerInput,
+  ValidatedUpdateMcpServerInput,
 } from "@open-inspect/shared/types/integrations";
 import { encryptToken, decryptToken } from "../auth/crypto";
 import { createLogger } from "../logger";
@@ -152,7 +152,7 @@ export class McpServerStore {
     return row ? rowToMetadata(row) : null;
   }
 
-  async create(config: CreateMcpServerInput): Promise<McpServerMetadata> {
+  async create(config: ValidatedCreateMcpServerInput): Promise<McpServerMetadata> {
     const id = generateId();
     const now = Date.now();
 
@@ -177,8 +177,8 @@ export class McpServerStore {
           id,
           config.name,
           config.type,
-          config.command ? JSON.stringify(config.command) : null,
-          config.url ?? null,
+          config.type === "local" ? JSON.stringify(config.command) : null,
+          config.type === "remote" ? config.url : null,
           encryptedEnv,
           config.repoScopes?.length
             ? JSON.stringify(config.repoScopes.map((r) => r.toLowerCase()))
@@ -202,12 +202,23 @@ export class McpServerStore {
     return created;
   }
 
-  async update(id: string, patch: UpdateMcpServerInput): Promise<McpServerMetadata | null> {
+  async update(
+    id: string,
+    patch: ValidatedUpdateMcpServerInput
+  ): Promise<McpServerMetadata | null> {
     const row = await this.db
       .prepare("SELECT * FROM mcp_servers WHERE id = ?")
       .bind(id)
       .first<McpServerRow>();
     if (!row) return null;
+
+    const mergedType = patch.type ?? (row.type as "local" | "remote");
+    if (mergedType === "local" && (patch.url !== undefined || patch.headers !== undefined)) {
+      throw new McpServerValidationError("Local MCP servers do not support url or headers");
+    }
+    if (mergedType === "remote" && (patch.command !== undefined || patch.env !== undefined)) {
+      throw new McpServerValidationError("Remote MCP servers do not support command or env");
+    }
 
     const credentialsChanged =
       patch.env !== undefined || patch.headers !== undefined || patch.type !== undefined;
@@ -225,7 +236,6 @@ export class McpServerStore {
       encryptedEnv = row.env;
     }
 
-    const mergedType = patch.type ?? (row.type as "local" | "remote");
     const mergedCommand =
       patch.command !== undefined ? patch.command : safeJsonParseCommand(row.command);
     const mergedUrl = patch.url !== undefined ? patch.url : (row.url ?? undefined);

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -1,8 +1,18 @@
-import type { McpServerConfig } from "@open-inspect/shared/types/integrations";
+import {
+  createMcpServerInputSchema,
+  updateMcpServerInputSchema,
+} from "@open-inspect/shared/types/integrations";
 import { McpServerStore, McpServerValidationError } from "../db/mcp-servers";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
-import { type Route, type RequestContext, parsePattern, json, error } from "./shared";
+import {
+  type Route,
+  type RequestContext,
+  parsePattern,
+  json,
+  error,
+  parseJsonBody,
+} from "./shared";
 
 const logger = createLogger("router:mcp-servers");
 
@@ -58,49 +68,14 @@ async function handleCreateMcpServer(
 ): Promise<Response> {
   if (!ctx.db) return error("Database not configured", 503);
 
-  let body: Partial<McpServerConfig>;
-  try {
-    body = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return error("Request body must be a JSON object", 400);
-  }
-
-  if (!body.name || typeof body.name !== "string") {
-    return error("name is required", 400);
-  }
-  if (body.type !== "local" && body.type !== "remote") {
-    return error("type must be 'local' or 'remote'", 400);
-  }
-  if (
-    body.command !== undefined &&
-    (!Array.isArray(body.command) || !body.command.every((c: unknown) => typeof c === "string"))
-  ) {
-    return error("command must be an array of strings", 400);
-  }
-  if (
-    body.repoScopes !== undefined &&
-    body.repoScopes !== null &&
-    (!Array.isArray(body.repoScopes) ||
-      !body.repoScopes.every((s: unknown) => typeof s === "string"))
-  ) {
-    return error("repoScopes must be an array of strings", 400);
-  }
+  const body = await parseJsonBody<unknown>(request);
+  if (body instanceof Response) return body;
+  const parsed = createMcpServerInputSchema.safeParse(body);
+  if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
   try {
     const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
-    const server = await store.create({
-      name: body.name,
-      type: body.type,
-      command: body.command,
-      url: body.url,
-      env: body.env,
-      headers: body.headers,
-      repoScopes: body.repoScopes ?? null,
-      enabled: body.enabled !== false,
-    });
+    const server = await store.create(parsed.data);
     logger.info("MCP server created", {
       event: "mcp_server.created",
       request_id: ctx.request_id,
@@ -127,41 +102,14 @@ async function handleUpdateMcpServer(
   if (!id) return error("Missing server ID", 400);
   if (!ctx.db) return error("Database not configured", 503);
 
-  let body: Partial<McpServerConfig>;
-  try {
-    body = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return error("Request body must be a JSON object", 400);
-  }
-
-  if (
-    body.name !== undefined &&
-    (!body.name || typeof body.name !== "string" || !body.name.trim())
-  ) {
-    return error("name must be a non-empty string", 400);
-  }
-
-  if (
-    body.command !== undefined &&
-    (!Array.isArray(body.command) || !body.command.every((c: unknown) => typeof c === "string"))
-  ) {
-    return error("command must be an array of strings", 400);
-  }
-  if (
-    body.repoScopes !== undefined &&
-    body.repoScopes !== null &&
-    (!Array.isArray(body.repoScopes) ||
-      !body.repoScopes.every((s: unknown) => typeof s === "string"))
-  ) {
-    return error("repoScopes must be an array of strings", 400);
-  }
+  const body = await parseJsonBody<unknown>(request);
+  if (body instanceof Response) return body;
+  const parsed = updateMcpServerInputSchema.safeParse(body);
+  if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
   try {
     const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
-    const updated = await store.update(id, body);
+    const updated = await store.update(id, parsed.data);
     if (!updated) return error("MCP server not found", 404);
 
     logger.info("MCP server updated", {

--- a/packages/control-plane/test/integration/mcp-servers.test.ts
+++ b/packages/control-plane/test/integration/mcp-servers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { cleanD1Tables } from "./cleanup";
 import { serviceFetch } from "./helpers";
 
@@ -285,6 +285,56 @@ describe("MCP Servers API", () => {
         body: JSON.stringify({ type: "local" }),
       });
       expect(response.status).toBe(400);
+    });
+
+    it("changes a local server to remote without retaining command", async () => {
+      const createRes = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({ name: "local-to-remote", type: "local", command: ["npx", "x"] }),
+      });
+      const created = await createRes.json<McpServerMetadata>();
+
+      const response = await serviceFetch(`https://test.local/mcp-servers/${created.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ type: "remote", url: "https://remote.example.com" }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json<McpServerMetadata>();
+      expect(body.type).toBe("remote");
+      expect(body.url).toBe("https://remote.example.com");
+      expect(body.command).toBeUndefined();
+      const row = await env.DB.prepare("SELECT command FROM mcp_servers WHERE id = ?")
+        .bind(created.id)
+        .first<{ command: string | null }>();
+      expect(row?.command).toBeNull();
+    });
+
+    it("changes a remote server to local without retaining URL", async () => {
+      const createRes = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "remote-to-local",
+          type: "remote",
+          url: "https://remote.example.com",
+        }),
+      });
+      const created = await createRes.json<McpServerMetadata>();
+
+      const response = await serviceFetch(`https://test.local/mcp-servers/${created.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ type: "local", command: ["npx", "x"] }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json<McpServerMetadata>();
+      expect(body.type).toBe("local");
+      expect(body.command).toEqual(["npx", "x"]);
+      expect(body.url).toBeUndefined();
+      const row = await env.DB.prepare("SELECT url FROM mcp_servers WHERE id = ?")
+        .bind(created.id)
+        .first<{ url: string | null }>();
+      expect(row?.url).toBeNull();
     });
 
     it.each([

--- a/packages/control-plane/test/integration/mcp-servers.test.ts
+++ b/packages/control-plane/test/integration/mcp-servers.test.ts
@@ -94,7 +94,9 @@ describe("MCP Servers API", () => {
 
     it.each([
       ["non-string URL", { url: 42 }],
+      ["malformed URL", { url: "not a url" }],
       ["non-string environment value", { env: { DEBUG: true } }],
+      ["environment on a remote server", { env: { TOKEN: "secret" } }],
       ["non-object headers", { headers: ["Authorization"] }],
       ["non-boolean enabled", { enabled: "yes" }],
       ["unknown fields", { unexpected: true }],
@@ -106,6 +108,20 @@ describe("MCP Servers API", () => {
           type: "remote",
           url: "https://test.example.com",
           ...invalidField,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 for headers on a local server", async () => {
+      const response = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "invalid-local-headers",
+          type: "local",
+          command: ["npx", "x"],
+          headers: { Authorization: "secret" },
         }),
       });
 
@@ -274,7 +290,9 @@ describe("MCP Servers API", () => {
     it.each([
       ["invalid type", { type: "stdio" }],
       ["non-string URL", { url: 42 }],
+      ["malformed URL", { url: "not a url" }],
       ["non-object environment", { env: ["DEBUG=1"] }],
+      ["environment on a remote server", { env: { DEBUG: "1" } }],
       ["non-string header value", { headers: { Authorization: 123 } }],
       ["non-boolean enabled", { enabled: 1 }],
       ["unknown fields", { id: "replacement" }],
@@ -292,6 +310,21 @@ describe("MCP Servers API", () => {
       const response = await serviceFetch(`https://test.local/mcp-servers/${created.id}`, {
         method: "PUT",
         body: JSON.stringify(patch),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 for headers on an existing local server", async () => {
+      const createRes = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({ name: "local-update", type: "local", command: ["npx", "x"] }),
+      });
+      const created = await createRes.json<McpServerMetadata>();
+
+      const response = await serviceFetch(`https://test.local/mcp-servers/${created.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ headers: { Authorization: "secret" } }),
       });
 
       expect(response.status).toBe(400);

--- a/packages/control-plane/test/integration/mcp-servers.test.ts
+++ b/packages/control-plane/test/integration/mcp-servers.test.ts
@@ -92,6 +92,26 @@ describe("MCP Servers API", () => {
       expect(response.status).toBe(400);
     });
 
+    it.each([
+      ["non-string URL", { url: 42 }],
+      ["non-string environment value", { env: { DEBUG: true } }],
+      ["non-object headers", { headers: ["Authorization"] }],
+      ["non-boolean enabled", { enabled: "yes" }],
+      ["unknown fields", { unexpected: true }],
+    ])("returns 400 for %s", async (_description, invalidField) => {
+      const response = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "invalid",
+          type: "remote",
+          url: "https://test.example.com",
+          ...invalidField,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
     it("returns 400 for duplicate name", async () => {
       await serviceFetch("https://test.local/mcp-servers", {
         method: "POST",
@@ -248,6 +268,32 @@ describe("MCP Servers API", () => {
         method: "PUT",
         body: JSON.stringify({ type: "local" }),
       });
+      expect(response.status).toBe(400);
+    });
+
+    it.each([
+      ["invalid type", { type: "stdio" }],
+      ["non-string URL", { url: 42 }],
+      ["non-object environment", { env: ["DEBUG=1"] }],
+      ["non-string header value", { headers: { Authorization: 123 } }],
+      ["non-boolean enabled", { enabled: 1 }],
+      ["unknown fields", { id: "replacement" }],
+    ])("returns 400 for %s", async (_description, patch) => {
+      const createRes = await serviceFetch("https://test.local/mcp-servers", {
+        method: "POST",
+        body: JSON.stringify({
+          name: `invalid-update-${_description}`,
+          type: "remote",
+          url: "https://test.example.com",
+        }),
+      });
+      const created = await createRes.json<McpServerMetadata>();
+
+      const response = await serviceFetch(`https://test.local/mcp-servers/${created.id}`, {
+        method: "PUT",
+        body: JSON.stringify(patch),
+      });
+
       expect(response.status).toBe(400);
     });
   });

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -412,6 +412,29 @@ export interface McpServerConfig {
   enabled: boolean;
 }
 
+const mcpServerWritableFields = {
+  name: z.string().trim().min(1),
+  type: z.enum(["local", "remote"]),
+  command: z.array(z.string()).optional(),
+  url: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  repoScopes: z.array(z.string()).nullable().optional(),
+  enabled: z.boolean().optional(),
+};
+
+export const createMcpServerInputSchema = z
+  .object({
+    ...mcpServerWritableFields,
+    enabled: mcpServerWritableFields.enabled.default(true),
+  })
+  .strict();
+
+export const updateMcpServerInputSchema = z.object(mcpServerWritableFields).partial().strict();
+
+export type CreateMcpServerInput = z.infer<typeof createMcpServerInputSchema>;
+export type UpdateMcpServerInput = z.infer<typeof updateMcpServerInputSchema>;
+
 /** MCP server metadata for API responses — no decrypted credentials. */
 export interface McpServerMetadata {
   id: string;

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -412,28 +412,49 @@ export interface McpServerConfig {
   enabled: boolean;
 }
 
-const mcpServerWritableFields = {
+const mcpServerCommonFields = {
   name: z.string().trim().min(1),
-  type: z.enum(["local", "remote"]),
-  command: z.array(z.string()).optional(),
-  url: z.string().optional(),
-  env: z.record(z.string(), z.string()).optional(),
-  headers: z.record(z.string(), z.string()).optional(),
   repoScopes: z.array(z.string()).nullable().optional(),
   enabled: z.boolean().optional(),
 };
 
-export const createMcpServerInputSchema = z
+export const createMcpServerInputSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      ...mcpServerCommonFields,
+      type: z.literal("local"),
+      command: z.array(z.string()).min(1),
+      env: z.record(z.string(), z.string()).optional(),
+      enabled: mcpServerCommonFields.enabled.default(true),
+    })
+    .strict(),
+  z
+    .object({
+      ...mcpServerCommonFields,
+      type: z.literal("remote"),
+      url: z.url(),
+      headers: z.record(z.string(), z.string()).optional(),
+      enabled: mcpServerCommonFields.enabled.default(true),
+    })
+    .strict(),
+]);
+
+export const updateMcpServerInputSchema = z
   .object({
-    ...mcpServerWritableFields,
-    enabled: mcpServerWritableFields.enabled.default(true),
+    ...mcpServerCommonFields,
+    type: z.enum(["local", "remote"]),
+    command: z.array(z.string()),
+    url: z.url(),
+    env: z.record(z.string(), z.string()),
+    headers: z.record(z.string(), z.string()),
   })
+  .partial()
   .strict();
 
-export const updateMcpServerInputSchema = z.object(mcpServerWritableFields).partial().strict();
-
-export type CreateMcpServerInput = z.infer<typeof createMcpServerInputSchema>;
-export type UpdateMcpServerInput = z.infer<typeof updateMcpServerInputSchema>;
+export type CreateMcpServerRequest = z.input<typeof createMcpServerInputSchema>;
+export type UpdateMcpServerRequest = z.input<typeof updateMcpServerInputSchema>;
+export type ValidatedCreateMcpServerInput = z.output<typeof createMcpServerInputSchema>;
+export type ValidatedUpdateMcpServerInput = z.output<typeof updateMcpServerInputSchema>;
 
 /** MCP server metadata for API responses — no decrypted credentials. */
 export interface McpServerMetadata {

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -412,6 +412,8 @@ export interface McpServerConfig {
   enabled: boolean;
 }
 
+export const DEFAULT_MCP_SERVER_ENABLED = true;
+
 const mcpServerCommonFields = {
   name: z.string().trim().min(1),
   repoScopes: z.array(z.string()).nullable().optional(),
@@ -425,7 +427,7 @@ export const createMcpServerInputSchema = z.discriminatedUnion("type", [
       type: z.literal("local"),
       command: z.array(z.string()).min(1),
       env: z.record(z.string(), z.string()).optional(),
-      enabled: mcpServerCommonFields.enabled.default(true),
+      enabled: mcpServerCommonFields.enabled.default(DEFAULT_MCP_SERVER_ENABLED),
     })
     .strict(),
   z
@@ -434,7 +436,7 @@ export const createMcpServerInputSchema = z.discriminatedUnion("type", [
       type: z.literal("remote"),
       url: z.url(),
       headers: z.record(z.string(), z.string()).optional(),
-      enabled: mcpServerCommonFields.enabled.default(true),
+      enabled: mcpServerCommonFields.enabled.default(DEFAULT_MCP_SERVER_ENABLED),
     })
     .strict(),
 ]);

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useCallback, type ClipboardEvent } from "react";
 import { toast } from "sonner";
-import type { McpServerConfig, McpServerMetadata } from "@open-inspect/shared/types/integrations";
+import type {
+  CreateMcpServerRequest,
+  McpServerMetadata,
+} from "@open-inspect/shared/types/integrations";
 import {
   useMcpServers,
   createMcpServer,
@@ -471,9 +474,8 @@ export function McpServersSettings() {
     setSaving(true);
 
     try {
-      const payload: Partial<McpServerConfig> = {
+      const common = {
         name: form.name.trim(),
-        type: form.type,
         enabled: form.enabled,
         repoScopes:
           form.scopeMode === "selected" && form.repoScopes.length > 0 ? form.repoScopes : null,
@@ -481,21 +483,24 @@ export function McpServersSettings() {
 
       const envRecord = envRowsToRecord(form.envRows);
       const hasEnvValues = Object.keys(envRecord).length > 0;
-
-      if (form.type === "remote") {
-        payload.url = form.url.trim();
-        if (hasEnvValues || editing === "new") {
-          payload.headers = envRecord;
-        }
-      } else {
-        payload.command = parseCommand(form.command);
-        if (hasEnvValues || editing === "new") {
-          payload.env = envRecord;
-        }
-      }
+      const includeCredentials = hasEnvValues || editing === "new";
+      const payload: CreateMcpServerRequest =
+        form.type === "remote"
+          ? {
+              ...common,
+              type: "remote",
+              url: form.url.trim(),
+              ...(includeCredentials ? { headers: envRecord } : {}),
+            }
+          : {
+              ...common,
+              type: "local",
+              command: parseCommand(form.command),
+              ...(includeCredentials ? { env: envRecord } : {}),
+            };
 
       if (editing === "new") {
-        await createMcpServer(payload as Omit<McpServerConfig, "id">);
+        await createMcpServer(payload);
         toast.success("MCP server created");
       } else if (editing) {
         await updateMcpServer(editing, payload);

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -6,6 +6,7 @@ import type {
   CreateMcpServerRequest,
   McpServerMetadata,
 } from "@open-inspect/shared/types/integrations";
+import { DEFAULT_MCP_SERVER_ENABLED } from "@open-inspect/shared/types/integrations";
 import {
   useMcpServers,
   createMcpServer,
@@ -68,7 +69,7 @@ const emptyForm: FormState = {
   envRows: [createEnvRow()],
   repoScopes: [],
   scopeMode: "global",
-  enabled: true,
+  enabled: DEFAULT_MCP_SERVER_ENABLED,
 };
 
 function metadataToForm(metadata: McpServerMetadata): FormState {

--- a/packages/web/src/hooks/use-mcp-servers.ts
+++ b/packages/web/src/hooks/use-mcp-servers.ts
@@ -1,7 +1,11 @@
 import useSWR from "swr";
 import { useAuthSession } from "@/lib/auth-session";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
-import type { McpServerConfig, McpServerMetadata } from "@open-inspect/shared/types/integrations";
+import type {
+  CreateMcpServerRequest,
+  McpServerMetadata,
+  UpdateMcpServerRequest,
+} from "@open-inspect/shared/types/integrations";
 
 const MCP_SERVERS_KEY = "/api/mcp-servers";
 
@@ -17,9 +21,7 @@ export function useMcpServers() {
   };
 }
 
-export async function createMcpServer(
-  config: Omit<McpServerConfig, "id">
-): Promise<McpServerMetadata> {
+export async function createMcpServer(config: CreateMcpServerRequest): Promise<McpServerMetadata> {
   const response = await browserApiFetch(MCP_SERVERS_KEY, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -34,7 +36,7 @@ export async function createMcpServer(
 
 export async function updateMcpServer(
   id: string,
-  patch: Partial<McpServerConfig>
+  patch: UpdateMcpServerRequest
 ): Promise<McpServerMetadata> {
   const response = await browserApiFetch(`${MCP_SERVERS_KEY}/${id}`, {
     method: "PUT",


### PR DESCRIPTION
## Summary
- add strict Zod schemas for MCP server create and update requests
- pass only parsed request values into `McpServerStore` and type store inputs from the schemas
- reject malformed credential maps, URLs, booleans, server types, and unknown fields
- add integration coverage for invalid create and update payloads

## Verification
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane -- src/db/mcp-servers.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- mcp-servers.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f28e520ab8c24c6cb7377be585f4cefc)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for MCP server creation and updates.
  * Invalid formats, field types, nested values, and unknown fields now return clear 400 errors.
  * Prevented incompatible settings, such as URLs for local servers or commands for remote servers.
  * New MCP servers default to enabled when unspecified.
  * Server-specific credentials and connection settings are handled more reliably.

* **Tests**
  * Added coverage for invalid requests, type changes, and incompatible settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->