### PR TITLE
fix: validate Vercel Sandbox API responses

### DIFF
--- a/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
@@ -158,6 +158,33 @@ describe("VercelSandboxClient", () => {
     expect(result).toEqual({ commandId: "cmd-1", exitCode: null });
   });
 
+  it.each([
+    ["createSandbox", () => createClient().createSandbox({ name: "sandbox-1" })],
+    [
+      "startCommand",
+      () => createClient().startCommand({ sessionId: "session-1", command: "true" }),
+    ],
+    ["snapshotSession", () => createClient().snapshotSession("session-1")],
+    ["listSnapshots", () => createClient().listSnapshots()],
+  ])("rejects a valid JSON error envelope from %s", async (_endpoint, request) => {
+    const responseBody = JSON.stringify({ error: { code: "provider_drift" } });
+    fetchSpy.mockResolvedValue(new Response(responseBody, { status: 200 }));
+
+    await expect(request()).rejects.toMatchObject({
+      name: "VercelSandboxApiError",
+      status: 200,
+      responseText: responseBody,
+    });
+  });
+
+  it("rejects invalid JSON from a JSON endpoint", async () => {
+    fetchSpy.mockResolvedValue(new Response("not-json", { status: 200 }));
+
+    await expect(createClient().listSnapshots()).rejects.toThrow(
+      "Vercel Sandbox API returned invalid JSON"
+    );
+  });
+
   it("parses NDJSON output from a waited command", async () => {
     fetchSpy.mockResolvedValue(
       new Response(

--- a/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
@@ -168,21 +168,27 @@ describe("VercelSandboxClient", () => {
     ["listSnapshots", () => createClient().listSnapshots()],
   ])("rejects a valid JSON error envelope from %s", async (_endpoint, request) => {
     const responseBody = JSON.stringify({ error: { code: "provider_drift" } });
-    fetchSpy.mockResolvedValue(new Response(responseBody, { status: 200 }));
+    fetchSpy.mockResolvedValue(new Response(responseBody, { status: 201 }));
 
     await expect(request()).rejects.toMatchObject({
       name: "VercelSandboxApiError",
-      status: 200,
+      status: 201,
       responseText: responseBody,
     });
   });
 
-  it("rejects invalid JSON from a JSON endpoint", async () => {
-    fetchSpy.mockResolvedValue(new Response("not-json", { status: 200 }));
+  it("preserves status and logs an error for invalid JSON", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    fetchSpy.mockResolvedValue(new Response("not-json", { status: 202 }));
 
-    await expect(createClient().listSnapshots()).rejects.toThrow(
-      "Vercel Sandbox API returned invalid JSON"
-    );
+    await expect(createClient().listSnapshots()).rejects.toMatchObject({
+      message: expect.stringContaining("Vercel Sandbox API returned invalid JSON"),
+      status: 202,
+    });
+    const requestLog = logSpy.mock.calls
+      .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+      .find((entry) => entry.event === "vercel_sandbox.request");
+    expect(requestLog).toMatchObject({ http_status: 202, outcome: "error" });
   });
 
   it("parses NDJSON output from a waited command", async () => {
@@ -295,7 +301,7 @@ describe("VercelSandboxClient", () => {
     expect(fetchSpy.mock.calls[1][1]).toEqual(expect.objectContaining({ method: "DELETE" }));
   });
 
-  it("lists snapshots by sandbox name", async () => {
+  it("lists snapshots without requiring an undocumented region", async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse({
         snapshots: [
@@ -303,7 +309,6 @@ describe("VercelSandboxClient", () => {
             id: "snapshot-1",
             sourceSessionId: "session-1",
             status: "created",
-            region: "iad1",
             sizeBytes: 1024,
             createdAt: 456,
             updatedAt: 789,
@@ -323,6 +328,7 @@ describe("VercelSandboxClient", () => {
       expect.objectContaining({ method: "GET" })
     );
     expect(snapshots[0]?.id).toBe("snapshot-1");
+    expect(snapshots[0]?.region).toBeUndefined();
   });
 
   it("stops a sandbox session with the expected endpoint", async () => {

--- a/packages/control-plane/src/sandbox/providers/vercel/client.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.ts
@@ -8,6 +8,7 @@
 
 import { createLogger } from "../../../logger";
 import type { CorrelationContext } from "../../../logger";
+import { z } from "zod";
 
 const log = createLogger("vercel-sandbox-client");
 
@@ -21,29 +22,45 @@ export interface VercelSandboxClientConfig {
   apiBaseUrl?: string;
 }
 
-export interface VercelSandboxRoute {
-  url?: string;
-  subdomain: string;
-  port: number;
-}
+const vercelSandboxStatusSchema = z.enum([
+  "pending",
+  "running",
+  "stopping",
+  "stopped",
+  "failed",
+  "aborted",
+  "snapshotting",
+]);
 
-export interface VercelSandboxSession {
-  id: string;
-  status: "pending" | "running" | "stopping" | "stopped" | "failed" | "aborted" | "snapshotting";
-  createdAt: number;
-  cwd: string;
-  timeout: number;
-}
+const vercelSandboxRouteSchema = z.object({
+  url: z.string().optional(),
+  subdomain: z.string(),
+  port: z.number(),
+});
+
+export type VercelSandboxRoute = z.infer<typeof vercelSandboxRouteSchema>;
+
+const vercelSandboxSessionSchema = z.object({
+  id: z.string(),
+  status: vercelSandboxStatusSchema,
+  createdAt: z.number(),
+  cwd: z.string(),
+  timeout: z.number(),
+});
+
+export type VercelSandboxSession = z.infer<typeof vercelSandboxSessionSchema>;
 
 export type VercelVcpus = 1 | 2 | 4 | 8;
 
-export interface VercelSandboxMetadata {
-  name: string;
-  currentSessionId: string;
-  currentSnapshotId?: string;
-  createdAt: number;
-  status: VercelSandboxSession["status"];
-}
+const vercelSandboxMetadataSchema = z.object({
+  name: z.string(),
+  currentSessionId: z.string(),
+  currentSnapshotId: z.string().optional(),
+  createdAt: z.number(),
+  status: vercelSandboxStatusSchema,
+});
+
+export type VercelSandboxMetadata = z.infer<typeof vercelSandboxMetadataSchema>;
 
 export interface VercelCreateSandboxRequest {
   name: string;
@@ -56,11 +73,13 @@ export interface VercelCreateSandboxRequest {
   sourceSnapshotId?: string;
 }
 
-export interface VercelCreateSandboxResponse {
-  sandbox: VercelSandboxMetadata;
-  session: VercelSandboxSession;
-  routes: VercelSandboxRoute[];
-}
+const vercelCreateSandboxResponseSchema = z.object({
+  sandbox: vercelSandboxMetadataSchema,
+  session: vercelSandboxSessionSchema,
+  routes: z.array(vercelSandboxRouteSchema),
+});
+
+export type VercelCreateSandboxResponse = z.infer<typeof vercelCreateSandboxResponseSchema>;
 
 export interface VercelRunCommandRequest {
   sessionId: string;
@@ -89,28 +108,45 @@ export interface VercelCommandResult {
   exitCode: number | null;
 }
 
-export interface VercelSnapshotMetadata {
-  id: string;
-  sourceSessionId: string;
-  status: "created" | "deleted" | "failed";
-  region: string;
-  sizeBytes: number;
-  createdAt: number;
-  updatedAt: number;
-  expiresAt?: number;
-  lastUsedAt?: number;
-  creationMethod?: string;
-  parentId?: string;
-}
+const vercelSnapshotStatusSchema = z.enum(["created", "deleted", "failed"]);
 
-export interface VercelSnapshotResponse {
-  snapshot: {
-    id: string;
-    status: "created" | "deleted" | "failed";
-    createdAt: number;
-  };
-  session: VercelSandboxSession;
-}
+const vercelSnapshotMetadataSchema = z.object({
+  id: z.string(),
+  sourceSessionId: z.string(),
+  status: vercelSnapshotStatusSchema,
+  region: z.string(),
+  sizeBytes: z.number(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  expiresAt: z.number().optional(),
+  lastUsedAt: z.number().optional(),
+  creationMethod: z.string().optional(),
+  parentId: z.string().optional(),
+});
+
+export type VercelSnapshotMetadata = z.infer<typeof vercelSnapshotMetadataSchema>;
+
+const vercelSnapshotResponseSchema = z.object({
+  snapshot: z.object({
+    id: z.string(),
+    status: vercelSnapshotStatusSchema,
+    createdAt: z.number(),
+  }),
+  session: vercelSandboxSessionSchema,
+});
+
+export type VercelSnapshotResponse = z.infer<typeof vercelSnapshotResponseSchema>;
+
+const vercelStartCommandResponseSchema = z.object({
+  command: z.object({
+    id: z.string(),
+    exitCode: z.number().nullable(),
+  }),
+});
+
+const vercelListSnapshotsResponseSchema = z.object({
+  snapshots: z.array(vercelSnapshotMetadataSchema),
+});
 
 export class VercelSandboxApiError extends Error {
   constructor(
@@ -136,7 +172,7 @@ export class VercelSandboxClient {
     request: VercelCreateSandboxRequest,
     correlation?: CorrelationContext
   ): Promise<VercelCreateSandboxResponse> {
-    const response = await this.request<VercelCreateSandboxResponse>(
+    const response = await this.request(
       "/v2/sandboxes",
       {
         method: "POST",
@@ -154,6 +190,7 @@ export class VercelSandboxClient {
             : undefined,
         }),
       },
+      vercelCreateSandboxResponseSchema,
       correlation,
       "createSandbox"
     );
@@ -165,7 +202,7 @@ export class VercelSandboxClient {
     request: VercelRunCommandRequest,
     correlation?: CorrelationContext
   ): Promise<VercelCommandResult> {
-    const response = await this.request<{ command: { id: string; exitCode: number | null } }>(
+    const response = await this.request(
       `/v2/sandboxes/sessions/${encodeURIComponent(request.sessionId)}/cmd`,
       {
         method: "POST",
@@ -178,6 +215,7 @@ export class VercelSandboxClient {
           timeout: request.timeoutMs,
         }),
       },
+      vercelStartCommandResponseSchema,
       correlation,
       "startCommand"
     );
@@ -236,9 +274,10 @@ export class VercelSandboxClient {
       opts.expirationMs === undefined
         ? undefined
         : JSON.stringify({ expiration: opts.expirationMs });
-    return this.request<VercelSnapshotResponse>(
+    return this.request(
       `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/snapshot`,
       { method: "POST", body, signal: opts.signal },
+      vercelSnapshotResponseSchema,
       correlation,
       "snapshotSession"
     );
@@ -248,7 +287,7 @@ export class VercelSandboxClient {
     request: VercelListSnapshotsRequest = {},
     correlation?: CorrelationContext
   ): Promise<VercelSnapshotMetadata[]> {
-    const response = await this.request<{ snapshots: VercelSnapshotMetadata[] }>(
+    const response = await this.request(
       buildQueryPath("/v2/sandboxes/snapshots", {
         project: this.config.projectId,
         name: request.name,
@@ -256,6 +295,7 @@ export class VercelSandboxClient {
         sortOrder: request.sortOrder,
       }),
       { method: "GET" },
+      vercelListSnapshotsResponseSchema,
       correlation,
       "listSnapshots"
     );
@@ -267,7 +307,7 @@ export class VercelSandboxClient {
     correlation?: CorrelationContext,
     signal?: AbortSignal
   ): Promise<void> {
-    await this.request<unknown>(
+    await this.requestText(
       `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/stop`,
       { method: "POST", signal },
       correlation,
@@ -280,7 +320,7 @@ export class VercelSandboxClient {
     correlation?: CorrelationContext,
     signal?: AbortSignal
   ): Promise<void> {
-    await this.request<unknown>(
+    await this.requestText(
       `/v2/sandboxes/snapshots/${encodeURIComponent(snapshotId)}`,
       { method: "DELETE", signal },
       correlation,
@@ -291,13 +331,23 @@ export class VercelSandboxClient {
   private async request<T>(
     path: string,
     init: RequestInit,
+    schema: z.ZodType<T>,
     correlation: CorrelationContext | undefined,
     endpoint: string
   ): Promise<T> {
     const text = await this.requestText(path, init, correlation, endpoint);
     try {
-      return JSON.parse(text || "{}") as T;
+      const parsed = schema.safeParse(JSON.parse(text));
+      if (!parsed.success) {
+        throw new VercelSandboxApiError(
+          `Vercel Sandbox API returned an invalid ${endpoint} response: ${z.prettifyError(parsed.error)}`,
+          200,
+          text
+        );
+      }
+      return parsed.data;
     } catch (error) {
+      if (error instanceof VercelSandboxApiError) throw error;
       throw new VercelSandboxApiError(
         `Vercel Sandbox API returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
         200,

--- a/packages/control-plane/src/sandbox/providers/vercel/client.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.ts
@@ -114,7 +114,7 @@ const vercelSnapshotMetadataSchema = z.object({
   id: z.string(),
   sourceSessionId: z.string(),
   status: vercelSnapshotStatusSchema,
-  region: z.string(),
+  region: z.string().optional(),
   sizeBytes: z.number(),
   createdAt: z.number(),
   updatedAt: z.number(),
@@ -172,7 +172,7 @@ export class VercelSandboxClient {
     request: VercelCreateSandboxRequest,
     correlation?: CorrelationContext
   ): Promise<VercelCreateSandboxResponse> {
-    const response = await this.request(
+    const response = await this.requestJson(
       "/v2/sandboxes",
       {
         method: "POST",
@@ -202,7 +202,7 @@ export class VercelSandboxClient {
     request: VercelRunCommandRequest,
     correlation?: CorrelationContext
   ): Promise<VercelCommandResult> {
-    const response = await this.request(
+    const response = await this.requestJson(
       `/v2/sandboxes/sessions/${encodeURIComponent(request.sessionId)}/cmd`,
       {
         method: "POST",
@@ -250,7 +250,7 @@ export class VercelSandboxClient {
     request: VercelWriteFileArchiveRequest,
     correlation?: CorrelationContext
   ): Promise<void> {
-    await this.requestText(
+    await this.requestVoid(
       `/v2/sandboxes/sessions/${encodeURIComponent(request.sessionId)}/fs/write`,
       {
         method: "POST",
@@ -274,7 +274,7 @@ export class VercelSandboxClient {
       opts.expirationMs === undefined
         ? undefined
         : JSON.stringify({ expiration: opts.expirationMs });
-    return this.request(
+    return this.requestJson(
       `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/snapshot`,
       { method: "POST", body, signal: opts.signal },
       vercelSnapshotResponseSchema,
@@ -287,7 +287,7 @@ export class VercelSandboxClient {
     request: VercelListSnapshotsRequest = {},
     correlation?: CorrelationContext
   ): Promise<VercelSnapshotMetadata[]> {
-    const response = await this.request(
+    const response = await this.requestJson(
       buildQueryPath("/v2/sandboxes/snapshots", {
         project: this.config.projectId,
         name: request.name,
@@ -307,7 +307,7 @@ export class VercelSandboxClient {
     correlation?: CorrelationContext,
     signal?: AbortSignal
   ): Promise<void> {
-    await this.requestText(
+    await this.requestVoid(
       `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/stop`,
       { method: "POST", signal },
       correlation,
@@ -320,7 +320,7 @@ export class VercelSandboxClient {
     correlation?: CorrelationContext,
     signal?: AbortSignal
   ): Promise<void> {
-    await this.requestText(
+    await this.requestVoid(
       `/v2/sandboxes/snapshots/${encodeURIComponent(snapshotId)}`,
       { method: "DELETE", signal },
       correlation,
@@ -328,80 +328,66 @@ export class VercelSandboxClient {
     );
   }
 
-  private async request<T>(
+  private requestJson<T>(
     path: string,
     init: RequestInit,
     schema: z.ZodType<T>,
     correlation: CorrelationContext | undefined,
     endpoint: string
   ): Promise<T> {
-    const text = await this.requestText(path, init, correlation, endpoint);
-    try {
-      const parsed = schema.safeParse(JSON.parse(text));
-      if (!parsed.success) {
-        throw new VercelSandboxApiError(
-          `Vercel Sandbox API returned an invalid ${endpoint} response: ${z.prettifyError(parsed.error)}`,
-          200,
-          text
-        );
-      }
-      return parsed.data;
-    } catch (error) {
-      if (error instanceof VercelSandboxApiError) throw error;
-      throw new VercelSandboxApiError(
-        `Vercel Sandbox API returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
-        200,
-        text
-      );
-    }
+    return this.send(path, init, correlation, endpoint, async (response) =>
+      this.parseJson(schema, await response.text(), response.status, endpoint)
+    );
   }
 
-  private async requestText(
+  private requestVoid(
     path: string,
     init: RequestInit,
     correlation: CorrelationContext | undefined,
     endpoint: string
-  ): Promise<string> {
-    const startTime = Date.now();
-    let httpStatus: number | undefined;
-    let outcome: "success" | "error" = "error";
-
-    try {
-      const url = this.buildUrl(path);
-      const headers = this.buildHeaders(init, correlation);
-
-      const response = await fetch(url.toString(), { ...init, headers });
-      httpStatus = response.status;
-      const text = await response.text();
-      if (!response.ok) {
-        throw new VercelSandboxApiError(
-          `Vercel Sandbox API error: ${response.status} ${text}`,
-          response.status,
-          text
-        );
-      }
-
-      outcome = "success";
-      return text;
-    } finally {
-      log.info("vercel_sandbox.request", {
-        event: "vercel_sandbox.request",
-        endpoint,
-        trace_id: correlation?.trace_id,
-        request_id: correlation?.request_id,
-        http_status: httpStatus,
-        duration_ms: Date.now() - startTime,
-        outcome,
-      });
-    }
+  ): Promise<void> {
+    return this.send(path, init, correlation, endpoint, () => {});
   }
 
-  private async requestCommandStream(
+  private parseJson<T>(schema: z.ZodType<T>, text: string, status: number, endpoint: string): T {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch (error) {
+      throw new VercelSandboxApiError(
+        `Vercel Sandbox API returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        status,
+        text
+      );
+    }
+
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      throw new VercelSandboxApiError(
+        `Vercel Sandbox API returned an invalid ${endpoint} response: ${z.prettifyError(parsed.error)}`,
+        status,
+        text
+      );
+    }
+    return parsed.data;
+  }
+
+  private requestCommandStream(
     path: string,
     init: RequestInit,
     correlation: CorrelationContext | undefined,
     endpoint: string
   ): Promise<VercelCommandResult> {
+    return this.send(path, init, correlation, endpoint, parseCommandNdjsonStream);
+  }
+
+  private async send<T>(
+    path: string,
+    init: RequestInit,
+    correlation: CorrelationContext | undefined,
+    endpoint: string,
+    consume: (response: Response) => T | Promise<T>
+  ): Promise<T> {
     const startTime = Date.now();
     let httpStatus: number | undefined;
     let outcome: "success" | "error" = "error";
@@ -421,7 +407,7 @@ export class VercelSandboxClient {
         );
       }
 
-      const result = await parseCommandNdjsonStream(response);
+      const result = await consume(response);
       outcome = "success";
       return result;
     } finally {
@@ -458,7 +444,7 @@ export class VercelSandboxClient {
   }
 }
 
-function parseCommandNdjson(text: string): VercelCommandResult {
+function parseCommandNdjson(text: string, status: number): VercelCommandResult {
   let commandId = "";
   let exitCode: number | null = null;
 
@@ -472,7 +458,7 @@ function parseCommandNdjson(text: string): VercelCommandResult {
   if (!commandId) {
     throw new VercelSandboxApiError(
       "Vercel command stream did not include a command id",
-      200,
+      status,
       text
     );
   }
@@ -482,7 +468,7 @@ function parseCommandNdjson(text: string): VercelCommandResult {
 
 async function parseCommandNdjsonStream(response: Response): Promise<VercelCommandResult> {
   if (!response.body) {
-    return parseCommandNdjson(await response.text());
+    return parseCommandNdjson(await response.text(), response.status);
   }
 
   const reader = response.body.getReader();
@@ -519,7 +505,7 @@ async function parseCommandNdjsonStream(response: Response): Promise<VercelComma
   if (!commandId) {
     throw new VercelSandboxApiError(
       "Vercel command stream did not include a command id",
-      200,
+      response.status,
       responseExcerpt
     );
   }


### PR DESCRIPTION
## Summary

- define runtime Zod schemas for Vercel sandbox, session, command, and snapshot responses
- derive exported response types from those schemas instead of caller-selected generics
- require each JSON endpoint to pass its response schema into the request helper
- treat stop/delete responses as unconsumed text rather than fabricated JSON values
- reject valid JSON error envelopes and malformed JSON before they reach lifecycle code

## Testing

- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/vercel/client.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane -- --no-warn-ignored src/sandbox/providers/vercel/client.ts src/sandbox/providers/vercel/client.test.ts`
- `npm run build -w @open-inspect/control-plane`

## Known unrelated failure

`npm test -w @open-inspect/control-plane` passes 2,593 tests but currently has 5 failures in `src/webhooks/automation-event.test.ts` for empty required-field validation. Those tests and implementation are unchanged by this PR.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/210a91152971fb99ac1430ea876a6e48)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for sandbox requests, including clearer messages and accurate HTTP status reporting.
  * Added validation for responses from sandbox and snapshot operations.
  * Improved handling of command-stream errors and invalid response data.
  * Snapshot listings now work when region information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->