### PR TITLE
refactor: narrow platform binding contracts

### DIFF
--- a/packages/control-plane/src/auth/authenticate.test.ts
+++ b/packages/control-plane/src/auth/authenticate.test.ts
@@ -11,6 +11,7 @@ import { generateInternalToken } from "@open-inspect/shared/auth";
 import { authenticate, isAuthError, SERVICE_REQUEST_MAX_BODY_BYTES } from "./authenticate";
 import type { RequestContext } from "../routes/shared";
 import type { Env } from "../types";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const SECRETS = {
   SERVICE_AUTH_SECRET_WEB: "web-secret",
@@ -36,6 +37,7 @@ function createCtx(identityRow: Record<string, unknown> | null = null): RequestC
   return {
     trace_id: "trace-test",
     request_id: "req-test",
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: { summarize: () => ({}) },
     db: { prepare: vi.fn(() => statement), batch: vi.fn(), exec: vi.fn() },
   } as unknown as RequestContext;

--- a/packages/control-plane/src/auth/identity-enforcement.test.ts
+++ b/packages/control-plane/src/auth/identity-enforcement.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Principal, ResolvedIdentity } from "./principal";
 import type { UserStore } from "../db/user-store";
 import type { RequestContext } from "../routes/shared";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const USER_PRINCIPAL: Principal = {
   kind: "user",
@@ -34,6 +35,7 @@ function createCtx(principal?: Principal): RequestContext {
     trace_id: "trace-test",
     request_id: "req-test",
     principal,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
   } as RequestContext;
 }
 

--- a/packages/control-plane/src/automation/session-target.test.ts
+++ b/packages/control-plane/src/automation/session-target.test.ts
@@ -5,6 +5,7 @@ import { HttpError, type RequestContext } from "../routes/shared";
 import type { AutomationRunRow } from "../db/automation-store";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 vi.mock("../repos/resolve", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -28,6 +29,7 @@ const ctx: RequestContext = {
   request_id: "req-1",
   metrics: {} as RequestContext["metrics"],
   db: env.DB,
+  executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
 };
 
 function run(overrides?: Partial<AutomationRunRow>): AutomationRunRow {

--- a/packages/control-plane/src/image-builds/save-hooks.ts
+++ b/packages/control-plane/src/image-builds/save-hooks.ts
@@ -54,9 +54,7 @@ export function scheduleImageBuildOnSave(
       });
     });
 
-  if (ctx.executionCtx) {
-    ctx.executionCtx.waitUntil(task);
-  }
+  ctx.executionCtx.waitUntil(task);
 }
 
 /**

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -1,16 +1,10 @@
-/** Capabilities consumed from a service binding that only performs HTTP requests. */
-export interface FetchClient {
-  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
-}
+import type { FetchClient } from "@open-inspect/shared/service-auth";
+
+export type { FetchClient } from "@open-inspect/shared/service-auth";
 
 /** Capability consumed by application services that schedule background work. */
 export interface BackgroundTaskContext {
   waitUntil(promise: Promise<unknown>): void;
-}
-
-/** Background-task context with the Durable Object identity used as a fallback session ID. */
-export interface DurableObjectTaskContext extends BackgroundTaskContext {
-  id: { toString(): string };
 }
 
 // Keep platform compatibility checked at the boundary rather than widening every consumer.
@@ -19,8 +13,4 @@ type _FetcherSatisfiesFetchClient = _AssertExtends<Fetcher, FetchClient>;
 type _ExecutionContextSatisfiesBackgroundTaskContext = _AssertExtends<
   ExecutionContext,
   BackgroundTaskContext
->;
-type _DurableObjectStateSatisfiesTaskContext = _AssertExtends<
-  DurableObjectState,
-  DurableObjectTaskContext
 >;

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -1,0 +1,26 @@
+/** Capabilities consumed from a service binding that only performs HTTP requests. */
+export interface FetchClient {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
+
+/** Capability consumed by application services that schedule background work. */
+export interface BackgroundTaskContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+/** Background-task context with the Durable Object identity used as a fallback session ID. */
+export interface DurableObjectTaskContext extends BackgroundTaskContext {
+  id: { toString(): string };
+}
+
+// Keep platform compatibility checked at the boundary rather than widening every consumer.
+type _AssertExtends<A extends B, B> = A;
+type _FetcherSatisfiesFetchClient = _AssertExtends<Fetcher, FetchClient>;
+type _ExecutionContextSatisfiesBackgroundTaskContext = _AssertExtends<
+  ExecutionContext,
+  BackgroundTaskContext
+>;
+type _DurableObjectStateSatisfiesTaskContext = _AssertExtends<
+  DurableObjectState,
+  DurableObjectTaskContext
+>;

--- a/packages/control-plane/src/repos/resolve.test.ts
+++ b/packages/control-plane/src/repos/resolve.test.ts
@@ -4,8 +4,13 @@ import { HttpError, type RequestContext } from "../routes/shared";
 import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
-const ctx = { request_id: "req-1", trace_id: "trace-1" } as unknown as RequestContext;
+const ctx = {
+  request_id: "req-1",
+  trace_id: "trace-1",
+  executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
+} as unknown as RequestContext;
 const env = {} as Env;
 const logger = {
   error: vi.fn(),

--- a/packages/control-plane/src/router.analytics.test.ts
+++ b/packages/control-plane/src/router.analytics.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import {
+  signedServiceRequest,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "./router.test-support";
 
 const mockStore = {
   getSummary: vi.fn(),
@@ -55,7 +59,8 @@ describe("analytics router integration", () => {
       await signedServiceRequest("https://test.local/analytics/summary", {
         service: "linear-bot",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(200);

--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleRequest, isWebServiceAuthRoute } from "./router";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "./router.test-support";
 
 function createEnv(verifyStatus: number) {
   const fetch = vi
@@ -43,7 +44,8 @@ describe("router sandbox-token fallback", () => {
         method: "POST",
         headers: { Authorization: "Bearer valid-sandbox-token" },
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(202);
@@ -57,7 +59,8 @@ describe("router sandbox-token fallback", () => {
         method: "POST",
         headers: { Authorization: "Bearer invalid-token" },
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(401);
@@ -70,7 +73,8 @@ describe("router sandbox-token fallback", () => {
       new Request("https://test.local/analytics/summary", {
         headers: { Authorization: "Bearer invalid-token" },
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(401);
@@ -87,7 +91,8 @@ describe("retired browser-auth routes", () => {
     const { env } = createEnv(401);
     const response = await handleRequest(
       new Request(`https://test.local${path}`, { method }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(404);

--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -3,7 +3,11 @@ import type { Principal } from "./auth/principal";
 import { SessionIndexStore } from "./db/session-index";
 import { UserStore } from "./db/user-store";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import {
+  signedServiceRequest,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "./router.test-support";
 import { sessionCreateRoutes } from "./routes/session-create";
 import { HttpError, resolveRepoOrError } from "./routes/shared";
 import { SessionInternalPaths } from "./session/contracts";
@@ -76,7 +80,8 @@ describe("handleCreateSession D1 ordering", () => {
         service: "slack-bot",
         actor: "slack:U0123",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
   }
 
@@ -97,7 +102,8 @@ describe("handleCreateSession D1 ordering", () => {
         service: "slack-bot",
         actor: "slack:U0123",
       }),
-      createEnv(vi.fn()) as never
+      createEnv(vi.fn()) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
   }
 
@@ -447,6 +453,7 @@ describe("handleCreateSession D1 ordering", () => {
         trace_id: "test-trace",
         principal: USER_PRINCIPAL,
         db: testEnv["DB"] as never,
+        executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
         metrics: {
           d1Queries: [],
           spans: {},

--- a/packages/control-plane/src/router.scm-credentials.test.ts
+++ b/packages/control-plane/src/router.scm-credentials.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { handleRequest, isScmAgnosticRoute } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import {
+  signedServiceRequest,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "./router.test-support";
 
 function createEnv() {
   const fetch = vi.fn(async (request: Request) => {
@@ -46,7 +50,8 @@ describe("SCM credentials router provider gate", () => {
         await signedServiceRequest(`https://test.local/sessions/session-1/${endpoint}`, {
           method: "POST",
         }),
-        env as never
+        env as never,
+        TEST_BACKGROUND_TASK_CONTEXT
       );
 
       expect(response.status).toBe(401);
@@ -60,7 +65,8 @@ describe("SCM credentials router provider gate", () => {
         method: "POST",
         headers: { Authorization: "Bearer sandbox-token" },
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(202);
@@ -76,7 +82,8 @@ describe("SCM credentials router provider gate", () => {
         method: "POST",
         service: "linear-bot",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(202);
@@ -92,7 +99,8 @@ describe("SCM credentials router provider gate", () => {
       await signedServiceRequest("https://test.local/sessions/session-1/tunnel-urls", {
         service: "linear-bot",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(202);
@@ -113,7 +121,8 @@ describe("SCM credentials router provider gate", () => {
       new Request("https://test.local/sessions/session-1/commit-signing", {
         headers: { Authorization: "Bearer sandbox-token" },
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(200);
@@ -128,7 +137,8 @@ describe("SCM credentials router provider gate", () => {
 
     const response = await handleRequest(
       await signedServiceRequest("https://test.local/sessions/session-1/commit-signing"),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(401);
@@ -142,7 +152,8 @@ describe("SCM credentials router provider gate", () => {
         method: "POST",
         body: JSON.stringify({ content: "Continue" }),
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(401);
@@ -160,7 +171,8 @@ describe("SCM credentials router provider gate", () => {
         },
         body: JSON.stringify({ content: "Continue" }),
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     // The null DB lookup rejects the unknown child after sandbox auth and SCM classification.
@@ -177,7 +189,8 @@ describe("SCM credentials router provider gate", () => {
         method: "POST",
         service: "linear-bot",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(501);

--- a/packages/control-plane/src/router.session-prompt.test.ts
+++ b/packages/control-plane/src/router.session-prompt.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserStore } from "./db/user-store";
 import { resolveGitHubEnrichmentForRequest } from "./session/identity";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import {
+  signedServiceRequest,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "./router.test-support";
 
 vi.mock("./db/user-store", () => ({
   UserStore: vi.fn(),
@@ -109,7 +113,8 @@ describe("session prompt identity enrichment", () => {
     });
     const response = await handleRequest(
       await userPromptRequest({ content: "Fix the bug" }),
-      createEnv(sessionFetch) as never
+      createEnv(sessionFetch) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(200);
@@ -132,7 +137,8 @@ describe("session prompt identity enrichment", () => {
     });
     const response = await handleRequest(
       await userPromptRequest({ content: "Fix the bug" }),
-      createEnv(sessionFetch) as never
+      createEnv(sessionFetch) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(200);
@@ -154,7 +160,8 @@ describe("session prompt identity enrichment", () => {
     });
     const response = await handleRequest(
       await userPromptRequest({ content: "Fix the bug" }),
-      createEnv(sessionFetch) as never
+      createEnv(sessionFetch) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(200);
@@ -165,7 +172,8 @@ describe("session prompt identity enrichment", () => {
     const sessionFetch = vi.fn(async () => Response.json({ status: "queued" }));
     const response = await handleRequest(
       await userPromptRequest({ content: "Fix the bug", authorId: "someone-else" }),
-      createEnv(sessionFetch) as never
+      createEnv(sessionFetch) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(400);

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import {
+  signedServiceRequest,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "./router.test-support";
 import { getEffectiveEnabledModels } from "./db/model-preferences";
 import { SessionIndexStore } from "./db/session-index";
 import { SessionInternalPaths } from "./session/contracts";
@@ -106,7 +110,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
         body: JSON.stringify(body),
         service: "linear-bot",
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
   }
 
@@ -462,7 +467,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
           model: "not-a-real-model",
         }),
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(400);
@@ -520,7 +526,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
         service: "linear-bot",
         body: JSON.stringify({ title: "Child task" }),
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(400);
@@ -660,7 +667,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
           model: "",
         }),
       }),
-      env as never
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(400);

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -7,6 +7,11 @@
  */
 
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
+import type { BackgroundTaskContext } from "./platform-ports";
+
+export const TEST_BACKGROUND_TASK_CONTEXT: BackgroundTaskContext = {
+  waitUntil: () => {},
+};
 
 /** Per-service secrets for unit-test env fixtures, mirrored by signedServiceRequest. */
 export const TEST_SERVICE_SECRETS = {

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -17,6 +17,7 @@ import { createSessionRuntimeClient } from "./session/runtime-client";
 
 import { createRequestMetrics, instrumentD1 } from "./db/instrumented-d1";
 import { createLogger } from "./logger";
+import type { BackgroundTaskContext } from "./platform-ports";
 import {
   type Route,
   type RequestContext,
@@ -391,7 +392,7 @@ const routes: Route[] = [
 export async function handleRequest(
   request: Request,
   env: Env,
-  executionCtx?: ExecutionContext
+  executionCtx: BackgroundTaskContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const path = url.pathname;

--- a/packages/control-plane/src/routes/analytics.test.ts
+++ b/packages/control-plane/src/routes/analytics.test.ts
@@ -4,6 +4,7 @@ import { HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
 import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const FIXED_NOW = 1_700_000_000_000;
 
@@ -46,6 +47,7 @@ function createCtx(): RequestContext {
     trace_id: "trace-1",
     request_id: "req-1",
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -12,6 +12,7 @@ import { HttpError, resolveRepoOrError, type RequestContext } from "./shared";
 import type { Principal } from "../auth/principal";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -137,6 +138,7 @@ function createCtx(principal: Principal = USER_PRINCIPAL): RequestContext {
     request_id: "req-1",
     principal,
     db: { batch: mockBatch } as unknown as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -135,7 +135,7 @@ function createContext(waitUntilTasks?: Promise<unknown>[]): RequestContext {
       waitUntil: (task: Promise<unknown>) => {
         waitUntilTasks?.push(task);
       },
-    } as unknown as ExecutionContext,
+    },
   };
 }
 

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -124,10 +124,7 @@ describe("repository list route", () => {
       match,
       {
         ...ctx,
-        executionCtx: {
-          waitUntil,
-          passThroughOnException: vi.fn(),
-        } as unknown as ExecutionContext,
+        executionCtx: { waitUntil },
       }
     );
 

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -4,6 +4,7 @@ import type { Env } from "../types";
 import { reposRoutes } from "./repos";
 import type * as SharedRoutes from "./shared";
 import type { RequestContext } from "./shared";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const {
   mockCacheDelete,
@@ -52,6 +53,7 @@ function createContext(): RequestContext {
     request_id: "request-1",
     principal: { kind: "user", userId: "user-1" },
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -156,7 +156,7 @@ async function handleListRepos(
   if (cached) {
     const isFresh = cached.freshUntil && Date.now() < cached.freshUntil;
 
-    if (!isFresh && ctx.executionCtx) {
+    if (!isFresh) {
       // Stale — serve immediately but refresh in background
       logger.info("Serving stale repos cache, refreshing in background", {
         trace_id: ctx.trace_id,
@@ -181,7 +181,7 @@ async function handleListRepos(
   const refresh = refreshReposCache(env, ctx.db, ctx.trace_id, (fn) =>
     ctx.metrics.time("scm_api", fn)
   );
-  ctx.executionCtx?.waitUntil(refresh);
+  ctx.executionCtx.waitUntil(refresh);
 
   const result = await refresh;
   if (!result.ok) {

--- a/packages/control-plane/src/routes/scm-settings.test.ts
+++ b/packages/control-plane/src/routes/scm-settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { scmSettingsRoutes } from "./scm-settings";
 import type { RequestContext, Route } from "./shared";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 function findRoute(method: string, path: string): { route: Route; match: RegExpMatchArray } {
   const route = scmSettingsRoutes.find(
@@ -14,6 +15,7 @@ function failingContext(): RequestContext {
   return {
     request_id: "request-1",
     trace_id: "trace-1",
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     db: {
       prepare: vi.fn(() => {
         throw new Error("D1 unavailable");

--- a/packages/control-plane/src/routes/session-attachments.test.ts
+++ b/packages/control-plane/src/routes/session-attachments.test.ts
@@ -4,6 +4,7 @@ import type { Env } from "../types";
 import { sessionAttachmentRoutes } from "./session-attachments";
 import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const PNG_BYTES = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -12,6 +13,7 @@ function createContext(): RequestContext {
     trace_id: "trace-1",
     request_id: "request-1",
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -286,7 +286,7 @@ async function handleSpawnChild(
     return error("Failed to enqueue child session prompt", 500);
   }
 
-  ctx.executionCtx?.waitUntil(
+  ctx.executionCtx.waitUntil(
     ctx.sessionRuntime
       .fetch(parentId, SessionInternalPaths.childSessionUpdate, {
         method: "POST",

--- a/packages/control-plane/src/routes/session-children.test.ts
+++ b/packages/control-plane/src/routes/session-children.test.ts
@@ -7,6 +7,7 @@ import type { Env } from "../types";
 import { handleCancelChild, handlePromptChild } from "./session-children";
 import type { SessionRouteContext } from "./session-route";
 import { parsePattern } from "./shared";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 vi.mock("../session/integration-settings-resolution", () => ({
   resolveSandboxSettings: vi.fn(),
@@ -36,6 +37,7 @@ function routeContext(
     metrics: {} as SessionRouteContext["metrics"],
     request_id: "request-id",
     trace_id: "trace-id",
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     sessionRuntime: {
       fetch: async (sessionId, path, init, search) => {
         if (sessionId === "parent" && path === "/internal/active-prompt-author") {

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -138,7 +138,7 @@ export async function handlePromptChild(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    ctx.executionCtx?.waitUntil(
+    ctx.executionCtx.waitUntil(
       sessionStore.touchUpdatedAt(childId).catch((error) => {
         logger.error("session_index.touch_updated_at.background_error", {
           parent_id: parentId,

--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -4,6 +4,7 @@ import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import type { Principal } from "../auth/principal";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const mockSessionIndexStore = {
   list: vi.fn(),
@@ -23,6 +24,7 @@ function createCtx(principal?: Principal): RequestContext {
     trace_id: "trace-1",
     request_id: "req-1",
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-media-artifacts.test.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRuntimeClient } from "../session/runtime-client";
 import type { SessionRouteContext } from "./session-route";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 import {
   getSessionArtifactFromRuntime,
   listSessionArtifactsFromRuntime,
@@ -17,6 +18,7 @@ function createContext(response: Response): SessionRouteContext {
     trace_id: "trace-1",
     request_id: "request-1",
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -152,7 +152,7 @@ async function handleSessionPrompt(
   });
 
   const store = new SessionIndexStore(ctx.db);
-  ctx.executionCtx?.waitUntil(
+  ctx.executionCtx.waitUntil(
     store.touchUpdatedAt(sessionId).catch((error) => {
       logger.error("session_index.touch_updated_at.background_error", {
         session_id: sessionId,

--- a/packages/control-plane/src/routes/session-runtime-proxy.test.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.test.ts
@@ -4,12 +4,14 @@ import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
 import { sessionRuntimeProxyRoutes } from "./session-runtime-proxy";
 import type { Env } from "../types";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 function createCtx(db: SqlDatabase = {} as SqlDatabase): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
     db,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     principal: {
       kind: "user",
       userId: "user-1",

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -9,6 +9,7 @@ import type { RequestMetrics } from "../db/instrumented-d1";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
+import type { BackgroundTaskContext } from "../platform-ports";
 import type { BetterAuthRuntime, UserAuthRuntime } from "../auth/user/runtime";
 import {
   createSourceControlProviderFromEnv,
@@ -29,8 +30,8 @@ export type RequestContext = CorrelationContext & {
    * src/routes and src/webhooks.
    */
   db: SqlDatabase;
-  /** Worker ExecutionContext for waitUntil (background tasks). */
-  executionCtx?: ExecutionContext;
+  /** Request-scoped capability for scheduling background tasks. */
+  executionCtx?: BackgroundTaskContext;
   /** Lazy runtime dependency used by user-session authentication and credential access. */
   getUserAuth?: () => BetterAuthRuntime;
   /** Lazy normalized auth runtime used by server-only authentication composition routes. */

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -31,7 +31,7 @@ export type RequestContext = CorrelationContext & {
    */
   db: SqlDatabase;
   /** Request-scoped capability for scheduling background tasks. */
-  executionCtx?: BackgroundTaskContext;
+  executionCtx: BackgroundTaskContext;
   /** Lazy runtime dependency used by user-session authentication and credential access. */
   getUserAuth?: () => BetterAuthRuntime;
   /** Lazy normalized auth runtime used by server-only authentication composition routes. */

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -5,6 +5,7 @@ import { handleSlackNotify } from "./slack-notify";
 import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
+import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
 const sessionStoreMock = {
   get: vi.fn(),
@@ -47,6 +48,7 @@ function createCtx(): RequestContext {
     trace_id: "trace-1",
     request_id: "req-1",
     db: {} as SqlDatabase,
+    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/scheduler/do-fetcher-adapter.test.ts
+++ b/packages/control-plane/src/scheduler/do-fetcher-adapter.test.ts
@@ -61,13 +61,4 @@ describe("DOFetcherAdapter", () => {
     expect(ns.idFromName).toHaveBeenCalledTimes(2);
     expect(ns.get).toHaveBeenCalledTimes(2);
   });
-
-  it("throws on connect()", () => {
-    const { ns } = createMockNamespace();
-    const adapter = new DOFetcherAdapter(ns, "global-scheduler");
-
-    expect(() => adapter.connect("127.0.0.1:8080")).toThrow(
-      "DOFetcherAdapter does not support connect()"
-    );
-  });
 });

--- a/packages/control-plane/src/scheduler/do-fetcher-adapter.ts
+++ b/packages/control-plane/src/scheduler/do-fetcher-adapter.ts
@@ -1,22 +1,20 @@
 /**
- * Adapts a DurableObjectNamespace + name to a Fetcher-compatible interface.
+ * Adapts a DurableObjectNamespace + name to the fetch-only callback interface.
  *
  * Used to route automation callbacks to the SchedulerDO via the existing
- * CallbackNotificationService, which expects a `Fetcher` binding.
+ * CallbackNotificationService.
  */
 
-export class DOFetcherAdapter implements Fetcher {
+import type { FetchClient } from "../platform-ports";
+
+export class DOFetcherAdapter implements FetchClient {
   constructor(
     private readonly ns: DurableObjectNamespace,
     private readonly name: string
   ) {}
 
-  fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
     const stub = this.ns.get(this.ns.idFromName(this.name));
     return stub.fetch(input, init);
-  }
-
-  connect(_address: string | SocketAddress, _options?: SocketOptions): Socket {
-    throw new Error("DOFetcherAdapter does not support connect()");
   }
 }

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -1339,6 +1339,7 @@ export class SchedulerDO extends DurableObject<Env> {
       request_id: run.id,
       metrics: createRequestMetrics(),
       db: this.db,
+      executionCtx: this.ctx,
     };
 
     // What the session opens — the run's repository snapshot or, for

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -7,6 +7,7 @@ import {
   type CallbackServiceDeps,
 } from "./callback-notification-service";
 import type { MessageRepository } from "./message-repository";
+import type { FetchClient } from "../platform-ports";
 
 // ---- Mock factories ----
 
@@ -27,10 +28,8 @@ function createMockRepository() {
   };
 }
 
-type MockFetcher = Fetcher & { fetch: ReturnType<typeof vi.fn> };
-
-function createMockFetcher(): MockFetcher {
-  return { fetch: vi.fn() } as unknown as MockFetcher;
+function createMockFetcher() {
+  return { fetch: vi.fn<FetchClient["fetch"]>() };
 }
 
 function createTestHarness(overrides?: {
@@ -97,9 +96,7 @@ describe("CallbackNotificationService", () => {
           duration_ms: expect.any(Number),
         })
       );
-      expect(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      ).not.toHaveBeenCalled();
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
     });
 
     it("skips when callback_context is null on the message", async () => {
@@ -110,9 +107,7 @@ describe("CallbackNotificationService", () => {
 
       await harness.service.notifyComplete("msg-1", true);
 
-      expect(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      ).not.toHaveBeenCalled();
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
     });
 
     it("absorbs and logs unexpected callback failures", async () => {
@@ -168,9 +163,7 @@ describe("CallbackNotificationService", () => {
 
       await h.service.notifyComplete("msg-1", true);
 
-      expect(
-        (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      ).not.toHaveBeenCalled();
+      expect(h.slackBot.fetch).not.toHaveBeenCalled();
     });
 
     it("skips when no binding for source", async () => {
@@ -204,13 +197,11 @@ describe("CallbackNotificationService", () => {
       });
 
       const mockResponse = new Response("ok", { status: 200 });
-      vi.mocked(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      ).mockResolvedValue(mockResponse);
+      vi.mocked(harness.slackBot.fetch).mockResolvedValue(mockResponse);
 
       await harness.service.notifyComplete("msg-1", true);
 
-      const fetchMock = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const fetchMock = harness.slackBot.fetch;
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(
         "https://internal/callbacks/complete",
@@ -221,7 +212,7 @@ describe("CallbackNotificationService", () => {
       );
 
       // Verify payload shape
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
         sessionId: "session-123",
         messageId: "msg-1",
@@ -255,9 +246,7 @@ describe("CallbackNotificationService", () => {
         source: "slack",
       });
 
-      const fetchMock = vi.mocked(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(harness.slackBot.fetch);
       fetchMock
         .mockRejectedValueOnce(new Error("network error"))
         .mockResolvedValueOnce(new Response("ok", { status: 200 }));
@@ -324,17 +313,14 @@ describe("CallbackNotificationService", () => {
       });
 
       const mockResponse = new Response("ok", { status: 200 });
-      vi.mocked(
-        (harness.linearBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      ).mockResolvedValue(mockResponse);
+      vi.mocked(harness.linearBot.fetch).mockResolvedValue(mockResponse);
 
       await harness.service.notifyComplete("msg-1", false);
 
-      const linearFetch = (harness.linearBot as unknown as { fetch: ReturnType<typeof vi.fn> })
-        .fetch;
+      const linearFetch = harness.linearBot.fetch;
       expect(linearFetch).toHaveBeenCalledTimes(1);
 
-      const slackFetch = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const slackFetch = harness.slackBot.fetch;
       expect(slackFetch).not.toHaveBeenCalled();
     });
   });
@@ -365,7 +351,7 @@ describe("CallbackNotificationService", () => {
         "https://internal/callbacks/start",
         expect.objectContaining({ method: "POST" })
       );
-      const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
         sessionId: "session-123",
         messageId: "msg-1",
@@ -469,7 +455,7 @@ describe("CallbackNotificationService", () => {
       await harness.service.notifyStarted("msg-1");
 
       expect(fetchMock).toHaveBeenCalledOnce();
-      const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body.context).toEqual({
         source: "linear",
         issueId: "issue-1",
@@ -498,9 +484,7 @@ describe("CallbackNotificationService", () => {
         source: "slack",
       });
 
-      const fetchMock = vi.mocked(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(harness.slackBot.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       // First call should go through
@@ -518,9 +502,7 @@ describe("CallbackNotificationService", () => {
         source: "slack",
       });
 
-      const fetchMock = vi.mocked(
-        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(harness.slackBot.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       await harness.service.notifyToolCall("msg-1", {
@@ -537,7 +519,7 @@ describe("CallbackNotificationService", () => {
         expect.objectContaining({ method: "POST" })
       );
 
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
         sessionId: "session-123",
         tool: "bash",
@@ -562,7 +544,7 @@ describe("CallbackNotificationService", () => {
       });
 
       // No forward at all — previously this 404'd against the SchedulerDO.
-      const slackFetch = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const slackFetch = harness.slackBot.fetch;
       expect(slackFetch).not.toHaveBeenCalled();
       expect(harness.log.debug).toHaveBeenCalledWith(
         "callback.tool_call",
@@ -579,7 +561,7 @@ describe("CallbackNotificationService", () => {
 
       await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
 
-      const fetchMock = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const fetchMock = harness.slackBot.fetch;
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
@@ -597,7 +579,7 @@ describe("CallbackNotificationService", () => {
 
       await h.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
 
-      const fetchMock = (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const fetchMock = h.slackBot.fetch;
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
@@ -617,9 +599,7 @@ describe("CallbackNotificationService", () => {
           callback_context: JSON.stringify({ channel: "C123" }),
           source: "slack",
         });
-        const fetchMock = vi.mocked(
-          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-        );
+        const fetchMock = vi.mocked(harness.slackBot.fetch);
         fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
         await harness.service.notifyToolCall("msg-1", {
@@ -651,9 +631,7 @@ describe("CallbackNotificationService", () => {
           callback_context: JSON.stringify({ channel: "C123" }),
           source: "slack",
         });
-        const fetchMock = vi.mocked(
-          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-        );
+        const fetchMock = vi.mocked(harness.slackBot.fetch);
         fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
         for (let i = 0; i < 3; i++) {
@@ -686,9 +664,7 @@ describe("CallbackNotificationService", () => {
           callback_context: JSON.stringify({ channel: "C123" }),
           source: "slack",
         });
-        const fetchMock = vi.mocked(
-          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-        );
+        const fetchMock = vi.mocked(harness.slackBot.fetch);
         fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
         // Cap is 500. Fire 501 distinct callIds; the first one ("call-0")
@@ -733,9 +709,7 @@ describe("CallbackNotificationService", () => {
           callback_context: JSON.stringify({ channel: "C123" }),
           source: "slack",
         });
-        const fetchMock = vi.mocked(
-          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-        );
+        const fetchMock = vi.mocked(harness.slackBot.fetch);
         fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
         await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
@@ -759,9 +733,7 @@ describe("CallbackNotificationService", () => {
           callback_context: JSON.stringify({ channel: "C123" }),
           source: "slack",
         });
-        const fetchMock = vi.mocked(
-          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-        );
+        const fetchMock = vi.mocked(harness.slackBot.fetch);
         fetchMock
           .mockRejectedValueOnce(new Error("network"))
           .mockResolvedValue(new Response("ok", { status: 200 }));
@@ -815,9 +787,7 @@ describe("CallbackNotificationService", () => {
         source: "automation",
       });
 
-      const fetchMock = vi.mocked(
-        (schedulerFetcher as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(schedulerFetcher.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       await h.service.notifyComplete("msg-1", true);
@@ -828,7 +798,7 @@ describe("CallbackNotificationService", () => {
         expect.objectContaining({ method: "POST" })
       );
 
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
         automationId: "auto-1",
         runId: "run-1",
@@ -856,14 +826,12 @@ describe("CallbackNotificationService", () => {
         source: "automation",
       });
 
-      const fetchMock = vi.mocked(
-        (schedulerFetcher as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(schedulerFetcher.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       await h.service.notifyComplete("msg-1", false, "Sandbox crashed");
 
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
         success: false,
         error: "Sandbox crashed",
@@ -921,9 +889,7 @@ describe("CallbackNotificationService", () => {
         source: "automation",
       });
 
-      const fetchMock = vi.mocked(
-        (schedulerFetcher as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(schedulerFetcher.fetch);
       fetchMock
         .mockRejectedValueOnce(new Error("network error"))
         .mockResolvedValueOnce(new Response("ok", { status: 200 }));
@@ -953,14 +919,12 @@ describe("CallbackNotificationService", () => {
         source: "automation",
       });
 
-      const fetchMock = vi.mocked(
-        (schedulerFetcher as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
-      );
+      const fetchMock = vi.mocked(schedulerFetcher.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       await h.service.notifyComplete("msg-1", true);
 
-      const slackFetch = (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      const slackFetch = h.slackBot.fetch;
       expect(slackFetch).not.toHaveBeenCalled();
     });
   });

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -14,6 +14,7 @@ import { deliverWithRetry } from "./callback-delivery";
 import { notifyLinearStarted } from "./linear-start-callback";
 import type { SessionRow } from "./types";
 import type { MessageRepository } from "./message-repository";
+import type { FetchClient } from "../platform-ports";
 
 /**
  * Narrow repository interface — only the methods CallbackNotificationService needs.
@@ -31,9 +32,9 @@ export interface CallbackServiceEnv {
   // destination's own.
   SERVICE_AUTH_SECRET_SLACK_BOT?: string;
   SERVICE_AUTH_SECRET_LINEAR_BOT?: string;
-  SLACK_BOT?: Fetcher;
-  LINEAR_BOT?: Fetcher;
-  SCHEDULER_CALLBACK?: Fetcher;
+  SLACK_BOT?: FetchClient;
+  LINEAR_BOT?: FetchClient;
+  SCHEDULER_CALLBACK?: FetchClient;
 }
 
 /**
@@ -106,7 +107,7 @@ export class CallbackNotificationService {
    * sources, etc.).
    */
   private resolveCallbackRoute(source: string | null): {
-    binding: Fetcher | undefined;
+    binding: FetchClient | undefined;
     secret: string | undefined;
   } {
     const destination: CallbackDestination = source === "linear" ? "linear-bot" : "slack-bot";

--- a/packages/control-plane/src/session/linear-start-callback.ts
+++ b/packages/control-plane/src/session/linear-start-callback.ts
@@ -1,13 +1,14 @@
 import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { Logger } from "../logger";
 import { deliverWithRetry } from "./callback-delivery";
+import type { FetchClient } from "../platform-ports";
 
 interface LinearStartCallbackOptions {
   messageId: string;
   callbackContext: string;
   sessionId: string;
   secret: string;
-  binding: Fetcher;
+  binding: FetchClient;
   log: Logger;
   sleep: (ms: number) => Promise<void>;
 }

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -199,7 +199,7 @@ function buildQueue() {
   const projectTerminalMessage = vi.fn(async () => {});
 
   const queue = new SessionMessageQueue(
-    { waitUntil, storage: { getAlarm, setAlarm } } as unknown as DurableObjectState,
+    { waitUntil },
     log,
     repository as unknown as SessionCoreRepository,
     repository as unknown as MessageRepository,

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -33,6 +33,7 @@ import type { SessionStatusService } from "./session-status-service";
 import type { EnqueuePromptRequest } from "./enqueue-prompt-contract";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
+import type { BackgroundTaskContext } from "../platform-ports";
 import { resolveGitAuthorIdentity } from "./identity";
 import { validateReasoningEffort } from "./reasoning-effort";
 import {
@@ -140,7 +141,7 @@ function resolveParticipantGitIdentity(
 
 export class SessionMessageQueue {
   constructor(
-    private readonly ctx: DurableObjectState,
+    private readonly ctx: BackgroundTaskContext,
     private readonly log: Logger,
     private readonly repository: SessionCoreRepository,
     private readonly messageRepository: MessageRepository,

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -84,7 +84,7 @@ function createProcessor() {
   };
 
   const processor = new SessionSandboxEventProcessor(
-    { waitUntil } as unknown as DurableObjectState,
+    { waitUntil },
     () => log,
     repository as unknown as SessionCoreRepository,
     repository as unknown as SandboxRepository,

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -15,6 +15,7 @@ import type { SessionMessenger } from "./messenger";
 import type { SessionStatusService } from "./session-status-service";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { SessionTitleUpdateOptions, SessionTitleUpdateResult } from "./title";
+import type { BackgroundTaskContext } from "../platform-ports";
 
 type PushResolver = { resolve: () => void; reject: (err: Error) => void };
 type SandboxEventWithAck = SandboxEvent & { ackId?: string };
@@ -36,7 +37,7 @@ export class SessionSandboxEventProcessor {
   private pendingPushResolvers = new Map<string, PushResolver>();
 
   constructor(
-    private readonly ctx: DurableObjectState,
+    private readonly ctx: BackgroundTaskContext,
     // The DO swaps its logger for a request-scoped child during fetch();
     // a getter keeps this singleton reading the current logger instead of
     // capturing one by value at construction time.

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -69,7 +69,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
         };
 
   const waitUntil = vi.fn();
-  const ctx = { waitUntil, id: { toString: () => "do-id" } } as unknown as DurableObjectState;
+  const ctx = { waitUntil, id: { toString: () => "do-id" } };
 
   const parentFetch = vi.fn(async (_request: Request) => new Response(null, { status: 200 }));
   const parentStub = { fetch: parentFetch };

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -69,7 +69,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
         };
 
   const waitUntil = vi.fn();
-  const ctx = { waitUntil, id: { toString: () => "do-id" } };
+  const ctx = { waitUntil };
 
   const parentFetch = vi.fn(async (_request: Request) => new Response(null, { status: 200 }));
   const parentStub = { fetch: parentFetch };

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -17,13 +17,14 @@ import type { SessionCoreRepository } from "./session-core-repository";
 import type { MessageRepository } from "./message-repository";
 import type { ArtifactRepository } from "./artifact-repository";
 import type { SessionMessenger } from "./messenger";
+import type { DurableObjectTaskContext } from "../platform-ports";
 
 /** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
 const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
 
 export class SessionStatusService {
   constructor(
-    private readonly ctx: DurableObjectState,
+    private readonly ctx: DurableObjectTaskContext,
     private readonly log: Logger,
     private readonly repository: SessionCoreRepository,
     private readonly messageRepository: MessageRepository,

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -17,14 +17,14 @@ import type { SessionCoreRepository } from "./session-core-repository";
 import type { MessageRepository } from "./message-repository";
 import type { ArtifactRepository } from "./artifact-repository";
 import type { SessionMessenger } from "./messenger";
-import type { DurableObjectTaskContext } from "../platform-ports";
+import type { BackgroundTaskContext } from "../platform-ports";
 
 /** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
 const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
 
 export class SessionStatusService {
   constructor(
-    private readonly ctx: DurableObjectTaskContext,
+    private readonly ctx: BackgroundTaskContext,
     private readonly log: Logger,
     private readonly repository: SessionCoreRepository,
     private readonly messageRepository: MessageRepository,
@@ -177,7 +177,7 @@ export class SessionStatusService {
   }
 
   private getPublicSessionId(session: SessionRow): string {
-    return session.session_name || session.id || this.ctx.id.toString();
+    return session.session_name || session.id;
   }
 
   private async syncSessionIndexStatusAndAdmission(

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -133,11 +133,7 @@ async function handleGitHubAutomationEvent(
   if (validated.response) return validated.response;
 
   const lifecycleWork = trackPullRequestLifecycle(env, validated.event, ctx);
-  if (ctx.executionCtx) {
-    ctx.executionCtx.waitUntil(lifecycleWork);
-  } else {
-    await lifecycleWork;
-  }
+  ctx.executionCtx.waitUntil(lifecycleWork);
 
   return forwardAutomationEventToScheduler(env, validated.event);
 }

--- a/packages/control-plane/test/integration/auth-sign-in-claim.test.ts
+++ b/packages/control-plane/test/integration/auth-sign-in-claim.test.ts
@@ -1,9 +1,9 @@
-import { env } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared/browser-auth-routes";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { UserStore } from "../../src/db/user-store";
-import { handleRequest } from "../../src/router";
+import { handleRequest as routeRequest } from "../../src/router";
 import { cleanD1Tables } from "./cleanup";
 import { createSignedGoogleIdToken } from "./google-id-token";
 import {
@@ -23,6 +23,13 @@ import {
  */
 
 const CONTROL_PLANE_ORIGIN = "https://control-plane.test.local";
+
+function handleRequest(
+  request: Request,
+  requestEnv: Parameters<typeof routeRequest>[1]
+): Promise<Response> {
+  return routeRequest(request, requestEnv, createExecutionContext());
+}
 const PUBLIC_WEB_ORIGIN = "https://app.test.local";
 const WEB_SERVICE_SECRET = "test-service-secret-web";
 const GOOGLE_CLIENT_ID = "google-client-id";

--- a/packages/control-plane/test/integration/browser-auth-callback.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-callback.test.ts
@@ -1,4 +1,4 @@
-import { env } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,7 +6,7 @@ import { getUserAuth } from "../../src/auth/user/runtime";
 import { resolveGitHubCredentialAuthority } from "../../src/source-control/github-credential-authority";
 import { decryptToken } from "../../src/auth/crypto";
 import { UserStore } from "../../src/db/user-store";
-import { handleRequest } from "../../src/router";
+import { handleRequest as routeRequest } from "../../src/router";
 import { resolveGitHubEnrichmentForRequest } from "../../src/session/identity";
 import { cleanD1Tables } from "./cleanup";
 import { createSignedGoogleIdToken } from "./google-id-token";
@@ -18,6 +18,13 @@ const GOOGLE_CLIENT_ID = "google-client-id";
 const GOOGLE_SUBJECT = "google-subject";
 const MS_PER_SECOND = 1000;
 const GOOGLE_ACCESS_TOKEN_LIFETIME_MS = 60 * 60 * MS_PER_SECOND;
+
+function handleRequest(
+  request: Request,
+  requestEnv: Parameters<typeof routeRequest>[1]
+): Promise<Response> {
+  return routeRequest(request, requestEnv, createExecutionContext());
+}
 
 let googleIdToken = "";
 let googlePublicKey: JsonWebKey;

--- a/packages/control-plane/test/integration/browser-auth-router.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-router.test.ts
@@ -1,12 +1,19 @@
-import { env } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
 import { describe, expect, it } from "vitest";
-import { handleRequest } from "../../src/router";
+import { handleRequest as routeRequest } from "../../src/router";
 import type { Env } from "../../src/types";
 
 const CONTROL_PLANE_ORIGIN = "https://control-plane.test.local";
 const PUBLIC_WEB_ORIGIN = "https://app.test.local";
 const WEB_SERVICE_SECRET = "test-service-secret-web";
+
+function handleRequest(
+  request: Request,
+  requestEnv: Parameters<typeof routeRequest>[1]
+): Promise<Response> {
+  return routeRequest(request, requestEnv, createExecutionContext());
+}
 
 async function signedServiceRequest(
   path: string,

--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -1,12 +1,14 @@
 /**
  * Environment bindings for the GitHub Bot Cloudflare Worker.
  */
+import type { ControlPlaneFetcher } from "@open-inspect/shared/service-auth";
+
 export interface Env {
   /** KV namespace for deduplicating webhook deliveries. */
   GITHUB_KV: KVNamespace;
 
   /** Service binding to the control plane worker. */
-  CONTROL_PLANE: Fetcher;
+  CONTROL_PLANE: ControlPlaneFetcher;
 
   /** Deployment name for logging/identification. */
   DEPLOYMENT_NAME: string;

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { LinearCallbackContext } from "@open-inspect/shared/types/session-api";
+import type { ControlPlaneFetcher } from "@open-inspect/shared/service-auth";
 import { z } from "zod";
 
 /**
@@ -13,7 +14,7 @@ export interface Env {
   LINEAR_KV: KVNamespace;
 
   // Service binding to control plane
-  CONTROL_PLANE: Fetcher;
+  CONTROL_PLANE: ControlPlaneFetcher;
 
   // Environment variables
   DEPLOYMENT_NAME: string;

--- a/packages/shared/src/service-auth.ts
+++ b/packages/shared/src/service-auth.ts
@@ -330,13 +330,16 @@ export async function buildOutboundAuthHeaders(
 }
 
 /**
- * Minimal interface for the control-plane service binding. Compatible with
+ * Minimal interface for an HTTP service binding. Compatible with
  * Cloudflare Workers' `Fetcher` type without depending on
  * `@cloudflare/workers-types`.
  */
-export interface ControlPlaneFetcher {
+export interface FetchClient {
   fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
 }
+
+/** Destination-specific name retained for control-plane API consumers. */
+export type ControlPlaneFetcher = FetchClient;
 
 /** Options a signed control-plane fetch accepts beyond the request being signed. */
 export interface SignedFetchInit {
@@ -353,7 +356,7 @@ export interface SignedFetchInit {
  */
 export async function signedControlPlaneFetch(
   service: ServiceName,
-  env: OutboundCredentialEnv & { CONTROL_PLANE: ControlPlaneFetcher },
+  env: OutboundCredentialEnv & { CONTROL_PLANE: FetchClient },
   request: OutboundRequestToSign,
   init?: SignedFetchInit
 ): Promise<Response> {

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Env } from "./types";
+import type { ControlPlaneFetcher } from "@open-inspect/shared/service-auth";
 import type * as SlackModule from "@open-inspect/shared/slack";
 
 const { mockVerifySlackSignature, mockPublishView, mockOpenView, mockGetUserInfo } = vi.hoisted(
@@ -74,42 +75,45 @@ function mockReposResponseBody(repos: Array<Record<string, unknown>>) {
   };
 }
 
-function makeEnv(): Env {
-  return {
+function makeEnv() {
+  const controlPlaneFetch = vi.fn<ControlPlaneFetcher["fetch"]>();
+  controlPlaneFetch.mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/repos")) {
+      return new Response(
+        JSON.stringify(
+          mockReposResponseBody([
+            {
+              id: "acme/app",
+              owner: "acme",
+              name: "app",
+              fullName: "acme/app",
+              defaultBranch: "main",
+              private: true,
+            },
+          ])
+        ),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  const env = {
     SLACK_KV: createMockKV() as unknown as KVNamespace,
     SLACK_COMPLETION_QUEUE: {
       send: vi.fn(),
-    } as unknown as Queue,
+    },
     CONTROL_PLANE: {
-      fetch: vi.fn(async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(
-            JSON.stringify(
-              mockReposResponseBody([
-                {
-                  id: "acme/app",
-                  owner: "acme",
-                  name: "app",
-                  fullName: "acme/app",
-                  defaultBranch: "main",
-                  private: true,
-                },
-              ])
-            ),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            }
-          );
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }),
-    } as unknown as Fetcher,
+      fetch: controlPlaneFetch,
+    },
     DEPLOYMENT_NAME: "test",
     CONTROL_PLANE_URL: "https://control-plane.test",
     WEB_APP_URL: "https://app.test",
@@ -121,6 +125,8 @@ function makeEnv(): Env {
     SERVICE_AUTH_SECRET: "test-secret",
     LOG_LEVEL: "error",
   };
+  env satisfies Env;
+  return env;
 }
 
 function makeCtx() {
@@ -147,23 +153,21 @@ function buildNumberedRepos(count: number) {
 }
 
 /** Point CONTROL_PLANE.fetch at a fixed repo list (other routes return enabledModels). */
-function mockReposFetch(env: Env, repos: Array<Record<string, unknown>>) {
-  (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-    async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("/repos")) {
-        return new Response(JSON.stringify(mockReposResponseBody(repos)), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-
-      return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+function mockReposFetch(env: ReturnType<typeof makeEnv>, repos: Array<Record<string, unknown>>) {
+  env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/repos")) {
+      return new Response(JSON.stringify(mockReposResponseBody(repos)), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
     }
-  );
+
+    return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
 }
 
 function createDeferred<T>() {
@@ -185,73 +189,71 @@ function makeSessionEnv(
     prompt?: unknown | unknown[];
     promptStatus?: number | number[];
   } = {}
-): Env {
+): ReturnType<typeof makeEnv> {
   const env = makeEnv();
   let promptResponseIndex = 0;
-  (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-    async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("/repos")) {
-        order.push("repos");
-        return new Response(
-          JSON.stringify(
-            mockReposResponseBody([
-              {
-                id: "acme/app",
-                owner: "acme",
-                name: "app",
-                fullName: "acme/app",
-                defaultBranch: "main",
-                private: true,
-              },
-            ])
-          ),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-      }
-
-      if (url.endsWith("/sessions")) {
-        order.push("session");
-        return new Response(
-          JSON.stringify(responses.session ?? { sessionId: "session-1", status: "created" }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-      }
-
-      if (url.includes("/attachments")) {
-        order.push("attachment");
-        return new Response(JSON.stringify({ attachmentId: "att-1", mimeType: "image/png" }), {
-          status: 201,
+  env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/repos")) {
+      order.push("repos");
+      return new Response(
+        JSON.stringify(
+          mockReposResponseBody([
+            {
+              id: "acme/app",
+              owner: "acme",
+              name: "app",
+              fullName: "acme/app",
+              defaultBranch: "main",
+              private: true,
+            },
+          ])
+        ),
+        {
+          status: 200,
           headers: { "Content-Type": "application/json" },
-        });
-      }
+        }
+      );
+    }
 
-      if (url.includes("/prompt")) {
-        order.push("prompt");
-        const promptResponse = Array.isArray(responses.prompt)
-          ? responses.prompt[promptResponseIndex++]
-          : responses.prompt;
-        const promptStatus = Array.isArray(responses.promptStatus)
-          ? responses.promptStatus[promptResponseIndex - 1]
-          : responses.promptStatus;
-        return new Response(JSON.stringify(promptResponse ?? { messageId: "msg-1" }), {
-          status: promptStatus ?? 200,
+    if (url.endsWith("/sessions")) {
+      order.push("session");
+      return new Response(
+        JSON.stringify(responses.session ?? { sessionId: "session-1", status: "created" }),
+        {
+          status: 200,
           headers: { "Content-Type": "application/json" },
-        });
-      }
+        }
+      );
+    }
 
-      return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-        status: 200,
+    if (url.includes("/attachments")) {
+      order.push("attachment");
+      return new Response(JSON.stringify({ attachmentId: "att-1", mimeType: "image/png" }), {
+        status: 201,
         headers: { "Content-Type": "application/json" },
       });
     }
-  );
+
+    if (url.includes("/prompt")) {
+      order.push("prompt");
+      const promptResponse = Array.isArray(responses.prompt)
+        ? responses.prompt[promptResponseIndex++]
+        : responses.prompt;
+      const promptStatus = Array.isArray(responses.promptStatus)
+        ? responses.promptStatus[promptResponseIndex - 1]
+        : responses.promptStatus;
+      return new Response(JSON.stringify(promptResponse ?? { messageId: "msg-1" }), {
+        status: promptStatus ?? 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
   return env;
 }
 
@@ -523,9 +525,7 @@ describe("POST /events", () => {
     const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
     expect(postBodies.some((body) => String(body.text).includes("Session started!"))).toBe(false);
 
-    const sessionBodies = sessionFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const sessionBodies = sessionFetchBodies(env.CONTROL_PLANE.fetch);
     expect(sessionBodies[0]).not.toHaveProperty("title");
     expect((env.SLACK_KV as unknown as { put: ReturnType<typeof vi.fn> }).put).toHaveBeenCalledWith(
       "thread:C123:111.222",
@@ -568,60 +568,58 @@ describe("POST /events", () => {
       ok: true,
       user: { id: "U123", name: "ajan", profile: { display_name: "Ajan" } },
     });
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(
-            JSON.stringify(
-              mockReposResponseBody([
-                { owner: "acme", name: "web", defaultBranch: "main", private: true },
-                { owner: "acme", name: "api", defaultBranch: "main", private: true },
-                { owner: "acme", name: "docs", defaultBranch: "main", private: true },
-              ])
-            ),
-            { status: 200, headers: { "Content-Type": "application/json" } }
-          );
-        }
+    env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(
+          JSON.stringify(
+            mockReposResponseBody([
+              { owner: "acme", name: "web", defaultBranch: "main", private: true },
+              { owner: "acme", name: "api", defaultBranch: "main", private: true },
+              { owner: "acme", name: "docs", defaultBranch: "main", private: true },
+            ])
+          ),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
 
-        if (url.includes("/integration-settings/slack")) {
-          return new Response(
-            JSON.stringify({
-              settings: {
-                defaults: {
-                  routingRules: [
-                    { keyword: "frontend", target: "acme/web" },
-                    { keyword: "backend", target: "acme/api" },
-                  ],
-                },
+      if (url.includes("/integration-settings/slack")) {
+        return new Response(
+          JSON.stringify({
+            settings: {
+              defaults: {
+                routingRules: [
+                  { keyword: "frontend", target: "acme/web" },
+                  { keyword: "backend", target: "acme/api" },
+                ],
               },
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } }
-          );
-        }
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
 
-        if (url.endsWith("/sessions")) {
-          order.push("session");
-          return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        if (url.includes("/prompt")) {
-          order.push("prompt");
-          return new Response(JSON.stringify({ messageId: "msg-1" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+      if (url.endsWith("/sessions")) {
+        order.push("session");
+        return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-    );
+
+      if (url.includes("/prompt")) {
+        order.push("prompt");
+        return new Response(JSON.stringify({ messageId: "msg-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
     const ctx = makeCtx();
     const response = await app.fetch(
@@ -703,9 +701,7 @@ describe("POST /events", () => {
     expect(selectionResponse.status).toBe(200);
     await flushWaitUntil(selectionCtx);
     expect(mockGetUserInfo).toHaveBeenCalledOnce();
-    expect(
-      promptFetchBodies(env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>)
-    ).toEqual([
+    expect(promptFetchBodies(env.CONTROL_PLANE.fetch)).toEqual([
       expect.objectContaining({
         content: expect.stringContaining("[Ajan (U123)]: frontend backend help"),
       }),
@@ -869,9 +865,7 @@ describe("POST /events", () => {
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("prompt"));
     expect(order).not.toContain("session");
 
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     expect(promptBodies[0].content).toContain("now add coverage");
     expect(promptBodies[0].content).toContain("[U123]: now add coverage");
@@ -990,9 +984,7 @@ describe("POST /events", () => {
           String(input).includes("conversations.replies") && String(input).includes("limit=200")
       )
     ).toHaveLength(1);
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(2);
     expect(promptBodies[1].content).toContain("Context from the Slack thread");
     expect(promptBodies[1].content).toContain("Earlier request");
@@ -1063,9 +1055,7 @@ describe("POST /events", () => {
     expect(repliesCalls).toHaveLength(1);
     expect(String(repliesCalls[0][0])).toContain("oldest=111.222");
 
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     const content = String(promptBodies[0].content);
     expect(content).toContain("New messages in the Slack thread since your last task");
@@ -1141,9 +1131,7 @@ describe("POST /events", () => {
     expect(order).toContain("attachment");
     expect(order).not.toContain("session");
     expect(order.indexOf("attachment")).toBeLessThan(order.indexOf("prompt"));
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     expect(promptBodies[0].attachments).toEqual([
       { attachmentId: "att-1", name: "screenshot.png" },
@@ -1215,9 +1203,7 @@ describe("POST /events", () => {
     expect(lookupCalls).toHaveLength(1);
     expect(order).toContain("filedownload");
     expect(order).toContain("attachment");
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     expect(promptBodies[0].attachments).toEqual([{ attachmentId: "att-1", name: "bug.png" }]);
 
@@ -1291,9 +1277,7 @@ describe("POST /events", () => {
     expect(response.status).toBe(200);
     await flushWaitUntil(ctx);
 
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     const content = String(promptBodies[0].content);
     expect(content).toContain("Slack messages forwarded with this request");
@@ -1354,9 +1338,7 @@ describe("POST /events", () => {
     expect(response.status).toBe(200);
     await flushWaitUntil(ctx);
 
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     const content = String(promptBodies[0].content);
     expect(content).toContain(
@@ -1552,9 +1534,7 @@ describe("POST /events", () => {
 
     // The prompt is still sent — thread context stays best effort — but the
     // checkpoint is not advanced past messages that were never considered.
-    const promptBodies = promptFetchBodies(
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
-    );
+    const promptBodies = promptFetchBodies(env.CONTROL_PLANE.fetch);
     expect(promptBodies).toHaveLength(1);
     expect(String(promptBodies[0].content)).not.toContain(
       "New messages in the Slack thread since your last task"
@@ -1696,21 +1676,19 @@ describe("POST /interactions", () => {
       })
     );
 
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(JSON.stringify(mockReposResponseBody([])), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        return new Response(JSON.stringify({ enabledModels: [] }), {
+    env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(JSON.stringify(mockReposResponseBody([])), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-    );
+      return new Response(JSON.stringify({ enabledModels: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
     const payload = {
       type: "block_actions",
@@ -2100,50 +2078,48 @@ describe("POST /interactions", () => {
       "repo-branch"
     );
 
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(
-            JSON.stringify(
-              mockReposResponseBody([
-                {
-                  id: "acme/app",
-                  owner: "acme",
-                  name: "app",
-                  fullName: "acme/app",
-                  defaultBranch: "main",
-                  private: true,
-                },
-              ])
-            ),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            }
-          );
-        }
-
-        if (url.endsWith("/sessions")) {
-          return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
+    env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(
+          JSON.stringify(
+            mockReposResponseBody([
+              {
+                id: "acme/app",
+                owner: "acme",
+                name: "app",
+                fullName: "acme/app",
+                defaultBranch: "main",
+                private: true,
+              },
+            ])
+          ),
+          {
             status: 200,
             headers: { "Content-Type": "application/json" },
-          });
-        }
+          }
+        );
+      }
 
-        if (url.includes("/prompt")) {
-          return new Response(JSON.stringify({ messageId: "msg-1" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+      if (url.endsWith("/sessions")) {
+        return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-    );
+
+      if (url.includes("/prompt")) {
+        return new Response(JSON.stringify({ messageId: "msg-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);
@@ -2155,9 +2131,7 @@ describe("POST /interactions", () => {
     await flushWaitUntil(ctx, 1);
     expect(ctx.waitUntil).toHaveBeenCalledTimes(3);
 
-    const sessionCall = (
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }
-    ).mock.calls.find(([input]) => {
+    const sessionCall = env.CONTROL_PLANE.fetch.mock.calls.find(([input]) => {
       const url = typeof input === "string" ? input : (input as URL).toString();
       return url.endsWith("/sessions");
     });
@@ -2223,53 +2197,49 @@ describe("POST /interactions", () => {
       })
     );
 
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(
-            JSON.stringify(
-              mockReposResponseBody([
-                {
-                  id: "acme/app",
-                  owner: "acme",
-                  name: "app",
-                  fullName: "acme/app",
-                  defaultBranch: "main",
-                  private: true,
-                },
-              ])
-            ),
-            { status: 200, headers: { "Content-Type": "application/json" } }
-          );
-        }
-        if (url.endsWith("/sessions")) {
-          return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        if (url.includes("/prompt")) {
-          return new Response(JSON.stringify({ messageId: "msg-1" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        return new Response(JSON.stringify({ enabledModels: [] }), {
+    env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(
+          JSON.stringify(
+            mockReposResponseBody([
+              {
+                id: "acme/app",
+                owner: "acme",
+                name: "app",
+                fullName: "acme/app",
+                defaultBranch: "main",
+                private: true,
+              },
+            ])
+          ),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (url.endsWith("/sessions")) {
+        return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-    );
+      if (url.includes("/prompt")) {
+        return new Response(JSON.stringify({ messageId: "msg-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ enabledModels: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);
     expect(response.status).toBe(200);
     await flushWaitUntil(ctx);
 
-    const sessionCall = (
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }
-    ).mock.calls.find(([input]) => {
+    const sessionCall = env.CONTROL_PLANE.fetch.mock.calls.find(([input]) => {
       const url = typeof input === "string" ? input : (input as URL).toString();
       return url.endsWith("/sessions");
     });
@@ -2329,53 +2299,49 @@ describe("POST /interactions", () => {
       })
     );
 
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(
-            JSON.stringify(
-              mockReposResponseBody([
-                {
-                  id: "acme/app",
-                  owner: "acme",
-                  name: "app",
-                  fullName: "acme/app",
-                  defaultBranch: "main",
-                  private: true,
-                },
-              ])
-            ),
-            { status: 200, headers: { "Content-Type": "application/json" } }
-          );
-        }
-        if (url.endsWith("/sessions")) {
-          return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        if (url.includes("/prompt")) {
-          return new Response(JSON.stringify({ messageId: "msg-1" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        return new Response(JSON.stringify({ enabledModels: [] }), {
+    env.CONTROL_PLANE.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(
+          JSON.stringify(
+            mockReposResponseBody([
+              {
+                id: "acme/app",
+                owner: "acme",
+                name: "app",
+                fullName: "acme/app",
+                defaultBranch: "main",
+                private: true,
+              },
+            ])
+          ),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (url.endsWith("/sessions")) {
+        return new Response(JSON.stringify({ sessionId: "session-1", status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-    );
+      if (url.includes("/prompt")) {
+        return new Response(JSON.stringify({ messageId: "msg-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ enabledModels: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);
     expect(response.status).toBe(200);
     await flushWaitUntil(ctx);
 
-    const sessionCall = (
-      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }
-    ).mock.calls.find(([input]) => {
+    const sessionCall = env.CONTROL_PLANE.fetch.mock.calls.find(([input]) => {
       const url = typeof input === "string" ? input : (input as URL).toString();
       return url.endsWith("/sessions");
     });

--- a/packages/slack-bot/src/internal-auth.ts
+++ b/packages/slack-bot/src/internal-auth.ts
@@ -12,8 +12,10 @@ import {
 } from "@open-inspect/shared/service-auth";
 import type { Env } from "./types";
 
+export type ControlPlaneEnv = Pick<Env, "CONTROL_PLANE" | "SERVICE_AUTH_SECRET">;
+
 export function signedControlPlaneFetch(
-  env: Env,
+  env: ControlPlaneEnv,
   request: OutboundRequestToSign,
   init?: SignedFetchInit
 ): Promise<Response> {

--- a/packages/slack-bot/src/sessions/control-plane-client.test.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Environment } from "@open-inspect/shared/types/environments";
-import type { Env } from "../types";
+import type { ControlPlaneEnv } from "../internal-auth";
 import { createSession, sendPrompt } from "./control-plane-client";
 import { OUTBOUND_REQUEST_TIMEOUT_MS } from "../request-options";
 
-function makeEnv(fetch: ReturnType<typeof vi.fn>): Env {
+function makeEnv(fetch: ControlPlaneEnv["CONTROL_PLANE"]["fetch"]): ControlPlaneEnv {
   return {
-    CONTROL_PLANE: { fetch } as unknown as Fetcher,
+    CONTROL_PLANE: { fetch },
     SERVICE_AUTH_SECRET: "test-secret",
-    LOG_LEVEL: "error",
-  } as Env;
+  };
 }
 
 const target = {
@@ -205,11 +204,11 @@ describe("control plane client request payloads", () => {
 });
 
 describe("service credential headers", () => {
-  function makeServiceEnv(fetch: ReturnType<typeof vi.fn>): Env {
+  function makeServiceEnv(fetch: ControlPlaneEnv["CONTROL_PLANE"]["fetch"]): ControlPlaneEnv {
     return {
       ...makeEnv(fetch),
       SERVICE_AUTH_SECRET: "slack-service-secret",
-    } as Env;
+    };
   }
 
   function sentHeaders(fetch: ReturnType<typeof vi.fn>): Record<string, string> {
@@ -249,9 +248,8 @@ describe("service credential headers", () => {
   it("sends no request at all when SERVICE_AUTH_SECRET is unset", async () => {
     const fetch = vi.fn(async () => new Response(JSON.stringify({ messageId: "m1" })));
     const env = {
-      CONTROL_PLANE: { fetch } as unknown as Fetcher,
-      LOG_LEVEL: "error",
-    } as Env;
+      CONTROL_PLANE: { fetch },
+    };
 
     const result = await sendPrompt(env, {
       sessionId: "session-1",

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -5,11 +5,10 @@ import {
   type SendPromptResponse,
 } from "@open-inspect/shared/types/session-api";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
-import { signedControlPlaneFetch } from "../internal-auth";
+import { signedControlPlaneFetch, type ControlPlaneEnv } from "../internal-auth";
 import { createLogger } from "../logger";
 import { buildSessionTargetRequestFields, targetId, type SlackSessionTarget } from "../targets";
 import type { CallbackContext } from "@open-inspect/shared/types/session-api";
-import type { Env } from "../types";
 import { OUTBOUND_REQUEST_TIMEOUT_MS } from "../request-options";
 
 const log = createLogger("handler");
@@ -30,7 +29,7 @@ export type SendPromptResult =
   | { ok: false; reason: "stale" | "transient" };
 
 export async function createSession(
-  env: Env,
+  env: ControlPlaneEnv,
   options: CreateSessionOptions
 ): Promise<CreateSessionResponse | null> {
   const {
@@ -119,7 +118,10 @@ export interface SendPromptOptions {
   traceId?: string;
 }
 
-export async function sendPrompt(env: Env, options: SendPromptOptions): Promise<SendPromptResult> {
+export async function sendPrompt(
+  env: ControlPlaneEnv,
+  options: SendPromptOptions
+): Promise<SendPromptResult> {
   const { sessionId, content, authorId, callbackContext, attachments, traceId } = options;
   const startTime = Date.now();
   const base = { trace_id: traceId, session_id: sessionId, source: "slack" };

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -3,6 +3,11 @@
  */
 
 import type { SlackCompletionJob } from "../completion/job";
+import type { ControlPlaneFetcher } from "@open-inspect/shared/service-auth";
+
+export interface SlackCompletionQueue {
+  send(message: SlackCompletionJob, options?: { contentType?: "json" }): Promise<unknown>;
+}
 
 /**
  * Cloudflare Worker environment bindings.
@@ -12,10 +17,10 @@ export interface Env {
   SLACK_KV: KVNamespace;
 
   // Service binding to control plane
-  CONTROL_PLANE: Fetcher;
+  CONTROL_PLANE: ControlPlaneFetcher;
 
   // Durable completion handoff. All Slack completion callbacks enqueue here.
-  SLACK_COMPLETION_QUEUE: Queue<SlackCompletionJob>;
+  SLACK_COMPLETION_QUEUE: SlackCompletionQueue;
 
   // Environment variables
   DEPLOYMENT_NAME: string;


### PR DESCRIPTION
## Summary

- introduce application-owned fetch and background-task capability ports in the control plane
- narrow callback delivery, route contexts, session services, and Slack control-plane clients to the methods they consume
- reuse the shared fetch-only binding contract across bot environments and add a send-only Slack completion queue contract
- preserve typed Vitest mock handles in high-volume test harnesses instead of casting full Cloudflare bindings back to mocks
- remove the fabricated `connect()` implementation from the Durable Object fetch adapter

## Verification

- `npm run typecheck`
- `npm run lint -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/github-bot`
- control-plane targeted tests: 163 passed
- Slack bot tests: 420 passed
- Linear bot tests: 224 passed
- GitHub bot tests: 130 passed
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/42630a2bb2cb353f18528f3d1ffbd5ba)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized request fetching and background-task scheduling across platform integrations.
  * Clarified control-plane, callback, session, authentication, and bot interfaces.
  * Background operations now consistently run asynchronously, improving reliability for cache updates, notifications, and lifecycle tracking.
  * Slack completion queue handling now uses a dedicated interface.

* **Tests**
  * Simplified test contexts and mocks while preserving existing coverage and assertions.
  * Removed obsolete unsupported-operation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->