### PR TITLE
fix: lint provider infrastructure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         run: ruff format --check src/ tests/
 
   lint-python:
-    name: Lint & Format (Python - modal-infra)
+    name: Lint & Format (Python - provider infra)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -138,10 +138,10 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run Ruff linter
-        run: ruff check src/
+        run: ruff check --config pyproject.toml src/ ../e2b-infra/ ../daytona-infra/
 
       - name: Run Ruff formatter check
-        run: ruff format --check src/
+        run: ruff format --config pyproject.toml --check src/ ../e2b-infra/ ../daytona-infra/
 
   typecheck-python:
     name: TypeCheck (Python)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
           pip install -e "packages/modal-infra[dev]"
 
       - name: Run Ruff linter
-        run: ruff check packages/modal-infra/src/ packages/e2b-infra/ packages/daytona-infra/
+        run: ruff check packages/modal-infra/ packages/e2b-infra/ packages/daytona-infra/
 
       - name: Run Ruff formatter check
-        run: ruff format --check packages/modal-infra/src/ packages/e2b-infra/ packages/daytona-infra/
+        run: ruff format --check packages/modal-infra/ packages/e2b-infra/ packages/daytona-infra/
 
   typecheck-python:
     name: TypeCheck (Python)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,8 @@ jobs:
     name: Lint & Format (Python - provider infra)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    defaults:
-      run:
-        working-directory: packages/modal-infra
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -134,14 +133,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ../sandbox-runtime
-          pip install -e ".[dev]"
+          pip install -e packages/sandbox-runtime
+          pip install -e "packages/modal-infra[dev]"
 
       - name: Run Ruff linter
-        run: ruff check --config pyproject.toml src/ ../e2b-infra/ ../daytona-infra/
+        run: ruff check packages/modal-infra/src/ packages/e2b-infra/ packages/daytona-infra/
 
       - name: Run Ruff formatter check
-        run: ruff format --config pyproject.toml --check src/ ../e2b-infra/ ../daytona-infra/
+        run: ruff format --check packages/modal-infra/src/ packages/e2b-infra/ packages/daytona-infra/
 
   typecheck-python:
     name: TypeCheck (Python)

--- a/package.json
+++ b/package.json
@@ -53,11 +53,7 @@
     "*.{js,jsx,json,md,yaml,yml,css}": [
       "prettier --write"
     ],
-    "packages/modal-infra/**/*.py": [
-      "ruff check --fix",
-      "ruff format"
-    ],
-    "packages/sandbox-runtime/**/*.py": [
+    "packages/{daytona-infra,e2b-infra,modal-infra,sandbox-runtime}/**/*.py": [
       "ruff check --fix",
       "ruff format"
     ]

--- a/packages/daytona-infra/src/config.py
+++ b/packages/daytona-infra/src/config.py
@@ -28,9 +28,7 @@ def load_config() -> DaytonaBootstrapConfig:
     if not base_snapshot:
         raise RuntimeError("DAYTONA_BASE_SNAPSHOT is required")
 
-    repo_root = Path(
-        os.environ.get("OPEN_INSPECT_REPO_ROOT", Path(__file__).resolve().parents[3])
-    )
+    repo_root = Path(os.environ.get("OPEN_INSPECT_REPO_ROOT", Path(__file__).resolve().parents[3]))
 
     return DaytonaBootstrapConfig(
         api_key=api_key,

--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from daytona import CreateSnapshotParams, Daytona, Image
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # OpenCode version to install.
 #
@@ -22,9 +25,7 @@ SANDBOX_VERSION = "daytona-v6-vnc-opencode-1-18-18"
 
 def build_base_image(repo_root: Path) -> Image:
     """Build the Open-Inspect Daytona base image."""
-    sandbox_runtime_dir = (
-        repo_root / "packages" / "sandbox-runtime" / "src" / "sandbox_runtime"
-    )
+    sandbox_runtime_dir = repo_root / "packages" / "sandbox-runtime" / "src" / "sandbox_runtime"
 
     return (
         Image.base("python:3.12-slim-bookworm")
@@ -72,7 +73,7 @@ def build_base_image(repo_root: Path) -> Image:
             # below. Mirror packages/modal-infra/src/images/base.py.
             "printf '%s\\n'"
             " '#!/bin/sh'"
-            ' \'exec python3 -m sandbox_runtime.credentials.git_credential_helper "$@"\''
+            " 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
             " > /usr/local/bin/oi-git-credentials",
             "chmod 0755 /usr/local/bin/oi-git-credentials",
             "git config --system credential.helper /usr/local/bin/oi-git-credentials",

--- a/packages/e2b-infra/build-template.py
+++ b/packages/e2b-infra/build-template.py
@@ -16,13 +16,13 @@ Env:
   E2B_TEMPLATE_MEM  (optional) — memory MB, even number (default 1024).
 """
 
+import atexit
+import json
 import os
 import shutil
 import sys
-import urllib.request
 import urllib.error
-import json
-import atexit
+import urllib.request
 from pathlib import Path
 
 from e2b import Template, default_build_logger
@@ -82,7 +82,8 @@ dockerfile = (SCRIPT_DIR / "e2b.Dockerfile").read_text()
 print(f"Building E2B template: {TEMPLATE_ID} (cpu={CPU}, mem={MEM})")
 
 template = (
-    Template().from_dockerfile(dockerfile)
+    Template()
+    .from_dockerfile(dockerfile)
     # Staged into this dir above; imported via PYTHONPATH=/app as `sandbox_runtime`.
     .copy("sandbox_runtime", "/app/sandbox_runtime")
     # E2B's non-root runtime cannot install this into /usr/local/bin itself.

--- a/packages/e2b-infra/oi-launch.py
+++ b/packages/e2b-infra/oi-launch.py
@@ -17,7 +17,6 @@ launcher only runs for a fresh spawn.
 
 import json
 import os
-import sys
 import time
 
 SESSION_ENV_PATH = "/tmp/oi-session.env"

--- a/packages/modal-infra/pyproject.toml
+++ b/packages/modal-infra/pyproject.toml
@@ -35,49 +35,11 @@ packages = ["src"]
 asyncio_mode = "auto"
 
 [tool.ruff]
-target-version = "py312"
-line-length = 100
+extend = "../../ruff.toml"
 src = ["src", "tests"]
-
-[tool.ruff.lint]
-select = [
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "F",      # Pyflakes
-    "I",      # isort
-    "B",      # flake8-bugbear
-    "C4",     # flake8-comprehensions
-    "UP",     # pyupgrade
-    "ARG",    # flake8-unused-arguments
-    "SIM",    # flake8-simplify
-    "TCH",    # flake8-type-checking
-    "PTH",    # flake8-use-pathlib
-    "RUF",    # Ruff-specific rules
-]
-ignore = [
-    "E501",   # line too long (handled by formatter)
-    "B008",   # do not perform function calls in argument defaults
-    "ARG001", # unused function argument (common in handlers)
-    "ARG002", # unused method argument (common in handlers)
-    "PTH110", # os.path.exists - keep for simplicity
-    "PTH123", # open() - keep for simplicity
-    "RUF006", # asyncio.create_task return value - intentional fire-and-forget
-    "B904",   # raise from - keep for simpler error handling
-    "SIM102", # nested if statements - keep for readability
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ARG", "S101"]
-"__init__.py" = ["F401"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["src", "sandbox_runtime"]
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
 
 [tool.mypy]
 python_version = "3.12"

--- a/packages/sandbox-runtime/pyproject.toml
+++ b/packages/sandbox-runtime/pyproject.toml
@@ -30,49 +30,11 @@ packages = ["src/sandbox_runtime"]
 asyncio_mode = "auto"
 
 [tool.ruff]
-target-version = "py312"
-line-length = 100
+extend = "../../ruff.toml"
 src = ["src", "tests"]
-
-[tool.ruff.lint]
-select = [
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "F",      # Pyflakes
-    "I",      # isort
-    "B",      # flake8-bugbear
-    "C4",     # flake8-comprehensions
-    "UP",     # pyupgrade
-    "ARG",    # flake8-unused-arguments
-    "SIM",    # flake8-simplify
-    "TCH",    # flake8-type-checking
-    "PTH",    # flake8-use-pathlib
-    "RUF",    # Ruff-specific rules
-]
-ignore = [
-    "E501",   # line too long (handled by formatter)
-    "B008",   # do not perform function calls in argument defaults
-    "ARG001", # unused function argument (common in handlers)
-    "ARG002", # unused method argument (common in handlers)
-    "PTH110", # os.path.exists - keep for simplicity
-    "PTH123", # open() - keep for simplicity
-    "RUF006", # asyncio.create_task return value - intentional fire-and-forget
-    "B904",   # raise from - keep for simpler error handling
-    "SIM102", # nested if statements - keep for readability
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ARG", "S101"]
-"__init__.py" = ["F401"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["sandbox_runtime"]
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
 
 [tool.mypy]
 python_version = "3.12"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,39 @@
+target-version = "py312"
+line-length = 100
+
+[lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # Pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade
+    "ARG",    # flake8-unused-arguments
+    "SIM",    # flake8-simplify
+    "TCH",    # flake8-type-checking
+    "PTH",    # flake8-use-pathlib
+    "RUF",    # Ruff-specific rules
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "B008",   # do not perform function calls in argument defaults
+    "ARG001", # unused function argument (common in handlers)
+    "ARG002", # unused method argument (common in handlers)
+    "PTH110", # os.path.exists - keep for simplicity
+    "PTH123", # open() - keep for simplicity
+    "RUF006", # asyncio.create_task return value - intentional fire-and-forget
+    "B904",   # raise from - keep for simpler error handling
+    "SIM102", # nested if statements - keep for readability
+]
+
+[lint.per-file-ignores]
+"**/tests/**/*.py" = ["ARG", "S101"]
+"**/__init__.py" = ["F401"]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"


### PR DESCRIPTION
## Summary
- fix Ruff lint and formatting issues in the E2B and Daytona infrastructure scripts
- extend the Python provider-infrastructure CI job to cover `e2b-infra` and `daytona-infra`
- explicitly reuse the existing `modal-infra` Ruff configuration for consistent checks

## Validation
- `ruff check --config pyproject.toml src/ ../e2b-infra/ ../daytona-infra/`
- `ruff format --config pyproject.toml --check src/ ../e2b-infra/ ../daytona-infra/`
- `npx prettier --check .github/workflows/ci.yml`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/28292aa94b7bf384c2a291edc954c0f2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized linting and formatting rules across infrastructure packages.
  * Expanded automated checks to cover additional infrastructure components.
  * Improved code consistency and removed an unused import without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->