### PR TITLE
refactor: extract session connection and broadcast port

### DIFF
--- a/packages/control-plane/src/session/connections.test.ts
+++ b/packages/control-plane/src/session/connections.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { InMemorySessionConnections } from "./connections";
+import { SessionMessengerImpl } from "./messenger";
+
+const participant = {
+  participantId: "participant-1",
+  userId: "user-1",
+  name: "Test User",
+  status: "active" as const,
+  lastSeen: 123,
+};
+
+describe("InMemorySessionConnections", () => {
+  it("broadcasts only to registered browser connections", async () => {
+    const connections = new InMemorySessionConnections();
+    await connections.registerBrowser({
+      connectionId: "browser-1",
+      clientId: "client-1",
+      participant,
+    });
+
+    const message = { type: "sandbox_status", status: "ready" } as const;
+    await connections.broadcastToBrowsers(message);
+
+    expect(connections.getBrowserMessages("browser-1")).toEqual([message]);
+    expect(connections.getSandboxMessages()).toEqual([]);
+  });
+
+  it("replaces the active sandbox connection and delivers to the replacement", async () => {
+    const connections = new InMemorySessionConnections();
+    await connections.registerSandbox({ connectionId: "sandbox-1", sandboxId: "sb-1" });
+    await connections.sendToSandbox({ type: "snapshot" });
+    await connections.registerSandbox({ connectionId: "sandbox-2", sandboxId: "sb-2" });
+    await connections.sendToSandbox({ type: "refresh_diff" });
+
+    expect(connections.getSandboxMessages("sandbox-1")).toEqual([{ type: "snapshot" }]);
+    expect(connections.getSandboxMessages("sandbox-2")).toEqual([{ type: "refresh_diff" }]);
+  });
+
+  it("lists connected participants without exposing transport details", async () => {
+    const connections = new InMemorySessionConnections();
+    await connections.registerBrowser({
+      connectionId: "browser-1",
+      clientId: "client-1",
+      participant,
+    });
+
+    await expect(connections.listParticipants()).resolves.toEqual([participant]);
+  });
+
+  it("records the sandbox disconnect reason and rejects later delivery", async () => {
+    const connections = new InMemorySessionConnections();
+    await connections.registerSandbox({ connectionId: "sandbox-1", sandboxId: "sb-1" });
+
+    const reason = { code: 1011, reason: "Unresponsive sandbox" };
+    await connections.disconnectSandbox(reason);
+
+    expect(connections.getSandboxDisconnect("sandbox-1")).toEqual(reason);
+    await expect(connections.sendToSandbox({ type: "stop" })).rejects.toThrow(
+      "No sandbox connected"
+    );
+  });
+});
+
+describe("SessionMessengerImpl with in-memory connections", () => {
+  it("can exercise engine messaging without WebSocket globals", async () => {
+    const connections = new InMemorySessionConnections();
+    await connections.registerBrowser({
+      connectionId: "browser-1",
+      clientId: "client-1",
+      participant,
+    });
+    await connections.registerSandbox({ connectionId: "sandbox-1", sandboxId: "sb-1" });
+    const messenger = new SessionMessengerImpl(connections);
+
+    const browserMessage = {
+      type: "diff_state_changed",
+      revisionId: "revision-1",
+      updatedAt: 1,
+    } as const;
+    messenger.broadcast(browserMessage);
+    await messenger.sendToSandbox({ type: "refresh_diff" });
+    await connections.flush();
+
+    expect(connections.getBrowserMessages("browser-1")).toEqual([browserMessage]);
+    expect(connections.getSandboxMessages()).toEqual([{ type: "refresh_diff" }]);
+  });
+});

--- a/packages/control-plane/src/session/connections.ts
+++ b/packages/control-plane/src/session/connections.ts
@@ -26,6 +26,37 @@ export interface DisconnectReason {
   reason: string;
 }
 
+export class SandboxDeliveryUnavailableError extends Error {
+  constructor(message = "No sandbox connected") {
+    super(message);
+    this.name = "SandboxDeliveryUnavailableError";
+  }
+}
+
+/** Project one participant per identity from one or more browser connections. */
+export function projectConnectedParticipants(
+  connections: Iterable<ConnectedParticipant>
+): ConnectedParticipant[] {
+  const participants = new Map<string, ConnectedParticipant>();
+  for (const connection of connections) {
+    const existing = participants.get(connection.participantId);
+    if (!existing) {
+      participants.set(connection.participantId, {
+        participantId: connection.participantId,
+        userId: connection.userId,
+        name: connection.name,
+        avatar: connection.avatar,
+        status: connection.status,
+        lastSeen: connection.lastSeen,
+      });
+      continue;
+    }
+    if (connection.status === "active") existing.status = "active";
+    if (connection.lastSeen > existing.lastSeen) existing.lastSeen = connection.lastSeen;
+  }
+  return Array.from(participants.values());
+}
+
 /** Platform-neutral connection and fan-out boundary consumed by the session engine. */
 export interface SessionConnections {
   registerBrowser(input: BrowserConnection): Promise<void>;
@@ -59,7 +90,7 @@ export class InMemorySessionConnections implements SessionConnections {
   }
 
   sendToSandbox(message: SandboxCommand): Promise<void> {
-    if (!this.sandbox) return Promise.reject(new Error("No sandbox connected"));
+    if (!this.sandbox) return Promise.reject(new SandboxDeliveryUnavailableError());
     this.sandboxMessages.get(this.sandbox.connectionId)!.push(message);
     return Promise.resolve();
   }
@@ -78,16 +109,11 @@ export class InMemorySessionConnections implements SessionConnections {
   }
 
   listParticipants(): Promise<ConnectedParticipant[]> {
-    const participants = new Map<string, ConnectedParticipant>();
-    for (const { participant } of this.browsers.values()) {
-      const existing = participants.get(participant.participantId);
-      const isActive = existing?.status === "active" || participant.status === "active";
-      if (!existing || participant.lastSeen > existing.lastSeen) {
-        participants.set(participant.participantId, { ...participant });
-      }
-      if (isActive) participants.get(participant.participantId)!.status = "active";
-    }
-    return Promise.resolve(Array.from(participants.values()));
+    return Promise.resolve(
+      projectConnectedParticipants(
+        Array.from(this.browsers.values(), ({ participant }) => participant)
+      )
+    );
   }
 
   getBrowserMessages(connectionId: string): readonly ServerMessage[] {

--- a/packages/control-plane/src/session/connections.ts
+++ b/packages/control-plane/src/session/connections.ts
@@ -1,0 +1,108 @@
+import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+import type { SandboxCommand } from "./types";
+
+export interface ConnectedParticipant {
+  participantId: string;
+  userId: string;
+  name: string;
+  avatar?: string;
+  status: "active" | "idle" | "away";
+  lastSeen: number;
+}
+
+export interface BrowserConnection {
+  connectionId: string;
+  clientId: string;
+  participant: ConnectedParticipant;
+}
+
+export interface SandboxConnection {
+  connectionId: string;
+  sandboxId?: string;
+}
+
+export interface DisconnectReason {
+  code: number;
+  reason: string;
+}
+
+/** Platform-neutral connection and fan-out boundary consumed by the session engine. */
+export interface SessionConnections {
+  registerBrowser(input: BrowserConnection): Promise<void>;
+  registerSandbox(input: SandboxConnection): Promise<void>;
+  sendToSandbox(message: SandboxCommand): Promise<void>;
+  broadcastToBrowsers(message: ServerMessage): Promise<void>;
+  disconnectSandbox(reason: DisconnectReason): Promise<void>;
+  listParticipants(): Promise<ConnectedParticipant[]>;
+}
+
+/** Deterministic connection adapter for application tests and non-WebSocket runtimes. */
+export class InMemorySessionConnections implements SessionConnections {
+  private readonly browsers = new Map<string, BrowserConnection>();
+  private readonly browserMessages = new Map<string, ServerMessage[]>();
+  private readonly sandboxMessages = new Map<string, SandboxCommand[]>();
+  private readonly sandboxDisconnects = new Map<string, DisconnectReason>();
+  private sandbox: SandboxConnection | null = null;
+
+  registerBrowser(input: BrowserConnection): Promise<void> {
+    this.browsers.set(input.connectionId, input);
+    this.browserMessages.set(input.connectionId, []);
+    return Promise.resolve();
+  }
+
+  registerSandbox(input: SandboxConnection): Promise<void> {
+    this.sandbox = input;
+    if (!this.sandboxMessages.has(input.connectionId)) {
+      this.sandboxMessages.set(input.connectionId, []);
+    }
+    return Promise.resolve();
+  }
+
+  sendToSandbox(message: SandboxCommand): Promise<void> {
+    if (!this.sandbox) return Promise.reject(new Error("No sandbox connected"));
+    this.sandboxMessages.get(this.sandbox.connectionId)!.push(message);
+    return Promise.resolve();
+  }
+
+  broadcastToBrowsers(message: ServerMessage): Promise<void> {
+    for (const connectionId of this.browsers.keys()) {
+      this.browserMessages.get(connectionId)!.push(message);
+    }
+    return Promise.resolve();
+  }
+
+  disconnectSandbox(reason: DisconnectReason): Promise<void> {
+    if (this.sandbox) this.sandboxDisconnects.set(this.sandbox.connectionId, reason);
+    this.sandbox = null;
+    return Promise.resolve();
+  }
+
+  listParticipants(): Promise<ConnectedParticipant[]> {
+    const participants = new Map<string, ConnectedParticipant>();
+    for (const { participant } of this.browsers.values()) {
+      const existing = participants.get(participant.participantId);
+      const isActive = existing?.status === "active" || participant.status === "active";
+      if (!existing || participant.lastSeen > existing.lastSeen) {
+        participants.set(participant.participantId, { ...participant });
+      }
+      if (isActive) participants.get(participant.participantId)!.status = "active";
+    }
+    return Promise.resolve(Array.from(participants.values()));
+  }
+
+  getBrowserMessages(connectionId: string): readonly ServerMessage[] {
+    return this.browserMessages.get(connectionId) ?? [];
+  }
+
+  getSandboxMessages(connectionId = this.sandbox?.connectionId): readonly SandboxCommand[] {
+    return connectionId ? (this.sandboxMessages.get(connectionId) ?? []) : [];
+  }
+
+  getSandboxDisconnect(connectionId: string): DisconnectReason | undefined {
+    return this.sandboxDisconnects.get(connectionId);
+  }
+
+  flush(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/control-plane/src/session/diffs/service.test.ts
+++ b/packages/control-plane/src/session/diffs/service.test.ts
@@ -101,7 +101,7 @@ function harness() {
   } as unknown as SessionCoreRepository;
   const messenger: SessionMessenger = {
     broadcast: vi.fn(),
-    sendToSandbox: vi.fn(() => true),
+    sendToSandbox: vi.fn(async () => {}),
   };
   const log: Logger = {
     debug: vi.fn(),
@@ -200,13 +200,13 @@ describe("SessionDiffService", () => {
     expect(() => service.resolveFile("revision-1", "missing")).toThrow(DiffFileNotFoundError);
   });
 
-  it("requests a refresh only while the sandbox is connected", () => {
+  it("requests a refresh only while the sandbox is connected", async () => {
     const { service, messenger } = harness();
 
-    service.requestRefresh();
+    await service.requestRefresh();
     expect(messenger.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
 
-    vi.mocked(messenger.sendToSandbox).mockReturnValue(false);
-    expect(() => service.requestRefresh()).toThrow(SandboxNotConnectedError);
+    vi.mocked(messenger.sendToSandbox).mockRejectedValue(new Error("disconnected"));
+    await expect(service.requestRefresh()).rejects.toThrow(SandboxNotConnectedError);
   });
 });

--- a/packages/control-plane/src/session/diffs/service.test.ts
+++ b/packages/control-plane/src/session/diffs/service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../logger";
+import { SandboxDeliveryUnavailableError } from "../connections";
 import type { SessionMessenger } from "../messenger";
 import type { SessionCoreRepository } from "../session-core-repository";
 import type { SqlResult, SqlStorage } from "../sql-storage";
@@ -206,7 +207,10 @@ describe("SessionDiffService", () => {
     await service.requestRefresh();
     expect(messenger.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
 
-    vi.mocked(messenger.sendToSandbox).mockRejectedValue(new Error("disconnected"));
+    vi.mocked(messenger.sendToSandbox).mockRejectedValue(new SandboxDeliveryUnavailableError());
     await expect(service.requestRefresh()).rejects.toThrow(SandboxNotConnectedError);
+
+    vi.mocked(messenger.sendToSandbox).mockRejectedValue(new TypeError("adapter bug"));
+    await expect(service.requestRefresh()).rejects.toThrow(TypeError);
   });
 });

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -157,8 +157,10 @@ export class SessionDiffService {
   }
 
   /** Request a non-blocking refresh from the connected session sandbox. */
-  requestRefresh(): void {
-    if (!this.messenger.sendToSandbox({ type: "refresh_diff" })) {
+  async requestRefresh(): Promise<void> {
+    try {
+      await this.messenger.sendToSandbox({ type: "refresh_diff" });
+    } catch {
       throw new SandboxNotConnectedError();
     }
   }

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -10,6 +10,7 @@ import {
 import { generateId } from "../../auth/crypto";
 import type { Logger } from "../../logger";
 import type { SessionMessenger } from "../messenger";
+import { SandboxDeliveryUnavailableError } from "../connections";
 import type { SessionCoreRepository } from "../session-core-repository";
 import { repoIdentityEquals, type SessionRepositoryEntry } from "../repository-target";
 import {
@@ -160,8 +161,11 @@ export class SessionDiffService {
   async requestRefresh(): Promise<void> {
     try {
       await this.messenger.sendToSandbox({ type: "refresh_diff" });
-    } catch {
-      throw new SandboxNotConnectedError();
+    } catch (error) {
+      if (error instanceof SandboxDeliveryUnavailableError) {
+        throw new SandboxNotConnectedError();
+      }
+      throw error;
     }
   }
 

--- a/packages/control-plane/src/session/durable-object-session-connections.test.ts
+++ b/packages/control-plane/src/session/durable-object-session-connections.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { DurableObjectSessionConnections } from "./durable-object-session-connections";
+import type { SessionWebSocketManager } from "./websocket-manager";
+
+vi.stubGlobal(
+  "WebSocketRequestResponsePair",
+  class WebSocketRequestResponsePair {
+    constructor(
+      readonly request: string,
+      readonly response: string
+    ) {}
+  }
+);
+
+function harness() {
+  const browser = { readyState: WebSocket.OPEN } as WebSocket;
+  const sandbox = { readyState: WebSocket.OPEN } as WebSocket;
+  const clientInfo = {
+    participantId: "part-1",
+    userId: "user-1",
+    name: "Test User",
+    status: "active" as const,
+    lastSeen: 123,
+    clientId: "client-1",
+    ws: browser,
+  };
+  const manager = {
+    classify: vi.fn((ws: WebSocket) =>
+      ws === sandbox
+        ? ({ kind: "sandbox" as const, sandboxId: "sb-1" } as const)
+        : ({ kind: "client" as const, wsId: "ws-1" } as const)
+    ),
+    forEachClientSocket: vi.fn(
+      (_mode: "all_clients" | "authenticated_only", fn: (ws: WebSocket) => void) => fn(browser)
+    ),
+    setClient: vi.fn(),
+    persistClientMapping: vi.fn(),
+    getSandboxSocket: vi.fn(() => sandbox),
+    send: vi.fn(() => true),
+    detachSandboxSocket: vi.fn(),
+    getAuthenticatedClients: vi.fn(() => [clientInfo].values()),
+    recoverClientMapping: vi.fn(() => null),
+  } as unknown as SessionWebSocketManager;
+  const state = { setWebSocketAutoResponse: vi.fn() } as unknown as DurableObjectState;
+  return {
+    connections: new DurableObjectSessionConnections(state, manager),
+    manager,
+    state,
+    browser,
+    sandbox,
+  };
+}
+
+describe("DurableObjectSessionConnections", () => {
+  it("owns Cloudflare auto-response configuration", () => {
+    const { state } = harness();
+
+    expect(state.setWebSocketAutoResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers and broadcasts to a browser through the WebSocket registry", async () => {
+    const { connections, manager, browser } = harness();
+    const input = {
+      connectionId: "ws-1",
+      clientId: "client-1",
+      participant: {
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Test User",
+        status: "active" as const,
+        lastSeen: 123,
+      },
+    };
+
+    await connections.registerBrowser(input);
+    const message = { type: "sandbox_status", status: "ready" } as const;
+    await connections.broadcastToBrowsers(message);
+
+    expect(manager.setClient).toHaveBeenCalledWith(
+      browser,
+      expect.objectContaining(input.participant)
+    );
+    expect(manager.persistClientMapping).toHaveBeenCalledWith("ws-1", "part-1", "client-1");
+    expect(manager.send).toHaveBeenCalledWith(browser, message);
+  });
+
+  it("sends to and disconnects the active sandbox", async () => {
+    const { connections, manager, sandbox } = harness();
+
+    await connections.registerSandbox({ connectionId: "sandbox-1", sandboxId: "sb-1" });
+    await connections.sendToSandbox({ type: "snapshot" });
+    await connections.disconnectSandbox({ code: 1011, reason: "Unresponsive sandbox" });
+
+    expect(manager.send).toHaveBeenCalledWith(sandbox, { type: "snapshot" });
+    expect(manager.detachSandboxSocket).toHaveBeenCalledWith(1011, "Unresponsive sandbox");
+  });
+
+  it("rejects registration for a different sandbox identity", async () => {
+    const { connections } = harness();
+
+    await expect(
+      connections.registerSandbox({ connectionId: "sandbox-2", sandboxId: "sb-2" })
+    ).rejects.toThrow("does not match");
+  });
+
+  it("lists participants without exposing WebSocket details", async () => {
+    const { connections } = harness();
+
+    await expect(connections.listParticipants()).resolves.toEqual([
+      {
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Test User",
+        status: "active",
+        lastSeen: 123,
+      },
+    ]);
+  });
+});

--- a/packages/control-plane/src/session/durable-object-session-connections.ts
+++ b/packages/control-plane/src/session/durable-object-session-connections.ts
@@ -6,6 +6,7 @@ import type {
   SandboxConnection,
   SessionConnections,
 } from "./connections";
+import { projectConnectedParticipants, SandboxDeliveryUnavailableError } from "./connections";
 import type { SandboxCommand } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
@@ -69,10 +70,10 @@ export class DurableObjectSessionConnections implements SessionConnections {
 
   sendToSandbox(message: SandboxCommand): Promise<void> {
     const ws = this.wsManager.getSandboxSocket();
-    if (!ws) return Promise.reject(new Error("No sandbox connected"));
+    if (!ws) return Promise.reject(new SandboxDeliveryUnavailableError());
     return this.wsManager.send(ws, message)
       ? Promise.resolve()
-      : Promise.reject(new Error("Failed to send message to sandbox"));
+      : Promise.reject(new SandboxDeliveryUnavailableError("Failed to send message to sandbox"));
   }
 
   broadcastToBrowsers(message: ServerMessage): Promise<void> {
@@ -88,35 +89,6 @@ export class DurableObjectSessionConnections implements SessionConnections {
   }
 
   listParticipants(): Promise<ConnectedParticipant[]> {
-    const participants = new Map<string, ConnectedParticipant>();
-    for (const client of this.wsManager.getAuthenticatedClients()) {
-      const participant: ConnectedParticipant = {
-        participantId: client.participantId,
-        userId: client.userId,
-        name: client.name,
-        avatar: client.avatar,
-        status: client.status,
-        lastSeen: client.lastSeen,
-      };
-      const existing = participants.get(client.participantId);
-      const isActive = existing?.status === "active" || participant.status === "active";
-      if (!existing || participant.lastSeen > existing.lastSeen) {
-        participants.set(client.participantId, participant);
-      }
-      if (isActive) participants.get(client.participantId)!.status = "active";
-    }
-
-    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
-      const mapping = this.wsManager.recoverClientMapping(ws);
-      if (!mapping || participants.has(mapping.participant_id)) return;
-      participants.set(mapping.participant_id, {
-        participantId: mapping.participant_id,
-        userId: mapping.canonical_user_id ?? mapping.user_id,
-        name: mapping.scm_name ?? mapping.auth_name ?? mapping.scm_login ?? mapping.user_id,
-        status: "active",
-        lastSeen: Date.now(),
-      });
-    });
-    return Promise.resolve(Array.from(participants.values()));
+    return Promise.resolve(projectConnectedParticipants(this.wsManager.getAuthenticatedClients()));
   }
 }

--- a/packages/control-plane/src/session/durable-object-session-connections.ts
+++ b/packages/control-plane/src/session/durable-object-session-connections.ts
@@ -1,0 +1,122 @@
+import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+import type {
+  BrowserConnection,
+  ConnectedParticipant,
+  DisconnectReason,
+  SandboxConnection,
+  SessionConnections,
+} from "./connections";
+import type { SandboxCommand } from "./types";
+import type { SessionWebSocketManager } from "./websocket-manager";
+
+/** Cloudflare Durable Object implementation of the session connection port. */
+export class DurableObjectSessionConnections implements SessionConnections {
+  constructor(
+    private readonly ctx: DurableObjectState,
+    private readonly wsManager: SessionWebSocketManager
+  ) {
+    this.ctx.setWebSocketAutoResponse(
+      new WebSocketRequestResponsePair(
+        JSON.stringify({ type: "ping" }),
+        JSON.stringify({ type: "pong", timestamp: Date.now() })
+      )
+    );
+  }
+
+  createUpgradeSockets(): { client: WebSocket; server: WebSocket } {
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    return { client, server };
+  }
+
+  registerBrowser(input: BrowserConnection): Promise<void> {
+    let matchedSocket: WebSocket | null = null;
+    this.wsManager.forEachClientSocket("all_clients", (ws) => {
+      const connection = this.wsManager.classify(ws);
+      if (connection.kind === "client" && connection.wsId === input.connectionId) {
+        matchedSocket = ws;
+      }
+    });
+    if (!matchedSocket) {
+      return Promise.reject(new Error(`Browser connection ${input.connectionId} not found`));
+    }
+
+    this.wsManager.setClient(matchedSocket, {
+      ...input.participant,
+      clientId: input.clientId,
+      ws: matchedSocket,
+    });
+    this.wsManager.persistClientMapping(
+      input.connectionId,
+      input.participant.participantId,
+      input.clientId
+    );
+    return Promise.resolve();
+  }
+
+  registerSandbox(input: SandboxConnection): Promise<void> {
+    const ws = this.wsManager.getSandboxSocket();
+    if (!ws) return Promise.reject(new Error(`Sandbox connection ${input.connectionId} not found`));
+    const connection = this.wsManager.classify(ws);
+    if (
+      connection.kind !== "sandbox" ||
+      (input.sandboxId !== undefined && connection.sandboxId !== input.sandboxId)
+    ) {
+      return Promise.reject(new Error(`Sandbox connection ${input.connectionId} does not match`));
+    }
+    return Promise.resolve();
+  }
+
+  sendToSandbox(message: SandboxCommand): Promise<void> {
+    const ws = this.wsManager.getSandboxSocket();
+    if (!ws) return Promise.reject(new Error("No sandbox connected"));
+    return this.wsManager.send(ws, message)
+      ? Promise.resolve()
+      : Promise.reject(new Error("Failed to send message to sandbox"));
+  }
+
+  broadcastToBrowsers(message: ServerMessage): Promise<void> {
+    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
+      this.wsManager.send(ws, message);
+    });
+    return Promise.resolve();
+  }
+
+  disconnectSandbox(reason: DisconnectReason): Promise<void> {
+    this.wsManager.detachSandboxSocket(reason.code, reason.reason);
+    return Promise.resolve();
+  }
+
+  listParticipants(): Promise<ConnectedParticipant[]> {
+    const participants = new Map<string, ConnectedParticipant>();
+    for (const client of this.wsManager.getAuthenticatedClients()) {
+      const participant: ConnectedParticipant = {
+        participantId: client.participantId,
+        userId: client.userId,
+        name: client.name,
+        avatar: client.avatar,
+        status: client.status,
+        lastSeen: client.lastSeen,
+      };
+      const existing = participants.get(client.participantId);
+      const isActive = existing?.status === "active" || participant.status === "active";
+      if (!existing || participant.lastSeen > existing.lastSeen) {
+        participants.set(client.participantId, participant);
+      }
+      if (isActive) participants.get(client.participantId)!.status = "active";
+    }
+
+    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
+      const mapping = this.wsManager.recoverClientMapping(ws);
+      if (!mapping || participants.has(mapping.participant_id)) return;
+      participants.set(mapping.participant_id, {
+        participantId: mapping.participant_id,
+        userId: mapping.canonical_user_id ?? mapping.user_id,
+        name: mapping.scm_name ?? mapping.auth_name ?? mapping.scm_login ?? mapping.user_id,
+        status: "active",
+        lastSeen: Date.now(),
+      });
+    });
+    return Promise.resolve(Array.from(participants.values()));
+  }
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -72,6 +72,7 @@ import { resolveParticipantName } from "./participant-name";
 import { validateReasoningEffort } from "./reasoning-effort";
 import { parseTunnelUrls } from "./tunnel-urls";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
+import { DurableObjectSessionConnections } from "./durable-object-session-connections";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
 import { refreshSessionPullRequests } from "./pull-request-refresh";
@@ -185,6 +186,7 @@ export class SessionDO extends DurableObject<Env> {
   private log: Logger;
   // WebSocket manager (lazily initialized like lifecycleManager)
   private _wsManager: SessionWebSocketManager | null = null;
+  private _connections: DurableObjectSessionConnections | null = null;
   // Session messenger (constructed in ensureInitialized once the session logger exists)
   private messenger!: SessionMessenger;
   // Session diff service (constructed in ensureInitialized once the session logger exists)
@@ -411,6 +413,13 @@ export class SessionDO extends DurableObject<Env> {
       );
     }
     return this._wsManager;
+  }
+
+  private get connections(): DurableObjectSessionConnections {
+    if (!this._connections) {
+      this._connections = new DurableObjectSessionConnections(this.ctx, this.wsManager);
+    }
+    return this._connections;
   }
 
   private get executionTimeoutMs(): number {
@@ -993,7 +1002,7 @@ export class SessionDO extends DurableObject<Env> {
     // Constructed here rather than in the constructor so they (and the
     // WebSocket manager they force) capture the session-scoped logger,
     // never the request-scoped child installed by fetch().
-    this.messenger = new SessionMessengerImpl(this.wsManager);
+    this.messenger = new SessionMessengerImpl(this.connections);
     this.diffService = new SessionDiffService(
       new SessionDiffStore(this.sql),
       this.sessionCoreRepository,
@@ -1001,7 +1010,6 @@ export class SessionDO extends DurableObject<Env> {
       this.log
     );
     this.diffsHandler = new SessionDiffsHandler(this.diffService);
-    this.wsManager.enableAutoPingPong();
   }
 
   /**
@@ -1138,8 +1146,7 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     try {
-      const pair = new WebSocketPair();
-      const [client, server] = Object.values(pair);
+      const { client, server } = this.connections.createUpgradeSockets();
 
       const sandboxId = request.headers.get("X-Sandbox-ID");
 
@@ -1151,7 +1158,6 @@ export class SessionDO extends DurableObject<Env> {
           server,
           sandboxId ?? undefined
         );
-
         // Notify manager that sandbox connected so it can reset the spawning flag
         this.lifecycleManager.onSandboxConnected();
         this.updateSandboxStatus("ready");
@@ -1280,7 +1286,7 @@ export class SessionDO extends DurableObject<Env> {
   async webSocketError(ws: WebSocket, error: Error): Promise<void> {
     this.ensureInitialized();
     this.log.error("WebSocket error", { error });
-    ws.close(1011, "Internal error");
+    this.wsManager.close(ws, 1011, "Internal error");
   }
 
   /**
@@ -1469,7 +1475,7 @@ export class SessionDO extends DurableObject<Env> {
         outcome: "auth_failed",
         reject_reason: "no_token",
       });
-      ws.close(4001, "Authentication required");
+      this.wsManager.close(ws, 4001, "Authentication required");
       return;
     }
 
@@ -1491,7 +1497,7 @@ export class SessionDO extends DurableObject<Env> {
           outcome: "auth_failed",
           reject_reason: "invalid_token",
         });
-        ws.close(4001, "Invalid authentication token");
+        this.wsManager.close(ws, 4001, "Invalid authentication token");
         return;
       }
 
@@ -1508,7 +1514,7 @@ export class SessionDO extends DurableObject<Env> {
           participant_id: participant.id,
           user_id: participant.user_id,
         });
-        ws.close(4001, "Token expired");
+        this.wsManager.close(ws, 4001, "Token expired");
         return;
       }
 

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -162,7 +162,7 @@ function createHandler() {
     artifact.metadata ? (JSON.parse(artifact.metadata) as Record<string, unknown>) : null
   );
   const broadcast = vi.fn();
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const enqueuePrompt = vi.fn(async () => ({
     messageId: "message-follow-up",
     status: "queued" as const,

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -92,7 +92,7 @@ function createHandler() {
   const getArtifactById = vi.fn<(artifactId: string) => ArtifactRow | null>(() => null);
   const updateArtifact = vi.fn();
   const broadcast = vi.fn();
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const now = vi.fn(() => 5000);
   const triggerPullRequestRefresh = vi.fn();
   const log = {

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -29,7 +29,7 @@ function createHandler() {
   const isManagedSecretsConfigured = vi.fn();
   const getScmCredentials = vi.fn();
   const broadcast = vi.fn();
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const generateId = vi.fn(() => "participant-1");
   const now = vi.fn(() => 1234);
 

--- a/packages/control-plane/src/session/http/handlers/session-diffs.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-diffs.handler.test.ts
@@ -142,25 +142,25 @@ describe("SessionDiffsHandler", () => {
 
   it("accepts retry and reports a disconnected sandbox as a conflict", async () => {
     const { handler } = harness();
-    expect(handler.retry().status).toBe(202);
+    expect((await handler.retry()).status).toBe(202);
 
     const disconnected = harness({
-      requestRefresh: vi.fn(() => {
+      requestRefresh: vi.fn(async () => {
         throw new SandboxNotConnectedError();
       }),
     });
-    const response = disconnected.handler.retry();
+    const response = await disconnected.handler.retry();
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({ error: "Sandbox is not connected" });
   });
 
-  it("rethrows errors that are not session diff errors", () => {
+  it("rethrows errors that are not session diff errors", async () => {
     const { handler } = harness({
-      requestRefresh: vi.fn(() => {
+      requestRefresh: vi.fn(async () => {
         throw new TypeError("unexpected");
       }),
     });
 
-    expect(() => handler.retry()).toThrow(TypeError);
+    await expect(handler.retry()).rejects.toThrow(TypeError);
   });
 });

--- a/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
@@ -68,9 +68,9 @@ export class SessionDiffsHandler {
   }
 
   /** Request a non-blocking diff refresh from the session sandbox. */
-  retry(): Response {
+  async retry(): Promise<Response> {
     try {
-      this.diffService.requestRefresh();
+      await this.diffService.requestRefresh();
       return Response.json({ accepted: true }, { status: 202 });
     } catch (e) {
       return this.errorResponse(e);

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -182,7 +182,7 @@ function buildQueue() {
   };
 
   const broadcast = vi.fn((_message: ServerMessage) => {});
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const sessionStatus = {
     transition: vi.fn(async (_status: string) => true),
     reconcileAfterExecution: vi.fn(async (_success: boolean) => {}),

--- a/packages/control-plane/src/session/messenger.test.ts
+++ b/packages/control-plane/src/session/messenger.test.ts
@@ -1,61 +1,53 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionMessengerImpl } from "./messenger";
-import type { SessionWebSocketManager } from "./websocket-manager";
+import type { SessionConnections } from "./connections";
 
-function harness(sandboxSocket: WebSocket | null = null) {
-  const clientSockets = [{} as WebSocket, {} as WebSocket];
-  const send = vi.fn(() => true);
-  const wsManager = {
-    forEachClientSocket: vi.fn(
-      (_mode: "all_clients" | "authenticated_only", fn: (ws: WebSocket) => void) => {
-        for (const ws of clientSockets) fn(ws);
-      }
-    ),
-    getSandboxSocket: vi.fn(() => sandboxSocket),
-    send,
-  } as unknown as SessionWebSocketManager;
-  return { messenger: new SessionMessengerImpl(wsManager), wsManager, clientSockets, send };
+function harness() {
+  const connections = {
+    registerBrowser: vi.fn(async () => {}),
+    registerSandbox: vi.fn(async () => {}),
+    sendToSandbox: vi.fn(async () => {}),
+    broadcastToBrowsers: vi.fn(async () => {}),
+    disconnectSandbox: vi.fn(async () => {}),
+    listParticipants: vi.fn(async () => []),
+  } satisfies SessionConnections;
+  return { messenger: new SessionMessengerImpl(connections), connections };
 }
 
 describe("SessionMessengerImpl", () => {
   it("broadcasts to every authenticated client socket", () => {
-    const { messenger, wsManager, clientSockets, send } = harness();
+    const { messenger, connections } = harness();
     const message = { type: "diff_state_changed", revisionId: "r1", updatedAt: 1 } as const;
 
     messenger.broadcast(message);
 
-    expect(wsManager.forEachClientSocket).toHaveBeenCalledWith(
-      "authenticated_only",
-      expect.any(Function)
-    );
-    expect(send).toHaveBeenCalledTimes(clientSockets.length);
-    for (const ws of clientSockets) expect(send).toHaveBeenCalledWith(ws, message);
+    expect(connections.broadcastToBrowsers).toHaveBeenCalledWith(message);
   });
 
-  it("sends a command to the connected sandbox socket", () => {
-    const sandboxSocket = {} as WebSocket;
-    const { messenger, send } = harness(sandboxSocket);
+  it("sends a command to the connected sandbox socket", async () => {
+    const { messenger, connections } = harness();
 
-    expect(messenger.sendToSandbox({ type: "refresh_diff" })).toBe(true);
-    expect(send).toHaveBeenCalledWith(sandboxSocket, { type: "refresh_diff" });
+    await messenger.sendToSandbox({ type: "refresh_diff" });
+    expect(connections.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
   });
 
   it("emits prompt queue updates to every authenticated client", () => {
-    const { messenger, clientSockets, send } = harness();
+    const { messenger, connections } = harness();
     const message = { type: "prompt_queue_updated", promptQueue: [] } satisfies Parameters<
       typeof messenger.broadcast
     >[0];
 
     messenger.broadcast(message);
 
-    expect(send).toHaveBeenCalledTimes(clientSockets.length);
-    for (const ws of clientSockets) expect(send).toHaveBeenCalledWith(ws, message);
+    expect(connections.broadcastToBrowsers).toHaveBeenCalledWith(message);
   });
 
-  it("reports failure when no sandbox is connected", () => {
-    const { messenger, send } = harness(null);
+  it("reports failure when no sandbox is connected", async () => {
+    const { messenger, connections } = harness();
+    connections.sendToSandbox.mockRejectedValue(new Error("No sandbox connected"));
 
-    expect(messenger.sendToSandbox({ type: "refresh_diff" })).toBe(false);
-    expect(send).not.toHaveBeenCalled();
+    await expect(messenger.sendToSandbox({ type: "refresh_diff" })).rejects.toThrow(
+      "No sandbox connected"
+    );
   });
 });

--- a/packages/control-plane/src/session/messenger.ts
+++ b/packages/control-plane/src/session/messenger.ts
@@ -1,35 +1,30 @@
 /**
  * SessionMessenger — higher-level session messaging on top of the
- * WebSocket registry: fan-out to authenticated clients and command
- * delivery to the sandbox socket.
+ * platform-neutral session connection port.
  */
 
 import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 import type { SandboxCommand } from "./types";
-import type { SessionWebSocketManager } from "./websocket-manager";
+import type { SessionConnections } from "./connections";
 
 export interface SessionMessenger {
   /** Broadcast a message to all authenticated client sockets. */
   broadcast(message: ServerMessage): void;
 
-  /**
-   * Send a command to the active sandbox socket. Returns false when no
-   * sandbox is connected or the send fails.
-   */
-  sendToSandbox(command: SandboxCommand): boolean;
+  /** Send a command to the active sandbox; rejects when delivery is unavailable. */
+  sendToSandbox(command: SandboxCommand): Promise<void>;
 }
 
 export class SessionMessengerImpl implements SessionMessenger {
-  constructor(private readonly wsManager: SessionWebSocketManager) {}
+  constructor(private readonly connections: SessionConnections) {}
 
   broadcast(message: ServerMessage): void {
-    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
-      this.wsManager.send(ws, message);
+    void this.connections.broadcastToBrowsers(message).catch(() => {
+      // Broadcast delivery is best effort; connection adapters handle per-client failures.
     });
   }
 
-  sendToSandbox(command: SandboxCommand): boolean {
-    const sandboxSocket = this.wsManager.getSandboxSocket();
-    return sandboxSocket ? this.wsManager.send(sandboxSocket, command) : false;
+  sendToSandbox(command: SandboxCommand): Promise<void> {
+    return this.connections.sendToSandbox(command);
   }
 }

--- a/packages/control-plane/src/session/presence-service.test.ts
+++ b/packages/control-plane/src/session/presence-service.test.ts
@@ -35,7 +35,7 @@ function createTestHarness() {
 
   const deps: PresenceServiceDeps = {
     getAuthenticatedClients: vi.fn(() => clients.values()),
-    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
+    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(async () => {}) },
     send: vi.fn(() => true),
     getSandboxSocket: vi.fn(() => null),
     isSpawning: vi.fn(() => false),

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -14,6 +14,7 @@ import type {
   ServerMessage,
 } from "@open-inspect/shared/types/server-messages";
 import type { ClientInfo } from "../types";
+import { projectConnectedParticipants } from "./connections";
 import type { SessionMessenger } from "./messenger";
 
 /**
@@ -45,24 +46,7 @@ export class PresenceService {
    * participant active, and we take the most recent lastSeen across sockets.
    */
   getPresenceList(): ParticipantPresence[] {
-    const byId = new Map<string, ParticipantPresence>();
-    for (const c of this.deps.getAuthenticatedClients()) {
-      const existing = byId.get(c.participantId);
-      if (!existing) {
-        byId.set(c.participantId, {
-          participantId: c.participantId,
-          userId: c.userId,
-          name: c.name,
-          avatar: c.avatar,
-          status: c.status,
-          lastSeen: c.lastSeen,
-        });
-        continue;
-      }
-      if (c.status === "active") existing.status = "active";
-      if (c.lastSeen > existing.lastSeen) existing.lastSeen = c.lastSeen;
-    }
-    return Array.from(byId.values());
+    return projectConnectedParticipants(this.deps.getAuthenticatedClients());
   }
 
   /**

--- a/packages/control-plane/src/session/pull-request-service.per-branch.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.per-branch.test.ts
@@ -216,7 +216,7 @@ function createTestHarness() {
     log,
     generateId: () => `id-${++idCounter}`,
     pushBranchToRemote: vi.fn(async () => ({ success: true as const })),
-    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
+    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(async () => {}) },
     appName: "Open-Inspect",
     sessionPullRequests,
     resolveScmSettings: vi.fn(async () => ({})),

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -203,7 +203,7 @@ function createTestHarness(options: { scmSettings?: ScmSettings } = {}) {
     log,
     generateId: () => `id-${++idCounter}`,
     pushBranchToRemote: vi.fn(async () => ({ success: true as const })),
-    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
+    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(async () => {}) },
     appName: "Open-Inspect",
     sessionPullRequests,
     resolveScmSettings: vi.fn(async () => options.scmSettings ?? {}),

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -64,7 +64,7 @@ function createProcessor() {
   };
 
   const broadcast = vi.fn((_message: ServerMessage) => {});
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const diffService = { pinBaselines: vi.fn() };
   const triggerSnapshot = vi.fn(async (_reason: string) => {});
   const projectTerminalMessage = vi.fn(async () => {});

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -57,7 +57,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
   } as unknown as ArtifactRepository;
 
   const broadcast = vi.fn();
-  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) } as SessionMessenger;
+  const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) } as SessionMessenger;
 
   const sessionIndex =
     options.sessionIndex === null

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -86,7 +86,6 @@ export interface SessionWebSocketManager {
   ): void;
 
   enforceAuthTimeout(ws: WebSocket, wsId: string): Promise<void>;
-  enableAutoPingPong(): void;
   getAuthenticatedClients(): IterableIterator<ClientInfo>;
   getConnectedClientCount(): number;
 }
@@ -358,15 +357,6 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
       timeout_ms: this.config.authTimeoutMs,
     });
     this.close(ws, 4008, "Authentication timeout");
-  }
-
-  enableAutoPingPong(): void {
-    this.ctx.setWebSocketAutoResponse(
-      new WebSocketRequestResponsePair(
-        JSON.stringify({ type: "ping" }),
-        JSON.stringify({ type: "pong", timestamp: Date.now() })
-      )
-    );
   }
 
   getAuthenticatedClients(): IterableIterator<ClientInfo> {


### PR DESCRIPTION
## Summary
- introduce the platform-neutral `SessionConnections` contract and an in-memory implementation for engine tests
- add `DurableObjectSessionConnections` to isolate WebSocket pair creation, auto-response configuration, browser fan-out, sandbox delivery, disconnects, and participant projection
- make `SessionMessenger` depend on the connection port instead of the Cloudflare WebSocket registry
- preserve synchronous browser registration during snapshot handoff and failed-sandbox self-healing reconnect behavior
- convert diff refresh delivery to the asynchronous sandbox-delivery contract

## Maintainability Review
- ran a thermonuclear maintainability review and iterated on its findings
- separated the Durable Object adapter from `SessionWebSocketManager` rather than combining two overlapping public contracts
- removed a failed-sandbox reconnect regression introduced by the initial extraction
- restored atomic browser identity registration and added sandbox identity validation

## Verification
- `npm test -w @open-inspect/control-plane` (173 files, 2606 tests)
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-client.test.ts test/integration/websocket-sandbox.test.ts test/integration/session-snapshot.test.ts` (51 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/236ca3d640903719fd36323d44618873)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified session connection handling for browser and sandbox communications.
  - Improved participant tracking, including connection status and latest activity.
  - Added reliable browser message broadcasting and sandbox disconnect reporting.

- **Bug Fixes**
  - Sandbox messages and refresh requests now complete asynchronously with clearer failure handling.
  - Improved connection validation and handling when a sandbox is unavailable.
  - Enhanced session behavior across persistent and in-memory connection environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->