### PR TITLE
feat: define asynchronous session store

### DIFF
--- a/packages/control-plane/src/session/session-store.test.ts
+++ b/packages/control-plane/src/session/session-store.test.ts
@@ -20,11 +20,12 @@ import type {
 
 it("does not expose persistence providers or transaction primitives", () => {
   const source = readFileSync(new URL("./session-store.ts", import.meta.url), "utf8");
+  const specifiers = [...source.matchAll(/from\s+"([^"]+)"/g)].map((match) => match[1]);
 
-  expect(source).not.toMatch(
-    /SqlStorage|D1Database|Hyperdrive|PostgreSQL|DurableObjectState|transactionSync/
-  );
-  expect(source).not.toMatch(/cloudflare:|@cloudflare|\.\/sql-storage/);
+  expect(specifiers).not.toHaveLength(0);
+  for (const specifier of specifiers) {
+    expect(specifier).toMatch(/^@open-inspect\/shared\/types\//);
+  }
 });
 
 it("defines the provider-neutral asynchronous session store contract", () => {
@@ -61,10 +62,12 @@ it("represents current atomic operations without storage primitives", () => {
     operation: "append",
     id: "event-1",
     event: {
-      type: "context_compacted",
+      type: "tool_result",
       sandboxId: "sandbox-1",
       messageId: "prompt-1",
       timestamp: 1,
+      callId: "call-1",
+      result: "done",
     },
     createdAt: 1_000,
   } satisfies AppendEvent;
@@ -103,7 +106,7 @@ it("represents current atomic operations without storage primitives", () => {
       requestFingerprint: "fingerprint-1",
       createdAt: 1_000,
     },
-    attachmentIds: ["attachment-1"],
+    attachments: [{ attachmentId: "attachment-1", name: "screenshot.png", mimeType: "image/png" }],
     maxUnfinishedPrompts: 10,
   } satisfies CreatePromptInput;
   const start = {
@@ -120,18 +123,21 @@ it("represents current atomic operations without storage primitives", () => {
   const complete = {
     type: "complete",
     expectedStatus: "processing",
-    completedAt: 3_000,
     event: {
-      type: "execution_complete",
-      sandboxId: "sandbox-1",
-      messageId: "prompt-1",
-      timestamp: 3,
-      success: true,
+      operation: "upsert",
+      createdAt: 3_000,
+      event: {
+        type: "execution_complete",
+        sandboxId: "sandbox-1",
+        messageId: "prompt-1",
+        timestamp: 3,
+        success: true,
+      },
     },
   } satisfies PromptUpdate;
   const accessUpdate = {
-    type: "update-access",
-    codeServer: { url: null },
+    type: "set-code-server-access",
+    url: null,
   } satisfies SandboxUpdate;
   const circuitBreakerUpdate = {
     type: "record-spawn-failure",
@@ -142,13 +148,9 @@ it("represents current atomic operations without storage primitives", () => {
     filter: { type: "for-prompt", promptId: "prompt-1" },
   } satisfies HistoryQuery;
 
-  expectTypeOf([append, upsert, compact]).toMatchTypeOf<PendingEvent[]>();
-  expectTypeOf(create).toMatchTypeOf<CreatePromptInput>();
-  expectTypeOf(start).toMatchTypeOf<PromptUpdate>();
-  expectTypeOf(complete).toMatchTypeOf<PromptUpdate>();
-  expectTypeOf(accessUpdate).toMatchTypeOf<SandboxUpdate>();
-  expectTypeOf(circuitBreakerUpdate).toMatchTypeOf<SandboxUpdate>();
-  expectTypeOf(history).toMatchTypeOf<HistoryQuery>();
+  const writes = [append, upsert, compact] satisfies PendingEvent[];
+  expect(writes).toHaveLength(3);
+  expect([create, start, complete, accessUpdate, circuitBreakerUpdate, history]).toHaveLength(6);
 });
 
 it("preserves nullable legacy repository state", () => {
@@ -159,6 +161,21 @@ it("preserves nullable legacy repository state", () => {
 
 it("models create outcomes explicitly", () => {
   expectTypeOf<CreatePromptResult["outcome"]>().toEqualTypeOf<
-    "created" | "duplicate" | "request-conflict" | "queue-full" | "session-not-promptable"
+    | "created"
+    | "duplicate"
+    | "request-conflict"
+    | "attachment-conflict"
+    | "queue-full"
+    | "session-not-promptable"
   >();
+});
+
+it("prevents lifecycle events from bypassing their atomic operations", () => {
+  expectTypeOf<
+    Extract<AppendEvent["event"], { type: "context_compacted" }>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<
+    Extract<AppendEvent["event"], { type: "execution_complete" }>
+  >().toEqualTypeOf<never>();
+  expectTypeOf<Extract<AppendEvent["event"], { type: "user_message" }>>().toEqualTypeOf<never>();
 });

--- a/packages/control-plane/src/session/session-store.test.ts
+++ b/packages/control-plane/src/session/session-store.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import { expect, expectTypeOf, it } from "vitest";
+import type {
+  AppendEvent,
+  CompactEvent,
+  CreatePromptInput,
+  CreatePromptResult,
+  HistoryQuery,
+  PendingEvent,
+  PersistedEvent,
+  PromptClaim,
+  PromptUpdate,
+  SandboxRecord,
+  SandboxUpdate,
+  SessionHistory,
+  SessionRecord,
+  SessionStore,
+  UpsertEvent,
+} from "./session-store";
+
+it("does not expose persistence providers or transaction primitives", () => {
+  const source = readFileSync(new URL("./session-store.ts", import.meta.url), "utf8");
+
+  expect(source).not.toMatch(
+    /SqlStorage|D1Database|Hyperdrive|PostgreSQL|DurableObjectState|transactionSync/
+  );
+  expect(source).not.toMatch(/cloudflare:|@cloudflare|\.\/sql-storage/);
+});
+
+it("defines the provider-neutral asynchronous session store contract", () => {
+  type ExpectedMethods =
+    | "getSession"
+    | "appendEvents"
+    | "createPrompt"
+    | "claimNextPrompt"
+    | "updatePrompt"
+    | "getSandbox"
+    | "updateSandbox"
+    | "getHistory";
+
+  expectTypeOf<keyof SessionStore>().toEqualTypeOf<ExpectedMethods>();
+  expectTypeOf<SessionStore["getSession"]>().returns.toEqualTypeOf<Promise<SessionRecord>>();
+  expectTypeOf<SessionStore["appendEvents"]>().parameter(0).toEqualTypeOf<PendingEvent[]>();
+  expectTypeOf<SessionStore["appendEvents"]>().returns.toEqualTypeOf<Promise<PersistedEvent[]>>();
+  expectTypeOf<SessionStore["createPrompt"]>().parameter(0).toEqualTypeOf<CreatePromptInput>();
+  expectTypeOf<SessionStore["createPrompt"]>().returns.toEqualTypeOf<Promise<CreatePromptResult>>();
+  expectTypeOf<SessionStore["claimNextPrompt"]>().returns.toEqualTypeOf<
+    Promise<PromptClaim | null>
+  >();
+  expectTypeOf<SessionStore["updatePrompt"]>().parameter(0).toEqualTypeOf<PromptUpdate>();
+  expectTypeOf<SessionStore["updatePrompt"]>().returns.toEqualTypeOf<Promise<void>>();
+  expectTypeOf<SessionStore["getSandbox"]>().returns.toEqualTypeOf<Promise<SandboxRecord | null>>();
+  expectTypeOf<SessionStore["updateSandbox"]>().parameter(0).toEqualTypeOf<SandboxUpdate>();
+  expectTypeOf<SessionStore["updateSandbox"]>().returns.toEqualTypeOf<Promise<void>>();
+  expectTypeOf<SessionStore["getHistory"]>().parameter(0).toEqualTypeOf<HistoryQuery>();
+  expectTypeOf<SessionStore["getHistory"]>().returns.toEqualTypeOf<Promise<SessionHistory>>();
+});
+
+it("represents current atomic operations without storage primitives", () => {
+  const append = {
+    operation: "append",
+    id: "event-1",
+    event: {
+      type: "context_compacted",
+      sandboxId: "sandbox-1",
+      messageId: "prompt-1",
+      timestamp: 1,
+    },
+    createdAt: 1_000,
+  } satisfies AppendEvent;
+  const upsert = {
+    operation: "upsert",
+    event: {
+      type: "token",
+      sandboxId: "sandbox-1",
+      messageId: "prompt-1",
+      timestamp: 2,
+      content: "hello",
+    },
+    createdAt: 2_000,
+  } satisfies UpsertEvent;
+  const compact = {
+    operation: "compact",
+    id: "compaction-1",
+    event: {
+      type: "context_compacted",
+      sandboxId: "sandbox-1",
+      messageId: "prompt-1",
+      timestamp: 3,
+    },
+    createdAt: 3_000,
+  } satisfies CompactEvent;
+  const create = {
+    prompt: {
+      id: "prompt-1",
+      authorId: "participant-1",
+      content: "Fix it",
+      source: "web",
+      model: null,
+      reasoningEffort: null,
+      callbackContext: null,
+      clientRequestId: "request-1",
+      requestFingerprint: "fingerprint-1",
+      createdAt: 1_000,
+    },
+    attachmentIds: ["attachment-1"],
+    maxUnfinishedPrompts: 10,
+  } satisfies CreatePromptInput;
+  const start = {
+    type: "start",
+    claimId: "claim-1",
+    startedAt: 2_000,
+    event: {
+      operation: "append",
+      id: "user_message:prompt-1",
+      event: { type: "user_message", content: "Fix it", messageId: "prompt-1", timestamp: 2 },
+      createdAt: 2_000,
+    },
+  } satisfies PromptUpdate;
+  const complete = {
+    type: "complete",
+    expectedStatus: "processing",
+    completedAt: 3_000,
+    event: {
+      type: "execution_complete",
+      sandboxId: "sandbox-1",
+      messageId: "prompt-1",
+      timestamp: 3,
+      success: true,
+    },
+  } satisfies PromptUpdate;
+  const accessUpdate = {
+    type: "update-access",
+    codeServer: { url: null },
+  } satisfies SandboxUpdate;
+  const circuitBreakerUpdate = {
+    type: "record-spawn-failure",
+    failedAt: 4_000,
+  } satisfies SandboxUpdate;
+  const history = {
+    limit: 100,
+    filter: { type: "for-prompt", promptId: "prompt-1" },
+  } satisfies HistoryQuery;
+
+  expectTypeOf([append, upsert, compact]).toMatchTypeOf<PendingEvent[]>();
+  expectTypeOf(create).toMatchTypeOf<CreatePromptInput>();
+  expectTypeOf(start).toMatchTypeOf<PromptUpdate>();
+  expectTypeOf(complete).toMatchTypeOf<PromptUpdate>();
+  expectTypeOf(accessUpdate).toMatchTypeOf<SandboxUpdate>();
+  expectTypeOf(circuitBreakerUpdate).toMatchTypeOf<SandboxUpdate>();
+  expectTypeOf(history).toMatchTypeOf<HistoryQuery>();
+});
+
+it("preserves nullable legacy repository state", () => {
+  expectTypeOf<SessionRecord["repositories"][number]["baseBranch"]>().toEqualTypeOf<
+    string | null
+  >();
+});
+
+it("models create outcomes explicitly", () => {
+  expectTypeOf<CreatePromptResult["outcome"]>().toEqualTypeOf<
+    "created" | "duplicate" | "request-conflict" | "queue-full" | "session-not-promptable"
+  >();
+});

--- a/packages/control-plane/src/session/session-store.ts
+++ b/packages/control-plane/src/session/session-store.ts
@@ -1,0 +1,278 @@
+import type { ResolvedSessionAttachment } from "@open-inspect/shared/types/session-attachments";
+import type { CallbackContext } from "@open-inspect/shared/types/session-api";
+import type { GitSyncStatus, SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
+import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
+import type {
+  MessageSource,
+  MessageStatus,
+  SandboxStatus,
+  SessionStatus,
+  SpawnSource,
+} from "@open-inspect/shared/types/sessions";
+
+type UserMessageEvent = Extract<SandboxEvent, { type: "user_message" }>;
+type MutableTimelineEvent = Extract<
+  SandboxEvent,
+  { type: "token" | "tool_call" | "execution_complete" }
+>;
+type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
+type ContextCompactedEvent = Extract<SandboxEvent, { type: "context_compacted" }>;
+
+export interface SessionStoreRepository {
+  position: number;
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string | null;
+  branchName: string | null;
+  baseSha: string | null;
+  currentSha: string | null;
+}
+
+/** Provider-neutral state for one session aggregate. */
+export interface SessionRecord {
+  id: string;
+  sessionName: string | null;
+  title: string | null;
+  repositories: SessionStoreRepository[];
+  model: string;
+  reasoningEffort: string | null;
+  status: SessionStatus;
+  parentSessionId: string | null;
+  spawnSource: SpawnSource;
+  spawnDepth: number;
+  codeServerEnabled: boolean;
+  vncEnabled: boolean;
+  totalCost: number;
+  sandboxSettings: SandboxSettings | null;
+  environmentId: string | null;
+  agentSessionId: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface EventWriteBase<TEvent extends SandboxEvent> {
+  event: TEvent;
+  createdAt: number;
+}
+
+/** Adds an immutable event at the end of the timeline. */
+export interface AppendEvent<
+  TEvent extends SandboxEvent = SandboxEvent,
+> extends EventWriteBase<TEvent> {
+  operation: "append";
+  id: string;
+}
+
+/**
+ * Replaces the mutable event identified by its canonical event identity.
+ * Existing timeline sequence is retained. Token and completion writes update
+ * createdAt; tool-call writes retain the original createdAt.
+ */
+export interface UpsertEvent extends EventWriteBase<MutableTimelineEvent> {
+  operation: "upsert";
+}
+
+/**
+ * Seals the prompt's current token event and appends a compaction marker atomically.
+ * The current and sealed token identities are derived from event.messageId and id.
+ */
+export interface CompactEvent extends EventWriteBase<ContextCompactedEvent> {
+  operation: "compact";
+  id: string;
+}
+
+export type PendingEvent = AppendEvent | UpsertEvent | CompactEvent;
+
+/** Stored timeline state; write instructions deliberately do not cross this boundary. */
+export interface PersistedEvent {
+  id: string;
+  event: SandboxEvent;
+  promptId: string | null;
+  createdAt: number;
+  sequence: number;
+}
+
+export interface PromptRecord {
+  id: string;
+  authorId: string;
+  content: string;
+  source: MessageSource;
+  model: string | null;
+  reasoningEffort: string | null;
+  attachments: ResolvedSessionAttachment[] | null;
+  callbackContext: CallbackContext | null;
+  clientRequestId: string | null;
+  requestFingerprint: string | null;
+  status: MessageStatus;
+  errorMessage: string | null;
+  stopConfirmationDeadline: number | null;
+  createdAt: number;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+/** Atomically validates queue admission, claims attachments, and creates a prompt. */
+export interface CreatePromptInput {
+  prompt: Omit<
+    PromptRecord,
+    | "attachments"
+    | "status"
+    | "errorMessage"
+    | "stopConfirmationDeadline"
+    | "startedAt"
+    | "completedAt"
+  >;
+  attachmentIds: string[];
+  maxUnfinishedPrompts: number;
+  event?: AppendEvent;
+}
+
+export type CreatePromptResult =
+  | { outcome: "created"; prompt: PromptRecord; position: number }
+  | { outcome: "duplicate"; prompt: PromptRecord; position: number | null }
+  | { outcome: "request-conflict" }
+  | { outcome: "queue-full" }
+  | { outcome: "session-not-promptable" };
+
+/**
+ * A short-lived reservation of the next pending prompt. Reserving does not mark
+ * the prompt as processing; callers start it only after sandbox delivery succeeds.
+ */
+export interface PromptClaim {
+  claimId: string;
+  prompt: PromptRecord & { status: "pending" };
+  claimedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * Atomic prompt lifecycle commands. Implementations reject stale claims and
+ * failed expected-status checks rather than silently applying partial updates.
+ */
+export type PromptUpdate =
+  | {
+      type: "start";
+      claimId: string;
+      startedAt: number;
+      event: AppendEvent<UserMessageEvent>;
+    }
+  | {
+      type: "complete";
+      expectedStatus: "pending" | "processing";
+      completedAt: number;
+      event: ExecutionCompleteEvent;
+    }
+  | { type: "requeue"; promptId: string; claimId: string }
+  | { type: "cancel"; promptId: string }
+  | { type: "await-stop-confirmation"; promptId: string; deadline: number }
+  | { type: "clear-stop-confirmation"; promptId: string };
+
+/** Provider-neutral persisted sandbox state. Credentials may be encrypted at rest. */
+export interface SandboxRecord {
+  id: string;
+  connectionId: string | null;
+  providerHandle: string | null;
+  snapshotId: string | null;
+  snapshotImageRef: string | null;
+  authToken: string | null;
+  authTokenHash: string | null;
+  status: SandboxStatus;
+  gitSyncStatus: GitSyncStatus;
+  lastHeartbeatAt: number | null;
+  lastActivityAt: number | null;
+  lastSpawnError: string | null;
+  lastSpawnErrorAt: number | null;
+  codeServerUrl: string | null;
+  codeServerCredential: string | null;
+  vncUrl: string | null;
+  vncCredential: string | null;
+  tunnelUrls: Record<string, string> | null;
+  terminalUrl: string | null;
+  terminalCredential: string | null;
+  spawnFailureCount: number;
+  lastSpawnFailureAt: number | null;
+  createdAt: number;
+}
+
+export type SandboxUpdate =
+  | {
+      type: "initialize";
+      sandboxId: string;
+      status: SandboxStatus;
+      gitSyncStatus: GitSyncStatus;
+      createdAt: number;
+    }
+  | {
+      type: "prepare-for-spawn";
+      connectionId: string;
+      authTokenHash: string;
+      status: SandboxStatus;
+      createdAt: number;
+    }
+  | { type: "resume"; status: SandboxStatus; createdAt: number }
+  | { type: "set-status"; status: SandboxStatus }
+  | { type: "set-provider-handle"; providerHandle: string }
+  | { type: "set-snapshot-image"; sandboxId: string; snapshotImageRef: string }
+  | { type: "record-heartbeat"; heartbeatAt: number }
+  | { type: "record-activity"; activityAt: number }
+  | { type: "set-git-sync-status"; status: GitSyncStatus }
+  | { type: "set-spawn-error"; error: string | null; errorAt: number | null }
+  | {
+      type: "update-access";
+      codeServer: { url?: string | null; credential?: string | null };
+    }
+  | { type: "update-access"; vnc: { url?: string | null; credential?: string | null } }
+  | { type: "update-access"; tunnelUrls: Record<string, string> | null }
+  | {
+      type: "update-access";
+      terminal: { url?: string | null; credential?: string | null };
+    }
+  | { type: "reset-circuit-breaker" }
+  | { type: "record-spawn-failure"; failedAt: number };
+
+export interface HistoryCursor {
+  createdAt: number;
+  eventId: string;
+  sequence?: number;
+}
+
+interface EventTypeHistoryFilter {
+  mode: "include" | "exclude";
+  eventTypes: SandboxEvent["type"][];
+}
+
+export type HistoryFilter =
+  | ({ type: "event-types" } & EventTypeHistoryFilter)
+  | { type: "for-prompt"; promptId: string; eventTypes?: EventTypeHistoryFilter }
+  | { type: "without-prompt"; eventTypes?: EventTypeHistoryFilter };
+
+export interface HistoryQuery {
+  cursor?: HistoryCursor | null;
+  limit: number;
+  filter?: HistoryFilter;
+}
+
+/** Events are ordered oldest-to-newest within each backward-paginated page. */
+export interface SessionHistory {
+  events: PersistedEvent[];
+  hasMore: boolean;
+  cursor: HistoryCursor | null;
+}
+
+/**
+ * Atomic persistence operations for one initialized session.
+ *
+ * Implementations may use embedded or remote storage, but callers only depend
+ * on asynchronous domain operations and normalized records.
+ */
+export interface SessionStore {
+  getSession(): Promise<SessionRecord>;
+  appendEvents(events: PendingEvent[]): Promise<PersistedEvent[]>;
+  createPrompt(input: CreatePromptInput): Promise<CreatePromptResult>;
+  claimNextPrompt(): Promise<PromptClaim | null>;
+  updatePrompt(input: PromptUpdate): Promise<void>;
+  getSandbox(): Promise<SandboxRecord | null>;
+  updateSandbox(input: SandboxUpdate): Promise<void>;
+  getHistory(input: HistoryQuery): Promise<SessionHistory>;
+}

--- a/packages/control-plane/src/session/session-store.ts
+++ b/packages/control-plane/src/session/session-store.ts
@@ -15,6 +15,11 @@ type MutableTimelineEvent = Extract<
   SandboxEvent,
   { type: "token" | "tool_call" | "execution_complete" }
 >;
+type LifecycleTimelineEvent = Extract<
+  SandboxEvent,
+  { type: "token" | "tool_call" | "execution_complete" | "context_compacted" | "user_message" }
+>;
+type ImmutableTimelineEvent = Exclude<SandboxEvent, LifecycleTimelineEvent>;
 type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
 type ContextCompactedEvent = Extract<SandboxEvent, { type: "context_compacted" }>;
 
@@ -51,15 +56,13 @@ export interface SessionRecord {
   updatedAt: number;
 }
 
-interface EventWriteBase<TEvent extends SandboxEvent> {
+interface EventWrite<TEvent extends SandboxEvent> {
   event: TEvent;
   createdAt: number;
 }
 
 /** Adds an immutable event at the end of the timeline. */
-export interface AppendEvent<
-  TEvent extends SandboxEvent = SandboxEvent,
-> extends EventWriteBase<TEvent> {
+export interface AppendEvent extends EventWrite<ImmutableTimelineEvent> {
   operation: "append";
   id: string;
 }
@@ -69,7 +72,9 @@ export interface AppendEvent<
  * Existing timeline sequence is retained. Token and completion writes update
  * createdAt; tool-call writes retain the original createdAt.
  */
-export interface UpsertEvent extends EventWriteBase<MutableTimelineEvent> {
+export interface UpsertEvent<
+  TEvent extends MutableTimelineEvent = MutableTimelineEvent,
+> extends EventWrite<TEvent> {
   operation: "upsert";
 }
 
@@ -77,7 +82,7 @@ export interface UpsertEvent extends EventWriteBase<MutableTimelineEvent> {
  * Seals the prompt's current token event and appends a compaction marker atomically.
  * The current and sealed token identities are derived from event.messageId and id.
  */
-export interface CompactEvent extends EventWriteBase<ContextCompactedEvent> {
+export interface CompactEvent extends EventWrite<ContextCompactedEvent> {
   operation: "compact";
   id: string;
 }
@@ -123,15 +128,15 @@ export interface CreatePromptInput {
     | "startedAt"
     | "completedAt"
   >;
-  attachmentIds: string[];
+  attachments: ResolvedSessionAttachment[];
   maxUnfinishedPrompts: number;
-  event?: AppendEvent;
 }
 
 export type CreatePromptResult =
   | { outcome: "created"; prompt: PromptRecord; position: number }
   | { outcome: "duplicate"; prompt: PromptRecord; position: number | null }
   | { outcome: "request-conflict" }
+  | { outcome: "attachment-conflict" }
   | { outcome: "queue-full" }
   | { outcome: "session-not-promptable" };
 
@@ -155,13 +160,12 @@ export type PromptUpdate =
       type: "start";
       claimId: string;
       startedAt: number;
-      event: AppendEvent<UserMessageEvent>;
+      event: EventWrite<UserMessageEvent> & { operation: "append"; id: string };
     }
   | {
       type: "complete";
       expectedStatus: "pending" | "processing";
-      completedAt: number;
-      event: ExecutionCompleteEvent;
+      event: UpsertEvent<ExecutionCompleteEvent>;
     }
   | { type: "requeue"; promptId: string; claimId: string }
   | { type: "cancel"; promptId: string }
@@ -173,9 +177,7 @@ export interface SandboxRecord {
   id: string;
   connectionId: string | null;
   providerHandle: string | null;
-  snapshotId: string | null;
   snapshotImageRef: string | null;
-  authToken: string | null;
   authTokenHash: string | null;
   status: SandboxStatus;
   gitSyncStatus: GitSyncStatus;
@@ -218,22 +220,17 @@ export type SandboxUpdate =
   | { type: "record-activity"; activityAt: number }
   | { type: "set-git-sync-status"; status: GitSyncStatus }
   | { type: "set-spawn-error"; error: string | null; errorAt: number | null }
-  | {
-      type: "update-access";
-      codeServer: { url?: string | null; credential?: string | null };
-    }
-  | { type: "update-access"; vnc: { url?: string | null; credential?: string | null } }
-  | { type: "update-access"; tunnelUrls: Record<string, string> | null }
-  | {
-      type: "update-access";
-      terminal: { url?: string | null; credential?: string | null };
-    }
+  | { type: "set-code-server-access"; url?: string | null; credential?: string | null }
+  | { type: "set-vnc-access"; url?: string | null; credential?: string | null }
+  | { type: "set-tunnel-urls"; tunnelUrls: Record<string, string> | null }
+  | { type: "set-terminal-access"; url?: string | null; credential?: string | null }
   | { type: "reset-circuit-breaker" }
   | { type: "record-spawn-failure"; failedAt: number };
 
 export interface HistoryCursor {
   createdAt: number;
   eventId: string;
+  /** Absent only while reading a cursor created before timeline sequencing was introduced. */
   sequence?: number;
 }
 
@@ -254,11 +251,9 @@ export interface HistoryQuery {
 }
 
 /** Events are ordered oldest-to-newest within each backward-paginated page. */
-export interface SessionHistory {
-  events: PersistedEvent[];
-  hasMore: boolean;
-  cursor: HistoryCursor | null;
-}
+export type SessionHistory =
+  | { events: PersistedEvent[]; hasMore: true; cursor: HistoryCursor }
+  | { events: PersistedEvent[]; hasMore: false; cursor: HistoryCursor | null };
 
 /**
  * Atomic persistence operations for one initialized session.


### PR DESCRIPTION
## Summary

- introduce a provider-neutral asynchronous `SessionStore` contract in the control-plane session domain
- define normalized session, prompt, event, sandbox, and history records without exposing SQL, D1, Hyperdrive, PostgreSQL clients, Durable Object state, or transaction primitives
- model atomic event append/upsert/compaction, prompt admission/reservation/transitions, and sandbox lifecycle updates as domain commands
- preserve legacy-null repository state and define explicit prompt creation outcomes and history ordering/filter semantics
- add compile-time contract coverage and an architecture regression test for provider leakage

## Testing

- `npm test -w @open-inspect/control-plane -- src/session/session-store.test.ts src/session/event-repository.test.ts src/session/message-repository.test.ts src/session/sandbox-repository.test.ts`
- `npm run typecheck`
- `npm run lint -w @open-inspect/control-plane`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a provider-neutral session storage contract for managing sessions, repositories, prompts, sandboxes, events, attachments, and history.
  * Added asynchronous operations for event persistence, prompt lifecycle updates, sandbox state changes, and filtered, paginated history retrieval.
  * Added typed outcomes for prompt creation and support for nullable repository branch information.
  * Standardized session records and history handling to support consistent behavior across storage providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->