### PR TITLE
fix: restore spacing above execution completion

### DIFF
--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -635,6 +635,7 @@ describe("terminal message visibility", () => {
     const outcomeTarget = observedTargets.find(
       (target) => target.getAttribute("data-terminal-message-id") === "message-1"
     );
+    expect(outcomeTarget).toHaveClass("space-y-2");
     expect(outcomeTarget).toHaveTextContent("The complete agent result");
     expect(outcomeTarget).toHaveTextContent("Execution complete");
   });

--- a/packages/web/src/components/terminal-message-read-observer.tsx
+++ b/packages/web/src/components/terminal-message-read-observer.tsx
@@ -127,7 +127,7 @@ export function TerminalMessageReadObserver({
   }, []);
 
   return (
-    <div ref={elementRef} data-terminal-message-id={messageId}>
+    <div ref={elementRef} data-terminal-message-id={messageId} className="space-y-2">
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- restore the timeline's standard vertical spacing inside the terminal-message observer wrapper
- keep the assistant response and `Execution complete` status from rendering flush together
- add a regression assertion for the grouped terminal outcome

## Verification
- `npm test -w @open-inspect/web -- src/components/session-timeline.test.tsx`
- `npm run lint -w @open-inspect/web -- --no-warn-ignored src/components/terminal-message-read-observer.tsx src/components/session-timeline.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx vitest run src/lib/client-auth-boundary-eslint.test.ts src/lib/server-auth-boundary-eslint.test.ts`

## Test note
The full web suite passed 1,012 of 1,014 tests. Two unrelated ESLint boundary tests exceeded their 5-second timeout under full-suite load; both passed when rerun together in isolation.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/4c07e8c6cfa271f7582a98e6a7aa7da2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing between terminal messages in the session timeline.
  * Preserved terminal message tracking while applying the updated layout styling.

* **Tests**
  * Added coverage to verify the terminal outcome uses the correct spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->