### PR TITLE
fix: paginate managed skill catalog

### DIFF
--- a/packages/control-plane/src/db/skills.ts
+++ b/packages/control-plane/src/db/skills.ts
@@ -71,21 +71,41 @@ interface ApplicableSkill extends SkillSummary {
   totalBytes: number;
 }
 
+interface SkillListResult {
+  skills: SkillSummary[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+const MAX_D1_QUERY_PARAMETERS = 100;
+
 /** Mutable catalog operations backed by immutable content revisions. */
 export class SkillStore {
   constructor(private readonly db: SqlDatabase) {}
 
-  async list(): Promise<SkillSummary[]> {
+  async list(options: { limit: number; cursor: string | null }): Promise<SkillListResult> {
     const result = await this.db
       .prepare(
         `${this.currentSkillSelect()}
          WHERE s.deleted_at IS NULL
-         ORDER BY s.name`
+           ${options.cursor ? "AND s.name > ?" : ""}
+         ORDER BY s.name
+         LIMIT ?`
       )
+      .bind(...(options.cursor ? [options.cursor] : []), options.limit + 1)
       .all<SkillRow>();
-    const rows = result.results ?? [];
+    const fetchedRows = result.results ?? [];
+    const hasMore = fetchedRows.length > options.limit;
+    const rows = hasMore ? fetchedRows.slice(0, options.limit) : fetchedRows;
     const assignments = await this.assignmentsForSkills(rows.map((row) => row.id));
-    return Promise.all(rows.map((row) => this.toSummary(row, assignments.get(row.id) ?? [])));
+    const skills = await Promise.all(
+      rows.map((row) => this.toSummary(row, assignments.get(row.id) ?? []))
+    );
+    return {
+      skills,
+      hasMore,
+      nextCursor: hasMore ? rows[rows.length - 1].name : null,
+    };
   }
 
   async get(id: string): Promise<Skill | null> {
@@ -418,18 +438,23 @@ export class SkillStore {
     const assignments = new Map<string, SkillAssignment[]>();
     for (const skillId of skillIds) assignments.set(skillId, []);
     if (skillIds.length === 0) return assignments;
-    const placeholders = skillIds.map(() => "?").join(", ");
-    const result = await this.db
-      .prepare(
-        `SELECT a.*, e.name AS environment_name
-         FROM skill_assignments a
-         LEFT JOIN environments e ON e.id = a.environment_id
-         WHERE a.skill_id IN (${placeholders})
-         ORDER BY a.skill_id, a.scope_type, a.id`
-      )
-      .bind(...skillIds)
-      .all<AssignmentRow>();
-    for (const row of result.results ?? []) {
+    const rows: AssignmentRow[] = [];
+    for (let start = 0; start < skillIds.length; start += MAX_D1_QUERY_PARAMETERS) {
+      const chunk = skillIds.slice(start, start + MAX_D1_QUERY_PARAMETERS);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const result = await this.db
+        .prepare(
+          `SELECT a.*, e.name AS environment_name
+           FROM skill_assignments a
+           LEFT JOIN environments e ON e.id = a.environment_id
+           WHERE a.skill_id IN (${placeholders})
+           ORDER BY a.skill_id, a.scope_type, a.id`
+        )
+        .bind(...chunk)
+        .all<AssignmentRow>();
+      rows.push(...(result.results ?? []));
+    }
+    for (const row of rows) {
       let assignment: SkillAssignment;
       if (row.scope_type === "repository") {
         assignment = {

--- a/packages/control-plane/src/routes/skills.ts
+++ b/packages/control-plane/src/routes/skills.ts
@@ -3,6 +3,8 @@ import {
   createSkillProfileInputSchema,
   replaceSkillContentAndAssignmentsInputSchema,
   setSkillEnabledInputSchema,
+  SKILL_LIST_PAGE_SIZE,
+  skillNameSchema,
   skillResolutionPreviewInputSchema,
   updateSkillProfileInputSchema,
 } from "@open-inspect/shared/types/skills";
@@ -65,12 +67,29 @@ function resourceId(match: RegExpMatchArray): string | Response {
 }
 
 async function handleListSkills(
-  _request: Request,
+  request: Request,
   _env: Env,
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  return json({ skills: await new SkillStore(ctx.db).list() });
+  const url = new URL(request.url);
+  const limitValue = url.searchParams.get("limit");
+  const cursorValue = url.searchParams.get("cursor");
+  if (url.searchParams.getAll("limit").length > 1 || url.searchParams.getAll("cursor").length > 1) {
+    return error("Invalid skill list query", 400);
+  }
+  const limit = limitValue === null ? SKILL_LIST_PAGE_SIZE : Number(limitValue);
+  if (!Number.isInteger(limit) || limit < 1 || limit > SKILL_LIST_PAGE_SIZE) {
+    return error("Invalid limit", 400);
+  }
+  const parsedCursor = cursorValue === null ? null : skillNameSchema.safeParse(cursorValue);
+  if (parsedCursor !== null && !parsedCursor.success) return error("Invalid cursor", 400);
+  return json(
+    await new SkillStore(ctx.db).list({
+      limit,
+      cursor: parsedCursor === null ? null : parsedCursor.data,
+    })
+  );
 }
 
 async function handleGetSkill(

--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -239,6 +239,44 @@ describe("managed skills persistence and resolution", () => {
     expect(getResponse.status).toBe(404);
   });
 
+  it("paginates catalogs and hydrates assignments beyond D1's parameter limit", async () => {
+    const skills = new SkillStore(env.DB);
+    for (let index = 0; index < 101; index++) {
+      await skills.create(
+        {
+          name: `catalog-skill-${String(index).padStart(3, "0")}`,
+          content,
+          assignments: [{ type: "global" }],
+        },
+        "user_1"
+      );
+    }
+
+    const applicable = await skills.listApplicable({ repositories: [], environmentId: null });
+    expect(applicable).toHaveLength(101);
+    expect(applicable.every((skill) => skill.assignments[0]?.type === "global")).toBe(true);
+
+    const firstResponse = await serviceFetch("https://test.local/skills?limit=100");
+    expect(firstResponse.status).toBe(200);
+    const firstPage = await firstResponse.json<{
+      skills: { name: string }[];
+      hasMore: boolean;
+      nextCursor: string | null;
+    }>();
+    expect(firstPage.skills).toHaveLength(100);
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.nextCursor).toBe("catalog-skill-099");
+
+    const secondResponse = await serviceFetch(
+      `https://test.local/skills?limit=100&cursor=${firstPage.nextCursor}`
+    );
+    await expect(secondResponse.json()).resolves.toMatchObject({
+      skills: [{ name: "catalog-skill-100" }],
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+
   it("maps typed profile validation and conflict failures", async () => {
     const first = await serviceFetch("https://test.local/skill-profiles", {
       method: "POST",

--- a/packages/shared/src/types/skills.test.ts
+++ b/packages/shared/src/types/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createSkillInputSchema,
+  listSkillsResponseSchema,
   sessionSkillSelectionSchema,
   skillContentInputSchema,
   skillNameSchema,
@@ -82,5 +83,18 @@ describe("managed skill contracts", () => {
       repoName: `repo-${index}`,
     }));
     expect(skillResolutionPreviewInputSchema.safeParse({ repositories }).success).toBe(false);
+  });
+
+  it("requires a cursor exactly when another skill catalog page exists", () => {
+    expect(
+      listSkillsResponseSchema.safeParse({ skills: [], hasMore: false, nextCursor: null }).success
+    ).toBe(true);
+    expect(
+      listSkillsResponseSchema.safeParse({ skills: [], hasMore: true, nextCursor: "next-skill" })
+        .success
+    ).toBe(true);
+    expect(
+      listSkillsResponseSchema.safeParse({ skills: [], hasMore: true, nextCursor: null }).success
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -15,6 +15,7 @@ export const MAX_SKILL_PATH_BYTES = 240;
 export const MAX_SKILL_PATH_DEPTH = 10;
 export const MAX_MANAGED_SKILLS_PER_SESSION = 20;
 export const MAX_MANAGED_SKILL_MANIFEST_BYTES = 5 * 1024 * 1024;
+export const SKILL_LIST_PAGE_SIZE = 100;
 
 const utf8 = new TextEncoder();
 const skillNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -204,7 +205,18 @@ export const skillSchema = skillSummarySchema.extend({
   files: z.array(skillFileSchema),
 });
 
-export const listSkillsResponseSchema = z.strictObject({ skills: z.array(skillSummarySchema) });
+export const listSkillsResponseSchema = z.discriminatedUnion("hasMore", [
+  z.strictObject({
+    skills: z.array(skillSummarySchema),
+    hasMore: z.literal(false),
+    nextCursor: z.null(),
+  }),
+  z.strictObject({
+    skills: z.array(skillSummarySchema),
+    hasMore: z.literal(true),
+    nextCursor: skillNameSchema,
+  }),
+]);
 export const skillResponseSchema = z.strictObject({ skill: skillSchema });
 
 export const createSkillProfileInputSchema = z.strictObject({
@@ -322,6 +334,7 @@ export type SkillFile = z.infer<typeof skillFileSchema>;
 export type SkillAssignment = z.infer<typeof skillAssignmentSchema>;
 export type SkillSummary = z.infer<typeof skillSummarySchema>;
 export type Skill = z.infer<typeof skillSchema>;
+export type ListSkillsResponse = z.infer<typeof listSkillsResponseSchema>;
 export type SkillProfile = z.infer<typeof skillProfileSchema>;
 export type SessionSkillSelection = z.infer<typeof sessionSkillSelectionSchema>;
 export type SessionSkillManifestSelection = z.infer<typeof sessionSkillManifestSelectionSchema>;

--- a/packages/web/src/app/api/skills/managed-skills-routes.test.ts
+++ b/packages/web/src/app/api/skills/managed-skills-routes.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { getServerAuthSession } from "@/lib/server-auth-session";
 import { DELETE, PUT } from "./[id]/route";
+import { GET } from "./route";
 
 vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
 vi.mock("@/lib/server-auth-session", () => ({ getServerAuthSession: vi.fn() }));
@@ -21,6 +22,24 @@ describe("managed skills BFF routes", () => {
 
     expect(response.status).toBe(401);
     expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards catalog pagination parameters", async () => {
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ skills: [], hasMore: false, nextCursor: null })
+    );
+    const request = new NextRequest(
+      "http://localhost/api/skills?limit=50&cursor=first-skill&ignored=value"
+    );
+
+    const response = await GET(request, { params: Promise.resolve(undefined) });
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
+      "/skills?limit=50&cursor=first-skill",
+      undefined
+    );
   });
 
   it("forwards the aggregate edit and revision precondition", async () => {

--- a/packages/web/src/app/api/skills/route.ts
+++ b/packages/web/src/app/api/skills/route.ts
@@ -1,3 +1,8 @@
 import { settingsProxy } from "@/lib/settings-proxy";
+import { buildControlPlanePath } from "@/lib/control-plane-query";
 
-export const { GET, POST } = settingsProxy(() => "/skills", "skills");
+export const { GET, POST } = settingsProxy(
+  (_params, request) =>
+    buildControlPlanePath("/skills", request.nextUrl.searchParams, ["limit", "cursor"]),
+  "skills"
+);

--- a/packages/web/src/hooks/use-managed-skills.ts
+++ b/packages/web/src/hooks/use-managed-skills.ts
@@ -5,6 +5,7 @@ import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   listSkillProfilesResponseSchema,
   listSkillsResponseSchema,
+  SKILL_LIST_PAGE_SIZE,
   skillProfileResponseSchema,
   skillResolutionPreviewResponseSchema,
   skillResponseSchema,
@@ -36,6 +37,22 @@ const errorResponseSchema = z.object({ error: z.string() });
 const SKILLS_KEY = "/api/skills";
 const SKILL_PROFILES_KEY = "/api/skill-profiles";
 
+async function fetchSkillCatalog(): Promise<z.infer<typeof listSkillsResponseSchema>["skills"]> {
+  const skills: z.infer<typeof listSkillsResponseSchema>["skills"] = [];
+  let cursor: string | null = null;
+  do {
+    const searchParams = new URLSearchParams({ limit: String(SKILL_LIST_PAGE_SIZE) });
+    if (cursor) searchParams.set("cursor", cursor);
+    const page = await validatedFetcher(
+      `${SKILLS_KEY}?${searchParams.toString()}`,
+      listSkillsResponseSchema
+    );
+    skills.push(...page.skills);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return skills;
+}
+
 async function validatedFetcher<T>(path: BrowserApiPath, schema: z.ZodType<T>): Promise<T> {
   const response = await browserApiFetch(path);
   if (!response.ok) throw new Error("Managed skills request failed");
@@ -61,11 +78,9 @@ async function apiRequest<T>(
 
 export function useSkills() {
   const { data: session, status } = useAuthSession();
-  const { data, isLoading, error, mutate } = useSWR(session ? SKILLS_KEY : null, (path) =>
-    validatedFetcher(path, listSkillsResponseSchema)
-  );
+  const { data, isLoading, error, mutate } = useSWR(session ? SKILLS_KEY : null, fetchSkillCatalog);
   return {
-    skills: data?.skills ?? [],
+    skills: data ?? [],
     loading: status === "loading" || isLoading,
     error,
     mutate,

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -31,7 +31,7 @@ async function proxyResponse(response: Response): Promise<NextResponse> {
 
 /** Creates the requested BFF route handlers for an authenticated control-plane resource. */
 export function settingsProxy<P>(
-  buildPath: (params: P) => string,
+  buildPath: (params: P, request: NextRequest) => string,
   label: string
 ): ProxyHandlers<P> {
   const proxy = async (
@@ -56,7 +56,7 @@ export function settingsProxy<P>(
         if (method !== "DELETE") init.body = JSON.stringify(await request.json());
         if (ifMatch) init.headers = { "If-Match": ifMatch };
       }
-      const response = await controlPlaneUserFetch(buildPath(params), init);
+      const response = await controlPlaneUserFetch(buildPath(params, request), init);
       return proxyResponse(response);
     } catch (error) {
       console.error(`Failed to ${METHOD_VERBS[method]} ${label}:`, error);


### PR DESCRIPTION
## Summary
- add cursor pagination to the managed skill catalog API with a maximum 100-skill page
- forward pagination through the web BFF and transparently load all pages for existing catalog/profile consumers
- chunk assignment hydration into D1-safe groups so target-aware resolution also supports more than 100 applicable skills
- add shared contract, BFF forwarding, and real-D1 boundary coverage for a 101-skill catalog

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/shared -- --run src/types/skills.test.ts`
- `npm test -w @open-inspect/web -- --run src/app/api/skills/managed-skills-routes.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/managed-skills.test.ts`
- focused ESLint on all changed files

## Note
The repository-wide lint command currently reports unrelated pre-existing global-environment errors under `.opencode/`; changed files pass focused lint.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/940bd5c279da661afeff9907c9bb652a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination to skill catalogs, including page-size limits and continuation metadata.
  * Skill catalog requests now forward pagination parameters and automatically load all available pages.
  * Added validation for pagination parameters and cursor states.

* **Bug Fixes**
  * Improved handling of catalogs with more than 100 assigned skills by reliably loading all assignments.
  * Prevented oversized requests when resolving large skill collections.

* **Tests**
  * Added coverage for pagination, cursor validation, parameter forwarding, and large skill catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->