### PR TITLE
fix: load skill catalog pages on demand

### DIFF
--- a/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
@@ -88,4 +88,53 @@ describe("SkillsCatalog", () => {
     expect(screen.getByText("first-skill")).toBeInTheDocument();
     expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith(null);
   });
+
+  it.each([
+    [
+      "empty",
+      {
+        skills: [],
+        hasMore: false,
+        nextCursor: null,
+        loading: false,
+        error: undefined,
+      },
+      "No skills on this page.",
+    ],
+    [
+      "failed",
+      {
+        skills: [],
+        hasMore: false,
+        nextCursor: null,
+        loading: false,
+        error: new Error("request failed"),
+      },
+      "Failed to load managed skills.",
+    ],
+  ])("can navigate back when a later page is %s", async (_state, page, message) => {
+    useSkillCatalogPageMock.mockImplementation((cursor: string | null) =>
+      cursor
+        ? page
+        : {
+            skills: [skill("1", "first-skill")],
+            hasMore: true,
+            nextCursor: "first-skill",
+            loading: false,
+            error: undefined,
+          }
+    );
+    const user = userEvent.setup();
+    render(<SkillsCatalog />);
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+
+    expect(screen.getByText("first-skill")).toBeInTheDocument();
+    expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith(null);
+  });
 });

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SkillSummary } from "@open-inspect/shared/types/skills";
+import { SkillsCatalog } from "./skills-catalog";
+
+expect.extend(matchers);
+
+const { useSkillCatalogPageMock } = vi.hoisted(() => ({
+  useSkillCatalogPageMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-managed-skills", () => ({
+  deleteSkill: vi.fn(),
+  revalidateSkillCatalogPage: vi.fn(),
+  setSkillEnabled: vi.fn(),
+  useSkill: () => ({ skill: undefined, loading: false, error: undefined, mutate: vi.fn() }),
+  useSkillCatalogPage: useSkillCatalogPageMock,
+}));
+
+function skill(id: string, name: string): SkillSummary {
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    enabled: true,
+    currentRevisionId: `revision-${id}`,
+    revisionNumber: 1,
+    revisionSha256: "a".repeat(64),
+    revisionCreatedBy: "user-1",
+    creatorDisplayName: "User One",
+    lastEditorDisplayName: "User One",
+    revisionAuthorDisplayName: "User One",
+    assignments: [],
+    createdBy: "user-1",
+    updatedBy: "user-1",
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+beforeEach(() => {
+  useSkillCatalogPageMock.mockReset();
+  useSkillCatalogPageMock.mockImplementation((cursor: string | null) =>
+    cursor
+      ? {
+          skills: [skill("2", "second-skill")],
+          hasMore: false,
+          nextCursor: null,
+          loading: false,
+          error: undefined,
+        }
+      : {
+          skills: [skill("1", "first-skill")],
+          hasMore: true,
+          nextCursor: "first-skill",
+          loading: false,
+          error: undefined,
+        }
+  );
+});
+
+afterEach(cleanup);
+
+describe("SkillsCatalog", () => {
+  it("loads catalog pages on demand and navigates back with cursor history", async () => {
+    const user = userEvent.setup();
+    render(<SkillsCatalog />);
+
+    expect(screen.getByText("first-skill")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+    expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith(null);
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByText("second-skill")).toBeInTheDocument();
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+    expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith("first-skill");
+
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+
+    expect(screen.getByText("first-skill")).toBeInTheDocument();
+    expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
@@ -27,6 +27,8 @@ export function SkillsCatalog() {
     error: skillError,
     mutate: mutateSkill,
   } = useSkill(selectedId);
+  const hasPreviousPage = cursorHistory.length > 0;
+  const showPagination = hasPreviousPage || (!loading && !error && skills.length > 0);
 
   async function toggleEnabled(id: string, enabled: boolean) {
     try {
@@ -104,7 +106,7 @@ export function SkillsCatalog() {
         <p className="text-sm text-destructive">Failed to load managed skills.</p>
       ) : loading ? (
         <p className="text-sm text-muted-foreground">Loading skills...</p>
-      ) : skills.length === 0 ? (
+      ) : skills.length === 0 && !hasPreviousPage ? (
         <div className="rounded border border-dashed border-border p-8 text-center">
           <SparkleIcon className="mx-auto h-6 w-6 text-muted-foreground" />
           <p className="mt-2 text-sm text-foreground">No shared skills yet</p>
@@ -112,66 +114,68 @@ export function SkillsCatalog() {
             Create one to give agents consistent workflows and context.
           </p>
         </div>
+      ) : skills.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No skills on this page.</p>
       ) : (
-        <>
-          <div className="divide-y divide-border-muted rounded border border-border-muted">
-            {skills.map((item) => (
-              <div key={item.id} className="flex items-start gap-3 p-4">
-                <button
-                  type="button"
-                  onClick={() => setSelectedId(item.id)}
-                  className="min-w-0 flex-1 text-left"
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="truncate font-mono text-sm font-medium text-foreground">
-                      {item.name}
-                    </span>
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                      r{item.revisionNumber}
-                    </span>
-                  </div>
-                  <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                    {item.description}
-                  </p>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
-                  </p>
-                </button>
-                <Switch
-                  checked={item.enabled}
-                  onCheckedChange={(value) => toggleEnabled(item.id, value)}
-                  aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.name}`}
-                />
-                <Button variant="ghost" size="xs" onClick={() => remove(item.id, item.name)}>
-                  Delete
-                </Button>
-              </div>
-            ))}
-          </div>
-          <div className="mt-4 flex items-center justify-between gap-3">
-            <p className="text-xs text-muted-foreground">Page {cursorHistory.length + 1}</p>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={cursorHistory.length === 0}
-                onClick={() => setCursorHistory((history) => history.slice(0, -1))}
+        <div className="divide-y divide-border-muted rounded border border-border-muted">
+          {skills.map((item) => (
+            <div key={item.id} className="flex items-start gap-3 p-4">
+              <button
+                type="button"
+                onClick={() => setSelectedId(item.id)}
+                className="min-w-0 flex-1 text-left"
               >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hasMore || !nextCursor}
-                onClick={() => {
-                  if (nextCursor) setCursorHistory((history) => [...history, nextCursor]);
-                }}
-              >
-                Next
+                <div className="flex items-center gap-2">
+                  <span className="truncate font-mono text-sm font-medium text-foreground">
+                    {item.name}
+                  </span>
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                    r{item.revisionNumber}
+                  </span>
+                </div>
+                <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                  {item.description}
+                </p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
+                </p>
+              </button>
+              <Switch
+                checked={item.enabled}
+                onCheckedChange={(value) => toggleEnabled(item.id, value)}
+                aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.name}`}
+              />
+              <Button variant="ghost" size="xs" onClick={() => remove(item.id, item.name)}>
+                Delete
               </Button>
             </div>
+          ))}
+        </div>
+      )}
+      {showPagination && (
+        <div className="mt-4 flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">Page {cursorHistory.length + 1}</p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasPreviousPage}
+              onClick={() => setCursorHistory((history) => history.slice(0, -1))}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={loading || Boolean(error) || !hasMore || !nextCursor}
+              onClick={() => {
+                if (nextCursor) setCursorHistory((history) => [...history, nextCursor]);
+              }}
+            >
+              Next
+            </Button>
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
@@ -2,7 +2,13 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { deleteSkill, setSkillEnabled, useSkill, useSkills } from "@/hooks/use-managed-skills";
+import {
+  deleteSkill,
+  revalidateSkillCatalogPage,
+  setSkillEnabled,
+  useSkill,
+  useSkillCatalogPage,
+} from "@/hooks/use-managed-skills";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { PlusIcon, SparkleIcon } from "@/components/ui/icons";
@@ -10,7 +16,9 @@ import { SkillEditor } from "./skill-editor";
 import { errorMessage } from "./shared";
 
 export function SkillsCatalog() {
-  const { skills, loading, error, mutate } = useSkills();
+  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
+  const cursor = cursorHistory.at(-1) ?? null;
+  const { skills, hasMore, nextCursor, loading, error } = useSkillCatalogPage(cursor);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const {
@@ -23,7 +31,7 @@ export function SkillsCatalog() {
   async function toggleEnabled(id: string, enabled: boolean) {
     try {
       await setSkillEnabled(id, { enabled });
-      await mutate();
+      await revalidateSkillCatalogPage(cursor);
     } catch (requestError) {
       toast.error(errorMessage(requestError));
     }
@@ -34,7 +42,13 @@ export function SkillsCatalog() {
     try {
       await deleteSkill(id);
       if (selectedId === id) setSelectedId(null);
-      await mutate();
+      const moveToPreviousPage = skills.length === 1 && cursorHistory.length > 0;
+      if (moveToPreviousPage) {
+        setCursorHistory((history) => history.slice(0, -1));
+      }
+      await revalidateSkillCatalogPage(
+        moveToPreviousPage ? (cursorHistory.at(-2) ?? null) : cursor
+      );
       toast.success("Skill deleted");
     } catch (requestError) {
       toast.error(errorMessage(requestError));
@@ -49,7 +63,8 @@ export function SkillsCatalog() {
         onSaved={async (id) => {
           setCreating(false);
           setSelectedId(id);
-          await mutate();
+          setCursorHistory([]);
+          await revalidateSkillCatalogPage(null);
         }}
       />
     );
@@ -66,7 +81,7 @@ export function SkillsCatalog() {
         creating={false}
         onCancel={() => setSelectedId(null)}
         onSaved={async () => {
-          await Promise.all([mutate(), mutateSkill()]);
+          await Promise.all([revalidateSkillCatalogPage(cursor), mutateSkill()]);
         }}
       />
     );
@@ -98,40 +113,65 @@ export function SkillsCatalog() {
           </p>
         </div>
       ) : (
-        <div className="divide-y divide-border-muted rounded border border-border-muted">
-          {skills.map((item) => (
-            <div key={item.id} className="flex items-start gap-3 p-4">
-              <button
-                type="button"
-                onClick={() => setSelectedId(item.id)}
-                className="min-w-0 flex-1 text-left"
+        <>
+          <div className="divide-y divide-border-muted rounded border border-border-muted">
+            {skills.map((item) => (
+              <div key={item.id} className="flex items-start gap-3 p-4">
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(item.id)}
+                  className="min-w-0 flex-1 text-left"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-mono text-sm font-medium text-foreground">
+                      {item.name}
+                    </span>
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                      r{item.revisionNumber}
+                    </span>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                    {item.description}
+                  </p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
+                  </p>
+                </button>
+                <Switch
+                  checked={item.enabled}
+                  onCheckedChange={(value) => toggleEnabled(item.id, value)}
+                  aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.name}`}
+                />
+                <Button variant="ghost" size="xs" onClick={() => remove(item.id, item.name)}>
+                  Delete
+                </Button>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">Page {cursorHistory.length + 1}</p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={cursorHistory.length === 0}
+                onClick={() => setCursorHistory((history) => history.slice(0, -1))}
               >
-                <div className="flex items-center gap-2">
-                  <span className="truncate font-mono text-sm font-medium text-foreground">
-                    {item.name}
-                  </span>
-                  <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                    r{item.revisionNumber}
-                  </span>
-                </div>
-                <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                  {item.description}
-                </p>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
-                </p>
-              </button>
-              <Switch
-                checked={item.enabled}
-                onCheckedChange={(value) => toggleEnabled(item.id, value)}
-                aria-label={`${item.enabled ? "Disable" : "Enable"} ${item.name}`}
-              />
-              <Button variant="ghost" size="xs" onClick={() => remove(item.id, item.name)}>
-                Delete
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasMore || !nextCursor}
+                onClick={() => {
+                  if (nextCursor) setCursorHistory((history) => [...history, nextCursor]);
+                }}
+              >
+                Next
               </Button>
             </div>
-          ))}
-        </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/packages/web/src/hooks/use-managed-skills.test.ts
+++ b/packages/web/src/hooks/use-managed-skills.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { revalidateSkillCatalogPage } from "./use-managed-skills";
+
+const { mutateSWRMock } = vi.hoisted(() => ({ mutateSWRMock: vi.fn() }));
+
+vi.mock("swr", () => ({
+  default: vi.fn(),
+  mutate: mutateSWRMock,
+}));
+
+beforeEach(() => {
+  mutateSWRMock.mockReset();
+  mutateSWRMock.mockResolvedValue(undefined);
+});
+
+describe("revalidateSkillCatalogPage", () => {
+  it("clears the aggregate cache without fetching it and refreshes the active page", async () => {
+    await revalidateSkillCatalogPage("first-skill");
+
+    expect(mutateSWRMock).toHaveBeenCalledWith("/api/skills", undefined, { revalidate: false });
+    expect(mutateSWRMock).toHaveBeenCalledWith("/api/skills?limit=25&cursor=first-skill");
+  });
+});

--- a/packages/web/src/hooks/use-managed-skills.test.ts
+++ b/packages/web/src/hooks/use-managed-skills.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { revalidateSkillCatalogPage } from "./use-managed-skills";
+import { revalidateSkillCatalogPage, SKILL_CATALOG_PAGE_SIZE } from "./use-managed-skills";
 
 const { mutateSWRMock } = vi.hoisted(() => ({ mutateSWRMock: vi.fn() }));
 
@@ -14,10 +14,13 @@ beforeEach(() => {
 });
 
 describe("revalidateSkillCatalogPage", () => {
-  it("clears the aggregate cache without fetching it and refreshes the active page", async () => {
-    await revalidateSkillCatalogPage("first-skill");
+  it.each([
+    ["initial", null, `/api/skills?limit=${SKILL_CATALOG_PAGE_SIZE}`],
+    ["later", "first-skill", `/api/skills?limit=${SKILL_CATALOG_PAGE_SIZE}&cursor=first-skill`],
+  ])("clears the aggregate cache and refreshes the %s page", async (_page, cursor, expectedKey) => {
+    await revalidateSkillCatalogPage(cursor);
 
     expect(mutateSWRMock).toHaveBeenCalledWith("/api/skills", undefined, { revalidate: false });
-    expect(mutateSWRMock).toHaveBeenCalledWith("/api/skills?limit=25&cursor=first-skill");
+    expect(mutateSWRMock).toHaveBeenCalledWith(expectedKey);
   });
 });

--- a/packages/web/src/hooks/use-managed-skills.ts
+++ b/packages/web/src/hooks/use-managed-skills.ts
@@ -108,8 +108,11 @@ export function useSkillCatalogPage(cursor: string | null) {
   };
 }
 
-export function revalidateSkillCatalogPage(cursor: string | null): Promise<unknown> {
-  return mutateSWR(skillCatalogPageKey(cursor));
+export async function revalidateSkillCatalogPage(cursor: string | null): Promise<void> {
+  await Promise.all([
+    mutateSWR(SKILLS_KEY, undefined, { revalidate: false }),
+    mutateSWR(skillCatalogPageKey(cursor)),
+  ]);
 }
 
 export function useSkill(id: string | null) {

--- a/packages/web/src/hooks/use-managed-skills.ts
+++ b/packages/web/src/hooks/use-managed-skills.ts
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import useSWR, { mutate as mutateSWR } from "swr";
 import { z } from "zod";
 import { useAuthSession } from "@/lib/auth-session";
 import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
@@ -36,6 +36,13 @@ const errorResponseSchema = z.object({ error: z.string() });
 
 const SKILLS_KEY = "/api/skills";
 const SKILL_PROFILES_KEY = "/api/skill-profiles";
+export const SKILL_CATALOG_PAGE_SIZE = 25;
+
+function skillCatalogPageKey(cursor: string | null): BrowserApiPath {
+  const searchParams = new URLSearchParams({ limit: String(SKILL_CATALOG_PAGE_SIZE) });
+  if (cursor) searchParams.set("cursor", cursor);
+  return `${SKILLS_KEY}?${searchParams.toString()}`;
+}
 
 async function fetchSkillCatalog(): Promise<z.infer<typeof listSkillsResponseSchema>["skills"]> {
   const skills: z.infer<typeof listSkillsResponseSchema>["skills"] = [];
@@ -85,6 +92,24 @@ export function useSkills() {
     error,
     mutate,
   };
+}
+
+export function useSkillCatalogPage(cursor: string | null) {
+  const { data: session, status } = useAuthSession();
+  const { data, isLoading, error } = useSWR(session ? skillCatalogPageKey(cursor) : null, (path) =>
+    validatedFetcher(path, listSkillsResponseSchema)
+  );
+  return {
+    skills: data?.skills ?? [],
+    hasMore: data?.hasMore ?? false,
+    nextCursor: data?.nextCursor ?? null,
+    loading: status === "loading" || isLoading,
+    error,
+  };
+}
+
+export function revalidateSkillCatalogPage(cursor: string | null): Promise<unknown> {
+  return mutateSWR(skillCatalogPageKey(cursor));
 }
 
 export function useSkill(id: string | null) {


### PR DESCRIPTION
## Summary
- replace eager full-catalog loading in the shared skills view with 25-item cursor pages
- add Previous and Next controls with cursor history and page numbering
- refresh only the affected catalog page after create, edit, enable, or delete operations
- handle deletion of the final item on a page by returning to the previous page
- add UI coverage for forward and backward page navigation

## Validation
- `npm test -w @open-inspect/web -- --run src/components/settings/skills-settings/skills-catalog.test.tsx src/components/settings/skills-settings/profiles.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- targeted ESLint and Prettier checks
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/736826c5972c2b2e84c7f718cad066d1)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to the skills catalog with page numbers and Previous/Next controls.
  * Added cursor-based navigation for browsing catalog pages.
  * Catalog changes now automatically refresh the relevant page.
  * Deleting the last skill on a page returns to the previous page.
  * Added distinct empty-state messages for the first page and later pages.

* **Tests**
  * Added coverage for pagination, navigation states, page refreshes, empty results, and failed page loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->