### PR TITLE
Allow prompt drafting while session connects

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -28,14 +28,9 @@ import {
   type SessionListResponse,
 } from "@/lib/session-list";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared/models";
 import { resolveModelPreference, type ModelPreference } from "@/lib/model-selection";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
-import {
-  DEFAULT_ATTACHMENT_ONLY_MESSAGE,
-  useSessionAttachments,
-} from "@/hooks/use-session-attachments";
 import type { ComboboxGroup } from "@/components/ui/combobox";
 import { useSessionDiffs } from "@/hooks/use-session-diffs";
 import { resolveDiffSelection, type DiffSelection } from "@/lib/session-diffs";
@@ -54,22 +49,18 @@ import { focusSessionDetailsTrigger } from "@/lib/session-details-focus";
 import { useSessionParticipantProfiles } from "@/hooks/use-session-participant-profiles";
 import { useSessionDetailsSidebar } from "@/hooks/use-session-details-sidebar";
 import {
-  promptRequestSignature,
-  resolvePromptRequestIdentity,
-  type PromptRequestIdentity,
-} from "@/lib/prompt-request-id";
-import {
   classifySessionReadAttempt,
   markMessageRead,
   reconcileSessionReadState,
   SessionReadRequestError,
 } from "@/lib/session-read-state";
-import { restoreQueuedPrompt } from "@/lib/restore-queued-prompt";
+import { usePromptInput } from "@/hooks/use-prompt-input";
 import { useSessionSnapshot } from "./session-snapshot-provider";
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
 const TERMINAL_VISIBLE_STORAGE_KEY = "terminal-visible";
+const DEFAULT_SESSION_STATUS = "created" as const;
 
 export default function SessionPage() {
   const initialSnapshot = useSessionSnapshot();
@@ -135,7 +126,7 @@ export default function SessionPage() {
     selectedModel,
     reasoningEffort,
     loadingEnabledModels,
-    sessionState?.status ?? "created",
+    sessionState?.status ?? DEFAULT_SESSION_STATUS,
     ready
   );
   const [cancellingPromptIds, setCancellingPromptIds] = useState<ReadonlySet<string>>(new Set());
@@ -351,7 +342,7 @@ export default function SessionPage() {
       <SessionPromptComposer
         session={{
           id: sessionId,
-          status: sessionState?.status ?? "created",
+          status: sessionState?.status ?? DEFAULT_SESSION_STATUS,
           artifacts,
           primaryRepo,
           onArchive: handleArchive,
@@ -404,7 +395,7 @@ export default function SessionPage() {
         onOpenMobileDetails={openMobileDetails}
         actions={{
           sessionId,
-          sessionStatus: sessionState?.status ?? "created",
+          sessionStatus: sessionState?.status ?? DEFAULT_SESSION_STATUS,
           artifacts,
           primaryRepo,
           onArchive: handleArchive,
@@ -688,176 +679,5 @@ function useModelSelection(sessionState: SessionState) {
     handleModelChange,
     modelItems,
     loadingEnabledModels,
-  };
-}
-
-/**
- * Prompt textarea state and handlers: submit, Cmd/Ctrl+Enter, and the
- * debounced typing indicator.
- */
-function usePromptInput(
-  sessionId: string,
-  sendPrompt: ReturnType<typeof useSessionSocket>["sendPrompt"],
-  sendTyping: ReturnType<typeof useSessionSocket>["sendTyping"],
-  selectedModel: string,
-  reasoningEffort: string | undefined,
-  loadingEnabledModels: boolean,
-  sessionStatus: NonNullable<SessionState>["status"],
-  canSubmit: boolean
-) {
-  const [prompt, setPromptState] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const sessionAttachments = useSessionAttachments();
-  const hasAttachments = sessionAttachments.hasAttachments;
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const submitInFlightRef = useRef(false);
-  const restoreFocusAfterSubmitRef = useRef(false);
-  const retryRequestRef = useRef<PromptRequestIdentity | null>(null);
-  const attachmentDraftSignature = sessionAttachments.attachments
-    .map((attachment) => attachment.id)
-    .join("\u0000");
-  const promptRef = useRef(prompt);
-  const setPrompt = useCallback((value: string) => {
-    promptRef.current = value;
-    setPromptState(value);
-  }, []);
-
-  const clearTypingTimeout = useCallback(() => {
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-      typingTimeoutRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => clearTypingTimeout, [clearTypingTimeout]);
-  useEffect(() => {
-    retryRequestRef.current = null;
-  }, [selectedModel, reasoningEffort, attachmentDraftSignature]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const hasAttachments = sessionAttachments.attachments.length > 0;
-    if (
-      submitInFlightRef.current ||
-      !canSubmit ||
-      (!prompt.trim() && !hasAttachments) ||
-      sessionStatus === "archived" ||
-      sessionStatus === "cancelled" ||
-      loadingEnabledModels ||
-      sessionAttachments.isUploading
-    ) {
-      return;
-    }
-
-    submitInFlightRef.current = true;
-    restoreFocusAfterSubmitRef.current = document.activeElement === inputRef.current;
-    setIsSubmitting(true);
-    setSubmitError(null);
-    try {
-      const content = prompt.trim() || DEFAULT_ATTACHMENT_ONLY_MESSAGE;
-      let attachments: SessionAttachmentReference[] | undefined;
-      if (hasAttachments) {
-        try {
-          attachments = await sessionAttachments.uploadAll(sessionId);
-        } catch (error) {
-          setSubmitError(error instanceof Error ? error.message : "Failed to upload attachments");
-          return;
-        }
-      }
-
-      // Drop any queued typing indicator — the prompt supersedes it
-      clearTypingTimeout();
-      const signature = promptRequestSignature({
-        content,
-        model: selectedModel,
-        reasoningEffort,
-        attachmentIds: sessionAttachments.attachments.map((attachment) => attachment.id),
-      });
-      const requestIdentity = resolvePromptRequestIdentity(signature, retryRequestRef.current);
-      retryRequestRef.current = requestIdentity;
-      const result = await sendPrompt(
-        content,
-        selectedModel,
-        reasoningEffort,
-        attachments,
-        requestIdentity.clientRequestId
-      );
-      if (!result.ok) {
-        setSubmitError(
-          result.message ??
-            (result.reason === "timeout"
-              ? "Confirmation timed out. Retry while this page is open to reuse the same request."
-              : result.reason === "disconnected"
-                ? "Disconnected before confirmation. Retry on this page after reconnecting."
-                : "The prompt could not be queued.")
-        );
-        return;
-      }
-
-      retryRequestRef.current = null;
-      setPrompt("");
-      sessionAttachments.clearAttachments();
-      // Revalidate sidebar so this session bubbles to the top
-      mutate(isUnarchivedSessionListKey);
-    } finally {
-      submitInFlightRef.current = false;
-      setIsSubmitting(false);
-      if (restoreFocusAfterSubmitRef.current) {
-        restoreFocusAfterSubmitRef.current = false;
-        requestAnimationFrame(() => {
-          if (document.activeElement === document.body) inputRef.current?.focus();
-        });
-      }
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
-
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
-      e.preventDefault();
-      handleSubmit(e);
-    }
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setPrompt(e.target.value);
-    setSubmitError(null);
-    retryRequestRef.current = null;
-
-    // Send typing indicator (debounced)
-    clearTypingTimeout();
-    typingTimeoutRef.current = setTimeout(() => {
-      sendTyping();
-    }, 300);
-  };
-
-  const restorePrompt = useCallback(
-    (content: string) => {
-      const restored = restoreQueuedPrompt({
-        content,
-        currentPrompt: promptRef.current,
-        hasAttachments: hasAttachments(),
-        setPrompt,
-        input: inputRef.current,
-      });
-      return restored;
-    },
-    [hasAttachments, setPrompt]
-  );
-
-  return {
-    prompt,
-    sessionAttachments,
-    inputRef,
-    isSubmitting,
-    submitError,
-    setSubmitError,
-    handleSubmit,
-    handleInputChange,
-    handleKeyDown,
-    restorePrompt,
   };
 }

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -135,7 +135,8 @@ export default function SessionPage() {
     selectedModel,
     reasoningEffort,
     loadingEnabledModels,
-    sessionState?.status ?? "created"
+    sessionState?.status ?? "created",
+    ready
   );
   const [cancellingPromptIds, setCancellingPromptIds] = useState<ReadonlySet<string>>(new Set());
   const cancellingPromptIdsRef = useRef(new Set<string>());
@@ -359,7 +360,8 @@ export default function SessionPage() {
         prompt={{
           value: prompt,
           isProcessing: ready && isProcessing,
-          draftLocked: !ready || isSubmitting || sessionAttachments.isUploading,
+          draftLocked: isSubmitting || sessionAttachments.isUploading,
+          sendBlocked: !ready,
           submitError,
           inputRef,
           onSubmit: handleSubmit,
@@ -700,7 +702,8 @@ function usePromptInput(
   selectedModel: string,
   reasoningEffort: string | undefined,
   loadingEnabledModels: boolean,
-  sessionStatus: NonNullable<SessionState>["status"]
+  sessionStatus: NonNullable<SessionState>["status"],
+  canSubmit: boolean
 ) {
   const [prompt, setPromptState] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -738,6 +741,7 @@ function usePromptInput(
     const hasAttachments = sessionAttachments.attachments.length > 0;
     if (
       submitInFlightRef.current ||
+      !canSubmit ||
       (!prompt.trim() && !hasAttachments) ||
       sessionStatus === "archived" ||
       sessionStatus === "cancelled" ||

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -40,12 +40,14 @@ function ComposerHarness({
   initialValue = "",
   isProcessing = false,
   isUploading = false,
+  connecting = false,
   status = "active",
   submitError = null,
 }: {
   initialValue?: string;
   isProcessing?: boolean;
   isUploading?: boolean;
+  connecting?: boolean;
   status?: "active" | "archived" | "cancelled";
   submitError?: string | null;
 }) {
@@ -65,6 +67,7 @@ function ComposerHarness({
         value,
         isProcessing,
         draftLocked: isUploading,
+        sendBlocked: connecting,
         submitError,
         inputRef,
         onSubmit: vi.fn(),
@@ -102,6 +105,19 @@ describe("SessionPromptComposer", () => {
       "maxlength",
       String(MAX_WEB_PROMPT_CHARS)
     );
+  });
+
+  it("allows drafting while the session connection is not ready", () => {
+    render(<ComposerHarness initialValue="Draft while connecting" connecting />);
+
+    const input = screen.getByDisplayValue("Draft while connecting");
+    expect(input).toBeEnabled();
+    fireEvent.change(input, { target: { value: "Updated while connecting" } });
+    expect(screen.getByDisplayValue("Updated while connecting")).toBeEnabled();
+    expect(screen.getByTitle("Attach images")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Model" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Reasoning" })).toBeEnabled();
+    expect(screen.getByTitle(/Send/)).toBeDisabled();
   });
 
   it("starts with one row and grows and shrinks with its content", () => {

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -27,6 +27,7 @@ type SessionPromptComposerProps = {
     value: string;
     isProcessing: boolean;
     draftLocked: boolean;
+    sendBlocked: boolean;
     submitError: string | null;
     inputRef: React.RefObject<HTMLTextAreaElement | null>;
     onSubmit: (e: React.FormEvent) => void;
@@ -59,7 +60,8 @@ export function SessionPromptComposer({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const hasContent = prompt.value.trim().length > 0 || attachments.items.length > 0;
   const sessionPromptable = session.status !== "archived" && session.status !== "cancelled";
-  const sendDisabled = !hasContent || prompt.draftLocked || !sessionPromptable;
+  const sendDisabled =
+    !hasContent || prompt.draftLocked || prompt.sendBlocked || !sessionPromptable;
   // Keep the complete draft stable while its attachments upload and until
   // the server confirms that the matching prompt was queued.
   const attachmentsLocked = prompt.draftLocked;

--- a/packages/web/src/hooks/use-prompt-input.test.tsx
+++ b/packages/web/src/hooks/use-prompt-input.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { usePromptInput } from "./use-prompt-input";
+
+expect.extend(matchers);
+
+const mocks = vi.hoisted(() => ({
+  sendPrompt: vi.fn(),
+  sendTyping: vi.fn(),
+  clearAttachments: vi.fn(),
+  uploadAll: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-session-attachments", () => ({
+  DEFAULT_ATTACHMENT_ONLY_MESSAGE: "See the attached files.",
+  useSessionAttachments: () => ({
+    attachments: [],
+    attachmentError: null,
+    isUploading: false,
+    addFiles: vi.fn(),
+    removeAttachment: vi.fn(),
+    clearAttachments: mocks.clearAttachments,
+    hasAttachments: () => false,
+    uploadAll: mocks.uploadAll,
+  }),
+}));
+
+function PromptHarness({ canSubmit }: { canSubmit: boolean }) {
+  const prompt = usePromptInput(
+    "session-1",
+    mocks.sendPrompt,
+    mocks.sendTyping,
+    "model-1",
+    undefined,
+    false,
+    "active",
+    canSubmit
+  );
+
+  return (
+    <textarea
+      aria-label="Prompt"
+      value={prompt.prompt}
+      onChange={prompt.handleInputChange}
+      onKeyDown={prompt.handleKeyDown}
+    />
+  );
+}
+
+beforeEach(() => {
+  mocks.sendPrompt.mockReset();
+  mocks.sendTyping.mockReset();
+  mocks.clearAttachments.mockReset();
+  mocks.uploadAll.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("usePromptInput", () => {
+  it("accepts draft edits but blocks the send shortcut before the session is ready", () => {
+    render(<PromptHarness canSubmit={false} />);
+
+    const input = screen.getByRole("textbox", { name: "Prompt" });
+    fireEvent.change(input, { target: { value: "Draft while connecting" } });
+    expect(input).toHaveValue("Draft while connecting");
+
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+    expect(mocks.sendPrompt).not.toHaveBeenCalled();
+    expect(input).toHaveValue("Draft while connecting");
+  });
+});

--- a/packages/web/src/hooks/use-prompt-input.ts
+++ b/packages/web/src/hooks/use-prompt-input.ts
@@ -17,6 +17,8 @@ import {
 } from "@/lib/prompt-request-id";
 import { restoreQueuedPrompt } from "@/lib/restore-queued-prompt";
 
+const TYPING_DEBOUNCE_MS = 300;
+
 /** Prompt state and handlers for submission, keyboard shortcuts, and typing indicators. */
 export function usePromptInput(
   sessionId: string,
@@ -151,7 +153,7 @@ export function usePromptInput(
     clearTypingTimeout();
     typingTimeoutRef.current = setTimeout(() => {
       sendTyping();
-    }, 300);
+    }, TYPING_DEBOUNCE_MS);
   };
 
   const restorePrompt = useCallback(

--- a/packages/web/src/hooks/use-prompt-input.ts
+++ b/packages/web/src/hooks/use-prompt-input.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { mutate } from "swr";
+import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
+import type { SessionStatus } from "@open-inspect/shared/types/sessions";
+import {
+  DEFAULT_ATTACHMENT_ONLY_MESSAGE,
+  useSessionAttachments,
+} from "@/hooks/use-session-attachments";
+import type { useSessionSocket } from "@/hooks/use-session-socket";
+import { isUnarchivedSessionListKey } from "@/lib/session-list";
+import {
+  promptRequestSignature,
+  resolvePromptRequestIdentity,
+  type PromptRequestIdentity,
+} from "@/lib/prompt-request-id";
+import { restoreQueuedPrompt } from "@/lib/restore-queued-prompt";
+
+/** Prompt state and handlers for submission, keyboard shortcuts, and typing indicators. */
+export function usePromptInput(
+  sessionId: string,
+  sendPrompt: ReturnType<typeof useSessionSocket>["sendPrompt"],
+  sendTyping: ReturnType<typeof useSessionSocket>["sendTyping"],
+  selectedModel: string,
+  reasoningEffort: string | undefined,
+  loadingEnabledModels: boolean,
+  sessionStatus: SessionStatus,
+  canSubmit: boolean
+) {
+  const [prompt, setPromptState] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const sessionAttachments = useSessionAttachments();
+  const hasAttachments = sessionAttachments.hasAttachments;
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const submitInFlightRef = useRef(false);
+  const restoreFocusAfterSubmitRef = useRef(false);
+  const retryRequestRef = useRef<PromptRequestIdentity | null>(null);
+  const attachmentDraftSignature = sessionAttachments.attachments
+    .map((attachment) => attachment.id)
+    .join("\u0000");
+  const promptRef = useRef(prompt);
+  const setPrompt = useCallback((value: string) => {
+    promptRef.current = value;
+    setPromptState(value);
+  }, []);
+
+  const clearTypingTimeout = useCallback(() => {
+    if (typingTimeoutRef.current) {
+      clearTimeout(typingTimeoutRef.current);
+      typingTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTypingTimeout, [clearTypingTimeout]);
+  useEffect(() => {
+    retryRequestRef.current = null;
+  }, [selectedModel, reasoningEffort, attachmentDraftSignature]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const hasAttachments = sessionAttachments.attachments.length > 0;
+    if (
+      submitInFlightRef.current ||
+      !canSubmit ||
+      (!prompt.trim() && !hasAttachments) ||
+      sessionStatus === "archived" ||
+      sessionStatus === "cancelled" ||
+      loadingEnabledModels ||
+      sessionAttachments.isUploading
+    ) {
+      return;
+    }
+
+    submitInFlightRef.current = true;
+    restoreFocusAfterSubmitRef.current = document.activeElement === inputRef.current;
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const content = prompt.trim() || DEFAULT_ATTACHMENT_ONLY_MESSAGE;
+      let attachments: SessionAttachmentReference[] | undefined;
+      if (hasAttachments) {
+        try {
+          attachments = await sessionAttachments.uploadAll(sessionId);
+        } catch (error) {
+          setSubmitError(error instanceof Error ? error.message : "Failed to upload attachments");
+          return;
+        }
+      }
+
+      clearTypingTimeout();
+      const signature = promptRequestSignature({
+        content,
+        model: selectedModel,
+        reasoningEffort,
+        attachmentIds: sessionAttachments.attachments.map((attachment) => attachment.id),
+      });
+      const requestIdentity = resolvePromptRequestIdentity(signature, retryRequestRef.current);
+      retryRequestRef.current = requestIdentity;
+      const result = await sendPrompt(
+        content,
+        selectedModel,
+        reasoningEffort,
+        attachments,
+        requestIdentity.clientRequestId
+      );
+      if (!result.ok) {
+        setSubmitError(
+          result.message ??
+            (result.reason === "timeout"
+              ? "Confirmation timed out. Retry while this page is open to reuse the same request."
+              : result.reason === "disconnected"
+                ? "Disconnected before confirmation. Retry on this page after reconnecting."
+                : "The prompt could not be queued.")
+        );
+        return;
+      }
+
+      retryRequestRef.current = null;
+      setPrompt("");
+      sessionAttachments.clearAttachments();
+      mutate(isUnarchivedSessionListKey);
+    } finally {
+      submitInFlightRef.current = false;
+      setIsSubmitting(false);
+      if (restoreFocusAfterSubmitRef.current) {
+        restoreFocusAfterSubmitRef.current = false;
+        requestAnimationFrame(() => {
+          if (document.activeElement === document.body) inputRef.current?.focus();
+        });
+      }
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPrompt(e.target.value);
+    setSubmitError(null);
+    retryRequestRef.current = null;
+
+    clearTypingTimeout();
+    typingTimeoutRef.current = setTimeout(() => {
+      sendTyping();
+    }, 300);
+  };
+
+  const restorePrompt = useCallback(
+    (content: string) =>
+      restoreQueuedPrompt({
+        content,
+        currentPrompt: promptRef.current,
+        hasAttachments: hasAttachments(),
+        setPrompt,
+        input: inputRef.current,
+      }),
+    [hasAttachments, setPrompt]
+  );
+
+  return {
+    prompt,
+    sessionAttachments,
+    inputRef,
+    isSubmitting,
+    submitError,
+    setSubmitError,
+    handleSubmit,
+    handleInputChange,
+    handleKeyDown,
+    restorePrompt,
+  };
+}


### PR DESCRIPTION
## Summary

- keep the session prompt textarea, attachments, and model controls editable while the WebSocket subscription is connecting
- disable only prompt submission until the socket is ready
- guard the submit handler itself so keyboard submission cannot bypass connection readiness
- add regression coverage for editing a draft during the connecting state

## Validation

- `npm test -w @open-inspect/web` (133 files, 1,016 tests)
- `npm run typecheck -w @open-inspect/web`
- `NODE_ENV=production npm run build -w @open-inspect/web`
- focused ESLint and Prettier checks
- visual verification at 1512x982: artifact `baf73b433e035883487a05063419191a`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1f2c666b401f0a82e4437bee05675f9d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session connection handling so drafts, attachments, and model or reasoning selections remain available while connecting.
  * Sending is now disabled until the session is ready, preventing premature submissions.
  * Improved prompt input handling, including attachment uploads, retries, queued prompts, typing indicators, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->