### PR TITLE
fix: stop prior sandbox before replacement

### DIFF
--- a/packages/control-plane/src/sandbox/daytona-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/daytona-rest-client.test.ts
@@ -175,6 +175,20 @@ describe("DaytonaRestClient", () => {
     });
   });
 
+  describe("deleteSandbox", () => {
+    it("sends DELETE /sandbox/{id}", async () => {
+      const client = new DaytonaRestClient(defaultConfig);
+      fetchSpy.mockResolvedValue(emptyResponse(204));
+
+      await client.deleteSandbox("sb-1");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://daytona.test/api/sandbox/sb-1",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+
   describe("recoverSandbox", () => {
     it("sends POST /sandbox/{id}/recover", async () => {
       const client = new DaytonaRestClient(defaultConfig);

--- a/packages/control-plane/src/sandbox/daytona-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/daytona-rest-client.test.ts
@@ -187,6 +187,18 @@ describe("DaytonaRestClient", () => {
         expect.objectContaining({ method: "DELETE" })
       );
     });
+
+    it("combines a caller abort signal with the request timeout", async () => {
+      const client = new DaytonaRestClient(defaultConfig);
+      const controller = new AbortController();
+      controller.abort();
+      fetchSpy.mockResolvedValue(emptyResponse(204));
+
+      await client.deleteSandbox("sb-1", controller.signal);
+
+      expect(fetchSpy.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+      expect(fetchSpy.mock.calls[0][1].signal.aborted).toBe(true);
+    });
   });
 
   describe("recoverSandbox", () => {

--- a/packages/control-plane/src/sandbox/daytona-rest-client.ts
+++ b/packages/control-plane/src/sandbox/daytona-rest-client.ts
@@ -37,6 +37,7 @@ const TIMEOUT_CREATE_MS = 90_000;
 const TIMEOUT_START_MS = 60_000;
 const TIMEOUT_RECOVER_MS = 60_000;
 const TIMEOUT_STOP_MS = 30_000;
+const TIMEOUT_DELETE_MS = 30_000;
 const TIMEOUT_GET_MS = 15_000;
 const TIMEOUT_PREVIEW_URL_MS = 15_000;
 
@@ -151,6 +152,10 @@ export class DaytonaRestClient {
     await this.requestVoid("POST", `/sandbox/${id}/stop`, TIMEOUT_STOP_MS);
   }
 
+  async deleteSandbox(id: string): Promise<void> {
+    await this.requestVoid("DELETE", `/sandbox/${id}`, TIMEOUT_DELETE_MS);
+  }
+
   async recoverSandbox(id: string): Promise<void> {
     await this.requestVoid("POST", `/sandbox/${id}/recover`, TIMEOUT_RECOVER_MS);
   }
@@ -203,7 +208,7 @@ export class DaytonaRestClient {
    * discarded, so neither shape can fail the call.
    */
   private requestVoid(
-    method: "GET" | "POST",
+    method: "DELETE" | "GET" | "POST",
     path: string,
     timeoutMs: number,
     options?: { body?: unknown }
@@ -237,7 +242,7 @@ export class DaytonaRestClient {
    * `consume`. The timeout stays armed while `consume` reads the body.
    */
   private async send<T>(
-    method: "GET" | "POST",
+    method: "DELETE" | "GET" | "POST",
     path: string,
     timeoutMs: number,
     options: { body?: unknown } | undefined,

--- a/packages/control-plane/src/sandbox/daytona-rest-client.ts
+++ b/packages/control-plane/src/sandbox/daytona-rest-client.ts
@@ -152,8 +152,8 @@ export class DaytonaRestClient {
     await this.requestVoid("POST", `/sandbox/${id}/stop`, TIMEOUT_STOP_MS);
   }
 
-  async deleteSandbox(id: string): Promise<void> {
-    await this.requestVoid("DELETE", `/sandbox/${id}`, TIMEOUT_DELETE_MS);
+  async deleteSandbox(id: string, signal?: AbortSignal): Promise<void> {
+    await this.requestVoid("DELETE", `/sandbox/${id}`, TIMEOUT_DELETE_MS, { signal });
   }
 
   async recoverSandbox(id: string): Promise<void> {
@@ -195,7 +195,7 @@ export class DaytonaRestClient {
     path: string,
     timeoutMs: number,
     schema: z.ZodType<T>,
-    options?: { body?: unknown }
+    options?: { body?: unknown; signal?: AbortSignal }
   ): Promise<T> {
     return this.send(method, path, timeoutMs, options, async (response) =>
       this.parseJson(schema, await response.text(), response.status)
@@ -211,7 +211,7 @@ export class DaytonaRestClient {
     method: "DELETE" | "GET" | "POST",
     path: string,
     timeoutMs: number,
-    options?: { body?: unknown }
+    options?: { body?: unknown; signal?: AbortSignal }
   ): Promise<void> {
     return this.send<void>(method, path, timeoutMs, options, () => {});
   }
@@ -245,7 +245,7 @@ export class DaytonaRestClient {
     method: "DELETE" | "GET" | "POST",
     path: string,
     timeoutMs: number,
-    options: { body?: unknown } | undefined,
+    options: { body?: unknown; signal?: AbortSignal } | undefined,
     consume: (response: Response) => T | Promise<T>
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
@@ -256,7 +256,9 @@ export class DaytonaRestClient {
       const init: RequestInit = {
         method,
         headers: this.getHeaders(),
-        signal: controller.signal,
+        signal: options?.signal
+          ? AbortSignal.any([controller.signal, options.signal])
+          : controller.signal,
       };
       if (options?.body !== undefined) {
         init.body = JSON.stringify(options.body);

--- a/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
@@ -137,6 +137,18 @@ describe("E2BRestClient", () => {
     await expect(client.killSandbox("sb-1")).resolves.toBeUndefined();
   });
 
+  it("combines a kill caller signal with the request timeout", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    const controller = new AbortController();
+    controller.abort();
+    fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await client.killSandbox("sb-1", controller.signal);
+
+    expect(fetchSpy.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    expect(fetchSpy.mock.calls[0][1].signal.aborted).toBe(true);
+  });
+
   it("rejects malformed E2B success responses", async () => {
     const client = new E2BRestClient(defaultConfig);
     fetchSpy.mockResolvedValue(jsonResponse({ sandboxID: "sb-1" }));

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -235,8 +235,8 @@ export class E2BRestClient {
     });
   }
 
-  async killSandbox(id: string): Promise<void> {
-    await this.requestVoid("DELETE", `/sandboxes/${id}`, TIMEOUT_KILL_MS);
+  async killSandbox(id: string, signal?: AbortSignal): Promise<void> {
+    await this.requestVoid("DELETE", `/sandboxes/${id}`, TIMEOUT_KILL_MS, { signal });
   }
 
   async setSandboxTimeout(id: string, timeoutSeconds: number): Promise<void> {
@@ -265,7 +265,7 @@ export class E2BRestClient {
     path: string,
     timeoutMs: number,
     schema: z.ZodType<T>,
-    options?: { body?: unknown }
+    options?: { body?: unknown; signal?: AbortSignal }
   ): Promise<T> {
     return this.send(method, path, timeoutMs, options, async (response) => {
       const contentType = response.headers.get("content-type") ?? "";
@@ -289,7 +289,7 @@ export class E2BRestClient {
     method: "GET" | "POST" | "DELETE",
     path: string,
     timeoutMs: number,
-    options?: { body?: unknown }
+    options?: { body?: unknown; signal?: AbortSignal }
   ): Promise<void> {
     return this.send<void>(method, path, timeoutMs, options, () => {});
   }
@@ -303,7 +303,7 @@ export class E2BRestClient {
     method: "GET" | "POST" | "DELETE",
     path: string,
     timeoutMs: number,
-    options: { body?: unknown } | undefined,
+    options: { body?: unknown; signal?: AbortSignal } | undefined,
     consume: (response: Response) => T | Promise<T>
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
@@ -314,7 +314,9 @@ export class E2BRestClient {
       const init: RequestInit = {
         method,
         headers: this.getHeaders(),
-        signal: controller.signal,
+        signal: options?.signal
+          ? AbortSignal.any([controller.signal, options.signal])
+          : controller.signal,
       };
       if (options?.body !== undefined) init.body = JSON.stringify(options.body);
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -495,6 +495,91 @@ describe("SandboxLifecycleManager", () => {
       ).toBe(true);
     });
 
+    it.each(["spawn", "restore"] as const)(
+      "stops the prior provider sandbox before %s overwrites its handle",
+      async (kind) => {
+        const calls: string[] = [];
+        const sandbox = createMockSandbox({
+          status: kind === "spawn" ? "pending" : "stopped",
+          snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+          created_at: Date.now() - 60000,
+        });
+        const storage = createMockStorage(createMockSession(), sandbox);
+        vi.mocked(storage.updateSandboxForSpawn).mockImplementation(() => {
+          calls.push("overwrite");
+        });
+        const stopSandbox = vi.fn(async () => {
+          calls.push("stop");
+          return { success: true };
+        });
+        const provider = createMockProvider({
+          capabilities: { supportsExplicitStop: true },
+          stopSandbox,
+        });
+        const manager = new SandboxLifecycleManager(
+          provider,
+          storage,
+          createMockBroadcaster(),
+          createMockWebSocketManager(false),
+          createMockAlarmScheduler(),
+          createMockIdGenerator(),
+          createTestConfig()
+        );
+
+        await manager.spawnSandbox();
+
+        expect(calls.slice(0, 2)).toEqual(["stop", "overwrite"]);
+        expect(stopSandbox).toHaveBeenCalledWith({
+          providerObjectId: "modal-obj-123",
+          sessionId: "test-session",
+          reason: "respawn",
+        });
+      }
+    );
+
+    it.each(["spawn", "restore"] as const)(
+      "continues %s when stopping the prior provider sandbox fails",
+      async (kind) => {
+        const sandbox = createMockSandbox({
+          status: kind === "spawn" ? "pending" : "stopped",
+          snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+          created_at: Date.now() - 60000,
+        });
+        const storage = createMockStorage(createMockSession(), sandbox);
+        const provider = createMockProvider({
+          capabilities: { supportsExplicitStop: true },
+          stopSandbox: vi.fn(async () => {
+            throw new Error("provider unavailable");
+          }),
+        });
+        const manager = new SandboxLifecycleManager(
+          provider,
+          storage,
+          createMockBroadcaster(),
+          createMockWebSocketManager(false),
+          createMockAlarmScheduler(),
+          createMockIdGenerator(),
+          createTestConfig()
+        );
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        await manager.spawnSandbox();
+
+        expect(storage.updateSandboxForSpawn).toHaveBeenCalledOnce();
+        expect(
+          kind === "spawn" ? provider.createSandbox : provider.restoreFromSnapshot
+        ).toHaveBeenCalledOnce();
+        expect(storage.updateSandboxStatus).toHaveBeenCalledWith("connecting");
+        expect(parseStructuredLogs(warnSpy)).toContainEqual(
+          expect.objectContaining({
+            msg: "Provider stop failed before sandbox replacement",
+            error: "provider unavailable",
+          })
+        );
+        warnSpy.mockRestore();
+      }
+    );
+
     it("stores VNC access without publishing it before the sandbox is ready", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(createMockSession({ vnc_enabled: 1 }), sandbox);

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -146,10 +146,10 @@ function createMockStorage(
         sandbox.auth_token_hash = data.authTokenHash;
         sandbox.auth_token = null;
         sandbox.modal_sandbox_id = data.modalSandboxId;
-        sandbox.modal_object_id = null;
+        if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
       }
     }),
-    updateSandboxModalObjectId: vi.fn((id: string) => {
+    updateSandboxModalObjectId: vi.fn((id: string | null) => {
       calls.push(`updateSandboxModalObjectId:${id}`);
       if (sandbox) sandbox.modal_object_id = id;
     }),
@@ -505,11 +505,19 @@ describe("SandboxLifecycleManager", () => {
           created_at: Date.now() - 60000,
         });
         const storage = createMockStorage(createMockSession(), sandbox);
-        vi.mocked(storage.updateSandboxForSpawn).mockImplementation(() => {
-          calls.push("overwrite");
+        vi.mocked(storage.updateSandboxForSpawn).mockImplementation((data) => {
+          calls.push("fence");
+          sandbox.status = data.status;
+          sandbox.auth_token_hash = data.authTokenHash;
+          sandbox.modal_sandbox_id = data.modalSandboxId;
+        });
+        vi.mocked(storage.updateSandboxModalObjectId).mockImplementation((id) => {
+          calls.push("clear");
+          sandbox.modal_object_id = id;
         });
         const stopSandbox = vi.fn(async () => {
           calls.push("stop");
+          expect(sandbox.modal_object_id).toBe("modal-obj-123");
           return { success: true };
         });
         const provider = createMockProvider({
@@ -528,12 +536,15 @@ describe("SandboxLifecycleManager", () => {
 
         await manager.spawnSandbox();
 
-        expect(calls.slice(0, 2)).toEqual(["stop", "overwrite"]);
-        expect(stopSandbox).toHaveBeenCalledWith({
-          providerObjectId: "modal-obj-123",
-          sessionId: "test-session",
-          reason: "respawn",
-        });
+        expect(calls.slice(0, 3)).toEqual(["fence", "stop", "clear"]);
+        expect(stopSandbox).toHaveBeenCalledWith(
+          expect.objectContaining({
+            providerObjectId: "modal-obj-123",
+            sessionId: "test-session",
+            reason: "respawn",
+            signal: expect.any(AbortSignal),
+          })
+        );
       }
     );
 
@@ -548,6 +559,11 @@ describe("SandboxLifecycleManager", () => {
         const storage = createMockStorage(createMockSession(), sandbox);
         const provider = createMockProvider({
           capabilities: { supportsExplicitStop: true },
+          createSandbox: vi.fn(async (config) => ({
+            sandboxId: config.sandboxId,
+            status: "connecting",
+            createdAt: Date.now(),
+          })),
           stopSandbox: vi.fn(async () => {
             throw new Error("provider unavailable");
           }),
@@ -566,6 +582,7 @@ describe("SandboxLifecycleManager", () => {
         await manager.spawnSandbox();
 
         expect(storage.updateSandboxForSpawn).toHaveBeenCalledOnce();
+        expect(sandbox.modal_object_id).toBe("modal-obj-123");
         expect(
           kind === "spawn" ? provider.createSandbox : provider.restoreFromSnapshot
         ).toHaveBeenCalledOnce();
@@ -579,6 +596,51 @@ describe("SandboxLifecycleManager", () => {
         warnSpy.mockRestore();
       }
     );
+
+    it("continues replacement when stopping the prior provider sandbox times out", async () => {
+      vi.useFakeTimers();
+      try {
+        const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+        const storage = createMockStorage(createMockSession(), sandbox);
+        const provider = createMockProvider({
+          capabilities: { supportsExplicitStop: true },
+          createSandbox: vi.fn(async (config) => ({
+            sandboxId: config.sandboxId,
+            status: "connecting",
+            createdAt: Date.now(),
+          })),
+          stopSandbox: vi.fn(() => new Promise<StopResult>(() => {})),
+        });
+        const manager = new SandboxLifecycleManager(
+          provider,
+          storage,
+          createMockBroadcaster(),
+          createMockWebSocketManager(false),
+          createMockAlarmScheduler(),
+          createMockIdGenerator(),
+          createTestConfig()
+        );
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        const spawning = manager.spawnSandbox();
+        await vi.waitFor(() => expect(provider.stopSandbox).toHaveBeenCalledOnce());
+        await vi.advanceTimersByTimeAsync(10_000);
+        await spawning;
+
+        expect(provider.createSandbox).toHaveBeenCalledOnce();
+        expect(storage.updateSandboxStatus).toHaveBeenCalledWith("connecting");
+        expect(sandbox.modal_object_id).toBe("modal-obj-123");
+        expect(parseStructuredLogs(warnSpy)).toContainEqual(
+          expect.objectContaining({
+            msg: "Provider stop failed before sandbox replacement",
+            error: "Provider stop timed out before sandbox replacement",
+          })
+        );
+        warnSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
 
     it("stores VNC access without publishing it before the sandbox is ready", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -429,6 +429,8 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const hasRepository = sessionHasRepository(session);
       let expectedSandboxId = buildSandboxIdForSession(session, now);
 
+      await this.stopPriorProviderSandbox();
+
       // Store expected sandbox ID and auth token BEFORE calling provider
       this.storage.updateSandboxForSpawn({
         status: "spawning",
@@ -744,6 +746,8 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
       const expectedSandboxId = buildSandboxIdForSession(session, now);
 
+      await this.stopPriorProviderSandbox();
+
       // Store expected sandbox ID and auth token
       this.storage.updateSandboxForSpawn({
         status: "spawning",
@@ -1043,6 +1047,23 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    */
   private usesProviderManagedStop(): boolean {
     return this.canStopProviderSandbox() && !!this.provider.capabilities.supportsPersistentResume;
+  }
+
+  /**
+   * Stop a sandbox that is about to be replaced before its provider handle is cleared.
+   */
+  private async stopPriorProviderSandbox(): Promise<void> {
+    if (!this.canStopProviderSandbox()) {
+      return;
+    }
+
+    try {
+      await this.stopProviderSandbox("respawn");
+    } catch (error) {
+      this.log.warn("Provider stop failed before sandbox replacement", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -59,6 +59,7 @@ const log = createLogger("lifecycle-manager");
 
 /** TTL for terminal auth JWTs (24 hours, matching typical sandbox lifetime). */
 const TERMINAL_TOKEN_TTL_SECONDS = 86400;
+const PROVIDER_REPLACEMENT_STOP_TIMEOUT_MS = 10_000;
 
 // ==================== Dependency Interfaces ====================
 
@@ -101,11 +102,12 @@ export interface SandboxStorage {
     createdAt: number;
     authTokenHash: string;
     modalSandboxId: string;
+    preserveProviderObjectId?: boolean;
   }): void;
   /** Update sandbox state for in-place resume without rotating auth/token identity */
   updateSandboxForResume?(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
-  updateSandboxModalObjectId(modalObjectId: string): void;
+  updateSandboxModalObjectId(modalObjectId: string | null): void;
   /** Update sandbox snapshot image ID */
   updateSandboxSnapshotImageId(sandboxId: string, imageId: string): void;
   /** Update last activity timestamp */
@@ -428,17 +430,19 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       let sandboxAuthToken = this.idGenerator.generateId();
       const hasRepository = sessionHasRepository(session);
       let expectedSandboxId = buildSandboxIdForSession(session, now);
-
-      await this.stopPriorProviderSandbox();
+      const authTokenHash = await hashToken(sandboxAuthToken);
 
       // Store expected sandbox ID and auth token BEFORE calling provider
       this.storage.updateSandboxForSpawn({
         status: "spawning",
         createdAt: now,
-        authTokenHash: await hashToken(sandboxAuthToken),
+        authTokenHash,
         modalSandboxId: expectedSandboxId,
+        preserveProviderObjectId: true,
       });
       this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
+
+      await this.stopPriorProviderSandbox();
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
@@ -746,16 +750,17 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
       const expectedSandboxId = buildSandboxIdForSession(session, now);
 
-      await this.stopPriorProviderSandbox();
-
       // Store expected sandbox ID and auth token
       this.storage.updateSandboxForSpawn({
         status: "spawning",
         createdAt: now,
         authTokenHash: sandboxAuthTokenHash,
         modalSandboxId: expectedSandboxId,
+        preserveProviderObjectId: true,
       });
       this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
+
+      await this.stopPriorProviderSandbox();
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
@@ -1053,16 +1058,37 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * Stop a sandbox that is about to be replaced before its provider handle is cleared.
    */
   private async stopPriorProviderSandbox(): Promise<void> {
-    if (!this.canStopProviderSandbox()) {
+    const providerObjectId = this.storage.getSandbox()?.modal_object_id;
+    if (!providerObjectId) {
       return;
     }
 
+    if (!this.canStopProviderSandbox()) {
+      this.storage.updateSandboxModalObjectId(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
-      await this.stopProviderSandbox("respawn");
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          controller.abort();
+          reject(new Error("Provider stop timed out before sandbox replacement"));
+        }, PROVIDER_REPLACEMENT_STOP_TIMEOUT_MS);
+      });
+      await Promise.race([
+        this.stopProviderSandbox("respawn", controller.signal, providerObjectId),
+        timeout,
+      ]);
+      this.storage.updateSandboxModalObjectId(null);
     } catch (error) {
       this.log.warn("Provider stop failed before sandbox replacement", {
+        provider_object_id: providerObjectId,
         error: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
     }
   }
 
@@ -1097,21 +1123,27 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * Stop a provider-managed sandbox via its API.
    */
-  private async stopProviderSandbox(reason: string): Promise<void> {
+  private async stopProviderSandbox(
+    reason: string,
+    signal?: AbortSignal,
+    providerObjectId?: string
+  ): Promise<void> {
     if (!this.provider.stopSandbox) {
       return;
     }
 
-    const sandbox = this.storage.getSandbox();
+    const sandbox = providerObjectId ? null : this.storage.getSandbox();
     const session = this.storage.getSession();
-    if (!sandbox?.modal_object_id || !session) {
+    const objectId = providerObjectId ?? sandbox?.modal_object_id;
+    if (!objectId || !session) {
       return;
     }
 
     const result = await this.provider.stopSandbox({
-      providerObjectId: sandbox.modal_object_id,
+      providerObjectId: objectId,
       sessionId: session.session_name || session.id,
       reason,
+      signal,
     });
 
     if (!result.success) {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -1071,7 +1071,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     const controller = new AbortController();
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
-      const timeout = new Promise<never>((_, reject) => {
+      const stopTimeoutPromise = new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           controller.abort();
           reject(new Error("Provider stop timed out before sandbox replacement"));
@@ -1079,7 +1079,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
       await Promise.race([
         this.stopProviderSandbox("respawn", controller.signal, providerObjectId),
-        timeout,
+        stopTimeoutPromise,
       ]);
       this.storage.updateSandboxModalObjectId(null);
     } catch (error) {

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -37,6 +37,7 @@ function createMockClient(
     getSandbox: (id: string) => Promise<DaytonaSandboxResponse>;
     startSandbox: (id: string) => Promise<void>;
     stopSandbox: (id: string) => Promise<void>;
+    deleteSandbox: (id: string) => Promise<void>;
     recoverSandbox: (id: string) => Promise<void>;
     getSignedPreviewUrl: (
       id: string,
@@ -62,6 +63,7 @@ function createMockClient(
     ),
     startSandbox: vi.fn(async () => {}),
     stopSandbox: vi.fn(async () => {}),
+    deleteSandbox: vi.fn(async () => {}),
     recoverSandbox: vi.fn(async () => {}),
     getSignedPreviewUrl: vi.fn(
       async (): Promise<DaytonaSignedPreviewUrlResponse> => ({
@@ -561,6 +563,17 @@ describe("DaytonaSandboxProvider", () => {
 
       expect(result.success).toBe(true);
       expect(client.stopSandbox).toHaveBeenCalledWith("daytona-sandbox-id");
+    });
+
+    it("deletes sandbox on replacement", async () => {
+      const client = createMockClient();
+      const provider = new DaytonaSandboxProvider(client, defaultProviderConfig);
+
+      const result = await provider.stopSandbox({ ...baseStopConfig, reason: "respawn" });
+
+      expect(result.success).toBe(true);
+      expect(client.deleteSandbox).toHaveBeenCalledWith("daytona-sandbox-id");
+      expect(client.stopSandbox).not.toHaveBeenCalled();
     });
 
     it("returns success when sandbox not found (already gone)", async () => {

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -568,11 +568,12 @@ describe("DaytonaSandboxProvider", () => {
     it("deletes sandbox on replacement", async () => {
       const client = createMockClient();
       const provider = new DaytonaSandboxProvider(client, defaultProviderConfig);
+      const signal = AbortSignal.timeout(1_000);
 
-      const result = await provider.stopSandbox({ ...baseStopConfig, reason: "respawn" });
+      const result = await provider.stopSandbox({ ...baseStopConfig, reason: "respawn", signal });
 
       expect(result.success).toBe(true);
-      expect(client.deleteSandbox).toHaveBeenCalledWith("daytona-sandbox-id");
+      expect(client.deleteSandbox).toHaveBeenCalledWith("daytona-sandbox-id", signal);
       expect(client.stopSandbox).not.toHaveBeenCalled();
     });
 

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -186,7 +186,11 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   async stopSandbox(config: StopConfig): Promise<StopResult> {
     try {
       try {
-        await this.client.stopSandbox(config.providerObjectId);
+        if (config.reason === "respawn") {
+          await this.client.deleteSandbox(config.providerObjectId);
+        } else {
+          await this.client.stopSandbox(config.providerObjectId);
+        }
       } catch (error) {
         if (error instanceof DaytonaNotFoundError) {
           return { success: true };
@@ -196,7 +200,10 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       return { success: true };
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
-      throw this.classifyError("Failed to stop Daytona sandbox", error);
+      throw this.classifyError(
+        `Failed to ${config.reason === "respawn" ? "delete" : "stop"} Daytona sandbox`,
+        error
+      );
     }
   }
 

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -187,7 +187,10 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     try {
       try {
         if (config.reason === "respawn") {
-          await this.client.deleteSandbox(config.providerObjectId);
+          await this.client.deleteSandbox(
+            config.providerObjectId,
+            ...(config.signal ? [config.signal] : [])
+          );
         } else {
           await this.client.stopSandbox(config.providerObjectId);
         }

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -223,6 +223,20 @@ describe("E2BSandboxProvider", () => {
     }
   );
 
+  it("forwards the caller signal when killing a replaced sandbox", async () => {
+    const client = mockClient();
+    const signal = AbortSignal.timeout(1_000);
+
+    await new E2BSandboxProvider(client, providerConfig).stopSandbox({
+      providerObjectId: "x",
+      sessionId: "s",
+      reason: "respawn",
+      signal,
+    });
+
+    expect(client.killSandbox).toHaveBeenCalledWith("x", signal);
+  });
+
   it("resumeSandbox: 404 during connect (post-GET race) returns shouldSpawnFresh", async () => {
     const client = mockClient({
       getSandbox: vi.fn(async () => ({ sandboxID: "e2b-id", templateID: "tmpl", state: "paused" })),

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -208,17 +208,20 @@ describe("E2BSandboxProvider", () => {
     }
   });
 
-  it("stopSandbox KILLS on connecting_timeout (terminal, non-resumable)", async () => {
-    const client = mockClient();
-    const res = await new E2BSandboxProvider(client, providerConfig).stopSandbox({
-      providerObjectId: "x",
-      sessionId: "s",
-      reason: "connecting_timeout",
-    });
-    expect(res.success).toBe(true);
-    expect(client.killSandbox).toHaveBeenCalledWith("x");
-    expect(client.pauseSandbox).not.toHaveBeenCalled();
-  });
+  it.each(["connecting_timeout", "respawn"])(
+    "stopSandbox KILLS on terminal reason %s",
+    async (reason) => {
+      const client = mockClient();
+      const res = await new E2BSandboxProvider(client, providerConfig).stopSandbox({
+        providerObjectId: "x",
+        sessionId: "s",
+        reason,
+      });
+      expect(res.success).toBe(true);
+      expect(client.killSandbox).toHaveBeenCalledWith("x");
+      expect(client.pauseSandbox).not.toHaveBeenCalled();
+    }
+  );
 
   it("resumeSandbox: 404 during connect (post-GET race) returns shouldSpawnFresh", async () => {
     const client = mockClient({

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -59,10 +59,10 @@ export class E2BSandboxProvider implements SandboxProvider {
   readonly name = "e2b";
 
   /**
-   * Stop reasons that are terminal (the manager sets the session `failed` and
-   * never resumes it) — kill instead of pausing to avoid orphaning a sandbox.
+   * Stop reasons after which the provider object cannot be resumed, including
+   * replacement by a newly-created sandbox.
    */
-  private static readonly TERMINAL_STOP_REASONS = new Set(["connecting_timeout"]);
+  private static readonly TERMINAL_STOP_REASONS = new Set(["connecting_timeout", "respawn"]);
 
   readonly capabilities: SandboxProviderCapabilities = {
     supportsSandboxTimeout: true,

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -258,7 +258,10 @@ export class E2BSandboxProvider implements SandboxProvider {
     try {
       try {
         if (terminal) {
-          await this.client.killSandbox(config.providerObjectId);
+          await this.client.killSandbox(
+            config.providerObjectId,
+            ...(config.signal ? [config.signal] : [])
+          );
         } else {
           await this.client.pauseSandbox(config.providerObjectId);
         }

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -962,4 +962,29 @@ describe("OpenComputerSandboxProvider", () => {
 
     expect(client.hibernateSandbox).toHaveBeenCalledWith("oc-sandbox-1");
   });
+
+  it("deletes sandboxes on replacement", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      sandboxAccessPasswordSecret: "secret",
+    });
+    const signal = AbortSignal.timeout(1_000);
+
+    await expect(
+      provider.stopSandbox({
+        providerObjectId: "oc-sandbox-1",
+        sessionId: "session-1",
+        reason: "respawn",
+        signal,
+      })
+    ).resolves.toEqual({ success: true });
+
+    expect(client.deleteSandbox).toHaveBeenCalledWith(
+      "oc-sandbox-1",
+      { deleteSecretStore: true },
+      signal
+    );
+    expect(client.hibernateSandbox).not.toHaveBeenCalled();
+  });
 });

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -318,7 +318,15 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
   async stopSandbox(config: StopConfig): Promise<StopResult> {
     try {
       try {
-        await this.client.hibernateSandbox(config.providerObjectId);
+        if (config.reason === "respawn") {
+          await this.client.deleteSandbox(
+            config.providerObjectId,
+            { deleteSecretStore: true },
+            ...(config.signal ? [config.signal] : [])
+          );
+        } else {
+          await this.client.hibernateSandbox(config.providerObjectId);
+        }
       } catch (error) {
         if (error instanceof OpenComputerNotFoundError) return { success: true };
         throw error;
@@ -326,7 +334,10 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       return { success: true };
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
-      throw this.classifyError("Failed to hibernate OpenComputer sandbox", error);
+      throw this.classifyError(
+        `Failed to ${config.reason === "respawn" ? "delete" : "hibernate"} OpenComputer sandbox`,
+        error
+      );
     }
   }
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -88,6 +88,18 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].query).toContain("vnc_password = NULL");
       expect(mock.calls[0].params).toEqual(["spawning", 1000, "token-hash-123", "modal-sb-1"]);
     });
+
+    it("can preserve the provider object ID while fencing a replacement", () => {
+      repository.updateSandboxForSpawn({
+        status: "spawning",
+        createdAt: 123,
+        authTokenHash: "hash",
+        modalSandboxId: "sandbox-new",
+        preserveProviderObjectId: true,
+      });
+
+      expect(mock.calls[0].query).toContain("modal_object_id = modal_object_id");
+    });
   });
 
   describe("updateSandboxModalObjectId", () => {

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -27,6 +27,7 @@ export interface SpawnSandboxData {
   createdAt: number;
   authTokenHash: string;
   modalSandboxId: string;
+  preserveProviderObjectId?: boolean;
 }
 
 /** Data for updating a sandbox during an in-place resume. */
@@ -83,7 +84,7 @@ export class SandboxRepository {
          auth_token_hash = ?,
          auth_token = NULL,
          modal_sandbox_id = ?,
-         modal_object_id = NULL,
+         modal_object_id = ${data.preserveProviderObjectId ? "modal_object_id" : "NULL"},
          code_server_url = NULL,
          code_server_password = NULL,
          vnc_url = NULL,
@@ -111,7 +112,7 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxModalObjectId(modalObjectId: string): void {
+  updateSandboxModalObjectId(modalObjectId: string | null): void {
     this.sql.exec(
       `UPDATE sandbox SET modal_object_id = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       modalObjectId


### PR DESCRIPTION
## Summary
- stop an existing provider sandbox before fresh spawn clears its provider handle
- apply the same best-effort cleanup before snapshot restore
- log stop failures while allowing replacement startup to continue
- cover ordering and non-fatal failure behavior for both paths

## Validation
- `npm test -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/sandbox/lifecycle/manager.ts packages/control-plane/src/sandbox/lifecycle/manager.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/77120ca554314deacae2fdf037ac449b)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Existing sandbox sessions are now stopped before new sessions are created or restored from snapshots.
  - New spawns and restores continue even if stopping the previous session fails or times out after 10 seconds.
  - Stop failures are recorded as warnings for improved visibility.
  - Sandbox replacements now remove obsolete resources instead of leaving them paused or hibernated.
  - Provider identifiers remain linked correctly during replacement and can be cleared when no longer supported.
  - Sandbox cleanup now supports cancellation, helping replacements respond reliably to interrupted operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->