### PR TITLE
fix: claim queued prompts atomically

### DIFF
--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -145,7 +145,7 @@ function buildQueue() {
       () => null as { id: string; created_at: number } | null
     ),
     getNextPendingMessage: vi.fn(() => null as MessageRow | null),
-    startMessageProcessing: vi.fn(),
+    startMessageProcessing: vi.fn<MessageRepository["startMessageProcessing"]>(() => true),
     updateMessageToProcessing: vi.fn(),
     updateMessageToPending: vi.fn(),
     getParticipantById: vi.fn(() => createParticipant()),
@@ -706,8 +706,12 @@ describe("SessionMessageQueue", () => {
 
     await h.queue.processMessageQueue();
 
-    expect(h.repository.startMessageProcessing).not.toHaveBeenCalled();
-    expect(h.repository.updateMessageToPending).not.toHaveBeenCalled();
+    expect(h.repository.startMessageProcessing).toHaveBeenCalledWith(
+      "msg-unsent",
+      expect.any(Number),
+      expect.objectContaining({ type: "user_message", messageId: "msg-unsent" })
+    );
+    expect(h.repository.updateMessageToPending).toHaveBeenCalledWith("msg-unsent");
     expect(
       h.broadcast.mock.calls.filter(
         ([message]) => message.type === "sandbox_event" && message.event.type === "user_message"
@@ -716,6 +720,20 @@ describe("SessionMessageQueue", () => {
     expect(h.callbackService.notifyStarted).not.toHaveBeenCalled();
     expect(h.sandboxLifecycle.terminateUnresponsiveSandbox).toHaveBeenCalledWith(
       "prompt_dispatch_send_failed"
+    );
+  });
+
+  it("does not dispatch when another worker wins the processing claim", async () => {
+    const h = buildQueue();
+    h.repository.getNextPendingMessage.mockReturnValue(createMessage({ id: "msg-lost" }));
+    h.repository.startMessageProcessing.mockReturnValue(false);
+    h.wsManager.getSandboxSocket.mockReturnValue({ readyState: 1 } as WebSocket);
+
+    await h.queue.processMessageQueue();
+
+    expect(h.wsManager.send).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "processing_status" })
     );
   });
 

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -378,12 +378,22 @@ export class SessionMessageQueue {
       ),
     };
 
+    const claimed = this.messageRepository.startMessageProcessing(
+      message.id,
+      now,
+      userMessageEvent
+    );
+    if (!claimed) {
+      this.log.debug("processMessageQueue: prompt claim lost", { message_id: message.id });
+      return;
+    }
+
     const sent = this.wsManager.send(sandboxWs, command);
 
     if (!sent) {
+      this.messageRepository.updateMessageToPending(message.id);
       await this.sandboxLifecycle.terminateUnresponsiveSandbox("prompt_dispatch_send_failed");
     } else {
-      this.messageRepository.startMessageProcessing(message.id, now, userMessageEvent);
       this.messenger.broadcast({ type: "sandbox_event", event: userMessageEvent });
       this.messenger.broadcast({ type: "processing_status", isProcessing: true });
       this.broadcastPromptQueue();

--- a/packages/control-plane/src/session/message-repository.test.ts
+++ b/packages/control-plane/src/session/message-repository.test.ts
@@ -10,6 +10,7 @@ import type { SqlResult, SqlStorage } from "./sql-storage";
 function createMockSql() {
   const calls: Array<{ query: string; params: unknown[] }> = [];
   const data = new Map<string, unknown[]>();
+  let defaultData: unknown[] = [];
   let oneValue: unknown = null;
   let rowsWritten = 0;
   const sql: SqlStorage = {
@@ -19,7 +20,7 @@ function createMockSql() {
       return {
         toArray: () => {
           consumed = true;
-          return data.get(query) ?? [];
+          return data.get(query) ?? defaultData;
         },
         one: () => oneValue,
         get rowsWritten() {
@@ -33,7 +34,10 @@ function createMockSql() {
     calls,
     setData: (query: string, rows: unknown[]) => data.set(query, rows),
     setOne: (value: unknown) => (oneValue = value),
-    setRowsWritten: (value: number) => (rowsWritten = value),
+    setRowsWritten: (value: number) => {
+      rowsWritten = value;
+      defaultData = Array.from({ length: value }, () => ({}));
+    },
   };
 }
 
@@ -212,22 +216,42 @@ describe("MessageRepository", () => {
   });
 
   it("atomically starts processing and creates the canonical user event", () => {
-    repository.startMessageProcessing("msg-1", 2000, {
-      type: "user_message",
-      content: "Hello",
-      messageId: "msg-1",
-      timestamp: 2,
-      author: { participantId: "p-1", userId: "u-1", name: "User" },
-    });
+    mock.setRowsWritten(1);
+    expect(
+      repository.startMessageProcessing("msg-1", 2000, {
+        type: "user_message",
+        content: "Hello",
+        messageId: "msg-1",
+        timestamp: 2,
+        author: { participantId: "p-1", userId: "u-1", name: "User" },
+      })
+    ).toBe(true);
     expect(transactionSyncCalls).toBe(1);
     expect(mock.calls[0].query).toContain("status = 'processing'");
+    expect(mock.calls[0].query).toContain("status = 'pending'");
+    expect(mock.calls[0].query).toContain("NOT EXISTS");
     expect(mock.calls[1].params[0]).toBe("user_message:msg-1");
   });
 
-  it("returns a processing message to pending", () => {
+  it("does not create a user event when the processing claim is lost", () => {
+    expect(
+      repository.startMessageProcessing("msg-1", 2000, {
+        type: "user_message",
+        content: "Hello",
+        messageId: "msg-1",
+        timestamp: 2,
+        author: { participantId: "p-1", userId: "u-1", name: "User" },
+      })
+    ).toBe(false);
+    expect(mock.calls).toHaveLength(1);
+  });
+
+  it("returns an undispatched processing message to pending and removes its user event", () => {
+    mock.setRowsWritten(1);
     repository.updateMessageToPending("msg-1");
     expect(mock.calls[0].query).toContain("status = 'pending'");
     expect(mock.calls[0].params).toEqual(["msg-1"]);
+    expect(mock.calls[1].params).toEqual(["user_message:msg-1"]);
   });
 
   it("atomically records message completion and its canonical event", () => {

--- a/packages/control-plane/src/session/message-repository.test.ts
+++ b/packages/control-plane/src/session/message-repository.test.ts
@@ -10,7 +10,7 @@ import type { SqlResult, SqlStorage } from "./sql-storage";
 function createMockSql() {
   const calls: Array<{ query: string; params: unknown[] }> = [];
   const data = new Map<string, unknown[]>();
-  let defaultData: unknown[] = [];
+  const matchingData: Array<{ pattern: RegExp; rows: unknown[] }> = [];
   let oneValue: unknown = null;
   let rowsWritten = 0;
   const sql: SqlStorage = {
@@ -20,7 +20,9 @@ function createMockSql() {
       return {
         toArray: () => {
           consumed = true;
-          return data.get(query) ?? defaultData;
+          return (
+            data.get(query) ?? matchingData.find(({ pattern }) => pattern.test(query))?.rows ?? []
+          );
         },
         one: () => oneValue,
         get rowsWritten() {
@@ -33,11 +35,9 @@ function createMockSql() {
     sql,
     calls,
     setData: (query: string, rows: unknown[]) => data.set(query, rows),
+    setMatchingData: (pattern: RegExp, rows: unknown[]) => matchingData.push({ pattern, rows }),
     setOne: (value: unknown) => (oneValue = value),
-    setRowsWritten: (value: number) => {
-      rowsWritten = value;
-      defaultData = Array.from({ length: value }, () => ({}));
-    },
+    setRowsWritten: (value: number) => (rowsWritten = value),
   };
 }
 
@@ -216,7 +216,9 @@ describe("MessageRepository", () => {
   });
 
   it("atomically starts processing and creates the canonical user event", () => {
-    mock.setRowsWritten(1);
+    mock.setMatchingData(/UPDATE messages SET status = 'processing'[\s\S]*RETURNING id/, [
+      { id: "msg-1" },
+    ]);
     expect(
       repository.startMessageProcessing("msg-1", 2000, {
         type: "user_message",
@@ -247,7 +249,9 @@ describe("MessageRepository", () => {
   });
 
   it("returns an undispatched processing message to pending and removes its user event", () => {
-    mock.setRowsWritten(1);
+    mock.setMatchingData(/UPDATE messages SET status = 'pending'[\s\S]*RETURNING id/, [
+      { id: "msg-1" },
+    ]);
     repository.updateMessageToPending("msg-1");
     expect(mock.calls[0].query).toContain("status = 'pending'");
     expect(mock.calls[0].params).toEqual(["msg-1"]);

--- a/packages/control-plane/src/session/message-repository.ts
+++ b/packages/control-plane/src/session/message-repository.ts
@@ -242,13 +242,18 @@ export class MessageRepository {
     messageId: string,
     startedAt: number,
     userMessageEvent: Extract<SandboxEvent, { type: "user_message" }>
-  ): void {
-    this.transactionSync(() => {
-      this.sql.exec(
-        `UPDATE messages SET status = 'processing', started_at = ? WHERE id = ?`,
+  ): boolean {
+    return this.transactionSync(() => {
+      const claimed = this.sql.exec(
+        `UPDATE messages SET status = 'processing', started_at = ?
+         WHERE id = ? AND status = 'pending'
+           AND NOT EXISTS (SELECT 1 FROM messages WHERE status = 'processing')
+         RETURNING id`,
         startedAt,
         messageId
       );
+      if (claimed.toArray().length !== 1) return false;
+
       this.eventRepository.createEvent({
         id: `user_message:${messageId}`,
         type: "user_message",
@@ -256,14 +261,22 @@ export class MessageRepository {
         messageId,
         createdAt: startedAt,
       });
+      return true;
     });
   }
 
   updateMessageToPending(messageId: string): void {
-    this.sql.exec(
-      `UPDATE messages SET status = 'pending', started_at = NULL WHERE id = ? AND status = 'processing'`,
-      messageId
-    );
+    this.transactionSync(() => {
+      const updated = this.sql.exec(
+        `UPDATE messages SET status = 'pending', started_at = NULL
+         WHERE id = ? AND status = 'processing'
+         RETURNING id`,
+        messageId
+      );
+      if (updated.toArray().length === 1) {
+        this.sql.exec(`DELETE FROM events WHERE id = ?`, `user_message:${messageId}`);
+      }
+    });
   }
 
   recordMessageCompletion(

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -431,23 +431,59 @@ describe("applyMigrations", () => {
 
   it("allows only one processing message per session", () => {
     const migration = MIGRATIONS.find((entry) => entry.id === 42);
-    expect(migration?.run).toContain("idx_messages_one_processing");
-    expect(migration?.run).toContain("WHERE status = 'processing'");
+    expect(typeof migration?.run).toBe("function");
 
     const db = new DatabaseSync(":memory:");
     const sql = createDatabaseSql(db);
     try {
-      db.exec("CREATE TABLE messages (id TEXT PRIMARY KEY, status TEXT NOT NULL)");
-      (migration!.run as string)
-        .split(";")
-        .filter(Boolean)
-        .forEach((statement) => sql.exec(statement));
-      db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("first", "processing");
+      db.exec(`CREATE TABLE messages (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        started_at INTEGER
+      )`);
+      db.exec(`CREATE TABLE events (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        message_id TEXT
+      )`);
+      db.prepare(
+        "INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)"
+      ).run("first", "processing", 100, 120);
+      db.prepare(
+        "INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)"
+      ).run("second", "processing", 110, 130);
+      db.prepare("INSERT INTO events (id, type, message_id) VALUES (?, ?, ?)").run(
+        "user_message:first",
+        "user_message",
+        "first"
+      );
+      db.prepare("INSERT INTO events (id, type, message_id) VALUES (?, ?, ?)").run(
+        "user_message:second",
+        "user_message",
+        "second"
+      );
+
+      const run = migration!.run as (sql: SqlStorage) => void;
+      expect(() => run(sql)).not.toThrow();
+      expect(() => run(sql)).not.toThrow();
+
+      expect(db.prepare("SELECT id, status, started_at FROM messages ORDER BY id").all()).toEqual([
+        { id: "first", status: "processing", started_at: 120 },
+        { id: "second", status: "pending", started_at: null },
+      ]);
+      expect(db.prepare("SELECT id FROM events ORDER BY id").all()).toEqual([
+        { id: "user_message:first" },
+      ]);
       expect(() =>
-        db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("second", "processing")
+        db
+          .prepare("INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)")
+          .run("third", "processing", 140, 150)
       ).toThrow();
       expect(() =>
-        db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("queued", "pending")
+        db
+          .prepare("INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)")
+          .run("queued", "pending", 160, null)
       ).not.toThrow();
     } finally {
       db.close();

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -453,6 +453,9 @@ describe("applyMigrations", () => {
       db.prepare(
         "INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)"
       ).run("second", "processing", 110, 130);
+      db.prepare(
+        "INSERT INTO messages (id, status, created_at, started_at) VALUES (?, ?, ?, ?)"
+      ).run("unrelated", "pending", 90, null);
       db.prepare("INSERT INTO events (id, type, message_id) VALUES (?, ?, ?)").run(
         "user_message:first",
         "user_message",
@@ -463,6 +466,11 @@ describe("applyMigrations", () => {
         "user_message",
         "second"
       );
+      db.prepare("INSERT INTO events (id, type, message_id) VALUES (?, ?, ?)").run(
+        "user_message:unrelated",
+        "user_message",
+        "unrelated"
+      );
 
       const run = migration!.run as (sql: SqlStorage) => void;
       expect(() => run(sql)).not.toThrow();
@@ -471,9 +479,11 @@ describe("applyMigrations", () => {
       expect(db.prepare("SELECT id, status, started_at FROM messages ORDER BY id").all()).toEqual([
         { id: "first", status: "processing", started_at: 120 },
         { id: "second", status: "pending", started_at: null },
+        { id: "unrelated", status: "pending", started_at: null },
       ]);
       expect(db.prepare("SELECT id FROM events ORDER BY id").all()).toEqual([
         { id: "user_message:first" },
+        { id: "user_message:unrelated" },
       ]);
       expect(() =>
         db

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -410,6 +410,7 @@ describe("applyMigrations", () => {
           "idx_messages_status",
           "idx_messages_author",
           "idx_messages_client_request_id",
+          "idx_messages_one_processing",
         ])
       );
       expectClientRequestIdIndex(db);
@@ -426,5 +427,30 @@ describe("applyMigrations", () => {
     expect(MIGRATIONS.find((entry) => entry.id === 41)?.run).toContain(
       "ADD COLUMN stop_confirmation_deadline INTEGER"
     );
+  });
+
+  it("allows only one processing message per session", () => {
+    const migration = MIGRATIONS.find((entry) => entry.id === 42);
+    expect(migration?.run).toContain("idx_messages_one_processing");
+    expect(migration?.run).toContain("WHERE status = 'processing'");
+
+    const db = new DatabaseSync(":memory:");
+    const sql = createDatabaseSql(db);
+    try {
+      db.exec("CREATE TABLE messages (id TEXT PRIMARY KEY, status TEXT NOT NULL)");
+      (migration!.run as string)
+        .split(";")
+        .filter(Boolean)
+        .forEach((statement) => sql.exec(statement));
+      db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("first", "processing");
+      expect(() =>
+        db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("second", "processing")
+      ).toThrow();
+      expect(() =>
+        db.prepare("INSERT INTO messages (id, status) VALUES (?, ?)").run("queued", "pending")
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
   });
 });

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -542,22 +542,20 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     description: "Allow only one processing message per session",
     run: (sql) => {
       // Preserve the oldest claim as the likely active execution and requeue later claims.
-      sql.exec(`WITH processing_messages AS (
+      const duplicateProcessingMessages = `SELECT id FROM (
           SELECT id, ROW_NUMBER() OVER (
             ORDER BY COALESCE(started_at, created_at), created_at, rowid
           ) AS processing_order
           FROM messages
           WHERE status = 'processing'
-        )
-        UPDATE messages
-        SET status = 'pending', started_at = NULL
-        WHERE id IN (
-          SELECT id FROM processing_messages WHERE processing_order > 1
-        )`);
+        ) WHERE processing_order > 1`;
       sql.exec(`DELETE FROM events
         WHERE type = 'user_message'
           AND id = 'user_message:' || message_id
-          AND message_id IN (SELECT id FROM messages WHERE status = 'pending')`);
+          AND message_id IN (${duplicateProcessingMessages})`);
+      sql.exec(`UPDATE messages
+        SET status = 'pending', started_at = NULL
+        WHERE id IN (${duplicateProcessingMessages})`);
       sql.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_one_processing
         ON messages(status) WHERE status = 'processing'`);
     },

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -540,8 +540,27 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
   {
     id: 42,
     description: "Allow only one processing message per session",
-    run: `CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_one_processing
-      ON messages(status) WHERE status = 'processing'`,
+    run: (sql) => {
+      // Preserve the oldest claim as the likely active execution and requeue later claims.
+      sql.exec(`WITH processing_messages AS (
+          SELECT id, ROW_NUMBER() OVER (
+            ORDER BY COALESCE(started_at, created_at), created_at, rowid
+          ) AS processing_order
+          FROM messages
+          WHERE status = 'processing'
+        )
+        UPDATE messages
+        SET status = 'pending', started_at = NULL
+        WHERE id IN (
+          SELECT id FROM processing_messages WHERE processing_order > 1
+        )`);
+      sql.exec(`DELETE FROM events
+        WHERE type = 'user_message'
+          AND id = 'user_message:' || message_id
+          AND message_id IN (SELECT id FROM messages WHERE status = 'pending')`);
+      sql.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_one_processing
+        ON messages(status) WHERE status = 'processing'`);
+    },
   },
 ];
 

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -199,6 +199,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(status);
 CREATE INDEX IF NOT EXISTS idx_messages_author ON messages(author_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_client_request_id
 ON messages(client_request_id) WHERE client_request_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_one_processing
+ON messages(status) WHERE status = 'processing';
 CREATE INDEX IF NOT EXISTS idx_events_message ON events(message_id);
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
 CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at, id);
@@ -534,6 +536,12 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 41,
     description: "Add dedicated stop confirmation deadline",
     run: `ALTER TABLE messages ADD COLUMN stop_confirmation_deadline INTEGER`,
+  },
+  {
+    id: 42,
+    description: "Allow only one processing message per session",
+    run: `CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_one_processing
+      ON messages(status) WHERE status = 'processing'`,
   },
 ];
 

--- a/packages/control-plane/test/integration/prompt-enqueue.test.ts
+++ b/packages/control-plane/test/integration/prompt-enqueue.test.ts
@@ -185,6 +185,39 @@ describe("POST /internal/prompt", () => {
     sandboxWs!.close();
   });
 
+  it("dispatches exactly one of two concurrent prompts and leaves the other queued", async () => {
+    const name = `prompt-concurrent-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+    const { ws: sandboxWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(sandboxWs).not.toBeNull();
+    sandboxWs!.accept();
+
+    const sandboxMessages = collectMessages(sandboxWs!, { timeoutMs: 500 });
+    const enqueue = (content: string) =>
+      stub.fetch("http://internal/internal/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content, authorId: "user-1", source: "web" }),
+      });
+    const responses = await Promise.all([enqueue("Concurrent A"), enqueue("Concurrent B")]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+
+    const prompts = (await sandboxMessages).filter((message) => message.type === "prompt");
+    expect(prompts).toHaveLength(1);
+    const rows = await queryDO<{ id: string; status: string }>(
+      stub,
+      `SELECT id, status FROM messages ORDER BY created_at ASC, rowid ASC`
+    );
+    expect(rows.map(({ status }) => status).sort()).toEqual(["pending", "processing"]);
+    expect(prompts[0].messageId).toBe(rows.find(({ status }) => status === "processing")?.id);
+
+    sandboxWs!.close();
+  });
+
   it("stores attachments as JSON", async () => {
     const { stub } = await initSession();
     const attachmentId = "attachment-1";


### PR DESCRIPTION
## Why

Prompt dispatch must be exclusive per session because two agents writing concurrently to the same sandbox can silently corrupt the working tree. Previously, exclusivity depended on Durable Object input gates: the queue checked for a processing message, sent the prompt over the sandbox WebSocket, and only then persisted the processing state. Under overlapping writers, failover, or a future non-DO session host, two handlers could both observe an idle session and dispatch before either status write became visible.

This change moves that invariant into SQLite, the shared source of truth. A prompt reaches the sandbox only after its conditional pending-to-processing update succeeds, and a partial unique index guarantees that a session cannot contain two processing messages. This removes a correctness dependency on workerd scheduling and establishes the storage-level safety needed for future session-host changes.

## What Changed

- make the pending-to-processing transition a single conditional SQL claim and gate sandbox dispatch on its returned row
- preserve pending and timeline state when sandbox delivery fails
- add session migration 42 with a partial unique index enforcing one processing message per session
- safely reconcile legacy duplicate processing rows during migration by keeping the earliest claim and requeueing later claims
- add a permanent workerd integration test covering two concurrent prompts to one session

## Verification

- `npm test -w @open-inspect/control-plane` (175 files, 2630 tests)
- `npm run test:integration -w @open-inspect/control-plane` (67 files, 843 tests)
- `npm run typecheck`
- `npm run lint -w @open-inspect/control-plane`

Linear: COL-44

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ef93ee03c6828ced70996ba458b85556)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple prompts are submitted concurrently.
  * Prevented duplicate sandbox dispatches by allowing only one message to process at a time.
  * Failed sandbox sends now return messages to the pending queue.
  * Messages are marked as processing only after a successful claim.
  * Existing processing states are safely normalized during database upgrades.

* **Tests**
  * Added coverage for concurrent submissions, processing conflicts, and failed dispatch recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->