### PR TITLE
Remove redundant settings proxy auth preflight

### DIFF
--- a/packages/control-plane/src/auth/authenticate.test.ts
+++ b/packages/control-plane/src/auth/authenticate.test.ts
@@ -326,6 +326,7 @@ describe("authenticate — compound browser credentials", () => {
   }
 
   it("requires the web sig1 channel and Better Auth session for a browser resource", async () => {
+    const userId = "0123456789abcdef0123456789abcdef";
     const request = await signedRequest({
       service: "web",
       method: "GET",
@@ -335,8 +336,8 @@ describe("authenticate — compound browser credentials", () => {
       },
     });
     const ctx = createUserAuthContext({
-      session: { id: "session-1", userId: "user-1" },
-      user: { id: "user-1" },
+      session: { id: "session-1", userId },
+      user: { id: userId },
     });
 
     const result = await authenticate(request, createEnv(), ctx, {
@@ -345,7 +346,7 @@ describe("authenticate — compound browser credentials", () => {
 
     expect(isAuthError(result)).toBe(false);
     if (isAuthError(result)) return;
-    expect(result.principal).toEqual({ kind: "user", userId: "user-1" });
+    expect(result.principal).toEqual({ kind: "user", userId });
     expect(result.authentication).toEqual({
       mechanism: "browser_session",
       credentialId: "session-1",

--- a/packages/control-plane/src/auth/user/session-authenticator.test.ts
+++ b/packages/control-plane/src/auth/user/session-authenticator.test.ts
@@ -3,16 +3,17 @@ import { authenticateSession, type SessionReader } from "./session-authenticator
 
 describe("authenticateSession", () => {
   it("authenticates a browser session without enumerating provider accounts", async () => {
+    const userId = "0123456789abcdef0123456789abcdef";
     const sessionReader: SessionReader = {
       getSession: vi.fn(async () => ({
-        session: { id: "session-1", userId: "user-1" },
-        user: { id: "user-1" },
+        session: { id: "session-1", userId },
+        user: { id: userId },
       })),
     };
     const headers = new Headers({ Cookie: "openinspect.session_token=session.signature" });
 
     await expect(authenticateSession(sessionReader, headers)).resolves.toEqual({
-      userId: "user-1",
+      userId,
       authentication: {
         mechanism: "browser_session",
         credentialId: "session-1",
@@ -36,13 +37,26 @@ describe("authenticateSession", () => {
   it("rejects a session whose user does not match", async () => {
     const sessionReader: SessionReader = {
       getSession: vi.fn(async () => ({
-        session: { id: "session-1", userId: "user-1" },
-        user: { id: "different-user" },
+        session: { id: "session-1", userId: "0123456789abcdef0123456789abcdef" },
+        user: { id: "11111111111111111111111111111111" },
       })),
     };
 
     await expect(authenticateSession(sessionReader, new Headers())).rejects.toThrow(
       "Better Auth returned a cross-user session"
+    );
+  });
+
+  it("rejects a non-canonical user principal", async () => {
+    const sessionReader: SessionReader = {
+      getSession: vi.fn(async () => ({
+        session: { id: "session-1", userId: "legacy-user" },
+        user: { id: "legacy-user" },
+      })),
+    };
+
+    await expect(authenticateSession(sessionReader, new Headers())).rejects.toThrow(
+      "Better Auth returned a malformed session"
     );
   });
 });

--- a/packages/control-plane/src/auth/user/session-authenticator.ts
+++ b/packages/control-plane/src/auth/user/session-authenticator.ts
@@ -13,6 +13,7 @@
  * Better Auth endpoints remain responsible for session refresh.
  */
 
+import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { z } from "zod";
 import type { AuthenticationContext } from "../principal";
 
@@ -22,7 +23,7 @@ const sessionSchema = z.object({
     userId: z.string().min(1),
   }),
   user: z.object({
-    id: z.string().min(1),
+    id: z.string().refine(isCanonicalUserId),
   }),
 });
 

--- a/packages/web/src/app/api/skills/managed-skills-routes.test.ts
+++ b/packages/web/src/app/api/skills/managed-skills-routes.test.ts
@@ -1,18 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
-import { getServerAuthSession } from "@/lib/server-auth-session";
 import { DELETE, PUT } from "./[id]/route";
 import { GET } from "./route";
 
 vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
-vi.mock("@/lib/server-auth-session", () => ({ getServerAuthSession: vi.fn() }));
 
 describe("managed skills BFF routes", () => {
   beforeEach(() => vi.resetAllMocks());
 
-  it("rejects unauthenticated aggregate updates", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue(null);
+  it("propagates unauthenticated aggregate updates from the control plane", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
     const request = new NextRequest("http://localhost/api/skills/skill-1", {
       method: "PUT",
       body: JSON.stringify({ description: "A skill", body: "Use it" }),
@@ -21,11 +21,11 @@ describe("managed skills BFF routes", () => {
     const response = await PUT(request, { params: Promise.resolve({ id: "skill-1" }) });
 
     expect(response.status).toBe(401);
-    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(controlPlaneUserFetch).toHaveBeenCalledTimes(1);
   });
 
   it("forwards catalog pagination parameters", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ skills: [], hasMore: false, nextCursor: null })
     );
@@ -43,7 +43,6 @@ describe("managed skills BFF routes", () => {
   });
 
   it("forwards the aggregate edit and revision precondition", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ skill: { id: "skill/one" } }, { status: 200 })
     );
@@ -68,7 +67,6 @@ describe("managed skills BFF routes", () => {
   });
 
   it("forwards empty control-plane responses without synthesizing a JSON body", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(new Response(null, { status: 204 }));
     const request = new NextRequest("http://localhost/api/skills/skill-1", {
       method: "DELETE",

--- a/packages/web/src/lib/settings-proxy.test.ts
+++ b/packages/web/src/lib/settings-proxy.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { controlPlaneUserFetch } from "./control-plane";
+import { settingsProxy } from "./settings-proxy";
+
+vi.mock("./control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
+
+describe("settingsProxy", () => {
+  const { GET } = settingsProxy(() => "/settings", "settings");
+
+  beforeEach(() => vi.resetAllMocks());
+
+  it("delegates authentication to the resource request", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
+
+    const response = await GET(new NextRequest("http://localhost/api/settings"), {
+      params: Promise.resolve(undefined),
+    });
+
+    expect(controlPlaneUserFetch).toHaveBeenCalledTimes(1);
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", undefined);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("keeps resource request failures distinct from unauthorized responses", async () => {
+    vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("authentication unavailable"));
+
+    const response = await GET(new NextRequest("http://localhost/api/settings"), {
+      params: Promise.resolve(undefined),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to fetch settings" });
+  });
+});

--- a/packages/web/src/lib/settings-proxy.test.ts
+++ b/packages/web/src/lib/settings-proxy.test.ts
@@ -6,7 +6,7 @@ import { settingsProxy } from "./settings-proxy";
 vi.mock("./control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
 
 describe("settingsProxy", () => {
-  const { GET } = settingsProxy(() => "/settings", "settings");
+  const { GET, POST } = settingsProxy(() => "/settings", "settings");
 
   beforeEach(() => vi.resetAllMocks());
 
@@ -23,6 +23,24 @@ describe("settingsProxy", () => {
     expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", undefined);
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("delegates authentication before malformed mutation JSON is interpreted", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      body: "{malformed",
+    });
+
+    const response = await POST(request, { params: Promise.resolve(undefined) });
+
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", {
+      method: "POST",
+      body: "{malformed",
+    });
+    expect(response.status).toBe(401);
   });
 
   it("keeps resource request failures distinct from unauthorized responses", async () => {

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -47,7 +47,7 @@ export function settingsProxy<P>(
       let init: RequestInit | undefined;
       if (method !== "GET") {
         init = { method };
-        if (method !== "DELETE") init.body = JSON.stringify(await request.json());
+        if (method !== "DELETE") init.body = await request.text();
         if (ifMatch) init.headers = { "If-Match": ifMatch };
       }
       const response = await controlPlaneUserFetch(buildPath(params, request), init);

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 type ProxyMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
@@ -39,11 +38,6 @@ export function settingsProxy<P>(
     context: { params: Promise<P> },
     method: ProxyMethod
   ): Promise<NextResponse> => {
-    const session = await getServerAuthSession();
-    if (!session?.user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const params = await context.params;
 
     try {


### PR DESCRIPTION
## Summary
- remove `getServerAuthSession()` preflights from settings proxy routes
- delegate missing-cookie handling and resource authorization to `controlPlaneUserFetch()` and the control-plane endpoint
- preserve authoritative upstream 401 responses and keep thrown request failures as 500 responses
- add focused coverage for the single resource call and error distinction

## Validation
- `npm test -w @open-inspect/web` (137 files, 1,024 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-cache`
- `npx prettier --check packages/web/src/lib/settings-proxy.ts packages/web/src/lib/settings-proxy.test.ts packages/web/src/app/api/skills/managed-skills-routes.test.ts`
- thermonuclear maintainability review: no in-scope findings

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/279160ca6e2ce4ae03cb47005027ad38)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings and managed-skills request handling by consistently propagating unauthorized responses.
  * Resource-fetch failures now return a clear settings-specific error response.
  * Strengthened session validation by rejecting malformed user identifiers.
  * Improved forwarding of request bodies to preserve submitted content.

* **Tests**
  * Expanded coverage for authorization, settings failures, request delegation, and malformed sessions.
  * Updated managed-skills route coverage to verify control-plane response handling across catalog, edit, and delete operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->