### PR TITLE
refactor: share Modal sandbox launch assembly

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -45,6 +45,17 @@ log = get_logger("manager")
 SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
 DEFAULT_VNC_ENABLED = False
+_RESERVED_LAUNCH_ENV_VARS = {
+    "RESTORED_FROM_SNAPSHOT",
+    "FROM_REPO_IMAGE",
+    "REPO_IMAGE_SHA",
+    "IMAGE_BUILD_MODE",
+    "TERMINAL_ENABLED",
+    "AGENT_SLACK_NOTIFY_ENABLED",
+    "SESSION_CONFIG",
+    VNC_PASSWORD_ENV_VAR,
+    NOVNC_PORT_ENV_VAR,
+}
 
 
 def _has_repository(repo_owner: str | None, repo_name: str | None) -> bool:
@@ -85,7 +96,7 @@ class SandboxConfig:
     repo_owner: str | None
     repo_name: str | None
     sandbox_id: str | None = None  # Expected sandbox ID from control plane
-    session_config: SessionConfig | None = None
+    session_config: SessionConfig | dict[str, Any] | None = None
     control_plane_url: str = ""
     sandbox_auth_token: str = ""
     timeout_seconds: int = DEFAULT_SANDBOX_TIMEOUT_SECONDS
@@ -128,27 +139,32 @@ class SandboxHandle:
         self.modal_sandbox.terminate()
 
 
-@dataclass
-class _SandboxLaunchSpec:
-    """Internal inputs shared by fresh and snapshot sandbox launches."""
+@dataclass(frozen=True)
+class _BaseImageSource:
+    pass
 
-    image: Any
-    repo_owner: str | None
-    repo_name: str | None
-    sandbox_id: str | None = None
-    control_plane_url: str = ""
-    sandbox_auth_token: str = ""
-    timeout_seconds: int = DEFAULT_SANDBOX_TIMEOUT_SECONDS
-    user_env_vars: dict[str, str] | None = None
-    system_env_vars: dict[str, str] | None = None
-    session_config_json: str | None = None
-    clone_token: str | None = None
-    include_github_cli_aliases: bool = False
-    code_server_enabled: bool = False
-    vnc_enabled: bool = DEFAULT_VNC_ENABLED
-    agent_slack_notify_enabled: bool = False
-    settings: dict[str, Any] | None = None
-    snapshot_id: str | None = None
+
+@dataclass(frozen=True)
+class _RepositoryImageSource:
+    image_id: str
+    sha: str | None
+
+
+@dataclass(frozen=True)
+class _SnapshotImageSource:
+    image_id: str
+    clone_token: str | None
+
+
+type _SandboxImageSource = _BaseImageSource | _RepositoryImageSource | _SnapshotImageSource
+
+
+@dataclass(frozen=True)
+class _SandboxLaunchSpec:
+    """Canonical launch configuration paired with one image source variant."""
+
+    config: SandboxConfig
+    source: _SandboxImageSource
 
 
 class SandboxManager:
@@ -347,67 +363,90 @@ class SandboxManager:
 
     async def _launch_sandbox(self, spec: _SandboxLaunchSpec) -> SandboxHandle:
         """Launch a Modal sandbox from a normalized create or restore specification."""
-        has_repository = bool(spec.repo_owner)
-        sandbox_id = spec.sandbox_id
+        config = spec.config
+        has_repository = bool(config.repo_owner)
+        sandbox_id = config.sandbox_id
         if not sandbox_id:
             sandbox_name = (
-                f"{spec.repo_owner}-{spec.repo_name}" if has_repository else "no-repository"
+                f"{config.repo_owner}-{config.repo_name}" if has_repository else "no-repository"
             )
             sandbox_id = f"sandbox-{sandbox_name}-{int(time.time() * 1000)}"
 
-        env_vars = dict(spec.user_env_vars or {})
-        env_vars.pop(VNC_PASSWORD_ENV_VAR, None)
-        env_vars.pop(NOVNC_PORT_ENV_VAR, None)
+        env_vars = {
+            key: value
+            for key, value in (config.user_env_vars or {}).items()
+            if key not in _RESERVED_LAUNCH_ENV_VARS
+        }
         env_vars.update(
             {
                 "PYTHONUNBUFFERED": "1",
                 "SANDBOX_ID": sandbox_id,
-                "CONTROL_PLANE_URL": spec.control_plane_url,
-                "SANDBOX_AUTH_TOKEN": spec.sandbox_auth_token,
-                SANDBOX_TIMEOUT_ENV_VAR: str(spec.timeout_seconds),
-                "REPO_OWNER": spec.repo_owner or "",
-                "REPO_NAME": spec.repo_name or "",
-                **(spec.system_env_vars or {}),
+                "CONTROL_PLANE_URL": config.control_plane_url,
+                "SANDBOX_AUTH_TOKEN": config.sandbox_auth_token,
+                SANDBOX_TIMEOUT_ENV_VAR: str(config.timeout_seconds),
+                "REPO_OWNER": config.repo_owner or "",
+                "REPO_NAME": config.repo_name or "",
             }
         )
-        if spec.session_config_json is not None:
-            env_vars["SESSION_CONFIG"] = spec.session_config_json
+
+        clone_token: str | None = None
+        include_github_cli_aliases = False
+        snapshot_id: str | None = None
+        if isinstance(spec.source, _BaseImageSource):
+            image = base_image
+        elif isinstance(spec.source, _RepositoryImageSource):
+            image = modal.Image.from_id(spec.source.image_id)
+            env_vars["FROM_REPO_IMAGE"] = "true"
+            env_vars["REPO_IMAGE_SHA"] = spec.source.sha or ""
+        else:
+            image = modal.Image.from_id(spec.source.image_id)
+            env_vars["RESTORED_FROM_SNAPSHOT"] = "true"
+            clone_token = spec.source.clone_token
+            include_github_cli_aliases = True
+            snapshot_id = spec.source.image_id
+
+        if config.session_config is not None:
+            env_vars["SESSION_CONFIG"] = (
+                json.dumps(config.session_config)
+                if isinstance(config.session_config, dict)
+                else config.session_config.model_dump_json()
+            )
 
         inject_vcs_env_vars(
             env_vars,
-            clone_token=spec.clone_token if has_repository else None,
-            include_github_cli_aliases=spec.include_github_cli_aliases,
+            clone_token=clone_token if has_repository else None,
+            include_github_cli_aliases=include_github_cli_aliases,
         )
 
         code_server_password: str | None = None
-        if spec.code_server_enabled:
+        if config.code_server_enabled:
             code_server_password = self._generate_code_server_password()
             env_vars["CODE_SERVER_PASSWORD"] = code_server_password
 
         vnc_password: str | None = None
-        if spec.vnc_enabled:
+        if config.vnc_enabled:
             vnc_password = self._generate_vnc_password()
             env_vars[VNC_PASSWORD_ENV_VAR] = vnc_password
 
-        terminal_enabled = bool((spec.settings or {}).get("terminalEnabled", False))
+        terminal_enabled = bool((config.settings or {}).get("terminalEnabled", False))
         if terminal_enabled:
             env_vars["TERMINAL_ENABLED"] = "true"
-        if spec.agent_slack_notify_enabled:
+        if config.agent_slack_notify_enabled:
             env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
 
-        code_server_port, novnc_port, ttyd_proxy_port = self._resolve_service_ports(spec.settings)
-        if spec.code_server_enabled:
+        code_server_port, novnc_port, ttyd_proxy_port = self._resolve_service_ports(config.settings)
+        if config.code_server_enabled:
             env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
-        if spec.vnc_enabled:
+        if config.vnc_enabled:
             env_vars[NOVNC_PORT_ENV_VAR] = str(novnc_port)
         if terminal_enabled:
             env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
 
         exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            spec.code_server_enabled,
-            spec.vnc_enabled,
+            config.code_server_enabled,
+            config.vnc_enabled,
             terminal_enabled,
-            spec.settings,
+            config.settings,
             code_server_port,
             novnc_port,
             ttyd_proxy_port,
@@ -416,13 +455,13 @@ class SandboxManager:
             env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
 
         create_kwargs: dict[str, Any] = {
-            "image": spec.image,
+            "image": image,
             "app": app,
             "secrets": [llm_secrets],
-            "timeout": spec.timeout_seconds,
+            "timeout": config.timeout_seconds,
             "workdir": "/workspace",
             "env": env_vars,
-            **_resource_kwargs(spec.settings),
+            **_resource_kwargs(config.settings),
         }
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
@@ -442,8 +481,8 @@ class SandboxManager:
         ) = await self._resolve_and_setup_tunnels(
             sandbox,
             sandbox_id,
-            spec.code_server_enabled,
-            spec.vnc_enabled,
+            config.code_server_enabled,
+            config.vnc_enabled,
             terminal_enabled,
             tunnel_ports,
             code_server_port,
@@ -456,7 +495,7 @@ class SandboxManager:
             modal_sandbox=sandbox,
             status=SandboxStatus.WARMING,
             created_at=time.time(),
-            snapshot_id=spec.snapshot_id,
+            snapshot_id=snapshot_id,
             modal_object_id=modal_object_id,
             code_server_url=code_server_url,
             code_server_password=code_server_password,
@@ -486,37 +525,15 @@ class SandboxManager:
         start_time = time.time()
         _has_repository(config.repo_owner, config.repo_name)
 
-        # Determine image to use (priority: repo image > base image)
-        system_env_vars: dict[str, str] = {}
         if config.repo_image_id:
-            image = modal.Image.from_id(config.repo_image_id)
-            system_env_vars = {
-                "FROM_REPO_IMAGE": "true",
-                "REPO_IMAGE_SHA": config.repo_image_sha or "",
-            }
-        else:
-            image = base_image
-
-        handle = await self._launch_sandbox(
-            _SandboxLaunchSpec(
-                image=image,
-                repo_owner=config.repo_owner,
-                repo_name=config.repo_name,
-                sandbox_id=config.sandbox_id,
-                control_plane_url=config.control_plane_url,
-                sandbox_auth_token=config.sandbox_auth_token,
-                timeout_seconds=config.timeout_seconds,
-                user_env_vars=config.user_env_vars,
-                system_env_vars=system_env_vars,
-                session_config_json=(
-                    config.session_config.model_dump_json() if config.session_config else None
-                ),
-                code_server_enabled=config.code_server_enabled,
-                vnc_enabled=config.vnc_enabled,
-                agent_slack_notify_enabled=config.agent_slack_notify_enabled,
-                settings=config.settings,
+            source: _SandboxImageSource = _RepositoryImageSource(
+                image_id=config.repo_image_id,
+                sha=config.repo_image_sha,
             )
-        )
+        else:
+            source = _BaseImageSource()
+
+        handle = await self._launch_sandbox(_SandboxLaunchSpec(config=config, source=source))
 
         duration_ms = int((time.time() - start_time) * 1000)
         log.info(
@@ -605,7 +622,7 @@ class SandboxManager:
     async def restore_from_snapshot(
         self,
         snapshot_image_id: str,
-        session_config: SessionConfig | dict,
+        session_config: SessionConfig | dict[str, Any],
         sandbox_id: str | None = None,
         control_plane_url: str = "",
         sandbox_auth_token: str = "",
@@ -639,15 +656,10 @@ class SandboxManager:
         if isinstance(session_config, dict):
             repo_owner = session_config.get("repo_owner")
             repo_name = session_config.get("repo_name")
-            session_config_json = json.dumps(session_config)
         else:
             repo_owner = session_config.repo_owner
             repo_name = session_config.repo_name
-            session_config_json = session_config.model_dump_json()
         _has_repository(repo_owner, repo_name)
-
-        # Lookup the image by ID
-        image = modal.Image.from_id(snapshot_image_id)
 
         # Snapshot restore still passes the clone token through for
         # repo-backed sandboxes. Snapshots taken before the credential-helper
@@ -659,23 +671,24 @@ class SandboxManager:
         # credentials are explicitly requested only by the restore path.
         handle = await self._launch_sandbox(
             _SandboxLaunchSpec(
-                image=image,
-                repo_owner=repo_owner,
-                repo_name=repo_name,
-                sandbox_id=sandbox_id,
-                control_plane_url=control_plane_url,
-                sandbox_auth_token=sandbox_auth_token,
-                timeout_seconds=timeout_seconds,
-                user_env_vars=user_env_vars,
-                system_env_vars={"RESTORED_FROM_SNAPSHOT": "true"},
-                session_config_json=session_config_json,
-                clone_token=clone_token,
-                include_github_cli_aliases=True,
-                code_server_enabled=code_server_enabled,
-                vnc_enabled=vnc_enabled,
-                agent_slack_notify_enabled=agent_slack_notify_enabled,
-                settings=settings,
-                snapshot_id=snapshot_image_id,
+                config=SandboxConfig(
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    sandbox_id=sandbox_id,
+                    session_config=session_config,
+                    control_plane_url=control_plane_url,
+                    sandbox_auth_token=sandbox_auth_token,
+                    timeout_seconds=timeout_seconds,
+                    user_env_vars=user_env_vars,
+                    code_server_enabled=code_server_enabled,
+                    vnc_enabled=vnc_enabled,
+                    agent_slack_notify_enabled=agent_slack_notify_enabled,
+                    settings=settings,
+                ),
+                source=_SnapshotImageSource(
+                    image_id=snapshot_image_id,
+                    clone_token=clone_token,
+                ),
             )
         )
 

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -347,7 +347,7 @@ class SandboxManager:
 
     async def _launch_sandbox(self, spec: _SandboxLaunchSpec) -> SandboxHandle:
         """Launch a Modal sandbox from a normalized create or restore specification."""
-        has_repository = _has_repository(spec.repo_owner, spec.repo_name)
+        has_repository = bool(spec.repo_owner)
         sandbox_id = spec.sandbox_id
         if not sandbox_id:
             sandbox_name = (
@@ -484,6 +484,7 @@ class SandboxManager:
             SandboxHandle with the running sandbox
         """
         start_time = time.time()
+        _has_repository(config.repo_owner, config.repo_name)
 
         # Determine image to use (priority: repo image > base image)
         system_env_vars: dict[str, str] = {}

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -128,6 +128,29 @@ class SandboxHandle:
         self.modal_sandbox.terminate()
 
 
+@dataclass
+class _SandboxLaunchSpec:
+    """Internal inputs shared by fresh and snapshot sandbox launches."""
+
+    image: Any
+    repo_owner: str | None
+    repo_name: str | None
+    sandbox_id: str | None = None
+    control_plane_url: str = ""
+    sandbox_auth_token: str = ""
+    timeout_seconds: int = DEFAULT_SANDBOX_TIMEOUT_SECONDS
+    user_env_vars: dict[str, str] | None = None
+    system_env_vars: dict[str, str] | None = None
+    session_config_json: str | None = None
+    clone_token: str | None = None
+    include_github_cli_aliases: bool = False
+    code_server_enabled: bool = False
+    vnc_enabled: bool = DEFAULT_VNC_ENABLED
+    agent_slack_notify_enabled: bool = False
+    settings: dict[str, Any] | None = None
+    snapshot_id: str | None = None
+
+
 class SandboxManager:
     """
     Manages sandbox lifecycle for Open-Inspect sessions.
@@ -322,6 +345,127 @@ class SandboxManager:
                 exc=e,
             )
 
+    async def _launch_sandbox(self, spec: _SandboxLaunchSpec) -> SandboxHandle:
+        """Launch a Modal sandbox from a normalized create or restore specification."""
+        has_repository = _has_repository(spec.repo_owner, spec.repo_name)
+        sandbox_id = spec.sandbox_id
+        if not sandbox_id:
+            sandbox_name = (
+                f"{spec.repo_owner}-{spec.repo_name}" if has_repository else "no-repository"
+            )
+            sandbox_id = f"sandbox-{sandbox_name}-{int(time.time() * 1000)}"
+
+        env_vars = dict(spec.user_env_vars or {})
+        env_vars.pop(VNC_PASSWORD_ENV_VAR, None)
+        env_vars.pop(NOVNC_PORT_ENV_VAR, None)
+        env_vars.update(
+            {
+                "PYTHONUNBUFFERED": "1",
+                "SANDBOX_ID": sandbox_id,
+                "CONTROL_PLANE_URL": spec.control_plane_url,
+                "SANDBOX_AUTH_TOKEN": spec.sandbox_auth_token,
+                SANDBOX_TIMEOUT_ENV_VAR: str(spec.timeout_seconds),
+                "REPO_OWNER": spec.repo_owner or "",
+                "REPO_NAME": spec.repo_name or "",
+                **(spec.system_env_vars or {}),
+            }
+        )
+        if spec.session_config_json is not None:
+            env_vars["SESSION_CONFIG"] = spec.session_config_json
+
+        inject_vcs_env_vars(
+            env_vars,
+            clone_token=spec.clone_token if has_repository else None,
+            include_github_cli_aliases=spec.include_github_cli_aliases,
+        )
+
+        code_server_password: str | None = None
+        if spec.code_server_enabled:
+            code_server_password = self._generate_code_server_password()
+            env_vars["CODE_SERVER_PASSWORD"] = code_server_password
+
+        vnc_password: str | None = None
+        if spec.vnc_enabled:
+            vnc_password = self._generate_vnc_password()
+            env_vars[VNC_PASSWORD_ENV_VAR] = vnc_password
+
+        terminal_enabled = bool((spec.settings or {}).get("terminalEnabled", False))
+        if terminal_enabled:
+            env_vars["TERMINAL_ENABLED"] = "true"
+        if spec.agent_slack_notify_enabled:
+            env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
+
+        code_server_port, novnc_port, ttyd_proxy_port = self._resolve_service_ports(spec.settings)
+        if spec.code_server_enabled:
+            env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
+        if spec.vnc_enabled:
+            env_vars[NOVNC_PORT_ENV_VAR] = str(novnc_port)
+        if terminal_enabled:
+            env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
+
+        exposed_ports, tunnel_ports = self._collect_exposed_ports(
+            spec.code_server_enabled,
+            spec.vnc_enabled,
+            terminal_enabled,
+            spec.settings,
+            code_server_port,
+            novnc_port,
+            ttyd_proxy_port,
+        )
+        if tunnel_ports:
+            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
+
+        create_kwargs: dict[str, Any] = {
+            "image": spec.image,
+            "app": app,
+            "secrets": [llm_secrets],
+            "timeout": spec.timeout_seconds,
+            "workdir": "/workspace",
+            "env": env_vars,
+            **_resource_kwargs(spec.settings),
+        }
+        if exposed_ports:
+            create_kwargs["encrypted_ports"] = exposed_ports
+
+        sandbox = await modal.Sandbox.create.aio(
+            "python",
+            "-m",
+            "sandbox_runtime.entrypoint",
+            **create_kwargs,
+        )
+        modal_object_id = sandbox.object_id
+        (
+            code_server_url,
+            vnc_url,
+            ttyd_url,
+            extra_tunnel_urls,
+        ) = await self._resolve_and_setup_tunnels(
+            sandbox,
+            sandbox_id,
+            spec.code_server_enabled,
+            spec.vnc_enabled,
+            terminal_enabled,
+            tunnel_ports,
+            code_server_port,
+            novnc_port,
+            ttyd_proxy_port,
+        )
+
+        return SandboxHandle(
+            sandbox_id=sandbox_id,
+            modal_sandbox=sandbox,
+            status=SandboxStatus.WARMING,
+            created_at=time.time(),
+            snapshot_id=spec.snapshot_id,
+            modal_object_id=modal_object_id,
+            code_server_url=code_server_url,
+            code_server_password=code_server_password,
+            vnc_url=vnc_url,
+            vnc_password=vnc_password,
+            ttyd_url=ttyd_url,
+            tunnel_urls=extra_tunnel_urls,
+        )
+
     async def create_sandbox(
         self,
         config: SandboxConfig,
@@ -341,150 +485,50 @@ class SandboxManager:
         """
         start_time = time.time()
 
-        # Use provided sandbox_id from control plane, or generate one
-        has_repository = _has_repository(config.repo_owner, config.repo_name)
-        if config.sandbox_id:
-            sandbox_id = config.sandbox_id
-        else:
-            sandbox_name = (
-                f"{config.repo_owner}-{config.repo_name}" if has_repository else "no-repository"
-            )
-            sandbox_id = f"sandbox-{sandbox_name}-{int(time.time() * 1000)}"
-
-        # Prepare environment variables (user vars first, system vars override)
-        env_vars: dict[str, str] = {}
-
-        if config.user_env_vars:
-            env_vars.update(config.user_env_vars)
-        env_vars.pop(VNC_PASSWORD_ENV_VAR, None)
-        env_vars.pop(NOVNC_PORT_ENV_VAR, None)
-
-        env_vars.update(
-            {
-                "PYTHONUNBUFFERED": "1",  # Ensure logs are flushed immediately
-                "SANDBOX_ID": sandbox_id,
-                "CONTROL_PLANE_URL": config.control_plane_url,
-                "SANDBOX_AUTH_TOKEN": config.sandbox_auth_token,
-                SANDBOX_TIMEOUT_ENV_VAR: str(config.timeout_seconds),
-                "REPO_OWNER": config.repo_owner or "",
-                "REPO_NAME": config.repo_name or "",
-            }
-        )
-
-        # Host scoping (VCS_HOST / VCS_CLONE_USERNAME) is injected even without a
-        # repository so GitLab/Bitbucket deployments don't fall back to github.com
-        # credential-helper behavior; fresh creates never carry a clone token.
-        inject_vcs_env_vars(env_vars, clone_token=None)
-
-        code_server_password: str | None = None
-        if config.code_server_enabled:
-            code_server_password = self._generate_code_server_password()
-            env_vars["CODE_SERVER_PASSWORD"] = code_server_password
-
-        vnc_password: str | None = None
-        if config.vnc_enabled:
-            vnc_password = self._generate_vnc_password()
-            env_vars[VNC_PASSWORD_ENV_VAR] = vnc_password
-
-        terminal_enabled = bool((config.settings or {}).get("terminalEnabled", False))
-        if terminal_enabled:
-            env_vars["TERMINAL_ENABLED"] = "true"
-
-        if config.agent_slack_notify_enabled:
-            env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
-
-        if config.session_config:
-            env_vars["SESSION_CONFIG"] = config.session_config.model_dump_json()
-
         # Determine image to use (priority: repo image > base image)
+        system_env_vars: dict[str, str] = {}
         if config.repo_image_id:
             image = modal.Image.from_id(config.repo_image_id)
-            env_vars["FROM_REPO_IMAGE"] = "true"
-            env_vars["REPO_IMAGE_SHA"] = config.repo_image_sha or ""
+            system_env_vars = {
+                "FROM_REPO_IMAGE": "true",
+                "REPO_IMAGE_SHA": config.repo_image_sha or "",
+            }
         else:
             image = base_image
 
-        code_server_port, novnc_port, ttyd_proxy_port = self._resolve_service_ports(config.settings)
-        if config.code_server_enabled:
-            env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
-        if config.vnc_enabled:
-            env_vars[NOVNC_PORT_ENV_VAR] = str(novnc_port)
-        if terminal_enabled:
-            env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
-
-        exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            config.code_server_enabled,
-            config.vnc_enabled,
-            terminal_enabled,
-            config.settings,
-            code_server_port,
-            novnc_port,
-            ttyd_proxy_port,
-        )
-        if tunnel_ports:
-            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
-
-        create_kwargs: dict = {
-            "image": image,
-            "app": app,
-            "secrets": [llm_secrets],
-            "timeout": config.timeout_seconds,
-            "workdir": "/workspace",
-            "env": env_vars,
-            **_resource_kwargs(config.settings),
-        }
-        if exposed_ports:
-            create_kwargs["encrypted_ports"] = exposed_ports
-
-        sandbox = await modal.Sandbox.create.aio(
-            "python",
-            "-m",
-            "sandbox_runtime.entrypoint",  # Run the supervisor entrypoint
-            **create_kwargs,
-        )
-
-        modal_object_id = sandbox.object_id
-        (
-            code_server_url,
-            vnc_url,
-            ttyd_url,
-            extra_tunnel_urls,
-        ) = await self._resolve_and_setup_tunnels(
-            sandbox,
-            sandbox_id,
-            config.code_server_enabled,
-            config.vnc_enabled,
-            terminal_enabled,
-            tunnel_ports,
-            code_server_port,
-            novnc_port,
-            ttyd_proxy_port,
+        handle = await self._launch_sandbox(
+            _SandboxLaunchSpec(
+                image=image,
+                repo_owner=config.repo_owner,
+                repo_name=config.repo_name,
+                sandbox_id=config.sandbox_id,
+                control_plane_url=config.control_plane_url,
+                sandbox_auth_token=config.sandbox_auth_token,
+                timeout_seconds=config.timeout_seconds,
+                user_env_vars=config.user_env_vars,
+                system_env_vars=system_env_vars,
+                session_config_json=(
+                    config.session_config.model_dump_json() if config.session_config else None
+                ),
+                code_server_enabled=config.code_server_enabled,
+                vnc_enabled=config.vnc_enabled,
+                agent_slack_notify_enabled=config.agent_slack_notify_enabled,
+                settings=config.settings,
+            )
         )
 
         duration_ms = int((time.time() - start_time) * 1000)
         log.info(
             "sandbox.create",
-            sandbox_id=sandbox_id,
-            modal_object_id=modal_object_id,
+            sandbox_id=handle.sandbox_id,
+            modal_object_id=handle.modal_object_id,
             repo_owner=config.repo_owner,
             repo_name=config.repo_name,
             duration_ms=duration_ms,
             outcome="success",
         )
 
-        return SandboxHandle(
-            sandbox_id=sandbox_id,
-            modal_sandbox=sandbox,
-            status=SandboxStatus.WARMING,
-            created_at=time.time(),
-            modal_object_id=modal_object_id,
-            code_server_url=code_server_url,
-            code_server_password=code_server_password,
-            vnc_url=vnc_url,
-            vnc_password=vnc_password,
-            ttyd_url=ttyd_url,
-            tunnel_urls=extra_tunnel_urls,
-        )
+        return handle
 
     async def take_snapshot(
         self,
@@ -599,37 +643,10 @@ class SandboxManager:
             repo_owner = session_config.repo_owner
             repo_name = session_config.repo_name
             session_config_json = session_config.model_dump_json()
-        has_repository = _has_repository(repo_owner, repo_name)
-
-        # Use provided sandbox_id or generate one
-        if not sandbox_id:
-            sandbox_name = f"{repo_owner}-{repo_name}" if has_repository else "no-repository"
-            sandbox_id = f"sandbox-{sandbox_name}-{int(time.time() * 1000)}"
+        _has_repository(repo_owner, repo_name)
 
         # Lookup the image by ID
         image = modal.Image.from_id(snapshot_image_id)
-
-        # Prepare environment variables (user vars first, system vars override)
-        env_vars: dict[str, str] = {}
-
-        if user_env_vars:
-            env_vars.update(user_env_vars)
-        env_vars.pop(VNC_PASSWORD_ENV_VAR, None)
-        env_vars.pop(NOVNC_PORT_ENV_VAR, None)
-
-        env_vars.update(
-            {
-                "PYTHONUNBUFFERED": "1",
-                "SANDBOX_ID": sandbox_id,
-                "CONTROL_PLANE_URL": control_plane_url,
-                "SANDBOX_AUTH_TOKEN": sandbox_auth_token,
-                SANDBOX_TIMEOUT_ENV_VAR: str(timeout_seconds),
-                "REPO_OWNER": repo_owner or "",
-                "REPO_NAME": repo_name or "",
-                "RESTORED_FROM_SNAPSHOT": "true",  # Signal to skip git clone
-                "SESSION_CONFIG": session_config_json,
-            }
-        )
 
         # Snapshot restore still passes the clone token through for
         # repo-backed sandboxes. Snapshots taken before the credential-helper
@@ -637,92 +654,35 @@ class SandboxManager:
         # and embeds it in the origin URL; without it, those legacy snapshots
         # can't fetch. GITHUB_TOKEN/GITHUB_APP_TOKEN aliases are restored too
         # so the gh CLI keeps working on snapshots predating the gh wrapper.
-        # Host scoping is injected even without a repository (matches
-        # create_sandbox); clone tokens stay repository-gated.
-        restore_clone_token = clone_token if has_repository else None
-        inject_vcs_env_vars(
-            env_vars, clone_token=restore_clone_token, include_github_cli_aliases=True
-        )
-
-        code_server_password: str | None = None
-        if code_server_enabled:
-            code_server_password = self._generate_code_server_password()
-            env_vars["CODE_SERVER_PASSWORD"] = code_server_password
-
-        vnc_password: str | None = None
-        if vnc_enabled:
-            vnc_password = self._generate_vnc_password()
-            env_vars[VNC_PASSWORD_ENV_VAR] = vnc_password
-
-        terminal_enabled = bool((settings or {}).get("terminalEnabled", False))
-        if terminal_enabled:
-            env_vars["TERMINAL_ENABLED"] = "true"
-
-        if agent_slack_notify_enabled:
-            env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
-
-        code_server_port, novnc_port, ttyd_proxy_port = self._resolve_service_ports(settings)
-        if code_server_enabled:
-            env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
-        if vnc_enabled:
-            env_vars[NOVNC_PORT_ENV_VAR] = str(novnc_port)
-        if terminal_enabled:
-            env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
-
-        exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            code_server_enabled,
-            vnc_enabled,
-            terminal_enabled,
-            settings,
-            code_server_port,
-            novnc_port,
-            ttyd_proxy_port,
-        )
-        if tunnel_ports:
-            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
-
-        create_kwargs: dict = {
-            "image": image,
-            "app": app,
-            "secrets": [llm_secrets],
-            "timeout": timeout_seconds,
-            "workdir": "/workspace",
-            "env": env_vars,
-            **_resource_kwargs(settings),
-        }
-        if exposed_ports:
-            create_kwargs["encrypted_ports"] = exposed_ports
-
-        sandbox = await modal.Sandbox.create.aio(
-            "python",
-            "-m",
-            "sandbox_runtime.entrypoint",
-            **create_kwargs,
-        )
-
-        modal_object_id = sandbox.object_id
-        (
-            code_server_url,
-            vnc_url,
-            ttyd_url,
-            extra_tunnel_urls,
-        ) = await self._resolve_and_setup_tunnels(
-            sandbox,
-            sandbox_id,
-            code_server_enabled,
-            vnc_enabled,
-            terminal_enabled,
-            tunnel_ports,
-            code_server_port,
-            novnc_port,
-            ttyd_proxy_port,
+        # Host scoping remains common with fresh creates. These compatibility
+        # credentials are explicitly requested only by the restore path.
+        handle = await self._launch_sandbox(
+            _SandboxLaunchSpec(
+                image=image,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                sandbox_id=sandbox_id,
+                control_plane_url=control_plane_url,
+                sandbox_auth_token=sandbox_auth_token,
+                timeout_seconds=timeout_seconds,
+                user_env_vars=user_env_vars,
+                system_env_vars={"RESTORED_FROM_SNAPSHOT": "true"},
+                session_config_json=session_config_json,
+                clone_token=clone_token,
+                include_github_cli_aliases=True,
+                code_server_enabled=code_server_enabled,
+                vnc_enabled=vnc_enabled,
+                agent_slack_notify_enabled=agent_slack_notify_enabled,
+                settings=settings,
+                snapshot_id=snapshot_image_id,
+            )
         )
 
         duration_ms = int((time.time() - start_time) * 1000)
         log.info(
             "sandbox.restore",
-            sandbox_id=sandbox_id,
-            modal_object_id=modal_object_id,
+            sandbox_id=handle.sandbox_id,
+            modal_object_id=handle.modal_object_id,
             snapshot_image_id=snapshot_image_id,
             repo_owner=repo_owner,
             repo_name=repo_name,
@@ -730,20 +690,7 @@ class SandboxManager:
             outcome="success",
         )
 
-        return SandboxHandle(
-            sandbox_id=sandbox_id,
-            modal_sandbox=sandbox,
-            status=SandboxStatus.WARMING,
-            created_at=time.time(),
-            snapshot_id=snapshot_image_id,
-            modal_object_id=modal_object_id,
-            code_server_url=code_server_url,
-            code_server_password=code_server_password,
-            vnc_url=vnc_url,
-            vnc_password=vnc_password,
-            ttyd_url=ttyd_url,
-            tunnel_urls=extra_tunnel_urls,
-        )
+        return handle
 
 
 # Global sandbox manager instance

--- a/packages/modal-infra/tests/test_sandbox_launch.py
+++ b/packages/modal-infra/tests/test_sandbox_launch.py
@@ -1,7 +1,7 @@
 """Behavior matrix for shared fresh, repository-image, and snapshot launches."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -39,17 +39,19 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
     monkeypatch.setattr("src.sandbox.manager.base_image", base_image)
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", images.__getitem__)
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_create(captured))
+    monkeypatch.delenv("SCM_PROVIDER", raising=False)
+    resolve_tunnels = AsyncMock(
+        return_value=(
+            "https://code.example",
+            "https://vnc.example",
+            "https://terminal.example",
+            {3000: "https://app.example"},
+        )
+    )
     monkeypatch.setattr(
         SandboxManager,
         "_resolve_and_setup_tunnels",
-        AsyncMock(
-            return_value=(
-                "https://code.example",
-                "https://vnc.example",
-                "https://terminal.example",
-                {3000: "https://app.example"},
-            )
-        ),
+        resolve_tunnels,
     )
     monkeypatch.setattr(
         SandboxManager, "_generate_code_server_password", staticmethod(lambda: "code-password")
@@ -153,3 +155,27 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
     assert handle.vnc_password == "vnc-pass"
     assert handle.ttyd_url == "https://terminal.example"
     assert handle.tunnel_urls == {3000: "https://app.example"}
+    resolve_tunnels.assert_awaited_once_with(
+        handle.modal_sandbox,
+        "sandbox-1",
+        True,
+        True,
+        True,
+        [3000],
+        9000,
+        9001,
+        9002,
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_image_create_validates_repo_before_image_lookup(monkeypatch):
+    from_id = Mock(side_effect=AssertionError("image lookup should not run"))
+    monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", from_id)
+
+    with pytest.raises(ValueError, match="repo_owner and repo_name must be provided together"):
+        await SandboxManager().create_sandbox(
+            SandboxConfig(repo_owner="acme", repo_name=None, repo_image_id="repo-image-1")
+        )
+
+    from_id.assert_not_called()

--- a/packages/modal-infra/tests/test_sandbox_launch.py
+++ b/packages/modal-infra/tests/test_sandbox_launch.py
@@ -1,0 +1,155 @@
+"""Behavior matrix for shared fresh, repository-image, and snapshot launches."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sandbox_runtime.constants import (
+    CODE_SERVER_PORT_ENV_VAR,
+    EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    NOVNC_PORT_ENV_VAR,
+    TTYD_PROXY_PORT_ENV_VAR,
+    VNC_PASSWORD_ENV_VAR,
+)
+from src.sandbox.manager import SandboxConfig, SandboxManager
+
+
+def _fake_create(captured: dict):
+    async def create_aio(*args, **kwargs):
+        captured["command"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(object_id="modal-object-1", stdout=None)
+
+    create_aio.aio = create_aio
+    return create_aio
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("image_source", ["base", "repository", "snapshot"])
+async def test_launch_matrix_preserves_common_and_source_specific_behavior(
+    monkeypatch, image_source
+):
+    captured: dict = {}
+    base_image = object()
+    images = {
+        "repo-image-1": object(),
+        "snapshot-image-1": object(),
+    }
+    monkeypatch.setattr("src.sandbox.manager.base_image", base_image)
+    monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", images.__getitem__)
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_create(captured))
+    monkeypatch.setattr(
+        SandboxManager,
+        "_resolve_and_setup_tunnels",
+        AsyncMock(
+            return_value=(
+                "https://code.example",
+                "https://vnc.example",
+                "https://terminal.example",
+                {3000: "https://app.example"},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        SandboxManager, "_generate_code_server_password", staticmethod(lambda: "code-password")
+    )
+    monkeypatch.setattr(SandboxManager, "_generate_vnc_password", staticmethod(lambda: "vnc-pass"))
+
+    manager = SandboxManager()
+    settings = {
+        "codeServerPort": 9000,
+        "vncPort": 9001,
+        "terminalPort": 9002,
+        "terminalEnabled": True,
+        "tunnelPorts": [3000],
+        "cpuCores": 1.5,
+        "memoryMib": 3072,
+    }
+    common = {
+        "sandbox_id": "sandbox-1",
+        "control_plane_url": "https://control.example",
+        "sandbox_auth_token": "sandbox-token",
+        "timeout_seconds": 4321,
+        "user_env_vars": {
+            "CONTROL_PLANE_URL": "https://user.example",
+            "CUSTOM_ENV": "preserved",
+            "RESTORED_FROM_SNAPSHOT": "false",
+            VNC_PASSWORD_ENV_VAR: "user-vnc-password",
+            NOVNC_PORT_ENV_VAR: "9999",
+        },
+        "code_server_enabled": True,
+        "vnc_enabled": True,
+        "agent_slack_notify_enabled": True,
+        "settings": settings,
+    }
+
+    if image_source == "snapshot":
+        handle = await manager.restore_from_snapshot(
+            snapshot_image_id="snapshot-image-1",
+            session_config={
+                "session_id": "session-1",
+                "repo_owner": "acme",
+                "repo_name": "repo",
+                "future_field": {"preserved": True},
+            },
+            clone_token="legacy-clone-token",
+            **common,
+        )
+        expected_image = images["snapshot-image-1"]
+    else:
+        handle = await manager.create_sandbox(
+            SandboxConfig(
+                repo_owner="acme",
+                repo_name="repo",
+                repo_image_id="repo-image-1" if image_source == "repository" else None,
+                repo_image_sha="abc123" if image_source == "repository" else None,
+                **common,
+            )
+        )
+        expected_image = images["repo-image-1"] if image_source == "repository" else base_image
+
+    kwargs = captured["kwargs"]
+    env = kwargs["env"]
+    assert captured["command"] == ("python", "-m", "sandbox_runtime.entrypoint")
+    assert kwargs["image"] is expected_image
+    assert kwargs["timeout"] == 4321
+    assert kwargs["cpu"] == 1.5
+    assert kwargs["memory"] == 3072
+    assert kwargs["encrypted_ports"] == [9000, 9001, 9002, 3000]
+
+    assert env["CONTROL_PLANE_URL"] == "https://control.example"
+    assert env["CUSTOM_ENV"] == "preserved"
+    assert env["CODE_SERVER_PASSWORD"] == "code-password"
+    assert env[VNC_PASSWORD_ENV_VAR] == "vnc-pass"
+    assert env[CODE_SERVER_PORT_ENV_VAR] == "9000"
+    assert env[NOVNC_PORT_ENV_VAR] == "9001"
+    assert env[TTYD_PROXY_PORT_ENV_VAR] == "9002"
+    assert env[EXPECTED_TUNNEL_PORTS_ENV_VAR] == "3000"
+    assert env["AGENT_SLACK_NOTIFY_ENABLED"] == "true"
+
+    if image_source == "repository":
+        assert env["FROM_REPO_IMAGE"] == "true"
+        assert env["REPO_IMAGE_SHA"] == "abc123"
+    else:
+        assert "FROM_REPO_IMAGE" not in env
+
+    if image_source == "snapshot":
+        assert env["RESTORED_FROM_SNAPSHOT"] == "true"
+        assert '"future_field": {"preserved": true}' in env["SESSION_CONFIG"]
+        assert env["VCS_CLONE_TOKEN"] == "legacy-clone-token"
+        assert env["GITHUB_TOKEN"] == "legacy-clone-token"
+        assert env["GITHUB_APP_TOKEN"] == "legacy-clone-token"
+    else:
+        assert env["RESTORED_FROM_SNAPSHOT"] == "false"
+        assert "VCS_CLONE_TOKEN" not in env
+
+    assert handle.sandbox_id == "sandbox-1"
+    assert handle.modal_object_id == "modal-object-1"
+    assert handle.snapshot_id == ("snapshot-image-1" if image_source == "snapshot" else None)
+    assert handle.code_server_url == "https://code.example"
+    assert handle.code_server_password == "code-password"
+    assert handle.vnc_url == "https://vnc.example"
+    assert handle.vnc_password == "vnc-pass"
+    assert handle.ttyd_url == "https://terminal.example"
+    assert handle.tunnel_urls == {3000: "https://app.example"}

--- a/packages/modal-infra/tests/test_sandbox_launch.py
+++ b/packages/modal-infra/tests/test_sandbox_launch.py
@@ -1,5 +1,6 @@
 """Behavior matrix for shared fresh, repository-image, and snapshot launches."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -12,6 +13,7 @@ from sandbox_runtime.constants import (
     TTYD_PROXY_PORT_ENV_VAR,
     VNC_PASSWORD_ENV_VAR,
 )
+from sandbox_runtime.types import SessionConfig
 from src.sandbox.manager import SandboxConfig, SandboxManager
 
 
@@ -76,7 +78,12 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
         "user_env_vars": {
             "CONTROL_PLANE_URL": "https://user.example",
             "CUSTOM_ENV": "preserved",
-            "RESTORED_FROM_SNAPSHOT": "false",
+            "RESTORED_FROM_SNAPSHOT": "true",
+            "FROM_REPO_IMAGE": "false",
+            "IMAGE_BUILD_MODE": "true",
+            "TERMINAL_ENABLED": "false",
+            "AGENT_SLACK_NOTIFY_ENABLED": "false",
+            "SESSION_CONFIG": "malicious",
             VNC_PASSWORD_ENV_VAR: "user-vnc-password",
             NOVNC_PORT_ENV_VAR: "9999",
         },
@@ -104,6 +111,12 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
             SandboxConfig(
                 repo_owner="acme",
                 repo_name="repo",
+                session_config=SessionConfig(
+                    session_id="session-1",
+                    repo_owner="acme",
+                    repo_name="repo",
+                    branch="feature/shared-launch",
+                ),
                 repo_image_id="repo-image-1" if image_source == "repository" else None,
                 repo_image_sha="abc123" if image_source == "repository" else None,
                 **common,
@@ -129,6 +142,8 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
     assert env[TTYD_PROXY_PORT_ENV_VAR] == "9002"
     assert env[EXPECTED_TUNNEL_PORTS_ENV_VAR] == "3000"
     assert env["AGENT_SLACK_NOTIFY_ENABLED"] == "true"
+    assert env["TERMINAL_ENABLED"] == "true"
+    assert "IMAGE_BUILD_MODE" not in env
 
     if image_source == "repository":
         assert env["FROM_REPO_IMAGE"] == "true"
@@ -143,8 +158,10 @@ async def test_launch_matrix_preserves_common_and_source_specific_behavior(
         assert env["GITHUB_TOKEN"] == "legacy-clone-token"
         assert env["GITHUB_APP_TOKEN"] == "legacy-clone-token"
     else:
-        assert env["RESTORED_FROM_SNAPSHOT"] == "false"
+        assert "RESTORED_FROM_SNAPSHOT" not in env
         assert "VCS_CLONE_TOKEN" not in env
+        session_config = json.loads(env["SESSION_CONFIG"])
+        assert session_config["branch"] == "feature/shared-launch"
 
     assert handle.sandbox_id == "sandbox-1"
     assert handle.modal_object_id == "modal-object-1"


### PR DESCRIPTION
## Summary
- normalize fresh, repository-image, and snapshot launches into a private launch specification
- centralize environment precedence, generated credentials, service ports, resources, Modal creation, tunnel setup, and `SandboxHandle` construction
- preserve restore-only forward-compatible session config serialization and legacy clone/GitHub credential aliases
- add a three-source behavior matrix covering images, environment precedence, ports, resources, credentials, tunnel forwarding, and handle metadata
- preserve repository metadata validation before provider image lookup

## Thermonuclear review
- ran the requested `/thermo-review` in a child session against the published branch
- fixed both in-scope medium findings: create-path validation order and SCM-dependent GitHub alias assertions
- added the review's directly related tunnel-argument assertion
- left the broader source-variant redesign observation unchanged to avoid expanding R15 scope

## Validation
- `uv run --extra dev pytest tests/ -q` (191 passed)
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev ruff format --check src tests`

Strict mypy retains the package's existing baseline errors.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/0a11ae659400631e4d5e1d18801d66af)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox creation and snapshot restoration consistency.
  * Preserved environment variables, resource settings, encrypted ports, credentials, and snapshot metadata across launch types.
  * Ensured repository configuration errors are reported before image lookup.
* **Tests**
  * Added coverage for fresh, repository-image, and snapshot-based sandbox launches.
  * Verified tunnel resolution, image selection, commands, and returned sandbox handles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->