### PR TITLE
fix: clarify child session tool routing

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-child.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-child",
   description:
-    "Spawn a child coding session in a separate sandbox. Invoke only when the user's current request explicitly asks for a 'child session' or 'child sessions'. Do not treat 'sub-agent', 'subagent', 'sub-task', or 'subtask' as requests for child sessions; those terms refer to in-process task delegation. Otherwise work directly. Never infer permission or suggest using a child session. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a child ID; check status only when its result is needed.",
+    "Use this tool ONLY when the user's current request explicitly and affirmatively asks to create a 'child session' or 'child sessions' in a separate sandbox. DO NOT use it for 'sub-agent', 'subagent', 'sub agent', 'sub-task', 'subtask', or Task tool requests; use the Task tool for those in-process delegations instead. Merely mentioning, comparing, or rejecting child sessions does not authorize this tool. Never infer permission or suggest creating a child session. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a child ID; check status only when its result is needed.",
   args: {
     title: z.string().describe("Short title describing the child session (shown in the UI)."),
     prompt: z


### PR DESCRIPTION
## Summary

- front-load the explicit opt-in requirement for `spawn-child`
- direct sub-agent and Task-tool requests to the in-process `Task` tool
- clarify that mentioning or rejecting child sessions does not authorize spawning one

## Testing

- `uv run --extra dev pytest tests/test_spawn_child_tool.py -v`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3e86650f936a51fd182c6190e90550cc)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use the child session tool.
  * Directed sub-agent and subtask requests to the appropriate task functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->