### PR TITLE
Centralize session rename mutation ownership

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/session-read-state";
 import { usePromptInput } from "@/hooks/use-prompt-input";
 import { useSessionSnapshot } from "./session-snapshot-provider";
+import { useSessionRename } from "@/hooks/use-session-rename";
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
@@ -99,7 +100,13 @@ export default function SessionPage() {
     title: initialSnapshot.session.title,
   };
 
-  const { handleArchive, handleUnarchive, renameSession } = useSessionListActions(sessionId);
+  const { handleArchive, handleUnarchive } = useSessionListActions(sessionId);
+  const { optimisticTitle, renameSession } = useSessionRename({
+    sessionId,
+    currentTitle: sessionState?.title ?? initialSnapshot.session.title,
+    authoritativeTitle: sessionState?.title,
+    awaitAuthoritativeTitle: true,
+  });
   const {
     selectedModel,
     reasoningEffort,
@@ -401,6 +408,7 @@ export default function SessionPage() {
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
         }}
+        optimisticTitle={optimisticTitle}
         renameSession={renameSession}
       />
 
@@ -535,26 +543,10 @@ export default function SessionPage() {
 }
 
 /**
- * Archive, unarchive, and rename actions for the current session, each keeping
- * the SWR session-list caches in sync.
+ * Archive and unarchive actions for the current session.
  */
 function useSessionListActions(sessionId: string) {
   const router = useRouter();
-
-  const { trigger: triggerRename } = useSWRMutation(
-    `/api/sessions/${sessionId}/title`,
-    (url: BrowserApiPath, { arg }: { arg: { title: string } }) =>
-      browserApiFetch(url, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: arg.title }),
-      }).then((r) => {
-        if (r.ok) return true;
-        console.error("Failed to update session title");
-        return false;
-      }),
-    { throwOnError: false }
-  );
 
   const handleArchive = useCallback(async () => {
     const didArchive = await archiveSession(sessionId);
@@ -570,42 +562,6 @@ function useSessionListActions(sessionId: string) {
       router.push("/");
     }
   }, [router, sessionId]);
-
-  const renameSession = useCallback(
-    async (title: string) => {
-      const updatedAt = Date.now();
-      const updateSessionsTitle = (data?: SessionListResponse): SessionListResponse | undefined => {
-        if (!data?.sessions) return data;
-        return {
-          ...data,
-          sessions: data.sessions.map((session) =>
-            session.id === sessionId ? { ...session, title, updatedAt } : session
-          ),
-        };
-      };
-
-      try {
-        const success = await triggerRename({ title });
-        if (!success) {
-          throw new Error("Failed to update session title");
-        }
-        await Promise.all([
-          mutate<SessionListResponse>(isUnarchivedSessionListKey, updateSessionsTitle, {
-            populateCache: true,
-            revalidate: true,
-          }),
-          mutate<SessionListResponse>(isArchivedSessionListKey, updateSessionsTitle, {
-            populateCache: true,
-            revalidate: false,
-          }),
-        ]);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    [sessionId, triggerRename]
-  );
 
   const { trigger: handleUnarchive } = useSWRMutation(
     `/api/sessions/${sessionId}/unarchive`,
@@ -628,7 +584,7 @@ function useSessionListActions(sessionId: string) {
     { throwOnError: false }
   );
 
-  return { handleArchive, handleUnarchive, renameSession };
+  return { handleArchive, handleUnarchive };
 }
 
 /**

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -109,7 +109,8 @@ export type SessionHeaderProps = {
   onToggleDesktopDetails: () => void;
   onOpenMobileDetails: () => void;
   actions: SessionActionProps;
-  renameSession: (title: string) => Promise<boolean | undefined>;
+  optimisticTitle?: string;
+  renameSession: (title: string) => Promise<boolean>;
 };
 
 export function SessionHeader({
@@ -126,6 +127,7 @@ export function SessionHeader({
   onToggleDesktopDetails,
   onOpenMobileDetails,
   actions,
+  optimisticTitle,
   renameSession,
 }: SessionHeaderProps) {
   const { isOpen } = useSidebarContext();
@@ -142,8 +144,6 @@ export function SessionHeader({
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [title, setTitle] = useState(baseResolvedTitle);
-  const [optimisticTitle, setOptimisticTitle] = useState<string | null>(null);
-
   const resolvedTitle =
     optimisticTitle ?? sessionState?.title ?? fallbackSessionInfo.title ?? repoLabel;
 
@@ -165,24 +165,13 @@ export function SessionHeader({
       return;
     }
 
-    const previousTitle = resolvedTitle;
     setIsRenaming(false);
-    setOptimisticTitle(trimmed);
 
     const success = await renameSession(trimmed);
     if (!success) {
-      setOptimisticTitle(null);
-      setTitle(previousTitle);
       setIsRenaming(true);
     }
   };
-
-  useEffect(() => {
-    if (!optimisticTitle) return;
-    if (sessionState?.title === optimisticTitle) {
-      setOptimisticTitle(null);
-    }
-  }, [optimisticTitle, sessionState?.title]);
 
   useEffect(() => {
     if (!isRenaming) setTitle(sessionState?.title ?? fallbackSessionInfo.title ?? "");

--- a/packages/web/src/components/session-list-item.tsx
+++ b/packages/web/src/components/session-list-item.tsx
@@ -9,7 +9,7 @@ import { PullRequestStateIcon } from "@/components/pr-state-icon";
 import { formatRelativeTime } from "@/lib/time";
 import { MoreIcon, ArchiveIcon, BranchIcon, BoxIcon } from "@/components/ui/icons";
 import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { useSessionRename } from "@/hooks/use-session-rename";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -29,7 +29,6 @@ export function SessionListItem({
   isMobile,
   onArchive,
   onSessionSelect,
-  onSessionRenamed,
   onMarkLatestMessageRead,
 }: {
   session: SessionItem;
@@ -38,7 +37,6 @@ export function SessionListItem({
   isMobile: boolean;
   onArchive: (sessionId: string) => Promise<void>;
   onSessionSelect?: () => void;
-  onSessionRenamed: (sessionId: string, title: string) => void;
   onMarkLatestMessageRead: (sessionId: string) => Promise<void>;
 }) {
   const timestamp = session.updatedAt || session.createdAt;
@@ -49,7 +47,11 @@ export function SessionListItem({
     session.repositories
   );
   const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
-  const displayTitle = session.title || repoInfo;
+  const { optimisticTitle, renameSession } = useSessionRename({
+    sessionId: session.id,
+    currentTitle: session.title,
+  });
+  const displayTitle = optimisticTitle ?? session.title ?? repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
   const [isRenaming, setIsRenaming] = useState(false);
@@ -133,21 +135,10 @@ export function SessionListItem({
       return;
     }
 
-    const previousTitle = displayTitle;
     setIsRenaming(false);
 
-    try {
-      const response = await browserApiFetch(`/api/sessions/${session.id}/title`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: trimmed }),
-      });
-      if (!response.ok) {
-        throw new Error("Failed to update session title");
-      }
-      onSessionRenamed(session.id, trimmed);
-    } catch {
-      setTitle(previousTitle);
+    const success = await renameSession(trimmed);
+    if (!success) {
       setIsRenaming(true);
     }
   };

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -89,7 +89,6 @@ export function SessionSidebar({
     scrollContainerRef,
     maybeLoadMoreSessions,
     handleSessionArchived,
-    handleSessionRenamed,
     handleMarkLatestMessageRead,
   } = useSidebarSessions(currentSessionId);
 
@@ -232,7 +231,6 @@ export function SessionSidebar({
                 isMobile={isMobile}
                 onArchive={handleSessionArchived}
                 onSessionSelect={onSessionSelect}
-                onSessionRenamed={handleSessionRenamed}
                 onMarkLatestMessageRead={handleMarkLatestMessageRead}
               />
             ))}
@@ -259,7 +257,6 @@ export function SessionSidebar({
                     isMobile={isMobile}
                     onArchive={handleSessionArchived}
                     onSessionSelect={onSessionSelect}
-                    onSessionRenamed={handleSessionRenamed}
                     onMarkLatestMessageRead={handleMarkLatestMessageRead}
                   />
                 ))}

--- a/packages/web/src/components/session-with-children.tsx
+++ b/packages/web/src/components/session-with-children.tsx
@@ -12,7 +12,6 @@ export function SessionWithChildren({
   isMobile,
   onArchive,
   onSessionSelect,
-  onSessionRenamed,
   onMarkLatestMessageRead,
 }: {
   session: SessionItem;
@@ -22,7 +21,6 @@ export function SessionWithChildren({
   isMobile: boolean;
   onArchive: (sessionId: string) => Promise<void>;
   onSessionSelect?: () => void;
-  onSessionRenamed: (sessionId: string, title: string) => void;
   onMarkLatestMessageRead: (sessionId: string) => Promise<void>;
 }) {
   return (
@@ -34,7 +32,6 @@ export function SessionWithChildren({
         isMobile={isMobile}
         onArchive={onArchive}
         onSessionSelect={onSessionSelect}
-        onSessionRenamed={onSessionRenamed}
         onMarkLatestMessageRead={onMarkLatestMessageRead}
       />
       <ChildSessionTree

--- a/packages/web/src/hooks/use-session-rename.test.tsx
+++ b/packages/web/src/hooks/use-session-rename.test.tsx
@@ -1,0 +1,345 @@
+// @vitest-environment jsdom
+
+import type { PropsWithChildren } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig, useSWRConfig } from "swr";
+import useSWR from "swr";
+import useSWRInfinite from "swr/infinite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "@open-inspect/shared/types/sessions";
+import { buildSessionsPageKey, type SessionListResponse } from "@/lib/session-list";
+import { useSessionRename } from "./use-session-rename";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createSession(title: string, id = "session-1"): Session {
+  return {
+    id,
+    title,
+    status: "active",
+    repoOwner: "acme",
+    repoName: "web",
+    baseBranch: null,
+    branchName: null,
+    baseSha: null,
+    currentSha: null,
+    opencodeSessionId: null,
+    parentSessionId: null,
+    spawnSource: "user",
+    spawnDepth: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    repositories: [],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSessionRename", () => {
+  it("serializes overlapping renames and ignores a stale failure", async () => {
+    const firstPageKey = buildSessionsPageKey({ excludeStatus: "archived" });
+    const secondPageKey = buildSessionsPageKey({ excludeStatus: "archived", offset: 50 });
+    const firstResponse = deferred<Response>();
+    const secondResponse = deferred<Response>();
+    let serverTitle = "Original";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PATCH") {
+        const title = JSON.parse(String(init.body)).title as string;
+        if (title === "Rename A") return firstResponse.promise;
+        serverTitle = title;
+        return secondResponse.promise;
+      }
+      if (String(input) === firstPageKey) {
+        return new Response(
+          JSON.stringify({ sessions: [createSession("Other", "session-other")], hasMore: true }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({ sessions: [createSession(serverTitle)], hasMore: false }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    function Wrapper({ children }: PropsWithChildren) {
+      return (
+        <SWRConfig
+          value={{
+            provider: () => new Map(),
+            dedupingInterval: 0,
+            fetcher: async (url: string) => (await fetch(url)).json(),
+          }}
+        >
+          {children}
+        </SWRConfig>
+      );
+    }
+
+    const { result } = renderHook(
+      () => {
+        useSWRInfinite<SessionListResponse>(
+          (index) => (index === 0 ? firstPageKey : index === 1 ? secondPageKey : null),
+          { initialSize: 2 }
+        );
+        const firstCaller = useSessionRename({ sessionId: "session-1", currentTitle: serverTitle });
+        const secondCaller = useSessionRename({
+          sessionId: "session-1",
+          currentTitle: serverTitle,
+        });
+        return {
+          optimisticTitle: firstCaller.optimisticTitle,
+          renameA: firstCaller.renameSession,
+          renameB: secondCaller.renameSession,
+          cache: useSWRConfig().cache,
+        };
+      },
+      { wrapper: Wrapper }
+    );
+    await waitFor(() => {
+      expect(result.current.cache.get(firstPageKey)?.data).toBeDefined();
+      expect(result.current.cache.get(secondPageKey)?.data).toBeDefined();
+    });
+
+    let renameA!: Promise<boolean>;
+    let renameB!: Promise<boolean>;
+    act(() => {
+      renameA = result.current.renameA("Rename A");
+      renameB = result.current.renameB("Rename B");
+    });
+
+    await waitFor(() => {
+      expect(result.current.optimisticTitle).toBe("Rename B");
+      expect(result.current.cache.get(firstPageKey)?.data.sessions[0].title).toBe("Other");
+      expect(result.current.cache.get(secondPageKey)?.data.sessions[0].title).toBe("Rename B");
+    });
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "PATCH")).toHaveLength(1);
+
+    firstResponse.resolve(new Response(null, { status: 500 }));
+    await expect(renameA).resolves.toBe(true);
+    expect(result.current.optimisticTitle).toBe("Rename B");
+    expect(result.current.cache.get(firstPageKey)?.data.sessions[0].title).toBe("Other");
+
+    secondResponse.resolve(new Response(null, { status: 204 }));
+    await expect(renameB).resolves.toBe(true);
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "PATCH")).toHaveLength(2);
+    await waitFor(() => {
+      expect(result.current.cache.get(firstPageKey)?.data.sessions[0].title).toBe("Other");
+      expect(result.current.cache.get(secondPageKey)?.data.sessions[0].title).toBe("Rename B");
+      expect(result.current.optimisticTitle).toBeUndefined();
+    });
+  });
+
+  it("rolls the latest failure back to an earlier confirmed rename", async () => {
+    const listKey = buildSessionsPageKey({ excludeStatus: "archived" });
+    const firstResponse = deferred<Response>();
+    const secondResponse = deferred<Response>();
+    let patchCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PATCH") {
+          patchCount += 1;
+          return patchCount === 1 ? firstResponse.promise : secondResponse.promise;
+        }
+        return new Response(
+          JSON.stringify({
+            sessions: [createSession("Original", "session-confirmed")],
+            hasMore: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      })
+    );
+
+    const { result } = renderHook(
+      () => {
+        useSWR<SessionListResponse>(listKey);
+        const firstCaller = useSessionRename({
+          sessionId: "session-confirmed",
+          currentTitle: "Original",
+        });
+        const secondCaller = useSessionRename({
+          sessionId: "session-confirmed",
+          currentTitle: "Original",
+        });
+        return {
+          renameA: firstCaller.renameSession,
+          renameB: secondCaller.renameSession,
+          cache: useSWRConfig().cache,
+        };
+      },
+      {
+        wrapper: ({ children }: PropsWithChildren) => (
+          <SWRConfig
+            value={{
+              provider: () => new Map(),
+              dedupingInterval: 0,
+              fetcher: async (url: string) => (await fetch(url)).json(),
+            }}
+          >
+            {children}
+          </SWRConfig>
+        ),
+      }
+    );
+    await waitFor(() => expect(result.current.cache.get(listKey)?.data).toBeDefined());
+
+    let renameA!: Promise<boolean>;
+    let renameB!: Promise<boolean>;
+    act(() => {
+      renameA = result.current.renameA("Rename A");
+      renameB = result.current.renameB("Rename B");
+    });
+    firstResponse.resolve(new Response(null, { status: 204 }));
+    await expect(renameA).resolves.toBe(true);
+    secondResponse.resolve(new Response(null, { status: 500 }));
+    await expect(renameB).resolves.toBe(false);
+
+    await waitFor(() =>
+      expect(result.current.cache.get(listKey)?.data.sessions[0].title).toBe("Rename A")
+    );
+  });
+
+  it("keeps the latest overlay until its authoritative title is cached", async () => {
+    const listKey = buildSessionsPageKey({ excludeStatus: "archived" });
+    const renameResponse = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PATCH") return renameResponse.promise;
+        return new Response(
+          JSON.stringify({
+            sessions: [createSession("Original", "session-authoritative")],
+            hasMore: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ authoritativeTitle }: { authoritativeTitle?: string }) => {
+        useSWR<SessionListResponse>(listKey);
+        const rename = useSessionRename({
+          sessionId: "session-authoritative",
+          currentTitle: authoritativeTitle ?? "Original",
+          authoritativeTitle,
+          awaitAuthoritativeTitle: true,
+        });
+        const { cache, mutate } = useSWRConfig();
+        return { ...rename, cache, mutate };
+      },
+      {
+        initialProps: { authoritativeTitle: undefined as string | undefined },
+        wrapper: ({ children }: PropsWithChildren) => (
+          <SWRConfig
+            value={{
+              provider: () => new Map(),
+              dedupingInterval: 0,
+              fetcher: async (url: string) => (await fetch(url)).json(),
+            }}
+          >
+            {children}
+          </SWRConfig>
+        ),
+      }
+    );
+    await waitFor(() => expect(result.current.cache.get(listKey)?.data).toBeDefined());
+
+    let rename!: Promise<boolean>;
+    act(() => {
+      rename = result.current.renameSession("Rename B");
+    });
+    await act(() =>
+      result.current.mutate<SessionListResponse>(
+        listKey,
+        (current) => ({
+          ...(current as SessionListResponse),
+          sessions: [createSession("Rename A", "session-authoritative")],
+        }),
+        { revalidate: false }
+      )
+    );
+    rerender({ authoritativeTitle: "Rename A" });
+    expect(result.current.optimisticTitle).toBe("Rename B");
+
+    rerender({ authoritativeTitle: "Rename B" });
+    expect(result.current.optimisticTitle).toBe("Rename B");
+    renameResponse.reject(new TypeError("Response connection lost"));
+    await expect(rename).resolves.toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.cache.get(listKey)?.data.sessions[0].title).toBe("Rename B");
+      expect(result.current.optimisticTitle).toBeUndefined();
+    });
+  });
+
+  it("rolls back the current optimistic rename after a failure", async () => {
+    const listKey = buildSessionsPageKey({ excludeStatus: "archived" });
+    const renameResponse = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "PATCH") return renameResponse.promise;
+        return new Response(
+          JSON.stringify({
+            sessions: [createSession("Original", "session-rollback")],
+            hasMore: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      })
+    );
+
+    const { result } = renderHook(
+      () => {
+        useSWR<SessionListResponse>(listKey);
+        const rename = useSessionRename({
+          sessionId: "session-rollback",
+          currentTitle: "Original",
+        });
+        return { ...rename, cache: useSWRConfig().cache };
+      },
+      {
+        wrapper: ({ children }: PropsWithChildren) => (
+          <SWRConfig
+            value={{
+              provider: () => new Map(),
+              dedupingInterval: 0,
+              fetcher: async (url: string) => (await fetch(url)).json(),
+            }}
+          >
+            {children}
+          </SWRConfig>
+        ),
+      }
+    );
+    await waitFor(() => expect(result.current.cache.get(listKey)?.data).toBeDefined());
+
+    let rename!: Promise<boolean>;
+    act(() => {
+      rename = result.current.renameSession("Optimistic");
+    });
+    await waitFor(() =>
+      expect(result.current.cache.get(listKey)?.data.sessions[0].title).toBe("Optimistic")
+    );
+
+    renameResponse.resolve(new Response(null, { status: 500 }));
+    await expect(rename).resolves.toBe(false);
+    await waitFor(() => {
+      expect(result.current.optimisticTitle).toBeUndefined();
+      expect(result.current.cache.get(listKey)?.data.sessions[0].title).toBe("Original");
+    });
+  });
+});

--- a/packages/web/src/hooks/use-session-rename.ts
+++ b/packages/web/src/hooks/use-session-rename.ts
@@ -1,0 +1,212 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { useSWRConfig } from "swr";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { applyTitleUpdate, isSessionListKey, type SessionListResponse } from "@/lib/session-list";
+
+interface RenameOwner {
+  latestRequestId: number;
+  confirmedTitle?: string | null;
+  optimisticTitle?: string;
+  queue: Promise<void>;
+  pendingRequests: number;
+  authoritativeSubscribers: number;
+  listeners: Set<() => void>;
+}
+
+const renameOwners = new Map<string, RenameOwner>();
+
+function getRenameOwner(sessionId: string): RenameOwner {
+  let owner = renameOwners.get(sessionId);
+  if (!owner) {
+    owner = {
+      latestRequestId: 0,
+      queue: Promise.resolve(),
+      pendingRequests: 0,
+      authoritativeSubscribers: 0,
+      listeners: new Set(),
+    };
+    renameOwners.set(sessionId, owner);
+  }
+  return owner;
+}
+
+function deleteIdleOwner(sessionId: string, owner: RenameOwner) {
+  if (
+    owner.listeners.size === 0 &&
+    owner.pendingRequests === 0 &&
+    owner.authoritativeSubscribers === 0
+  ) {
+    renameOwners.delete(sessionId);
+  }
+}
+
+function publishOptimisticTitle(owner: RenameOwner, title: string | undefined) {
+  owner.optimisticTitle = title;
+  owner.listeners.forEach((listener) => listener());
+}
+
+interface UseSessionRenameOptions {
+  sessionId: string;
+  currentTitle: string | null;
+  authoritativeTitle?: string | null;
+  awaitAuthoritativeTitle?: boolean;
+}
+
+export function useSessionRename({
+  sessionId,
+  currentTitle,
+  authoritativeTitle,
+  awaitAuthoritativeTitle = false,
+}: UseSessionRenameOptions) {
+  const { mutate } = useSWRConfig();
+  const currentTitleRef = useRef(currentTitle);
+  const authoritativeTitleRef = useRef(authoritativeTitle);
+  currentTitleRef.current = currentTitle;
+  authoritativeTitleRef.current = authoritativeTitle;
+
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      const owner = getRenameOwner(sessionId);
+      owner.listeners.add(listener);
+      return () => {
+        owner.listeners.delete(listener);
+        deleteIdleOwner(sessionId, owner);
+      };
+    },
+    [sessionId]
+  );
+  const getSnapshot = useCallback(() => getRenameOwner(sessionId).optimisticTitle, [sessionId]);
+  const optimisticTitle = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    const owner = getRenameOwner(sessionId);
+    if (awaitAuthoritativeTitle) {
+      owner.authoritativeSubscribers += 1;
+    }
+
+    if (authoritativeTitle !== undefined) {
+      if (owner.pendingRequests === 0) {
+        owner.confirmedTitle = authoritativeTitle;
+      }
+      if (authoritativeTitle === owner.optimisticTitle && owner.pendingRequests === 0) {
+        void mutate<SessionListResponse>(
+          isSessionListKey,
+          (current) => applyTitleUpdate(current, sessionId, authoritativeTitle),
+          { populateCache: true, revalidate: false }
+        )
+          .catch(() => undefined)
+          .then(() => {
+            if (owner.pendingRequests === 0 && owner.optimisticTitle === authoritativeTitle) {
+              publishOptimisticTitle(owner, undefined);
+            }
+          });
+      }
+    }
+
+    return () => {
+      if (awaitAuthoritativeTitle) {
+        owner.authoritativeSubscribers -= 1;
+      }
+      deleteIdleOwner(sessionId, owner);
+    };
+  }, [authoritativeTitle, awaitAuthoritativeTitle, mutate, sessionId]);
+
+  const renameSession = useCallback(
+    (title: string): Promise<boolean> => {
+      const owner = getRenameOwner(sessionId);
+      const requestId = ++owner.latestRequestId;
+      if (owner.pendingRequests === 0) {
+        owner.confirmedTitle = currentTitleRef.current;
+      }
+      owner.pendingRequests += 1;
+
+      publishOptimisticTitle(owner, title);
+      const optimisticUpdate = mutate<SessionListResponse>(
+        isSessionListKey,
+        (current) => applyTitleUpdate(current, sessionId, title),
+        { populateCache: true, revalidate: false }
+      );
+
+      const request = owner.queue.then(async () => {
+        await optimisticUpdate.catch(() => undefined);
+        const response = await browserApiFetch(`/api/sessions/${sessionId}/title`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title }),
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to update session title");
+        }
+
+        owner.confirmedTitle = title;
+      });
+
+      owner.queue = request.then(
+        () => undefined,
+        () => undefined
+      );
+
+      return request.then(
+        async () => {
+          owner.pendingRequests -= 1;
+          if (owner.latestRequestId === requestId) {
+            await mutate<SessionListResponse>(
+              isSessionListKey,
+              (current) => applyTitleUpdate(current, sessionId, title),
+              { populateCache: true, revalidate: false }
+            ).catch(() => undefined);
+            if (owner.authoritativeSubscribers === 0 || authoritativeTitleRef.current === title) {
+              publishOptimisticTitle(owner, undefined);
+            }
+            void mutate(isSessionListKey).catch(() => undefined);
+          }
+          deleteIdleOwner(sessionId, owner);
+          return true;
+        },
+        async () => {
+          owner.pendingRequests -= 1;
+          if (owner.latestRequestId !== requestId) {
+            deleteIdleOwner(sessionId, owner);
+            return true;
+          }
+
+          if (authoritativeTitleRef.current === title) {
+            owner.confirmedTitle = title;
+            await mutate<SessionListResponse>(
+              isSessionListKey,
+              (current) => applyTitleUpdate(current, sessionId, title),
+              { populateCache: true, revalidate: false }
+            ).catch(() => undefined);
+            publishOptimisticTitle(owner, undefined);
+            void mutate(isSessionListKey).catch(() => undefined);
+            deleteIdleOwner(sessionId, owner);
+            return true;
+          }
+
+          publishOptimisticTitle(
+            owner,
+            owner.confirmedTitle === currentTitleRef.current
+              ? undefined
+              : (owner.confirmedTitle ?? undefined)
+          );
+          await mutate<SessionListResponse>(
+            isSessionListKey,
+            (current) => applyTitleUpdate(current, sessionId, owner.confirmedTitle ?? null),
+            { populateCache: true, revalidate: false }
+          ).catch(() => undefined);
+          if (owner.authoritativeSubscribers === 0) {
+            publishOptimisticTitle(owner, undefined);
+          }
+          deleteIdleOwner(sessionId, owner);
+          return false;
+        }
+      );
+    },
+    [mutate, sessionId]
+  );
+
+  return { optimisticTitle, renameSession };
+}

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -8,7 +8,6 @@ import useSWRInfinite from "swr/infinite";
 import type { SessionListQuery } from "@open-inspect/shared/session-list-query";
 import { isInactiveSession } from "@/lib/time";
 import {
-  applyTitleUpdate,
   applySessionReadState,
   buildSessionsPageKey,
   CURRENT_USER_CREATED_BY,
@@ -254,27 +253,6 @@ export function useSidebarSessions(currentSessionId: string | null) {
     [currentSessionId, mutateExtraPages, mutateFirstPage, router]
   );
 
-  const handleSessionRenamed = useCallback(
-    (sessionId: string, title: string) => {
-      const updatedAt = Date.now();
-      void mutateFirstPage((current) => applyTitleUpdate(current, sessionId, title, updatedAt), {
-        revalidate: false,
-      });
-      void mutateExtraPages(
-        (current) =>
-          current?.map((page) => applyTitleUpdate(page, sessionId, title, updatedAt) ?? page),
-        { revalidate: false }
-      );
-
-      void mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (currentData) => applyTitleUpdate(currentData, sessionId, title, updatedAt),
-        { revalidate: false }
-      );
-    },
-    [mutateExtraPages, mutateFirstPage]
-  );
-
   const handleMarkLatestMessageRead = useCallback(
     async (sessionId: string) => {
       const result = await markLatestMessageRead(sessionId);
@@ -306,7 +284,6 @@ export function useSidebarSessions(currentSessionId: string | null) {
     scrollContainerRef,
     maybeLoadMoreSessions,
     handleSessionArchived,
-    handleSessionRenamed,
     handleMarkLatestMessageRead,
   };
 }

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -158,17 +158,17 @@ describe("isArchivedSessionListKey", () => {
 });
 
 describe("applyTitleUpdate", () => {
-  it("replaces the title and updatedAt of the matching session", () => {
+  it("replaces only the title of the matching session", () => {
     const before: SessionListResponse = {
       sessions: [session("a"), session("b"), session("c")],
       hasMore: false,
     };
 
-    const after = applyTitleUpdate(before, "b", "Renamed", 9999);
+    const after = applyTitleUpdate(before, "b", "Renamed");
 
     expect(after?.sessions).toEqual([
       session("a"),
-      session("b", { title: "Renamed", updatedAt: 9999 }),
+      session("b", { title: "Renamed" }),
       session("c"),
     ]);
   });
@@ -179,13 +179,13 @@ describe("applyTitleUpdate", () => {
       hasMore: true,
     };
 
-    const after = applyTitleUpdate(before, "a", "New", 1);
+    const after = applyTitleUpdate(before, "a", "New");
 
     expect(after?.hasMore).toBe(true);
   });
 
   it("returns undefined when data is undefined (cache miss)", () => {
-    expect(applyTitleUpdate(undefined, "a", "New", 1)).toBeUndefined();
+    expect(applyTitleUpdate(undefined, "a", "New")).toBeUndefined();
   });
 
   it("leaves the list unchanged when sessionId does not match", () => {
@@ -194,7 +194,7 @@ describe("applyTitleUpdate", () => {
       hasMore: false,
     };
 
-    const after = applyTitleUpdate(before, "missing", "New", 9999);
+    const after = applyTitleUpdate(before, "missing", "New");
 
     expect(after?.sessions).toEqual(before.sessions);
   });
@@ -206,7 +206,7 @@ describe("applyTitleUpdate", () => {
     };
     const beforeSnapshot = structuredClone(before);
 
-    applyTitleUpdate(before, "a", "Mutated", 9999);
+    applyTitleUpdate(before, "a", "Mutated");
 
     expect(before).toEqual(beforeSnapshot);
   });

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -64,14 +64,13 @@ export function isArchivedSessionListKey(key: unknown): key is string {
 export function applyTitleUpdate(
   data: SessionListResponse | undefined,
   sessionId: string,
-  title: string,
-  updatedAt: number
+  title: string | null
 ): SessionListResponse | undefined {
   if (!data) return data;
   return {
     ...data,
     sessions: data.sessions.map((session) =>
-      session.id === sessionId ? { ...session, title, updatedAt } : session
+      session.id === sessionId ? { ...session, title } : session
     ),
   };
 }


### PR DESCRIPTION
## Summary
- add a single session rename hook that serializes overlapping requests per session
- centralize optimistic title display, exact rollback, owner cleanup, and all session-list cache reconciliation
- migrate header and sidebar list callers so components retain only their independent editing drafts
- preserve newer optimistic renames across stale failures and authoritative events, including committed mutations whose HTTP response is lost
- remove the separate page and sidebar rename mutation/cache flows

## Validation
- `npm test -w @open-inspect/web -- --maxWorkers=4` (137 files, 1026 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- thermonuclear sub-agent review completed with no remaining merge blockers

## Test Coverage
- cross-caller A/B request serialization
- stale failure with newer optimistic success
- A success followed by B rollback
- authoritative title races and lost HTTP responses
- optimistic rollback and successful settlement
- SWRInfinite pagination cache reconciliation

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/50836632eea97a384130fba353802677)*