### PR TITLE
Bound settings proxy mutation bodies

### DIFF
--- a/packages/web/src/app/api/skills/managed-skills-routes.test.ts
+++ b/packages/web/src/app/api/skills/managed-skills-routes.test.ts
@@ -15,6 +15,7 @@ describe("managed skills BFF routes", () => {
     );
     const request = new NextRequest("http://localhost/api/skills/skill-1", {
       method: "PUT",
+      headers: { Cookie: "__Secure-openinspect.session_token=session.signature" },
       body: JSON.stringify({ description: "A skill", body: "Use it" }),
     });
 
@@ -52,7 +53,10 @@ describe("managed skills BFF routes", () => {
     };
     const request = new NextRequest("http://localhost/api/skills/skill%2Fone", {
       method: "PUT",
-      headers: { "If-Match": "revision-3" },
+      headers: {
+        Cookie: "__Secure-openinspect.session_token=session.signature",
+        "If-Match": "revision-3",
+      },
       body: JSON.stringify(body),
     });
 

--- a/packages/web/src/lib/settings-proxy.test.ts
+++ b/packages/web/src/lib/settings-proxy.test.ts
@@ -1,9 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { controlPlaneUserFetch } from "./control-plane";
-import { settingsProxy } from "./settings-proxy";
+import { SETTINGS_PROXY_MAX_BODY_BYTES, settingsProxy } from "./settings-proxy";
 
 vi.mock("./control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
+
+function streamingMutationRequest(size: number, cookie?: string): NextRequest {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(size));
+      controller.close();
+    },
+  });
+  return new NextRequest("http://localhost/api/settings", {
+    method: "POST",
+    headers: cookie ? { Cookie: cookie } : undefined,
+    body,
+    duplex: "half",
+  } as never);
+}
 
 describe("settingsProxy", () => {
   const { GET, POST } = settingsProxy(() => "/settings", "settings");
@@ -31,16 +46,40 @@ describe("settingsProxy", () => {
     );
     const request = new NextRequest("http://localhost/api/settings", {
       method: "POST",
+      headers: { Cookie: "__Secure-openinspect.session_token=session.signature" },
       body: "{malformed",
     });
 
     const response = await POST(request, { params: Promise.resolve(undefined) });
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", {
-      method: "POST",
-      body: "{malformed",
-    });
+    const options = vi.mocked(controlPlaneUserFetch).mock.calls[0]?.[1];
+    expect(options?.method).toBe("POST");
+    expect(options?.body).toBe("{malformed");
     expect(response.status).toBe(401);
+  });
+
+  it("rejects a missing session cookie before reading an oversized body", async () => {
+    const request = streamingMutationRequest(SETTINGS_PROXY_MAX_BODY_BYTES + 1);
+
+    const response = await POST(request, { params: Promise.resolve(undefined) });
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+    expect(request.bodyUsed).toBe(false);
+  });
+
+  it("caps oversized bodies carrying an unverified session cookie", async () => {
+    const response = await POST(
+      streamingMutationRequest(
+        SETTINGS_PROXY_MAX_BODY_BYTES + 1,
+        "__Secure-openinspect.session_token=forged.invalid-session"
+      ),
+      { params: Promise.resolve(undefined) }
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body is too large" });
+    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
   });
 
   it("keeps resource request failures distinct from unauthorized responses", async () => {

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -1,5 +1,7 @@
+import { readBodyCapped } from "@open-inspect/shared/http-body";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { serializeBrowserSessionCookies } from "@/lib/browser-session-cookie";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 type ProxyMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
@@ -18,6 +20,15 @@ type RouteHandler<P> = (
 ) => Promise<NextResponse>;
 
 type ProxyHandlers<P> = Record<ProxyMethod, RouteHandler<P>>;
+
+/** JSON mutation budget kept below portable web-function request limits. */
+export const SETTINGS_PROXY_MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+async function readMutationBody(request: NextRequest): Promise<Uint8Array | null> {
+  const contentLength = Number(request.headers.get("Content-Length"));
+  if (Number.isFinite(contentLength) && contentLength > SETTINGS_PROXY_MAX_BODY_BYTES) return null;
+  return readBodyCapped(request.body, SETTINGS_PROXY_MAX_BODY_BYTES);
+}
 
 async function proxyResponse(response: Response): Promise<NextResponse> {
   const text = await response.text();
@@ -47,7 +58,17 @@ export function settingsProxy<P>(
       let init: RequestInit | undefined;
       if (method !== "GET") {
         init = { method };
-        if (method !== "DELETE") init.body = await request.text();
+        if (method !== "DELETE") {
+          const cookieHeader = serializeBrowserSessionCookies(request.cookies.getAll());
+          if (!cookieHeader) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+          }
+          const body = await readMutationBody(request);
+          if (!body) {
+            return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
+          }
+          init.body = new TextDecoder().decode(body);
+        }
         if (ifMatch) init.headers = { "If-Match": ifMatch };
       }
       const response = await controlPlaneUserFetch(buildPath(params, request), init);


### PR DESCRIPTION
## Summary
- reject body-bearing settings mutations without a browser session cookie before consuming their streams
- cap settings mutation bodies at 4 MiB using the shared streaming body reader and return 413 before signing or forwarding oversized requests
- preserve delegated Better Auth validation for cookies that are present
- add regression coverage for unread missing-cookie bodies and oversized forged-cookie bodies

Follow-up to #1480 based on security review feedback about unauthenticated web-process resource exhaustion.

## Validation
- `npm test -w @open-inspect/web` (137 files, 1,027 tests)
- `npm test -w @open-inspect/web -- --run src/lib/settings-proxy.test.ts src/app/api/skills/managed-skills-routes.test.ts src/lib/control-plane.test.ts` (18 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-cache`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/279160ca6e2ce4ae03cb47005027ad38)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session validation for settings updates and other authenticated requests.
  * Requests without a valid session are now rejected before their body is processed.
  * Oversized mutation requests are rejected with a clear `413` response.
  * Accepted request bodies are reliably forwarded after decoding.
  * Enhanced handling of malformed request data and session cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->