### PR TITLE
fix: disable Next.js agent rules

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from "next";
 const monorepoRoot = path.join(__dirname, "../..");
 
 const nextConfig: NextConfig = {
+  agentRules: false,
   output: "standalone",
   // Both must match the monorepo root for Turbopack to resolve workspace packages
   outputFileTracingRoot: monorepoRoot,


### PR DESCRIPTION
## Summary
- disable automatic Next.js agent rule generation for the web app
- keep the existing repository-authored agent guidance authoritative

## Testing
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9e263fcbec43783b3e03ce0533672109)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to disable agent rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->