### PR TITLE
Reconcile Git signing configuration on every refresh

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
@@ -185,7 +185,7 @@ class GitSigningRuntime:
             await self._run_git_config(repository, "--unset-all", key, allow_missing=True)
 
     async def _set_git_config(self, repository: Path, key: str, value: str) -> None:
-        await self._run_git_config(repository, key, value)
+        await self._run_git_config(repository, "--replace-all", key, value)
 
     async def _run_git_config(
         self,

--- a/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
@@ -111,12 +111,8 @@ class GitSigningRuntime:
             else Path(os.environ.get(BIN_INSTALL_DIR_ENV_VAR, DEFAULT_BIN_INSTALL_DIR))
             / GIT_SIGNER_COMMAND
         )
-        self._installed_signing_revision: tuple[str, ...] | None = None
-        self._installed_repository_paths: tuple[Path, ...] = ()
 
     async def initialize(self, author: GitUser | None) -> None:
-        self._installed_signing_revision = None
-        self._installed_repository_paths = ()
         await self.refresh(author)
 
     async def refresh(self, author: GitUser | None) -> None:
@@ -151,22 +147,13 @@ class GitSigningRuntime:
             repositories = read_repo_manifest(self.repo_manifest_path)
         except RepoConfigError:
             raise GitSigningError("Invalid repository manifest") from None
-        repository_paths = tuple(repository.path for repository in repositories)
-        signing_revision = self._signing_revision(configuration)
-        signing_state_changed = (
-            signing_revision != self._installed_signing_revision
-            or repository_paths != self._installed_repository_paths
-        )
 
         if isinstance(configuration, DisabledCommitSigningConfiguration):
             effective_author = author or UNSIGNED_GIT_USER
-            if signing_state_changed:
-                for repository in repositories:
-                    await self._remove_signing_git_config(repository.path)
             for repository in repositories:
+                await self._remove_signing_git_config(repository.path)
                 await self._set_git_config(repository.path, "user.name", effective_author.name)
                 await self._set_git_config(repository.path, "user.email", effective_author.email)
-            self._record_installed_state(signing_revision, repository_paths)
             return
 
         effective_author = author or GitUser(
@@ -188,31 +175,10 @@ class GitSigningRuntime:
             ("user.email", effective_author.email),
         )
         for repository in repositories:
-            if signing_state_changed:
-                for key, value in signing_values:
-                    await self._set_git_config(repository.path, key, value)
+            for key, value in signing_values:
+                await self._set_git_config(repository.path, key, value)
             for key, value in author_values:
                 await self._set_git_config(repository.path, key, value)
-        self._record_installed_state(signing_revision, repository_paths)
-
-    @staticmethod
-    def _signing_revision(configuration: CommitSigningConfiguration) -> tuple[str, ...]:
-        if isinstance(configuration, DisabledCommitSigningConfiguration):
-            return ("disabled",)
-        return (
-            "enabled",
-            configuration.committerName,
-            configuration.committerEmail,
-            configuration.publicKey,
-        )
-
-    def _record_installed_state(
-        self,
-        signing_revision: tuple[str, ...],
-        repository_paths: tuple[Path, ...],
-    ) -> None:
-        self._installed_signing_revision = signing_revision
-        self._installed_repository_paths = repository_paths
 
     async def _remove_signing_git_config(self, repository: Path) -> None:
         for key in SIGNING_CONFIG_KEYS:

--- a/packages/sandbox-runtime/tests/test_git_signing.py
+++ b/packages/sandbox-runtime/tests/test_git_signing.py
@@ -1,6 +1,5 @@
 import subprocess
 import textwrap
-from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -23,6 +22,16 @@ ENABLED_CONFIGURATION = {
     "committerEmail": "open-inspect@example.com",
     "publicKey": PUBLIC_KEY,
 }
+OWNED_SIGNING_CONFIG_KEYS = (
+    "author.name",
+    "author.email",
+    "committer.name",
+    "committer.email",
+    "gpg.format",
+    "gpg.ssh.program",
+    "user.signingkey",
+    "commit.gpgsign",
+)
 
 
 def git(repo, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -298,32 +307,72 @@ async def test_enabled_configuration_applies_to_every_manifest_repository(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_participant_change_updates_only_author_identity(tmp_path, monkeypatch):
+async def test_reapplying_enabled_configuration_repairs_drift_and_updates_participant(tmp_path):
     repo = create_repository(tmp_path / "repo")
     manifest = create_manifest(tmp_path, [repo])
     runtime = create_runtime(tmp_path, manifest)
     await runtime.apply_configuration(
         ENABLED_CONFIGURATION, GitUser(name="Jane Dev", email="123+jane@users.noreply.github.com")
     )
-    set_git_config = AsyncMock(side_effect=runtime._set_git_config)
-    monkeypatch.setattr(runtime, "_set_git_config", set_git_config)
+    git(repo, "config", "user.signingkey", "key::externally-changed")
+    git(repo, "config", "--unset-all", "commit.gpgsign")
 
     await runtime.apply_configuration(
         ENABLED_CONFIGURATION, GitUser(name="Ada Dev", email="456+ada@users.noreply.github.com")
     )
 
-    assert [call.args[1] for call in set_git_config.await_args_list] == [
-        "author.name",
-        "author.email",
-        "user.name",
-        "user.email",
-    ]
+    assert git(repo, "config", "user.signingkey").stdout.strip() == f"key::{PUBLIC_KEY}"
+    assert git(repo, "config", "commit.gpgsign").stdout.strip() == "true"
     assert git(repo, "config", "author.name").stdout.strip() == "Ada Dev"
     assert git(repo, "config", "author.email").stdout.strip() == (
         "456+ada@users.noreply.github.com"
     )
+    assert git(repo, "config", "user.name").stdout.strip() == "Ada Dev"
+    assert git(repo, "config", "user.email").stdout.strip() == "456+ada@users.noreply.github.com"
     assert git(repo, "config", "committer.name").stdout.strip() == "Open Inspect"
     assert git(repo, "config", "committer.email").stdout.strip() == ("open-inspect@example.com")
+
+
+@pytest.mark.asyncio
+async def test_reapplying_disabled_configuration_removes_external_signing_state(tmp_path):
+    repo = create_repository(tmp_path / "repo")
+    manifest = create_manifest(tmp_path, [repo])
+    runtime = create_runtime(tmp_path, manifest)
+    await runtime.apply_configuration({"enabled": False}, None)
+    git(repo, "config", "user.signingkey", "key::externally-added")
+    git(repo, "config", "commit.gpgsign", "true")
+
+    await runtime.apply_configuration({"enabled": False}, None)
+
+    assert git(repo, "config", "--get", "user.signingkey", check=False).returncode == 1
+    assert git(repo, "config", "--get", "commit.gpgsign", check=False).returncode == 1
+
+
+@pytest.mark.asyncio
+async def test_enabled_disabled_transition_reconciles_owned_config_only(tmp_path):
+    repo = create_repository(tmp_path / "repo")
+    unowned_key = "gpg.ssh.allowedSignersFile"
+    unowned_value = str(tmp_path / "allowed-signers")
+    git(repo, "config", unowned_key, unowned_value)
+    runtime = create_runtime(tmp_path, create_manifest(tmp_path, [repo]))
+    await runtime.apply_configuration(ENABLED_CONFIGURATION, None)
+
+    await runtime.apply_configuration({"enabled": False}, None)
+
+    for key in OWNED_SIGNING_CONFIG_KEYS:
+        assert git(repo, "config", "--get", key, check=False).returncode == 1
+    assert git(repo, "config", unowned_key).stdout.strip() == unowned_value
+    assert git(repo, "config", "user.name").stdout.strip() == "OpenInspect"
+    assert git(repo, "config", "user.email").stdout.strip() == "open-inspect@noreply.github.com"
+
+    await runtime.apply_configuration(ENABLED_CONFIGURATION, None)
+
+    assert git(repo, "config", "author.name").stdout.strip() == "Open Inspect"
+    assert git(repo, "config", "committer.name").stdout.strip() == "Open Inspect"
+    assert git(repo, "config", "gpg.format").stdout.strip() == "ssh"
+    assert git(repo, "config", "user.signingkey").stdout.strip() == f"key::{PUBLIC_KEY}"
+    assert git(repo, "config", "commit.gpgsign").stdout.strip() == "true"
+    assert git(repo, "config", unowned_key).stdout.strip() == unowned_value
 
 
 @pytest.mark.asyncio

--- a/packages/sandbox-runtime/tests/test_git_signing.py
+++ b/packages/sandbox-runtime/tests/test_git_signing.py
@@ -314,15 +314,17 @@ async def test_reapplying_enabled_configuration_repairs_drift_and_updates_partic
     await runtime.apply_configuration(
         ENABLED_CONFIGURATION, GitUser(name="Jane Dev", email="123+jane@users.noreply.github.com")
     )
-    git(repo, "config", "user.signingkey", "key::externally-changed")
-    git(repo, "config", "--unset-all", "commit.gpgsign")
+    git(repo, "config", "--add", "user.signingkey", "key::externally-added")
+    git(repo, "config", "--add", "commit.gpgsign", "false")
 
     await runtime.apply_configuration(
         ENABLED_CONFIGURATION, GitUser(name="Ada Dev", email="456+ada@users.noreply.github.com")
     )
 
-    assert git(repo, "config", "user.signingkey").stdout.strip() == f"key::{PUBLIC_KEY}"
-    assert git(repo, "config", "commit.gpgsign").stdout.strip() == "true"
+    assert git(repo, "config", "--get-all", "user.signingkey").stdout.splitlines() == [
+        f"key::{PUBLIC_KEY}"
+    ]
+    assert git(repo, "config", "--get-all", "commit.gpgsign").stdout.splitlines() == ["true"]
     assert git(repo, "config", "author.name").stdout.strip() == "Ada Dev"
     assert git(repo, "config", "author.email").stdout.strip() == (
         "456+ada@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- remove the process-local Git-signing revision and repository-path cache
- reconcile owned signing configuration declaratively on every refresh
- add coverage for enabled and disabled drift repair, participant changes, transitions, and preservation of unowned Git configuration

## Validation
- `PYTHONPATH=src uv run --extra dev pytest tests/test_git_signing.py -q` (17 passed)
- `uv run --extra dev ruff check src/sandbox_runtime/git_signing.py tests/test_git_signing.py`
- `uv run --extra dev ruff format --check src/sandbox_runtime/git_signing.py tests/test_git_signing.py`
- `uv run --extra dev mypy src/sandbox_runtime/git_signing.py`
- `git diff --check`

## Additional testing notes
- Full sandbox-runtime suite: 737 passed, 4 unrelated failures. Three credential-helper tests inherited live control-plane session credentials from the environment; one Git signer test expects a `-U` argument not emitted by the installed Git version.
- Package-wide mypy has one unrelated existing `no-any-return` error in `src/sandbox_runtime/auth/github_app.py:62`.

## Review
- Ran the requested thermo-review in a sub-agent and iterated on all in-scope findings. Final review reported no remaining in-scope findings.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/79480e2311c5946b99feb5f609553e21)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git signing configuration is now refreshed consistently when signing is enabled or disabled.
  - Disabling signing removes managed signing settings while preserving unrelated Git configuration.
  - Author identity settings are reapplied reliably during configuration updates.
  - Configuration changes now correctly handle externally introduced signing settings.
  - Signing and author settings are applied consistently across repositories after configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->