### PR TITLE
fix: validate Linear callback payloads once

### DIFF
--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -14,6 +14,14 @@ import {
   linearToolCallCallbackSchema,
 } from "@open-inspect/shared/types/session-api";
 
+const LINEAR_CALLBACK_CONTEXT = {
+  source: "linear",
+  issueId: "issue-1",
+  issueIdentifier: "ENG-1",
+  issueUrl: "https://linear.app/acme/issue/ENG-1",
+  model: "anthropic/claude-haiku-4-5",
+};
+
 // ---- Mock factories ----
 
 function createMockLogger(): Logger {
@@ -335,7 +343,8 @@ describe("CallbackNotificationService", () => {
       expect(slackFetch).not.toHaveBeenCalled();
 
       const body = JSON.parse(String(linearFetch.mock.calls[0][1]?.body));
-      expect(linearCompletionCallbackSchema.parse(body).context.issueId).toBe("issue-1");
+      expect(body.context.issueId).toBe("issue-1");
+      expect(linearCompletionCallbackSchema.safeParse(body).success).toBe(true);
       expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
     });
   });
@@ -513,13 +522,7 @@ describe("CallbackNotificationService", () => {
 
     it("fires callback on first call", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
-        callback_context: JSON.stringify({
-          model: "anthropic/claude-haiku-4-5",
-          issueUrl: "https://linear.app/acme/issue/ENG-1",
-          issueIdentifier: "ENG-1",
-          issueId: "issue-1",
-          source: "linear",
-        }),
+        callback_context: JSON.stringify(LINEAR_CALLBACK_CONTEXT),
         source: "linear",
       });
 
@@ -552,6 +555,25 @@ describe("CallbackNotificationService", () => {
       expect(body.signature).toEqual(expect.any(String));
       expect(linearToolCallCallbackSchema.safeParse(body).success).toBe(true);
       expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
+    });
+
+    it("skips Linear callbacks whose tool arguments are missing", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(LINEAR_CALLBACK_CONTEXT),
+        source: "linear",
+      });
+
+      await harness.service.notifyToolCall("msg-1", {
+        type: "tool_call",
+        tool: "bash",
+        callId: "call-1",
+      });
+
+      expect(harness.linearBot.fetch).not.toHaveBeenCalled();
+      expect(harness.log.warn).toHaveBeenCalledWith(
+        "callback.tool_call",
+        expect.objectContaining({ outcome: "skipped", skip_reason: "invalid_payload" })
+      );
     });
 
     it("skips automation source — the SchedulerDO has no tool-call consumer", async () => {
@@ -643,6 +665,30 @@ describe("CallbackNotificationService", () => {
           status: "completed",
         });
         expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not throttle a valid Linear callback after rejecting an invalid one", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_700_000_000_000);
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify(LINEAR_CALLBACK_CONTEXT),
+          source: "linear",
+        });
+        harness.linearBot.fetch.mockResolvedValue(new Response("ok", { status: 200 }));
+
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          args: { command: "invalid without callId" },
+        });
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          args: { command: "valid" },
+          callId: "call-valid",
+        });
+
+        expect(harness.linearBot.fetch).toHaveBeenCalledOnce();
       });
 
       it("fires once per distinct callId across many tool calls", async () => {

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -8,6 +8,11 @@ import {
 } from "./callback-notification-service";
 import type { MessageRepository } from "./message-repository";
 import type { FetchClient } from "../platform-ports";
+import { verifyCallbackSignature } from "@open-inspect/shared/auth";
+import {
+  linearCompletionCallbackSchema,
+  linearToolCallCallbackSchema,
+} from "@open-inspect/shared/types/session-api";
 
 // ---- Mock factories ----
 
@@ -308,7 +313,13 @@ describe("CallbackNotificationService", () => {
 
     it("routes to LINEAR_BOT for linear source", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
-        callback_context: JSON.stringify({ issueId: "LIN-123" }),
+        callback_context: JSON.stringify({
+          source: "linear",
+          issueId: " issue-1 ",
+          issueIdentifier: "LIN-123",
+          issueUrl: "https://linear.app/acme/issue/LIN-123",
+          model: "anthropic/claude-haiku-4-5",
+        }),
         source: "linear",
       });
 
@@ -322,6 +333,10 @@ describe("CallbackNotificationService", () => {
 
       const slackFetch = harness.slackBot.fetch;
       expect(slackFetch).not.toHaveBeenCalled();
+
+      const body = JSON.parse(String(linearFetch.mock.calls[0][1]?.body));
+      expect(linearCompletionCallbackSchema.parse(body).context.issueId).toBe("issue-1");
+      expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
     });
   });
 
@@ -498,11 +513,17 @@ describe("CallbackNotificationService", () => {
 
     it("fires callback on first call", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
-        callback_context: JSON.stringify({ channel: "C123" }),
-        source: "slack",
+        callback_context: JSON.stringify({
+          model: "anthropic/claude-haiku-4-5",
+          issueUrl: "https://linear.app/acme/issue/ENG-1",
+          issueIdentifier: "ENG-1",
+          issueId: "issue-1",
+          source: "linear",
+        }),
+        source: "linear",
       });
 
-      const fetchMock = vi.mocked(harness.slackBot.fetch);
+      const fetchMock = vi.mocked(harness.linearBot.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
 
       await harness.service.notifyToolCall("msg-1", {
@@ -526,9 +547,11 @@ describe("CallbackNotificationService", () => {
         args: { cmd: "ls" },
         callId: "call-1",
         status: "running",
-        context: { channel: "C123" },
+        context: expect.objectContaining({ source: "linear", issueId: "issue-1" }),
       });
       expect(body.signature).toEqual(expect.any(String));
+      expect(linearToolCallCallbackSchema.safeParse(body).success).toBe(true);
+      expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
     });
 
     it("skips automation source — the SchedulerDO has no tool-call consumer", async () => {

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -8,6 +8,10 @@
  */
 
 import { computeHmacHex } from "@open-inspect/shared/auth";
+import {
+  linearCompletionCallbackPayloadSchema,
+  linearToolCallCallbackPayloadSchema,
+} from "@open-inspect/shared/types/session-api";
 import { callbackSigningSecret, type CallbackDestination } from "../auth/service/callback-signing";
 import type { Logger } from "../logger";
 import { deliverWithRetry } from "./callback-delivery";
@@ -181,12 +185,12 @@ export class CallbackNotificationService {
         return;
       }
 
-      const context = JSON.parse(message.callback_context);
-      source = context.source === "automation" ? "automation" : (message.source ?? null);
+      const rawContext = JSON.parse(message.callback_context);
+      source = rawContext.source === "automation" ? "automation" : (message.source ?? null);
 
       // Route automation callbacks to SchedulerDO (different URL + payload).
       if (source === "automation") {
-        result = await this.notifyAutomationComplete(context, success, error, messageId);
+        result = await this.notifyAutomationComplete(rawContext, success, error, messageId);
         return;
       }
 
@@ -201,14 +205,23 @@ export class CallbackNotificationService {
       }
 
       const timestamp = Date.now();
-      const payloadData = {
+      const callbackData = {
         sessionId,
         messageId,
         success,
         ...(error != null ? { error } : {}),
         timestamp,
-        context,
+        context: rawContext,
       };
+      const parsedCallback =
+        source === "linear"
+          ? linearCompletionCallbackPayloadSchema.safeParse(callbackData)
+          : undefined;
+      if (parsedCallback && !parsedCallback.success) {
+        result.rejectReason = "invalid_payload";
+        return;
+      }
+      const payloadData = parsedCallback?.data ?? callbackData;
       const signature = await this.signPayload(payloadData, secret);
       const payload = { ...payloadData, signature };
       result = await deliverWithRetry(
@@ -396,18 +409,31 @@ export class CallbackNotificationService {
     }
 
     const sessionId = this.getSessionId();
-    const context = JSON.parse(message.callback_context);
+    const rawContext = JSON.parse(message.callback_context);
 
-    const payloadData = {
+    const callbackData = {
       sessionId,
       tool,
       args: event.args ?? {},
       callId,
       status: event.status,
       timestamp: now,
-      context,
+      context: rawContext,
     };
-
+    const parsedPayload =
+      source === "linear" ? linearToolCallCallbackPayloadSchema.safeParse(callbackData) : undefined;
+    if (parsedPayload && !parsedPayload.success) {
+      this.log.warn("callback.tool_call", {
+        message_id: messageId,
+        session_id: sessionId,
+        source,
+        tool,
+        outcome: "skipped",
+        skip_reason: "invalid_payload",
+      });
+      return;
+    }
+    const payloadData = parsedPayload?.data ?? callbackData;
     const signature = await this.signPayload(payloadData, secret);
     const payload = { ...payloadData, signature };
 

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -60,6 +60,7 @@ export interface CallbackServiceDeps {
  * single duplicate Linear/Slack activity, not data loss.
  */
 const NOTIFIED_CALL_IDS_CAP = 500;
+const EMPTY_TOOL_ARGS: Record<string, unknown> = {};
 
 interface CallbackDeliveryResult {
   delivered: boolean;
@@ -354,10 +355,8 @@ export class CallbackNotificationService {
     // a later event for the same callId can retry.
     if (callId && this.notifiedCallIds.has(callId)) return;
 
-    // Throttle: max 1 per 3 seconds
+    // Use one timestamp for validation, throttling, and the callback payload.
     const now = Date.now();
-    if (now - this._lastToolCallCallbackTs < 3000) return;
-    this._lastToolCallCallbackTs = now;
 
     const tool = event.tool ?? "unknown";
 
@@ -414,7 +413,7 @@ export class CallbackNotificationService {
     const callbackData = {
       sessionId,
       tool,
-      args: event.args ?? {},
+      args: source === "linear" ? event.args : (event.args ?? EMPTY_TOOL_ARGS),
       callId,
       status: event.status,
       timestamp: now,
@@ -433,6 +432,11 @@ export class CallbackNotificationService {
       });
       return;
     }
+
+    // Invalid callbacks must not consume the delivery throttle window.
+    if (now - this._lastToolCallCallbackTs < 3000) return;
+    this._lastToolCallCallbackTs = now;
+
     const payloadData = parsedPayload?.data ?? callbackData;
     const signature = await this.signPayload(payloadData, secret);
     const payload = { ...payloadData, signature };

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -4,11 +4,9 @@ import {
   resolveSessionModelSettings,
   resolveStaticTarget,
 } from "../model-resolution";
-import { isValidPayload } from "../callbacks";
 import { buildOAuthSuccessHtml } from "../index";
 import { matchExplicitRepo } from "../target-resolution";
 import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
-import type { CompletionCallback } from "../types";
 
 describe("buildOAuthSuccessHtml", () => {
   it("renders the configured app name in the heading", () => {
@@ -276,48 +274,5 @@ describe("resolveSessionModelSettings", () => {
 
     expect(result.model).toBe("anthropic/claude-opus-4-6");
     expect(result.reasoningEffort).toBe("max");
-  });
-});
-
-// ─── isValidPayload ─────────────────────────────────────────────────────────
-
-describe("isValidPayload", () => {
-  const validPayload: CompletionCallback = {
-    sessionId: "sess-1",
-    messageId: "msg-1",
-    success: true,
-    timestamp: Date.now(),
-    signature: "abc123",
-    context: {
-      source: "linear",
-      issueId: "issue-1",
-      issueIdentifier: "ENG-123",
-      issueUrl: "https://linear.app/issue/ENG-123",
-      repoFullName: "org/repo",
-      model: "claude-sonnet-4-5",
-    },
-  };
-
-  it("accepts a complete payload", () => {
-    expect(isValidPayload(validPayload)).toBe(true);
-  });
-
-  it("rejects null", () => {
-    expect(isValidPayload(null)).toBe(false);
-  });
-
-  it("rejects missing sessionId", () => {
-    const { sessionId: _sessionId, ...rest } = validPayload;
-    expect(isValidPayload(rest)).toBe(false);
-  });
-
-  it("rejects missing context.issueId", () => {
-    const bad = { ...validPayload, context: { ...validPayload.context, issueId: undefined } };
-    expect(isValidPayload(bad)).toBe(false);
-  });
-
-  it("rejects missing signature", () => {
-    const { signature: _signature, ...rest } = validPayload;
-    expect(isValidPayload(rest)).toBe(false);
   });
 });

--- a/packages/linear-bot/src/callbacks.helpers.test.ts
+++ b/packages/linear-bot/src/callbacks.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatCompletionComment, formatToolAction, isValidToolCallPayload } from "./callbacks";
+import { formatCompletionComment, formatToolAction } from "./callbacks";
 
 // ─── formatToolAction ────────────────────────────────────────────────────────
 
@@ -117,66 +117,5 @@ describe("formatCompletionComment", () => {
     expect(formatCompletionComment("Open-Inspect", true, "ok")).toBe(
       "## 🤖 Open-Inspect completed\n\nok"
     );
-  });
-});
-
-// ─── isValidToolCallPayload ──────────────────────────────────────────────────
-
-describe("isValidToolCallPayload", () => {
-  const valid = {
-    sessionId: "sess-1",
-    tool: "bash",
-    args: { command: "ls" },
-    callId: "call-1",
-    timestamp: Date.now(),
-    signature: "abc123",
-    context: {
-      source: "linear" as const,
-      issueId: "issue-1",
-      issueIdentifier: "ENG-1",
-      issueUrl: "https://linear.app/issue/ENG-1",
-      repoFullName: "org/repo",
-      model: "claude-sonnet-4-5",
-    },
-  };
-
-  it("accepts a complete valid payload", () => {
-    expect(isValidToolCallPayload(valid)).toBe(true);
-  });
-
-  it("rejects null", () => {
-    expect(isValidToolCallPayload(null)).toBe(false);
-  });
-
-  it("rejects undefined", () => {
-    expect(isValidToolCallPayload(undefined)).toBe(false);
-  });
-
-  it("rejects missing sessionId", () => {
-    const { sessionId: _, ...rest } = valid;
-    expect(isValidToolCallPayload(rest)).toBe(false);
-  });
-
-  it("rejects missing tool", () => {
-    const { tool: _, ...rest } = valid;
-    expect(isValidToolCallPayload(rest)).toBe(false);
-  });
-
-  it("rejects missing timestamp", () => {
-    const { timestamp: _, ...rest } = valid;
-    expect(isValidToolCallPayload(rest)).toBe(false);
-  });
-
-  it("rejects missing signature", () => {
-    const { signature: _, ...rest } = valid;
-    expect(isValidToolCallPayload(rest)).toBe(false);
-  });
-
-  it("rejects context: null", () => {
-    expect(isValidToolCallPayload({ ...valid, context: null })).toBe(false);
-  });
-
-  it("rejects sessionId of wrong type", () => {
-    expect(isValidToolCallPayload({ ...valid, sessionId: 123 })).toBe(false);
   });
 });

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -4,7 +4,12 @@
  */
 
 import { Hono } from "hono";
-import type { Env, CompletionCallback, ToolCallCallback } from "./types";
+import type { Env } from "./types";
+import {
+  linearCompletionCallbackSchema,
+  linearToolCallCallbackSchema,
+  type LinearCompletionCallback,
+} from "@open-inspect/shared/types/session-api";
 import {
   getLinearClient,
   emitAgentActivity,
@@ -30,30 +35,21 @@ export function formatCompletionComment(
     : `## ⚠️ ${appName} encountered an issue\n\n${message}`;
 }
 
-export function isValidPayload(payload: unknown): payload is CompletionCallback {
-  if (!payload || typeof payload !== "object") return false;
-  const p = payload as Record<string, unknown>;
-  return (
-    typeof p.sessionId === "string" &&
-    typeof p.messageId === "string" &&
-    typeof p.success === "boolean" &&
-    typeof p.timestamp === "number" &&
-    typeof p.signature === "string" &&
-    p.context !== null &&
-    typeof p.context === "object" &&
-    typeof (p.context as Record<string, unknown>).issueId === "string"
-  );
-}
-
 export const callbacksRouter = new Hono<{ Bindings: Env }>();
 callbacksRouter.route("/", createStartCallbackRouter());
 
 callbacksRouter.post("/complete", async (c) => {
   const startTime = Date.now();
   const traceId = c.req.header("x-trace-id") || crypto.randomUUID();
-  const payload = await c.req.json();
+  let rawPayload: unknown;
+  try {
+    rawPayload = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid payload" }, 400);
+  }
+  const parsed = linearCompletionCallbackSchema.safeParse(rawPayload);
 
-  if (!isValidPayload(payload)) {
+  if (!parsed.success) {
     log.warn("http.request", {
       trace_id: traceId,
       http_path: "/callbacks/complete",
@@ -64,8 +60,10 @@ callbacksRouter.post("/complete", async (c) => {
     });
     return c.json({ error: "invalid payload" }, 400);
   }
+  const payload = parsed.data;
 
-  const rejection = await rejectInvalidCallback(c, payload, {
+  // Verify the original object because the signature covers its JSON key order.
+  const rejection = await rejectInvalidCallback(c, rawPayload, {
     path: "/callbacks/complete",
     traceId,
     startTime,
@@ -114,25 +112,18 @@ export function formatToolAction(
   }
 }
 
-export function isValidToolCallPayload(payload: unknown): payload is ToolCallCallback {
-  if (!payload || typeof payload !== "object") return false;
-  const p = payload as Record<string, unknown>;
-  return (
-    typeof p.sessionId === "string" &&
-    typeof p.tool === "string" &&
-    typeof p.timestamp === "number" &&
-    typeof p.signature === "string" &&
-    p.context !== null &&
-    typeof p.context === "object"
-  );
-}
-
 callbacksRouter.post("/tool_call", async (c) => {
   const startTime = Date.now();
   const traceId = c.req.header("x-trace-id") || crypto.randomUUID();
-  const payload = await c.req.json();
+  let rawPayload: unknown;
+  try {
+    rawPayload = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid payload" }, 400);
+  }
+  const parsed = linearToolCallCallbackSchema.safeParse(rawPayload);
 
-  if (!isValidToolCallPayload(payload)) {
+  if (!parsed.success) {
     log.warn("http.request", {
       trace_id: traceId,
       http_path: "/callbacks/tool_call",
@@ -143,8 +134,10 @@ callbacksRouter.post("/tool_call", async (c) => {
     });
     return c.json({ error: "invalid payload" }, 400);
   }
+  const payload = parsed.data;
 
-  const rejection = await rejectInvalidCallback(c, payload, {
+  // Verify the original object because the signature covers its JSON key order.
+  const rejection = await rejectInvalidCallback(c, rawPayload, {
     path: "/callbacks/tool_call",
     traceId,
     startTime,
@@ -234,7 +227,7 @@ callbacksRouter.post("/tool_call", async (c) => {
 // ─── Completion Callback ─────────────────────────────────────────────────────
 
 async function handleCompletionCallback(
-  payload: CompletionCallback,
+  payload: LinearCompletionCallback,
   env: Env,
   traceId?: string
 ): Promise<void> {

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -103,9 +103,7 @@ export function formatToolAction(
     default: {
       const firstStringArg = Object.values(args).find((v) => typeof v === "string");
       return {
-        // Linear rejects activities with an empty `action`; the upstream
-        // validator allows tool === "" so guard here.
-        action: tool || "Tool",
+        action: tool,
         parameter: firstStringArg ? String(firstStringArg).slice(0, 200) : "(no args)",
       };
     }

--- a/packages/linear-bot/src/callbacks.validation.test.ts
+++ b/packages/linear-bot/src/callbacks.validation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { computeHmacHex } from "@open-inspect/shared/auth";
+import { callbacksRouter } from "./callbacks";
+import { createFakeKV, makeExecutionContext, makeLinearBotEnv } from "./test-helpers";
+
+const SECRET = "callback-secret";
+
+const validToolCall = {
+  sessionId: "session-1",
+  tool: "bash",
+  args: { command: "npm test" },
+  callId: "call-1",
+  status: "running",
+  timestamp: 1_700_000_000_000,
+  context: {
+    source: "linear",
+    issueId: "issue-1",
+    issueIdentifier: "ENG-1",
+    issueUrl: "https://linear.app/acme/issue/ENG-1",
+    model: "anthropic/claude-haiku-4-5",
+  },
+};
+
+const validCompletion = {
+  sessionId: "session-1",
+  messageId: "message-1",
+  success: true,
+  timestamp: 1_700_000_000_000,
+  context: validToolCall.context,
+};
+
+async function sign(payload: Record<string, unknown>) {
+  return { ...payload, signature: await computeHmacHex(JSON.stringify(payload), SECRET) };
+}
+
+async function postToolCall(payload: unknown): Promise<Response> {
+  const { kv } = createFakeKV();
+  return callbacksRouter.fetch(
+    new Request("http://localhost/tool_call", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    }),
+    makeLinearBotEnv(kv, { SERVICE_AUTH_SECRET: SECRET }),
+    makeExecutionContext()
+  );
+}
+
+async function postCompletion(payload: unknown): Promise<Response> {
+  const { kv } = createFakeKV();
+  return callbacksRouter.fetch(
+    new Request("http://localhost/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    }),
+    makeLinearBotEnv(kv, { SERVICE_AUTH_SECRET: SECRET }),
+    makeExecutionContext()
+  );
+}
+
+describe("POST /tool_call callback validation", () => {
+  it("accepts a valid signed callback", async () => {
+    const response = await postToolCall(await sign(validToolCall));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it.each(["args", "callId"])("rejects a callback missing %s", async (field) => {
+    const payload = { ...validToolCall } as Record<string, unknown>;
+    delete payload[field];
+
+    const response = await postToolCall(await sign(payload));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects malformed Linear context", async () => {
+    const response = await postToolCall(
+      await sign({ ...validToolCall, context: { source: "linear", issueId: "issue-1" } })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an invalid signature", async () => {
+    const response = await postToolCall({ ...validToolCall, signature: "invalid" });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /complete callback validation", () => {
+  it("accepts a valid signed callback", async () => {
+    const response = await postCompletion(await sign(validCompletion));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it("rejects malformed Linear context", async () => {
+    const response = await postCompletion(
+      await sign({ ...validCompletion, context: { source: "linear", issueId: "issue-1" } })
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/packages/linear-bot/src/callbacks/reject-invalid-callback.ts
+++ b/packages/linear-bot/src/callbacks/reject-invalid-callback.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import { verifyCallbackFromControlPlane } from "@open-inspect/shared/auth";
+import { isSignedCallbackPayload, verifyCallbackFromControlPlane } from "@open-inspect/shared/auth";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 
@@ -15,7 +15,7 @@ const log = createLogger("callback");
  */
 export async function rejectInvalidCallback(
   c: Context<{ Bindings: Env }>,
-  payload: { signature: string },
+  payload: unknown,
   logContext?: { path: string; traceId: string; startTime: number; sessionId?: string }
 ): Promise<Response | null> {
   if (!c.env.SERVICE_AUTH_SECRET) {
@@ -32,7 +32,8 @@ export async function rejectInvalidCallback(
     return c.json({ error: "not configured" }, 500);
   }
 
-  const authentic = await verifyCallbackFromControlPlane(payload, c.env);
+  const authentic =
+    isSignedCallbackPayload(payload) && (await verifyCallbackFromControlPlane(payload, c.env));
   if (!authentic) {
     if (logContext) {
       log.warn("http.request", {

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -2,7 +2,6 @@
  * Type definitions for the Linear bot.
  */
 
-import type { LinearCallbackContext } from "@open-inspect/shared/types/session-api";
 import type { ControlPlaneFetcher } from "@open-inspect/shared/service-auth";
 import { z } from "zod";
 
@@ -122,33 +121,6 @@ export const issueSessionSchema = z.object({
 });
 
 export type IssueSession = z.infer<typeof issueSessionSchema>;
-
-/**
- * Completion callback payload from control-plane.
- */
-export interface CompletionCallback {
-  sessionId: string;
-  messageId: string;
-  success: boolean;
-  error?: string;
-  timestamp: number;
-  signature: string;
-  context: LinearCallbackContext;
-}
-
-/**
- * Tool call callback payload from control-plane (ephemeral, best-effort).
- */
-export interface ToolCallCallback {
-  sessionId: string;
-  tool: string;
-  args: Record<string, unknown>;
-  callId: string;
-  status?: string;
-  timestamp: number;
-  context: LinearCallbackContext;
-  signature: string;
-}
 
 // ─── Linear Issue Details ────────────────────────────────────────────────────
 

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -465,6 +465,7 @@ describe("boundary schemas", () => {
       expect(linearToolCallCallbackSchema.safeParse({ ...callback, callId: "" }).success).toBe(
         false
       );
+      expect(linearToolCallCallbackSchema.safeParse({ ...callback, tool: "" }).success).toBe(false);
     });
   });
 

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -18,6 +18,8 @@ import {
   createSessionRequestSchema,
   createSessionResponseSchema,
   MAX_CHILD_FOLLOW_UP_PROMPT_CHARS,
+  linearCompletionCallbackSchema,
+  linearToolCallCallbackSchema,
   sendPromptRequestSchema,
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
@@ -415,6 +417,54 @@ describe("boundary schemas", () => {
         }).success
       ).toBe(false);
       expect(callbackContextSchema.safeParse({ source: "github" }).success).toBe(false);
+    });
+  });
+
+  describe("Linear callback schemas", () => {
+    const context = {
+      source: "linear",
+      issueId: "issue-1",
+      issueIdentifier: "OI-123",
+      issueUrl: "https://linear.app/open-inspect/issue/OI-123/test",
+      model: "anthropic/claude-sonnet-4-6",
+    };
+
+    it("requires a complete completion callback and valid Linear context", () => {
+      const callback = {
+        sessionId: "session-1",
+        messageId: "message-1",
+        success: true,
+        timestamp: 123,
+        context,
+        signature: "signature",
+      };
+
+      expect(linearCompletionCallbackSchema.safeParse(callback).success).toBe(true);
+      expect(
+        linearCompletionCallbackSchema.safeParse({
+          ...callback,
+          context: { source: "linear", issueId: "issue-1" },
+        }).success
+      ).toBe(false);
+    });
+
+    it("requires tool args and callId", () => {
+      const callback = {
+        sessionId: "session-1",
+        tool: "bash",
+        args: { command: "npm test" },
+        callId: "call-1",
+        timestamp: 123,
+        context,
+        signature: "signature",
+      };
+
+      expect(linearToolCallCallbackSchema.safeParse(callback).success).toBe(true);
+      const { args: _args, ...withoutArgs } = callback;
+      expect(linearToolCallCallbackSchema.safeParse(withoutArgs).success).toBe(false);
+      expect(linearToolCallCallbackSchema.safeParse({ ...callback, callId: "" }).success).toBe(
+        false
+      );
     });
   });
 

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -82,6 +82,37 @@ export const linearStartCallbackSchema = z.strictObject({
 
 export type LinearStartCallback = z.infer<typeof linearStartCallbackSchema>;
 
+export const linearCompletionCallbackPayloadSchema = z.strictObject({
+  sessionId: nonEmptyStringSchema,
+  messageId: nonEmptyStringSchema,
+  success: z.boolean(),
+  error: z.string().optional(),
+  timestamp: z.number().refine(Number.isFinite),
+  context: linearCallbackContextSchema,
+});
+
+export const linearCompletionCallbackSchema = linearCompletionCallbackPayloadSchema.extend({
+  signature: nonEmptyStringSchema,
+});
+
+export type LinearCompletionCallback = z.infer<typeof linearCompletionCallbackSchema>;
+
+export const linearToolCallCallbackPayloadSchema = z.strictObject({
+  sessionId: nonEmptyStringSchema,
+  tool: z.string(),
+  args: z.record(z.string(), z.unknown()),
+  callId: nonEmptyStringSchema,
+  status: z.string().optional(),
+  timestamp: z.number().refine(Number.isFinite),
+  context: linearCallbackContextSchema,
+});
+
+export const linearToolCallCallbackSchema = linearToolCallCallbackPayloadSchema.extend({
+  signature: nonEmptyStringSchema,
+});
+
+export type LinearToolCallCallback = z.infer<typeof linearToolCallCallbackSchema>;
+
 export const automationCallbackContextSchema = z.object({
   source: z.literal("automation"),
   automationId: z.string(),

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -99,7 +99,7 @@ export type LinearCompletionCallback = z.infer<typeof linearCompletionCallbackSc
 
 export const linearToolCallCallbackPayloadSchema = z.strictObject({
   sessionId: nonEmptyStringSchema,
-  tool: z.string(),
+  tool: nonEmptyStringSchema,
   args: z.record(z.string(), z.unknown()),
   callId: nonEmptyStringSchema,
   status: z.string().optional(),


### PR DESCRIPTION
## Summary
- define shared unsigned and signed schemas for Linear completion and tool-call callbacks
- parse Linear callback payloads once at producer and consumer boundaries while retaining raw objects only for HMAC verification
- reject malformed contexts and missing required tool fields before callback processing
- remove divergent handwritten callback interfaces and guards
- verify producer payloads remain schema-valid and correctly signed after normalization

## Testing
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/linear-bot`
- `npm test -w @open-inspect/control-plane`
- ESLint for all three affected packages
- Prettier check for all changed files

## Review
- ran a thermonuclear maintainability review in a sub-agent
- addressed the finding that producer parsing after signing could normalize fields and invalidate HMAC verification
- re-review found no remaining in-scope issues

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a47608a5bda013f5032a40d04cefc563)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened verification of callback signatures and payloads.
  - Invalid or malformed callback requests are rejected before processing.
  - Callback validation helps protect against tampered or incomplete requests.

- **Reliability**
  - Linear completion and tool-call callbacks now require complete, correctly formatted data.
  - Invalid tool-call notifications are safely skipped without affecting throttling.
  - Valid callbacks continue processing normally with improved request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->