### PR TITLE
Consolidate ordinary analytics BFF relays

### DIFF
--- a/packages/web/src/app/api/analytics/breakdown/route.test.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.test.ts
@@ -1,14 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/server-auth-session", () => ({
-  getServerAuthSession: vi.fn(),
-}));
-
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -17,8 +12,10 @@ describe("analytics breakdown API route", () => {
     vi.resetAllMocks();
   });
 
-  it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue(null);
+  it("passes through an upstream unauthorized response", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
 
     const response = await GET(
       new Request("http://localhost/api/analytics/breakdown?days=30&by=user") as never
@@ -29,7 +26,6 @@ describe("analytics breakdown API route", () => {
   });
 
   it("forwards only days and by query params", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ entries: [] }, { status: 200 })
     );
@@ -38,13 +34,15 @@ describe("analytics breakdown API route", () => {
       new Request("http://localhost/api/analytics/breakdown?days=90&foo=bar&by=repo") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/breakdown?days=90&by=repo");
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
+      "/analytics/breakdown?days=90&by=repo",
+      undefined
+    );
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ entries: [] });
   });
 
   it("returns 500 when the control plane request throws", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("boom"));
 
     const response = await GET(new Request("http://localhost/api/analytics/breakdown") as never);

--- a/packages/web/src/app/api/analytics/breakdown/route.test.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.test.ts
@@ -34,10 +34,7 @@ describe("analytics breakdown API route", () => {
       new Request("http://localhost/api/analytics/breakdown?days=90&foo=bar&by=repo") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
-      "/analytics/breakdown?days=90&by=repo",
-      undefined
-    );
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/breakdown?days=90&by=repo");
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ entries: [] });
   });

--- a/packages/web/src/app/api/analytics/breakdown/route.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.ts
@@ -1,26 +1,12 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { getServerAuthSession } from "@/lib/server-auth-session";
-import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
+import { jsonResourceProxy } from "@/lib/settings-proxy";
 
-export async function GET(request: NextRequest) {
-  const session = await getServerAuthSession();
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const path = buildControlPlanePath("/analytics/breakdown", new URL(request.url).searchParams, [
-    "days",
-    "by",
-  ]);
-
-  try {
-    const response = await controlPlaneUserFetch(path);
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error) {
-    console.error("Failed to fetch analytics breakdown:", error);
-    return NextResponse.json({ error: "Failed to fetch analytics breakdown" }, { status: 500 });
-  }
-}
+export const { GET } = jsonResourceProxy(
+  (request: NextRequest) =>
+    buildControlPlanePath("/analytics/breakdown", new URL(request.url).searchParams, [
+      "days",
+      "by",
+    ]),
+  "analytics breakdown"
+);

--- a/packages/web/src/app/api/analytics/breakdown/route.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
-import { jsonResourceProxy } from "@/lib/settings-proxy";
+import { controlPlaneJsonGetProxy } from "@/lib/control-plane-json-proxy";
 
-export const { GET } = jsonResourceProxy(
+export const { GET } = controlPlaneJsonGetProxy(
   (request: NextRequest) =>
     buildControlPlanePath("/analytics/breakdown", new URL(request.url).searchParams, [
       "days",

--- a/packages/web/src/app/api/analytics/pull-requests/route.test.ts
+++ b/packages/web/src/app/api/analytics/pull-requests/route.test.ts
@@ -19,10 +19,7 @@ describe("pull request analytics API route", () => {
       new Request("http://localhost/api/analytics/pull-requests?days=30&debug=true") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
-      "/analytics/pull-requests?days=30",
-      undefined
-    );
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/pull-requests?days=30");
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ pullRequests: [] });
   });

--- a/packages/web/src/app/api/analytics/pull-requests/route.test.ts
+++ b/packages/web/src/app/api/analytics/pull-requests/route.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneUserFetch: vi.fn(),
+}));
+
+import { controlPlaneUserFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+describe("pull request analytics API route", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("forwards only the days query parameter", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ pullRequests: [] }, { status: 200 })
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/pull-requests?days=30&debug=true") as never
+    );
+
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
+      "/analytics/pull-requests?days=30",
+      undefined
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ pullRequests: [] });
+  });
+});

--- a/packages/web/src/app/api/analytics/pull-requests/route.ts
+++ b/packages/web/src/app/api/analytics/pull-requests/route.ts
@@ -1,27 +1,9 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { getServerAuthSession } from "@/lib/server-auth-session";
-import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
+import { jsonResourceProxy } from "@/lib/settings-proxy";
 
-export async function GET(request: NextRequest) {
-  const session = await getServerAuthSession();
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const path = buildControlPlanePath(
-    "/analytics/pull-requests",
-    new URL(request.url).searchParams,
-    ["days"]
-  );
-
-  try {
-    const response = await controlPlaneUserFetch(path);
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error) {
-    console.error("Failed to fetch pull request analytics:", error);
-    return NextResponse.json({ error: "Failed to fetch pull request analytics" }, { status: 500 });
-  }
-}
+export const { GET } = jsonResourceProxy(
+  (request: NextRequest) =>
+    buildControlPlanePath("/analytics/pull-requests", new URL(request.url).searchParams, ["days"]),
+  "pull request analytics"
+);

--- a/packages/web/src/app/api/analytics/pull-requests/route.ts
+++ b/packages/web/src/app/api/analytics/pull-requests/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
-import { jsonResourceProxy } from "@/lib/settings-proxy";
+import { controlPlaneJsonGetProxy } from "@/lib/control-plane-json-proxy";
 
-export const { GET } = jsonResourceProxy(
+export const { GET } = controlPlaneJsonGetProxy(
   (request: NextRequest) =>
     buildControlPlanePath("/analytics/pull-requests", new URL(request.url).searchParams, ["days"]),
   "pull request analytics"

--- a/packages/web/src/app/api/analytics/summary/route.test.ts
+++ b/packages/web/src/app/api/analytics/summary/route.test.ts
@@ -1,14 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/server-auth-session", () => ({
-  getServerAuthSession: vi.fn(),
-}));
-
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -17,8 +12,10 @@ describe("analytics summary API route", () => {
     vi.resetAllMocks();
   });
 
-  it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue(null);
+  it("delegates authentication to the resource request", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
 
     const response = await GET(
       new Request("http://localhost/api/analytics/summary?days=14") as never
@@ -26,11 +23,10 @@ describe("analytics summary API route", () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
-    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+    expect(controlPlaneUserFetch).toHaveBeenCalledTimes(1);
   });
 
   it("forwards only the allowed summary query params", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ totalSessions: 5 }, { status: 200 })
     );
@@ -39,13 +35,12 @@ describe("analytics summary API route", () => {
       new Request("http://localhost/api/analytics/summary?debug=true&days=14") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/summary?days=14");
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/summary?days=14", undefined);
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ totalSessions: 5 });
   });
 
   it("returns 500 when the control plane request throws", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("boom"));
 
     const response = await GET(new Request("http://localhost/api/analytics/summary") as never);

--- a/packages/web/src/app/api/analytics/summary/route.test.ts
+++ b/packages/web/src/app/api/analytics/summary/route.test.ts
@@ -35,7 +35,7 @@ describe("analytics summary API route", () => {
       new Request("http://localhost/api/analytics/summary?debug=true&days=14") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/summary?days=14", undefined);
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/summary?days=14");
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ totalSessions: 5 });
   });

--- a/packages/web/src/app/api/analytics/summary/route.ts
+++ b/packages/web/src/app/api/analytics/summary/route.ts
@@ -1,25 +1,9 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { getServerAuthSession } from "@/lib/server-auth-session";
-import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
+import { jsonResourceProxy } from "@/lib/settings-proxy";
 
-export async function GET(request: NextRequest) {
-  const session = await getServerAuthSession();
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const path = buildControlPlanePath("/analytics/summary", new URL(request.url).searchParams, [
-    "days",
-  ]);
-
-  try {
-    const response = await controlPlaneUserFetch(path);
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error) {
-    console.error("Failed to fetch analytics summary:", error);
-    return NextResponse.json({ error: "Failed to fetch analytics summary" }, { status: 500 });
-  }
-}
+export const { GET } = jsonResourceProxy(
+  (request: NextRequest) =>
+    buildControlPlanePath("/analytics/summary", new URL(request.url).searchParams, ["days"]),
+  "analytics summary"
+);

--- a/packages/web/src/app/api/analytics/summary/route.ts
+++ b/packages/web/src/app/api/analytics/summary/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
-import { jsonResourceProxy } from "@/lib/settings-proxy";
+import { controlPlaneJsonGetProxy } from "@/lib/control-plane-json-proxy";
 
-export const { GET } = jsonResourceProxy(
+export const { GET } = controlPlaneJsonGetProxy(
   (request: NextRequest) =>
     buildControlPlanePath("/analytics/summary", new URL(request.url).searchParams, ["days"]),
   "analytics summary"

--- a/packages/web/src/app/api/analytics/timeseries/route.test.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.test.ts
@@ -1,14 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/server-auth-session", () => ({
-  getServerAuthSession: vi.fn(),
-}));
-
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -17,8 +12,10 @@ describe("analytics timeseries API route", () => {
     vi.resetAllMocks();
   });
 
-  it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue(null);
+  it("passes through an upstream unauthorized response", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 })
+    );
 
     const response = await GET(
       new Request("http://localhost/api/analytics/timeseries?days=30") as never
@@ -29,7 +26,6 @@ describe("analytics timeseries API route", () => {
   });
 
   it("forwards only the days query param", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ series: [] }, { status: 200 })
     );
@@ -38,13 +34,12 @@ describe("analytics timeseries API route", () => {
       new Request("http://localhost/api/analytics/timeseries?trace=1&view=status&days=7") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/timeseries?days=7");
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/timeseries?days=7", undefined);
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ series: [] });
   });
 
   it("passes through upstream error statuses", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "Bad request" }, { status: 400 })
     );

--- a/packages/web/src/app/api/analytics/timeseries/route.test.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.test.ts
@@ -34,7 +34,7 @@ describe("analytics timeseries API route", () => {
       new Request("http://localhost/api/analytics/timeseries?trace=1&view=status&days=7") as never
     );
 
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/timeseries?days=7", undefined);
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/analytics/timeseries?days=7");
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ series: [] });
   });

--- a/packages/web/src/app/api/analytics/timeseries/route.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
-import { jsonResourceProxy } from "@/lib/settings-proxy";
+import { controlPlaneJsonGetProxy } from "@/lib/control-plane-json-proxy";
 
-export const { GET } = jsonResourceProxy(
+export const { GET } = controlPlaneJsonGetProxy(
   (request: NextRequest) =>
     buildControlPlanePath("/analytics/timeseries", new URL(request.url).searchParams, ["days"]),
   "analytics timeseries"

--- a/packages/web/src/app/api/analytics/timeseries/route.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.ts
@@ -1,25 +1,9 @@
 import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { getServerAuthSession } from "@/lib/server-auth-session";
-import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
+import { jsonResourceProxy } from "@/lib/settings-proxy";
 
-export async function GET(request: NextRequest) {
-  const session = await getServerAuthSession();
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const path = buildControlPlanePath("/analytics/timeseries", new URL(request.url).searchParams, [
-    "days",
-  ]);
-
-  try {
-    const response = await controlPlaneUserFetch(path);
-    const data = await response.json();
-    return NextResponse.json(data, { status: response.status });
-  } catch (error) {
-    console.error("Failed to fetch analytics timeseries:", error);
-    return NextResponse.json({ error: "Failed to fetch analytics timeseries" }, { status: 500 });
-  }
-}
+export const { GET } = jsonResourceProxy(
+  (request: NextRequest) =>
+    buildControlPlanePath("/analytics/timeseries", new URL(request.url).searchParams, ["days"]),
+  "analytics timeseries"
+);

--- a/packages/web/src/lib/control-plane-json-proxy.test.ts
+++ b/packages/web/src/lib/control-plane-json-proxy.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { controlPlaneUserFetch } from "./control-plane";
+import { controlPlaneJsonGetProxy } from "./control-plane-json-proxy";
+
+vi.mock("./control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
+
+describe("controlPlaneJsonGetProxy", () => {
+  const { GET } = controlPlaneJsonGetProxy(() => "/resources", "resources");
+
+  beforeEach(() => vi.resetAllMocks());
+
+  it("forwards JSON status and selected safe headers with private caching", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json(
+        { resources: [] },
+        {
+          status: 202,
+          headers: {
+            ETag: '"revision-4"',
+            "Retry-After": "30",
+            "X-Request-Id": "request-1",
+            "Set-Cookie": "private=value",
+          },
+        }
+      )
+    );
+
+    const response = await GET(new NextRequest("http://localhost/api/resources"));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ resources: [] });
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("ETag")).toBe('"revision-4"');
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(response.headers.get("X-Request-Id")).toBe("request-1");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  it("forwards empty no-content responses", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(new Response(null, { status: 204 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/resources"));
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  it("keeps request failures distinct from upstream responses", async () => {
+    vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("authentication unavailable"));
+
+    const response = await GET(new NextRequest("http://localhost/api/resources"));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to fetch resources" });
+  });
+});

--- a/packages/web/src/lib/control-plane-json-proxy.ts
+++ b/packages/web/src/lib/control-plane-json-proxy.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { controlPlaneUserFetch } from "@/lib/control-plane";
+
+const RELAYED_RESPONSE_HEADERS = ["etag", "retry-after", "x-request-id"] as const;
+
+export async function relayJsonResponse(response: Response): Promise<NextResponse> {
+  const text = await response.text();
+  const headers = new Headers({ "Cache-Control": "private, no-store" });
+  for (const name of RELAYED_RESPONSE_HEADERS) {
+    const value = response.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  const init = { status: response.status, headers };
+  return text ? NextResponse.json(JSON.parse(text), init) : new NextResponse(null, init);
+}
+
+/** Creates a GET handler for an ordinary authenticated JSON/no-content resource. */
+export function controlPlaneJsonGetProxy(
+  buildPath: (request: NextRequest) => string,
+  label: string
+): { GET: (request: NextRequest) => Promise<NextResponse> } {
+  return {
+    async GET(request) {
+      try {
+        return relayJsonResponse(await controlPlaneUserFetch(buildPath(request)));
+      } catch (error) {
+        console.error(`Failed to fetch ${label}:`, error);
+        return NextResponse.json({ error: `Failed to fetch ${label}` }, { status: 500 });
+      }
+    },
+  };
+}

--- a/packages/web/src/lib/settings-proxy.test.ts
+++ b/packages/web/src/lib/settings-proxy.test.ts
@@ -42,39 +42,6 @@ describe("settingsProxy", () => {
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
   });
 
-  it("forwards JSON responses and selected safe headers", async () => {
-    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
-      Response.json(
-        { settings: [] },
-        {
-          headers: {
-            ETag: '"revision-4"',
-            "Retry-After": "30",
-            "X-Request-Id": "request-1",
-            "Set-Cookie": "private=value",
-          },
-        }
-      )
-    );
-
-    const response = await GET(new NextRequest("http://localhost/api/settings"), context);
-
-    await expect(response.json()).resolves.toEqual({ settings: [] });
-    expect(response.headers.get("ETag")).toBe('"revision-4"');
-    expect(response.headers.get("Retry-After")).toBe("30");
-    expect(response.headers.get("X-Request-Id")).toBe("request-1");
-    expect(response.headers.get("Set-Cookie")).toBeNull();
-  });
-
-  it("forwards empty no-content responses", async () => {
-    vi.mocked(controlPlaneUserFetch).mockResolvedValue(new Response(null, { status: 204 }));
-
-    const response = await GET(new NextRequest("http://localhost/api/settings"), context);
-
-    expect(response.status).toBe(204);
-    expect(await response.text()).toBe("");
-  });
-
   it("forwards If-Match and non-success responses without interpretation", async () => {
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "Revision conflict" }, { status: 412 })

--- a/packages/web/src/lib/settings-proxy.test.ts
+++ b/packages/web/src/lib/settings-proxy.test.ts
@@ -21,7 +21,8 @@ function streamingMutationRequest(size: number, cookie?: string): NextRequest {
 }
 
 describe("settingsProxy", () => {
-  const { GET, POST } = settingsProxy(() => "/settings", "settings");
+  const { GET, POST, PUT } = settingsProxy(() => "/settings", "settings");
+  const context = { params: Promise.resolve(undefined) };
 
   beforeEach(() => vi.resetAllMocks());
 
@@ -38,6 +39,64 @@ describe("settingsProxy", () => {
     expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", undefined);
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("forwards JSON responses and selected safe headers", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json(
+        { settings: [] },
+        {
+          headers: {
+            ETag: '"revision-4"',
+            "Retry-After": "30",
+            "X-Request-Id": "request-1",
+            "Set-Cookie": "private=value",
+          },
+        }
+      )
+    );
+
+    const response = await GET(new NextRequest("http://localhost/api/settings"), context);
+
+    await expect(response.json()).resolves.toEqual({ settings: [] });
+    expect(response.headers.get("ETag")).toBe('"revision-4"');
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(response.headers.get("X-Request-Id")).toBe("request-1");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  it("forwards empty no-content responses", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(new Response(null, { status: 204 }));
+
+    const response = await GET(new NextRequest("http://localhost/api/settings"), context);
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  it("forwards If-Match and non-success responses without interpretation", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Revision conflict" }, { status: 412 })
+    );
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "PUT",
+      headers: {
+        Cookie: "__Secure-openinspect.session_token=session.signature",
+        "If-Match": 'W/"revision-2"',
+      },
+      body: JSON.stringify({ enabled: true }),
+    });
+
+    const response = await PUT(request, context);
+
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith("/settings", {
+      method: "PUT",
+      headers: { "If-Match": 'W/"revision-2"' },
+      body: JSON.stringify({ enabled: true }),
+    });
+    expect(response.status).toBe(412);
+    await expect(response.json()).resolves.toEqual({ error: "Revision conflict" });
   });
 
   it("delegates authentication before malformed mutation JSON is interpreted", async () => {

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { serializeBrowserSessionCookies } from "@/lib/browser-session-cookie";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
+import { relayJsonResponse } from "@/lib/control-plane-json-proxy";
 
 type ProxyMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
 
@@ -14,16 +15,12 @@ const METHOD_VERBS: Record<ProxyMethod, string> = {
   DELETE: "delete",
 };
 
-const RELAYED_RESPONSE_HEADERS = ["etag", "retry-after", "x-request-id"] as const;
-
 type RouteHandler<P> = (
   request: NextRequest,
   context: { params: Promise<P> }
 ) => Promise<NextResponse>;
 
 type ProxyHandlers<P> = Record<ProxyMethod, RouteHandler<P>>;
-type StaticRouteHandler = (request: NextRequest) => Promise<NextResponse>;
-type StaticProxyHandlers = Record<ProxyMethod, StaticRouteHandler>;
 
 /** JSON mutation budget kept below portable web-function request limits. */
 export const SETTINGS_PROXY_MAX_BODY_BYTES = 4 * 1024 * 1024;
@@ -34,21 +31,7 @@ async function readMutationBody(request: NextRequest): Promise<Uint8Array | null
   return readBodyCapped(request.body, SETTINGS_PROXY_MAX_BODY_BYTES);
 }
 
-async function proxyResponse(response: Response): Promise<NextResponse> {
-  const text = await response.text();
-  const headers = new Headers({ "Cache-Control": "private, no-store" });
-  for (const name of RELAYED_RESPONSE_HEADERS) {
-    const value = response.headers.get(name);
-    if (value) headers.set(name, value);
-  }
-  const init = {
-    status: response.status,
-    headers,
-  };
-  return text ? NextResponse.json(JSON.parse(text), init) : new NextResponse(null, init);
-}
-
-async function relayJsonResource(
+async function relaySettingsResource(
   request: NextRequest,
   buildPath: () => string | Promise<string>,
   label: string,
@@ -75,7 +58,7 @@ async function relayJsonResource(
       if (ifMatch) init.headers = { "If-Match": ifMatch };
     }
     const response = await controlPlaneUserFetch(await buildPath(), init);
-    return proxyResponse(response);
+    return relayJsonResponse(response);
   } catch (error) {
     console.error(`Failed to ${METHOD_VERBS[method]} ${label}:`, error);
     return NextResponse.json(
@@ -93,31 +76,12 @@ export function settingsProxy<P>(
   const handler =
     (method: ProxyMethod): RouteHandler<P> =>
     (request, context) =>
-      relayJsonResource(
+      relaySettingsResource(
         request,
         async () => buildPath(await context.params, request),
         label,
         method
       );
-
-  return {
-    GET: handler("GET"),
-    POST: handler("POST"),
-    PATCH: handler("PATCH"),
-    PUT: handler("PUT"),
-    DELETE: handler("DELETE"),
-  };
-}
-
-/** Creates BFF handlers for an ordinary static JSON/no-content resource. */
-export function jsonResourceProxy(
-  buildPath: (request: NextRequest) => string,
-  label: string
-): StaticProxyHandlers {
-  const handler =
-    (method: ProxyMethod): StaticRouteHandler =>
-    (request) =>
-      relayJsonResource(request, () => buildPath(request), label, method);
 
   return {
     GET: handler("GET"),

--- a/packages/web/src/lib/settings-proxy.ts
+++ b/packages/web/src/lib/settings-proxy.ts
@@ -14,12 +14,16 @@ const METHOD_VERBS: Record<ProxyMethod, string> = {
   DELETE: "delete",
 };
 
+const RELAYED_RESPONSE_HEADERS = ["etag", "retry-after", "x-request-id"] as const;
+
 type RouteHandler<P> = (
   request: NextRequest,
   context: { params: Promise<P> }
 ) => Promise<NextResponse>;
 
 type ProxyHandlers<P> = Record<ProxyMethod, RouteHandler<P>>;
+type StaticRouteHandler = (request: NextRequest) => Promise<NextResponse>;
+type StaticProxyHandlers = Record<ProxyMethod, StaticRouteHandler>;
 
 /** JSON mutation budget kept below portable web-function request limits. */
 export const SETTINGS_PROXY_MAX_BODY_BYTES = 4 * 1024 * 1024;
@@ -32,11 +36,53 @@ async function readMutationBody(request: NextRequest): Promise<Uint8Array | null
 
 async function proxyResponse(response: Response): Promise<NextResponse> {
   const text = await response.text();
+  const headers = new Headers({ "Cache-Control": "private, no-store" });
+  for (const name of RELAYED_RESPONSE_HEADERS) {
+    const value = response.headers.get(name);
+    if (value) headers.set(name, value);
+  }
   const init = {
     status: response.status,
-    headers: { "Cache-Control": "private, no-store" },
+    headers,
   };
   return text ? NextResponse.json(JSON.parse(text), init) : new NextResponse(null, init);
+}
+
+async function relayJsonResource(
+  request: NextRequest,
+  buildPath: () => string | Promise<string>,
+  label: string,
+  method: ProxyMethod
+): Promise<NextResponse> {
+  try {
+    // The revision ID is an opaque CAS token; forwarding it unchanged keeps
+    // stale web editors from replacing content and assignments.
+    const ifMatch = request.headers.get("if-match");
+    let init: RequestInit | undefined;
+    if (method !== "GET") {
+      init = { method };
+      if (method !== "DELETE") {
+        const cookieHeader = serializeBrowserSessionCookies(request.cookies.getAll());
+        if (!cookieHeader) {
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const body = await readMutationBody(request);
+        if (!body) {
+          return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
+        }
+        init.body = new TextDecoder().decode(body);
+      }
+      if (ifMatch) init.headers = { "If-Match": ifMatch };
+    }
+    const response = await controlPlaneUserFetch(await buildPath(), init);
+    return proxyResponse(response);
+  } catch (error) {
+    console.error(`Failed to ${METHOD_VERBS[method]} ${label}:`, error);
+    return NextResponse.json(
+      { error: `Failed to ${METHOD_VERBS[method]} ${label}` },
+      { status: 500 }
+    );
+  }
 }
 
 /** Creates the requested BFF route handlers for an authenticated control-plane resource. */
@@ -44,48 +90,34 @@ export function settingsProxy<P>(
   buildPath: (params: P, request: NextRequest) => string,
   label: string
 ): ProxyHandlers<P> {
-  const proxy = async (
-    request: NextRequest,
-    context: { params: Promise<P> },
-    method: ProxyMethod
-  ): Promise<NextResponse> => {
-    const params = await context.params;
-
-    try {
-      // The revision ID is an opaque CAS token; forwarding it unchanged keeps
-      // stale web editors from replacing content and assignments.
-      const ifMatch = request.headers.get("if-match");
-      let init: RequestInit | undefined;
-      if (method !== "GET") {
-        init = { method };
-        if (method !== "DELETE") {
-          const cookieHeader = serializeBrowserSessionCookies(request.cookies.getAll());
-          if (!cookieHeader) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-          }
-          const body = await readMutationBody(request);
-          if (!body) {
-            return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
-          }
-          init.body = new TextDecoder().decode(body);
-        }
-        if (ifMatch) init.headers = { "If-Match": ifMatch };
-      }
-      const response = await controlPlaneUserFetch(buildPath(params, request), init);
-      return proxyResponse(response);
-    } catch (error) {
-      console.error(`Failed to ${METHOD_VERBS[method]} ${label}:`, error);
-      return NextResponse.json(
-        { error: `Failed to ${METHOD_VERBS[method]} ${label}` },
-        { status: 500 }
-      );
-    }
-  };
-
   const handler =
     (method: ProxyMethod): RouteHandler<P> =>
     (request, context) =>
-      proxy(request, context, method);
+      relayJsonResource(
+        request,
+        async () => buildPath(await context.params, request),
+        label,
+        method
+      );
+
+  return {
+    GET: handler("GET"),
+    POST: handler("POST"),
+    PATCH: handler("PATCH"),
+    PUT: handler("PUT"),
+    DELETE: handler("DELETE"),
+  };
+}
+
+/** Creates BFF handlers for an ordinary static JSON/no-content resource. */
+export function jsonResourceProxy(
+  buildPath: (request: NextRequest) => string,
+  label: string
+): StaticProxyHandlers {
+  const handler =
+    (method: ProxyMethod): StaticRouteHandler =>
+    (request) =>
+      relayJsonResource(request, () => buildPath(request), label, method);
 
   return {
     GET: handler("GET"),


### PR DESCRIPTION
## Summary
- extend the existing JSON/no-content BFF relay with explicit safe response-header forwarding
- add a static-resource relay contract while preserving typed params for dynamic settings routes
- migrate only the homogeneous analytics GET route family and remove redundant auth preflights
- preserve analytics query allowlists and route-specific transport error messages
- add central coverage for JSON, 204, non-2xx, `If-Match`, no-store caching, and selected response headers

## Validation
- `npm test -w @open-inspect/web` (1,078 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-cache`
- thermonuclear maintainability review in a sub-agent, with its type-contract blocker resolved and re-review approved

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d6431251d846606e8c7ac92f73f770fc)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics summary, breakdown, pull-request, and timeseries endpoints now consistently relay upstream responses and query parameters.
  - Responses preserve relevant status codes and selected headers, including ETags, retry guidance, and request IDs.
  - Settings updates now support safer response-header forwarding, cache-control behavior, empty successful responses, and conditional request handling.

- **Bug Fixes**
  - Unauthorized and error responses are forwarded more accurately.
  - Improved handling of no-content responses and conditional update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->