### PR TITLE
fix: arm sandbox watchdog before provider calls

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -435,7 +435,7 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
   expect(storage.calls.filter((call) => call === "updateSandboxStatus:connecting")).toHaveLength(
     kind === "resume" ? 1 : 0
   );
-  expect(alarmScheduler.alarms).toEqual([]);
+  expect(alarmScheduler.alarms).toHaveLength(1);
   expect(manager.isProviderStartupPending()).toBe(false);
   const readyIndex = broadcaster.messages.findIndex(
     (message) =>
@@ -833,14 +833,24 @@ describe("SandboxLifecycleManager", () => {
       ).toBe(false);
     });
 
-    it("schedules connecting timeout alarm after spawn", async () => {
+    it("schedules connecting timeout alarm before spawn provider call", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(createMockSession(), sandbox);
       const alarmScheduler = createMockAlarmScheduler();
       const config = createTestConfig();
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async (createConfig) => {
+          expect(alarmScheduler.alarms).toHaveLength(1);
+          return {
+            sandboxId: createConfig.sandboxId,
+            status: "connecting",
+            createdAt: Date.now(),
+          };
+        }),
+      });
 
       const manager = new SandboxLifecycleManager(
-        createMockProvider(),
+        provider,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -1146,7 +1156,7 @@ describe("SandboxLifecycleManager", () => {
       expect(terminalLogs[0]).toEqual(expect.objectContaining({ outcome: "error" }));
     });
 
-    it("schedules connecting timeout alarm after restore", async () => {
+    it("schedules connecting timeout alarm before restore provider call", async () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
@@ -1154,9 +1164,15 @@ describe("SandboxLifecycleManager", () => {
       const storage = createMockStorage(createMockSession(), sandbox);
       const alarmScheduler = createMockAlarmScheduler();
       const config = createTestConfig();
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async (restoreConfig) => {
+          expect(alarmScheduler.alarms).toHaveLength(1);
+          return { success: true, sandboxId: restoreConfig.sandboxId };
+        }),
+      });
 
       const manager = new SandboxLifecycleManager(
-        createMockProvider(),
+        provider,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -1173,6 +1189,38 @@ describe("SandboxLifecycleManager", () => {
       const scheduledTime = alarmScheduler.alarms[0];
       expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
       expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
+    });
+
+    it("schedules connecting timeout alarm before resume provider call", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        modal_object_id: "provider-obj",
+        snapshot_image_id: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const alarmScheduler = createMockAlarmScheduler();
+      const provider = createMockProvider({
+        capabilities: { supportsPersistentResume: true },
+        resumeSandbox: vi.fn(async () => {
+          expect(alarmScheduler.alarms).toHaveLength(1);
+          return { success: true };
+        }),
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        alarmScheduler,
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.resumeSandbox).toHaveBeenCalledOnce();
+      expect(alarmScheduler.alarms).toHaveLength(1);
     });
 
     it("stores providerObjectId after successful restore for future snapshots", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -149,6 +149,13 @@ function createMockStorage(
         if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
       }
     }),
+    updateSandboxForResume: vi.fn((data) => {
+      calls.push(`updateSandboxForResume:${data.status}`);
+      if (sandbox) {
+        sandbox.status = data.status;
+        sandbox.created_at = data.createdAt;
+      }
+    }),
     updateSandboxModalObjectId: vi.fn((id: string | null) => {
       calls.push(`updateSandboxModalObjectId:${id}`);
       if (sandbox) sandbox.modal_object_id = id;
@@ -389,6 +396,7 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
     }
   });
   const connectBridge = () => {
+    expect(alarmScheduler.alarms).toHaveLength(1);
     sandbox.status = "ready";
     vi.mocked(wsManager.getSandboxWebSocket).mockReturnValue({} as WebSocket);
     broadcaster.broadcast({ type: "sandbox_status", status: "ready" });
@@ -432,7 +440,8 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
   await manager.spawnSandbox();
 
   expect(sandbox.status).toBe("ready");
-  expect(storage.calls.filter((call) => call === "updateSandboxStatus:connecting")).toHaveLength(
+  expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
+  expect(storage.calls.filter((call) => call === "updateSandboxForResume:connecting")).toHaveLength(
     kind === "resume" ? 1 : 0
   );
   expect(alarmScheduler.alarms).toHaveLength(1);
@@ -505,6 +514,11 @@ describe("SandboxLifecycleManager", () => {
           created_at: Date.now() - 60000,
         });
         const storage = createMockStorage(createMockSession(), sandbox);
+        const alarmScheduler = createMockAlarmScheduler();
+        vi.mocked(alarmScheduler.scheduleAlarm).mockImplementation(async (timestamp) => {
+          calls.push("alarm");
+          alarmScheduler.alarms.push(timestamp);
+        });
         vi.mocked(storage.updateSandboxForSpawn).mockImplementation((data) => {
           calls.push("fence");
           sandbox.status = data.status;
@@ -529,14 +543,14 @@ describe("SandboxLifecycleManager", () => {
           storage,
           createMockBroadcaster(),
           createMockWebSocketManager(false),
-          createMockAlarmScheduler(),
+          alarmScheduler,
           createMockIdGenerator(),
           createTestConfig()
         );
 
         await manager.spawnSandbox();
 
-        expect(calls.slice(0, 3)).toEqual(["fence", "stop", "clear"]);
+        expect(calls.slice(0, 4)).toEqual(["fence", "alarm", "stop", "clear"]);
         expect(stopSandbox).toHaveBeenCalledWith(
           expect.objectContaining({
             providerObjectId: "modal-obj-123",
@@ -833,24 +847,14 @@ describe("SandboxLifecycleManager", () => {
       ).toBe(false);
     });
 
-    it("schedules connecting timeout alarm before spawn provider call", async () => {
+    it("schedules the connecting timeout from the persisted startup timestamp", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(createMockSession(), sandbox);
       const alarmScheduler = createMockAlarmScheduler();
       const config = createTestConfig();
-      const provider = createMockProvider({
-        createSandbox: vi.fn(async (createConfig) => {
-          expect(alarmScheduler.alarms).toHaveLength(1);
-          return {
-            sandboxId: createConfig.sandboxId,
-            status: "connecting",
-            createdAt: Date.now(),
-          };
-        }),
-      });
 
       const manager = new SandboxLifecycleManager(
-        provider,
+        createMockProvider(),
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -859,14 +863,11 @@ describe("SandboxLifecycleManager", () => {
         config
       );
 
-      const before = Date.now();
       await manager.spawnSandbox();
-      const after = Date.now();
 
-      expect(alarmScheduler.alarms.length).toBe(1);
-      const scheduledTime = alarmScheduler.alarms[0];
-      expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
-      expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
+      expect(alarmScheduler.alarms).toEqual([
+        sandbox.created_at + config.connectingTimeout.timeoutMs,
+      ]);
     });
 
     it("passes user env vars to provider", async () => {
@@ -1154,73 +1155,6 @@ describe("SandboxLifecycleManager", () => {
 
       expect(terminalLogs).toHaveLength(1);
       expect(terminalLogs[0]).toEqual(expect.objectContaining({ outcome: "error" }));
-    });
-
-    it("schedules connecting timeout alarm before restore provider call", async () => {
-      const sandbox = createMockSandbox({
-        status: "stopped",
-        snapshot_image_id: "img-abc123",
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const alarmScheduler = createMockAlarmScheduler();
-      const config = createTestConfig();
-      const provider = createMockProvider({
-        restoreFromSnapshot: vi.fn(async (restoreConfig) => {
-          expect(alarmScheduler.alarms).toHaveLength(1);
-          return { success: true, sandboxId: restoreConfig.sandboxId };
-        }),
-      });
-
-      const manager = new SandboxLifecycleManager(
-        provider,
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(false),
-        alarmScheduler,
-        createMockIdGenerator(),
-        config
-      );
-
-      const before = Date.now();
-      await manager.spawnSandbox();
-      const after = Date.now();
-
-      expect(alarmScheduler.alarms.length).toBe(1);
-      const scheduledTime = alarmScheduler.alarms[0];
-      expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
-      expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
-    });
-
-    it("schedules connecting timeout alarm before resume provider call", async () => {
-      const sandbox = createMockSandbox({
-        status: "stopped",
-        modal_object_id: "provider-obj",
-        snapshot_image_id: null,
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const alarmScheduler = createMockAlarmScheduler();
-      const provider = createMockProvider({
-        capabilities: { supportsPersistentResume: true },
-        resumeSandbox: vi.fn(async () => {
-          expect(alarmScheduler.alarms).toHaveLength(1);
-          return { success: true };
-        }),
-      });
-
-      const manager = new SandboxLifecycleManager(
-        provider,
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(false),
-        alarmScheduler,
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      await manager.spawnSandbox();
-
-      expect(provider.resumeSandbox).toHaveBeenCalledOnce();
-      expect(alarmScheduler.alarms).toHaveLength(1);
     });
 
     it("stores providerObjectId after successful restore for future snapshots", async () => {
@@ -2629,6 +2563,7 @@ describe("SandboxLifecycleManager", () => {
       provider?: SandboxProvider;
       environmentImageLookup?: ImageBuildLookup;
       sessionRepositories?: SessionRepositoryInfo[];
+      alarmScheduler?: AlarmScheduler;
     }) {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(
@@ -2643,7 +2578,7 @@ describe("SandboxLifecycleManager", () => {
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
-        createMockAlarmScheduler(),
+        overrides?.alarmScheduler ?? createMockAlarmScheduler(),
         createMockIdGenerator(),
         createTestConfig(),
         {},
@@ -2763,9 +2698,11 @@ describe("SandboxLifecycleManager", () => {
           status: "connecting",
           createdAt: Date.now(),
         }));
+      const alarmScheduler = createMockAlarmScheduler();
       const { manager, storage } = createEnvironmentSessionManager({
         environmentImageLookup,
         provider: createMockProvider({ createSandbox }),
+        alarmScheduler,
       });
 
       await manager.spawnSandbox();
@@ -2789,6 +2726,13 @@ describe("SandboxLifecycleManager", () => {
       expect(retryAttempt.sandboxAuthToken).not.toBe(firstAttempt.sandboxAuthToken);
       expect(retryAttempt.sandboxId).not.toBe(firstAttempt.sandboxId);
       expect(vi.mocked(storage.updateSandboxForSpawn)).toHaveBeenCalledTimes(2);
+      expect(alarmScheduler.alarms).toEqual(
+        vi
+          .mocked(storage.updateSandboxForSpawn)
+          .mock.calls.map(
+            ([data]) => data.createdAt + DEFAULT_LIFECYCLE_CONFIG.connectingTimeout.timeoutMs
+          )
+      );
       expect(storage.calls).toContain("updateSandboxStatus:connecting");
       expect(storage.calls).not.toContain("updateSandboxStatus:failed");
     });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -504,6 +504,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       };
 
       let result: CreateSandboxResult;
+      await this.armConnectingTimeout();
       try {
         result = await this.provider.createSandbox(createConfig);
       } catch (error) {
@@ -772,6 +773,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const mcpServers = await this.loadMcpServers(repositories);
       const sandboxSettings = this.parseSandboxSettings(session);
       const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
+      await this.armConnectingTimeout();
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
         sessionId: session.session_name || session.id,
@@ -907,6 +909,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const sandboxSettings = this.parseSandboxSettings(session);
       const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
 
+      await this.armConnectingTimeout();
       const result = await this.provider.resumeSandbox({
         providerObjectId,
         sessionId: session.session_name || session.id,
@@ -1540,7 +1543,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.storage.updateSandboxStatus("connecting");
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
     }
+  }
 
+  private async armConnectingTimeout(): Promise<void> {
     // The bridge replaces this with its inactivity alarm when it connects.
     await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
   }

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -105,7 +105,7 @@ export interface SandboxStorage {
     preserveProviderObjectId?: boolean;
   }): void;
   /** Update sandbox state for in-place resume without rotating auth/token identity */
-  updateSandboxForResume?(data: { status: SandboxStatus; createdAt: number }): void;
+  updateSandboxForResume(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
   updateSandboxModalObjectId(modalObjectId: string | null): void;
   /** Update sandbox snapshot image ID */
@@ -433,14 +433,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const authTokenHash = await hashToken(sandboxAuthToken);
 
       // Store expected sandbox ID and auth token BEFORE calling provider
-      this.storage.updateSandboxForSpawn({
-        status: "spawning",
-        createdAt: now,
-        authTokenHash,
-        modalSandboxId: expectedSandboxId,
-        preserveProviderObjectId: true,
-      });
-      this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
+      await this.enterProviderStartup("spawning", now, () =>
+        this.storage.updateSandboxForSpawn({
+          status: "spawning",
+          createdAt: now,
+          authTokenHash,
+          modalSandboxId: expectedSandboxId,
+          preserveProviderObjectId: true,
+        })
+      );
 
       await this.stopPriorProviderSandbox();
 
@@ -504,7 +505,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       };
 
       let result: CreateSandboxResult;
-      await this.armConnectingTimeout();
       try {
         result = await this.provider.createSandbox(createConfig);
       } catch (error) {
@@ -525,15 +525,18 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         // indistinguishable here), and rotating the token hash and sandbox id
         // locks such an orphan out of this DO exactly like the next
         // user-initiated respawn would.
-        const retryNow = Math.max(Date.now(), now + 1);
         sandboxAuthToken = this.idGenerator.generateId();
+        const retryAuthTokenHash = await hashToken(sandboxAuthToken);
+        const retryNow = Math.max(Date.now(), now + 1);
         expectedSandboxId = buildSandboxIdForSession(session, retryNow);
-        this.storage.updateSandboxForSpawn({
-          status: "spawning",
-          createdAt: retryNow,
-          authTokenHash: await hashToken(sandboxAuthToken),
-          modalSandboxId: expectedSandboxId,
-        });
+        await this.enterProviderStartup("spawning", retryNow, () =>
+          this.storage.updateSandboxForSpawn({
+            status: "spawning",
+            createdAt: retryNow,
+            authTokenHash: retryAuthTokenHash,
+            modalSandboxId: expectedSandboxId,
+          })
+        );
         result = await this.provider.createSandbox({
           ...createConfig,
           sandboxId: expectedSandboxId,
@@ -752,14 +755,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const expectedSandboxId = buildSandboxIdForSession(session, now);
 
       // Store expected sandbox ID and auth token
-      this.storage.updateSandboxForSpawn({
-        status: "spawning",
-        createdAt: now,
-        authTokenHash: sandboxAuthTokenHash,
-        modalSandboxId: expectedSandboxId,
-        preserveProviderObjectId: true,
-      });
-      this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
+      await this.enterProviderStartup("spawning", now, () =>
+        this.storage.updateSandboxForSpawn({
+          status: "spawning",
+          createdAt: now,
+          authTokenHash: sandboxAuthTokenHash,
+          modalSandboxId: expectedSandboxId,
+          preserveProviderObjectId: true,
+        })
+      );
 
       await this.stopPriorProviderSandbox();
 
@@ -773,7 +777,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const mcpServers = await this.loadMcpServers(repositories);
       const sandboxSettings = this.parseSandboxSettings(session);
       const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
-      await this.armConnectingTimeout();
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
         sessionId: session.session_name || session.id,
@@ -897,19 +900,16 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
       const now = Date.now();
       this.storage.setLastSpawnError(null, null);
-      this.storage.updateSandboxForResume?.({
-        status: "connecting",
-        createdAt: now,
-      });
-      if (!this.storage.updateSandboxForResume) {
-        this.storage.updateSandboxStatus("connecting");
-      }
-      this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
+      await this.enterProviderStartup("connecting", now, () =>
+        this.storage.updateSandboxForResume({
+          status: "connecting",
+          createdAt: now,
+        })
+      );
 
       const sandboxSettings = this.parseSandboxSettings(session);
       const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
 
-      await this.armConnectingTimeout();
       const result = await this.provider.resumeSandbox({
         providerObjectId,
         sessionId: session.session_name || session.id,
@@ -1545,9 +1545,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
   }
 
-  private async armConnectingTimeout(): Promise<void> {
+  private async enterProviderStartup(
+    status: "spawning" | "connecting",
+    createdAt: number,
+    persist: () => void
+  ): Promise<void> {
+    persist();
+    this.broadcaster.broadcast({ type: "sandbox_status", status });
     // The bridge replaces this with its inactivity alarm when it connects.
-    await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
+    await this.alarmScheduler.scheduleAlarm(createdAt + this.config.connectingTimeout.timeoutMs);
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -683,7 +683,14 @@ export class SessionDO extends DurableObject<Env> {
           validateReasoningEffort(model, effort, this.log),
         generateId: (bytes) => generateId(bytes),
         now: () => Date.now(),
-        scheduleWarmSandbox: () => this.backgroundJobs.submit(this.warmSandbox()),
+        scheduleWarmSandbox: () =>
+          this.backgroundJobs.submit(
+            this.warmSandbox().catch((error) => {
+              this.log.error("sandbox.warm.background_error", {
+                error: error instanceof Error ? error : String(error),
+              });
+            })
+          ),
         getSession: () => this.getSession(),
         getSandbox: () => this.getSandbox(),
         getPublicSessionId: (session) => this.getPublicSessionId(session),


### PR DESCRIPTION
## Summary
- schedule the connecting-timeout alarm before spawn, restore, and resume provider round-trips
- prevent provider startup completion from re-arming and extending the watchdog
- catch and structurally log background sandbox-warming failures
- assert watchdog ordering for all three provider paths while preserving early bridge behavior

## Verification
- `npm test -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `git show --check HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/0a26b528dc08434f0d4e7fbbe286b4e1)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox startup reliability by scheduling connection timeout protection before spawn, restore, and resume operations.
  - Added timeout coverage during sandbox resume startup.
  - Prevented asynchronous warm-up failures from becoming unhandled errors and improved background error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->