### PR TITLE
Require sandbox authentication for SCM credentials

### DIFF
--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -93,8 +93,11 @@ describe("router sandbox-token fallback", () => {
   it("does not fall back after a failed service credential attempt", async () => {
     const { env, doFetch } = createEnv(204);
     const request = await signedServiceRequest(
-      "https://test.local/sessions/session-1/scm-credentials",
-      { method: "POST", service: "linear-bot" }
+      "https://test.local/sessions/session-1/tunnel-urls",
+      {
+        service: "linear-bot",
+        headers: { Authorization: "Bearer valid-sandbox-token" },
+      }
     );
     request.headers.set("X-OpenInspect-Service-Signature", "invalid");
 

--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -32,7 +32,6 @@ describe("route policy table", () => {
 
   it.each([
     ["POST", "/sessions/session-1/pr"],
-    ["POST", "/sessions/session-1/scm-credentials"],
     ["GET", "/sessions/session-1/tunnel-urls"],
     ["POST", "/sessions/session-1/media"],
     ["GET", "/sessions/session-1/attachments/attachment-1"],
@@ -53,6 +52,7 @@ describe("route policy table", () => {
   });
 
   it.each([
+    ["POST", "/sessions/session-1/scm-credentials"],
     ["GET", "/sessions/session-1/commit-signing"],
     ["POST", "/sessions/session-1/commit-signing"],
     ["POST", "/sessions/parent-1/children/child-1/prompt"],

--- a/packages/control-plane/src/router.scm-credentials.test.ts
+++ b/packages/control-plane/src/router.scm-credentials.test.ts
@@ -80,22 +80,44 @@ describe("SCM credentials router provider gate", () => {
     expect(new URL(fetch.mock.calls[1][0].url).pathname).toBe("/internal/xai-token-refresh");
   });
 
-  it("allows GitLab deployments to reach the SCM credential broker", async () => {
+  it.each(["slack-bot", "github-bot", "linear-bot"] as const)(
+    "rejects %s authentication before reaching the SCM credential broker",
+    async (service) => {
+      const { env, fetch } = createEnv();
+
+      const response = await handleRequest(
+        await signedServiceRequest("https://test.local/sessions/session-1/scm-credentials", {
+          method: "POST",
+          service,
+        }),
+        env as never,
+        TEST_BACKGROUND_TASK_CONTEXT
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: "Unauthorized: Missing sandbox token",
+      });
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it("allows a matching sandbox token to reach the GitLab SCM credential broker", async () => {
     const { env, fetch } = createEnv();
 
     const response = await handleRequest(
-      await signedServiceRequest("https://test.local/sessions/session-1/scm-credentials", {
+      new Request("https://test.local/sessions/session-1/scm-credentials", {
         method: "POST",
-        service: "linear-bot",
+        headers: { Authorization: "Bearer sandbox-token" },
       }),
       env as never,
       TEST_BACKGROUND_TASK_CONTEXT
     );
 
     expect(response.status).toBe(202);
-    expect(fetch).toHaveBeenCalledOnce();
-    const request = fetch.mock.calls[0][0];
-    expect(new URL(request.url).pathname).toBe("/internal/scm-credentials");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(new URL(fetch.mock.calls[0][0].url).pathname).toBe("/internal/verify-sandbox-token");
+    expect(new URL(fetch.mock.calls[1][0].url).pathname).toBe("/internal/scm-credentials");
   });
 
   it("allows GitLab deployments to reach the tunnel URLs endpoint", async () => {

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -138,7 +138,7 @@ export const SCM_AGNOSTIC_SANDBOX_FALLBACK_ROUTE = {
 } as const satisfies RoutePolicy;
 
 export const SCM_CREDENTIALS_ROUTE = {
-  authentication: { kind: "user-or-service-with-sandbox-fallback", ...SESSION_ID_BINDING },
+  authentication: { kind: "sandbox", ...SESSION_ID_BINDING },
   supportedScmProviders: ["github", "gitlab"],
 } as const satisfies RoutePolicy;
 

--- a/packages/control-plane/test/integration/scm-credentials.test.ts
+++ b/packages/control-plane/test/integration/scm-credentials.test.ts
@@ -14,8 +14,16 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SELF } from "cloudflare:test";
+import type { ServiceName } from "@open-inspect/shared/service-auth";
 import { cleanD1Tables } from "./cleanup";
-import { initNamedSession, seedSandboxAuth } from "./helpers";
+import { initNamedSession, seedSandboxAuth, serviceFetch } from "./helpers";
+
+const NON_SANDBOX_SERVICES = [
+  "web",
+  "slack-bot",
+  "github-bot",
+  "linear-bot",
+] as const satisfies readonly ServiceName[];
 
 async function setupSession(): Promise<{ sessionName: string; sandboxToken: string }> {
   const sessionName = `scm-creds-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
@@ -24,7 +32,7 @@ async function setupSession(): Promise<{ sessionName: string; sandboxToken: stri
     repoName: "web-app",
   });
 
-  const sandboxToken = `sb-tok-${Date.now()}`;
+  const sandboxToken = `sb-tok-${sessionName}`;
   await seedSandboxAuth(stub, {
     authToken: sandboxToken,
     sandboxId: `sb-${Date.now()}`,
@@ -64,10 +72,21 @@ describe("POST /sessions/:id/scm-credentials", () => {
     });
   });
 
-  it("reaches the service and returns 500 when no SCM provider is configured", async () => {
+  it("rejects user and service credentials while accepting the bound sandbox", async () => {
     const { sessionName, sandboxToken } = await setupSession();
+    const url = `https://test.local/sessions/${sessionName}/scm-credentials`;
 
-    const res = await SELF.fetch(`https://test.local/sessions/${sessionName}/scm-credentials`, {
+    for (const service of NON_SANDBOX_SERVICES) {
+      const rejected = await serviceFetch(url, { method: "POST", service });
+
+      expect(rejected.status, service).toBe(401);
+      const body = await rejected.json<Record<string, unknown>>();
+      expect(body, service).toEqual({ error: "Unauthorized: Missing sandbox token" });
+      expect(body, service).not.toHaveProperty("username");
+      expect(body, service).not.toHaveProperty("password");
+    }
+
+    const res = await SELF.fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${sandboxToken}` },
     });
@@ -80,6 +99,22 @@ describe("POST /sessions/:id/scm-credentials", () => {
     expect(res.status).toBe(500);
     const body = await res.json<{ error: string }>();
     expect(body.error).toMatch(/GitHub App not configured/i);
+  });
+
+  it("rejects a sandbox token bound to another session", async () => {
+    const { sandboxToken } = await setupSession();
+    const { sessionName } = await setupSession();
+
+    const res = await SELF.fetch(`https://test.local/sessions/${sessionName}/scm-credentials`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sandboxToken}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ error: "Unauthorized: Invalid sandbox token" });
+    expect(body).not.toHaveProperty("username");
+    expect(body).not.toHaveProperty("password");
   });
 
   it("does not respond to GET requests on the route", async () => {

--- a/packages/control-plane/test/integration/scm-credentials.test.ts
+++ b/packages/control-plane/test/integration/scm-credentials.test.ts
@@ -14,16 +14,9 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SELF } from "cloudflare:test";
-import type { ServiceName } from "@open-inspect/shared/service-auth";
+import { SERVICE_NAMES } from "@open-inspect/shared/service-auth";
 import { cleanD1Tables } from "./cleanup";
 import { initNamedSession, seedSandboxAuth, serviceFetch } from "./helpers";
-
-const NON_SANDBOX_SERVICES = [
-  "web",
-  "slack-bot",
-  "github-bot",
-  "linear-bot",
-] as const satisfies readonly ServiceName[];
 
 async function setupSession(): Promise<{ sessionName: string; sandboxToken: string }> {
   const sessionName = `scm-creds-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
@@ -76,7 +69,7 @@ describe("POST /sessions/:id/scm-credentials", () => {
     const { sessionName, sandboxToken } = await setupSession();
     const url = `https://test.local/sessions/${sessionName}/scm-credentials`;
 
-    for (const service of NON_SANDBOX_SERVICES) {
+    for (const service of SERVICE_NAMES) {
       const rejected = await serviceFetch(url, { method: "POST", service });
 
       expect(rejected.status, service).toBe(401);


### PR DESCRIPTION
## Security issue

`POST /sessions/:id/scm-credentials` used the user-or-service policy with sandbox fallback. Any valid human or bot/service principal could therefore reach the session credential broker without proving possession of the sandbox token bound to the path session.

## Behavior change

- Classify `SCM_CREDENTIALS_ROUTE` as strict sandbox authentication.
- Require the bearer sandbox token to verify against the Session Durable Object selected by `:id` before the credential handler can run.
- Reject valid compound web/user credentials and every non-web bot credential before any Session DO access.
- Retain wrong-session token rejection and credential-free error responses.

## Preserved behavior

- GitHub and GitLab remain the exact supported SCM providers for this endpoint.
- Authentication still runs before SCM provider enforcement.
- Other user/service-with-sandbox-fallback routes are unchanged.
- A malformed service credential remains terminal and cannot fall through to sandbox authentication on routes that still support fallback.
- PR #1487 is not modified.

## Tests

- `npm test -w @open-inspect/control-plane -- router.policy.test.ts router.auth.test.ts router.scm-credentials.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- scm-credentials.test.ts`
- `npm run test:integration -w @open-inspect/control-plane` (68 files, 855 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/router.auth.test.ts packages/control-plane/src/router.policy.test.ts packages/control-plane/src/router.scm-credentials.test.ts packages/control-plane/src/routes/shared.ts packages/control-plane/test/integration/scm-credentials.test.ts`
- `npx prettier --check packages/control-plane/src/router.auth.test.ts packages/control-plane/src/router.policy.test.ts packages/control-plane/src/router.scm-credentials.test.ts packages/control-plane/src/routes/shared.ts packages/control-plane/test/integration/scm-credentials.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6a64c400a769317c72c9113a95dee593)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SCM credential access to require a valid sandbox token.
  * Prevented user or service credentials from accessing SCM credentials without sandbox authentication.
  * Ensured sandbox tokens are scoped to their associated session and rejected for other sessions.
  * Added coverage for GitHub, GitLab, Slack, and Linear authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->