### PR TITLE
test: make Slack channel integration test deterministic

### DIFF
--- a/packages/control-plane/test/integration/automations-slack-route.test.ts
+++ b/packages/control-plane/test/integration/automations-slack-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SELF, env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
 import { SlackChannelStore } from "../../src/db/slack-channel-store";
@@ -282,6 +282,7 @@ describe("GET /integration-settings/slack/watched-channels (integration)", () =>
 
 describe("GET /integration-settings/slack/channels (integration)", () => {
   beforeEach(cleanD1Tables);
+  afterEach(() => vi.unstubAllGlobals());
 
   async function getSlackChannels(auth = true): Promise<Response> {
     const url = "https://test.local/integration-settings/slack/channels";
@@ -294,14 +295,17 @@ describe("GET /integration-settings/slack/channels (integration)", () => {
   });
 
   it("degrades to an empty channel list (never a 500) when listing is unavailable", async () => {
-    // The integration env has no usable bot token, so the route returns an empty
-    // list with an error — `not_configured` when unset, or a Slack error such as
-    // `invalid_auth` when a placeholder token is present — rather than throwing.
+    const slackFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, error: "invalid_auth" }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", slackFetch);
+
     const res = await getSlackChannels();
     expect(res.status).toBe(200);
     const body = await res.json<{ channels: string[]; error?: string }>();
     expect(body.channels).toEqual([]);
-    expect(typeof body.error).toBe("string");
-    expect(body.error).toBeTruthy();
+    expect(body.error).toBe("invalid_auth");
+    expect(slackFetch).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- stub the Slack `conversations.list` response in the channel-list integration test
- assert the route degrades to an empty list with `invalid_auth`
- restore the global fetch stub after each test

## Root cause
The test previously called Slack with a placeholder token and waited for the live API response. In the flaky CI attempt that request took 5,043 ms, exceeding Vitest's 5,000 ms timeout and stalling a concurrently running scheduler test.

## Verification
- `npm run test:integration -- test/integration/automations-slack-route.test.ts test/integration/scheduler-slack-events.test.ts` (21 passed)
- `npm run typecheck --workspace=@open-inspect/control-plane`
- Prettier check
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/cf019484667035dec7f31f8bfa606dba)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Slack integration test isolation by restoring stubs after each test.
  * Added coverage for invalid authentication responses, including empty channel results and propagated errors.
  * Verified Slack is called exactly once in the unavailable-listing scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->