### PR TITLE
fix: reduce Fluxbox log noise

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/browser_desktop.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/browser_desktop.py
@@ -125,11 +125,12 @@ class BrowserDesktop:
     async def _forward_logs(self, name: str, process: asyncio.subprocess.Process) -> None:
         if not process.stdout:
             return
+        log = self.log.debug if name == "fluxbox" else self.log.info
         async for line in iter_process_lines(
             process.stdout,
             on_error=lambda error: self.log.warn(f"{name}.log_forward_error", exc=error),
         ):
-            self.log.info(f"{name}.stdout", line=line)
+            log(f"{name}.stdout", line=line)
 
     def _clear_display_artifacts(self) -> None:
         display_number = VNC_DISPLAY.removeprefix(":").split(".", maxsplit=1)[0]

--- a/packages/sandbox-runtime/tests/test_browser_desktop.py
+++ b/packages/sandbox-runtime/tests/test_browser_desktop.py
@@ -85,6 +85,21 @@ class TestStartVnc:
         assert not password_path.exists()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(("name", "level"), [("fluxbox", "debug"), ("xvfb", "info")])
+    async def test_forwards_fluxbox_logs_at_debug_and_other_desktop_logs_at_info(self, name, level):
+        log = MagicMock()
+        desktop = BrowserDesktop(log, password="secret")
+        process = _process()
+        process.stdout = asyncio.StreamReader()
+        process.stdout.feed_data(b"child output\n")
+        process.stdout.feed_eof()
+
+        await desktop._forward_logs(name, process)
+
+        getattr(log, level).assert_called_once_with(f"{name}.stdout", line="child output")
+        getattr(log, "info" if level == "debug" else "debug").assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_starts_dependencies_in_order_with_internal_raw_vnc(self, tmp_path):
         supervisor = _make_browser_desktop("secret12")
         events: list[str] = []


### PR DESCRIPTION
## Summary

- forward Fluxbox child-process output at debug level instead of info
- preserve info-level forwarding for the other desktop components
- add regression coverage for both logging paths

Fluxbox emits a large startup burst while defaulting missing session resource values. Desktop lifecycle signals such as `vnc.started`, `vnc.crash`, `vnc.start_failed`, and `vnc.max_restarts` remain unchanged.

## Verification

- `PYTHONPATH=src uv run pytest tests/test_browser_desktop.py -v` (18 passed)
- `uv run ruff check src/sandbox_runtime/browser_desktop.py tests/test_browser_desktop.py`
- `uv run ruff format --check src/sandbox_runtime/browser_desktop.py tests/test_browser_desktop.py`
- Full sandbox-runtime suite: 739 passed, 4 environment-dependent failures. Three credential-helper failures passed when inherited live control-plane credentials were removed. The remaining existing Git signer failure expects a Git CLI argument shape not produced by the installed Git version.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/35af296b4830a32b89cb7360541b2304)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the visibility of Fluxbox desktop log messages by recording them at debug level.
  * Continued recording other desktop process messages at info level.
  * Log forwarding errors remain reported as warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->