### PR TITLE
test: isolate integration tests from external services

### DIFF
--- a/packages/control-plane/test/integration/automations-slack-route.test.ts
+++ b/packages/control-plane/test/integration/automations-slack-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SELF, env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
 import { SlackChannelStore } from "../../src/db/slack-channel-store";
@@ -282,6 +282,7 @@ describe("GET /integration-settings/slack/watched-channels (integration)", () =>
 
 describe("GET /integration-settings/slack/channels (integration)", () => {
   beforeEach(cleanD1Tables);
+  afterEach(() => vi.unstubAllGlobals());
 
   async function getSlackChannels(auth = true): Promise<Response> {
     const url = "https://test.local/integration-settings/slack/channels";
@@ -294,14 +295,17 @@ describe("GET /integration-settings/slack/channels (integration)", () => {
   });
 
   it("degrades to an empty channel list (never a 500) when listing is unavailable", async () => {
-    // The integration env has no usable bot token, so the route returns an empty
-    // list with an error — `not_configured` when unset, or a Slack error such as
-    // `invalid_auth` when a placeholder token is present — rather than throwing.
+    const slackFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: false, error: "invalid_auth" }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", slackFetch);
+
     const res = await getSlackChannels();
     expect(res.status).toBe(200);
     const body = await res.json<{ channels: string[]; error?: string }>();
     expect(body.channels).toEqual([]);
-    expect(typeof body.error).toBe("string");
-    expect(body.error).toBeTruthy();
+    expect(body.error).toBe("invalid_auth");
+    expect(slackFetch).toHaveBeenCalledOnce();
   });
 });

--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -49,6 +49,13 @@ export default defineConfig({
           // otherwise defaults its runner to today's compatibility date.
           compatibilityDate: "2024-09-23",
           compatibilityFlags: ["nodejs_compat"],
+          outboundService(request) {
+            const url = new URL(request.url);
+            if (url.hostname.endsWith(".modal.run")) {
+              return new Response("Modal is unavailable in integration tests", { status: 404 });
+            }
+            throw new Error(`Unexpected outbound request: ${request.url}`);
+          },
           queueProducers: ["IMAGE_BUILD_FINALIZATION_QUEUE"],
           bindings: {
             IMAGE_CALLBACK_TOKEN_PEPPER: "test-callback-pepper",


### PR DESCRIPTION
## Summary
- stub Slack channel listing in the route integration test instead of calling the live Slack API
- route all integration-test Modal requests through a deterministic Miniflare outbound handler
- preserve the existing permanent 404 sandbox-failure lifecycle expected by SessionDO tests
- reject any other unstubbed external request so future network leaks fail visibly

## Root cause
The Slack channel test previously called Slack with a placeholder token and waited for a live response. A flaky 5,043 ms response exceeded Vitest's 5,000 ms timeout and stalled a concurrent scheduler test.

A repository-wide audit found the same pattern across SessionDO integration tests: 30 files could reach a public `*.modal.run` endpoint with placeholder credentials, and several tests explicitly waited for that live request to fail before proceeding.

## Verification
- `npm run test:integration -- test/integration/session-snapshot.test.ts test/integration/session-lifecycle.test.ts test/integration/websocket-client.test.ts` (51 passed)
- `npm run test:integration -- test/integration/do-internal-routes.test.ts test/integration/slack-notify.test.ts test/integration/automations-slack-route.test.ts test/integration/browser-auth.test.ts test/integration/browser-auth-callback.test.ts test/integration/auth-sign-in-claim.test.ts` (67 passed)
- `npm run test:integration` (68 files, 854 tests passed)
- `npm run typecheck --workspace=@open-inspect/control-plane`
- Prettier check
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/cf019484667035dec7f31f8bfa606dba)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Slack authentication failures so channel requests return an empty list while preserving the error details.
  * Ensured failed external requests do not cause unexpected integration-test behavior.

* **Tests**
  * Added verification that Slack channel retrieval makes exactly one request.
  * Improved cleanup of test stubs between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->