### PR TITLE
fix(github-bot): forward automation events after dispatch errors

### DIFF
--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -168,37 +168,40 @@ async function handleWebhook(
   };
 
   const start = Date.now();
-  let result: HandlerResult;
+  let result: HandlerResult | undefined;
+  let dispatchFailure: { error: unknown } | undefined;
 
   try {
     result = await dispatchHandler(env, log, event, p, payload, traceId);
   } catch (err) {
+    dispatchFailure = { error: err };
     log.info("webhook.handled", {
       ...wideEventBase,
       outcome: "error",
       duration_ms: Date.now() - start,
       error: err instanceof Error ? err : new Error(String(err)),
     });
-    throw err;
   }
 
-  const wideEvent: Record<string, unknown> = {
-    ...wideEventBase,
-    outcome: result.outcome,
-    duration_ms: Date.now() - start,
-  };
-  if (result.outcome === "skipped") {
-    wideEvent.skip_reason = result.skip_reason;
-  } else {
-    wideEvent.session_id = result.session_id;
-    wideEvent.message_id = result.message_id;
-    wideEvent.handler_action = result.handler_action;
+  if (result !== undefined) {
+    const wideEvent: Record<string, unknown> = {
+      ...wideEventBase,
+      outcome: result.outcome,
+      duration_ms: Date.now() - start,
+    };
+    if (result.outcome === "skipped") {
+      wideEvent.skip_reason = result.skip_reason;
+    } else {
+      wideEvent.session_id = result.session_id;
+      wideEvent.message_id = result.message_id;
+      wideEvent.handler_action = result.handler_action;
+    }
+    log.info("webhook.handled", wideEvent);
   }
-  log.info("webhook.handled", wideEvent);
 
-  // Forward normalized event to control-plane for automation triggering.
-  // Use the passthrough parse so nested lifecycle fields are not stripped by
-  // the summary schema used for logging and bot dispatch.
+  // Forwarding and built-in dispatch are independent; both must run before a
+  // failure reaches the waitUntil cleanup path. Use the passthrough parse so
+  // nested lifecycle fields are not stripped by the summary schema.
   if (event) {
     const normalizationPayload = actionResult.success ? actionResult.data : {};
     const normalizedEvent = normalizeGitHubEvent(event, normalizationPayload);
@@ -225,6 +228,8 @@ async function handleWebhook(
       }
     }
   }
+
+  if (dispatchFailure !== undefined) throw dispatchFailure.error;
 }
 
 function dispatchHandler(

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -173,7 +173,7 @@ describe("POST /webhooks/github", () => {
         base: { ref: "main" },
         draft: false,
       },
-      repository: null,
+      repository: { owner: { login: "test" }, name: "repo" },
       sender: { login: "alice" },
     });
     const signature = await sign(SECRET, body);
@@ -202,6 +202,18 @@ describe("POST /webhooks/github", () => {
     await flushWaitUntil(ctx, 1);
 
     expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    const controlPlaneFetch = (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> })
+      .fetch;
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(2);
+    for (const [url, init] of controlPlaneFetch.mock.calls) {
+      expect(url).toBe("https://internal/internal/github-event");
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        eventType: "pull_request.opened",
+        repoOwner: "test",
+        repoName: "repo",
+        pullRequest: { number: 42 },
+      });
+    }
     const githubKv = env.GITHUB_KV as unknown as {
       get: ReturnType<typeof vi.fn>;
       put: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## Summary
- let automation forwarding run even when the built-in GitHub handler fails
- rethrow the dispatch failure afterward so delivery deduplication remains retry-safe
- extend webhook coverage to verify forwarding and redelivery together

## Problem
`handleWebhook` rethrows a built-in dispatch error before it reaches the independent control-plane forwarding block. GitHub has already received a successful webhook response at that point, so the normalized automation event is silently lost unless someone manually redelivers it.

The failure is now held until forwarding gets its chance to run. It is then rethrown through the existing `waitUntil` error path, preserving dedupe-key cleanup and processing-error logging.

## Testing
- `npm test -w @open-inspect/github-bot -- webhook.test.ts` — 8 passed
- `npm test -w @open-inspect/github-bot` — 130 passed
- `npm run typecheck -w @open-inspect/github-bot` — passed
- `npm run lint -w @open-inspect/github-bot` — passed
- `npx prettier --check packages/github-bot/src/index.ts packages/github-bot/test/webhook.test.ts` — passed

Fixes #1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook error handling so control-plane forwarding can complete even when built-in processing fails.
  * Preserved failure reporting after forwarding, ensuring errors continue to reach the appropriate cleanup path.
  * Successful processing results are now logged only when available.
* **Tests**
  * Expanded retry coverage to verify correct forwarding URLs and pull-request payload details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->