### PR TITLE
fix: bound shared Slack API requests and pagination

### DIFF
--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -1256,7 +1256,7 @@ async function handleGetWatchedSlackChannels(
  * by the router (non-public route).
  */
 async function handleGetSlackChannels(
-  _request: Request,
+  request: Request,
   env: Env,
   _match: RegExpMatchArray,
   _ctx: RequestContext
@@ -1264,7 +1264,7 @@ async function handleGetSlackChannels(
   if (!env.SLACK_BOT_TOKEN) {
     return json({ channels: [], error: "not_configured" });
   }
-  const result = await listChannels(env.SLACK_BOT_TOKEN);
+  const result = await listChannels(env.SLACK_BOT_TOKEN, { signal: request.signal });
   if (!result.ok) {
     logger.warn("slack.channels.list_failed", { slack_error: result.error });
     return json({ channels: [], error: result.error });

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -624,7 +624,10 @@ describe("handleSlackNotify", () => {
 
     const res = await responsePromise;
     expect(res.status).toBe(502);
-    await expect(res.json()).resolves.toEqual({ error: "slack_api_error", message: "timeout" });
+    await expect(res.json()).resolves.toEqual({
+      error: "delivery_unknown",
+      message: "delivery_unknown",
+    });
   });
 
   it("rejects raw text longer than the input cap", async () => {

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -604,6 +604,29 @@ describe("handleSlackNotify", () => {
     expect(sessionFetchMock).not.toHaveBeenCalled();
   });
 
+  it("returns a deterministic Slack API error when posting times out", async () => {
+    seedActiveSession();
+    integrationStoreMock.getResolvedConfig.mockResolvedValue({
+      enabledRepos: null,
+      settings: { agentNotificationsEnabled: true, mentionsPolicy: "allow" },
+    });
+    const timeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    fetchMock.mockImplementationOnce((_url, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+
+    const responsePromise = callHandler({ channel: "#ops", text: "hello" });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    const res = await responsePromise;
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({ error: "slack_api_error", message: "timeout" });
+  });
+
   it("rejects raw text longer than the input cap", async () => {
     seedActiveSession();
     integrationStoreMock.getResolvedConfig.mockResolvedValue({

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -266,6 +266,7 @@ function mapSlackError(slackError: string | undefined): SlackWireDenialReason {
     return "channel_not_found_or_forbidden";
   }
   if (slackError === "ratelimited") return "rate_limited";
+  if (slackError === "delivery_unknown") return "delivery_unknown";
   return "slack_api_error";
 }
 

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -128,6 +128,7 @@ export async function handleSlackNotify(
   // Without top-level text, Slack derives screen-reader text from the blocks.
   const post = await postBlocks(token, parsed.channel, blocks, {
     thread_ts: parsed.threadTs,
+    signal: request.signal,
   });
 
   if (!post.ok) {
@@ -138,7 +139,7 @@ export async function handleSlackNotify(
 
   const channelId = post.channel;
   const messageTs = post.ts;
-  const permalinkResp = await getPermalink(token, channelId, messageTs);
+  const permalinkResp = await getPermalink(token, channelId, messageTs, { signal: request.signal });
   const permalink = permalinkResp.ok ? permalinkResp.permalink : "";
 
   const result: SlackNotifySuccessOutput = {

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/slack-notify.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/slack-notify.js
@@ -18,6 +18,8 @@ const REASON_GUIDANCE = {
     "The message body was empty after sanitization. Try again with non-empty content.",
   rate_limited: "Slack rate-limited the request. Wait before retrying.",
   slack_api_error: "Slack returned an unexpected error. The post did not go through.",
+  delivery_unknown:
+    "Slack may have posted the notification, but confirmation timed out. Do not retry automatically; check the channel first to avoid posting it twice.",
   invalid_input: "The notification arguments were invalid; correct them and retry.",
   bridge_error: "Could not reach the control plane to post the notification.",
 };

--- a/packages/shared/src/slack/client-timeout.test.ts
+++ b/packages/shared/src/slack/client-timeout.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getExternalUploadUrl,
+  getThreadMessages,
+  getUserInfo,
+  listChannels,
+  postMessage,
+  SLACK_PAGINATION_TIMEOUT_MS,
+  SLACK_REQUEST_TIMEOUT_MS,
+} from "./client";
+
+function stalledFetch() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+    });
+  });
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Slack request deadlines", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aborts a stalled read at the shared request deadline", async () => {
+    const timeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    stalledFetch();
+
+    const resultPromise = getUserInfo("xoxb-token", "U1");
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
+  });
+
+  it("marks a timed-out write as having unknown delivery", async () => {
+    const timeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    stalledFetch();
+
+    const resultPromise = postMessage("xoxb-token", "C123", "hi");
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "delivery_unknown" });
+  });
+
+  it("combines caller cancellation with the shared request deadline", async () => {
+    const timeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    const caller = new AbortController();
+    const fetchSpy = stalledFetch();
+
+    const resultPromise = getExternalUploadUrl("xoxb-token", {
+      filename: "chart.png",
+      length: 1234,
+      signal: caller.signal,
+    });
+    caller.abort();
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "cancelled" });
+    expect(fetchSpy.mock.calls[0]![1]?.signal).not.toBe(caller.signal);
+    expect(timeout.signal.aborted).toBe(false);
+  });
+});
+
+describe("Slack pagination deadlines", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("bounds the aggregate duration across channel pages", async () => {
+    const paginationTimeout = new AbortController();
+    const requestTimeouts: AbortController[] = [];
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
+      if (timeoutMs === SLACK_PAGINATION_TIMEOUT_MS) return paginationTimeout.signal;
+      const requestTimeout = new AbortController();
+      requestTimeouts.push(requestTimeout);
+      return requestTimeout.signal;
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channels: [{ id: "C1", name: "a" }],
+          response_metadata: { next_cursor: "cur-2" },
+        })
+      )
+      .mockImplementationOnce((_url, init) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        });
+      });
+
+    const resultPromise = listChannels("xoxb-token");
+    await vi.waitFor(() => expect(requestTimeouts).toHaveLength(2));
+    paginationTimeout.abort(new DOMException("pagination deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_PAGINATION_TIMEOUT_MS);
+    expect(requestTimeouts.every((controller) => !controller.signal.aborted)).toBe(true);
+  });
+
+  it("combines caller cancellation with the thread pagination deadline", async () => {
+    const caller = new AbortController();
+    stalledFetch();
+
+    const resultPromise = getThreadMessages("xoxb-token", "C123", "1.0", undefined, {
+      signal: caller.signal,
+    });
+    caller.abort();
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "cancelled" });
+  });
+});

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -15,7 +15,8 @@ import {
   postMessage,
   publishView,
   removeReaction,
-  SLACK_USER_INFO_TIMEOUT_MS,
+  SLACK_PAGINATION_TIMEOUT_MS,
+  SLACK_REQUEST_TIMEOUT_MS,
   updateMessage,
   uploadToExternalUrl,
 } from "./client";
@@ -63,7 +64,8 @@ describe("external file uploads", () => {
     );
     expect(init?.method).toBe("GET");
     expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer xoxb-token");
-    expect(init?.signal).toBe(signal);
+    expect(init?.signal).not.toBe(signal);
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
     expect(init?.body).toBeUndefined();
   });
 
@@ -86,7 +88,8 @@ describe("external file uploads", () => {
     expect(init?.method).toBe("POST");
     expect(init?.body).toBe(body);
     expect(init?.headers).toEqual({ "Content-Type": "image/png" });
-    expect(init?.signal).toBe(signal);
+    expect(init?.signal).not.toBe(signal);
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("normalizes raw upload HTTP and network failures", async () => {
@@ -123,7 +126,8 @@ describe("external file uploads", () => {
     expect(result.ok).toBe(true);
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("https://slack.com/api/files.completeUploadExternal");
-    expect(init?.signal).toBe(signal);
+    expect(init?.signal).not.toBe(signal);
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
     expect(JSON.parse(String(init?.body))).toEqual({
       files: [
         { id: "F123", title: "Revenue chart" },
@@ -276,6 +280,44 @@ describe("postMessage", () => {
     const result = await postMessage("xoxb-token", "C123", "hi");
     expect(result.ok).toBe(false);
     expect(result.error).toBe("network_error");
+  });
+
+  it("aborts a stalled fetch at the shared request deadline", async () => {
+    const timeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    vi.spyOn(globalThis, "fetch").mockImplementationOnce((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+
+    const resultPromise = postMessage("xoxb-token", "C123", "hi");
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
+  });
+
+  it("combines caller cancellation with the shared request deadline", async () => {
+    const timeout = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    const caller = new AbortController();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementationOnce((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+
+    const resultPromise = getExternalUploadUrl("xoxb-token", {
+      filename: "chart.png",
+      length: 1234,
+      signal: caller.signal,
+    });
+    caller.abort();
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "network_error" });
+    expect(fetchSpy.mock.calls[0]![1]?.signal).not.toBe(caller.signal);
+    expect(timeout.signal.aborted).toBe(false);
   });
 });
 
@@ -618,7 +660,7 @@ describe("getUserInfo", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches user info via GET with user query", async () => {
+  it("fetches user info via GET with the shared request deadline", async () => {
     const timeoutSignal = new AbortController().signal;
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
@@ -637,7 +679,7 @@ describe("getUserInfo", () => {
     }
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("https://slack.com/api/users.info?user=U1");
-    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_USER_INFO_TIMEOUT_MS);
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
     expect(fetchSpy.mock.calls[0]![1]?.signal).toBe(timeoutSignal);
   });
 
@@ -782,6 +824,40 @@ describe("listChannels", () => {
     }
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(String(fetchSpy.mock.calls[1]![0])).toContain("cursor=cur-2");
+  });
+
+  it("bounds the aggregate duration across pagination pages", async () => {
+    const paginationTimeout = new AbortController();
+    const requestTimeouts: AbortController[] = [];
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
+      if (timeoutMs === SLACK_PAGINATION_TIMEOUT_MS) return paginationTimeout.signal;
+      const requestTimeout = new AbortController();
+      requestTimeouts.push(requestTimeout);
+      return requestTimeout.signal;
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          channels: [{ id: "C1", name: "a" }],
+          response_metadata: { next_cursor: "cur-2" },
+        })
+      )
+      .mockImplementationOnce((_url, init) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        });
+      });
+
+    const resultPromise = listChannels("xoxb-token");
+    await vi.waitFor(() => expect(requestTimeouts).toHaveLength(2));
+    paginationTimeout.abort(new DOMException("pagination deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
+    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_PAGINATION_TIMEOUT_MS);
+    expect(requestTimeouts.every((controller) => !controller.signal.aborted)).toBe(true);
   });
 
   it("returns the Slack failure envelope when a page errors", async () => {

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -15,8 +15,6 @@ import {
   postMessage,
   publishView,
   removeReaction,
-  SLACK_PAGINATION_TIMEOUT_MS,
-  SLACK_REQUEST_TIMEOUT_MS,
   updateMessage,
   uploadToExternalUrl,
 } from "./client";
@@ -280,44 +278,6 @@ describe("postMessage", () => {
     const result = await postMessage("xoxb-token", "C123", "hi");
     expect(result.ok).toBe(false);
     expect(result.error).toBe("network_error");
-  });
-
-  it("aborts a stalled fetch at the shared request deadline", async () => {
-    const timeout = new AbortController();
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
-    vi.spyOn(globalThis, "fetch").mockImplementationOnce((_url, init) => {
-      return new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
-      });
-    });
-
-    const resultPromise = postMessage("xoxb-token", "C123", "hi");
-    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
-
-    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
-    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
-  });
-
-  it("combines caller cancellation with the shared request deadline", async () => {
-    const timeout = new AbortController();
-    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
-    const caller = new AbortController();
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementationOnce((_url, init) => {
-      return new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
-      });
-    });
-
-    const resultPromise = getExternalUploadUrl("xoxb-token", {
-      filename: "chart.png",
-      length: 1234,
-      signal: caller.signal,
-    });
-    caller.abort();
-
-    await expect(resultPromise).resolves.toEqual({ ok: false, error: "network_error" });
-    expect(fetchSpy.mock.calls[0]![1]?.signal).not.toBe(caller.signal);
-    expect(timeout.signal.aborted).toBe(false);
   });
 });
 
@@ -660,9 +620,7 @@ describe("getUserInfo", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches user info via GET with the shared request deadline", async () => {
-    const timeoutSignal = new AbortController().signal;
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+  it("fetches user info via GET with user query", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({
         ok: true,
@@ -679,8 +637,6 @@ describe("getUserInfo", () => {
     }
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe("https://slack.com/api/users.info?user=U1");
-    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_REQUEST_TIMEOUT_MS);
-    expect(fetchSpy.mock.calls[0]![1]?.signal).toBe(timeoutSignal);
   });
 
   it("returns Slack's error envelope on user_not_found", async () => {
@@ -824,40 +780,6 @@ describe("listChannels", () => {
     }
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(String(fetchSpy.mock.calls[1]![0])).toContain("cursor=cur-2");
-  });
-
-  it("bounds the aggregate duration across pagination pages", async () => {
-    const paginationTimeout = new AbortController();
-    const requestTimeouts: AbortController[] = [];
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
-      if (timeoutMs === SLACK_PAGINATION_TIMEOUT_MS) return paginationTimeout.signal;
-      const requestTimeout = new AbortController();
-      requestTimeouts.push(requestTimeout);
-      return requestTimeout.signal;
-    });
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ok: true,
-          channels: [{ id: "C1", name: "a" }],
-          response_metadata: { next_cursor: "cur-2" },
-        })
-      )
-      .mockImplementationOnce((_url, init) => {
-        return new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
-            once: true,
-          });
-        });
-      });
-
-    const resultPromise = listChannels("xoxb-token");
-    await vi.waitFor(() => expect(requestTimeouts).toHaveLength(2));
-    paginationTimeout.abort(new DOMException("pagination deadline exceeded", "TimeoutError"));
-
-    await expect(resultPromise).resolves.toEqual({ ok: false, error: "timeout" });
-    expect(timeoutSpy).toHaveBeenCalledWith(SLACK_PAGINATION_TIMEOUT_MS);
-    expect(requestTimeouts.every((controller) => !controller.signal.aborted)).toBe(true);
   });
 
   it("returns the Slack failure envelope when a page errors", async () => {

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -20,8 +20,8 @@ export const SLACK_PAGINATION_TIMEOUT_MS = 30_000;
  *
  * The success arm is `{ ok: true } & T`; the failure arm carries an `error`
  * string (Slack's `error` field, or one of the synthesized values
- * `network_error` / `timeout` / `invalid_response` / `http_<status>` /
- * `ratelimited`).
+ * `network_error` / `timeout` / `cancelled` / `delivery_unknown` /
+ * `invalid_response` / `http_<status>` / `ratelimited`).
  *
  * `T` is never supplied by hand: each endpoint passes a schema for its success
  * payload and `T` is inferred from it, so the type a caller reads and the shape
@@ -76,10 +76,15 @@ function boundedSignal(signal?: AbortSignal, timeoutMs = SLACK_REQUEST_TIMEOUT_M
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
-function requestError(signal: AbortSignal): "timeout" | "network_error" {
+function requestError(
+  signal: AbortSignal,
+  method: "GET" | "POST"
+): "timeout" | "cancelled" | "delivery_unknown" | "network_error" {
+  if (!signal.aborted) return "network_error";
+  if (method === "POST") return "delivery_unknown";
   return signal.reason instanceof DOMException && signal.reason.name === "TimeoutError"
     ? "timeout"
-    : "network_error";
+    : "cancelled";
 }
 
 async function slackFetch<S extends z.ZodType<object>>(
@@ -107,7 +112,7 @@ async function slackFetch<S extends z.ZodType<object>>(
   try {
     response = await fetch(url, { method, headers, body, signal });
   } catch {
-    return { ok: false, error: requestError(signal) };
+    return { ok: false, error: requestError(signal, method) };
   }
 
   if (response.status === 429) {
@@ -128,7 +133,10 @@ async function slackFetch<S extends z.ZodType<object>>(
     const parsed = slackEnvelopeSchema(payload).safeParse(await response.json());
     return parsed.success ? parsed.data : { ok: false, error: "invalid_response" };
   } catch {
-    return { ok: false, error: signal.aborted ? requestError(signal) : "invalid_response" };
+    return {
+      ok: false,
+      error: signal.aborted ? requestError(signal, method) : "invalid_response",
+    };
   }
 }
 
@@ -187,7 +195,7 @@ export async function uploadToExternalUrl(
     });
     return response.ok ? { ok: true } : { ok: false, error: `http_${response.status}` };
   } catch {
-    return { ok: false, error: requestError(boundedRequestSignal) };
+    return { ok: false, error: requestError(boundedRequestSignal, "POST") };
   }
 }
 
@@ -502,9 +510,10 @@ export async function getThreadMessages(
   token: string,
   channelId: string,
   threadTs: string,
-  oldest?: string
+  oldest?: string,
+  options?: SlackRequestOptions
 ): Promise<SlackEnvelope<{ messages: SlackThreadMessage[] }>> {
-  const paginationSignal = AbortSignal.timeout(SLACK_PAGINATION_TIMEOUT_MS);
+  const paginationSignal = boundedSignal(options?.signal, SLACK_PAGINATION_TIMEOUT_MS);
   const messages: SlackThreadMessage[] = [];
   let cursor: string | undefined;
   // Bound the loop defensively: 200/page × 25 pages caps at 5k messages.

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -12,14 +12,16 @@ import { z } from "zod";
 import { computeHmacHex, timingSafeEqual } from "../auth";
 
 const SLACK_API_BASE = "https://slack.com/api";
-export const SLACK_USER_INFO_TIMEOUT_MS = 10_000;
+export const SLACK_REQUEST_TIMEOUT_MS = 10_000;
+export const SLACK_PAGINATION_TIMEOUT_MS = 30_000;
 
 /**
  * Discriminated success/failure envelope returned by every Slack API method.
  *
  * The success arm is `{ ok: true } & T`; the failure arm carries an `error`
  * string (Slack's `error` field, or one of the synthesized values
- * `network_error` / `invalid_response` / `http_<status>` / `ratelimited`).
+ * `network_error` / `timeout` / `invalid_response` / `http_<status>` /
+ * `ratelimited`).
  *
  * `T` is never supplied by hand: each endpoint passes a schema for its success
  * payload and `T` is inferred from it, so the type a caller reads and the shape
@@ -65,6 +67,21 @@ export interface CompleteExternalUploadOptions {
   signal?: AbortSignal;
 }
 
+export interface SlackRequestOptions {
+  signal?: AbortSignal;
+}
+
+function boundedSignal(signal?: AbortSignal, timeoutMs = SLACK_REQUEST_TIMEOUT_MS) {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
+function requestError(signal: AbortSignal): "timeout" | "network_error" {
+  return signal.reason instanceof DOMException && signal.reason.name === "TimeoutError"
+    ? "timeout"
+    : "network_error";
+}
+
 async function slackFetch<S extends z.ZodType<object>>(
   token: string,
   endpoint: string,
@@ -85,11 +102,12 @@ async function slackFetch<S extends z.ZodType<object>>(
     body = JSON.stringify(init.body);
   }
 
+  const signal = boundedSignal(init?.signal);
   let response: Response;
   try {
-    response = await fetch(url, { method, headers, body, signal: init?.signal });
+    response = await fetch(url, { method, headers, body, signal });
   } catch {
-    return { ok: false, error: "network_error" };
+    return { ok: false, error: requestError(signal) };
   }
 
   if (response.status === 429) {
@@ -110,7 +128,7 @@ async function slackFetch<S extends z.ZodType<object>>(
     const parsed = slackEnvelopeSchema(payload).safeParse(await response.json());
     return parsed.success ? parsed.data : { ok: false, error: "invalid_response" };
   } catch {
-    return { ok: false, error: "invalid_response" };
+    return { ok: false, error: signal.aborted ? requestError(signal) : "invalid_response" };
   }
 }
 
@@ -159,16 +177,17 @@ export async function uploadToExternalUrl(
   contentType: string,
   signal?: AbortSignal
 ): Promise<SlackEnvelope> {
+  const boundedRequestSignal = boundedSignal(signal);
   try {
     const response = await fetch(uploadUrl, {
       method: "POST",
       headers: { "Content-Type": contentType },
       body,
-      signal,
+      signal: boundedRequestSignal,
     });
     return response.ok ? { ok: true } : { ok: false, error: `http_${response.status}` };
   } catch {
-    return { ok: false, error: "network_error" };
+    return { ok: false, error: requestError(boundedRequestSignal) };
   }
 }
 
@@ -252,14 +271,21 @@ export function postBlocks(
   options?: {
     thread_ts?: string;
     reply_broadcast?: boolean;
+    signal?: AbortSignal;
   }
 ): Promise<SlackEnvelope<{ channel: string; ts: string }>> {
-  return slackPost(token, "chat.postMessage", postedMessagePayloadSchema, {
-    channel,
-    blocks,
-    thread_ts: options?.thread_ts,
-    reply_broadcast: options?.reply_broadcast,
-  });
+  return slackPost(
+    token,
+    "chat.postMessage",
+    postedMessagePayloadSchema,
+    {
+      channel,
+      blocks,
+      thread_ts: options?.thread_ts,
+      reply_broadcast: options?.reply_broadcast,
+    },
+    options?.signal
+  );
 }
 
 const permalinkPayloadSchema = z.object({ permalink: z.string(), channel: z.string() });
@@ -267,12 +293,19 @@ const permalinkPayloadSchema = z.object({ permalink: z.string(), channel: z.stri
 export function getPermalink(
   token: string,
   channel: string,
-  messageTs: string
+  messageTs: string,
+  options?: SlackRequestOptions
 ): Promise<SlackEnvelope<{ permalink: string; channel: string }>> {
-  return slackGet(token, "chat.getPermalink", permalinkPayloadSchema, {
-    channel,
-    message_ts: messageTs,
-  });
+  return slackGet(
+    token,
+    "chat.getPermalink",
+    permalinkPayloadSchema,
+    {
+      channel,
+      message_ts: messageTs,
+    },
+    options?.signal
+  );
 }
 
 /**
@@ -405,8 +438,10 @@ export interface SlackChannelListing {
  * (private) scopes. Returns the SlackEnvelope failure arm on any page's error.
  */
 export async function listChannels(
-  token: string
+  token: string,
+  options?: SlackRequestOptions
 ): Promise<SlackEnvelope<{ channels: SlackChannelListing[] }>> {
+  const paginationSignal = boundedSignal(options?.signal, SLACK_PAGINATION_TIMEOUT_MS);
   const channels: SlackChannelListing[] = [];
   let cursor: string | undefined;
   // Bound the loop defensively: 1000/page × 20 pages caps at 20k channels.
@@ -418,7 +453,13 @@ export async function listChannels(
     };
     if (cursor) query.cursor = cursor;
 
-    const res = await slackGet(token, "conversations.list", conversationsListPayloadSchema, query);
+    const res = await slackGet(
+      token,
+      "conversations.list",
+      conversationsListPayloadSchema,
+      query,
+      paginationSignal
+    );
     if (!res.ok) return res;
 
     for (const c of res.channels) {
@@ -463,6 +504,7 @@ export async function getThreadMessages(
   threadTs: string,
   oldest?: string
 ): Promise<SlackEnvelope<{ messages: SlackThreadMessage[] }>> {
+  const paginationSignal = AbortSignal.timeout(SLACK_PAGINATION_TIMEOUT_MS);
   const messages: SlackThreadMessage[] = [];
   let cursor: string | undefined;
   // Bound the loop defensively: 200/page × 25 pages caps at 5k messages.
@@ -479,7 +521,8 @@ export async function getThreadMessages(
       token,
       "conversations.replies",
       conversationsRepliesPayloadSchema,
-      query
+      query,
+      paginationSignal
     );
     if (!res.ok) return res;
 
@@ -627,13 +670,7 @@ export function getUserInfo(
   token: string,
   userId: string
 ): Promise<SlackEnvelope<{ user: SlackUser }>> {
-  return slackGet(
-    token,
-    "users.info",
-    userInfoPayloadSchema,
-    { user: userId },
-    AbortSignal.timeout(SLACK_USER_INFO_TIMEOUT_MS)
-  );
+  return slackGet(token, "users.info", userInfoPayloadSchema, { user: userId });
 }
 
 export function publishView(

--- a/packages/shared/src/slack/index.ts
+++ b/packages/shared/src/slack/index.ts
@@ -15,6 +15,8 @@ export {
   postMessage,
   publishView,
   removeReaction,
+  SLACK_PAGINATION_TIMEOUT_MS,
+  SLACK_REQUEST_TIMEOUT_MS,
   slackMessageAttachmentSchema,
   slackMessageFileSchema,
   updateMessage,
@@ -30,6 +32,7 @@ export type {
   ExternalUploadUrlOptions,
   SlackMessageAttachment,
   SlackMessageFile,
+  SlackRequestOptions,
   SlackThreadMessage,
   SlackUser,
 } from "./client";

--- a/packages/shared/src/slack/types.test.ts
+++ b/packages/shared/src/slack/types.test.ts
@@ -46,4 +46,14 @@ describe("slack notify tool envelope schema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("parses an indeterminate delivery envelope", () => {
+    const result = slackNotifyToolEnvelopeSchema.safeParse({
+      ok: false,
+      reason: "delivery_unknown",
+      agentMessage: "Check the channel before retrying.",
+    });
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/shared/src/slack/types.ts
+++ b/packages/shared/src/slack/types.ts
@@ -23,6 +23,7 @@ export const SLACK_DENIAL_REASONS = [
   "channel_not_found_or_forbidden",
   "rate_limited",
   "slack_api_error",
+  "delivery_unknown",
   "invalid_input",
   "bridge_error",
 ] as const;
@@ -40,6 +41,7 @@ export const SLACK_DENIAL_STATUS: Record<SlackWireDenialReason, number> = {
   channel_not_found_or_forbidden: 404,
   rate_limited: 429,
   slack_api_error: 502,
+  delivery_unknown: 502,
   invalid_input: 400,
 };
 

--- a/packages/web/src/components/slack-notify-event.test.tsx
+++ b/packages/web/src/components/slack-notify-event.test.tsx
@@ -149,6 +149,12 @@ describe("SlackNotifyEvent", () => {
     expect(screen.getByText(/couldn't reach the control plane/i)).toBeInTheDocument();
   });
 
+  it("warns against retrying when delivery is unknown", () => {
+    renderExpanded(denialEvent("delivery_unknown"));
+    expect(screen.getByText(/may have posted/i)).toBeInTheDocument();
+    expect(screen.getByText(/check the channel before retrying/i)).toBeInTheDocument();
+  });
+
   it("renders legacy denial events (status=error, bare reason) for backward compat", () => {
     renderExpanded(legacyDenialEvent("channel_not_found_or_forbidden"));
     expect(screen.getByText(/channel not found or bot is not in the channel/i)).toBeInTheDocument();

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -37,6 +37,10 @@ const DENIAL_COPY: Record<SlackDenialReason, { headline: string; hint?: string }
   slack_api_error: {
     headline: "Slack returned an unexpected error.",
   },
+  delivery_unknown: {
+    headline: "Slack may have posted the notification, but confirmation timed out.",
+    hint: "Check the channel before retrying to avoid posting it twice.",
+  },
   invalid_input: {
     headline: "The notification arguments were invalid.",
   },


### PR DESCRIPTION
## Summary
- apply a default 10-second deadline to all shared Slack API and external upload requests
- combine caller cancellation with application-owned deadlines and return deterministic timeout envelopes
- cap channel and thread pagination at a 30-second aggregate duration
- propagate inline request cancellation through Slack notification and channel-list handlers
- cover stalled requests, caller cancellation, aggregate pagination timeout, and inline timeout responses

## Verification
- `npm test -w @open-inspect/shared` (630 tests)
- `npm test -w @open-inspect/control-plane -- src/routes/slack-notify.test.ts` (22 tests)
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/automations-slack-route.test.ts` (15 tests)
- `npm run typecheck`
- targeted ESLint and Prettier checks for changed files

Linear: COL-67

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/b3829e3da9fd1c54bd56bd1107f3a90e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack requests now stop promptly when a client disconnects or cancels a request.
  * Added consistent timeouts for Slack requests, pagination, and uploads.
  * Improved handling of timeout, cancellation, and network errors.
  * Indeterminate Slack delivery now returns a clear HTTP 502 response.
  * Added guidance to check the channel before retrying when message delivery cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->