### PR TITLE
fix: bound Linear bot provider requests

### DIFF
--- a/packages/linear-bot/src/callbacks.start.test.ts
+++ b/packages/linear-bot/src/callbacks.start.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { callbacksRouter } from "./callbacks";
 import {
   createStartCallbackRouter,
@@ -16,6 +16,10 @@ const client: LinearApiClient = {
   organizationId: "org-1",
   renewAccessToken: vi.fn(async () => "renewed-token"),
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 async function signedPayload(overrides: Record<string, unknown> = {}) {
   const data = {
@@ -148,6 +152,21 @@ describe("POST /start", () => {
     const response = await postStart(router);
 
     expect(response.status).toBe(502);
+  });
+
+  it("returns a timeout response when the transition GraphQL request times out", async () => {
+    const router = createStartCallbackRouter({
+      getLinearClient: vi.fn(async () => client),
+      transitionIssueToStarted: vi.fn(async () => {
+        throw new DOMException("timed out", "TimeoutError");
+      }),
+      now: () => NOW,
+    });
+
+    const response = await postStart(router);
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual({ error: "Linear request timed out" });
   });
 
   it("acknowledges a message that did not opt into the transition", async () => {

--- a/packages/linear-bot/src/callbacks.start.test.ts
+++ b/packages/linear-bot/src/callbacks.start.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { callbacksRouter } from "./callbacks";
-import { createStartCallbackRouter } from "./callbacks/start-callback";
+import {
+  createStartCallbackRouter,
+  START_CALLBACK_LINEAR_TIMEOUT_MS,
+} from "./callbacks/start-callback";
 import { computeHmacHex } from "@open-inspect/shared/auth";
 import { createFakeKV, makeExecutionContext, makeLinearBotEnv } from "./test-helpers";
 import type { LinearApiClient } from "./utils/linear-client";
@@ -69,7 +72,7 @@ describe("POST /start", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true, outcome: "transitioned" });
     expect(getLinearClient).toHaveBeenCalledWith(expect.anything(), "org-1", "app-user-1");
-    expect(transitionIssueToStarted).toHaveBeenCalledWith(client, "issue-1");
+    expect(transitionIssueToStarted).toHaveBeenCalledWith(client, "issue-1", expect.anything());
   });
 
   it("verifies the original callback field order after schema validation", async () => {
@@ -187,6 +190,22 @@ describe("POST /start", () => {
     const response = await postStart(router);
 
     expect(response.status).toBe(503);
+  });
+
+  it("returns within the callback deadline when credential lookup stalls", async () => {
+    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    const router = createStartCallbackRouter({
+      getLinearClient: vi.fn(() => new Promise<LinearApiClient | null>(() => undefined)),
+      transitionIssueToStarted: vi.fn(),
+      now: () => NOW,
+    });
+
+    const response = await postStart(router);
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual({ error: "Linear request timed out" });
+    expect(timeoutSpy).toHaveBeenCalledWith(START_CALLBACK_LINEAR_TIMEOUT_MS);
   });
 
   it("rejects malformed identity fields before credential lookup", async () => {

--- a/packages/linear-bot/src/callbacks/start-callback.ts
+++ b/packages/linear-bot/src/callbacks/start-callback.ts
@@ -6,10 +6,12 @@ import { createLogger } from "../logger";
 import { rejectInvalidCallback } from "./reject-invalid-callback";
 import { getLinearClient } from "../utils/linear-client";
 import { transitionIssueToStarted } from "../utils/issue-start-transition";
+import { abortable } from "../utils/abortable";
 
 const log = createLogger("callback");
 const START_CALLBACK_MAX_AGE_MS = 5 * 60 * 1000;
 const START_CALLBACK_MAX_FUTURE_SKEW_MS = 60 * 1000;
+export const START_CALLBACK_LINEAR_TIMEOUT_MS = 20_000;
 
 interface StartCallbackDependencies {
   getLinearClient: typeof getLinearClient;
@@ -76,9 +78,14 @@ export function createStartCallbackRouter(
       return c.json({ ok: true, outcome: "not_eligible" });
     }
 
+    const linearSignal = AbortSignal.timeout(START_CALLBACK_LINEAR_TIMEOUT_MS);
+
     let client;
     try {
-      client = await dependencies.getLinearClient(c.env, context.organizationId, context.appUserId);
+      client = await abortable(
+        dependencies.getLinearClient(c.env, context.organizationId, context.appUserId),
+        linearSignal
+      );
     } catch (error) {
       log.warn("callback.started", {
         ...callbackLogFields,
@@ -86,12 +93,17 @@ export function createStartCallbackRouter(
         error: error instanceof Error ? error : new Error(String(error)),
         duration_ms: dependencies.now() - requestStartedAt,
       });
-      return c.json({ error: "Linear authentication failed" }, 503);
+      return linearSignal.aborted
+        ? c.json({ error: "Linear request timed out" }, 504)
+        : c.json({ error: "Linear authentication failed" }, 503);
     }
     if (!client) return c.json({ error: "Linear authentication failed" }, 503);
 
     try {
-      const result = await dependencies.transitionIssueToStarted(client, context.issueId);
+      const result = await abortable(
+        dependencies.transitionIssueToStarted(client, context.issueId, linearSignal),
+        linearSignal
+      );
       log.info("callback.started", {
         ...callbackLogFields,
         issue_identifier: context.issueIdentifier,
@@ -112,7 +124,9 @@ export function createStartCallbackRouter(
         error: error instanceof Error ? error : new Error(String(error)),
         duration_ms: dependencies.now() - requestStartedAt,
       });
-      return c.json({ error: "Linear issue transition failed" }, 502);
+      return linearSignal.aborted
+        ? c.json({ error: "Linear request timed out" }, 504)
+        : c.json({ error: "Linear issue transition failed" }, 502);
     }
   });
 

--- a/packages/linear-bot/src/callbacks/start-callback.ts
+++ b/packages/linear-bot/src/callbacks/start-callback.ts
@@ -124,7 +124,9 @@ export function createStartCallbackRouter(
         error: error instanceof Error ? error : new Error(String(error)),
         duration_ms: dependencies.now() - requestStartedAt,
       });
-      return linearSignal.aborted
+      const timedOut =
+        linearSignal.aborted || (error instanceof DOMException && error.name === "TimeoutError");
+      return timedOut
         ? c.json({ error: "Linear request timed out" }, 504)
         : c.json({ error: "Linear issue transition failed" }, 502);
     }

--- a/packages/linear-bot/src/classifier/index.test.ts
+++ b/packages/linear-bot/src/classifier/index.test.ts
@@ -1,5 +1,40 @@
-import { describe, expect, it } from "vitest";
-import { anthropicMessagesResponseSchema, classifyToolInputSchema } from "./index";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RepoConfig } from "@open-inspect/shared/types/repository-catalog";
+import {
+  anthropicMessagesResponseSchema,
+  CLASSIFIER_REQUEST_TIMEOUT_MS,
+  classifyRepo,
+  classifyToolInputSchema,
+} from "./index";
+import { createFakeKV, makeLinearBotEnv } from "../test-helpers";
+
+const { getAvailableRepos, buildRepoDescriptions } = vi.hoisted(() => ({
+  getAvailableRepos: vi.fn(),
+  buildRepoDescriptions: vi.fn(),
+}));
+
+vi.mock("./repos", () => ({ getAvailableRepos, buildRepoDescriptions }));
+
+const repos: RepoConfig[] = ["api", "web"].map((name) => ({
+  id: `acme/${name}`,
+  owner: "acme",
+  name,
+  fullName: `acme/${name}`,
+  displayName: name,
+  description: `${name} repository`,
+  defaultBranch: "main",
+  private: true,
+}));
+
+beforeEach(() => {
+  getAvailableRepos.mockResolvedValue(repos);
+  buildRepoDescriptions.mockResolvedValue("- acme/api\n- acme/web");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("anthropicMessagesResponseSchema", () => {
   it("parses a response with the consumed tool block fields", () => {
@@ -61,5 +96,41 @@ describe("classifyToolInputSchema", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe("classifyRepo", () => {
+  it("falls back to clarification when the classifier request times out", async () => {
+    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        expect(init?.signal).toBe(timeoutSignal);
+        throw timeoutSignal.reason;
+      })
+    );
+    const { kv } = createFakeKV();
+
+    const result = await classifyRepo(
+      makeLinearBotEnv(kv),
+      "Update service",
+      null,
+      [],
+      null,
+      "Engineering",
+      "ENG",
+      null
+    );
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLASSIFIER_REQUEST_TIMEOUT_MS);
+    expect(result).toEqual({
+      repo: null,
+      confidence: "low",
+      reasoning:
+        "Could not classify repository automatically. Please reply with the repository name (e.g., `owner/repo`).",
+      alternatives: repos,
+      needsClarification: true,
+    });
   });
 });

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -15,6 +15,7 @@ import { createLogger } from "../logger";
 const log = createLogger("classifier");
 
 const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
+export const CLASSIFIER_REQUEST_TIMEOUT_MS = 10_000;
 
 export const classifyToolInputSchema = z.object({
   repoId: z.string().nullable(),
@@ -135,6 +136,7 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
       tool_choice: { type: "tool", name: CLASSIFY_REPO_TOOL_NAME },
       messages: [{ role: "user", content: prompt }],
     }),
+    signal: AbortSignal.timeout(CLASSIFIER_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/packages/linear-bot/src/utils/abortable.ts
+++ b/packages/linear-bot/src/utils/abortable.ts
@@ -1,0 +1,21 @@
+export function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    void promise.catch(() => undefined);
+    return Promise.reject(signal.reason);
+  }
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}

--- a/packages/linear-bot/src/utils/issue-start-transition.test.ts
+++ b/packages/linear-bot/src/utils/issue-start-transition.test.ts
@@ -32,6 +32,7 @@ describe("transitionIssueToStarted", () => {
   });
 
   it("moves an unstarted issue to the team's first started state", async () => {
+    const signal = new AbortController().signal;
     mockLinearGraphQL
       .mockResolvedValueOnce(
         transitionContext("unstarted", [
@@ -41,7 +42,7 @@ describe("transitionIssueToStarted", () => {
       )
       .mockResolvedValueOnce({ data: { issueUpdate: { success: true } } });
 
-    await expect(transitionIssueToStarted(client, "issue-1")).resolves.toEqual({
+    await expect(transitionIssueToStarted(client, "issue-1", signal)).resolves.toEqual({
       outcome: "transitioned",
       previousStateType: "unstarted",
       stateId: "progress",
@@ -51,6 +52,8 @@ describe("transitionIssueToStarted", () => {
       issueId: "issue-1",
       stateId: "progress",
     });
+    expect(mockLinearGraphQL.mock.calls[0][3]).toBe(signal);
+    expect(mockLinearGraphQL.mock.calls[1][3]).toBe(signal);
   });
 
   it.each([

--- a/packages/linear-bot/src/utils/issue-start-transition.ts
+++ b/packages/linear-bot/src/utils/issue-start-transition.ts
@@ -44,7 +44,8 @@ export type IssueStartTransitionResult =
 /** Move an issue forward to the team's first started workflow state. */
 export async function transitionIssueToStarted(
   client: LinearApiClient,
-  issueId: string
+  issueId: string,
+  signal?: AbortSignal
 ): Promise<IssueStartTransitionResult> {
   const contextResponse = transitionContextSchema.parse(
     await linearGraphQL(
@@ -61,7 +62,8 @@ export async function transitionIssueToStarted(
         }
       }
     `,
-      { issueId }
+      { issueId },
+      signal
     )
   );
 
@@ -94,7 +96,8 @@ export async function transitionIssueToStarted(
         }
       }
     `,
-      { issueId, stateId: target.id }
+      { issueId, stateId: target.id },
+      signal
     )
   );
 

--- a/packages/linear-bot/src/utils/linear-client.test.ts
+++ b/packages/linear-bot/src/utils/linear-client.test.ts
@@ -4,6 +4,7 @@ import {
   fetchIssueDetails,
   fetchUser,
   getRepoSuggestions,
+  LINEAR_GRAPHQL_TIMEOUT_MS,
   linearGraphQL,
   postIssueComment,
 } from "./linear-client";
@@ -52,6 +53,47 @@ describe("linearGraphQL", () => {
     await expect(linearGraphQL(client, "query { viewer { id } }", {})).resolves.toEqual({
       data: { viewer: { id: "user-1" } },
     });
+  });
+
+  it("times out the first GraphQL attempt", async () => {
+    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        expect(init?.signal).toBe(timeoutSignal);
+        throw timeoutSignal.reason;
+      })
+    );
+
+    await expect(linearGraphQL(client, "query { viewer { id } }", {})).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(timeoutSpy).toHaveBeenCalledWith(LINEAR_GRAPHQL_TIMEOUT_MS);
+  });
+
+  it("uses the same deadline for a renewed-token retry", async () => {
+    const deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    const renewAccessToken = vi.fn(async () => "renewed-token");
+    const retryClient: LinearApiClient = {
+      accessToken: "expired-token",
+      organizationId: "org-1",
+      renewAccessToken,
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.signal).toBe(deadline.signal);
+      if (fetchMock.mock.calls.length === 1) return new Response(null, { status: 401 });
+      deadline.abort(new DOMException("timed out", "TimeoutError"));
+      throw deadline.signal.reason;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(linearGraphQL(retryClient, "query { viewer { id } }", {})).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(renewAccessToken).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -286,6 +328,22 @@ describe("postIssueComment", () => {
       vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.reject(new SyntaxError("Unexpected token")),
+      })
+    );
+
+    await expect(postIssueComment("token", "issue-1", "hello")).resolves.toEqual({
+      success: false,
+    });
+  });
+
+  it("returns false when the comment request times out", async () => {
+    const timeoutSignal = AbortSignal.abort(new DOMException("timed out", "TimeoutError"));
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input, init) => {
+        expect(init?.signal).toBe(timeoutSignal);
+        throw timeoutSignal.reason;
       })
     );
 

--- a/packages/linear-bot/src/utils/linear-client.test.ts
+++ b/packages/linear-bot/src/utils/linear-client.test.ts
@@ -29,6 +29,7 @@ function mockFetchResponse(data: unknown): void {
 describe("linearGraphQL", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("rejects a GraphQL response that is not an object", async () => {
@@ -94,6 +95,37 @@ describe("linearGraphQL", () => {
     });
     expect(renewAccessToken).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves the aggregate timeout while token renewal is stalled", async () => {
+    const deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    let renewalStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      renewalStarted = resolve;
+    });
+    const renewAccessToken = vi.fn(
+      () =>
+        new Promise<string>(() => {
+          renewalStarted?.();
+        })
+    );
+    const renewalClient: LinearApiClient = {
+      accessToken: "expired-token",
+      organizationId: "org-1",
+      renewAccessToken,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 }))
+    );
+
+    const request = linearGraphQL(renewalClient, "query { viewer { id } }", {});
+    await started;
+    deadline.abort(new DOMException("timed out", "TimeoutError"));
+
+    await expect(request).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(renewAccessToken).toHaveBeenCalledOnce();
   });
 });
 
@@ -278,6 +310,7 @@ describe("emitAgentActivity", () => {
 describe("postIssueComment", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("returns success from a valid comment mutation response", async () => {

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -133,6 +133,7 @@ export async function linearGraphQL(
     try {
       renewedToken = await abortable(client.renewAccessToken(), signal);
     } catch (error) {
+      if (signal.aborted) throw signal.reason;
       if (error instanceof LinearAuthError) throw error;
       throw new LinearAuthError({ reason: "client_credentials_error" });
     }

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -17,6 +17,7 @@ import {
   LinearAuthError,
 } from "./linear-credentials";
 import { z } from "zod";
+import { abortable } from "./abortable";
 
 export {
   completeLinearOAuthInstallation,
@@ -27,6 +28,7 @@ export {
 const log = createLogger("linear-client");
 
 const LINEAR_API_URL = "https://api.linear.app/graphql";
+export const LINEAR_GRAPHQL_TIMEOUT_MS = 15_000;
 
 const linearCommentCreateResponseSchema = z.object({
   data: z
@@ -107,8 +109,11 @@ export async function getLinearClientOrThrow(
 export async function linearGraphQL(
   client: LinearApiClient,
   query: string,
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  callerSignal?: AbortSignal
 ): Promise<Record<string, unknown>> {
+  const deadlineSignal = AbortSignal.timeout(LINEAR_GRAPHQL_TIMEOUT_MS);
+  const signal = callerSignal ? AbortSignal.any([callerSignal, deadlineSignal]) : deadlineSignal;
   const body = JSON.stringify({ query, variables });
   const send = (accessToken: string) =>
     fetch(LINEAR_API_URL, {
@@ -118,6 +123,7 @@ export async function linearGraphQL(
         Authorization: `Bearer ${accessToken}`,
       },
       body,
+      signal,
     });
 
   let res = await send(client.accessToken);
@@ -125,7 +131,7 @@ export async function linearGraphQL(
     log.warn("linear.graphql.unauthorized", { org_id: client.organizationId });
     let renewedToken: string;
     try {
-      renewedToken = await client.renewAccessToken();
+      renewedToken = await abortable(client.renewAccessToken(), signal);
     } catch (error) {
       if (error instanceof LinearAuthError) throw error;
       throw new LinearAuthError({ reason: "client_credentials_error" });
@@ -394,26 +400,31 @@ export async function postIssueComment(
   issueId: string,
   body: string
 ): Promise<{ success: boolean }> {
-  const response = await fetch(LINEAR_API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: apiKey,
-    },
-    body: JSON.stringify({
-      query: `
-        mutation CommentCreate($input: CommentCreateInput!) {
-          commentCreate(input: $input) { success }
-        }
-      `,
-      variables: { input: { issueId, body } },
-    }),
-  });
+  try {
+    const response = await fetch(LINEAR_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: apiKey,
+      },
+      body: JSON.stringify({
+        query: `
+          mutation CommentCreate($input: CommentCreateInput!) {
+            commentCreate(input: $input) { success }
+          }
+        `,
+        variables: { input: { issueId, body } },
+      }),
+      signal: AbortSignal.timeout(LINEAR_GRAPHQL_TIMEOUT_MS),
+    });
 
-  if (!response.ok) return { success: false };
-  const result = linearCommentCreateResponseSchema.safeParse(
-    await response.json().catch(() => null)
-  );
-  if (!result.success) return { success: false };
-  return { success: result.data.data?.commentCreate?.success ?? false };
+    if (!response.ok) return { success: false };
+    const result = linearCommentCreateResponseSchema.safeParse(
+      await response.json().catch(() => null)
+    );
+    if (!result.success) return { success: false };
+    return { success: result.data.data?.commentCreate?.success ?? false };
+  } catch {
+    return { success: false };
+  }
 }


### PR DESCRIPTION
## Summary
- add a 15-second aggregate deadline across Linear GraphQL requests, token renewal, and renewed-token replay
- bound Anthropic repository classification to 10 seconds and preserve the existing clarification fallback on timeout
- bound `/callbacks/start` Linear work to 20 seconds, propagate its signal through issue transitions, and return a deterministic 504 on timeout
- make fallback comment delivery return `{ success: false }` for request timeouts and network failures

## Tests
- first-attempt GraphQL timeout
- renewed-token retry timeout using the same aggregate deadline
- classifier timeout clarification fallback
- stalled start-callback credential lookup
- callback signal propagation across transition query and mutation

## Verification
- `npm test -w @open-inspect/linear-bot`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/linear-bot`
- `npm run build -w @open-inspect/linear-bot`

Linear: COL-72

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6cadb7d1ab303c9558321e3388d7ca4d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Added time limits to Linear authentication, issue updates, GraphQL requests, and classifier requests.
  - Operations now stop promptly when requests exceed their time limits.
  - Retry and token-renewal requests respect the same deadline.

- **Bug Fixes**
  - Stalled start actions now return a clear timeout response instead of hanging.
  - Classifier timeouts provide a low-confidence clarification with repository alternatives.
  - Failed issue-comment requests now report failure safely without disrupting the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->