### PR TITLE
fix: bound repository clone and fetch during startup

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_boot.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_boot.py
@@ -158,16 +158,32 @@ class RepositoryBoot:
         git_sync_success = not sync_result.failures
         if sync_result.failures:
             if boot_mode in (BootMode.FRESH, BootMode.BUILD):
-                failed_names = ", ".join(
-                    f"{repo.owner}/{repo.name}" for repo in sync_result.failures
+                messages = []
+                if sync_result.timed_out:
+                    timed_out_names = ", ".join(
+                        f"{repo.owner}/{repo.name}" for repo in sync_result.timed_out
+                    )
+                    messages.append(f"git sync timed out for {timed_out_names}")
+                failed = tuple(
+                    repo for repo in sync_result.failures if repo not in sync_result.timed_out
                 )
-                raise RuntimeError(f"git sync failed for {failed_names}")
-            for repo in sync_result.failures:
-                self.warnings.record(
-                    "sync",
-                    f"Could not update {repo.owner}/{repo.name} from origin; the checkout may be stale.",
-                    repo,
-                )
+                if failed:
+                    failed_names = ", ".join(f"{repo.owner}/{repo.name}" for repo in failed)
+                    messages.append(f"git sync failed for {failed_names}")
+                raise RuntimeError("; ".join(messages))
+            if boot_mode in (BootMode.SNAPSHOT_RESTORE, BootMode.REPO_IMAGE):
+                for repo in sync_result.failures:
+                    if repo in sync_result.timed_out:
+                        message = (
+                            f"Timed out updating {repo.owner}/{repo.name} from origin; "
+                            "the checkout may be stale."
+                        )
+                    else:
+                        message = (
+                            f"Could not update {repo.owner}/{repo.name} from origin; "
+                            "the checkout may be stale."
+                        )
+                    self.warnings.record("sync", message, repo)
         self._write_repo_manifest()
 
         repository_shas: list[dict[str, str]] = []

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_boot.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_boot.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from .constants import REPO_MANIFEST_FILE_PATH
 from .repo_config import RepoConfigError, RepoEntry, dump_repo_manifest, parse_repositories
+from .repository_sync import RepositorySyncStatus
 from .runtime_config import BootMode, RepositoryConfig
 
 if TYPE_CHECKING:
@@ -164,16 +165,18 @@ class RepositoryBoot:
                         f"{repo.owner}/{repo.name}" for repo in sync_result.timed_out
                     )
                     messages.append(f"git sync timed out for {timed_out_names}")
-                failed = tuple(
-                    repo for repo in sync_result.failures if repo not in sync_result.timed_out
-                )
-                if failed:
-                    failed_names = ", ".join(f"{repo.owner}/{repo.name}" for repo in failed)
+                if sync_result.non_timeout_failures:
+                    failed_names = ", ".join(
+                        f"{repo.owner}/{repo.name}" for repo in sync_result.non_timeout_failures
+                    )
                     messages.append(f"git sync failed for {failed_names}")
                 raise RuntimeError("; ".join(messages))
-            if boot_mode in (BootMode.SNAPSHOT_RESTORE, BootMode.REPO_IMAGE):
-                for repo in sync_result.failures:
-                    if repo in sync_result.timed_out:
+            else:
+                for outcome in sync_result.outcomes:
+                    repo = outcome.repository
+                    if outcome.status is RepositorySyncStatus.SUCCEEDED:
+                        continue
+                    if outcome.status is RepositorySyncStatus.TIMED_OUT:
                         message = (
                             f"Timed out updating {repo.owner}/{repo.name} from origin; "
                             "the checkout may be stale."

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
@@ -17,20 +17,36 @@ if TYPE_CHECKING:
 GH_WRAPPER_REAL_PATH = "/usr/bin/gh"
 GH_WRAPPER_INSTALL_PATH = Path("/usr/local/bin/gh")
 GH_WRAPPER_BODY = Path(__file__).with_name("gh-wrapper.sh").read_text()
+DEFAULT_GIT_CLONE_TIMEOUT_SECONDS = 300.0
+DEFAULT_GIT_FETCH_TIMEOUT_SECONDS = 120.0
+
+
+class RepositorySyncTimeout(TimeoutError):
+    pass
 
 
 @dataclass(frozen=True)
 class RepositorySyncResult:
     repositories: tuple[RepoEntry, ...]
     failures: tuple[RepoEntry, ...]
+    timed_out: tuple[RepoEntry, ...] = ()
 
 
 class RepositorySynchronizer:
     CLONE_DEPTH_COMMITS = 100
 
-    def __init__(self, vcs_host: str, log: Any) -> None:
+    def __init__(
+        self,
+        vcs_host: str,
+        log: Any,
+        *,
+        clone_timeout_seconds: float = DEFAULT_GIT_CLONE_TIMEOUT_SECONDS,
+        fetch_timeout_seconds: float = DEFAULT_GIT_FETCH_TIMEOUT_SECONDS,
+    ) -> None:
         self.vcs_host = vcs_host
         self.log = log
+        self.clone_timeout_seconds = clone_timeout_seconds
+        self.fetch_timeout_seconds = fetch_timeout_seconds
 
     def _build_repo_url(self, repo: RepoEntry) -> str:
         return f"https://{self.vcs_host}/{repo.owner}/{repo.name}.git"
@@ -62,7 +78,18 @@ class RepositorySynchronizer:
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
             )
-            _stdout, stderr = await self._communicate_owned_subprocess(result)
+            _stdout, stderr = await asyncio.wait_for(
+                self._communicate_owned_subprocess(result),
+                timeout=self.clone_timeout_seconds,
+            )
+        except TimeoutError as error:
+            self.log.error(
+                "git.clone_timeout",
+                repo_owner=repo.owner,
+                repo_name=repo.name,
+                timeout_seconds=self.clone_timeout_seconds,
+            )
+            raise RepositorySyncTimeout from error
         except Exception as error:
             self.log.error("git.clone_error", exc=error, repo_owner=repo.owner, repo_name=repo.name)
             return False
@@ -169,7 +196,19 @@ class RepositorySynchronizer:
             stderr=asyncio.subprocess.PIPE,
             start_new_session=True,
         )
-        _stdout, stderr = await self._communicate_owned_subprocess(process)
+        try:
+            _stdout, stderr = await asyncio.wait_for(
+                self._communicate_owned_subprocess(process),
+                timeout=self.fetch_timeout_seconds,
+            )
+        except TimeoutError as error:
+            self.log.error(
+                "git.fetch_timeout",
+                repo_owner=repo.owner,
+                repo_name=repo.name,
+                timeout_seconds=self.fetch_timeout_seconds,
+            )
+            raise RepositorySyncTimeout from error
         if process.returncode != 0:
             self.log.error(
                 "git.fetch_error",
@@ -220,6 +259,8 @@ class RepositorySynchronizer:
             if preserve_checkout:
                 return True
             return await self._checkout_branch(repo, repo.branch)
+        except RepositorySyncTimeout:
+            raise
         except Exception as error:
             if preserve_checkout:
                 self.log.warn(
@@ -265,19 +306,34 @@ class RepositorySynchronizer:
             return False
         return await self._update_existing_repo(repo, boot_mode)
 
+    async def _sync_repo_result(self, repo: RepoEntry, boot_mode: BootMode) -> tuple[bool, bool]:
+        try:
+            return await self._sync_repo(repo, boot_mode), False
+        except RepositorySyncTimeout:
+            return False, True
+
     async def sync(
         self, repositories: list[RepoEntry], boot_mode: BootMode
     ) -> RepositorySyncResult:
         if not repositories:
             self.log.info("git.skip_clone", reason="no_repo_configured")
             return RepositorySyncResult((), ())
-        results = await asyncio.gather(*(self._sync_repo(repo, boot_mode) for repo in repositories))
+        results = await asyncio.gather(
+            *(self._sync_repo_result(repo, boot_mode) for repo in repositories)
+        )
         failures = tuple(
-            repo for repo, succeeded in zip(repositories, results, strict=True) if not succeeded
+            repo
+            for repo, (succeeded, _timed_out) in zip(repositories, results, strict=True)
+            if not succeeded
+        )
+        timed_out = tuple(
+            repo
+            for repo, (_succeeded, did_time_out) in zip(repositories, results, strict=True)
+            if did_time_out
         )
         resolved = await resolve_session_diff_baselines(
             repositories,
             discover_missing=boot_mode is not BootMode.SNAPSHOT_RESTORE,
             get_head_sha=self._get_head_sha,
         )
-        return RepositorySyncResult(tuple(resolved), failures)
+        return RepositorySyncResult(tuple(resolved), failures, timed_out)

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import re
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -25,11 +26,46 @@ class RepositorySyncTimeout(TimeoutError):
     pass
 
 
+class RepositorySyncStatus(StrEnum):
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+
+
+@dataclass(frozen=True)
+class RepositorySyncOutcome:
+    repository: RepoEntry
+    status: RepositorySyncStatus
+
+
 @dataclass(frozen=True)
 class RepositorySyncResult:
     repositories: tuple[RepoEntry, ...]
-    failures: tuple[RepoEntry, ...]
-    timed_out: tuple[RepoEntry, ...] = ()
+    outcomes: tuple[RepositorySyncOutcome, ...]
+
+    @property
+    def failures(self) -> tuple[RepoEntry, ...]:
+        return tuple(
+            outcome.repository
+            for outcome in self.outcomes
+            if outcome.status is not RepositorySyncStatus.SUCCEEDED
+        )
+
+    @property
+    def non_timeout_failures(self) -> tuple[RepoEntry, ...]:
+        return tuple(
+            outcome.repository
+            for outcome in self.outcomes
+            if outcome.status is RepositorySyncStatus.FAILED
+        )
+
+    @property
+    def timed_out(self) -> tuple[RepoEntry, ...]:
+        return tuple(
+            outcome.repository
+            for outcome in self.outcomes
+            if outcome.status is RepositorySyncStatus.TIMED_OUT
+        )
 
 
 class RepositorySynchronizer:
@@ -306,11 +342,12 @@ class RepositorySynchronizer:
             return False
         return await self._update_existing_repo(repo, boot_mode)
 
-    async def _sync_repo_result(self, repo: RepoEntry, boot_mode: BootMode) -> tuple[bool, bool]:
+    async def _sync_repo_status(self, repo: RepoEntry, boot_mode: BootMode) -> RepositorySyncStatus:
         try:
-            return await self._sync_repo(repo, boot_mode), False
+            succeeded = await self._sync_repo(repo, boot_mode)
         except RepositorySyncTimeout:
-            return False, True
+            return RepositorySyncStatus.TIMED_OUT
+        return RepositorySyncStatus.SUCCEEDED if succeeded else RepositorySyncStatus.FAILED
 
     async def sync(
         self, repositories: list[RepoEntry], boot_mode: BootMode
@@ -318,22 +355,16 @@ class RepositorySynchronizer:
         if not repositories:
             self.log.info("git.skip_clone", reason="no_repo_configured")
             return RepositorySyncResult((), ())
-        results = await asyncio.gather(
-            *(self._sync_repo_result(repo, boot_mode) for repo in repositories)
+        statuses = await asyncio.gather(
+            *(self._sync_repo_status(repo, boot_mode) for repo in repositories)
         )
-        failures = tuple(
-            repo
-            for repo, (succeeded, _timed_out) in zip(repositories, results, strict=True)
-            if not succeeded
-        )
-        timed_out = tuple(
-            repo
-            for repo, (_succeeded, did_time_out) in zip(repositories, results, strict=True)
-            if did_time_out
+        outcomes = tuple(
+            RepositorySyncOutcome(repo, status)
+            for repo, status in zip(repositories, statuses, strict=True)
         )
         resolved = await resolve_session_diff_baselines(
             repositories,
             discover_missing=boot_mode is not BootMode.SNAPSHOT_RESTORE,
             get_head_sha=self._get_head_sha,
         )
-        return RepositorySyncResult(tuple(resolved), failures, timed_out)
+        return RepositorySyncResult(tuple(resolved), outcomes)

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -9,7 +9,11 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
-from sandbox_runtime.repository_sync import RepositorySyncResult
+from sandbox_runtime.repository_sync import (
+    RepositorySyncOutcome,
+    RepositorySyncResult,
+    RepositorySyncStatus,
+)
 from sandbox_runtime.runtime_config import BootMode
 from sandbox_runtime.supervisor import ImageBuildExecutionCancelled
 
@@ -89,8 +93,16 @@ def _completion_callback(supervisor):
     return callback
 
 
+def _sync_result(repositories, status=RepositorySyncStatus.SUCCEEDED):
+    repositories = tuple(repositories)
+    return RepositorySyncResult(
+        repositories,
+        tuple(RepositorySyncOutcome(repo, status) for repo in repositories),
+    )
+
+
 def _successful_sync(repository_boot):
-    return RepositorySyncResult(tuple(repository_boot.repositories), ())
+    return _sync_result(repository_boot.repositories)
 
 
 class TestImageBuildMode:
@@ -137,12 +149,11 @@ class TestImageBuildMode:
     async def test_resolves_diff_baseline_after_sync_before_setup(self, build_env):
         supervisor = _make_supervisor(build_env)
         supervisor.repository_boot.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(
+            return_value=_sync_result(
                 tuple(
                     replace(repo, base_sha="a" * 40)
                     for repo in supervisor.repository_boot.repositories
-                ),
-                (),
+                )
             )
         )
         observed_baselines = []
@@ -283,12 +294,11 @@ class TestImageBuildMode:
         _repoint_primary(supervisor.repository_boot)
 
         supervisor.repository_boot.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(
+            return_value=_sync_result(
                 tuple(
                     replace(repo, base_sha="abc123def456")
                     for repo in supervisor.repository_boot.repositories
-                ),
-                (),
+                )
             )
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
@@ -344,12 +354,11 @@ class TestImageBuildMode:
             repo.path.mkdir(parents=True, exist_ok=True)
 
         supervisor.repository_boot.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(
+            return_value=_sync_result(
                 (
                     replace(supervisor.repository_boot.repositories[0], base_sha="aaa111"),
                     replace(supervisor.repository_boot.repositories[1], base_sha="bbb222"),
-                ),
-                (),
+                )
             )
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
@@ -395,12 +404,11 @@ class TestImageBuildMode:
         _repoint_primary(supervisor.repository_boot)
 
         supervisor.repository_boot.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(
+            return_value=_sync_result(
                 tuple(
                     replace(repo, base_sha="abc123def456")
                     for repo in supervisor.repository_boot.repositories
-                ),
-                (),
+                )
             )
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
@@ -952,9 +960,9 @@ class TestSnapshotRestoreMode:
         supervisor.repository_boot.warnings.log = shared_log
 
         supervisor.repository_boot.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(
+            return_value=_sync_result(
                 tuple(supervisor.repository_boot.repositories),
-                tuple(supervisor.repository_boot.repositories),
+                RepositorySyncStatus.FAILED,
             )
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -224,6 +224,39 @@ class TestSyncRepositories:
         assert warning["scope"] == "sync"
         assert warning["repoName"] == "backend"
 
+    @pytest.mark.parametrize("boot_mode", [BootMode.FRESH, BootMode.BUILD])
+    @pytest.mark.asyncio
+    async def test_fresh_and_build_timeouts_are_fatal(self, tmp_path, boot_mode):
+        sup = _make_repository_boot(tmp_path)
+        _mock_repository_boot(sup)
+        timed_out = sup.repositories[1]
+        sup.synchronizer.sync = AsyncMock(
+            return_value=RepositorySyncResult(tuple(sup.repositories), (timed_out,), (timed_out,))
+        )
+
+        with pytest.raises(RuntimeError, match="git sync timed out for acme/backend"):
+            await sup.boot(boot_mode, [])
+
+    @pytest.mark.parametrize("boot_mode", [BootMode.SNAPSHOT_RESTORE, BootMode.REPO_IMAGE])
+    @pytest.mark.asyncio
+    async def test_restore_and_repo_image_timeouts_warn_and_continue(self, tmp_path, boot_mode):
+        sup = _make_repository_boot(tmp_path)
+        _mock_repository_boot(sup)
+        timed_out = sup.repositories[1]
+        sup.synchronizer.sync = AsyncMock(
+            return_value=RepositorySyncResult(tuple(sup.repositories), (timed_out,), (timed_out,))
+        )
+
+        with patch(
+            "sandbox_runtime.boot_warnings.BOOT_WARNINGS_FILE_PATH",
+            str(tmp_path / "warnings.jsonl"),
+        ):
+            await sup.boot(boot_mode, [])
+
+        warning = json.loads((tmp_path / "warnings.jsonl").read_text().splitlines()[0])
+        assert warning["repoName"] == "backend"
+        assert warning["message"].startswith("Timed out updating acme/backend")
+
 
 class TestHookOrchestration:
     @pytest.mark.asyncio

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -14,7 +14,11 @@ import pytest
 
 from sandbox_runtime.opencode_server import OpenCodeServer
 from sandbox_runtime.repository_boot import RepositoryBoot
-from sandbox_runtime.repository_sync import RepositorySyncResult
+from sandbox_runtime.repository_sync import (
+    RepositorySyncOutcome,
+    RepositorySyncResult,
+    RepositorySyncStatus,
+)
 from sandbox_runtime.runtime_config import BootMode
 from tests.runtime_helpers import make_repository_boot, make_runtime_config
 
@@ -47,12 +51,25 @@ def _make_repository_boot(tmp_path, session_config: str = MULTI_SESSION_CONFIG) 
     )
 
 
+def _sync_result(
+    repositories, statuses: tuple[RepositorySyncStatus, ...] | None = None
+) -> RepositorySyncResult:
+    repositories = tuple(repositories)
+    if statuses is None:
+        statuses = (RepositorySyncStatus.SUCCEEDED,) * len(repositories)
+    return RepositorySyncResult(
+        repositories,
+        tuple(
+            RepositorySyncOutcome(repo, status)
+            for repo, status in zip(repositories, statuses, strict=True)
+        ),
+    )
+
+
 def _mock_repository_boot(sup: RepositoryBoot) -> None:
     sup._write_repo_manifest = MagicMock()
     sup.synchronizer.ensure_credentials_configured = AsyncMock()
-    sup.synchronizer.sync = AsyncMock(
-        return_value=RepositorySyncResult(tuple(sup.repositories), ())
-    )
+    sup.synchronizer.sync = AsyncMock(return_value=_sync_result(sup.repositories))
     sup.hooks.run_setup = AsyncMock(return_value=True)
     sup.hooks.run_start = AsyncMock(return_value=True)
 
@@ -191,7 +208,10 @@ class TestSyncRepositories:
         sup = _make_repository_boot(tmp_path)
         _mock_repository_boot(sup)
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), (sup.repositories[1],))
+            return_value=_sync_result(
+                sup.repositories,
+                (RepositorySyncStatus.SUCCEEDED, RepositorySyncStatus.FAILED),
+            )
         )
 
         with (
@@ -209,7 +229,10 @@ class TestSyncRepositories:
         sup = _make_repository_boot(tmp_path)
         _mock_repository_boot(sup)
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), (sup.repositories[1],))
+            return_value=_sync_result(
+                sup.repositories,
+                (RepositorySyncStatus.SUCCEEDED, RepositorySyncStatus.FAILED),
+            )
         )
 
         with (
@@ -229,9 +252,11 @@ class TestSyncRepositories:
     async def test_fresh_and_build_timeouts_are_fatal(self, tmp_path, boot_mode):
         sup = _make_repository_boot(tmp_path)
         _mock_repository_boot(sup)
-        timed_out = sup.repositories[1]
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), (timed_out,), (timed_out,))
+            return_value=_sync_result(
+                sup.repositories,
+                (RepositorySyncStatus.SUCCEEDED, RepositorySyncStatus.TIMED_OUT),
+            )
         )
 
         with pytest.raises(RuntimeError, match="git sync timed out for acme/backend"):
@@ -242,9 +267,11 @@ class TestSyncRepositories:
     async def test_restore_and_repo_image_timeouts_warn_and_continue(self, tmp_path, boot_mode):
         sup = _make_repository_boot(tmp_path)
         _mock_repository_boot(sup)
-        timed_out = sup.repositories[1]
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), (timed_out,), (timed_out,))
+            return_value=_sync_result(
+                sup.repositories,
+                (RepositorySyncStatus.SUCCEEDED, RepositorySyncStatus.TIMED_OUT),
+            )
         )
 
         with patch(

--- a/packages/sandbox-runtime/tests/test_repository_sync.py
+++ b/packages/sandbox-runtime/tests/test_repository_sync.py
@@ -1,0 +1,115 @@
+import asyncio
+import signal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandbox_runtime.repo_config import RepoEntry
+from sandbox_runtime.repository_sync import (
+    DEFAULT_GIT_CLONE_TIMEOUT_SECONDS,
+    DEFAULT_GIT_FETCH_TIMEOUT_SECONDS,
+    RepositorySynchronizer,
+    RepositorySyncTimeout,
+)
+from sandbox_runtime.runtime_config import BootMode
+
+
+def _repository(tmp_path: Path, name: str = "app") -> RepoEntry:
+    return RepoEntry(owner="acme", name=name, branch="main", path=tmp_path / name)
+
+
+def _hung_process() -> MagicMock:
+    async def communicate_forever() -> tuple[bytes, bytes]:
+        await asyncio.Event().wait()
+        return b"", b""
+
+    process = MagicMock(returncode=None, pid=4321)
+    process.communicate = AsyncMock(side_effect=communicate_forever)
+    process.wait = AsyncMock(return_value=-signal.SIGKILL)
+    return process
+
+
+def test_git_operation_timeout_defaults_are_named() -> None:
+    synchronizer = RepositorySynchronizer("github.com", MagicMock())
+
+    assert synchronizer.clone_timeout_seconds == DEFAULT_GIT_CLONE_TIMEOUT_SECONDS
+    assert synchronizer.fetch_timeout_seconds == DEFAULT_GIT_FETCH_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_hung_clone_times_out_and_cleans_up_process_group(tmp_path: Path) -> None:
+    process = _hung_process()
+    log = MagicMock()
+    synchronizer = RepositorySynchronizer("github.com", log, clone_timeout_seconds=0.01)
+    repo = _repository(tmp_path)
+
+    with (
+        patch(
+            "sandbox_runtime.repository_sync.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ) as create_process,
+        patch("sandbox_runtime.repository_sync.os.killpg") as kill_process_group,
+        pytest.raises(RepositorySyncTimeout),
+    ):
+        await synchronizer._clone_repo(repo)
+
+    kill_process_group.assert_called_once_with(process.pid, signal.SIGKILL)
+    process.wait.assert_awaited_once()
+    assert create_process.await_args.kwargs["start_new_session"] is True
+    log.error.assert_called_once_with(
+        "git.clone_timeout",
+        repo_owner="acme",
+        repo_name="app",
+        timeout_seconds=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hung_fetch_times_out_and_cleans_up_process_group(tmp_path: Path) -> None:
+    process = _hung_process()
+    log = MagicMock()
+    synchronizer = RepositorySynchronizer("github.com", log, fetch_timeout_seconds=0.01)
+    repo = _repository(tmp_path)
+    repo.path.mkdir()
+
+    with (
+        patch(
+            "sandbox_runtime.repository_sync.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ) as create_process,
+        patch("sandbox_runtime.repository_sync.os.killpg") as kill_process_group,
+        pytest.raises(RepositorySyncTimeout),
+    ):
+        await synchronizer._fetch_branch(repo, repo.branch)
+
+    kill_process_group.assert_called_once_with(process.pid, signal.SIGKILL)
+    process.wait.assert_awaited_once()
+    assert create_process.await_args.kwargs["start_new_session"] is True
+    log.error.assert_called_once_with(
+        "git.fetch_timeout",
+        repo_owner="acme",
+        repo_name="app",
+        timeout_seconds=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_repository_sync_identifies_timed_out_member(tmp_path: Path) -> None:
+    repositories = [_repository(tmp_path, "frontend"), _repository(tmp_path, "backend")]
+    synchronizer = RepositorySynchronizer("github.com", MagicMock())
+
+    async def sync_repo(repo: RepoEntry, _boot_mode: BootMode) -> bool:
+        if repo.name == "backend":
+            raise RepositorySyncTimeout
+        return True
+
+    synchronizer._sync_repo = AsyncMock(side_effect=sync_repo)
+
+    result = await synchronizer.sync(repositories, BootMode.FRESH)
+
+    assert result.failures == (repositories[1],)
+    assert result.timed_out == (repositories[1],)
+    assert synchronizer._sync_repo.await_count == 2

--- a/packages/sandbox-runtime/tests/test_repository_sync.py
+++ b/packages/sandbox-runtime/tests/test_repository_sync.py
@@ -10,6 +10,8 @@ from sandbox_runtime.repository_sync import (
     DEFAULT_GIT_CLONE_TIMEOUT_SECONDS,
     DEFAULT_GIT_FETCH_TIMEOUT_SECONDS,
     RepositorySynchronizer,
+    RepositorySyncOutcome,
+    RepositorySyncStatus,
     RepositorySyncTimeout,
 )
 from sandbox_runtime.runtime_config import BootMode
@@ -110,6 +112,10 @@ async def test_multi_repository_sync_identifies_timed_out_member(tmp_path: Path)
 
     result = await synchronizer.sync(repositories, BootMode.FRESH)
 
+    assert result.outcomes == (
+        RepositorySyncOutcome(repositories[0], RepositorySyncStatus.SUCCEEDED),
+        RepositorySyncOutcome(repositories[1], RepositorySyncStatus.TIMED_OUT),
+    )
     assert result.failures == (repositories[1],)
     assert result.timed_out == (repositories[1],)
     assert synchronizer._sync_repo.await_count == 2

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -287,10 +287,20 @@ class TestSetupInRepositoryBoot:
         sup._write_repo_manifest = MagicMock()
         sup._write_workspace_manifest = MagicMock()
         sup.synchronizer.ensure_credentials_configured = AsyncMock()
-        from sandbox_runtime.repository_sync import RepositorySyncResult
+        from sandbox_runtime.repository_sync import (
+            RepositorySyncOutcome,
+            RepositorySyncResult,
+            RepositorySyncStatus,
+        )
 
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), ())
+            return_value=RepositorySyncResult(
+                tuple(sup.repositories),
+                tuple(
+                    RepositorySyncOutcome(repo, RepositorySyncStatus.SUCCEEDED)
+                    for repo in sup.repositories
+                ),
+            )
         )
         sup.hooks.run_setup = AsyncMock(return_value=True)
         sup.hooks.run_start = AsyncMock(return_value=True)

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from sandbox_runtime.repository_boot import RepositoryBoot
-from sandbox_runtime.repository_sync import RepositorySyncResult
+from sandbox_runtime.repository_sync import (
+    RepositorySyncOutcome,
+    RepositorySyncResult,
+    RepositorySyncStatus,
+)
 from sandbox_runtime.runtime_config import BootMode
 from tests.runtime_helpers import make_repository_boot
 
@@ -221,7 +225,13 @@ class TestStartInRepositoryBootStrict:
         sup = _make_repository_boot(tmp_path)
 
         sup.synchronizer.sync = AsyncMock(
-            return_value=RepositorySyncResult(tuple(sup.repositories), ())
+            return_value=RepositorySyncResult(
+                tuple(sup.repositories),
+                tuple(
+                    RepositorySyncOutcome(repo, RepositorySyncStatus.SUCCEEDED)
+                    for repo in sup.repositories
+                ),
+            )
         )
         sup._write_repo_manifest = MagicMock()
         sup.synchronizer.ensure_credentials_configured = AsyncMock()


### PR DESCRIPTION
## Summary
- add named, injectable elapsed-time defaults for startup `git clone` and `git fetch`
- reuse owned process-group cancellation so timed-out Git processes are killed and reaped
- retain timeout identity across concurrent multi-repository synchronization and report affected repositories
- keep fresh/build timeouts fatal while restore/repository-image timeouts emit repository-specific warnings
- cover hung clone/fetch cleanup, timeout defaults, multi-repository reporting, and all boot-mode policies

## Testing
- `PYTHONPATH=src uv run pytest tests/test_repository_sync.py -q` (4 passed)
- `PYTHONPATH=src uv run pytest tests/test_multi_repo_workspace.py tests/test_entrypoint_build_mode.py -q` (84 passed)
- `uv run ruff check src tests` (passed)
- `uv run ruff format --check src tests` (passed)
- `PYTHONPATH=src uv run mypy src/sandbox_runtime/repository_sync.py src/sandbox_runtime/repository_boot.py` (passed)
- full sandbox-runtime suite: 747 passed, 4 unrelated environment-sensitive failures (live control-plane credentials affected three credential-helper tests; installed Git behavior affected one signer assertion)

Closes COL-70.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d8073ff7aaecf25cf5832478876ecd5a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout handling for repository cloning and fetching.
  * Improved error messages to distinguish timed-out repositories from other synchronization failures.
  * Fresh and build environments now fail with repository-specific timeout details.
  * Snapshot restores and repository-image boots continue with a clear warning when synchronization times out.
  * Improved cleanup of stalled repository operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->