### PR TITLE
Bound GitHub authentication and bot API requests

### DIFF
--- a/packages/control-plane/src/auth/github.test.ts
+++ b/packages/control-plane/src/auth/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { refreshAccessToken } from "./github";
+import { GITHUB_OAUTH_REQUEST_TIMEOUT_MS, refreshAccessToken } from "./github";
 import type { GitHubOAuthConfig, GitHubTokenResponse } from "./github";
 
 describe("github auth", () => {
@@ -11,6 +11,7 @@ describe("github auth", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   describe("refreshAccessToken", () => {
@@ -65,6 +66,30 @@ describe("github auth", () => {
 
       await expect(refreshAccessToken("old-refresh", config)).rejects.toThrow(
         "The code passed is incorrect or expired."
+      );
+    });
+
+    it("aborts a stalled token refresh at the request deadline", async () => {
+      const timeout = new AbortController();
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+      globalThis.fetch = vi.fn().mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          })
+      );
+
+      const refreshPromise = refreshAccessToken("old-refresh", config);
+      const timeoutError = new DOMException("deadline exceeded", "TimeoutError");
+      timeout.abort(timeoutError);
+
+      await expect(refreshPromise).rejects.toBe(timeoutError);
+      expect(timeoutSpy).toHaveBeenCalledWith(GITHUB_OAUTH_REQUEST_TIMEOUT_MS);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "https://github.com/login/oauth/access_token",
+        expect.objectContaining({ signal: timeout.signal })
       );
     });
   });

--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export const GITHUB_OAUTH_REQUEST_TIMEOUT_MS = 10_000;
+
 const githubOAuthErrorSchema = z.object({
   error: z.string().optional(),
   error_description: z.string().optional(),
@@ -54,6 +56,7 @@ export async function refreshAccessToken(
       grant_type: "refresh_token",
       refresh_token: refreshToken,
     }),
+    signal: AbortSignal.timeout(GITHUB_OAUTH_REQUEST_TIMEOUT_MS),
   });
 
   return parseGitHubTokenResponse(response);

--- a/packages/control-plane/src/session/participant-service.test.ts
+++ b/packages/control-plane/src/session/participant-service.test.ts
@@ -556,6 +556,43 @@ describe("ParticipantService", () => {
       );
     });
 
+    it("falls back to local refresh after a centralized OAuth timeout", async () => {
+      const h = createCentralizedHarness();
+      mockStore.getTokens.mockResolvedValue({
+        accessToken: "old-access",
+        refreshToken: "d1-refresh",
+        expiresAt: Date.now() - 1000,
+        refreshTokenEncrypted: "enc-d1-refresh",
+      });
+      mockStore.isTokenFresh.mockReturnValue(false);
+      vi.mocked(refreshAccessToken)
+        .mockRejectedValueOnce(new DOMException("deadline exceeded", "TimeoutError"))
+        .mockResolvedValueOnce({
+          access_token: "fallback-access",
+          refresh_token: "fallback-refresh",
+          token_type: "bearer",
+          scope: "repo",
+          expires_in: 28800,
+        });
+
+      const refreshedParticipant = createParticipant({
+        scm_user_id: "gh-123",
+        scm_access_token_encrypted: "enc:fallback-access",
+      });
+      vi.mocked(h.repository.getParticipantById).mockReturnValue(refreshedParticipant);
+
+      const participant = createParticipant({
+        scm_user_id: "gh-123",
+        scm_refresh_token_encrypted: "enc:local-refresh",
+      });
+      const result = await h.service.refreshToken(participant);
+
+      expect(result).toBe(refreshedParticipant);
+      expect(refreshAccessToken).toHaveBeenNthCalledWith(1, "d1-refresh", expect.any(Object));
+      expect(refreshAccessToken).toHaveBeenNthCalledWith(2, "local-refresh", expect.any(Object));
+      expect(mockStore.casUpdateTokens).not.toHaveBeenCalled();
+    });
+
     it("returns null when D1 token expired and no GitHub OAuth credentials", async () => {
       const h = createCentralizedHarness({
         env: { GITHUB_CLIENT_ID: undefined, GITHUB_CLIENT_SECRET: undefined },

--- a/packages/github-bot/src/github-auth.ts
+++ b/packages/github-bot/src/github-auth.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import { z } from "zod";
 
+export const GITHUB_API_REQUEST_TIMEOUT_MS = 10_000;
+
 const collaboratorPermissionResponseSchema = z.object({
   permission: z.string(),
 });
@@ -90,6 +92,7 @@ async function getInstallationToken(
       "X-GitHub-Api-Version": "2022-11-28",
       "User-Agent": userAgent,
     },
+    signal: AbortSignal.timeout(GITHUB_API_REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {
@@ -140,6 +143,7 @@ export async function checkSenderPermission(
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": userAgent,
         },
+        signal: AbortSignal.timeout(GITHUB_API_REQUEST_TIMEOUT_MS),
       }
     );
     if (!response.ok) return { hasPermission: false, error: true };
@@ -168,6 +172,7 @@ export async function postReaction(
         "User-Agent": userAgent,
       },
       body: JSON.stringify({ content }),
+      signal: AbortSignal.timeout(GITHUB_API_REQUEST_TIMEOUT_MS),
     });
     return response.ok;
   } catch {

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -23,8 +23,6 @@ export type HandlerResult =
   | { outcome: "processed"; session_id: string; message_id: string; handler_action: string }
   | { outcome: "skipped"; skip_reason: string };
 
-export type BackgroundTaskScheduler = (task: Promise<unknown>) => void;
-
 export function isReviewRequestedForBot(payload: unknown, botUsername: string): boolean {
   const parsed = requestedReviewerPayloadSchema.safeParse(payload);
   if (!parsed.success) return false;
@@ -104,22 +102,26 @@ function stripMention(body: string, botUsername: string): string {
   return body.replace(new RegExp(`@${escapeRegExp(botUsername)}`, "gi"), "").trim();
 }
 
-function scheduleReaction(
+async function withReaction<T>(
   log: Logger,
   token: string,
   url: string,
   userAgent: string,
   meta: Record<string, unknown>,
-  scheduleBackgroundTask?: BackgroundTaskScheduler
-): void {
-  const task = postReaction(token, url, "eyes", userAgent).then(
+  action: () => Promise<T>
+): Promise<T> {
+  const reaction = postReaction(token, url, "eyes", userAgent).then(
     (ok) => {
       if (ok) log.debug("acknowledgment.posted", meta);
       else log.warn("acknowledgment.failed", meta);
     },
     () => log.warn("acknowledgment.failed", meta)
   );
-  if (scheduleBackgroundTask) scheduleBackgroundTask(task);
+  try {
+    return await action();
+  } finally {
+    await reaction;
+  }
 }
 
 type CallerGatingResult =
@@ -183,8 +185,7 @@ export async function handleReviewRequested(
   env: Env,
   log: Logger,
   payload: ReviewRequestedPayload,
-  traceId: string,
-  scheduleBackgroundTask?: BackgroundTaskScheduler
+  traceId: string
 ): Promise<HandlerResult> {
   const { pull_request: pr, repository: repo, requested_reviewer, sender } = payload;
   const owner = repo.owner.login;
@@ -220,73 +221,72 @@ export async function handleReviewRequested(
   const { ghToken } = gating;
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  scheduleReaction(
+  return withReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
-    scheduleBackgroundTask
+    async () => {
+      const target = await resolveSessionTarget(env, log, {
+        owner,
+        repoName,
+        senderLogin: sender.login,
+        config,
+        ghToken,
+        traceId,
+      });
+      const sessionId = await createSession(env, traceId, {
+        target,
+        title: `GitHub: Review PR #${pr.number}`,
+        model: config.model,
+        reasoningEffort: config.reasoningEffort,
+        scmLogin: sender.login,
+        scmUserId: String(sender.id),
+        scmAvatarUrl: sender.avatar_url,
+      });
+      log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
+
+      const prompt = buildCodeReviewPrompt({
+        owner,
+        repo: repoName,
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        author: pr.user.login,
+        base: pr.base.ref,
+        head: pr.head.ref,
+        isPublic: !repo.private,
+        codeReviewInstructions: config.codeReviewInstructions,
+      });
+
+      const messageId = await sendPrompt(env, traceId, sessionId, {
+        content: prompt,
+        authorId: `github:${payload.sender.id}`,
+      });
+      log.info("prompt.sent", {
+        ...meta,
+        session_id: sessionId,
+        message_id: messageId,
+        source: "github",
+        content_length: prompt.length,
+      });
+
+      return {
+        outcome: "processed",
+        session_id: sessionId,
+        message_id: messageId,
+        handler_action: "review",
+      };
+    }
   );
-
-  const target = await resolveSessionTarget(env, log, {
-    owner,
-    repoName,
-    senderLogin: sender.login,
-    config,
-    ghToken,
-    traceId,
-  });
-  const sessionId = await createSession(env, traceId, {
-    target,
-    title: `GitHub: Review PR #${pr.number}`,
-    model: config.model,
-    reasoningEffort: config.reasoningEffort,
-    scmLogin: sender.login,
-    scmUserId: String(sender.id),
-    scmAvatarUrl: sender.avatar_url,
-  });
-  log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
-
-  const prompt = buildCodeReviewPrompt({
-    owner,
-    repo: repoName,
-    number: pr.number,
-    title: pr.title,
-    body: pr.body,
-    author: pr.user.login,
-    base: pr.base.ref,
-    head: pr.head.ref,
-    isPublic: !repo.private,
-    codeReviewInstructions: config.codeReviewInstructions,
-  });
-
-  const messageId = await sendPrompt(env, traceId, sessionId, {
-    content: prompt,
-    authorId: `github:${payload.sender.id}`,
-  });
-  log.info("prompt.sent", {
-    ...meta,
-    session_id: sessionId,
-    message_id: messageId,
-    source: "github",
-    content_length: prompt.length,
-  });
-
-  return {
-    outcome: "processed",
-    session_id: sessionId,
-    message_id: messageId,
-    handler_action: "review",
-  };
 }
 
 export async function handlePullRequestOpened(
   env: Env,
   log: Logger,
   payload: PullRequestOpenedPayload,
-  traceId: string,
-  scheduleBackgroundTask?: BackgroundTaskScheduler
+  traceId: string
 ): Promise<HandlerResult> {
   const { pull_request: pr, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -324,74 +324,73 @@ export async function handlePullRequestOpened(
   const { ghToken } = gating;
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  scheduleReaction(
+  return withReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
-    scheduleBackgroundTask
+    async () => {
+      const target = await resolveSessionTarget(env, log, {
+        owner,
+        repoName,
+        senderLogin: sender.login,
+        config,
+        ghToken,
+        traceId,
+      });
+      const sessionId = await createSession(env, traceId, {
+        target,
+        title: `GitHub: Review PR #${pr.number}`,
+        model: config.model,
+        reasoningEffort: config.reasoningEffort,
+        scmLogin: sender.login,
+        scmUserId: String(sender.id),
+        scmAvatarUrl: sender.avatar_url,
+      });
+      log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
+
+      const prompt = buildCodeReviewPrompt({
+        owner,
+        repo: repoName,
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        author: pr.user.login,
+        base: pr.base.ref,
+        head: pr.head.ref,
+        isPublic: !repo.private,
+        codeReviewInstructions: config.codeReviewInstructions,
+        isSelfReview: pr.user.login.toLowerCase() === env.GITHUB_BOT_USERNAME.toLowerCase(),
+      });
+
+      const messageId = await sendPrompt(env, traceId, sessionId, {
+        content: prompt,
+        authorId: `github:${sender.id}`,
+      });
+      log.info("prompt.sent", {
+        ...meta,
+        session_id: sessionId,
+        message_id: messageId,
+        source: "github",
+        content_length: prompt.length,
+      });
+
+      return {
+        outcome: "processed",
+        session_id: sessionId,
+        message_id: messageId,
+        handler_action: "auto_review",
+      };
+    }
   );
-
-  const target = await resolveSessionTarget(env, log, {
-    owner,
-    repoName,
-    senderLogin: sender.login,
-    config,
-    ghToken,
-    traceId,
-  });
-  const sessionId = await createSession(env, traceId, {
-    target,
-    title: `GitHub: Review PR #${pr.number}`,
-    model: config.model,
-    reasoningEffort: config.reasoningEffort,
-    scmLogin: sender.login,
-    scmUserId: String(sender.id),
-    scmAvatarUrl: sender.avatar_url,
-  });
-  log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
-
-  const prompt = buildCodeReviewPrompt({
-    owner,
-    repo: repoName,
-    number: pr.number,
-    title: pr.title,
-    body: pr.body,
-    author: pr.user.login,
-    base: pr.base.ref,
-    head: pr.head.ref,
-    isPublic: !repo.private,
-    codeReviewInstructions: config.codeReviewInstructions,
-    isSelfReview: pr.user.login.toLowerCase() === env.GITHUB_BOT_USERNAME.toLowerCase(),
-  });
-
-  const messageId = await sendPrompt(env, traceId, sessionId, {
-    content: prompt,
-    authorId: `github:${sender.id}`,
-  });
-  log.info("prompt.sent", {
-    ...meta,
-    session_id: sessionId,
-    message_id: messageId,
-    source: "github",
-    content_length: prompt.length,
-  });
-
-  return {
-    outcome: "processed",
-    session_id: sessionId,
-    message_id: messageId,
-    handler_action: "auto_review",
-  };
 }
 
 export async function handleIssueComment(
   env: Env,
   log: Logger,
   payload: IssueCommentPayload,
-  traceId: string,
-  scheduleBackgroundTask?: BackgroundTaskScheduler
+  traceId: string
 ): Promise<HandlerResult> {
   const { issue, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -440,71 +439,70 @@ export async function handleIssueComment(
   const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: issue.number };
-  scheduleReaction(
+  return withReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
-    scheduleBackgroundTask
+    async () => {
+      const target = await resolveSessionTarget(env, log, {
+        owner,
+        repoName,
+        senderLogin: sender.login,
+        config,
+        ghToken,
+        traceId,
+      });
+      const sessionId = await createSession(env, traceId, {
+        target,
+        title: `GitHub: PR #${issue.number} comment`,
+        model: config.model,
+        reasoningEffort: config.reasoningEffort,
+        scmLogin: sender.login,
+        scmUserId: String(sender.id),
+        scmAvatarUrl: sender.avatar_url,
+      });
+      log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
+
+      const prompt = buildCommentActionPrompt({
+        owner,
+        repo: repoName,
+        number: issue.number,
+        title: issue.title,
+        commentBody,
+        commenter: sender.login,
+        isPublic: !repo.private,
+        commentActionInstructions: config.commentActionInstructions,
+      });
+
+      const messageId = await sendPrompt(env, traceId, sessionId, {
+        content: prompt,
+        authorId: `github:${sender.id}`,
+      });
+      log.info("prompt.sent", {
+        ...meta,
+        session_id: sessionId,
+        message_id: messageId,
+        source: "github",
+        content_length: prompt.length,
+      });
+
+      return {
+        outcome: "processed",
+        session_id: sessionId,
+        message_id: messageId,
+        handler_action: "comment",
+      };
+    }
   );
-
-  const target = await resolveSessionTarget(env, log, {
-    owner,
-    repoName,
-    senderLogin: sender.login,
-    config,
-    ghToken,
-    traceId,
-  });
-  const sessionId = await createSession(env, traceId, {
-    target,
-    title: `GitHub: PR #${issue.number} comment`,
-    model: config.model,
-    reasoningEffort: config.reasoningEffort,
-    scmLogin: sender.login,
-    scmUserId: String(sender.id),
-    scmAvatarUrl: sender.avatar_url,
-  });
-  log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
-
-  const prompt = buildCommentActionPrompt({
-    owner,
-    repo: repoName,
-    number: issue.number,
-    title: issue.title,
-    commentBody,
-    commenter: sender.login,
-    isPublic: !repo.private,
-    commentActionInstructions: config.commentActionInstructions,
-  });
-
-  const messageId = await sendPrompt(env, traceId, sessionId, {
-    content: prompt,
-    authorId: `github:${sender.id}`,
-  });
-  log.info("prompt.sent", {
-    ...meta,
-    session_id: sessionId,
-    message_id: messageId,
-    source: "github",
-    content_length: prompt.length,
-  });
-
-  return {
-    outcome: "processed",
-    session_id: sessionId,
-    message_id: messageId,
-    handler_action: "comment",
-  };
 }
 
 export async function handleReviewComment(
   env: Env,
   log: Logger,
   payload: ReviewCommentPayload,
-  traceId: string,
-  scheduleBackgroundTask?: BackgroundTaskScheduler
+  traceId: string
 ): Promise<HandlerResult> {
   const { pull_request: pr, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -548,66 +546,66 @@ export async function handleReviewComment(
   const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  scheduleReaction(
+  return withReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/pulls/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
-    scheduleBackgroundTask
+    async () => {
+      const target = await resolveSessionTarget(env, log, {
+        owner,
+        repoName,
+        senderLogin: sender.login,
+        config,
+        ghToken,
+        traceId,
+      });
+      const sessionId = await createSession(env, traceId, {
+        target,
+        title: `GitHub: PR #${pr.number} review comment`,
+        model: config.model,
+        reasoningEffort: config.reasoningEffort,
+        scmLogin: sender.login,
+        scmUserId: String(sender.id),
+        scmAvatarUrl: sender.avatar_url,
+      });
+      log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
+
+      const prompt = buildCommentActionPrompt({
+        owner,
+        repo: repoName,
+        number: pr.number,
+        title: pr.title,
+        base: pr.base.ref,
+        head: pr.head.ref,
+        commentBody,
+        commenter: sender.login,
+        isPublic: !repo.private,
+        filePath: comment.path,
+        diffHunk: comment.diff_hunk,
+        commentId: comment.id,
+        commentActionInstructions: config.commentActionInstructions,
+      });
+
+      const messageId = await sendPrompt(env, traceId, sessionId, {
+        content: prompt,
+        authorId: `github:${sender.id}`,
+      });
+      log.info("prompt.sent", {
+        ...meta,
+        session_id: sessionId,
+        message_id: messageId,
+        source: "github",
+        content_length: prompt.length,
+      });
+
+      return {
+        outcome: "processed",
+        session_id: sessionId,
+        message_id: messageId,
+        handler_action: "review_comment",
+      };
+    }
   );
-
-  const target = await resolveSessionTarget(env, log, {
-    owner,
-    repoName,
-    senderLogin: sender.login,
-    config,
-    ghToken,
-    traceId,
-  });
-  const sessionId = await createSession(env, traceId, {
-    target,
-    title: `GitHub: PR #${pr.number} review comment`,
-    model: config.model,
-    reasoningEffort: config.reasoningEffort,
-    scmLogin: sender.login,
-    scmUserId: String(sender.id),
-    scmAvatarUrl: sender.avatar_url,
-  });
-  log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
-
-  const prompt = buildCommentActionPrompt({
-    owner,
-    repo: repoName,
-    number: pr.number,
-    title: pr.title,
-    base: pr.base.ref,
-    head: pr.head.ref,
-    commentBody,
-    commenter: sender.login,
-    isPublic: !repo.private,
-    filePath: comment.path,
-    diffHunk: comment.diff_hunk,
-    commentId: comment.id,
-    commentActionInstructions: config.commentActionInstructions,
-  });
-
-  const messageId = await sendPrompt(env, traceId, sessionId, {
-    content: prompt,
-    authorId: `github:${sender.id}`,
-  });
-  log.info("prompt.sent", {
-    ...meta,
-    session_id: sessionId,
-    message_id: messageId,
-    source: "github",
-    content_length: prompt.length,
-  });
-
-  return {
-    outcome: "processed",
-    session_id: sessionId,
-    message_id: messageId,
-    handler_action: "review_comment",
-  };
 }

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -23,6 +23,8 @@ export type HandlerResult =
   | { outcome: "processed"; session_id: string; message_id: string; handler_action: string }
   | { outcome: "skipped"; skip_reason: string };
 
+export type BackgroundTaskScheduler = (task: Promise<unknown>) => void;
+
 export function isReviewRequestedForBot(payload: unknown, botUsername: string): boolean {
   const parsed = requestedReviewerPayloadSchema.safeParse(payload);
   if (!parsed.success) return false;
@@ -102,20 +104,22 @@ function stripMention(body: string, botUsername: string): string {
   return body.replace(new RegExp(`@${escapeRegExp(botUsername)}`, "gi"), "").trim();
 }
 
-function fireAndForgetReaction(
+function scheduleReaction(
   log: Logger,
   token: string,
   url: string,
   userAgent: string,
-  meta: Record<string, unknown>
+  meta: Record<string, unknown>,
+  scheduleBackgroundTask?: BackgroundTaskScheduler
 ): void {
-  postReaction(token, url, "eyes", userAgent).then(
+  const task = postReaction(token, url, "eyes", userAgent).then(
     (ok) => {
       if (ok) log.debug("acknowledgment.posted", meta);
       else log.warn("acknowledgment.failed", meta);
     },
     () => log.warn("acknowledgment.failed", meta)
   );
+  if (scheduleBackgroundTask) scheduleBackgroundTask(task);
 }
 
 type CallerGatingResult =
@@ -179,7 +183,8 @@ export async function handleReviewRequested(
   env: Env,
   log: Logger,
   payload: ReviewRequestedPayload,
-  traceId: string
+  traceId: string,
+  scheduleBackgroundTask?: BackgroundTaskScheduler
 ): Promise<HandlerResult> {
   const { pull_request: pr, repository: repo, requested_reviewer, sender } = payload;
   const owner = repo.owner.login;
@@ -215,12 +220,13 @@ export async function handleReviewRequested(
   const { ghToken } = gating;
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  fireAndForgetReaction(
+  scheduleReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
     resolveAppName(env),
-    meta
+    meta,
+    scheduleBackgroundTask
   );
 
   const target = await resolveSessionTarget(env, log, {
@@ -279,7 +285,8 @@ export async function handlePullRequestOpened(
   env: Env,
   log: Logger,
   payload: PullRequestOpenedPayload,
-  traceId: string
+  traceId: string,
+  scheduleBackgroundTask?: BackgroundTaskScheduler
 ): Promise<HandlerResult> {
   const { pull_request: pr, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -317,12 +324,13 @@ export async function handlePullRequestOpened(
   const { ghToken } = gating;
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  fireAndForgetReaction(
+  scheduleReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
     resolveAppName(env),
-    meta
+    meta,
+    scheduleBackgroundTask
   );
 
   const target = await resolveSessionTarget(env, log, {
@@ -382,7 +390,8 @@ export async function handleIssueComment(
   env: Env,
   log: Logger,
   payload: IssueCommentPayload,
-  traceId: string
+  traceId: string,
+  scheduleBackgroundTask?: BackgroundTaskScheduler
 ): Promise<HandlerResult> {
   const { issue, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -431,12 +440,13 @@ export async function handleIssueComment(
   const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: issue.number };
-  fireAndForgetReaction(
+  scheduleReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/comments/${comment.id}/reactions`,
     resolveAppName(env),
-    meta
+    meta,
+    scheduleBackgroundTask
   );
 
   const target = await resolveSessionTarget(env, log, {
@@ -493,7 +503,8 @@ export async function handleReviewComment(
   env: Env,
   log: Logger,
   payload: ReviewCommentPayload,
-  traceId: string
+  traceId: string,
+  scheduleBackgroundTask?: BackgroundTaskScheduler
 ): Promise<HandlerResult> {
   const { pull_request: pr, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
@@ -537,12 +548,13 @@ export async function handleReviewComment(
   const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
 
   const meta = { trace_id: traceId, repo: repoFullName, pull_number: pr.number };
-  fireAndForgetReaction(
+  scheduleReaction(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/pulls/comments/${comment.id}/reactions`,
     resolveAppName(env),
-    meta
+    meta,
+    scheduleBackgroundTask
   );
 
   const target = await resolveSessionTarget(env, log, {

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from "@open-inspect/shared/regex";
+import { encodeRepositoryPathSegments } from "@open-inspect/shared/types/repositories";
 import {
   createSessionResponseSchema,
   sendPromptResponseSchema,
@@ -190,6 +191,7 @@ export async function handleReviewRequested(
   const { pull_request: pr, repository: repo, requested_reviewer, sender } = payload;
   const owner = repo.owner.login;
   const repoName = repo.name;
+  const repositoryPath = encodeRepositoryPathSegments({ repoOwner: owner, repoName });
   const repoFullName = `${owner}/${repoName}`.toLowerCase();
 
   if (requested_reviewer?.login !== env.GITHUB_BOT_USERNAME) {
@@ -224,7 +226,7 @@ export async function handleReviewRequested(
   return withReaction(
     log,
     ghToken,
-    `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    `https://api.github.com/repos/${repositoryPath}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
     async () => {
@@ -291,6 +293,7 @@ export async function handlePullRequestOpened(
   const { pull_request: pr, repository: repo, sender } = payload;
   const owner = repo.owner.login;
   const repoName = repo.name;
+  const repositoryPath = encodeRepositoryPathSegments({ repoOwner: owner, repoName });
   const repoFullName = `${owner}/${repoName}`.toLowerCase();
 
   if (pr.draft) {
@@ -327,7 +330,7 @@ export async function handlePullRequestOpened(
   return withReaction(
     log,
     ghToken,
-    `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    `https://api.github.com/repos/${repositoryPath}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
     async () => {
@@ -395,6 +398,7 @@ export async function handleIssueComment(
   const { issue, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
   const repoName = repo.name;
+  const repositoryPath = encodeRepositoryPathSegments({ repoOwner: owner, repoName });
   const repoFullName = `${owner}/${repoName}`.toLowerCase();
 
   if (!issue.pull_request) {
@@ -442,7 +446,7 @@ export async function handleIssueComment(
   return withReaction(
     log,
     ghToken,
-    `https://api.github.com/repos/${owner}/${repoName}/issues/comments/${comment.id}/reactions`,
+    `https://api.github.com/repos/${repositoryPath}/issues/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
     async () => {
@@ -507,6 +511,7 @@ export async function handleReviewComment(
   const { pull_request: pr, comment, repository: repo, sender } = payload;
   const owner = repo.owner.login;
   const repoName = repo.name;
+  const repositoryPath = encodeRepositoryPathSegments({ repoOwner: owner, repoName });
   const repoFullName = `${owner}/${repoName}`.toLowerCase();
 
   if (!comment.body.toLowerCase().includes(`@${env.GITHUB_BOT_USERNAME.toLowerCase()}`)) {
@@ -549,7 +554,7 @@ export async function handleReviewComment(
   return withReaction(
     log,
     ghToken,
-    `https://api.github.com/repos/${owner}/${repoName}/pulls/comments/${comment.id}/reactions`,
+    `https://api.github.com/repos/${repositoryPath}/pulls/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
     async () => {

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -27,7 +27,6 @@ import {
   handleIssueComment,
   handleReviewComment,
   isReviewRequestedForBot,
-  type BackgroundTaskScheduler,
   type HandlerResult,
 } from "./handlers";
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
@@ -100,9 +99,8 @@ app.post("/webhooks/github", async (c) => {
     action,
   });
 
-  const scheduleBackgroundTask: BackgroundTaskScheduler = (task) => c.executionCtx.waitUntil(task);
-  scheduleBackgroundTask(
-    handleWebhook(c.env, log, event, payload, traceId, deliveryId, scheduleBackgroundTask)
+  c.executionCtx.waitUntil(
+    handleWebhook(c.env, log, event, payload, traceId, deliveryId)
       .then(async () => {
         if (!dedupeKey) return;
 
@@ -148,8 +146,7 @@ async function handleWebhook(
   event: string | undefined,
   payload: unknown,
   traceId: string,
-  deliveryId: string | undefined,
-  scheduleBackgroundTask: BackgroundTaskScheduler
+  deliveryId: string | undefined
 ): Promise<void> {
   const parsed = webhookSummaryPayloadSchema.safeParse(payload);
   const actionResult = webhookActionPayloadSchema.safeParse(payload);
@@ -174,7 +171,7 @@ async function handleWebhook(
   let result: HandlerResult;
 
   try {
-    result = await dispatchHandler(env, log, event, p, payload, traceId, scheduleBackgroundTask);
+    result = await dispatchHandler(env, log, event, p, payload, traceId);
   } catch (err) {
     log.info("webhook.handled", {
       ...wideEventBase,
@@ -236,15 +233,14 @@ function dispatchHandler(
   event: string | undefined,
   p: WebhookSummaryPayload,
   payload: unknown,
-  traceId: string,
-  scheduleBackgroundTask: BackgroundTaskScheduler
+  traceId: string
 ): Promise<HandlerResult> {
   switch (event) {
     case "pull_request":
       if (p.action === "opened") {
         const parsed = pullRequestOpenedPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed pull_request opened payload");
-        return handlePullRequestOpened(env, log, parsed.data, traceId, scheduleBackgroundTask);
+        return handlePullRequestOpened(env, log, parsed.data, traceId);
       }
       if (p.action === "review_requested") {
         if (!isReviewRequestedForBot(payload, env.GITHUB_BOT_USERNAME)) {
@@ -252,7 +248,7 @@ function dispatchHandler(
         }
         const parsed = reviewRequestedPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed pull_request review_requested payload");
-        return handleReviewRequested(env, log, parsed.data, traceId, scheduleBackgroundTask);
+        return handleReviewRequested(env, log, parsed.data, traceId);
       }
       return Promise.resolve({
         outcome: "skipped",
@@ -262,7 +258,7 @@ function dispatchHandler(
       if (p.action === "created") {
         const parsed = issueCommentPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed issue_comment created payload");
-        return handleIssueComment(env, log, parsed.data, traceId, scheduleBackgroundTask);
+        return handleIssueComment(env, log, parsed.data, traceId);
       }
       return Promise.resolve({
         outcome: "skipped",
@@ -273,7 +269,7 @@ function dispatchHandler(
         const parsed = reviewCommentPayloadSchema.safeParse(payload);
         if (!parsed.success)
           throw new Error("Malformed pull_request_review_comment created payload");
-        return handleReviewComment(env, log, parsed.data, traceId, scheduleBackgroundTask);
+        return handleReviewComment(env, log, parsed.data, traceId);
       }
       return Promise.resolve({
         outcome: "skipped",

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -27,6 +27,7 @@ import {
   handleIssueComment,
   handleReviewComment,
   isReviewRequestedForBot,
+  type BackgroundTaskScheduler,
   type HandlerResult,
 } from "./handlers";
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
@@ -99,8 +100,9 @@ app.post("/webhooks/github", async (c) => {
     action,
   });
 
-  c.executionCtx.waitUntil(
-    handleWebhook(c.env, log, event, payload, traceId, deliveryId)
+  const scheduleBackgroundTask: BackgroundTaskScheduler = (task) => c.executionCtx.waitUntil(task);
+  scheduleBackgroundTask(
+    handleWebhook(c.env, log, event, payload, traceId, deliveryId, scheduleBackgroundTask)
       .then(async () => {
         if (!dedupeKey) return;
 
@@ -146,7 +148,8 @@ async function handleWebhook(
   event: string | undefined,
   payload: unknown,
   traceId: string,
-  deliveryId: string | undefined
+  deliveryId: string | undefined,
+  scheduleBackgroundTask: BackgroundTaskScheduler
 ): Promise<void> {
   const parsed = webhookSummaryPayloadSchema.safeParse(payload);
   const actionResult = webhookActionPayloadSchema.safeParse(payload);
@@ -171,7 +174,7 @@ async function handleWebhook(
   let result: HandlerResult;
 
   try {
-    result = await dispatchHandler(env, log, event, p, payload, traceId);
+    result = await dispatchHandler(env, log, event, p, payload, traceId, scheduleBackgroundTask);
   } catch (err) {
     log.info("webhook.handled", {
       ...wideEventBase,
@@ -233,14 +236,15 @@ function dispatchHandler(
   event: string | undefined,
   p: WebhookSummaryPayload,
   payload: unknown,
-  traceId: string
+  traceId: string,
+  scheduleBackgroundTask: BackgroundTaskScheduler
 ): Promise<HandlerResult> {
   switch (event) {
     case "pull_request":
       if (p.action === "opened") {
         const parsed = pullRequestOpenedPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed pull_request opened payload");
-        return handlePullRequestOpened(env, log, parsed.data, traceId);
+        return handlePullRequestOpened(env, log, parsed.data, traceId, scheduleBackgroundTask);
       }
       if (p.action === "review_requested") {
         if (!isReviewRequestedForBot(payload, env.GITHUB_BOT_USERNAME)) {
@@ -248,7 +252,7 @@ function dispatchHandler(
         }
         const parsed = reviewRequestedPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed pull_request review_requested payload");
-        return handleReviewRequested(env, log, parsed.data, traceId);
+        return handleReviewRequested(env, log, parsed.data, traceId, scheduleBackgroundTask);
       }
       return Promise.resolve({
         outcome: "skipped",
@@ -258,7 +262,7 @@ function dispatchHandler(
       if (p.action === "created") {
         const parsed = issueCommentPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed issue_comment created payload");
-        return handleIssueComment(env, log, parsed.data, traceId);
+        return handleIssueComment(env, log, parsed.data, traceId, scheduleBackgroundTask);
       }
       return Promise.resolve({
         outcome: "skipped",
@@ -269,7 +273,7 @@ function dispatchHandler(
         const parsed = reviewCommentPayloadSchema.safeParse(payload);
         if (!parsed.success)
           throw new Error("Malformed pull_request_review_comment created payload");
-        return handleReviewComment(env, log, parsed.data, traceId);
+        return handleReviewComment(env, log, parsed.data, traceId, scheduleBackgroundTask);
       }
       return Promise.resolve({
         outcome: "skipped",

--- a/packages/github-bot/test/github-auth.test.ts
+++ b/packages/github-bot/test/github-auth.test.ts
@@ -4,7 +4,17 @@ import {
   generateInstallationToken,
   postReaction,
   checkSenderPermission,
+  GITHUB_API_REQUEST_TIMEOUT_MS,
 } from "../src/github-auth";
+
+function stalledFetch() {
+  return vi.mocked(globalThis.fetch).mockImplementation(
+    (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      })
+  );
+}
 
 /** Generate a PKCS#8 PEM RSA key pair for testing. */
 async function generateTestKeyPair(): Promise<{ privateKeyPem: string }> {
@@ -67,6 +77,7 @@ describe("postReaction", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("calls fetch with correct parameters", async () => {
@@ -84,6 +95,7 @@ describe("postReaction", () => {
         "User-Agent": "Open-Inspect",
       },
       body: JSON.stringify({ content: "eyes" }),
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -134,6 +146,18 @@ describe("postReaction", () => {
       })
     );
   });
+
+  it("returns false when a stalled reaction reaches its deadline", async () => {
+    const timeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    stalledFetch();
+
+    const resultPromise = postReaction("tok", "https://api.github.com/test", "eyes");
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toBe(false);
+    expect(timeoutSpy).toHaveBeenCalledWith(GITHUB_API_REQUEST_TIMEOUT_MS);
+  });
 });
 
 describe("generateInstallationToken", () => {
@@ -145,6 +169,7 @@ describe("generateInstallationToken", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("returns the token from a valid GitHub response", async () => {
@@ -189,6 +214,24 @@ describe("generateInstallationToken", () => {
       })
     ).rejects.toThrow("Failed to get installation token: invalid response");
   });
+
+  it("rejects when a stalled installation-token request reaches its deadline", async () => {
+    const { privateKeyPem } = await generateTestKeyPair();
+    const timeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    stalledFetch();
+
+    const tokenPromise = generateInstallationToken({
+      appId: "12345",
+      privateKey: privateKeyPem,
+      installationId: "67890",
+    });
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(tokenPromise).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(timeoutSpy).toHaveBeenCalledWith(GITHUB_API_REQUEST_TIMEOUT_MS);
+  });
 });
 
 describe("checkSenderPermission", () => {
@@ -200,6 +243,7 @@ describe("checkSenderPermission", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("returns hasPermission true for write permission", async () => {
@@ -277,6 +321,7 @@ describe("checkSenderPermission", () => {
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": "Open-Inspect",
         },
+        signal: expect.any(AbortSignal),
       }
     );
   });
@@ -293,5 +338,17 @@ describe("checkSenderPermission", () => {
         headers: expect.objectContaining({ "User-Agent": "Acme Bot" }),
       })
     );
+  });
+
+  it("fails closed when a stalled permission check reaches its deadline", async () => {
+    const timeout = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    stalledFetch();
+
+    const resultPromise = checkSenderPermission("tok", "acme", "widgets", "alice");
+    timeout.abort(new DOMException("deadline exceeded", "TimeoutError"));
+
+    await expect(resultPromise).resolves.toEqual({ hasPermission: false, error: true });
+    expect(timeoutSpy).toHaveBeenCalledWith(GITHUB_API_REQUEST_TIMEOUT_MS);
   });
 });

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -726,10 +726,16 @@ describe("error handling", () => {
     const log = createMockLogger();
     vi.mocked(postReaction).mockResolvedValue(false);
 
-    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction");
+    const backgroundTasks: Promise<unknown>[] = [];
+    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction", (task) =>
+      backgroundTasks.push(task)
+    );
 
     // Session should still be created despite reaction failure
     expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(3);
+    expect(backgroundTasks).toHaveLength(1);
+    await backgroundTasks[0];
+    expect(log.warn).toHaveBeenCalledWith("acknowledgment.failed", expect.any(Object));
   });
 });
 

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -712,13 +712,28 @@ describe("error handling", () => {
   it("throws when session creation fails", async () => {
     const env = createMockEnv();
     const log = createMockLogger();
+    let finishReaction!: (ok: boolean) => void;
+    vi.mocked(postReaction).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        finishReaction = resolve;
+      })
+    );
     getControlPlaneFetch(env).mockResolvedValue(
       new Response("Internal Server Error", { status: 500 })
     );
 
-    await expect(
-      handleReviewRequested(env, log, reviewRequestedPayload, "trace-err")
-    ).rejects.toThrow("Session creation failed: 500");
+    const handlerPromise = handleReviewRequested(env, log, reviewRequestedPayload, "trace-err");
+    let handlerSettled = false;
+    void handlerPromise
+      .finally(() => {
+        handlerSettled = true;
+      })
+      .catch(() => {});
+    await vi.waitFor(() => expect(getControlPlaneFetch(env)).toHaveBeenCalled());
+    expect(handlerSettled).toBe(false);
+
+    finishReaction(true);
+    await expect(handlerPromise).rejects.toThrow("Session creation failed: 500");
   });
 
   it("proceeds with session even if reaction fails", async () => {
@@ -726,15 +741,10 @@ describe("error handling", () => {
     const log = createMockLogger();
     vi.mocked(postReaction).mockResolvedValue(false);
 
-    const backgroundTasks: Promise<unknown>[] = [];
-    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction", (task) =>
-      backgroundTasks.push(task)
-    );
+    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction");
 
     // Session should still be created despite reaction failure
     expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(3);
-    expect(backgroundTasks).toHaveLength(1);
-    await backgroundTasks[0];
     expect(log.warn).toHaveBeenCalledWith("acknowledgment.failed", expect.any(Object));
   });
 });

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -483,6 +483,27 @@ describe("handleReviewRequested", () => {
     );
   });
 
+  it("encodes nested repository owners in the reaction URL", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload = {
+      ...reviewRequestedPayload,
+      repository: {
+        ...reviewRequestedPayload.repository,
+        owner: { login: "group/platform" },
+      },
+    };
+
+    await handleReviewRequested(env, log, payload, "trace-nested-owner");
+
+    expect(postReaction).toHaveBeenCalledWith(
+      "test-installation-token",
+      "https://api.github.com/repos/group%2Fplatform/widgets/issues/42/reactions",
+      "eyes",
+      "Open-Inspect"
+    );
+  });
+
   it("returns early if reviewer is not the bot", async () => {
     const env = createMockEnv();
     const log = createMockLogger();

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -8,6 +8,7 @@ vi.mock("../src/github-auth", () => ({
 }));
 
 import app from "../src/index";
+import { postReaction } from "../src/github-auth";
 
 /** Generate a valid GitHub webhook signature for a given secret and body. */
 async function sign(secret: string, body: string): Promise<string> {
@@ -130,7 +131,13 @@ describe("POST /webhooks/github", () => {
     await flushWaitUntil(ctx);
   });
 
-  it("registers reaction work with the Worker lifecycle", async () => {
+  it("keeps reaction work in the root Worker lifecycle task", async () => {
+    let finishReaction!: (ok: boolean) => void;
+    vi.mocked(postReaction).mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        finishReaction = resolve;
+      })
+    );
     const body = JSON.stringify({
       action: "review_requested",
       pull_request: {
@@ -185,8 +192,23 @@ describe("POST /webhooks/github", () => {
     );
 
     expect(res.status).toBe(200);
-    await vi.waitFor(() => expect(ctx.waitUntil).toHaveBeenCalledTimes(2));
-    await Promise.all(ctx.waitUntil.mock.calls.map(([task]: [Promise<unknown>]) => task));
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+    const rootTask = ctx.waitUntil.mock.calls[0][0] as Promise<void>;
+    let rootSettled = false;
+    void rootTask.finally(() => {
+      rootSettled = true;
+    });
+    await vi.waitFor(() =>
+      expect(controlPlaneFetch).toHaveBeenCalledWith(
+        "https://internal/sessions/session-123/prompt",
+        expect.any(Object)
+      )
+    );
+    expect(rootSettled).toBe(false);
+
+    finishReaction(true);
+    await rootTask;
+    expect(rootSettled).toBe(true);
   });
 
   it("deduplicates repeated deliveries by X-GitHub-Delivery", async () => {

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Env } from "../src/types";
+
+vi.mock("../src/github-auth", () => ({
+  generateInstallationToken: vi.fn().mockResolvedValue("installation-token"),
+  postReaction: vi.fn().mockResolvedValue(true),
+  checkSenderPermission: vi.fn().mockResolvedValue({ hasPermission: true }),
+}));
+
 import app from "../src/index";
 
 /** Generate a valid GitHub webhook signature for a given secret and body. */
@@ -121,6 +128,65 @@ describe("POST /webhooks/github", () => {
     expect(await res.json()).toEqual({ ok: true });
     expect(ctx.waitUntil).toHaveBeenCalledOnce();
     await flushWaitUntil(ctx);
+  });
+
+  it("registers reaction work with the Worker lifecycle", async () => {
+    const body = JSON.stringify({
+      action: "review_requested",
+      pull_request: {
+        number: 42,
+        title: "Bound GitHub requests",
+        body: null,
+        user: { login: "alice" },
+        head: { ref: "feature/timeouts", sha: "abc123" },
+        base: { ref: "main" },
+      },
+      requested_reviewer: { login: "test-bot[bot]" },
+      repository: { owner: { login: "test" }, name: "repo", private: false },
+      sender: {
+        login: "alice",
+        id: 1001,
+        avatar_url: "https://avatars.githubusercontent.com/u/1001",
+      },
+    });
+    const signature = await sign(SECRET, body);
+    const ctx = makeCtx();
+    const env = makeEnv();
+    const controlPlaneFetch = vi.mocked(env.CONTROL_PLANE.fetch);
+    controlPlaneFetch.mockImplementation(async (url) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes("/integration-settings/github/resolved/")) {
+        return new Response(JSON.stringify({ config: null }));
+      }
+      if (requestUrl.endsWith("/metadata")) {
+        return new Response(JSON.stringify({ repo: "test/repo", metadata: null }));
+      }
+      if (requestUrl === "https://internal/sessions") {
+        return new Response(JSON.stringify({ sessionId: "session-123", status: "created" }));
+      }
+      if (requestUrl.endsWith("/prompt")) {
+        return new Response(JSON.stringify({ messageId: "message-123" }));
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": signature,
+          "X-GitHub-Event": "pull_request",
+          "X-GitHub-Delivery": "delivery-reaction",
+        },
+      }),
+      env,
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => expect(ctx.waitUntil).toHaveBeenCalledTimes(2));
+    await Promise.all(ctx.waitUntil.mock.calls.map(([task]: [Promise<unknown>]) => task));
   });
 
   it("deduplicates repeated deliveries by X-GitHub-Delivery", async () => {


### PR DESCRIPTION
## Summary
- add explicit 10-second deadlines to GitHub OAuth refresh and GitHub App token, permission, and reaction requests
- preserve centralized-to-local OAuth fallback after timeout while bounding both attempts
- attach non-blocking reaction work to the Cloudflare Worker lifecycle via `waitUntil`
- cover stalled requests, timeout fallback, fail-closed permissions, reaction timeout, and webhook lifecycle registration

## Validation
- `npm test -w @open-inspect/control-plane -- --run src/auth/github.test.ts src/session/participant-service.test.ts`
- `npm test -w @open-inspect/github-bot`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/github-bot`
- `npm run lint -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/github-bot`

Closes COL-68.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e241036665ab15d744c7e84051a429db)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 10-second timeouts to GitHub authentication and API requests.
  * GitHub event processing now coordinates acknowledgment reactions with the main operation.
  * Repository paths are safely encoded in GitHub reaction requests.

* **Bug Fixes**
  * Timed-out token refreshes now fall back to local refresh when available.
  * Prevented stalled requests from hanging indefinitely.
  * Ensured acknowledgment failures are logged and webhook processing waits for reaction completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->