### PR TITLE
fix: bound Modal and Vercel sandbox requests

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -1,9 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_MODAL_REQUEST_DEADLINE_MS,
   buildModalSandboxDashboardUrl,
   buildModalWorkspaceSlug,
   createModalClient,
 } from "./client";
+
+function rejectWhenAborted(signal: AbortSignal): Promise<Response> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+}
+
+function stalledBodyResponse(signal: AbortSignal): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        if (signal.aborted) {
+          controller.error(signal.reason);
+          return;
+        }
+        signal.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
 
 describe("buildModalWorkspaceSlug", () => {
   it("uses the raw workspace when the Modal environment has no web suffix", () => {
@@ -70,7 +93,80 @@ describe("buildModalSandboxDashboardUrl", () => {
 
 describe("ModalClient", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("times out image-build creation when response headers stall", async () => {
+    vi.useFakeTimers();
+    let markFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => (markFetchStarted = resolve));
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      markFetchStarted();
+      return rejectWhenAborted(init?.signal as AbortSignal);
+    });
+
+    const request = createModalClient("secret", "acme").createImageBuildSandbox({
+      scopeKind: "repo",
+      scopeId: "acme/repo",
+      buildId: "imgb-1",
+      repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "main" }],
+      callbackUrl: "https://cp.test/image-builds/build-complete",
+      failureCallbackUrl: "https://cp.test/image-builds/build-failed",
+      buildExecutionTimeoutSeconds: 1800,
+      providerSessionTimeoutSeconds: 2400,
+    });
+
+    const rejection = expect(request).rejects.toThrow(
+      `Modal request timeout after ${DEFAULT_MODAL_REQUEST_DEADLINE_MS}ms (createImageBuildSandbox)`
+    );
+    await fetchStarted;
+    await vi.advanceTimersByTimeAsync(DEFAULT_MODAL_REQUEST_DEADLINE_MS);
+    await rejection;
+  });
+
+  it("keeps the deadline armed while reading a Modal response body", async () => {
+    vi.useFakeTimers();
+    let markFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => (markFetchStarted = resolve));
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      markFetchStarted();
+      return Promise.resolve(stalledBodyResponse(init?.signal as AbortSignal));
+    });
+
+    const request = createModalClient("secret", "acme").snapshotSandbox({
+      providerObjectId: "mo-1",
+      sessionId: "session-1",
+      reason: "manual",
+    });
+
+    const rejection = expect(request).rejects.toThrow(
+      `Modal request timeout after ${DEFAULT_MODAL_REQUEST_DEADLINE_MS}ms (snapshotSandbox)`
+    );
+    await fetchStarted;
+    await vi.advanceTimersByTimeAsync(DEFAULT_MODAL_REQUEST_DEADLINE_MS);
+    await rejection;
+  });
+
+  it("combines caller cancellation with the Modal deadline", async () => {
+    const caller = new AbortController();
+    const callerReason = new DOMException("caller cancelled", "AbortError");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_url, init) => rejectWhenAborted(init?.signal as AbortSignal));
+
+    const request = createModalClient("secret", "acme").snapshotSandbox({
+      providerObjectId: "mo-1",
+      sessionId: "session-1",
+      reason: "manual",
+      signal: caller.signal,
+    });
+    caller.abort(callerReason);
+
+    await expect(request).rejects.toBe(callerReason);
+    const providerSignal = fetchMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+    expect(providerSignal).not.toBe(caller.signal);
+    expect(providerSignal.reason).toBe(callerReason);
   });
 
   it("routes the restore session_config through buildSessionConfig (carries mcp_servers)", async () => {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  DEFAULT_MODAL_REQUEST_DEADLINE_MS,
+  MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
+  MODAL_SNAPSHOT_REQUEST_DEADLINE_MS,
   buildModalSandboxDashboardUrl,
   buildModalWorkspaceSlug,
   createModalClient,
 } from "./client";
+import { RequestDeadlineError } from "./request-deadline";
 
 function rejectWhenAborted(signal: AbortSignal): Promise<Response> {
   if (signal.aborted) return Promise.reject(signal.reason);
@@ -117,11 +119,14 @@ describe("ModalClient", () => {
       providerSessionTimeoutSeconds: 2400,
     });
 
-    const rejection = expect(request).rejects.toThrow(
-      `Modal request timeout after ${DEFAULT_MODAL_REQUEST_DEADLINE_MS}ms (createImageBuildSandbox)`
-    );
+    const rejection = expect(request).rejects.toMatchObject({
+      name: RequestDeadlineError.name,
+      provider: "Modal",
+      endpoint: "createImageBuildSandbox",
+      timeoutMs: MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
+    });
     await fetchStarted;
-    await vi.advanceTimersByTimeAsync(DEFAULT_MODAL_REQUEST_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(MODAL_SANDBOX_START_REQUEST_DEADLINE_MS);
     await rejection;
   });
 
@@ -129,7 +134,7 @@ describe("ModalClient", () => {
     vi.useFakeTimers();
     let markFetchStarted!: () => void;
     const fetchStarted = new Promise<void>((resolve) => (markFetchStarted = resolve));
-    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
       markFetchStarted();
       return Promise.resolve(stalledBodyResponse(init?.signal as AbortSignal));
     });
@@ -141,10 +146,12 @@ describe("ModalClient", () => {
     });
 
     const rejection = expect(request).rejects.toThrow(
-      `Modal request timeout after ${DEFAULT_MODAL_REQUEST_DEADLINE_MS}ms (snapshotSandbox)`
+      `Modal request timeout after ${MODAL_SNAPSHOT_REQUEST_DEADLINE_MS}ms (snapshotSandbox)`
     );
     await fetchStarted;
-    await vi.advanceTimersByTimeAsync(DEFAULT_MODAL_REQUEST_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(MODAL_SNAPSHOT_REQUEST_DEADLINE_MS - 10_000);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(10_000);
     await rejection;
   });
 

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -23,7 +23,10 @@ const MODAL_APP_NAME = "open-inspect";
 // Modal's default environment name; unrelated to the git branch named "main".
 const DEFAULT_MODAL_ENVIRONMENT = "main";
 
-export const DEFAULT_MODAL_REQUEST_DEADLINE_MS = 60_000;
+export const MODAL_SANDBOX_START_REQUEST_DEADLINE_MS = 60_000;
+// Allows Modal's provider-side snapshot timeout to settle before the client deadline.
+export const MODAL_SNAPSHOT_REQUEST_DEADLINE_MS = 310_000;
+export const MODAL_CLEANUP_REQUEST_DEADLINE_MS = 60_000;
 
 const modalErrorResponseSchema = z.object({
   success: z.literal(false),
@@ -326,6 +329,7 @@ export class ModalClient {
   private async postJson<T>(
     url: string,
     endpoint: string,
+    deadlineMs: number,
     body: unknown,
     schema: z.ZodType<T>,
     correlation: CorrelationContext | undefined,
@@ -333,26 +337,20 @@ export class ModalClient {
     onResponse: (status: number) => void
   ): Promise<T> {
     const headers = await this.getPostHeaders(correlation);
-    return withRequestDeadline(
-      "Modal",
-      endpoint,
-      DEFAULT_MODAL_REQUEST_DEADLINE_MS,
-      callerSignal,
-      async (signal) => {
-        const response = await fetch(url, {
-          method: "POST",
-          headers,
-          signal,
-          body: JSON.stringify(body),
-        });
-        onResponse(response.status);
-        if (!response.ok) {
-          const text = await response.text();
-          throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-        }
-        return parseModalApiResponse(schema, await response.json());
+    return withRequestDeadline("Modal", endpoint, deadlineMs, callerSignal, async (signal) => {
+      const response = await fetch(url, {
+        method: "POST",
+        headers,
+        signal,
+        body: JSON.stringify(body),
+      });
+      onResponse(response.status);
+      if (!response.ok) {
+        const text = await response.text();
+        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
       }
-    );
+      return parseModalApiResponse(schema, await response.json());
+    });
   }
 
   constructor(secret: string, workspace: string, environmentWebSuffix?: string) {
@@ -406,6 +404,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.createSandboxUrl,
         endpoint,
+        MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
         {
           session_id: request.sessionId,
           sandbox_id: request.sandboxId || null, // Use control-plane-generated ID
@@ -487,6 +486,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.restoreSandboxUrl,
         endpoint,
+        MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
         {
           snapshot_image_id: request.snapshotImageId,
           session_config: buildSessionConfig(request),
@@ -553,6 +553,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.snapshotSandboxUrl,
         endpoint,
+        MODAL_SNAPSHOT_REQUEST_DEADLINE_MS,
         {
           sandbox_id: request.providerObjectId,
           session_id: request.sessionId,
@@ -604,6 +605,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.snapshotBuildSandboxUrl,
         endpoint,
+        MODAL_SNAPSHOT_REQUEST_DEADLINE_MS,
         {
           build_id: request.buildId,
           provider_session_id: request.providerSessionId,
@@ -650,6 +652,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.createImageBuildSandboxUrl,
         endpoint,
+        MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
         {
           scope_kind: request.scopeKind,
           scope_id: request.scopeId,
@@ -701,6 +704,7 @@ export class ModalClient {
     await this.postImageBuildOperation(
       this.startImageBuildSandboxUrl,
       "startImageBuildSandbox",
+      MODAL_SANDBOX_START_REQUEST_DEADLINE_MS,
       request,
       {
         build_id: request.buildId,
@@ -718,6 +722,7 @@ export class ModalClient {
     await this.postImageBuildOperation(
       this.terminateImageBuildSandboxUrl,
       "terminateImageBuildSandbox",
+      MODAL_CLEANUP_REQUEST_DEADLINE_MS,
       request,
       {
         build_id: request.buildId,
@@ -731,6 +736,7 @@ export class ModalClient {
   private async postImageBuildOperation(
     url: string,
     endpoint: string,
+    deadlineMs: number,
     request: { buildId: string; providerSessionId: string; signal?: AbortSignal },
     body: Record<string, unknown>,
     correlation?: CorrelationContext
@@ -742,6 +748,7 @@ export class ModalClient {
       const result = await this.postJson(
         url,
         endpoint,
+        deadlineMs,
         body,
         imageBuildOperationModalResponseSchema,
         correlation,
@@ -783,6 +790,7 @@ export class ModalClient {
       const result = await this.postJson(
         this.deleteProviderImageUrl,
         endpoint,
+        MODAL_CLEANUP_REQUEST_DEADLINE_MS,
         {
           provider_image_id: request.providerImageId,
         },

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -13,6 +13,7 @@ import { createLogger } from "../logger";
 import type { CorrelationContext } from "../logger";
 import { buildSessionConfig, toRepositoryConfigPayload } from "./sandbox-env";
 import type { SessionRepositoryInfo } from "./provider";
+import { withRequestDeadline } from "./request-deadline";
 
 const log = createLogger("modal-client");
 
@@ -21,6 +22,8 @@ const MODAL_APP_NAME = "open-inspect";
 
 // Modal's default environment name; unrelated to the git branch named "main".
 const DEFAULT_MODAL_ENVIRONMENT = "main";
+
+export const DEFAULT_MODAL_REQUEST_DEADLINE_MS = 60_000;
 
 const modalErrorResponseSchema = z.object({
   success: z.literal(false),
@@ -172,6 +175,7 @@ export interface CreateSandboxRequest {
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
   repositories?: SessionRepositoryInfo[];
+  signal?: AbortSignal;
 }
 
 export interface CreateSandboxResponse {
@@ -206,6 +210,7 @@ export interface RestoreSandboxRequest {
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
   repositories?: SessionRepositoryInfo[];
+  signal?: AbortSignal;
 }
 
 export interface RestoreSandboxResponse {
@@ -257,6 +262,7 @@ export interface CreateImageBuildSandboxRequest {
   buildExecutionTimeoutSeconds: number;
   /** Provider-session lifetime, including deferred Queue finalization headroom. */
   providerSessionTimeoutSeconds: number;
+  signal?: AbortSignal;
 }
 
 export interface CreateImageBuildSandboxResponse {
@@ -267,6 +273,7 @@ export interface StartImageBuildSandboxRequest {
   buildId: string;
   providerSessionId: string;
   callbackToken: string;
+  signal?: AbortSignal;
 }
 
 export interface TerminateImageBuildSandboxRequest {
@@ -316,6 +323,38 @@ export class ModalClient {
   private deleteProviderImageUrl: string;
   private secret: string;
 
+  private async postJson<T>(
+    url: string,
+    endpoint: string,
+    body: unknown,
+    schema: z.ZodType<T>,
+    correlation: CorrelationContext | undefined,
+    callerSignal: AbortSignal | undefined,
+    onResponse: (status: number) => void
+  ): Promise<T> {
+    const headers = await this.getPostHeaders(correlation);
+    return withRequestDeadline(
+      "Modal",
+      endpoint,
+      DEFAULT_MODAL_REQUEST_DEADLINE_MS,
+      callerSignal,
+      async (signal) => {
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          signal,
+          body: JSON.stringify(body),
+        });
+        onResponse(response.status);
+        if (!response.ok) {
+          const text = await response.text();
+          throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
+        }
+        return parseModalApiResponse(schema, await response.json());
+      }
+    );
+  }
+
   constructor(secret: string, workspace: string, environmentWebSuffix?: string) {
     if (!secret) {
       throw new Error("ModalClient requires MODAL_API_SECRET for authentication");
@@ -364,11 +403,10 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.createSandboxUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.createSandboxUrl,
+        endpoint,
+        {
           session_id: request.sessionId,
           sandbox_id: request.sandboxId || null, // Use control-plane-generated ID
           repo_owner: request.repoOwner,
@@ -394,17 +432,12 @@ export class ModalClient {
           repositories: request.repositories?.length
             ? request.repositories.map(toRepositoryConfigPayload)
             : null,
-        }),
-      });
-
-      httpStatus = response.status;
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(createSandboxModalResponseSchema, await response.json());
+        },
+        createSandboxModalResponseSchema,
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
+      );
 
       if (!result.success) {
         throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
@@ -451,11 +484,10 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.restoreSandboxUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.restoreSandboxUrl,
+        endpoint,
+        {
           snapshot_image_id: request.snapshotImageId,
           session_config: buildSessionConfig(request),
           sandbox_id: request.sandboxId,
@@ -467,19 +499,11 @@ export class ModalClient {
           vnc_enabled: request.vncEnabled ?? false,
           agent_slack_notify_enabled: request.agentSlackNotifyEnabled ?? false,
           sandbox_settings: request.sandboxSettings ?? null,
-        }),
-      });
-
-      httpStatus = response.status;
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(
+        },
         restoreSandboxModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
 
       if (!result.success) {
@@ -526,28 +550,18 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.snapshotSandboxUrl, {
-        method: "POST",
-        headers,
-        signal: request.signal,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.snapshotSandboxUrl,
+        endpoint,
+        {
           sandbox_id: request.providerObjectId,
           session_id: request.sessionId,
           reason: request.reason,
-        }),
-      });
-
-      httpStatus = response.status;
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(
+        },
         snapshotSandboxModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
       if (!result.success) {
         return { success: false, error: result.error || "Unknown snapshot error" };
@@ -587,26 +601,17 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.snapshotBuildSandboxUrl, {
-        method: "POST",
-        headers,
-        signal: request.signal,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.snapshotBuildSandboxUrl,
+        endpoint,
+        {
           build_id: request.buildId,
           provider_session_id: request.providerSessionId,
-        }),
-      });
-
-      httpStatus = response.status;
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(
+        },
         snapshotSandboxModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
       if (!result.success) {
         return { success: false, error: result.error || "Unknown snapshot error" };
@@ -642,11 +647,10 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.createImageBuildSandboxUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.createImageBuildSandboxUrl,
+        endpoint,
+        {
           scope_kind: request.scopeKind,
           scope_id: request.scopeId,
           build_id: request.buildId,
@@ -659,19 +663,11 @@ export class ModalClient {
           user_env_vars: request.userEnvVars,
           build_execution_timeout_seconds: request.buildExecutionTimeoutSeconds,
           provider_session_timeout_seconds: request.providerSessionTimeoutSeconds,
-        }),
-      });
-
-      httpStatus = response.status;
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(
+        },
         createImageBuildSandboxModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
 
       if (result.success === false) {
@@ -743,22 +739,14 @@ export class ModalClient {
     let httpStatus: number | undefined;
     let outcome: "success" | "error" = "error";
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: await this.getPostHeaders(correlation),
-        signal: request.signal,
-        body: JSON.stringify(body),
-      });
-      httpStatus = response.status;
-      if (!response.ok) {
-        throw new ModalApiError(
-          `Modal API error: ${response.status} ${await response.text()}`,
-          response.status
-        );
-      }
-      const result = parseModalApiResponse(
+      const result = await this.postJson(
+        url,
+        endpoint,
+        body,
         imageBuildOperationModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
       if (result.success === false) {
         throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
@@ -792,26 +780,16 @@ export class ModalClient {
     let outcome: "success" | "error" = "error";
 
     try {
-      const headers = await this.getPostHeaders(correlation);
-      const response = await fetch(this.deleteProviderImageUrl, {
-        method: "POST",
-        headers,
-        signal: request.signal,
-        body: JSON.stringify({
+      const result = await this.postJson(
+        this.deleteProviderImageUrl,
+        endpoint,
+        {
           provider_image_id: request.providerImageId,
-        }),
-      });
-
-      httpStatus = response.status;
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
-      }
-
-      const result = parseModalApiResponse(
+        },
         deleteProviderImageModalResponseSchema,
-        await response.json()
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
       );
 
       if (result.success === false) {

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -8,6 +8,7 @@
 import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import type { CorrelationContext } from "../logger";
+import { RequestDeadlineError } from "./request-deadline";
 import type { McpServerConfig } from "@open-inspect/shared/types/integrations";
 
 /** Default sandbox lifetime in seconds (2 hours). */
@@ -393,6 +394,7 @@ export class SandboxProviderError extends Error {
    * Check if an error is likely a transient network error.
    */
   static isTransientNetworkError(error: unknown): boolean {
+    if (error instanceof RequestDeadlineError) return true;
     if (error instanceof Error) {
       const message = error.message.toLowerCase();
       return (

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi } from "vitest";
 import { ModalSandboxProvider } from "./modal-provider";
 import { SandboxProviderError } from "../provider";
 import { ModalApiError } from "../client";
+import { RequestDeadlineError } from "../request-deadline";
 import type {
   ModalClient,
   CreateSandboxRequest,
@@ -194,10 +195,10 @@ describe("ModalSandboxProvider", () => {
         }
       });
 
-      it("classifies 'timeout' errors as transient", async () => {
+      it("classifies typed request deadline errors as transient", async () => {
         const client = createMockModalClient({
           createSandbox: vi.fn(async () => {
-            throw new Error("Request timeout after 30000ms");
+            throw new RequestDeadlineError("Modal", "createSandbox", 30_000);
           }),
         });
         const provider = new ModalSandboxProvider(client);

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -384,18 +384,20 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
    * Classify an error as transient or permanent for circuit breaker handling.
    */
   private classifyError(message: string, error: unknown): SandboxProviderError {
+    if (SandboxProviderError.isTransientNetworkError(error)) {
+      return new SandboxProviderError(
+        `${message}: ${error instanceof Error ? error.message : String(error)}`,
+        "transient",
+        error instanceof Error ? error : undefined
+      );
+    }
+
     // Check for fetch/network errors
     if (error instanceof Error) {
       const errorMessage = error.message.toLowerCase();
 
       // Transient network errors
       if (
-        errorMessage.includes("fetch failed") ||
-        errorMessage.includes("etimedout") ||
-        errorMessage.includes("econnreset") ||
-        errorMessage.includes("econnrefused") ||
-        errorMessage.includes("network") ||
-        errorMessage.includes("timeout") ||
         errorMessage.includes("502") ||
         errorMessage.includes("503") ||
         errorMessage.includes("504") ||

--- a/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
@@ -4,11 +4,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  DEFAULT_VERCEL_REQUEST_DEADLINE_MS,
+  VERCEL_CLEANUP_REQUEST_DEADLINE_MS,
+  VERCEL_COMMAND_REQUEST_DEADLINE_MS,
   VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS,
+  VERCEL_SANDBOX_START_REQUEST_DEADLINE_MS,
+  VERCEL_SNAPSHOT_REQUEST_DEADLINE_MS,
   VercelSandboxApiError,
   VercelSandboxClient,
 } from "./client";
+import { RequestDeadlineError } from "../../request-deadline";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -91,10 +95,13 @@ describe("VercelSandboxClient", () => {
     );
 
     const request = createClient().createSandbox({ name: "sandbox-1" });
-    const rejection = expect(request).rejects.toThrow(
-      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (createSandbox)`
-    );
-    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    const rejection = expect(request).rejects.toMatchObject({
+      name: RequestDeadlineError.name,
+      provider: "Vercel Sandbox",
+      endpoint: "createSandbox",
+      timeoutMs: VERCEL_SANDBOX_START_REQUEST_DEADLINE_MS,
+    });
+    await vi.advanceTimersByTimeAsync(VERCEL_SANDBOX_START_REQUEST_DEADLINE_MS);
     await rejection;
   });
 
@@ -109,9 +116,9 @@ describe("VercelSandboxClient", () => {
       command: "bash",
     });
     const rejection = expect(request).rejects.toThrow(
-      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (runCommandAndWait)`
+      `Vercel Sandbox request timeout after ${VERCEL_COMMAND_REQUEST_DEADLINE_MS}ms (runCommandAndWait)`
     );
-    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(VERCEL_COMMAND_REQUEST_DEADLINE_MS);
     await rejection;
   });
 
@@ -120,7 +127,7 @@ describe("VercelSandboxClient", () => {
     fetchSpy.mockImplementation((_url, init) =>
       Promise.resolve(stalledStreamResponse((init as RequestInit).signal as AbortSignal))
     );
-    const commandTimeoutMs = DEFAULT_VERCEL_REQUEST_DEADLINE_MS * 2;
+    const commandTimeoutMs = VERCEL_COMMAND_REQUEST_DEADLINE_MS * 2;
 
     const request = createClient().runCommandAndWait({
       sessionId: "session-1",
@@ -145,7 +152,7 @@ describe("VercelSandboxClient", () => {
     );
 
     const request = createClient().snapshotSession("session-1", { signal: caller.signal });
-    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS - 1);
+    await vi.advanceTimersByTimeAsync(VERCEL_SNAPSHOT_REQUEST_DEADLINE_MS - 1);
     caller.abort(callerReason);
     vi.advanceTimersByTime(1);
 
@@ -163,9 +170,9 @@ describe("VercelSandboxClient", () => {
 
     const request = createClient().deleteSnapshot("snapshot-1");
     const rejection = expect(request).rejects.toThrow(
-      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (deleteSnapshot)`
+      `Vercel Sandbox request timeout after ${VERCEL_CLEANUP_REQUEST_DEADLINE_MS}ms (deleteSnapshot)`
     );
-    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    await vi.advanceTimersByTimeAsync(VERCEL_CLEANUP_REQUEST_DEADLINE_MS);
     await rejection;
   });
 

--- a/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VercelSandboxApiError, VercelSandboxClient } from "./client";
+import {
+  DEFAULT_VERCEL_REQUEST_DEADLINE_MS,
+  VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS,
+  VercelSandboxApiError,
+  VercelSandboxClient,
+} from "./client";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -27,6 +32,28 @@ function streamResponse(chunks: string[], status = 200): Response {
   );
 }
 
+function rejectWhenAborted(signal: AbortSignal): Promise<Response> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+}
+
+function stalledStreamResponse(signal: AbortSignal): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        if (signal.aborted) {
+          controller.error(signal.reason);
+          return;
+        }
+        signal.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+      },
+    }),
+    { status: 200 }
+  );
+}
+
 let fetchSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -35,6 +62,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -56,6 +84,91 @@ function lastFetchBody(): Record<string, unknown> {
 }
 
 describe("VercelSandboxClient", () => {
+  it("times out when response headers stall", async () => {
+    vi.useFakeTimers();
+    fetchSpy.mockImplementation((_url, init) =>
+      rejectWhenAborted((init as RequestInit).signal as AbortSignal)
+    );
+
+    const request = createClient().createSandbox({ name: "sandbox-1" });
+    const rejection = expect(request).rejects.toThrow(
+      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (createSandbox)`
+    );
+    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    await rejection;
+  });
+
+  it("keeps the deadline armed while reading a command stream", async () => {
+    vi.useFakeTimers();
+    fetchSpy.mockImplementation((_url, init) =>
+      Promise.resolve(stalledStreamResponse((init as RequestInit).signal as AbortSignal))
+    );
+
+    const request = createClient().runCommandAndWait({
+      sessionId: "session-1",
+      command: "bash",
+    });
+    const rejection = expect(request).rejects.toThrow(
+      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (runCommandAndWait)`
+    );
+    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    await rejection;
+  });
+
+  it("allows an explicit command timeout before applying deadline headroom", async () => {
+    vi.useFakeTimers();
+    fetchSpy.mockImplementation((_url, init) =>
+      Promise.resolve(stalledStreamResponse((init as RequestInit).signal as AbortSignal))
+    );
+    const commandTimeoutMs = DEFAULT_VERCEL_REQUEST_DEADLINE_MS * 2;
+
+    const request = createClient().runCommandAndWait({
+      sessionId: "session-1",
+      command: "bash",
+      timeoutMs: commandTimeoutMs,
+    });
+    const rejection = expect(request).rejects.toThrow(
+      `Vercel Sandbox request timeout after ${commandTimeoutMs + VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS}ms (runCommandAndWait)`
+    );
+    await vi.advanceTimersByTimeAsync(commandTimeoutMs);
+    expect(lastFetchInit().signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS);
+    await rejection;
+  });
+
+  it("preserves caller cancellation when it wins just before the Vercel deadline", async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const callerReason = new DOMException("caller cancelled", "AbortError");
+    fetchSpy.mockImplementation((_url, init) =>
+      rejectWhenAborted((init as RequestInit).signal as AbortSignal)
+    );
+
+    const request = createClient().snapshotSession("session-1", { signal: caller.signal });
+    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS - 1);
+    caller.abort(callerReason);
+    vi.advanceTimersByTime(1);
+
+    await expect(request).rejects.toBe(callerReason);
+    const providerSignal = lastFetchInit().signal as AbortSignal;
+    expect(providerSignal).not.toBe(caller.signal);
+    expect(providerSignal.reason).toBe(callerReason);
+  });
+
+  it("keeps the deadline armed while consuming a successful void response", async () => {
+    vi.useFakeTimers();
+    fetchSpy.mockImplementation((_url, init) =>
+      Promise.resolve(stalledStreamResponse((init as RequestInit).signal as AbortSignal))
+    );
+
+    const request = createClient().deleteSnapshot("snapshot-1");
+    const rejection = expect(request).rejects.toThrow(
+      `Vercel Sandbox request timeout after ${DEFAULT_VERCEL_REQUEST_DEADLINE_MS}ms (deleteSnapshot)`
+    );
+    await vi.advanceTimersByTimeAsync(DEFAULT_VERCEL_REQUEST_DEADLINE_MS);
+    await rejection;
+  });
+
   it("validates required configuration", () => {
     expect(() => new VercelSandboxClient({ token: "", projectId: "project" })).toThrow(
       "VERCEL_TOKEN"

--- a/packages/control-plane/src/sandbox/providers/vercel/client.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.ts
@@ -9,11 +9,15 @@
 import { createLogger } from "../../../logger";
 import type { CorrelationContext } from "../../../logger";
 import { z } from "zod";
+import { withRequestDeadline } from "../../request-deadline";
 
 const log = createLogger("vercel-sandbox-client");
 
 const DEFAULT_VERCEL_API_BASE_URL = "https://vercel.com/api";
 const USER_AGENT = "open-inspect/vercel-sandbox";
+
+export const DEFAULT_VERCEL_REQUEST_DEADLINE_MS = 60_000;
+export const VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS = 10_000;
 
 export interface VercelSandboxClientConfig {
   token: string;
@@ -71,6 +75,7 @@ export interface VercelCreateSandboxRequest {
   env?: Record<string, string>;
   tags?: Record<string, string>;
   sourceSnapshotId?: string;
+  signal?: AbortSignal;
 }
 
 const vercelCreateSandboxResponseSchema = z.object({
@@ -89,18 +94,21 @@ export interface VercelRunCommandRequest {
   env?: Record<string, string>;
   sudo?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 export interface VercelWriteFileArchiveRequest {
   sessionId: string;
   archive: Uint8Array;
   extractDir: string;
+  signal?: AbortSignal;
 }
 
 export interface VercelListSnapshotsRequest {
   name?: string;
   limit?: number;
   sortOrder?: "asc" | "desc";
+  signal?: AbortSignal;
 }
 
 export interface VercelCommandResult {
@@ -176,6 +184,7 @@ export class VercelSandboxClient {
       "/v2/sandboxes",
       {
         method: "POST",
+        signal: request.signal,
         body: JSON.stringify({
           projectId: this.config.projectId,
           name: request.name,
@@ -206,6 +215,7 @@ export class VercelSandboxClient {
       `/v2/sandboxes/sessions/${encodeURIComponent(request.sessionId)}/cmd`,
       {
         method: "POST",
+        signal: request.signal,
         body: JSON.stringify({
           command: request.command,
           args: request.args ?? [],
@@ -231,6 +241,7 @@ export class VercelSandboxClient {
       `/v2/sandboxes/sessions/${encodeURIComponent(request.sessionId)}/cmd`,
       {
         method: "POST",
+        signal: request.signal,
         body: JSON.stringify({
           command: request.command,
           args: request.args ?? [],
@@ -242,7 +253,10 @@ export class VercelSandboxClient {
         }),
       },
       correlation,
-      "runCommandAndWait"
+      "runCommandAndWait",
+      request.timeoutMs === undefined
+        ? DEFAULT_VERCEL_REQUEST_DEADLINE_MS
+        : request.timeoutMs + VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS
     );
   }
 
@@ -258,6 +272,7 @@ export class VercelSandboxClient {
           "content-type": "application/gzip",
           "x-cwd": request.extractDir,
         },
+        signal: request.signal,
         body: request.archive,
       },
       correlation,
@@ -294,7 +309,7 @@ export class VercelSandboxClient {
         limit: request.limit,
         sortOrder: request.sortOrder,
       }),
-      { method: "GET" },
+      { method: "GET", signal: request.signal },
       vercelListSnapshotsResponseSchema,
       correlation,
       "listSnapshots"
@@ -346,7 +361,9 @@ export class VercelSandboxClient {
     correlation: CorrelationContext | undefined,
     endpoint: string
   ): Promise<void> {
-    return this.send(path, init, correlation, endpoint, () => {});
+    return this.send(path, init, correlation, endpoint, async (response) => {
+      await response.arrayBuffer();
+    });
   }
 
   private parseJson<T>(schema: z.ZodType<T>, text: string, status: number, endpoint: string): T {
@@ -376,9 +393,10 @@ export class VercelSandboxClient {
     path: string,
     init: RequestInit,
     correlation: CorrelationContext | undefined,
-    endpoint: string
+    endpoint: string,
+    deadlineMs: number
   ): Promise<VercelCommandResult> {
-    return this.send(path, init, correlation, endpoint, parseCommandNdjsonStream);
+    return this.send(path, init, correlation, endpoint, parseCommandNdjsonStream, deadlineMs);
   }
 
   private async send<T>(
@@ -386,7 +404,8 @@ export class VercelSandboxClient {
     init: RequestInit,
     correlation: CorrelationContext | undefined,
     endpoint: string,
-    consume: (response: Response) => T | Promise<T>
+    consume: (response: Response) => T | Promise<T>,
+    deadlineMs = DEFAULT_VERCEL_REQUEST_DEADLINE_MS
   ): Promise<T> {
     const startTime = Date.now();
     let httpStatus: number | undefined;
@@ -395,19 +414,27 @@ export class VercelSandboxClient {
     try {
       const url = this.buildUrl(path);
       const headers = this.buildHeaders(init, correlation);
-      const response = await fetch(url.toString(), { ...init, headers });
-      httpStatus = response.status;
+      const result = await withRequestDeadline(
+        "Vercel Sandbox",
+        endpoint,
+        deadlineMs,
+        init.signal,
+        async (signal) => {
+          const response = await fetch(url.toString(), { ...init, headers, signal });
+          httpStatus = response.status;
 
-      if (!response.ok) {
-        const text = await readResponseText(response);
-        throw new VercelSandboxApiError(
-          `Vercel Sandbox API error: ${response.status} ${text}`,
-          response.status,
-          text
-        );
-      }
+          if (!response.ok) {
+            const text = await readResponseText(response);
+            throw new VercelSandboxApiError(
+              `Vercel Sandbox API error: ${response.status} ${text}`,
+              response.status,
+              text
+            );
+          }
 
-      const result = await consume(response);
+          return await consume(response);
+        }
+      );
       outcome = "success";
       return result;
     } finally {

--- a/packages/control-plane/src/sandbox/providers/vercel/client.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/client.ts
@@ -16,7 +16,12 @@ const log = createLogger("vercel-sandbox-client");
 const DEFAULT_VERCEL_API_BASE_URL = "https://vercel.com/api";
 const USER_AGENT = "open-inspect/vercel-sandbox";
 
-export const DEFAULT_VERCEL_REQUEST_DEADLINE_MS = 60_000;
+export const VERCEL_SANDBOX_START_REQUEST_DEADLINE_MS = 60_000;
+export const VERCEL_COMMAND_REQUEST_DEADLINE_MS = 60_000;
+// Exceeds the lifecycle's snapshot budget so caller cancellation retains precedence.
+export const VERCEL_SNAPSHOT_REQUEST_DEADLINE_MS = 310_000;
+export const VERCEL_API_REQUEST_DEADLINE_MS = 60_000;
+export const VERCEL_CLEANUP_REQUEST_DEADLINE_MS = 60_000;
 export const VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS = 10_000;
 
 export interface VercelSandboxClientConfig {
@@ -201,7 +206,8 @@ export class VercelSandboxClient {
       },
       vercelCreateSandboxResponseSchema,
       correlation,
-      "createSandbox"
+      "createSandbox",
+      VERCEL_SANDBOX_START_REQUEST_DEADLINE_MS
     );
 
     return response;
@@ -227,7 +233,8 @@ export class VercelSandboxClient {
       },
       vercelStartCommandResponseSchema,
       correlation,
-      "startCommand"
+      "startCommand",
+      VERCEL_COMMAND_REQUEST_DEADLINE_MS
     );
 
     return { commandId: response.command.id, exitCode: response.command.exitCode };
@@ -255,7 +262,7 @@ export class VercelSandboxClient {
       correlation,
       "runCommandAndWait",
       request.timeoutMs === undefined
-        ? DEFAULT_VERCEL_REQUEST_DEADLINE_MS
+        ? VERCEL_COMMAND_REQUEST_DEADLINE_MS
         : request.timeoutMs + VERCEL_COMMAND_REQUEST_DEADLINE_HEADROOM_MS
     );
   }
@@ -276,7 +283,8 @@ export class VercelSandboxClient {
         body: request.archive,
       },
       correlation,
-      "writeFileArchive"
+      "writeFileArchive",
+      VERCEL_API_REQUEST_DEADLINE_MS
     );
   }
 
@@ -294,7 +302,8 @@ export class VercelSandboxClient {
       { method: "POST", body, signal: opts.signal },
       vercelSnapshotResponseSchema,
       correlation,
-      "snapshotSession"
+      "snapshotSession",
+      VERCEL_SNAPSHOT_REQUEST_DEADLINE_MS
     );
   }
 
@@ -312,7 +321,8 @@ export class VercelSandboxClient {
       { method: "GET", signal: request.signal },
       vercelListSnapshotsResponseSchema,
       correlation,
-      "listSnapshots"
+      "listSnapshots",
+      VERCEL_API_REQUEST_DEADLINE_MS
     );
     return response.snapshots;
   }
@@ -326,7 +336,8 @@ export class VercelSandboxClient {
       `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/stop`,
       { method: "POST", signal },
       correlation,
-      "stopSession"
+      "stopSession",
+      VERCEL_CLEANUP_REQUEST_DEADLINE_MS
     );
   }
 
@@ -339,7 +350,8 @@ export class VercelSandboxClient {
       `/v2/sandboxes/snapshots/${encodeURIComponent(snapshotId)}`,
       { method: "DELETE", signal },
       correlation,
-      "deleteSnapshot"
+      "deleteSnapshot",
+      VERCEL_CLEANUP_REQUEST_DEADLINE_MS
     );
   }
 
@@ -348,10 +360,16 @@ export class VercelSandboxClient {
     init: RequestInit,
     schema: z.ZodType<T>,
     correlation: CorrelationContext | undefined,
-    endpoint: string
+    endpoint: string,
+    deadlineMs: number
   ): Promise<T> {
-    return this.send(path, init, correlation, endpoint, async (response) =>
-      this.parseJson(schema, await response.text(), response.status, endpoint)
+    return this.send(
+      path,
+      init,
+      correlation,
+      endpoint,
+      async (response) => this.parseJson(schema, await response.text(), response.status, endpoint),
+      deadlineMs
     );
   }
 
@@ -359,11 +377,19 @@ export class VercelSandboxClient {
     path: string,
     init: RequestInit,
     correlation: CorrelationContext | undefined,
-    endpoint: string
+    endpoint: string,
+    deadlineMs: number
   ): Promise<void> {
-    return this.send(path, init, correlation, endpoint, async (response) => {
-      await response.arrayBuffer();
-    });
+    return this.send(
+      path,
+      init,
+      correlation,
+      endpoint,
+      async (response) => {
+        await response.arrayBuffer();
+      },
+      deadlineMs
+    );
   }
 
   private parseJson<T>(schema: z.ZodType<T>, text: string, status: number, endpoint: string): T {
@@ -405,7 +431,7 @@ export class VercelSandboxClient {
     correlation: CorrelationContext | undefined,
     endpoint: string,
     consume: (response: Response) => T | Promise<T>,
-    deadlineMs = DEFAULT_VERCEL_REQUEST_DEADLINE_MS
+    deadlineMs: number
   ): Promise<T> {
     const startTime = Date.now();
     let httpStatus: number | undefined;

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -14,6 +14,7 @@ import type {
   VercelSnapshotResponse,
 } from "./client";
 import { VercelSandboxApiError } from "./client";
+import { RequestDeadlineError } from "../../request-deadline";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   parseRuntimeVersionNumber,
@@ -145,7 +146,7 @@ describe("VercelSandboxProvider", () => {
   it("classifies request deadline failures as transient", async () => {
     const client = createMockClient({
       createSandbox: vi.fn(async () => {
-        throw new Error("Vercel Sandbox request timeout after 60000ms (createSandbox)");
+        throw new RequestDeadlineError("Vercel Sandbox", "createSandbox", 60_000);
       }),
     });
     const provider = new VercelSandboxProvider(client, providerConfig);

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -142,6 +142,19 @@ function environmentBuildConfig() {
 }
 
 describe("VercelSandboxProvider", () => {
+  it("classifies request deadline failures as transient", async () => {
+    const client = createMockClient({
+      createSandbox: vi.fn(async () => {
+        throw new Error("Vercel Sandbox request timeout after 60000ms (createSandbox)");
+      }),
+    });
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await expect(provider.createSandbox(baseCreateConfig)).rejects.toMatchObject({
+      errorType: "transient",
+    });
+  });
+
   it("reports Vercel capabilities", () => {
     const provider = new VercelSandboxProvider(createMockClient(), providerConfig);
 

--- a/packages/control-plane/src/sandbox/request-deadline.ts
+++ b/packages/control-plane/src/sandbox/request-deadline.ts
@@ -1,0 +1,27 @@
+export async function withRequestDeadline<T>(
+  provider: string,
+  endpoint: string,
+  timeoutMs: number,
+  callerSignal: AbortSignal | null | undefined,
+  operation: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const deadlineReason = new DOMException("Request deadline exceeded", "TimeoutError");
+  const timeoutId = setTimeout(() => controller.abort(deadlineReason), timeoutMs);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, controller.signal])
+    : controller.signal;
+
+  try {
+    return await operation(signal);
+  } catch (error) {
+    if (signal.reason === deadlineReason) {
+      throw new Error(`${provider} request timeout after ${timeoutMs}ms (${endpoint})`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/control-plane/src/sandbox/request-deadline.ts
+++ b/packages/control-plane/src/sandbox/request-deadline.ts
@@ -1,3 +1,15 @@
+export class RequestDeadlineError extends Error {
+  constructor(
+    public readonly provider: string,
+    public readonly endpoint: string,
+    public readonly timeoutMs: number,
+    cause?: unknown
+  ) {
+    super(`${provider} request timeout after ${timeoutMs}ms (${endpoint})`, { cause });
+    this.name = "RequestDeadlineError";
+  }
+}
+
 export async function withRequestDeadline<T>(
   provider: string,
   endpoint: string,
@@ -16,9 +28,7 @@ export async function withRequestDeadline<T>(
     return await operation(signal);
   } catch (error) {
     if (signal.reason === deadlineReason) {
-      throw new Error(`${provider} request timeout after ${timeoutMs}ms (${endpoint})`, {
-        cause: error,
-      });
+      throw new RequestDeadlineError(provider, endpoint, timeoutMs, error);
     }
     throw error;
   } finally {


### PR DESCRIPTION
## Summary
- add named 60-second request deadlines to every Modal and Vercel sandbox HTTP operation
- combine caller cancellation with provider deadlines and preserve the signal that wins
- keep deadlines active through JSON, error-body, void-body, and NDJSON stream consumption
- allow long-running Vercel commands to use their execution timeout plus explicit deadline headroom
- surface deadline failures as attributed timeout errors so existing provider classification and image-build lifecycle accounting handle them as transient failures

## Testing
- `npm test -w @open-inspect/control-plane` (177 files, 2,751 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- ESLint on changed files
- Prettier check on changed files

Closes COL-69

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2fd60dbe4b0f26414179dd61a77c388b)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent request timeouts for Modal and Vercel sandbox operations.
  * Requests now stop promptly when canceled by the caller.
  * Improved handling of stalled response bodies and completed empty responses.
  * Vercel sandbox creation timeout errors are now classified as temporary failures.
  * Timeout errors include clearer provider, endpoint, and duration details.
  * Improved classification of timeout and network failures for more reliable retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->