### PR TITLE
test: speed up managed skills boundary fixture

### DIFF
--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -241,15 +241,43 @@ describe("managed skills persistence and resolution", () => {
 
   it("paginates catalogs and hydrates assignments beyond D1's parameter limit", async () => {
     const skills = new SkillStore(env.DB);
-    for (let index = 0; index < 101; index++) {
-      await skills.create(
-        {
-          name: `catalog-skill-${String(index).padStart(3, "0")}`,
-          content,
-          assignments: [{ type: "global" }],
-        },
-        "user_1"
-      );
+    const catalog = Array.from({ length: 101 }, (_, index) => ({
+      id: `catalog-skill-${String(index).padStart(3, "0")}`,
+      revisionId: `catalog-revision-${String(index).padStart(3, "0")}`,
+    }));
+    const phases = [
+      catalog.map(({ id }) =>
+        env.DB.prepare(
+          `INSERT INTO skills
+           (id, name, enabled, created_by, updated_by, created_at, updated_at)
+           VALUES (?, ?, 1, 'user_1', 'user_1', 1, 1)`
+        ).bind(id, id)
+      ),
+      catalog.map(({ id, revisionId }) =>
+        env.DB.prepare(
+          `INSERT INTO skill_revisions
+           (id, skill_id, revision_number, revision_sha256, description, body,
+            metadata_json, total_bytes, created_by, created_at)
+           VALUES (?, ?, 1, ?, 'Catalog fixture', '', '{}', 0, 'user_1', 1)`
+        ).bind(revisionId, id, revisionId)
+      ),
+      catalog.map(({ id, revisionId }) =>
+        env.DB.prepare("UPDATE skills SET current_revision_id = ? WHERE id = ?").bind(
+          revisionId,
+          id
+        )
+      ),
+      catalog.map(({ id }) =>
+        env.DB.prepare(
+          `INSERT INTO skill_assignments
+           (id, skill_id, scope_type, created_by, created_at)
+           VALUES (?, ?, 'global', 'user_1', 1)`
+        ).bind(`catalog-assignment-${id}`, id)
+      ),
+    ];
+    for (const phase of phases) {
+      await env.DB.batch(phase.slice(0, 100));
+      await env.DB.batch(phase.slice(100));
     }
 
     const applicable = await skills.listApplicable({ repositories: [], environmentId: null });

--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -6,6 +6,7 @@ import { SessionSkillStore } from "../../src/db/session-skills";
 import { SkillConflictError, SkillStore } from "../../src/db/skills";
 import { EnvironmentStore } from "../../src/db/environments";
 import { resolveManagedSkills } from "../../src/session/skill-resolution";
+import { buildSkillRevision } from "../../src/skills/content-addressing";
 import { cleanD1Tables } from "./cleanup";
 import { initNamedSessionDO, seedSandboxAuthHash, serviceFetch } from "./helpers";
 
@@ -241,10 +242,17 @@ describe("managed skills persistence and resolution", () => {
 
   it("paginates catalogs and hydrates assignments beyond D1's parameter limit", async () => {
     const skills = new SkillStore(env.DB);
-    const catalog = Array.from({ length: 101 }, (_, index) => ({
-      id: `catalog-skill-${String(index).padStart(3, "0")}`,
-      revisionId: `catalog-revision-${String(index).padStart(3, "0")}`,
-    }));
+    const catalog = await Promise.all(
+      Array.from({ length: 101 }, async (_, index) => {
+        const suffix = String(index).padStart(3, "0");
+        const id = `catalog-skill-${suffix}`;
+        return {
+          id,
+          revisionId: `catalog-revision-${suffix}`,
+          revision: await buildSkillRevision(id, content),
+        };
+      })
+    );
     const phases = [
       catalog.map(({ id }) =>
         env.DB.prepare(
@@ -253,13 +261,37 @@ describe("managed skills persistence and resolution", () => {
            VALUES (?, ?, 1, 'user_1', 'user_1', 1, 1)`
         ).bind(id, id)
       ),
-      catalog.map(({ id, revisionId }) =>
+      catalog.map(({ id, revisionId, revision }) =>
         env.DB.prepare(
           `INSERT INTO skill_revisions
            (id, skill_id, revision_number, revision_sha256, description, body,
             metadata_json, total_bytes, created_by, created_at)
-           VALUES (?, ?, 1, ?, 'Catalog fixture', '', '{}', 0, 'user_1', 1)`
-        ).bind(revisionId, id, revisionId)
+           VALUES (?, ?, 1, ?, ?, ?, ?, ?, 'user_1', 1)`
+        ).bind(
+          revisionId,
+          id,
+          revision.revisionSha256,
+          content.description,
+          content.body,
+          JSON.stringify(content.metadata),
+          revision.totalBytes
+        )
+      ),
+      catalog.flatMap(({ revisionId, revision }) =>
+        revision.files.map((file) =>
+          env.DB.prepare(
+            `INSERT INTO skill_revision_files
+             (revision_id, path, content, content_sha256, size_bytes, executable)
+             VALUES (?, ?, ?, ?, ?, ?)`
+          ).bind(
+            revisionId,
+            file.path,
+            file.content,
+            file.sha256,
+            file.sizeBytes,
+            file.executable ? 1 : 0
+          )
+        )
       ),
       catalog.map(({ id, revisionId }) =>
         env.DB.prepare("UPDATE skills SET current_revision_id = ? WHERE id = ?").bind(
@@ -276,8 +308,9 @@ describe("managed skills persistence and resolution", () => {
       ),
     ];
     for (const phase of phases) {
-      await env.DB.batch(phase.slice(0, 100));
-      await env.DB.batch(phase.slice(100));
+      for (let start = 0; start < phase.length; start += 100) {
+        await env.DB.batch(phase.slice(start, start + 100));
+      }
     }
 
     const applicable = await skills.listApplicable({ repositories: [], environmentId: null });


### PR DESCRIPTION
## Summary
- replace 101 sequential `SkillStore.create()` calls with dependency-ordered D1 fixture batches
- retain real schema, trigger, assignment hydration, and 100/101 pagination boundary coverage
- avoid increasing or disabling Vitest's per-test timeout

## Root cause
The test previously exercised the full validation, hashing, transactional create, and read-back path 101 times. Under parallel workerd CI load, this occasionally exceeded Vitest's 5-second per-test timeout even though the pagination queries themselves were fast.

The optimized test completes in 47 ms in the focused run, compared with 345-489 ms before the change.

## Verification
- `npm run test:integration -w @open-inspect/control-plane -- managed-skills.test.ts --reporter=verbose`
- `npm run test:integration -w @open-inspect/control-plane -- --shard=1/2`
- `npm run test:integration -w @open-inspect/control-plane -- --shard=2/2`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/test/integration/managed-skills.test.ts`
- `npx prettier --check packages/control-plane/test/integration/managed-skills.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8623a66fb3df3b124c415e2c45feb228)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved catalog pagination integration coverage by seeding a larger skill set in controlled batches.
  * Continued validating skill applicability and multi-page catalog navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->