### PR TITLE
fix: clone repositories atomically

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -101,23 +102,36 @@ class RepositorySynchronizer:
     async def _clone_repo(self, repo: RepoEntry) -> bool:
         self.log.info("git.clone_start", repo_owner=repo.owner, repo_name=repo.name)
         try:
-            result = await asyncio.create_subprocess_exec(
-                "git",
-                "clone",
-                "--depth",
-                str(self.CLONE_DEPTH_COMMITS),
-                "--branch",
-                repo.branch,
-                self._build_repo_url(repo),
-                str(repo.path),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                start_new_session=True,
-            )
-            _stdout, stderr = await asyncio.wait_for(
-                self._communicate_owned_subprocess(result),
-                timeout=self.clone_timeout_seconds,
-            )
+            with tempfile.TemporaryDirectory(
+                prefix=f".{repo.name}.clone-", dir=repo.path.parent
+            ) as clone_dir:
+                result = await asyncio.create_subprocess_exec(
+                    "git",
+                    "clone",
+                    "--depth",
+                    str(self.CLONE_DEPTH_COMMITS),
+                    "--branch",
+                    repo.branch,
+                    self._build_repo_url(repo),
+                    clone_dir,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    start_new_session=True,
+                )
+                _stdout, stderr = await asyncio.wait_for(
+                    self._communicate_owned_subprocess(result),
+                    timeout=self.clone_timeout_seconds,
+                )
+                if result.returncode != 0:
+                    self.log.error(
+                        "git.clone_error",
+                        repo_owner=repo.owner,
+                        repo_name=repo.name,
+                        stderr=self._redact_git_stderr(stderr),
+                        exit_code=result.returncode,
+                    )
+                    return False
+                Path(clone_dir).rename(repo.path)
         except TimeoutError as error:
             self.log.error(
                 "git.clone_timeout",
@@ -128,15 +142,6 @@ class RepositorySynchronizer:
             raise RepositorySyncTimeout from error
         except Exception as error:
             self.log.error("git.clone_error", exc=error, repo_owner=repo.owner, repo_name=repo.name)
-            return False
-        if result.returncode != 0:
-            self.log.error(
-                "git.clone_error",
-                repo_owner=repo.owner,
-                repo_name=repo.name,
-                stderr=self._redact_git_stderr(stderr),
-                exit_code=result.returncode,
-            )
             return False
         self.log.info("git.clone_complete", repo_path=str(repo.path))
         return True

--- a/packages/sandbox-runtime/tests/test_repository_sync.py
+++ b/packages/sandbox-runtime/tests/test_repository_sync.py
@@ -40,17 +40,46 @@ def test_git_operation_timeout_defaults_are_named() -> None:
 
 
 @pytest.mark.asyncio
+async def test_successful_clone_is_promoted_from_temporary_directory(tmp_path: Path) -> None:
+    process = MagicMock(returncode=0)
+    process.communicate = AsyncMock(return_value=(b"", b""))
+    synchronizer = RepositorySynchronizer("github.com", MagicMock())
+    repo = _repository(tmp_path)
+
+    async def create_clone(*args: object, **_kwargs: object) -> MagicMock:
+        clone_path = Path(str(args[-1]))
+        assert clone_path.parent == repo.path.parent
+        assert clone_path != repo.path
+        (clone_path / ".git").mkdir()
+        return process
+
+    with patch(
+        "sandbox_runtime.repository_sync.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+        side_effect=create_clone,
+    ):
+        assert await synchronizer._clone_repo(repo)
+
+    assert (repo.path / ".git").is_dir()
+    assert list(tmp_path.iterdir()) == [repo.path]
+
+
+@pytest.mark.asyncio
 async def test_hung_clone_times_out_and_cleans_up_process_group(tmp_path: Path) -> None:
     process = _hung_process()
     log = MagicMock()
     synchronizer = RepositorySynchronizer("github.com", log, clone_timeout_seconds=0.01)
     repo = _repository(tmp_path)
 
+    async def create_partial_clone(*args: object, **_kwargs: object) -> MagicMock:
+        (Path(str(args[-1])) / ".git").mkdir()
+        return process
+
     with (
         patch(
             "sandbox_runtime.repository_sync.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
-            return_value=process,
+            side_effect=create_partial_clone,
         ) as create_process,
         patch("sandbox_runtime.repository_sync.os.killpg") as kill_process_group,
         pytest.raises(RepositorySyncTimeout),
@@ -60,6 +89,8 @@ async def test_hung_clone_times_out_and_cleans_up_process_group(tmp_path: Path) 
     kill_process_group.assert_called_once_with(process.pid, signal.SIGKILL)
     process.wait.assert_awaited_once()
     assert create_process.await_args.kwargs["start_new_session"] is True
+    assert not repo.path.exists()
+    assert list(tmp_path.iterdir()) == []
     log.error.assert_called_once_with(
         "git.clone_timeout",
         repo_owner="acme",


### PR DESCRIPTION
## Summary
- clone new repositories into a hidden temporary sibling directory
- atomically rename completed clones into the canonical workspace path
- clean partial clone data after timeouts and other clone failures so retries start from a genuinely absent destination
- add regression coverage for timeout cleanup and successful promotion

## Root cause
`_sync_repo` uses destination-path existence to distinguish a new clone from an existing checkout. `git clone` previously wrote directly to that destination, so a timeout could leave a partial directory that every later startup misclassified as an existing repository and attempted to fetch/update.

Using a temporary sibling keeps the canonical destination absent until clone completion. The same-filesystem rename publishes the completed checkout atomically, while `TemporaryDirectory` cleans unsuccessful attempts across timeout, nonzero exit, spawn error, and rename failure paths.

## TDD
The timeout test was first changed to model Git creating a partial destination and failed because `repo.path` remained after cancellation. The implementation then made that regression pass, with a complementary success-path test covering atomic promotion.

## Verification
- `PYTHONPATH=src uv run --extra dev pytest tests/test_repository_sync.py tests/test_multi_repo_workspace.py tests/test_entrypoint_build_mode.py -q` (`89 passed`)
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev ruff format --check src tests`
- `PYTHONPATH=src uv run --extra dev mypy src/sandbox_runtime/repository_sync.py`
- Full sandbox-runtime suite: `748 passed`, with 4 pre-existing environment-sensitive failures (3 live credential environment tests and 1 installed-Git signer argument assertion)


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/fb4273ae3dd14b981daeda6b68f8fee1)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository synchronization reliability by completing clones in a temporary location before making them available.
  * Prevented incomplete or failed clones from replacing existing repository data.
  * Improved cleanup of temporary files after successful, failed, or timed-out clone operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->