### PR TITLE
fix: retire sandbox snapshots taken by an incompatible runtime

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../../image-builds/model";
 import {
   evaluateCircuitBreaker,
   evaluateSpawnDecision,
@@ -14,6 +15,7 @@ import {
   evaluateWarmDecision,
   evaluateExecutionTimeout,
   isSandboxReconnectBlockedStatus,
+  isSnapshotRuntimeCompatible,
   DEFAULT_CONNECTING_TIMEOUT_CONFIG,
   DEFAULT_EXECUTION_TIMEOUT_MS,
   type CircuitBreakerState,
@@ -147,6 +149,7 @@ describe("evaluateSpawnDecision", () => {
       status: "stopped",
       createdAt: now - 120000,
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -164,6 +167,7 @@ describe("evaluateSpawnDecision", () => {
       status: "stale",
       createdAt: now - 120000,
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -178,6 +182,7 @@ describe("evaluateSpawnDecision", () => {
       status: "failed",
       createdAt: now - 120000,
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -186,12 +191,77 @@ describe("evaluateSpawnDecision", () => {
     expect(decision.action).toBe("restore");
   });
 
+  it("spawns fresh instead of restoring a snapshot below the runtime floor", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: `v${MIN_COMPATIBLE_RUNTIME_VERSION - 1}-retired`,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, false);
+
+    expect(decision.action).toBe("spawn");
+    if (decision.action === "spawn") {
+      expect(decision.reason).toContain(`v${MIN_COMPATIBLE_RUNTIME_VERSION - 1}-retired`);
+    }
+  });
+
+  it("spawns fresh when the snapshot predates runtime-version recording", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: null,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, false);
+
+    expect(decision.action).toBe("spawn");
+    if (decision.action === "spawn") {
+      expect(decision.reason).toContain("unknown");
+    }
+  });
+
+  it("restores a snapshot taken exactly at the runtime floor", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: `v${MIN_COMPATIBLE_RUNTIME_VERSION}-at-floor`,
+      hasActiveWebSocket: false,
+    };
+
+    expect(evaluateSpawnDecision(state, config, now, false).action).toBe("restore");
+  });
+
+  it("keeps the in-memory spawn guard ahead of the runtime floor check", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: null,
+      hasActiveWebSocket: false,
+    };
+
+    // A rejected snapshot must not let a concurrent evaluation start a second
+    // spawn while the first is still in flight.
+    expect(evaluateSpawnDecision(state, config, now, true).action).toBe("skip");
+  });
+
   it('returns "skip" when already spawning', () => {
     const now = Date.now();
     const state: SandboxState = {
       status: "spawning",
       createdAt: now - 5000,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -209,6 +279,7 @@ describe("evaluateSpawnDecision", () => {
       status: "connecting",
       createdAt: now - 5000,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -223,6 +294,7 @@ describe("evaluateSpawnDecision", () => {
       status: "spawning",
       createdAt: now - (config.spawningTimeoutMs + 1000),
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -237,6 +309,7 @@ describe("evaluateSpawnDecision", () => {
       status: "connecting",
       createdAt: now - (config.spawningTimeoutMs + 1000),
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -251,6 +324,7 @@ describe("evaluateSpawnDecision", () => {
       status: "spawning",
       createdAt: now - (config.spawningTimeoutMs + 1000),
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -265,6 +339,7 @@ describe("evaluateSpawnDecision", () => {
       status: "ready",
       createdAt: now - 120000,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: true,
     };
 
@@ -282,6 +357,7 @@ describe("evaluateSpawnDecision", () => {
       status: "ready",
       createdAt: now - 30000, // 30 seconds ago, less than readyWaitMs
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -299,6 +375,7 @@ describe("evaluateSpawnDecision", () => {
       status: "pending",
       createdAt: now - 10000, // 10 seconds ago, less than cooldownMs
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -316,6 +393,7 @@ describe("evaluateSpawnDecision", () => {
       status: "pending",
       createdAt: now - 60000,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -336,6 +414,7 @@ describe("evaluateSpawnDecision", () => {
       status: "stopped",
       createdAt: now - 120000,
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -353,6 +432,7 @@ describe("evaluateSpawnDecision", () => {
       status: "stopped",
       createdAt: now - 120000,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       providerObjectId: "sb-123",
       hasActiveWebSocket: false,
     };
@@ -371,6 +451,7 @@ describe("evaluateSpawnDecision", () => {
       status: "pending",
       createdAt: now - 60000, // Past cooldown
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -385,6 +466,7 @@ describe("evaluateSpawnDecision", () => {
       status: "failed",
       createdAt: now - 5000, // Within cooldown, but status is failed
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -399,6 +481,7 @@ describe("evaluateSpawnDecision", () => {
       status: "stopped",
       createdAt: now - 5000, // Within cooldown, but status is stopped
       snapshotImageId: null, // No snapshot, so fresh spawn
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -416,6 +499,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: "daytona-abc123",
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -434,6 +518,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: "daytona-abc123",
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -449,6 +534,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: "daytona-abc123",
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -464,6 +550,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: null,
       snapshotImageId: "img-abc123",
+      snapshotRuntimeVersion: "v99-test",
       hasActiveWebSocket: false,
     };
 
@@ -479,6 +566,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: null,
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -494,6 +582,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: "daytona-abc123",
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -509,6 +598,7 @@ describe("evaluateSpawnDecision", () => {
       createdAt: now - 120000,
       providerObjectId: "daytona-abc123",
       snapshotImageId: null,
+      snapshotRuntimeVersion: null,
       hasActiveWebSocket: false,
     };
 
@@ -955,5 +1045,24 @@ describe("evaluateExecutionTimeout", () => {
 
     expect(result.isTimedOut).toBe(true);
     expect(result.elapsedMs).toBe(6000);
+  });
+});
+
+// ==================== Snapshot Runtime Floor ====================
+
+describe("isSnapshotRuntimeCompatible", () => {
+  it("accepts a snapshot at or above the floor", () => {
+    expect(isSnapshotRuntimeCompatible(`v${MIN_COMPATIBLE_RUNTIME_VERSION}-x`)).toBe(true);
+    expect(isSnapshotRuntimeCompatible(`v${MIN_COMPATIBLE_RUNTIME_VERSION + 1}-x`)).toBe(true);
+  });
+
+  it("rejects a snapshot below the floor", () => {
+    expect(isSnapshotRuntimeCompatible(`v${MIN_COMPATIBLE_RUNTIME_VERSION - 1}-x`)).toBe(false);
+  });
+
+  it("fails closed on missing or unparseable versions", () => {
+    expect(isSnapshotRuntimeCompatible(null)).toBe(false);
+    expect(isSnapshotRuntimeCompatible("")).toBe(false);
+    expect(isSnapshotRuntimeCompatible("daytona-v6-vnc")).toBe(false);
   });
 });

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -218,7 +218,7 @@ export function isSnapshotRuntimeCompatible(snapshotRuntimeVersion: string | nul
 export type SpawnAction =
   | { action: "spawn"; reason?: string }
   | { action: "resume"; providerObjectId: string }
-  | { action: "restore"; snapshotImageId: string }
+  | { action: "restore"; snapshotImageId: string; snapshotRuntimeVersion: string }
   | { action: "skip"; reason: string }
   | { action: "wait"; reason: string };
 
@@ -292,7 +292,12 @@ export function evaluateSpawnDecision(
     (state.status === "stopped" || state.status === "stale" || state.status === "failed")
   ) {
     if (isSnapshotRuntimeCompatible(state.snapshotRuntimeVersion)) {
-      return { action: "restore", snapshotImageId: state.snapshotImageId };
+      return {
+        action: "restore",
+        snapshotImageId: state.snapshotImageId,
+        // Non-null: the compatibility check above rejects a missing version.
+        snapshotRuntimeVersion: state.snapshotRuntimeVersion as string,
+      };
     }
     // Fall through to a fresh spawn rather than booting a retired runtime.
     return {

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -10,6 +10,10 @@
  */
 
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
+import {
+  MIN_COMPATIBLE_RUNTIME_VERSION,
+  parseRuntimeVersionNumber,
+} from "../../image-builds/model";
 
 // ==================== Dead-Sandbox Policy ====================
 
@@ -146,6 +150,12 @@ export interface SandboxState {
   providerObjectId?: string | null;
   /** Snapshot image ID if available for restore */
   snapshotImageId: string | null;
+  /**
+   * SANDBOX_VERSION of the runtime that produced `snapshotImageId`, or null
+   * when the snapshot predates version recording. Gates restore — see
+   * {@link isSnapshotRuntimeCompatible}.
+   */
+  snapshotRuntimeVersion: string | null;
   /** Whether an active WebSocket connection exists */
   hasActiveWebSocket: boolean;
 }
@@ -181,10 +191,32 @@ export const DEFAULT_SPAWN_CONFIG: SpawnConfig = {
 };
 
 /**
+ * Whether a filesystem snapshot may be booted again.
+ *
+ * A snapshot carries the whole sandbox filesystem, including the pinned agent
+ * binary, so restoring one silently resurrects the runtime that took it. A
+ * runtime fix therefore never reaches a session that keeps restoring — the
+ * failure mode that stranded every pre-existing session on the OpenCode
+ * message-ID wraparound. Bumping MIN_COMPATIBLE_RUNTIME_VERSION now retires
+ * those snapshots the same way it retires prebuilt images.
+ *
+ * Fails closed, matching image selection: a snapshot whose runtime version was
+ * never recorded (taken before this column existed) or does not parse is
+ * treated as below the floor. The cost is one fresh spawn — the sandbox's
+ * uncommitted filesystem state — after which the next snapshot records its
+ * version and restores resume as normal.
+ */
+export function isSnapshotRuntimeCompatible(snapshotRuntimeVersion: string | null): boolean {
+  if (!snapshotRuntimeVersion) return false;
+  const version = parseRuntimeVersionNumber(snapshotRuntimeVersion);
+  return version !== null && version >= MIN_COMPATIBLE_RUNTIME_VERSION;
+}
+
+/**
  * Possible spawn actions.
  */
 export type SpawnAction =
-  | { action: "spawn" }
+  | { action: "spawn"; reason?: string }
   | { action: "resume"; providerObjectId: string }
   | { action: "restore"; snapshotImageId: string }
   | { action: "skip"; reason: string }
@@ -194,7 +226,8 @@ export type SpawnAction =
  * Evaluate what spawn action to take.
  *
  * This function encapsulates the complex spawn decision logic:
- * - Restore from snapshot if available and sandbox is stopped/stale/failed
+ * - Restore from snapshot if available, compatible, and sandbox is
+ *   stopped/stale/failed
  * - Skip if already spawning/connecting
  * - Skip if ready with active WebSocket
  * - Wait if ready without WebSocket but recently spawned
@@ -211,7 +244,13 @@ export type SpawnAction =
  * @example
  * ```typescript
  * const decision = evaluateSpawnDecision(
- *   { status: "stopped", createdAt: ..., snapshotImageId: "img-123", hasActiveWebSocket: false },
+ *   {
+ *     status: "stopped",
+ *     createdAt: ...,
+ *     snapshotImageId: "img-123",
+ *     snapshotRuntimeVersion: "v59-runtime",
+ *     hasActiveWebSocket: false,
+ *   },
  *   { cooldownMs: 30000, readyWaitMs: 60000 },
  *   Date.now(),
  *   false
@@ -252,7 +291,14 @@ export function evaluateSpawnDecision(
     state.snapshotImageId &&
     (state.status === "stopped" || state.status === "stale" || state.status === "failed")
   ) {
-    return { action: "restore", snapshotImageId: state.snapshotImageId };
+    if (isSnapshotRuntimeCompatible(state.snapshotRuntimeVersion)) {
+      return { action: "restore", snapshotImageId: state.snapshotImageId };
+    }
+    // Fall through to a fresh spawn rather than booting a retired runtime.
+    return {
+      action: "spawn",
+      reason: `snapshot runtime ${state.snapshotRuntimeVersion ?? "unknown"} is below the v${MIN_COMPATIBLE_RUNTIME_VERSION} floor`,
+    };
   }
 
   // Don't spawn if a spawn/connect is genuinely in progress (persisted status).

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -80,6 +80,8 @@ function createMockSandbox(
     modal_object_id: "modal-obj-123",
     snapshot_id: null,
     snapshot_image_id: null,
+    snapshot_runtime_version: null,
+    runtime_version: COMPATIBLE_RUNTIME_VERSION,
     auth_token: "auth-token-123",
     auth_token_hash: "auth-token-hash-123",
     status: "ready",
@@ -160,10 +162,15 @@ function createMockStorage(
       calls.push(`updateSandboxModalObjectId:${id}`);
       if (sandbox) sandbox.modal_object_id = id;
     }),
-    updateSandboxSnapshotImageId: vi.fn((sandboxId: string, imageId: string) => {
-      calls.push(`updateSandboxSnapshotImageId:${imageId}`);
-      if (sandbox) sandbox.snapshot_image_id = imageId;
-    }),
+    updateSandboxSnapshotImageId: vi.fn(
+      (sandboxId: string, imageId: string, runtimeVersion: string | null) => {
+        calls.push(`updateSandboxSnapshotImageId:${imageId}:${runtimeVersion}`);
+        if (sandbox) {
+          sandbox.snapshot_image_id = imageId;
+          sandbox.snapshot_runtime_version = runtimeVersion;
+        }
+      }
+    ),
     updateSandboxLastActivity: vi.fn((timestamp: number) => {
       calls.push("updateSandboxLastActivity");
       if (sandbox) sandbox.last_activity = timestamp;
@@ -371,6 +378,7 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
     status: kind === "spawn" ? "pending" : "stopped",
     created_at: Date.now() - 60000,
     snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+    snapshot_runtime_version: kind === "restore" ? COMPATIBLE_RUNTIME_VERSION : null,
   });
   const storage = createMockStorage(
     createMockSession({ code_server_enabled: 1, vnc_enabled: 1 }),
@@ -513,6 +521,7 @@ describe("SandboxLifecycleManager", () => {
         const sandbox = createMockSandbox({
           status: kind === "spawn" ? "pending" : "stopped",
           snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+          snapshot_runtime_version: kind === "restore" ? COMPATIBLE_RUNTIME_VERSION : null,
           created_at: Date.now() - 60000,
         });
         const storage = createMockStorage(createMockSession(), sandbox);
@@ -570,6 +579,7 @@ describe("SandboxLifecycleManager", () => {
         const sandbox = createMockSandbox({
           status: kind === "spawn" ? "pending" : "stopped",
           snapshot_image_id: kind === "restore" ? "img-abc123" : null,
+          snapshot_runtime_version: kind === "restore" ? COMPATIBLE_RUNTIME_VERSION : null,
           created_at: Date.now() - 60000,
         });
         const storage = createMockStorage(createMockSession(), sandbox);
@@ -1021,6 +1031,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
@@ -1047,6 +1058,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
@@ -1080,6 +1092,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const provider = createMockProvider({
         restoreFromSnapshot: vi.fn(
@@ -1122,6 +1135,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       vi.mocked(storage.updateSandboxModalObjectId).mockImplementation(() => {
@@ -1163,6 +1177,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
@@ -1195,6 +1210,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
@@ -1321,10 +1337,59 @@ describe("SandboxLifecycleManager", () => {
       ]);
     });
 
+    it("spawns fresh instead of restoring a snapshot taken by a retired runtime", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: "v1-retired",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).not.toHaveBeenCalled();
+      expect(provider.createSandbox).toHaveBeenCalled();
+    });
+
+    it("spawns fresh when the snapshot predates runtime-version recording", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).not.toHaveBeenCalled();
+      expect(provider.createSandbox).toHaveBeenCalled();
+    });
+
     it("resets isSpawningSandbox flag after restore throws error", async () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
@@ -1359,6 +1424,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
@@ -1546,7 +1612,9 @@ describe("SandboxLifecycleManager", () => {
       await manager.triggerSnapshot("test_reason");
 
       expect(provider.takeSnapshot).toHaveBeenCalled();
-      expect(storage.calls).toContain("updateSandboxSnapshotImageId:snapshot-img-123");
+      expect(storage.calls).toContain(
+        `updateSandboxSnapshotImageId:snapshot-img-123:${COMPATIBLE_RUNTIME_VERSION}`
+      );
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "snapshot_saved")
       ).toBe(true);
@@ -1610,7 +1678,9 @@ describe("SandboxLifecycleManager", () => {
 
       await manager.triggerSnapshot("execution_complete");
 
-      expect(storage.calls).toContain("updateSandboxSnapshotImageId:custom-snapshot-id");
+      expect(storage.calls).toContain(
+        `updateSandboxSnapshotImageId:custom-snapshot-id:${COMPATIBLE_RUNTIME_VERSION}`
+      );
     });
 
     it("handles snapshot errors gracefully", async () => {
@@ -2909,6 +2979,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "snapshot-img-1",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
         created_at: Date.now() - 60000,
       });
       const { manager, provider } = createMultiRepoManager({ sandbox });
@@ -2952,6 +3023,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const provider = createMockProvider();
       const manager = new SandboxLifecycleManager(
@@ -3277,6 +3349,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(session, sandbox);
       const provider = createMockProvider();
@@ -3305,6 +3378,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(session, sandbox);
       const provider = createMockProvider();
@@ -3335,6 +3409,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const storage = createMockStorage(session, sandbox);
       const broadcaster = createMockBroadcaster();
@@ -3394,7 +3469,11 @@ describe("SandboxLifecycleManager", () => {
     }
 
     function snapshotSandbox() {
-      return createMockSandbox({ status: "stopped", snapshot_image_id: "img-abc123" });
+      return createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
+      });
     }
 
     it("passes agentSlackNotifyEnabled=true when the lookup returns true", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -163,6 +163,10 @@ function createMockStorage(
       calls.push(`updateSandboxModalObjectId:${id}`);
       if (sandbox) sandbox.modal_object_id = id;
     }),
+    updateSandboxRuntimeVersion: vi.fn((runtimeVersion: string | null) => {
+      calls.push(`updateSandboxRuntimeVersion:${runtimeVersion}`);
+      if (sandbox) sandbox.runtime_version = runtimeVersion;
+    }),
     updateSandboxSnapshotImageId: vi.fn(
       (sandboxId: string, imageId: string, runtimeVersion: string | null) => {
         calls.push(`updateSandboxSnapshotImageId:${imageId}:${runtimeVersion}`);
@@ -1363,6 +1367,34 @@ describe("SandboxLifecycleManager", () => {
 
       expect(sandbox.runtime_version).toBeNull();
       expect(storage.calls).toContain("updateSandboxSnapshotImageId:snapshot-img-123:null");
+    });
+
+    it("seeds the restored sandbox's runtime version from the snapshot", async () => {
+      // OpenComputer and Vercel export the current SANDBOX_VERSION into every
+      // sandbox they start, including ones forked from an old checkpoint, so
+      // the snapshot's own version has to win.
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).toHaveBeenCalled();
+      expect(storage.calls).toContain(`updateSandboxRuntimeVersion:${COMPATIBLE_RUNTIME_VERSION}`);
+      expect(sandbox.runtime_version).toBe(COMPATIBLE_RUNTIME_VERSION);
     });
 
     it("spawns fresh instead of restoring a snapshot taken by a retired runtime", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -148,6 +148,7 @@ function createMockStorage(
         sandbox.auth_token_hash = data.authTokenHash;
         sandbox.auth_token = null;
         sandbox.modal_sandbox_id = data.modalSandboxId;
+        sandbox.runtime_version = null;
         if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
       }
     }),
@@ -1335,6 +1336,33 @@ describe("SandboxLifecycleManager", () => {
           url: "https://provider.example/same-provider-obj",
         },
       ]);
+    });
+
+    it("does not carry a predecessor's runtime version onto a replacement's snapshot", async () => {
+      // The row starts out describing a sandbox that reported a compatible
+      // runtime. Once it is replaced, a snapshot the replacement takes must be
+      // stamped unknown until the new sandbox reports for itself — otherwise a
+      // downgraded or silent runtime inherits a clean bill of health.
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      expect(sandbox.runtime_version).toBe(COMPATIBLE_RUNTIME_VERSION);
+
+      await manager.spawnSandbox();
+      await manager.triggerSnapshot("execution_complete");
+
+      expect(sandbox.runtime_version).toBeNull();
+      expect(storage.calls).toContain("updateSandboxSnapshotImageId:snapshot-img-123:null");
     });
 
     it("spawns fresh instead of restoring a snapshot taken by a retired runtime", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -113,6 +113,8 @@ export interface SandboxStorage {
   updateSandboxForResume(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
   updateSandboxModalObjectId(modalObjectId: string | null): void;
+  /** Set the runtime version describing the sandbox's current filesystem. */
+  updateSandboxRuntimeVersion(runtimeVersion: string | null): void;
   /**
    * Update sandbox snapshot image ID and the runtime version that produced it
    * (null when the sandbox never reported one).
@@ -403,8 +405,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       case "restore":
         this.log.info("Spawn decision: restore", {
           snapshot_image_id: spawnDecision.snapshotImageId,
+          snapshot_runtime_version: spawnDecision.snapshotRuntimeVersion,
         });
-        await this.restoreFromSnapshot(spawnDecision.snapshotImageId);
+        await this.restoreFromSnapshot(
+          spawnDecision.snapshotImageId,
+          spawnDecision.snapshotRuntimeVersion
+        );
         return;
 
       case "resume":
@@ -747,7 +753,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * Restore a sandbox from a filesystem snapshot.
    */
-  private async restoreFromSnapshot(snapshotImageId: string): Promise<void> {
+  private async restoreFromSnapshot(
+    snapshotImageId: string,
+    snapshotRuntimeVersion: string
+  ): Promise<void> {
     if (!this.provider.restoreFromSnapshot) {
       this.log.info("Provider does not support restore, falling back to fresh spawn");
       // Fall back to fresh spawn
@@ -784,6 +793,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           preserveProviderObjectId: true,
         })
       );
+
+      // A restored sandbox runs the snapshot's binaries whatever the provider
+      // exports at launch, so the snapshot's version is the authoritative one.
+      // Seeding it here also makes the sandbox's own report a no-op, since the
+      // ready handler only fills a row with nothing recorded yet.
+      this.storage.updateSandboxRuntimeVersion(snapshotRuntimeVersion);
 
       await this.stopPriorProviderSandbox();
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -71,6 +71,7 @@ interface SandboxCircuitBreakerInfo {
   created_at: number;
   modal_object_id: string | null;
   snapshot_image_id: string | null;
+  snapshot_runtime_version: string | null;
   spawn_failure_count: number | null;
   last_spawn_failure: number | null;
 }
@@ -108,8 +109,15 @@ export interface SandboxStorage {
   updateSandboxForResume(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
   updateSandboxModalObjectId(modalObjectId: string | null): void;
-  /** Update sandbox snapshot image ID */
-  updateSandboxSnapshotImageId(sandboxId: string, imageId: string): void;
+  /**
+   * Update sandbox snapshot image ID and the runtime version that produced it
+   * (null when the sandbox never reported one).
+   */
+  updateSandboxSnapshotImageId(
+    sandboxId: string,
+    imageId: string,
+    runtimeVersion: string | null
+  ): void;
   /** Update last activity timestamp */
   updateSandboxLastActivity(timestamp: number): void;
   /** Increment circuit breaker failure count */
@@ -361,6 +369,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       createdAt: sandboxState?.created_at || 0,
       providerObjectId: sandboxState?.modal_object_id || null,
       snapshotImageId: sandboxState?.snapshot_image_id || null,
+      snapshotRuntimeVersion: sandboxState?.snapshot_runtime_version || null,
       hasActiveWebSocket: this.wsManager.getSandboxWebSocket() !== null,
     };
 
@@ -402,6 +411,13 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         return;
 
       case "spawn":
+        if (spawnDecision.reason) {
+          this.log.info("Spawn decision: spawn", {
+            event: "sandbox.snapshot_rejected",
+            reason: spawnDecision.reason,
+            snapshot_image_id: spawnState.snapshotImageId,
+          });
+        }
         await this.doSpawn();
         return;
     }
@@ -1012,10 +1028,18 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
 
       if (result.success && result.imageId) {
-        this.storage.updateSandboxSnapshotImageId(sandbox.id, result.imageId);
+        // Stamp the snapshot with the runtime that produced it: the image
+        // carries that runtime's binaries, so this is what a later restore is
+        // gated on, not whatever the session runs next.
+        this.storage.updateSandboxSnapshotImageId(
+          sandbox.id,
+          result.imageId,
+          sandbox.runtime_version
+        );
         this.log.info("Snapshot saved", {
           event: "sandbox.snapshot_saved",
           image_id: result.imageId,
+          runtime_version: sandbox.runtime_version,
           reason,
         });
         this.broadcaster.broadcast({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -97,7 +97,11 @@ export interface SandboxStorage {
   getUserEnvVars(): Promise<Record<string, string> | undefined>;
   /** Update sandbox status */
   updateSandboxStatus(status: SandboxStatus): void;
-  /** Update sandbox for spawn (status, auth token, sandbox ID, created_at) */
+  /**
+   * Update sandbox for spawn (status, auth token, sandbox ID, created_at).
+   * Clears every field describing the previous sandbox instance, runtime
+   * version included.
+   */
   updateSandboxForSpawn(data: {
     status: SandboxStatus;
     createdAt: number;

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -188,6 +188,10 @@ describe("VercelSandboxProvider", () => {
       expect.objectContaining({
         USER_SECRET: "value",
         SANDBOX_ID: "sandbox-456",
+        // The base snapshot bakes none, so the sandbox can only report a
+        // runtime version — and so keep its snapshots restorable — if the
+        // provider exports it here.
+        SANDBOX_VERSION: VERCEL_SANDBOX_VERSION,
         PATH: expect.stringContaining("/vercel/runtimes/node24/bin"),
         CONTROL_PLANE_URL: "https://control-plane.test",
         SANDBOX_AUTH_TOKEN: "auth-token",

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -376,15 +376,17 @@ export class VercelSandboxProvider implements SandboxProvider {
       cloneToken: config.cloneToken,
       baseEnvVars: config.userEnvVars,
     });
-    Object.assign(envVars, this.buildPlatformEnvVars(), {
-      SANDBOX_VERSION: VERCEL_SANDBOX_VERSION,
-    });
+    // SANDBOX_VERSION comes from buildPlatformEnvVars now.
+    Object.assign(envVars, this.buildPlatformEnvVars());
     return envVars;
   }
 
   /** Vercel base-image paths layered on top of the canonical sandbox env. */
   private buildPlatformEnvVars(): Record<string, string> {
     return {
+      // The base snapshot bakes no SANDBOX_VERSION, so without this every
+      // sandbox reports an unknown runtime and its snapshots are unrestorable.
+      SANDBOX_VERSION: VERCEL_SANDBOX_VERSION,
       HOME: "/root",
       NODE_ENV: "development",
       PATH: buildVercelRuntimePath(this.providerConfig.runtime),

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -912,6 +912,8 @@ export class SessionDO extends DurableObject<Env> {
       updateSandboxForSpawn: (data) => this.sandboxRepository.updateSandboxForSpawn(data),
       updateSandboxForResume: (data) => this.sandboxRepository.updateSandboxForResume(data),
       updateSandboxModalObjectId: (id) => this.sandboxRepository.updateSandboxModalObjectId(id),
+      updateSandboxRuntimeVersion: (runtimeVersion) =>
+        this.sandboxRepository.updateSandboxRuntimeVersion(runtimeVersion),
       updateSandboxSnapshotImageId: (sandboxId, imageId, runtimeVersion) =>
         this.sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion),
       updateSandboxLastActivity: (timestamp) =>

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -912,8 +912,8 @@ export class SessionDO extends DurableObject<Env> {
       updateSandboxForSpawn: (data) => this.sandboxRepository.updateSandboxForSpawn(data),
       updateSandboxForResume: (data) => this.sandboxRepository.updateSandboxForResume(data),
       updateSandboxModalObjectId: (id) => this.sandboxRepository.updateSandboxModalObjectId(id),
-      updateSandboxSnapshotImageId: (sandboxId, imageId) =>
-        this.sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId),
+      updateSandboxSnapshotImageId: (sandboxId, imageId, runtimeVersion) =>
+        this.sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion),
       updateSandboxLastActivity: (timestamp) =>
         this.sandboxRepository.updateSandboxLastActivity(timestamp),
       incrementCircuitBreakerFailure: (timestamp) =>

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -77,6 +77,8 @@ function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
     modal_object_id: null,
     snapshot_id: null,
     snapshot_image_id: null,
+    snapshot_runtime_version: null,
+    runtime_version: null,
     auth_token: null,
     auth_token_hash: null,
     status: "running",

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -46,6 +46,8 @@ function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
     modal_object_id: null,
     snapshot_id: null,
     snapshot_image_id: null,
+    snapshot_runtime_version: null,
+    runtime_version: null,
     auth_token: null,
     auth_token_hash: null,
     status: "running",

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -228,16 +228,19 @@ describe("SessionSandboxEventProcessor", () => {
     expect(h.repository.updateSandboxRuntimeVersion).toHaveBeenCalledWith("v59-opencode-1-18-18");
   });
 
-  it("leaves the recorded runtime version alone when the sandbox reports none", async () => {
+  it("clears the recorded runtime version when the sandbox reports none", async () => {
     const h = createProcessor();
 
+    // A replacement sandbox that reports nothing must not inherit its
+    // predecessor's version, or a snapshot it takes is stamped with a runtime
+    // that never produced it.
     await h.processor.processSandboxEvent({
       type: "ready",
       sandboxId: "sb-1",
       timestamp: 1000,
     });
 
-    expect(h.repository.updateSandboxRuntimeVersion).not.toHaveBeenCalled();
+    expect(h.repository.updateSandboxRuntimeVersion).toHaveBeenCalledWith(null);
   });
 
   it("persists token event and broadcasts it", async () => {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -29,6 +29,7 @@ function createProcessor() {
   const getProcessingMessage = vi.fn(() => null as { id: string } | null);
   const repository = {
     updateSandboxHeartbeat: vi.fn(),
+    updateSandboxRuntimeVersion: vi.fn(),
     getProcessingMessage,
     addSessionCost: vi.fn(),
     recordMessageCompletion: vi.fn((event: { messageId: string }, completedAt: number) => {
@@ -212,6 +213,31 @@ describe("SessionSandboxEventProcessor", () => {
     await h.processor.processSandboxEvent(event);
 
     expect(h.diffService.pinBaselines).toHaveBeenCalledWith(event);
+  });
+
+  it("records the reported runtime version on ready", async () => {
+    const h = createProcessor();
+
+    await h.processor.processSandboxEvent({
+      type: "ready",
+      sandboxId: "sb-1",
+      timestamp: 1000,
+      runtimeVersion: "v59-opencode-1-18-18",
+    });
+
+    expect(h.repository.updateSandboxRuntimeVersion).toHaveBeenCalledWith("v59-opencode-1-18-18");
+  });
+
+  it("leaves the recorded runtime version alone when the sandbox reports none", async () => {
+    const h = createProcessor();
+
+    await h.processor.processSandboxEvent({
+      type: "ready",
+      sandboxId: "sb-1",
+      timestamp: 1000,
+    });
+
+    expect(h.repository.updateSandboxRuntimeVersion).not.toHaveBeenCalled();
   });
 
   it("persists token event and broadcasts it", async () => {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -29,7 +29,7 @@ function createProcessor() {
   const getProcessingMessage = vi.fn(() => null as { id: string } | null);
   const repository = {
     updateSandboxHeartbeat: vi.fn(),
-    updateSandboxRuntimeVersion: vi.fn(),
+    recordReportedSandboxRuntimeVersion: vi.fn(),
     getProcessingMessage,
     addSessionCost: vi.fn(),
     recordMessageCompletion: vi.fn((event: { messageId: string }, completedAt: number) => {
@@ -225,22 +225,25 @@ describe("SessionSandboxEventProcessor", () => {
       runtimeVersion: "v59-opencode-1-18-18",
     });
 
-    expect(h.repository.updateSandboxRuntimeVersion).toHaveBeenCalledWith("v59-opencode-1-18-18");
+    expect(h.repository.recordReportedSandboxRuntimeVersion).toHaveBeenCalledWith(
+      "v59-opencode-1-18-18"
+    );
   });
 
-  it("clears the recorded runtime version when the sandbox reports none", async () => {
+  it("records a null runtime version when the sandbox reports none", async () => {
     const h = createProcessor();
 
     // A replacement sandbox that reports nothing must not inherit its
     // predecessor's version, or a snapshot it takes is stamped with a runtime
-    // that never produced it.
+    // that never produced it. Spawn clears the column; this write keeps it
+    // clear rather than filling it in.
     await h.processor.processSandboxEvent({
       type: "ready",
       sandboxId: "sb-1",
       timestamp: 1000,
     });
 
-    expect(h.repository.updateSandboxRuntimeVersion).toHaveBeenCalledWith(null);
+    expect(h.repository.recordReportedSandboxRuntimeVersion).toHaveBeenCalledWith(null);
   });
 
   it("persists token event and broadcasts it", async () => {

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -95,9 +95,9 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "ready") {
       this.diffService.pinBaselines(event);
-      // Always write, including null: a sandbox that reports no version must
-      // not inherit the one its predecessor recorded on this row.
-      this.sandboxRepository.updateSandboxRuntimeVersion(event.runtimeVersion ?? null);
+      // Fills the column a fresh spawn cleared; a restore has already seeded
+      // the snapshot's version, which outranks whatever this sandbox reports.
+      this.sandboxRepository.recordReportedSandboxRuntimeVersion(event.runtimeVersion ?? null);
     }
 
     const eventMessageId = "messageId" in event ? event.messageId : null;

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -95,6 +95,9 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "ready") {
       this.diffService.pinBaselines(event);
+      if (event.runtimeVersion) {
+        this.sandboxRepository.updateSandboxRuntimeVersion(event.runtimeVersion);
+      }
     }
 
     const eventMessageId = "messageId" in event ? event.messageId : null;

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -95,9 +95,9 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "ready") {
       this.diffService.pinBaselines(event);
-      if (event.runtimeVersion) {
-        this.sandboxRepository.updateSandboxRuntimeVersion(event.runtimeVersion);
-      }
+      // Always write, including null: a sandbox that reports no version must
+      // not inherit the one its predecessor recorded on this row.
+      this.sandboxRepository.updateSandboxRuntimeVersion(event.runtimeVersion ?? null);
     }
 
     const eventMessageId = "messageId" in event ? event.messageId : null;

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -140,10 +140,23 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].params).toEqual(["v59-runtime"]);
     });
 
-    it("clears the recorded version when the sandbox reports none", () => {
+    it("clears the recorded version when set to null", () => {
       repository.updateSandboxRuntimeVersion(null);
 
       expect(mock.calls[0].params).toEqual([null]);
+    });
+  });
+
+  describe("recordReportedSandboxRuntimeVersion", () => {
+    it("only fills a row with nothing recorded yet", () => {
+      repository.recordReportedSandboxRuntimeVersion("v59-runtime");
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toContain("UPDATE sandbox SET runtime_version");
+      // A restore seeds the snapshot's version first; the sandbox's own report
+      // must not overwrite it.
+      expect(mock.calls[0].query).toContain("runtime_version IS NULL");
+      expect(mock.calls[0].params).toEqual(["v59-runtime"]);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -86,6 +86,8 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].query).toContain("modal_object_id = NULL");
       expect(mock.calls[0].query).toContain("vnc_url = NULL");
       expect(mock.calls[0].query).toContain("vnc_password = NULL");
+      // A replacement sandbox must not inherit the predecessor's runtime.
+      expect(mock.calls[0].query).toContain("runtime_version = NULL");
       expect(mock.calls[0].params).toEqual(["spawning", 1000, "token-hash-123", "modal-sb-1"]);
     });
 
@@ -136,6 +138,12 @@ describe("SandboxRepository", () => {
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toContain("UPDATE sandbox SET runtime_version");
       expect(mock.calls[0].params).toEqual(["v59-runtime"]);
+    });
+
+    it("clears the recorded version when the sandbox reports none", () => {
+      repository.updateSandboxRuntimeVersion(null);
+
+      expect(mock.calls[0].params).toEqual([null]);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -113,12 +113,29 @@ describe("SandboxRepository", () => {
   });
 
   describe("updateSandboxSnapshotImageId", () => {
-    it("updates snapshot image ID for specific sandbox", () => {
-      repository.updateSandboxSnapshotImageId("sb-1", "img-123");
+    it("stamps the snapshot with the runtime that produced it", () => {
+      repository.updateSandboxSnapshotImageId("sb-1", "img-123", "v59-runtime");
 
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toContain("UPDATE sandbox SET snapshot_image_id");
-      expect(mock.calls[0].params).toEqual(["img-123", "sb-1"]);
+      expect(mock.calls[0].query).toContain("snapshot_runtime_version");
+      expect(mock.calls[0].params).toEqual(["img-123", "v59-runtime", "sb-1"]);
+    });
+
+    it("records a null runtime when the sandbox never reported one", () => {
+      repository.updateSandboxSnapshotImageId("sb-1", "img-123", null);
+
+      expect(mock.calls[0].params).toEqual(["img-123", null, "sb-1"]);
+    });
+  });
+
+  describe("updateSandboxRuntimeVersion", () => {
+    it("records the running sandbox's runtime version", () => {
+      repository.updateSandboxRuntimeVersion("v59-runtime");
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toContain("UPDATE sandbox SET runtime_version");
+      expect(mock.calls[0].params).toEqual(["v59-runtime"]);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -92,7 +92,8 @@ export class SandboxRepository {
          vnc_password = NULL,
          tunnel_urls = NULL,
          ttyd_url = NULL,
-         ttyd_token = NULL
+         ttyd_token = NULL,
+         runtime_version = NULL
        WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       data.status,
       data.createdAt,
@@ -133,8 +134,13 @@ export class SandboxRepository {
     );
   }
 
-  /** Record the SANDBOX_VERSION the running sandbox reported when it came up. */
-  updateSandboxRuntimeVersion(runtimeVersion: string): void {
+  /**
+   * Record the SANDBOX_VERSION the running sandbox reported when it came up,
+   * or null when it reported none — never leave a predecessor's version in
+   * place, or a snapshot taken by this sandbox inherits a version it did not
+   * produce.
+   */
+  updateSandboxRuntimeVersion(runtimeVersion: string | null): void {
     this.sql.exec(
       `UPDATE sandbox SET runtime_version = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       runtimeVersion

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -9,6 +9,7 @@ export interface SandboxCircuitBreakerState {
   created_at: number;
   modal_object_id: string | null;
   snapshot_image_id: string | null;
+  snapshot_runtime_version: string | null;
   spawn_failure_count: number | null;
   last_spawn_failure: number | null;
 }
@@ -52,7 +53,7 @@ export class SandboxRepository {
 
   getSandboxWithCircuitBreaker(): SandboxCircuitBreakerState | null {
     const result = this.sql.exec(
-      `SELECT status, created_at, modal_object_id, snapshot_image_id, spawn_failure_count, last_spawn_failure FROM sandbox LIMIT 1`
+      `SELECT status, created_at, modal_object_id, snapshot_image_id, snapshot_runtime_version, spawn_failure_count, last_spawn_failure FROM sandbox LIMIT 1`
     );
     const rows = this.rows<SandboxCircuitBreakerState>(result);
     return rows[0] ?? null;
@@ -119,8 +120,25 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxSnapshotImageId(sandboxId: string, imageId: string): void {
-    this.sql.exec(`UPDATE sandbox SET snapshot_image_id = ? WHERE id = ?`, imageId, sandboxId);
+  updateSandboxSnapshotImageId(
+    sandboxId: string,
+    imageId: string,
+    runtimeVersion: string | null
+  ): void {
+    this.sql.exec(
+      `UPDATE sandbox SET snapshot_image_id = ?, snapshot_runtime_version = ? WHERE id = ?`,
+      imageId,
+      runtimeVersion,
+      sandboxId
+    );
+  }
+
+  /** Record the SANDBOX_VERSION the running sandbox reported when it came up. */
+  updateSandboxRuntimeVersion(runtimeVersion: string): void {
+    this.sql.exec(
+      `UPDATE sandbox SET runtime_version = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      runtimeVersion
+    );
   }
 
   updateSandboxHeartbeat(timestamp: number): void {

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -135,14 +135,33 @@ export class SandboxRepository {
   }
 
   /**
-   * Record the SANDBOX_VERSION the running sandbox reported when it came up,
-   * or null when it reported none — never leave a predecessor's version in
-   * place, or a snapshot taken by this sandbox inherits a version it did not
-   * produce.
+   * Set the runtime version describing the sandbox's current filesystem.
+   *
+   * Used when the control plane already knows it authoritatively — restoring a
+   * snapshot puts that snapshot's runtime on disk regardless of what the
+   * provider exports into the new sandbox.
    */
   updateSandboxRuntimeVersion(runtimeVersion: string | null): void {
     this.sql.exec(
       `UPDATE sandbox SET runtime_version = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      runtimeVersion
+    );
+  }
+
+  /**
+   * Record the SANDBOX_VERSION a sandbox reported at startup, but only when
+   * nothing authoritative is on the row yet.
+   *
+   * A fresh spawn clears the column, so its report lands. A restore seeds the
+   * snapshot's version first, so a report is ignored: OpenComputer and Vercel
+   * export the *current* SANDBOX_VERSION into every sandbox they start,
+   * including ones forked from an old checkpoint, and trusting that would hand
+   * a stale filesystem a clean bill of health.
+   */
+  recordReportedSandboxRuntimeVersion(runtimeVersion: string | null): void {
+    this.sql.exec(
+      `UPDATE sandbox SET runtime_version = ?
+       WHERE runtime_version IS NULL AND id = (SELECT id FROM sandbox LIMIT 1)`,
       runtimeVersion
     );
   }

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -157,6 +157,8 @@ CREATE TABLE IF NOT EXISTS sandbox (
   modal_object_id TEXT,                             -- Legacy provider object ID (Modal object ID or Daytona handle)
   snapshot_id TEXT,
   snapshot_image_id TEXT,                           -- Modal Image ID for filesystem snapshot restoration
+  snapshot_runtime_version TEXT,                    -- SANDBOX_VERSION that produced snapshot_image_id (restore compatibility floor)
+  runtime_version TEXT,                             -- SANDBOX_VERSION reported by the running sandbox
   auth_token TEXT,                                  -- Token for sandbox to authenticate back to control plane
   auth_token_hash TEXT,                             -- SHA-256 hash of sandbox auth token (preferred)
   status TEXT DEFAULT 'pending',                    -- 'pending', 'spawning', 'connecting', 'warming', 'syncing', 'ready', 'running', 'stale', 'snapshotting', 'stopped', 'failed'
@@ -574,6 +576,14 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 43,
     description: "Persist session alarm scheduling state",
     run: SESSION_ALARM_STATE_TABLE_SQL,
+  },
+  {
+    id: 44,
+    description: "Record sandbox runtime version and stamp it on snapshots",
+    run: (sql) => {
+      runMigration(sql, `ALTER TABLE sandbox ADD COLUMN runtime_version TEXT`);
+      runMigration(sql, `ALTER TABLE sandbox ADD COLUMN snapshot_runtime_version TEXT`);
+    },
   },
 ];
 

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -150,6 +150,8 @@ export interface SandboxRow {
   modal_object_id: string | null; // Legacy column: provider object ID (Modal object ID or Daytona handle)
   snapshot_id: string | null;
   snapshot_image_id: string | null; // Modal Image ID for filesystem snapshot restoration
+  snapshot_runtime_version: string | null; // SANDBOX_VERSION that produced snapshot_image_id
+  runtime_version: string | null; // SANDBOX_VERSION reported by the running sandbox
   auth_token: string | null;
   auth_token_hash: string | null; // SHA-256 hash of sandbox auth token
   status: SandboxStatus;

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -161,6 +161,8 @@ function createSandboxRow(modalSandboxId: string): SandboxRow {
     modal_object_id: null,
     snapshot_id: null,
     snapshot_image_id: null,
+    snapshot_runtime_version: null,
+    runtime_version: null,
     auth_token: null,
     auth_token_hash: null,
     status: "ready",

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -287,10 +287,15 @@ class AgentBridge:
 
     def _build_ready_event(self) -> dict[str, Any]:
         repositories = load_repo_manifest(self.repo_manifest_path)
+        # The image bakes SANDBOX_VERSION; reporting it lets the control plane
+        # stamp snapshots with the runtime that produced them and retire the
+        # ones a later compatibility floor rules out.
+        runtime_version = os.environ.get("SANDBOX_VERSION", "")
         return {
             "type": "ready",
             "sandboxId": self.sandbox_id,
             "opencodeSessionId": self.opencode_session_id,
+            **({"runtimeVersion": runtime_version} if runtime_version else {}),
             "repositories": [
                 {
                     "position": position,

--- a/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
+++ b/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -77,7 +79,10 @@ def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path:
     bridge = _bridge()
     bridge.repo_manifest_path = _manifest(tmp_path)
 
-    assert bridge._build_ready_event() == {
+    with patch.dict(os.environ, {"SANDBOX_VERSION": ""}, clear=False):
+        event = bridge._build_ready_event()
+
+    assert event == {
         "type": "ready",
         "sandboxId": "sandbox-1",
         "opencodeSessionId": None,
@@ -90,6 +95,17 @@ def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path:
             }
         ],
     }
+
+
+def test_ready_event_reports_the_image_runtime_version(tmp_path: Path) -> None:
+    """The control plane stamps snapshots with this, so a restore can be gated on it."""
+    bridge = _bridge()
+    bridge.repo_manifest_path = _manifest(tmp_path)
+
+    with patch.dict(os.environ, {"SANDBOX_VERSION": "v59-opencode-1-18-18"}, clear=False):
+        event = bridge._build_ready_event()
+
+    assert event["runtimeVersion"] == "v59-opencode-1-18-18"
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/types/sandbox-events.ts
+++ b/packages/shared/src/types/sandbox-events.ts
@@ -55,6 +55,9 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
     // Present in essentially every session's replay history.
     type: z.literal("ready"),
     opencodeSessionId: z.string().nullable().optional(),
+    // SANDBOX_VERSION of the image this sandbox booted from. Stamped onto any
+    // snapshot it produces so a later restore can be gated on it.
+    runtimeVersion: z.string().optional(),
     repositories: z.array(sessionDiffBaselineRepositorySchema).optional(),
   }),
   messageSandboxEventBaseSchema.extend({


### PR DESCRIPTION
Closes #1429.

## Problem

`restoreFromSnapshot()` boots the stored `snapshot_image_id` with no runtime-version gate, and the id
is never cleared. A snapshot carries the whole sandbox filesystem, including the pinned agent binary,
so a session that keeps restoring keeps resurrecting the runtime that took the snapshot — a runtime
fix can never reach it.

This is the residue #1430 called out under "Not covered here". After the OpenCode message-ID
wraparound, every session whose history predated 2026-08-14 11:19:55 UTC stayed wedged even once new
sandboxes shipped 1.18.18: each follow-up prompt restored the pre-fix snapshot and re-ran 1.18.11, so
the turn loop still exited at step 0 and the run failed in ~1s with "OpenCode completed without
emitting assistant output."

Prebuilt repo images already have this protection (`MIN_COMPATIBLE_RUNTIME_VERSION` in
`image-selection.ts`); session snapshots did not.

## Change

- The bridge reports its baked `SANDBOX_VERSION` as `runtimeVersion` on the `ready` event.
- The control plane records it on the sandbox row, and `triggerSnapshot()` stamps each snapshot with
  the runtime that produced it (`sandbox.snapshot_runtime_version`), not whatever the session runs
  next — DO migration 44.
- `evaluateSpawnDecision()` gates `restore` on that stamp against `MIN_COMPATIBLE_RUNTIME_VERSION`
  and falls through to a fresh spawn otherwise, carrying a `reason` the manager logs as
  `sandbox.snapshot_rejected`.

Bumping the floor now retires stale snapshots the same way it already retires prebuilt images. No
floor bump is included here — that stays a deliberate act.

## Fail-closed behaviour, and what it costs

A snapshot with no recorded version (every snapshot taken before this lands) or an unparseable one is
treated as below the floor, matching `parseRuntimeVersionNumber`'s documented contract. That is what
unwedges the sessions stranded by the wraparound without a floor bump, but it means the first resume
of an already-snapshotted session spawns fresh and discards that sandbox's uncommitted filesystem
state. It is one spawn per session: the next snapshot carries a version and restores resume as
normal.

Providers that take snapshots (Modal, OpenComputer, Vercel) all use `v<N>-…` versions, so none of
them are affected beyond that one-time cost.

## Deliberately not covered

- **The `resume` path.** Persistent resume reuses the same filesystem and has the identical defect,
  but Daytona (`daytona-v6-…`) and E2B (`e2b-v3-vnc`) set `SANDBOX_VERSION` strings that
  `parseRuntimeVersionNumber` cannot read, and both set `supportsPersistentResume: true`. Gating
  resume on the same predicate would disable resume for them outright. Fixing that means
  normalising those version strings first; happy to do it in a follow-up if you want it.
- **A floor bump to retire the 1.18.11 images specifically.** Not needed here — unrecorded versions
  already fail closed.

## Test plan

- [x] `vitest run packages/control-plane/src/sandbox/lifecycle/` — 201 passed (new: restore below the
      floor, restore with no recorded version, restore exactly at the floor, in-memory spawn guard
      still ordered ahead of the gate, manager-level fresh-spawn-instead-of-restore)
- [x] `npm run test -w @open-inspect/control-plane` — 177 files, 2755 passed
- [x] `npm run test:integration -w @open-inspect/control-plane` — 68 files, 861 passed
- [x] `npm run typecheck -w @open-inspect/control-plane` — clean
- [x] `pytest` in `packages/sandbox-runtime` — 752 passed (new: ready event reports the runtime
      version, and omits the key when `SANDBOX_VERSION` is unset)
- [x] `eslint`, `prettier --check`, `ruff check`, `ruff format --check` — clean
- [x] `npm test` at the root — one pre-existing failure in
      `packages/web/src/hooks/use-session-rename.test.tsx`, identical on a clean tree; `mypy src`
      reports one pre-existing `github_app.py:62` error, also identical on a clean tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox snapshots now record the runtime version that created them.
  * Snapshots are restored only when compatible with the available runtime.
  * Incompatible, missing, or invalid runtime versions automatically trigger a fresh sandbox.
  * Sandbox startup events report the running runtime version when available.
  * Fresh-spawn decisions include a reason for improved visibility.

* **Bug Fixes**
  * Prevented restoration of snapshots created by outdated or retired runtimes.

* **Tests**
  * Added coverage for compatible, incompatible, missing, and invalid runtime versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->