### PR TITLE
ci: drop the obsolete workerd libc++ apt install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,9 +246,6 @@ jobs:
       - name: Build shared package
         run: npm run build -w @open-inspect/shared
 
-      - name: Install workerd runtime dependency
-        run: sudo apt-get update && sudo apt-get install -y libc++1
-
       - name: Run control-plane integration tests
         run: npm run test:integration -w @open-inspect/control-plane -- --shard=${{ matrix.shard }}
 


### PR DESCRIPTION
## Problem

`Test (control-plane integration 1/2)` and `2/2` are currently dying on the 10-minute job timeout with no test output on every run — e.g. [run 32274136465](https://github.com/ColeMurray/background-agents/actions/runs/32274136465) (both shards, `The job has exceeded the maximum execution time of 10m0s`).

The tests are not the problem. The `Install workerd runtime dependency` step is:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
...
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
2026-08-19T16:18:06Z ##[error]The operation was canceled.
```

`apt-get update` stalls for ~9 minutes: the runners' Azure mirror ignores every Ubuntu index and the `archive.ubuntu.com` fallback hangs mid-`InRelease`. Third-party repos (`packages.microsoft.com`, `dl.google.com`) fetch fine in the same step, so this is Ubuntu-archive-specific.

## Why removal rather than a retry wrapper

`libc++1` is no longer needed. The pinned `workerd` (1.20260617.1) linux-64 binary declares only three `DT_NEEDED` entries:

```
libm.so.6
libc.so.6
ld-linux-x86-64.so.2
```

(read from the ELF dynamic section of the `@cloudflare/workerd-linux-64@1.20260617.1` npm tarball — Cloudflare links libc++ statically now). The step dates from #73, when it was genuinely required.

I first tried hardening the step with bounded, retried `apt-get` calls; that run showed three consecutive 60s `apt-get update` attempts failing and confirmed the runner image does **not** ship libc++, which is what prompted checking whether the dependency still exists at all.

## Verification

Applied on a downstream fork of this repo, on the same workflow and the same `workerd` pin, with the step removed:

- both integration shards pass — 2m19s and 2m09s, versus 4m22s + timeout before
- no other native binary in the integration path links libc++; `@cloudflare/workerd-linux-64` ships only `bin/workerd`

Net effect: the shards no longer depend on Ubuntu mirror availability, and each one gets ~2 minutes faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified control-plane integration test setup by removing an unnecessary runtime dependency installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->