### PR TITLE
feat: add provider account management API

### DIFF
--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
@@ -167,6 +167,27 @@ describe("ClaimedProviderCredentialExchange", () => {
     expect(terminalFailure).not.toHaveBeenCalled();
   });
 
+  it("preserves a retry-safe refresh failure when clearing the claim also fails", async () => {
+    const failure = new ProviderRefreshError("retry", "retry_safe");
+    const { complete, exchange, providerAdapter, store } = setup(
+      adapter(vi.fn().mockRejectedValue(failure))
+    );
+    vi.mocked(store.clearSafeFailure).mockRejectedValue(new Error("D1 unavailable"));
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({ phase: "refresh", cause: failure });
+  });
+
   it.each(["ambiguous", "unauthorized"] as const)(
     "atomically fences the claim and requires reconnect after a %s refresh failure",
     async (classification) => {
@@ -247,6 +268,28 @@ describe("ClaimedProviderCredentialExchange", () => {
     expect(store.clearSafeFailure).toHaveBeenCalledWith("account-1", 3, 7, "owner-1", NOW);
   });
 
+  it("preserves a parse failure when clearing the claim also fails", async () => {
+    const { complete, exchange, providerAdapter, store } = setup();
+    const parseFailure = new Error("invalid credential");
+    vi.mocked(providerAdapter.parseCredential).mockImplementation(() => {
+      throw parseFailure;
+    });
+    vi.mocked(store.clearSafeFailure).mockRejectedValue(new Error("D1 unavailable"));
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({ phase: "parse", cause: parseFailure });
+  });
+
   it("atomically fences when the caller's completion cannot commit", async () => {
     const { exchange, providerAdapter, terminalFailure } = setup();
     const complete = vi.fn().mockResolvedValue(false);
@@ -285,6 +328,24 @@ describe("ClaimedProviderCredentialExchange", () => {
   it("reports when terminal fencing loses a failed completion claim", async () => {
     const { exchange, providerAdapter, terminalFailure } = setup();
     terminalFailure.mockResolvedValue(false);
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete: vi.fn().mockResolvedValue(false),
+      })
+    ).rejects.toMatchObject({ phase: "completion", terminalFence: "lost" });
+  });
+
+  it("preserves a failed completion when terminal fencing also fails", async () => {
+    const { exchange, providerAdapter, terminalFailure } = setup();
+    terminalFailure.mockRejectedValue(new Error("D1 unavailable"));
 
     await expect(
       exchange.run({

--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProviderCredentialState } from "../db/provider-account-credentials";
+import {
+  ModelProviderAccountAdapterRegistry,
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+} from "./model-provider-account-adapters";
+import {
+  ClaimedProviderCredentialExchange,
+  ClaimedProviderCredentialExchangeError,
+  type ClaimedProviderCredentialExchangeStore,
+} from "./claimed-provider-credential-exchange";
+
+type Credential = { refreshToken: string };
+
+const NOW = 1_000;
+
+function state(): ProviderCredentialState<Credential> {
+  return {
+    payload: { refreshToken: "stored" },
+    credentialSchemaVersion: 1,
+    credentialVersion: 3,
+    exchangeGeneration: 0,
+    exchangeState: "idle",
+    exchangeOwner: null,
+    exchangeStartedAt: null,
+    accessTokenExpiresAt: null,
+    updatedAt: 1,
+  };
+}
+
+function adapter(
+  refresh: ModelProviderAccountAdapter<Credential, never>["refresh"] = vi.fn().mockResolvedValue({
+    credential: { refreshToken: "rotated" },
+    accessToken: "access",
+    accessTokenExpiresAt: 4_000,
+  })
+): ModelProviderAccountAdapter<Credential, never> {
+  return {
+    provider: "openai",
+    credentialSchemaVersion: 1,
+    refreshBufferMs: 1,
+    parseConnectInput: vi.fn() as never,
+    connect: vi.fn() as never,
+    parseCredential: vi.fn((value) => value as Credential),
+    refresh,
+    cachedAccess: vi.fn(() => null),
+    runtimeMetadata: vi.fn(() => ({})),
+  };
+}
+
+function setup(providerAdapter = adapter()) {
+  const calls: string[] = [];
+  const complete = vi.fn(async () => {
+    calls.push("complete");
+    return true;
+  });
+  const store: ClaimedProviderCredentialExchangeStore = {
+    tryBeginExchange: vi.fn(async () => {
+      calls.push("claim");
+      return { acquired: true, generation: 7 };
+    }),
+    clearSafeFailure: vi.fn(async () => {
+      calls.push("clear");
+      return true;
+    }),
+  };
+  const terminalFailure = vi.fn(async () => {
+    calls.push("terminal");
+    return true;
+  });
+  const registry = new ModelProviderAccountAdapterRegistry([providerAdapter]);
+  const exchange = new ClaimedProviderCredentialExchange(store, terminalFailure);
+  return {
+    calls,
+    complete,
+    exchange,
+    providerAdapter: registry.get("openai")!,
+    store,
+    terminalFailure,
+  };
+}
+
+describe("ClaimedProviderCredentialExchange", () => {
+  it("claims before parsing and refresh, then dispatches one fenced completion", async () => {
+    const { calls, complete, exchange, providerAdapter } = setup();
+    vi.mocked(providerAdapter.parseCredential).mockImplementation((value) => {
+      calls.push("parse");
+      return value as Credential;
+    });
+    vi.mocked(providerAdapter.refresh).mockImplementation(async () => {
+      calls.push("refresh");
+      return {
+        credential: { refreshToken: "rotated" },
+        accessToken: "access",
+        accessTokenExpiresAt: 4_000,
+      };
+    });
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).resolves.toMatchObject({ kind: "completed", refreshed: { accessToken: "access" } });
+
+    expect(calls).toEqual(["claim", "parse", "refresh", "complete"]);
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        write: expect.objectContaining({
+          providerAccountId: "account-1",
+          expectedCredentialVersion: 3,
+          exchangeGeneration: 7,
+          exchangeOwner: "owner-1",
+          expectedAccountStatus: "active",
+          payload: { refreshToken: "rotated" },
+        }),
+      })
+    );
+  });
+
+  it("does not parse or refresh when the durable claim is unavailable", async () => {
+    const { complete, exchange, providerAdapter, store } = setup();
+    vi.mocked(store.tryBeginExchange).mockResolvedValue({ acquired: false });
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).resolves.toEqual({ kind: "claim_unavailable" });
+    expect(providerAdapter.parseCredential).not.toHaveBeenCalled();
+    expect(providerAdapter.refresh).not.toHaveBeenCalled();
+  });
+
+  it("clears the fenced claim after retry-safe refresh failure", async () => {
+    const failure = new ProviderRefreshError("retry", "retry_safe");
+    const { complete, exchange, providerAdapter, store, terminalFailure } = setup(
+      adapter(vi.fn().mockRejectedValue(failure))
+    );
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({ phase: "refresh", cause: failure });
+    expect(store.clearSafeFailure).toHaveBeenCalledWith("account-1", 3, 7, "owner-1", NOW);
+    expect(terminalFailure).not.toHaveBeenCalled();
+  });
+
+  it.each(["ambiguous", "unauthorized"] as const)(
+    "atomically fences the claim and requires reconnect after a %s refresh failure",
+    async (classification) => {
+      const failure = new ProviderRefreshError(classification, classification);
+      const { complete, exchange, providerAdapter, store, terminalFailure } = setup(
+        adapter(vi.fn().mockRejectedValue(failure))
+      );
+
+      await expect(
+        exchange.run({
+          providerAccountId: "account-1",
+          provider: "openai",
+          state: state(),
+          expectedAccountStatus: "active",
+          adapter: providerAdapter,
+          owner: "owner-1",
+          now: () => NOW,
+          complete,
+        })
+      ).rejects.toBeInstanceOf(ClaimedProviderCredentialExchangeError);
+      expect(terminalFailure).toHaveBeenCalledWith({
+        providerAccountId: "account-1",
+        credentialVersion: 3,
+        exchangeGeneration: 7,
+        exchangeOwner: "owner-1",
+        now: NOW,
+      });
+      expect(store.clearSafeFailure).not.toHaveBeenCalled();
+    }
+  );
+
+  it("clears the claim when credential parsing fails before refresh dispatch", async () => {
+    const { complete, exchange, providerAdapter, store } = setup();
+    vi.mocked(providerAdapter.parseCredential).mockImplementation(() => {
+      throw new Error("invalid credential");
+    });
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({ phase: "parse" });
+    expect(store.clearSafeFailure).toHaveBeenCalledWith("account-1", 3, 7, "owner-1", NOW);
+  });
+
+  it("atomically fences when the caller's completion cannot commit", async () => {
+    const { exchange, providerAdapter, terminalFailure } = setup();
+    const complete = vi.fn().mockResolvedValue(false);
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({ phase: "completion" });
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        write: expect.objectContaining({
+          expectedCredentialVersion: 3,
+          exchangeGeneration: 7,
+          exchangeOwner: "owner-1",
+          expectedAccountStatus: "active",
+        }),
+      })
+    );
+    expect(terminalFailure).toHaveBeenCalledWith({
+      providerAccountId: "account-1",
+      credentialVersion: 3,
+      exchangeGeneration: 7,
+      exchangeOwner: "owner-1",
+      now: NOW,
+    });
+  });
+});

--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
@@ -7,7 +7,6 @@ import {
 } from "./model-provider-account-adapters";
 import {
   ClaimedProviderCredentialExchange,
-  ClaimedProviderCredentialExchangeError,
   type ClaimedProviderCredentialExchangeStore,
 } from "./claimed-provider-credential-exchange";
 
@@ -46,6 +45,7 @@ function adapter(
     refresh,
     cachedAccess: vi.fn(() => null),
     runtimeMetadata: vi.fn(() => ({})),
+    validateExternalIdentity: vi.fn(),
   };
 }
 
@@ -186,7 +186,10 @@ describe("ClaimedProviderCredentialExchange", () => {
           now: () => NOW,
           complete,
         })
-      ).rejects.toBeInstanceOf(ClaimedProviderCredentialExchangeError);
+      ).rejects.toMatchObject({
+        phase: "refresh",
+        terminalFence: "committed",
+      });
       expect(terminalFailure).toHaveBeenCalledWith({
         providerAccountId: "account-1",
         credentialVersion: 3,
@@ -197,6 +200,31 @@ describe("ClaimedProviderCredentialExchange", () => {
       expect(store.clearSafeFailure).not.toHaveBeenCalled();
     }
   );
+
+  it("reports when terminal fencing loses the refresh claim", async () => {
+    const failure = new ProviderRefreshError("ambiguous", "ambiguous");
+    const { complete, exchange, providerAdapter, terminalFailure } = setup(
+      adapter(vi.fn().mockRejectedValue(failure))
+    );
+    terminalFailure.mockResolvedValue(false);
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete,
+      })
+    ).rejects.toMatchObject({
+      phase: "refresh",
+      cause: failure,
+      terminalFence: "lost",
+    });
+  });
 
   it("clears the claim when credential parsing fails before refresh dispatch", async () => {
     const { complete, exchange, providerAdapter, store } = setup();
@@ -252,5 +280,23 @@ describe("ClaimedProviderCredentialExchange", () => {
       exchangeOwner: "owner-1",
       now: NOW,
     });
+  });
+
+  it("reports when terminal fencing loses a failed completion claim", async () => {
+    const { exchange, providerAdapter, terminalFailure } = setup();
+    terminalFailure.mockResolvedValue(false);
+
+    await expect(
+      exchange.run({
+        providerAccountId: "account-1",
+        provider: "openai",
+        state: state(),
+        expectedAccountStatus: "active",
+        adapter: providerAdapter,
+        owner: "owner-1",
+        now: () => NOW,
+        complete: vi.fn().mockResolvedValue(false),
+      })
+    ).rejects.toMatchObject({ phase: "completion", terminalFence: "lost" });
   });
 });

--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
@@ -1,0 +1,147 @@
+import type {
+  CompleteProviderExchangeInput,
+  ProviderCredentialExchangeAccountStatus,
+  ProviderCredentialState,
+  ProviderCredentialStore,
+} from "../db/provider-account-credentials";
+import type { FenceProviderCredentialExchangeInput } from "../db/model-provider-account-atomic-writer";
+import type { ModelProviderId } from "../model-provider-accounts/provider-auth-contracts";
+import {
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+  type ProviderRefreshResult,
+} from "./model-provider-account-adapters";
+
+type ErasedProviderAccountAdapter = ModelProviderAccountAdapter<unknown, unknown>;
+
+export type ClaimedProviderCredentialExchangeStore = Pick<
+  ProviderCredentialStore,
+  "tryBeginExchange" | "clearSafeFailure"
+>;
+
+type ProviderCredentialTerminalFailure = (
+  input: FenceProviderCredentialExchangeInput
+) => Promise<boolean>;
+
+interface CompletionContext {
+  write: CompleteProviderExchangeInput & { now: number };
+  refreshed: ProviderRefreshResult<unknown>;
+}
+
+export interface ClaimedProviderCredentialExchangeRequest {
+  providerAccountId: string;
+  provider: ModelProviderId;
+  state: ProviderCredentialState;
+  expectedAccountStatus: ProviderCredentialExchangeAccountStatus;
+  adapter: ErasedProviderAccountAdapter;
+  owner: string;
+  now: () => number;
+  complete: (context: CompletionContext) => Promise<boolean>;
+}
+
+export type ClaimedProviderCredentialExchangeResult =
+  | { kind: "claim_unavailable" }
+  | {
+      kind: "completed";
+      refreshed: ProviderRefreshResult<unknown>;
+    };
+
+export class ClaimedProviderCredentialExchangeError extends Error {
+  constructor(
+    readonly phase: "parse" | "refresh" | "completion",
+    cause: unknown
+  ) {
+    super(`Provider credential exchange failed during ${phase}`, { cause });
+  }
+}
+
+export class ClaimedProviderCredentialExchange {
+  constructor(
+    private readonly store: ClaimedProviderCredentialExchangeStore,
+    private readonly terminalFailure: ProviderCredentialTerminalFailure
+  ) {}
+
+  async run(
+    request: ClaimedProviderCredentialExchangeRequest
+  ): Promise<ClaimedProviderCredentialExchangeResult> {
+    const claim = await this.store.tryBeginExchange(
+      request.providerAccountId,
+      request.state.credentialVersion,
+      request.owner,
+      request.expectedAccountStatus,
+      request.now()
+    );
+    if (!claim.acquired) return { kind: "claim_unavailable" };
+
+    let credential: unknown;
+    try {
+      credential = request.adapter.parseCredential(
+        request.state.payload,
+        request.state.credentialSchemaVersion
+      );
+    } catch (cause) {
+      await this.clear(request, claim.generation);
+      throw new ClaimedProviderCredentialExchangeError("parse", cause);
+    }
+
+    let refreshed: ProviderRefreshResult<unknown>;
+    try {
+      refreshed = await request.adapter.refresh(credential, request.now());
+    } catch (cause) {
+      if (cause instanceof ProviderRefreshError && cause.classification === "retry_safe") {
+        await this.clear(request, claim.generation);
+      } else {
+        await this.failTerminally(request, claim.generation);
+      }
+      throw new ClaimedProviderCredentialExchangeError("refresh", cause);
+    }
+
+    const write: CompleteProviderExchangeInput & { now: number } = {
+      providerAccountId: request.providerAccountId,
+      provider: request.provider,
+      credentialSchemaVersion: request.adapter.credentialSchemaVersion,
+      payload: refreshed.credential,
+      accessTokenExpiresAt: refreshed.accessTokenExpiresAt,
+      expectedCredentialVersion: request.state.credentialVersion,
+      exchangeGeneration: claim.generation,
+      exchangeOwner: request.owner,
+      expectedAccountStatus: request.expectedAccountStatus,
+      now: request.now(),
+    };
+    try {
+      const completed = await request.complete({ write, refreshed });
+      if (!completed) {
+        throw new ClaimedProviderCredentialExchangeError(
+          "completion",
+          new Error("Provider credential exchange lost its durable claim")
+        );
+      }
+    } catch (cause) {
+      await this.failTerminally(request, claim.generation);
+      if (cause instanceof ClaimedProviderCredentialExchangeError) throw cause;
+      throw new ClaimedProviderCredentialExchangeError("completion", cause);
+    }
+
+    return { kind: "completed", refreshed };
+  }
+
+  private clear(request: ClaimedProviderCredentialExchangeRequest, generation: number) {
+    return this.store.clearSafeFailure(
+      request.providerAccountId,
+      request.state.credentialVersion,
+      generation,
+      request.owner,
+      request.now()
+    );
+  }
+
+  private failTerminally(request: ClaimedProviderCredentialExchangeRequest, generation: number) {
+    return this.terminalFailure({
+      providerAccountId: request.providerAccountId,
+      credentialVersion: request.state.credentialVersion,
+      exchangeGeneration: generation,
+      exchangeOwner: request.owner,
+      now: request.now(),
+    });
+  }
+}

--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
@@ -49,7 +49,8 @@ export type ClaimedProviderCredentialExchangeResult =
 export class ClaimedProviderCredentialExchangeError extends Error {
   constructor(
     readonly phase: "parse" | "refresh" | "completion",
-    cause: unknown
+    cause: unknown,
+    readonly terminalFence: "not_attempted" | "committed" | "lost" = "not_attempted"
   ) {
     super(`Provider credential exchange failed during ${phase}`, { cause });
   }
@@ -90,10 +91,14 @@ export class ClaimedProviderCredentialExchange {
     } catch (cause) {
       if (cause instanceof ProviderRefreshError && cause.classification === "retry_safe") {
         await this.clear(request, claim.generation);
-      } else {
-        await this.failTerminally(request, claim.generation);
+        throw new ClaimedProviderCredentialExchangeError("refresh", cause);
       }
-      throw new ClaimedProviderCredentialExchangeError("refresh", cause);
+      const fenced = await this.failTerminally(request, claim.generation);
+      throw new ClaimedProviderCredentialExchangeError(
+        "refresh",
+        cause,
+        fenced ? "committed" : "lost"
+      );
     }
 
     const write: CompleteProviderExchangeInput & { now: number } = {
@@ -117,9 +122,14 @@ export class ClaimedProviderCredentialExchange {
         );
       }
     } catch (cause) {
-      await this.failTerminally(request, claim.generation);
-      if (cause instanceof ClaimedProviderCredentialExchangeError) throw cause;
-      throw new ClaimedProviderCredentialExchangeError("completion", cause);
+      const fenced = await this.failTerminally(request, claim.generation);
+      const underlying =
+        cause instanceof ClaimedProviderCredentialExchangeError ? cause.cause : cause;
+      throw new ClaimedProviderCredentialExchangeError(
+        "completion",
+        underlying,
+        fenced ? "committed" : "lost"
+      );
     }
 
     return { kind: "completed", refreshed };

--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.ts
@@ -81,7 +81,7 @@ export class ClaimedProviderCredentialExchange {
         request.state.credentialSchemaVersion
       );
     } catch (cause) {
-      await this.clear(request, claim.generation);
+      await this.clearAfterFailure(request, claim.generation);
       throw new ClaimedProviderCredentialExchangeError("parse", cause);
     }
 
@@ -90,7 +90,7 @@ export class ClaimedProviderCredentialExchange {
       refreshed = await request.adapter.refresh(credential, request.now());
     } catch (cause) {
       if (cause instanceof ProviderRefreshError && cause.classification === "retry_safe") {
-        await this.clear(request, claim.generation);
+        await this.clearAfterFailure(request, claim.generation);
         throw new ClaimedProviderCredentialExchangeError("refresh", cause);
       }
       const fenced = await this.failTerminally(request, claim.generation);
@@ -145,13 +145,34 @@ export class ClaimedProviderCredentialExchange {
     );
   }
 
-  private failTerminally(request: ClaimedProviderCredentialExchangeRequest, generation: number) {
-    return this.terminalFailure({
-      providerAccountId: request.providerAccountId,
-      credentialVersion: request.state.credentialVersion,
-      exchangeGeneration: generation,
-      exchangeOwner: request.owner,
-      now: request.now(),
-    });
+  private async clearAfterFailure(
+    request: ClaimedProviderCredentialExchangeRequest,
+    generation: number
+  ): Promise<void> {
+    try {
+      await this.clear(request, generation);
+    } catch {
+      // The original classified failure is authoritative. A failed clear leaves
+      // the durable lease in flight until the stale-exchange path reconciles it.
+    }
+  }
+
+  private async failTerminally(
+    request: ClaimedProviderCredentialExchangeRequest,
+    generation: number
+  ): Promise<boolean> {
+    try {
+      return await this.terminalFailure({
+        providerAccountId: request.providerAccountId,
+        credentialVersion: request.state.credentialVersion,
+        exchangeGeneration: generation,
+        exchangeOwner: request.owner,
+        now: request.now(),
+      });
+    } catch {
+      // Preserve the original exchange failure and force the caller through
+      // authoritative reconciliation when terminal fencing cannot be observed.
+      return false;
+    }
   }
 }

--- a/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { OpenAIModelProviderAccountAdapter } from "./model-provider-account-openai-adapter";
 import { XaiModelProviderAccountAdapter } from "./model-provider-account-xai-adapter";
 import { modelProviderAccountAdapterRegistry } from "./model-provider-account-default-adapters";
+import { ProviderIdentityError } from "./model-provider-account-adapters";
+import type { ModelProviderAccountAdapterRegistry } from "./model-provider-account-adapters";
 import { OpenAITokenRefreshError } from "./openai";
 
 describe("model provider account adapters", () => {
@@ -14,6 +16,39 @@ describe("model provider account adapters", () => {
     );
   });
 
+  it("requires complete adapters at the registry boundary", () => {
+    type RegistryAdapters = ConstructorParameters<typeof ModelProviderAccountAdapterRegistry>[0];
+    expectTypeOf<
+      readonly [{ readonly provider: "openai" }]
+    >().not.toMatchTypeOf<RegistryAdapters>();
+  });
+
+  it("uses the canonical provider request schemas", () => {
+    const openai = new OpenAIModelProviderAccountAdapter();
+    const xai = new XaiModelProviderAccountAdapter();
+
+    expect(() =>
+      openai.parseConnectInput({
+        provider: "openai",
+        refreshToken: "refresh-token",
+      })
+    ).toThrow();
+    expect(() =>
+      openai.parseConnectInput({
+        provider: "openai",
+        refreshToken: "x".repeat(65_537),
+        accountId: "acct-1",
+      })
+    ).toThrow();
+    expect(() =>
+      xai.parseConnectInput({
+        provider: "xai",
+        refreshToken: "refresh-token",
+        accountId: "unexpected",
+      })
+    ).toThrow();
+  });
+
   it("requires OpenAI to return a replacement refresh token", async () => {
     const adapter = new OpenAIModelProviderAccountAdapter(
       vi.fn().mockResolvedValue({ id_token: "id", access_token: "access" })
@@ -24,7 +59,7 @@ describe("model provider account adapters", () => {
     });
   });
 
-  it("does not use a claimed OpenAI account ID when trusted extraction fails", async () => {
+  it("rejects a claimed OpenAI account ID when trusted extraction fails", async () => {
     const adapter = new OpenAIModelProviderAccountAdapter(
       vi.fn().mockResolvedValue({
         id_token: "not-a-jwt",
@@ -33,10 +68,13 @@ describe("model provider account adapters", () => {
       })
     );
 
-    const result = await adapter.connect({ refreshToken: "old", accountId: "claimed-account" });
-
-    expect(result.externalAccountId).toBeUndefined();
-    expect(result.credential).not.toHaveProperty("accountId");
+    await expect(
+      adapter.connect({
+        provider: "openai",
+        refreshToken: "old",
+        accountId: "claimed-account",
+      })
+    ).rejects.toBeInstanceOf(ProviderIdentityError);
   });
 
   it("distinguishes a definitive OpenAI invalid_grant from an ambiguous failure", async () => {

--- a/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpenAIModelProviderAccountAdapter } from "./model-provider-account-openai-adapter";
+import { XaiModelProviderAccountAdapter } from "./model-provider-account-xai-adapter";
+import { modelProviderAccountAdapterRegistry } from "./model-provider-account-default-adapters";
+import { OpenAITokenRefreshError } from "./openai";
+
+describe("model provider account adapters", () => {
+  it("registers OpenAI and xAI", () => {
+    expect(modelProviderAccountAdapterRegistry.get("openai")).toBeInstanceOf(
+      OpenAIModelProviderAccountAdapter
+    );
+    expect(modelProviderAccountAdapterRegistry.get("xai")).toBeInstanceOf(
+      XaiModelProviderAccountAdapter
+    );
+  });
+
+  it("requires OpenAI to return a replacement refresh token", async () => {
+    const adapter = new OpenAIModelProviderAccountAdapter(
+      vi.fn().mockResolvedValue({ id_token: "id", access_token: "access" })
+    );
+
+    await expect(adapter.refresh({ refreshToken: "old" })).rejects.toMatchObject({
+      classification: "ambiguous",
+    });
+  });
+
+  it("does not use a claimed OpenAI account ID when trusted extraction fails", async () => {
+    const adapter = new OpenAIModelProviderAccountAdapter(
+      vi.fn().mockResolvedValue({
+        id_token: "not-a-jwt",
+        access_token: "access",
+        refresh_token: "replacement",
+      })
+    );
+
+    const result = await adapter.connect({ refreshToken: "old", accountId: "claimed-account" });
+
+    expect(result.externalAccountId).toBeUndefined();
+    expect(result.credential).not.toHaveProperty("accountId");
+  });
+
+  it("distinguishes a definitive OpenAI invalid_grant from an ambiguous failure", async () => {
+    const unauthorized = new OpenAIModelProviderAccountAdapter(
+      vi
+        .fn()
+        .mockRejectedValue(
+          new OpenAITokenRefreshError("failed", 400, JSON.stringify({ error: "invalid_grant" }))
+        )
+    );
+    const ambiguous = new OpenAIModelProviderAccountAdapter(
+      vi.fn().mockRejectedValue(new OpenAITokenRefreshError("failed", 500, "upstream failure"))
+    );
+
+    await expect(unauthorized.refresh({ refreshToken: "old" })).rejects.toMatchObject({
+      classification: "unauthorized",
+    });
+    await expect(ambiguous.refresh({ refreshToken: "old" })).rejects.toMatchObject({
+      classification: "ambiguous",
+    });
+  });
+
+  it("retains the xAI refresh token when replacement is omitted", async () => {
+    const adapter = new XaiModelProviderAccountAdapter(
+      vi.fn().mockResolvedValue({ access_token: "access", expires_in: 120 })
+    );
+
+    const result = await adapter.refresh({ refreshToken: "old" }, 1_000);
+
+    expect(result.credential).toEqual({
+      refreshToken: "old",
+      accessToken: "access",
+      accessTokenExpiresAt: 121_000,
+    });
+  });
+
+  it("uses a bounded default expiry when a provider omits expiry", async () => {
+    const adapter = new XaiModelProviderAccountAdapter(
+      vi.fn().mockResolvedValue({ access_token: "access" })
+    );
+
+    const result = await adapter.refresh({ refreshToken: "refresh" }, 10_000);
+
+    expect(result.accessTokenExpiresAt).toBe(3_610_000);
+    expect(result.credential.accessTokenExpiresAt).toBe(3_610_000);
+  });
+
+  it("only exposes allowlisted runtime metadata", () => {
+    const openai = new OpenAIModelProviderAccountAdapter();
+    const xai = new XaiModelProviderAccountAdapter();
+
+    expect(
+      openai.runtimeMetadata(
+        { refreshToken: "secret", accountId: "credential-account" },
+        "stored-account"
+      )
+    ).toEqual({ accountId: "credential-account" });
+    expect(openai.runtimeMetadata({ refreshToken: "secret" }, "stored-account")).toEqual({
+      accountId: "stored-account",
+    });
+    expect(xai.runtimeMetadata({ refreshToken: "secret" }, null)).toEqual({});
+  });
+});

--- a/packages/control-plane/src/auth/model-provider-account-adapters.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.ts
@@ -1,0 +1,76 @@
+import type { ModelProviderId } from "../model-provider-accounts/provider-auth-contracts";
+
+export const DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+export const DEFAULT_PROVIDER_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export interface ProviderConnectionResult<TCredential> {
+  credential: TCredential;
+  externalAccountId?: string;
+  accessTokenExpiresAt?: number;
+}
+
+export interface ProviderRefreshResult<TCredential> {
+  credential: TCredential;
+  accessToken: string;
+  accessTokenExpiresAt: number;
+  externalAccountId?: string;
+}
+
+export interface CachedProviderAccess {
+  accessToken: string;
+  accessTokenExpiresAt: number;
+}
+
+export interface ModelProviderAccountAdapter<TCredential, TConnectInput> {
+  readonly provider: ModelProviderId;
+  readonly credentialSchemaVersion: number;
+  readonly refreshBufferMs: number;
+  parseConnectInput(input: unknown): TConnectInput;
+  connect(input: TConnectInput): Promise<ProviderConnectionResult<TCredential>>;
+  parseCredential(payload: unknown, schemaVersion: number): TCredential;
+  refresh(credential: TCredential, now?: number): Promise<ProviderRefreshResult<TCredential>>;
+  cachedAccess(credential: TCredential): CachedProviderAccess | null;
+  runtimeMetadata(
+    credential: TCredential,
+    externalAccountId: string | null
+  ): Record<string, string>;
+}
+
+export type ProviderRefreshFailureClassification = "unauthorized" | "ambiguous" | "retry_safe";
+
+export class ProviderRefreshError extends Error {
+  constructor(
+    message: string,
+    readonly classification: ProviderRefreshFailureClassification,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+  }
+}
+
+export class ProviderCredentialError extends Error {}
+
+type ErasedAdapter = ModelProviderAccountAdapter<unknown, unknown>;
+
+export class ModelProviderAccountAdapterRegistry {
+  private readonly adapters = new Map<ModelProviderId, ErasedAdapter>();
+
+  constructor(adapters: readonly { readonly provider: ModelProviderId }[]) {
+    for (const adapter of adapters as readonly ErasedAdapter[]) {
+      if (this.adapters.has(adapter.provider)) {
+        throw new Error(`Duplicate model provider account adapter: ${adapter.provider}`);
+      }
+      this.adapters.set(adapter.provider, adapter);
+    }
+  }
+
+  get(provider: ModelProviderId): ErasedAdapter | undefined {
+    return this.adapters.get(provider);
+  }
+
+  require(provider: ModelProviderId): ErasedAdapter {
+    const adapter = this.get(provider);
+    if (!adapter) throw new Error(`Model provider account adapter unavailable: ${provider}`);
+    return adapter;
+  }
+}

--- a/packages/control-plane/src/auth/model-provider-account-adapters.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.ts
@@ -34,6 +34,7 @@ export interface ModelProviderAccountAdapter<TCredential, TConnectInput> {
     credential: TCredential,
     externalAccountId: string | null
   ): Record<string, string>;
+  validateExternalIdentity(actual: string | undefined, expected: string | null): void;
 }
 
 export type ProviderRefreshFailureClassification = "unauthorized" | "ambiguous" | "retry_safe";
@@ -49,14 +50,15 @@ export class ProviderRefreshError extends Error {
 }
 
 export class ProviderCredentialError extends Error {}
+export class ProviderIdentityError extends Error {}
 
 type ErasedAdapter = ModelProviderAccountAdapter<unknown, unknown>;
 
 export class ModelProviderAccountAdapterRegistry {
   private readonly adapters = new Map<ModelProviderId, ErasedAdapter>();
 
-  constructor(adapters: readonly { readonly provider: ModelProviderId }[]) {
-    for (const adapter of adapters as readonly ErasedAdapter[]) {
+  constructor(adapters: readonly ErasedAdapter[]) {
+    for (const adapter of adapters) {
       if (this.adapters.has(adapter.provider)) {
         throw new Error(`Duplicate model provider account adapter: ${adapter.provider}`);
       }

--- a/packages/control-plane/src/auth/model-provider-account-broker.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+import type { ProviderCredentialState } from "../db/provider-account-credentials";
+import {
+  ModelProviderAccountAdapterRegistry,
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+} from "./model-provider-account-adapters";
+import {
+  ModelProviderAccountBroker,
+  ModelProviderAccountBrokerError,
+  type ModelProviderAccountBrokerStores,
+} from "./model-provider-account-broker";
+
+type Credential = {
+  refreshToken: string;
+  accessToken?: string;
+  accessTokenExpiresAt?: number;
+};
+
+const NOW = 1_000_000;
+
+function account(overrides: Partial<ModelProviderAccount> = {}): ModelProviderAccount {
+  return {
+    id: "account-1",
+    provider: "openai",
+    displayName: "Primary",
+    externalAccountId: "external-1",
+    status: "active",
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function state(
+  overrides: Partial<ProviderCredentialState<Credential>> = {}
+): ProviderCredentialState<Credential> {
+  return {
+    payload: { refreshToken: "refresh" },
+    credentialSchemaVersion: 1,
+    credentialVersion: 1,
+    exchangeGeneration: 0,
+    exchangeState: "idle",
+    exchangeOwner: null,
+    exchangeStartedAt: null,
+    accessTokenExpiresAt: null,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function adapter(
+  refresh: ModelProviderAccountAdapter<Credential, never>["refresh"] = vi.fn()
+): ModelProviderAccountAdapter<Credential, never> {
+  return {
+    provider: "openai",
+    credentialSchemaVersion: 1,
+    refreshBufferMs: 300_000,
+    parseConnectInput: vi.fn() as never,
+    connect: vi.fn() as never,
+    parseCredential: (value, version) => {
+      if (version !== 1 || !value || typeof value !== "object" || !("refreshToken" in value)) {
+        throw new Error("invalid credential");
+      }
+      return value as Credential;
+    },
+    refresh,
+    cachedAccess: (credential) =>
+      credential.accessToken && credential.accessTokenExpiresAt
+        ? {
+            accessToken: credential.accessToken,
+            accessTokenExpiresAt: credential.accessTokenExpiresAt,
+          }
+        : null,
+    runtimeMetadata: (_credential, externalAccountId): Record<string, string> =>
+      externalAccountId ? { accountId: externalAccountId } : {},
+  };
+}
+
+function setup(
+  options: {
+    providerAccount?: ModelProviderAccount | null;
+    credentialStates?: Array<ProviderCredentialState<Credential> | null>;
+    refresh?: ModelProviderAccountAdapter<Credential, never>["refresh"];
+    tryBegin?: ModelProviderAccountBrokerStores["credentials"]["tryBeginExchange"];
+    complete?: ModelProviderAccountBrokerStores["credentials"]["completeExchange"];
+    terminalFailure?: ModelProviderAccountBrokerStores["atomicWriter"]["fenceExchangeAndRequireReconnect"];
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    useDefaultPolling?: boolean;
+    exchangeTimeoutMs?: number;
+    pollDelayMs?: number;
+  } = {}
+) {
+  const states = [...(options.credentialStates ?? [state()])];
+  let lastState = states.at(-1) ?? null;
+  const stores: ModelProviderAccountBrokerStores = {
+    accounts: {
+      getById: vi
+        .fn()
+        .mockResolvedValue(
+          options.providerAccount === undefined ? account() : options.providerAccount
+        ),
+      touchLastUsed: vi.fn().mockResolvedValue(true),
+    },
+    credentials: {
+      readCredentialState: vi.fn().mockImplementation(async () => {
+        if (states.length) lastState = states.shift() ?? null;
+        return lastState;
+      }),
+      tryBeginExchange:
+        options.tryBegin ?? vi.fn().mockResolvedValue({ acquired: true, generation: 1 }),
+      completeExchange: options.complete ?? vi.fn().mockResolvedValue(true),
+      clearSafeFailure: vi.fn().mockResolvedValue(true),
+    },
+    atomicWriter: {
+      fenceExchangeAndRequireReconnect: options.terminalFailure ?? vi.fn().mockResolvedValue(true),
+    },
+  };
+  const refresh =
+    options.refresh ??
+    vi.fn().mockResolvedValue({
+      credential: {
+        refreshToken: "replacement",
+        accessToken: "new-access",
+        accessTokenExpiresAt: NOW + 3_600_000,
+      },
+      accessToken: "new-access",
+      accessTokenExpiresAt: NOW + 3_600_000,
+      externalAccountId: "external-1",
+    });
+  const registry = new ModelProviderAccountAdapterRegistry([adapter(refresh)]);
+  const broker = new ModelProviderAccountBroker(stores, registry, {
+    now: options.now ?? (() => NOW),
+    sleep: options.sleep ?? (() => Promise.resolve()),
+    createOwner: () => "owner-1",
+    ...(options.useDefaultPolling ? {} : { maxPollAttempts: 3 }),
+    exchangeTimeoutMs: options.exchangeTimeoutMs ?? 10_000,
+    pollDelayMs: options.pollDelayMs,
+  });
+  return { broker, stores, refresh };
+}
+
+describe("ModelProviderAccountBroker", () => {
+  it("reuses a valid cached access token", async () => {
+    const { broker, stores, refresh } = setup({
+      credentialStates: [
+        state({
+          payload: {
+            refreshToken: "refresh",
+            accessToken: "cached",
+            accessTokenExpiresAt: NOW + 600_000,
+          },
+          accessTokenExpiresAt: NOW + 600_000,
+        }),
+      ],
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).resolves.toMatchObject({
+      accessToken: "cached",
+      providerMetadata: { accountId: "external-1" },
+    });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(stores.credentials.tryBeginExchange).not.toHaveBeenCalled();
+  });
+
+  it("coalesces refreshes for the same account and credential version locally", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const refresh = vi.fn().mockImplementation(async () => {
+      await gate;
+      return {
+        credential: {
+          refreshToken: "next",
+          accessToken: "access",
+          accessTokenExpiresAt: NOW + 600_000,
+        },
+        accessToken: "access",
+        accessTokenExpiresAt: NOW + 600_000,
+        externalAccountId: "external-1",
+      };
+    });
+    const { broker, stores } = setup({ refresh, credentialStates: [state(), state()] });
+
+    const first = broker.getAccess("account-1", "openai");
+    const second = broker.getAccess("account-1", "openai");
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+    release();
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(stores.credentials.tryBeginExchange).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls when another process owns the durable claim and returns its token", async () => {
+    const winner = state({
+      payload: { refreshToken: "next", accessToken: "winner", accessTokenExpiresAt: NOW + 600_000 },
+      credentialVersion: 2,
+      accessTokenExpiresAt: NOW + 600_000,
+    });
+    const { broker, refresh, stores } = setup({
+      credentialStates: [state(), winner],
+      tryBegin: vi.fn().mockResolvedValue({ acquired: false }),
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).resolves.toMatchObject({
+      accessToken: "winner",
+    });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(stores.credentials.readCredentialState).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for a cross-isolate exchange through its claim deadline", async () => {
+    const inFlight = state({
+      exchangeState: "in_flight",
+      exchangeGeneration: 1,
+      exchangeOwner: "other-isolate",
+      exchangeStartedAt: NOW,
+    });
+    const winner = state({
+      payload: { refreshToken: "next", accessToken: "winner", accessTokenExpiresAt: NOW + 600_000 },
+      credentialVersion: 2,
+      exchangeGeneration: 1,
+      accessTokenExpiresAt: NOW + 600_000,
+    });
+    const { broker, stores } = setup({
+      credentialStates: [inFlight, inFlight, inFlight, inFlight, inFlight, inFlight, winner],
+      useDefaultPolling: true,
+      exchangeTimeoutMs: 1_000,
+      pollDelayMs: 100,
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).resolves.toMatchObject({
+      accessToken: "winner",
+    });
+    expect(stores.credentials.readCredentialState).toHaveBeenCalledTimes(7);
+  });
+
+  it("fences a stale exchange before marking reconnect required", async () => {
+    const calls: string[] = [];
+    const terminalFailure = vi.fn().mockImplementation(async () => {
+      calls.push("terminal");
+      return true;
+    });
+    const { broker } = setup({
+      credentialStates: [
+        state({
+          exchangeState: "in_flight",
+          exchangeGeneration: 4,
+          exchangeOwner: "dead-owner",
+          exchangeStartedAt: NOW - 20_000,
+        }),
+      ],
+      terminalFailure,
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+      code: "reconnect_required",
+    });
+    expect(terminalFailure).toHaveBeenCalledWith({
+      providerAccountId: "account-1",
+      credentialVersion: 1,
+      exchangeGeneration: 4,
+      exchangeOwner: "dead-owner",
+      now: NOW,
+    });
+    expect(calls).toEqual(["terminal"]);
+  });
+
+  it("uses a late completion when stale fencing loses the race", async () => {
+    const stale = state({
+      exchangeState: "in_flight",
+      exchangeGeneration: 4,
+      exchangeOwner: "slow-owner",
+      exchangeStartedAt: NOW - 20_000,
+    });
+    const completed = state({
+      payload: { refreshToken: "next", accessToken: "late", accessTokenExpiresAt: NOW + 600_000 },
+      credentialVersion: 2,
+      exchangeGeneration: 4,
+      accessTokenExpiresAt: NOW + 600_000,
+    });
+    const { broker, refresh } = setup({
+      credentialStates: [stale, completed],
+      terminalFailure: vi.fn().mockResolvedValue(false),
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).resolves.toMatchObject({
+      accessToken: "late",
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it.each(["unauthorized", "ambiguous"] as const)(
+    "marks %s refresh failures reconnect required",
+    async (classification) => {
+      const terminalFailure = vi.fn().mockResolvedValue(true);
+      const { broker } = setup({
+        refresh: vi.fn().mockRejectedValue(new ProviderRefreshError("failed", classification)),
+        terminalFailure,
+      });
+
+      await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+        code: "reconnect_required",
+      });
+      expect(terminalFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ providerAccountId: "account-1", credentialVersion: 1 })
+      );
+    }
+  );
+
+  it.each([undefined, "different-account"])(
+    "rejects refreshed OpenAI identity %s before persisting rotated credentials",
+    async (externalAccountId) => {
+      const terminalFailure = vi.fn().mockResolvedValue(true);
+      const { broker, stores } = setup({
+        refresh: vi.fn().mockResolvedValue({
+          credential: {
+            refreshToken: "replacement",
+            accessToken: "new-access",
+            accessTokenExpiresAt: NOW + 3_600_000,
+          },
+          accessToken: "new-access",
+          accessTokenExpiresAt: NOW + 3_600_000,
+          externalAccountId,
+        }),
+        terminalFailure,
+      });
+
+      await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+        code: "reconnect_required",
+      });
+      expect(stores.credentials.completeExchange).not.toHaveBeenCalled();
+      expect(terminalFailure).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("never returns a token when completion persistence fails", async () => {
+    const terminalFailure = vi.fn().mockResolvedValue(true);
+    const { broker } = setup({
+      complete: vi.fn().mockRejectedValue(new Error("D1 unavailable")),
+      terminalFailure,
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+      code: "reconnect_required",
+    });
+    expect(terminalFailure).toHaveBeenCalled();
+  });
+
+  it.each([
+    [account({ status: "disabled" }), "account_inactive"],
+    [account({ status: "reconnect_required" }), "account_inactive"],
+    [account({ archivedAt: NOW }), "account_archived"],
+    [account({ provider: "xai" }), "provider_mismatch"],
+  ] as const)(
+    "rejects inactive, archived, and mismatched accounts",
+    async (providerAccount, code) => {
+      const { broker, stores } = setup({ providerAccount });
+
+      await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({ code });
+      expect(stores.credentials.readCredentialState).not.toHaveBeenCalled();
+    }
+  );
+
+  it("does not fall back to a different account", async () => {
+    const { broker, stores } = setup({ providerAccount: null });
+
+    await expect(broker.getAccess("missing", "openai")).rejects.toBeInstanceOf(
+      ModelProviderAccountBrokerError
+    );
+    expect(stores.accounts.getById).toHaveBeenCalledTimes(1);
+    expect(stores.credentials.readCredentialState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/auth/model-provider-account-broker.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.test.ts
@@ -302,6 +302,27 @@ describe("ModelProviderAccountBroker", () => {
     expect(refresh).not.toHaveBeenCalled();
   });
 
+  it("observes reconnect state when another caller wins stale fencing", async () => {
+    const stale = state({
+      exchangeState: "in_flight",
+      exchangeGeneration: 4,
+      exchangeOwner: "slow-owner",
+      exchangeStartedAt: NOW - 20_000,
+    });
+    const { broker, stores, refresh } = setup({
+      credentialStates: [stale],
+      terminalFailure: vi.fn().mockResolvedValue(false),
+    });
+    vi.mocked(stores.accounts.getById)
+      .mockResolvedValueOnce(account())
+      .mockResolvedValue(account({ status: "reconnect_required" }));
+
+    await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+      code: "reconnect_required",
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
   it.each(["unauthorized", "ambiguous"] as const)(
     "marks %s refresh failures reconnect required",
     async (classification) => {

--- a/packages/control-plane/src/auth/model-provider-account-broker.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.test.ts
@@ -3,6 +3,7 @@ import type { ModelProviderAccount } from "../db/model-provider-accounts";
 import type { ProviderCredentialState } from "../db/provider-account-credentials";
 import {
   ModelProviderAccountAdapterRegistry,
+  ProviderIdentityError,
   ProviderRefreshError,
   type ModelProviderAccountAdapter,
 } from "./model-provider-account-adapters";
@@ -80,6 +81,11 @@ function adapter(
         : null,
     runtimeMetadata: (_credential, externalAccountId): Record<string, string> =>
       externalAccountId ? { accountId: externalAccountId } : {},
+    validateExternalIdentity: (actual, expected) => {
+      if (!actual || !expected || actual !== expected) {
+        throw new ProviderIdentityError("OpenAI account identity did not match");
+      }
+    },
   };
 }
 
@@ -313,6 +319,54 @@ describe("ModelProviderAccountBroker", () => {
       );
     }
   );
+
+  it("uses the authoritative lifecycle when terminal fencing loses its claim", async () => {
+    const { broker, stores } = setup({
+      refresh: vi.fn().mockRejectedValue(new ProviderRefreshError("failed", "ambiguous")),
+      terminalFailure: vi.fn().mockResolvedValue(false),
+    });
+    vi.mocked(stores.accounts.getById)
+      .mockResolvedValueOnce(account())
+      .mockResolvedValue(account({ status: "disabled" }));
+
+    await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+      code: "account_inactive",
+    });
+    expect(stores.credentials.readCredentialState).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a concurrent credential replacement when terminal fencing loses its claim", async () => {
+    const completed = state({
+      payload: {
+        refreshToken: "next",
+        accessToken: "winner",
+        accessTokenExpiresAt: NOW + 600_000,
+      },
+      credentialVersion: 2,
+      accessTokenExpiresAt: NOW + 600_000,
+    });
+    const { broker } = setup({
+      credentialStates: [state(), completed],
+      refresh: vi.fn().mockRejectedValue(new ProviderRefreshError("failed", "ambiguous")),
+      terminalFailure: vi.fn().mockResolvedValue(false),
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).resolves.toMatchObject({
+      accessToken: "winner",
+    });
+  });
+
+  it("does not claim reconnect when terminal fencing loses an unchanged claim", async () => {
+    const { broker } = setup({
+      credentialStates: [state(), state()],
+      refresh: vi.fn().mockRejectedValue(new ProviderRefreshError("failed", "ambiguous")),
+      terminalFailure: vi.fn().mockResolvedValue(false),
+    });
+
+    await expect(broker.getAccess("account-1", "openai")).rejects.toMatchObject({
+      code: "exchange_busy",
+    });
+  });
 
   it.each([undefined, "different-account"])(
     "rejects refreshed OpenAI identity %s before persisting rotated credentials",

--- a/packages/control-plane/src/auth/model-provider-account-broker.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.ts
@@ -156,6 +156,7 @@ export class ModelProviderAccountBroker {
           if (fenced) {
             throw this.reconnectError(account.provider, "A credential exchange became stale");
           }
+          return this.reconcileLostTerminalFence(account, adapter, state);
         }
         await this.sleep(this.pollDelayMs);
         state = await this.readState(account.id, account.provider);

--- a/packages/control-plane/src/auth/model-provider-account-broker.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.ts
@@ -17,6 +17,7 @@ import {
   ClaimedProviderCredentialExchange,
   ClaimedProviderCredentialExchangeError,
 } from "./claimed-provider-credential-exchange";
+import { providerAccountIneligibility } from "../model-provider-accounts/account-lifecycle-policy";
 
 type ErasedProviderAccountAdapter = ModelProviderAccountAdapter<unknown, unknown>;
 
@@ -171,7 +172,10 @@ export class ModelProviderAccountBroker {
           owner: this.createOwner(),
           now: this.now,
           complete: ({ write, refreshed }) => {
-            this.assertRefreshIdentity(account, refreshed.externalAccountId);
+            adapter.validateExternalIdentity(
+              refreshed.externalAccountId,
+              account.externalAccountId
+            );
             return this.stores.credentials.completeExchange(write);
           },
         });
@@ -204,6 +208,9 @@ export class ModelProviderAccountBroker {
             `${account.provider} credential refresh failed safely`,
             { cause: error.cause }
           );
+        }
+        if (error.terminalFence === "lost") {
+          return this.reconcileLostTerminalFence(account, adapter, state);
         }
         const reread = await this.readState(account.id, account.provider);
         if (reread.credentialVersion !== state.credentialVersion) {
@@ -269,28 +276,56 @@ export class ModelProviderAccountBroker {
         `Provider account does not belong to ${expectedProvider}`
       );
     }
-    if (account.archivedAt !== null) {
+    const ineligibility = providerAccountIneligibility(account, "active_use");
+    if (ineligibility === "archived") {
       throw new ModelProviderAccountBrokerError("account_archived", "Provider account is archived");
     }
-    if (account.status !== "active") {
+    if (ineligibility) {
       throw new ModelProviderAccountBrokerError(
         "account_inactive",
         `Provider account is ${account.status}`
       );
     }
-    return { ...account, status: account.status };
+    return { ...account, status: "active" };
   }
 
-  private assertRefreshIdentity(
-    account: ModelProviderAccount,
-    refreshedExternalAccountId: string | undefined
-  ): void {
-    if (
-      account.provider === "openai" &&
-      (!account.externalAccountId || refreshedExternalAccountId !== account.externalAccountId)
-    ) {
-      throw new Error("Refreshed OpenAI credential identity does not match the provider account");
+  private async reconcileLostTerminalFence(
+    previousAccount: ModelProviderAccount,
+    adapter: ErasedProviderAccountAdapter,
+    previousState: ProviderCredentialState
+  ): Promise<ProviderAccess> {
+    const account = await this.stores.accounts.getById(previousAccount.id);
+    if (!account) {
+      throw new ModelProviderAccountBrokerError("account_not_found", "Provider account not found");
     }
+    if (account.provider !== previousAccount.provider) {
+      throw new ModelProviderAccountBrokerError(
+        "provider_mismatch",
+        `Provider account does not belong to ${previousAccount.provider}`
+      );
+    }
+    const ineligibility = providerAccountIneligibility(account, "active_use");
+    if (ineligibility === "archived") {
+      throw new ModelProviderAccountBrokerError("account_archived", "Provider account is archived");
+    }
+    if (ineligibility === "reconnect_required") {
+      throw this.reconnectError(account.provider, "Credential refresh requires reconnection");
+    }
+    if (ineligibility) {
+      throw new ModelProviderAccountBrokerError(
+        "account_inactive",
+        `Provider account is ${account.status}`
+      );
+    }
+
+    const state = await this.readState(account.id, account.provider);
+    if (state.credentialVersion !== previousState.credentialVersion) {
+      return this.accessFromConcurrentUpdate(account, adapter, state);
+    }
+    throw new ModelProviderAccountBrokerError(
+      "exchange_busy",
+      `${account.provider} credential exchange lost its durable claim`
+    );
   }
 
   private async readState(

--- a/packages/control-plane/src/auth/model-provider-account-broker.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.ts
@@ -1,0 +1,344 @@
+import type {
+  ModelProviderAccount,
+  ModelProviderAccountStore,
+} from "../db/model-provider-accounts";
+import type {
+  ProviderCredentialState,
+  ProviderCredentialStore,
+} from "../db/provider-account-credentials";
+import type { ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
+import type { ModelProviderId } from "../model-provider-accounts/provider-auth-contracts";
+import { ProviderRefreshError } from "./model-provider-account-adapters";
+import type {
+  ModelProviderAccountAdapter,
+  ModelProviderAccountAdapterRegistry,
+} from "./model-provider-account-adapters";
+import {
+  ClaimedProviderCredentialExchange,
+  ClaimedProviderCredentialExchangeError,
+} from "./claimed-provider-credential-exchange";
+
+type ErasedProviderAccountAdapter = ModelProviderAccountAdapter<unknown, unknown>;
+
+const LAST_USED_WRITE_INTERVAL_MS = 15 * 60 * 1000;
+const DEFAULT_EXCHANGE_TIMEOUT_MS = 15_000;
+const DEFAULT_POLL_DELAY_MS = 100;
+
+export interface ProviderAccess {
+  accessToken: string;
+  expiresIn?: number;
+  externalAccountId?: string;
+  providerMetadata?: Record<string, string>;
+}
+
+export type ModelProviderAccountBrokerErrorCode =
+  | "account_not_found"
+  | "account_inactive"
+  | "account_archived"
+  | "provider_mismatch"
+  | "provider_unavailable"
+  | "credential_not_found"
+  | "credential_invalid"
+  | "exchange_busy"
+  | "reconnect_required"
+  | "upstream_retry_safe";
+
+export class ModelProviderAccountBrokerError extends Error {
+  constructor(
+    readonly code: ModelProviderAccountBrokerErrorCode,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+  }
+}
+
+export interface ModelProviderAccountBrokerStores {
+  accounts: Pick<ModelProviderAccountStore, "getById" | "touchLastUsed">;
+  credentials: Pick<
+    ProviderCredentialStore,
+    "readCredentialState" | "tryBeginExchange" | "completeExchange" | "clearSafeFailure"
+  >;
+  atomicWriter: Pick<ModelProviderAccountAtomicWriter, "fenceExchangeAndRequireReconnect">;
+}
+
+interface BrokerOptions {
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  createOwner?: () => string;
+  exchangeTimeoutMs?: number;
+  maxPollAttempts?: number;
+  pollDelayMs?: number;
+}
+
+export class ModelProviderAccountBroker {
+  private readonly inFlight = new Map<string, Promise<ProviderAccess>>();
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly createOwner: () => string;
+  private readonly exchangeTimeoutMs: number;
+  private readonly maxPollAttempts: number;
+  private readonly pollDelayMs: number;
+  private readonly exchange: ClaimedProviderCredentialExchange;
+
+  constructor(
+    private readonly stores: ModelProviderAccountBrokerStores,
+    private readonly registry: ModelProviderAccountAdapterRegistry,
+    options: BrokerOptions = {}
+  ) {
+    this.now = options.now ?? Date.now;
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.createOwner = options.createOwner ?? (() => crypto.randomUUID());
+    this.exchangeTimeoutMs = options.exchangeTimeoutMs ?? DEFAULT_EXCHANGE_TIMEOUT_MS;
+    this.pollDelayMs = options.pollDelayMs ?? DEFAULT_POLL_DELAY_MS;
+    this.maxPollAttempts =
+      options.maxPollAttempts ?? Math.ceil(this.exchangeTimeoutMs / this.pollDelayMs) + 1;
+    this.exchange = new ClaimedProviderCredentialExchange(
+      stores.credentials,
+      stores.atomicWriter.fenceExchangeAndRequireReconnect.bind(stores.atomicWriter)
+    );
+  }
+
+  async getAccess(accountId: string, expectedProvider: ModelProviderId): Promise<ProviderAccess> {
+    const account = await this.requireUsableAccount(accountId, expectedProvider);
+    const adapter = this.registry.get(expectedProvider);
+    if (!adapter) {
+      throw new ModelProviderAccountBrokerError(
+        "provider_unavailable",
+        `Provider account adapter unavailable for ${expectedProvider}`
+      );
+    }
+    const state = await this.readState(accountId, expectedProvider);
+    const credential = this.parseCredential(adapter, state);
+    const cached = adapter.cachedAccess(credential);
+    if (cached && cached.accessTokenExpiresAt - this.now() > adapter.refreshBufferMs) {
+      await this.touchLastUsed(account);
+      return this.toAccess(account, adapter, credential, cached);
+    }
+
+    const key = `${accountId}:${state.credentialVersion}`;
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+    const promise = this.refreshWithClaim(account, adapter, state).finally(() => {
+      if (this.inFlight.get(key) === promise) this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, promise);
+    return promise;
+  }
+
+  private async refreshWithClaim(
+    account: ModelProviderAccount & { status: "active" },
+    adapter: ErasedProviderAccountAdapter,
+    initialState: ProviderCredentialState
+  ): Promise<ProviderAccess> {
+    let state = initialState;
+    for (let attempt = 0; attempt < this.maxPollAttempts; attempt++) {
+      const credential = this.parseCredential(adapter, state);
+      const cached = adapter.cachedAccess(credential);
+      if (cached && cached.accessTokenExpiresAt - this.now() > adapter.refreshBufferMs) {
+        await this.touchLastUsed(account);
+        return this.toAccess(account, adapter, credential, cached);
+      }
+
+      if (state.exchangeState === "in_flight") {
+        const stale =
+          state.exchangeStartedAt === null ||
+          this.now() - state.exchangeStartedAt >= this.exchangeTimeoutMs;
+        if (stale) {
+          const fenced = await this.stores.atomicWriter.fenceExchangeAndRequireReconnect({
+            providerAccountId: account.id,
+            credentialVersion: state.credentialVersion,
+            exchangeGeneration: state.exchangeGeneration,
+            exchangeOwner: state.exchangeOwner ?? "",
+            now: this.now(),
+          });
+          if (fenced) {
+            throw this.reconnectError(account.provider, "A credential exchange became stale");
+          }
+        }
+        await this.sleep(this.pollDelayMs);
+        state = await this.readState(account.id, account.provider);
+        continue;
+      }
+
+      try {
+        const result = await this.exchange.run({
+          providerAccountId: account.id,
+          provider: account.provider,
+          state,
+          expectedAccountStatus: account.status,
+          adapter,
+          owner: this.createOwner(),
+          now: this.now,
+          complete: ({ write, refreshed }) => {
+            this.assertRefreshIdentity(account, refreshed.externalAccountId);
+            return this.stores.credentials.completeExchange(write);
+          },
+        });
+        if (result.kind === "claim_unavailable") {
+          await this.sleep(this.pollDelayMs);
+          state = await this.readState(account.id, account.provider);
+          continue;
+        }
+        await this.touchLastUsed(account);
+        return this.toAccess(account, adapter, result.refreshed.credential, {
+          accessToken: result.refreshed.accessToken,
+          accessTokenExpiresAt: result.refreshed.accessTokenExpiresAt,
+        });
+      } catch (error) {
+        if (!(error instanceof ClaimedProviderCredentialExchangeError)) throw error;
+        if (error.phase === "parse") {
+          throw new ModelProviderAccountBrokerError(
+            "credential_invalid",
+            `Stored ${adapter.provider} credential is invalid`,
+            { cause: error.cause }
+          );
+        }
+        if (
+          error.phase === "refresh" &&
+          error.cause instanceof ProviderRefreshError &&
+          error.cause.classification === "retry_safe"
+        ) {
+          throw new ModelProviderAccountBrokerError(
+            "upstream_retry_safe",
+            `${account.provider} credential refresh failed safely`,
+            { cause: error.cause }
+          );
+        }
+        const reread = await this.readState(account.id, account.provider);
+        if (reread.credentialVersion !== state.credentialVersion) {
+          return this.accessFromConcurrentUpdate(account, adapter, reread);
+        }
+        throw this.reconnectError(
+          account.provider,
+          error.phase === "completion"
+            ? "Refreshed credentials could not be persisted"
+            : "Credential refresh requires reconnection",
+          error.cause
+        );
+      }
+    }
+    throw new ModelProviderAccountBrokerError(
+      "exchange_busy",
+      `${account.provider} credential exchange did not complete`
+    );
+  }
+
+  private accessFromConcurrentUpdate(
+    account: ModelProviderAccount,
+    adapter: ErasedProviderAccountAdapter,
+    state: ProviderCredentialState
+  ): ProviderAccess {
+    const credential = this.parseCredential(adapter, state);
+    const cached = adapter.cachedAccess(credential);
+    if (!cached || cached.accessTokenExpiresAt - this.now() <= adapter.refreshBufferMs) {
+      throw this.reconnectError(
+        account.provider,
+        "Concurrent credential replacement has no usable access token"
+      );
+    }
+    return this.toAccess(account, adapter, credential, cached);
+  }
+
+  private parseCredential(
+    adapter: ErasedProviderAccountAdapter,
+    state: ProviderCredentialState
+  ): unknown {
+    try {
+      return adapter.parseCredential(state.payload, state.credentialSchemaVersion);
+    } catch (error) {
+      throw new ModelProviderAccountBrokerError(
+        "credential_invalid",
+        `Stored ${adapter.provider} credential is invalid`,
+        { cause: error }
+      );
+    }
+  }
+
+  private async requireUsableAccount(
+    accountId: string,
+    expectedProvider: ModelProviderId
+  ): Promise<ModelProviderAccount & { status: "active" }> {
+    const account = await this.stores.accounts.getById(accountId);
+    if (!account) {
+      throw new ModelProviderAccountBrokerError("account_not_found", "Provider account not found");
+    }
+    if (account.provider !== expectedProvider) {
+      throw new ModelProviderAccountBrokerError(
+        "provider_mismatch",
+        `Provider account does not belong to ${expectedProvider}`
+      );
+    }
+    if (account.archivedAt !== null) {
+      throw new ModelProviderAccountBrokerError("account_archived", "Provider account is archived");
+    }
+    if (account.status !== "active") {
+      throw new ModelProviderAccountBrokerError(
+        "account_inactive",
+        `Provider account is ${account.status}`
+      );
+    }
+    return { ...account, status: account.status };
+  }
+
+  private assertRefreshIdentity(
+    account: ModelProviderAccount,
+    refreshedExternalAccountId: string | undefined
+  ): void {
+    if (
+      account.provider === "openai" &&
+      (!account.externalAccountId || refreshedExternalAccountId !== account.externalAccountId)
+    ) {
+      throw new Error("Refreshed OpenAI credential identity does not match the provider account");
+    }
+  }
+
+  private async readState(
+    accountId: string,
+    provider: ModelProviderId
+  ): Promise<ProviderCredentialState> {
+    const state = await this.stores.credentials.readCredentialState(accountId, provider);
+    if (!state) {
+      throw new ModelProviderAccountBrokerError(
+        "credential_not_found",
+        "Provider account credential not found"
+      );
+    }
+    return state;
+  }
+
+  private toAccess(
+    account: ModelProviderAccount,
+    adapter: ErasedProviderAccountAdapter,
+    credential: unknown,
+    cached: { accessToken: string; accessTokenExpiresAt: number }
+  ): ProviderAccess {
+    const expiresIn = Math.max(0, Math.floor((cached.accessTokenExpiresAt - this.now()) / 1000));
+    return {
+      accessToken: cached.accessToken,
+      expiresIn,
+      ...(account.externalAccountId ? { externalAccountId: account.externalAccountId } : {}),
+      providerMetadata: adapter.runtimeMetadata(credential, account.externalAccountId),
+    };
+  }
+
+  private async touchLastUsed(account: ModelProviderAccount): Promise<void> {
+    try {
+      await this.stores.accounts.touchLastUsed(
+        account.id,
+        this.now() - LAST_USED_WRITE_INTERVAL_MS,
+        this.now()
+      );
+    } catch {
+      // Usage attribution must not invalidate already-persisted authentication state.
+    }
+  }
+
+  private reconnectError(provider: ModelProviderId, message: string, cause?: unknown) {
+    return new ModelProviderAccountBrokerError(
+      "reconnect_required",
+      `${provider}: ${message}`,
+      cause === undefined ? undefined : { cause }
+    );
+  }
+}

--- a/packages/control-plane/src/auth/model-provider-account-default-adapters.ts
+++ b/packages/control-plane/src/auth/model-provider-account-default-adapters.ts
@@ -1,0 +1,8 @@
+import { ModelProviderAccountAdapterRegistry } from "./model-provider-account-adapters";
+import { OpenAIModelProviderAccountAdapter } from "./model-provider-account-openai-adapter";
+import { XaiModelProviderAccountAdapter } from "./model-provider-account-xai-adapter";
+
+export const modelProviderAccountAdapterRegistry = new ModelProviderAccountAdapterRegistry([
+  new OpenAIModelProviderAccountAdapter(),
+  new XaiModelProviderAccountAdapter(),
+]);

--- a/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
+import {
+  connectOpenAIModelProviderAccountRequestSchema,
+  reconnectOpenAIModelProviderAccountRequestSchema,
+  type ConnectModelProviderAccountRequest,
+  type ReconnectModelProviderAccountRequest,
+} from "@open-inspect/shared/types/provider-accounts";
 import { extractOpenAIAccountId, refreshOpenAIToken, OpenAITokenRefreshError } from "./openai";
 import {
   DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS,
   DEFAULT_PROVIDER_REFRESH_BUFFER_MS,
   ProviderCredentialError,
+  ProviderIdentityError,
   ProviderRefreshError,
   type ModelProviderAccountAdapter,
   type ProviderConnectionResult,
@@ -16,13 +23,15 @@ const credentialSchema = z.object({
   accessTokenExpiresAt: z.number().int().positive().optional(),
   accountId: z.string().min(1).optional(),
 });
-const connectInputSchema = z.object({
-  refreshToken: z.string().min(1),
-  accountId: z.string().min(1).optional(),
-});
+const connectInputSchema = z.union([
+  connectOpenAIModelProviderAccountRequestSchema,
+  reconnectOpenAIModelProviderAccountRequestSchema,
+]);
 
 export type OpenAIProviderCredential = z.infer<typeof credentialSchema>;
-export type OpenAIProviderConnectInput = z.infer<typeof connectInputSchema>;
+export type OpenAIProviderConnectInput =
+  | Extract<ConnectModelProviderAccountRequest, { provider: "openai" }>
+  | Extract<ReconnectModelProviderAccountRequest, { provider: "openai" }>;
 
 type RefreshOpenAI = typeof refreshOpenAIToken;
 
@@ -54,6 +63,7 @@ export class OpenAIModelProviderAccountAdapter implements ModelProviderAccountAd
     input: OpenAIProviderConnectInput
   ): Promise<ProviderConnectionResult<OpenAIProviderCredential>> {
     const result = await this.refresh({ refreshToken: input.refreshToken });
+    this.validateExternalIdentity(result.externalAccountId, input.accountId);
     return {
       credential: result.credential,
       externalAccountId: result.externalAccountId,
@@ -126,5 +136,14 @@ export class OpenAIModelProviderAccountAdapter implements ModelProviderAccountAd
   ): Record<string, string> {
     const accountId = credential.accountId ?? externalAccountId;
     return accountId ? { accountId } : {};
+  }
+
+  validateExternalIdentity(actual: string | undefined, expected: string | null): void {
+    if (!actual) {
+      throw new ProviderIdentityError("OpenAI account identity could not be verified");
+    }
+    if (!expected || actual !== expected) {
+      throw new ProviderIdentityError("OpenAI account identity did not match");
+    }
   }
 }

--- a/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import { extractOpenAIAccountId, refreshOpenAIToken, OpenAITokenRefreshError } from "./openai";
+import {
+  DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS,
+  DEFAULT_PROVIDER_REFRESH_BUFFER_MS,
+  ProviderCredentialError,
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+  type ProviderConnectionResult,
+  type ProviderRefreshResult,
+} from "./model-provider-account-adapters";
+
+const credentialSchema = z.object({
+  refreshToken: z.string().min(1),
+  accessToken: z.string().min(1).optional(),
+  accessTokenExpiresAt: z.number().int().positive().optional(),
+  accountId: z.string().min(1).optional(),
+});
+const connectInputSchema = z.object({
+  refreshToken: z.string().min(1),
+  accountId: z.string().min(1).optional(),
+});
+
+export type OpenAIProviderCredential = z.infer<typeof credentialSchema>;
+export type OpenAIProviderConnectInput = z.infer<typeof connectInputSchema>;
+
+type RefreshOpenAI = typeof refreshOpenAIToken;
+
+function isUnauthorized(error: OpenAITokenRefreshError): boolean {
+  if (error.status === 401) return true;
+  try {
+    const body: unknown = JSON.parse(error.body);
+    return !!body && typeof body === "object" && "error" in body && body.error === "invalid_grant";
+  } catch {
+    return false;
+  }
+}
+
+export class OpenAIModelProviderAccountAdapter implements ModelProviderAccountAdapter<
+  OpenAIProviderCredential,
+  OpenAIProviderConnectInput
+> {
+  readonly provider = "openai" as const;
+  readonly credentialSchemaVersion = 1;
+  readonly refreshBufferMs = DEFAULT_PROVIDER_REFRESH_BUFFER_MS;
+
+  constructor(private readonly refreshToken: RefreshOpenAI = refreshOpenAIToken) {}
+
+  parseConnectInput(input: unknown): OpenAIProviderConnectInput {
+    return connectInputSchema.parse(input);
+  }
+
+  async connect(
+    input: OpenAIProviderConnectInput
+  ): Promise<ProviderConnectionResult<OpenAIProviderCredential>> {
+    const result = await this.refresh({ refreshToken: input.refreshToken });
+    return {
+      credential: result.credential,
+      externalAccountId: result.externalAccountId,
+      accessTokenExpiresAt: result.accessTokenExpiresAt,
+    };
+  }
+
+  parseCredential(payload: unknown, schemaVersion: number): OpenAIProviderCredential {
+    if (schemaVersion !== this.credentialSchemaVersion) {
+      throw new ProviderCredentialError(
+        `Unsupported OpenAI credential schema version: ${schemaVersion}`
+      );
+    }
+    const result = credentialSchema.safeParse(payload);
+    if (!result.success) throw new ProviderCredentialError("Invalid OpenAI provider credential");
+    return result.data;
+  }
+
+  async refresh(
+    credential: OpenAIProviderCredential,
+    now = Date.now()
+  ): Promise<ProviderRefreshResult<OpenAIProviderCredential>> {
+    try {
+      const tokens = await this.refreshToken(credential.refreshToken);
+      if (!tokens.refresh_token) {
+        throw new ProviderRefreshError(
+          "OpenAI refresh did not return a replacement refresh token",
+          "ambiguous"
+        );
+      }
+      const accessTokenExpiresAt =
+        now + (tokens.expires_in ?? DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS / 1000) * 1000;
+      const accountId = extractOpenAIAccountId(tokens);
+      return {
+        credential: {
+          refreshToken: tokens.refresh_token,
+          accessToken: tokens.access_token,
+          accessTokenExpiresAt,
+          ...(accountId ? { accountId } : {}),
+        },
+        accessToken: tokens.access_token,
+        accessTokenExpiresAt,
+        externalAccountId: accountId,
+      };
+    } catch (error) {
+      if (error instanceof ProviderRefreshError) throw error;
+      if (error instanceof OpenAITokenRefreshError && isUnauthorized(error)) {
+        throw new ProviderRefreshError("OpenAI refresh was unauthorized", "unauthorized", {
+          cause: error,
+        });
+      }
+      throw new ProviderRefreshError("OpenAI refresh outcome was ambiguous", "ambiguous", {
+        cause: error,
+      });
+    }
+  }
+
+  cachedAccess(credential: OpenAIProviderCredential) {
+    return credential.accessToken && credential.accessTokenExpiresAt
+      ? {
+          accessToken: credential.accessToken,
+          accessTokenExpiresAt: credential.accessTokenExpiresAt,
+        }
+      : null;
+  }
+
+  runtimeMetadata(
+    credential: OpenAIProviderCredential,
+    externalAccountId: string | null
+  ): Record<string, string> {
+    const accountId = credential.accountId ?? externalAccountId;
+    return accountId ? { accountId } : {};
+  }
+}

--- a/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
+import {
+  connectXaiModelProviderAccountRequestSchema,
+  reconnectXaiModelProviderAccountRequestSchema,
+  type ConnectModelProviderAccountRequest,
+  type ReconnectModelProviderAccountRequest,
+} from "@open-inspect/shared/types/provider-accounts";
 import { refreshXaiToken, XaiTokenRefreshError } from "./xai";
 import {
   DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS,
   DEFAULT_PROVIDER_REFRESH_BUFFER_MS,
   ProviderCredentialError,
+  ProviderIdentityError,
   ProviderRefreshError,
   type ModelProviderAccountAdapter,
   type ProviderConnectionResult,
@@ -15,10 +22,15 @@ const credentialSchema = z.object({
   accessToken: z.string().min(1).optional(),
   accessTokenExpiresAt: z.number().int().positive().optional(),
 });
-const connectInputSchema = z.object({ refreshToken: z.string().min(1) });
+const connectInputSchema = z.union([
+  connectXaiModelProviderAccountRequestSchema,
+  reconnectXaiModelProviderAccountRequestSchema,
+]);
 
 export type XaiProviderCredential = z.infer<typeof credentialSchema>;
-export type XaiProviderConnectInput = z.infer<typeof connectInputSchema>;
+export type XaiProviderConnectInput =
+  | Extract<ConnectModelProviderAccountRequest, { provider: "xai" }>
+  | Extract<ReconnectModelProviderAccountRequest, { provider: "xai" }>;
 
 type RefreshXai = typeof refreshXaiToken;
 
@@ -100,5 +112,11 @@ export class XaiModelProviderAccountAdapter implements ModelProviderAccountAdapt
 
   runtimeMetadata(_credential: XaiProviderCredential, _externalAccountId: string | null) {
     return {};
+  }
+
+  validateExternalIdentity(actual: string | undefined, expected: string | null): void {
+    if (actual && expected && actual !== expected) {
+      throw new ProviderIdentityError("xAI account identity did not match");
+    }
   }
 }

--- a/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import { refreshXaiToken, XaiTokenRefreshError } from "./xai";
+import {
+  DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS,
+  DEFAULT_PROVIDER_REFRESH_BUFFER_MS,
+  ProviderCredentialError,
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+  type ProviderConnectionResult,
+  type ProviderRefreshResult,
+} from "./model-provider-account-adapters";
+
+const credentialSchema = z.object({
+  refreshToken: z.string().min(1),
+  accessToken: z.string().min(1).optional(),
+  accessTokenExpiresAt: z.number().int().positive().optional(),
+});
+const connectInputSchema = z.object({ refreshToken: z.string().min(1) });
+
+export type XaiProviderCredential = z.infer<typeof credentialSchema>;
+export type XaiProviderConnectInput = z.infer<typeof connectInputSchema>;
+
+type RefreshXai = typeof refreshXaiToken;
+
+export class XaiModelProviderAccountAdapter implements ModelProviderAccountAdapter<
+  XaiProviderCredential,
+  XaiProviderConnectInput
+> {
+  readonly provider = "xai" as const;
+  readonly credentialSchemaVersion = 1;
+  readonly refreshBufferMs = DEFAULT_PROVIDER_REFRESH_BUFFER_MS;
+
+  constructor(private readonly refreshToken: RefreshXai = refreshXaiToken) {}
+
+  parseConnectInput(input: unknown): XaiProviderConnectInput {
+    return connectInputSchema.parse(input);
+  }
+
+  async connect(
+    input: XaiProviderConnectInput
+  ): Promise<ProviderConnectionResult<XaiProviderCredential>> {
+    const result = await this.refresh({ refreshToken: input.refreshToken });
+    return {
+      credential: result.credential,
+      accessTokenExpiresAt: result.accessTokenExpiresAt,
+    };
+  }
+
+  parseCredential(payload: unknown, schemaVersion: number): XaiProviderCredential {
+    if (schemaVersion !== this.credentialSchemaVersion) {
+      throw new ProviderCredentialError(
+        `Unsupported xAI credential schema version: ${schemaVersion}`
+      );
+    }
+    const result = credentialSchema.safeParse(payload);
+    if (!result.success) throw new ProviderCredentialError("Invalid xAI provider credential");
+    return result.data;
+  }
+
+  async refresh(
+    credential: XaiProviderCredential,
+    now = Date.now()
+  ): Promise<ProviderRefreshResult<XaiProviderCredential>> {
+    try {
+      const tokens = await this.refreshToken(credential.refreshToken);
+      const accessTokenExpiresAt =
+        now + (tokens.expires_in ?? DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS / 1000) * 1000;
+      return {
+        credential: {
+          refreshToken: tokens.refresh_token ?? credential.refreshToken,
+          accessToken: tokens.access_token,
+          accessTokenExpiresAt,
+        },
+        accessToken: tokens.access_token,
+        accessTokenExpiresAt,
+      };
+    } catch (error) {
+      if (error instanceof XaiTokenRefreshError) {
+        const unauthorized = error.reason === "invalid_grant" || error.reason === "unauthorized";
+        throw new ProviderRefreshError(
+          unauthorized ? "xAI refresh was unauthorized" : "xAI refresh outcome was ambiguous",
+          unauthorized ? "unauthorized" : "ambiguous",
+          { cause: error }
+        );
+      }
+      throw new ProviderRefreshError("xAI refresh outcome was ambiguous", "ambiguous", {
+        cause: error,
+      });
+    }
+  }
+
+  cachedAccess(credential: XaiProviderCredential) {
+    return credential.accessToken && credential.accessTokenExpiresAt
+      ? {
+          accessToken: credential.accessToken,
+          accessTokenExpiresAt: credential.accessTokenExpiresAt,
+        }
+      : null;
+  }
+
+  runtimeMetadata(_credential: XaiProviderCredential, _externalAccountId: string | null) {
+    return {};
+  }
+}

--- a/packages/control-plane/src/auth/openai.ts
+++ b/packages/control-plane/src/auth/openai.ts
@@ -3,10 +3,10 @@
  */
 
 import { z } from "zod";
+import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
 
 const OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const OPENAI_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
 const openAITokenResponseSchema = z.object({
   id_token: z.string(),
@@ -33,7 +33,7 @@ export class OpenAITokenRefreshError extends Error {
 export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAITokenResponse> {
   const response = await fetch(OPENAI_TOKEN_URL, {
     method: "POST",
-    signal: AbortSignal.timeout(OPENAI_TOKEN_REQUEST_TIMEOUT_MS),
+    signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
     },

--- a/packages/control-plane/src/auth/xai.ts
+++ b/packages/control-plane/src/auth/xai.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
+import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
 
 const XAI_TOKEN_URL = "https://auth.x.ai/oauth2/token";
 const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
-const XAI_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
 const xaiTokenResponseSchema = z.object({
   access_token: z.string().min(1),
@@ -44,7 +44,7 @@ function classifyRefreshError(status: number, body: string): XaiTokenRefreshErro
 export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenResponse> {
   const response = await fetch(XAI_TOKEN_URL, {
     method: "POST",
-    signal: AbortSignal.timeout(XAI_TOKEN_REQUEST_TIMEOUT_MS),
+    signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       Accept: "application/json",

--- a/packages/control-plane/src/db/model-provider-account-atomic-writer.ts
+++ b/packages/control-plane/src/db/model-provider-account-atomic-writer.ts
@@ -149,8 +149,9 @@ export class D1ModelProviderAccountAtomicWriter implements ModelProviderAccountA
              AND exchange_generation = ? AND exchange_owner = ? AND exchange_state = 'in_flight'
              AND EXISTS (
                SELECT 1 FROM model_provider_accounts
-               WHERE id = provider_account_id AND status = 'reconnect_required'
-                 AND archived_at IS NULL
+               WHERE model_provider_accounts.id = model_provider_account_credentials.provider_account_id
+                 AND model_provider_accounts.status = 'reconnect_required'
+                 AND model_provider_accounts.archived_at IS NULL
              )`
         )
         .bind(

--- a/packages/control-plane/src/db/model-provider-account-atomic-writer.ts
+++ b/packages/control-plane/src/db/model-provider-account-atomic-writer.ts
@@ -129,11 +129,8 @@ export class D1ModelProviderAccountAtomicWriter implements ModelProviderAccountA
       this.db
         .prepare(
           `UPDATE model_provider_accounts
-            SET status = CASE WHEN status = 'active' THEN 'reconnect_required' ELSE status END,
-                updated_by = CASE WHEN status = 'active' THEN NULL ELSE updated_by END,
-                updated_at = CASE WHEN status = 'active' THEN ? ELSE updated_at END
-            WHERE id = ? AND archived_at IS NULL
-              AND status IN ('active', 'disabled', 'reconnect_required')
+            SET status = 'reconnect_required', updated_by = NULL, updated_at = ?
+            WHERE id = ? AND archived_at IS NULL AND status = 'active'
               AND EXISTS (${leaseGuard})`
         )
         .bind(
@@ -152,7 +149,8 @@ export class D1ModelProviderAccountAtomicWriter implements ModelProviderAccountA
              AND exchange_generation = ? AND exchange_owner = ? AND exchange_state = 'in_flight'
              AND EXISTS (
                SELECT 1 FROM model_provider_accounts
-               WHERE id = provider_account_id AND archived_at IS NULL
+               WHERE id = provider_account_id AND status = 'reconnect_required'
+                 AND archived_at IS NULL
              )`
         )
         .bind(

--- a/packages/control-plane/src/model-provider-accounts/account-lifecycle-policy.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/account-lifecycle-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+import { providerAccountIneligibility } from "./account-lifecycle-policy";
+
+function account(overrides: Partial<ModelProviderAccount> = {}): ModelProviderAccount {
+  return {
+    id: "0123456789abcdef0123456789abcdef",
+    provider: "openai",
+    displayName: "Team ChatGPT",
+    externalAccountId: "acct-1",
+    status: "active",
+    createdBy: "user-1",
+    updatedBy: "user-1",
+    lastVerifiedAt: 1,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe("providerAccountIneligibility", () => {
+  it.each(["disabled", "reconnect_required"] as const)(
+    "rejects %s accounts for active use",
+    (status) => {
+      expect(providerAccountIneligibility(account({ status }), "active_use")).toBe(status);
+    }
+  );
+
+  it("rejects archived accounts for every operation", () => {
+    const archived = account({ archivedAt: 2 });
+    expect(providerAccountIneligibility(archived, "active_use")).toBe("archived");
+    expect(providerAccountIneligibility(archived, "reconnect")).toBe("archived");
+  });
+
+  it.each(["active", "disabled", "reconnect_required"] as const)(
+    "allows reconnect for a non-archived %s account",
+    (status) => {
+      expect(providerAccountIneligibility(account({ status }), "reconnect")).toBeNull();
+    }
+  );
+});

--- a/packages/control-plane/src/model-provider-accounts/account-lifecycle-policy.ts
+++ b/packages/control-plane/src/model-provider-accounts/account-lifecycle-policy.ts
@@ -1,0 +1,19 @@
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+
+export type ProviderAccountOperation = "active_use" | "reconnect";
+export type ProviderAccountIneligibility = "archived" | "disabled" | "reconnect_required";
+
+/**
+ * Canonical lifecycle policy for provider-account operations.
+ * Runtime access, selection, defaults, and verification require an active
+ * account. Reconnect accepts any non-archived account because it installs a
+ * fresh credential and returns the account to active state.
+ */
+export function providerAccountIneligibility(
+  account: ModelProviderAccount,
+  operation: ProviderAccountOperation
+): ProviderAccountIneligibility | null {
+  if (account.archivedAt !== null) return "archived";
+  if (operation === "reconnect") return null;
+  return account.status === "active" ? null : account.status;
+}

--- a/packages/control-plane/src/model-provider-accounts/legacy-provider-credentials.ts
+++ b/packages/control-plane/src/model-provider-accounts/legacy-provider-credentials.ts
@@ -1,0 +1,51 @@
+import type { SqlDatabase } from "../db/sql-database";
+import type { LegacyProviderKeyLocation } from "@open-inspect/shared/types/provider-accounts";
+
+const LEGACY_KEYS = [
+  "OPENAI_OAUTH_REFRESH_TOKEN",
+  "OPENAI_OAUTH_ACCESS_TOKEN",
+  "OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT",
+  "OPENAI_OAUTH_ACCOUNT_ID",
+  "XAI_OAUTH_REFRESH_TOKEN",
+  "XAI_OAUTH_ACCESS_TOKEN",
+  "XAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT",
+] as const;
+
+interface InventoryRow {
+  scope: "global" | "repository" | "environment";
+  scope_id: string | null;
+  scope_name: string | null;
+  key: string;
+}
+
+export async function listLegacyProviderCredentials(
+  db: SqlDatabase
+): Promise<LegacyProviderKeyLocation[]> {
+  const placeholders = LEGACY_KEYS.map(() => "?").join(", ");
+  const result = await db
+    .prepare(
+      `SELECT 'global' AS scope, NULL AS scope_id, NULL AS scope_name, key
+         FROM global_secrets WHERE key IN (${placeholders})
+         UNION ALL
+         SELECT 'repository', CAST(repo_id AS TEXT), repo_owner || '/' || repo_name, key
+         FROM repo_secrets WHERE key IN (${placeholders})
+         UNION ALL
+         SELECT 'environment', environment_id, NULL, key
+         FROM environment_secrets WHERE key IN (${placeholders})
+         ORDER BY scope, scope_id, key`
+    )
+    .bind(...LEGACY_KEYS, ...LEGACY_KEYS, ...LEGACY_KEYS)
+    .all<InventoryRow>();
+  return result.results.map((row) => {
+    if (row.scope === "global") return { scope: "global", key: row.key };
+    if (row.scope === "repository") {
+      return {
+        scope: "repository",
+        scopeId: row.scope_id!,
+        repository: row.scope_name!,
+        key: row.key,
+      };
+    }
+    return { scope: "environment", scopeId: row.scope_id!, key: row.key };
+  });
+}

--- a/packages/control-plane/src/model-provider-accounts/legacy-provider-credentials.ts
+++ b/packages/control-plane/src/model-provider-accounts/legacy-provider-credentials.ts
@@ -1,5 +1,6 @@
 import type { SqlDatabase } from "../db/sql-database";
 import type { LegacyProviderKeyLocation } from "@open-inspect/shared/types/provider-accounts";
+import { formatRepositoryFullName } from "@open-inspect/shared/types/repositories";
 
 const LEGACY_KEYS = [
   "OPENAI_OAUTH_REFRESH_TOKEN",
@@ -14,8 +15,14 @@ const LEGACY_KEYS = [
 interface InventoryRow {
   scope: "global" | "repository" | "environment";
   scope_id: string | null;
-  scope_name: string | null;
+  scope_owner: string | null;
+  scope_repo_name: string | null;
   key: string;
+}
+
+function requireInventoryValue(value: string | null, field: string): string {
+  if (value) return value;
+  throw new Error(`Legacy provider credential inventory row is missing ${field}`);
 }
 
 export async function listLegacyProviderCredentials(
@@ -24,13 +31,14 @@ export async function listLegacyProviderCredentials(
   const placeholders = LEGACY_KEYS.map(() => "?").join(", ");
   const result = await db
     .prepare(
-      `SELECT 'global' AS scope, NULL AS scope_id, NULL AS scope_name, key
+      `SELECT 'global' AS scope, NULL AS scope_id,
+              NULL AS scope_owner, NULL AS scope_repo_name, key
          FROM global_secrets WHERE key IN (${placeholders})
          UNION ALL
-         SELECT 'repository', CAST(repo_id AS TEXT), repo_owner || '/' || repo_name, key
+         SELECT 'repository', CAST(repo_id AS TEXT), repo_owner, repo_name, key
          FROM repo_secrets WHERE key IN (${placeholders})
          UNION ALL
-         SELECT 'environment', environment_id, NULL, key
+         SELECT 'environment', environment_id, NULL, NULL, key
          FROM environment_secrets WHERE key IN (${placeholders})
          ORDER BY scope, scope_id, key`
     )
@@ -41,11 +49,18 @@ export async function listLegacyProviderCredentials(
     if (row.scope === "repository") {
       return {
         scope: "repository",
-        scopeId: row.scope_id!,
-        repository: row.scope_name!,
+        scopeId: requireInventoryValue(row.scope_id, "repository scope ID"),
+        repository: formatRepositoryFullName({
+          repoOwner: requireInventoryValue(row.scope_owner, "repository owner"),
+          repoName: requireInventoryValue(row.scope_repo_name, "repository name"),
+        }),
         key: row.key,
       };
     }
-    return { scope: "environment", scopeId: row.scope_id!, key: row.key };
+    return {
+      scope: "environment",
+      scopeId: requireInventoryValue(row.scope_id, "environment scope ID"),
+      key: row.key,
+    };
   });
 }

--- a/packages/control-plane/src/model-provider-accounts/selection-policy.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/selection-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+import {
+  ProviderAccountSelectionPolicy,
+  ProviderAccountSelectionPolicyError,
+} from "./selection-policy";
+
+const ACCOUNT_ID = "1".repeat(32);
+
+function account(overrides: Partial<ModelProviderAccount> = {}): ModelProviderAccount {
+  return {
+    id: ACCOUNT_ID,
+    provider: "openai",
+    displayName: "OpenAI account",
+    externalAccountId: null,
+    status: "active",
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function policy(value: ModelProviderAccount | null = account(), adapter: object | null = {}) {
+  return new ProviderAccountSelectionPolicy(
+    { getById: vi.fn(async () => value) },
+    { get: vi.fn(() => adapter ?? undefined) }
+  );
+}
+
+async function expectPolicyError(
+  promise: Promise<unknown>,
+  status: 400 | 404 | 409
+): Promise<void> {
+  const error = await promise.catch((cause: unknown) => cause);
+  expect(error).toBeInstanceOf(ProviderAccountSelectionPolicyError);
+  expect(error).toMatchObject({ status });
+}
+
+describe("ProviderAccountSelectionPolicy", () => {
+  it.each([
+    [
+      "selection",
+      (value: ProviderAccountSelectionPolicy) => value.validateSelection("openai", "bad"),
+    ],
+    ["default", (value: ProviderAccountSelectionPolicy) => value.validateDefault("openai", "bad")],
+  ])("rejects a malformed %s account ID with 400", async (_name, validate) => {
+    await expectPolicyError(validate(policy()), 400);
+  });
+
+  it.each([
+    ["missing", null, 404],
+    ["provider mismatch", account({ provider: "xai" }), 400],
+    ["disabled", account({ status: "disabled" }), 409],
+    ["reconnect required", account({ status: "reconnect_required" }), 409],
+    ["archived", account({ archivedAt: 2 }), 409],
+  ] as const)("classifies a %s selection", async (_name, value, status) => {
+    await expectPolicyError(policy(value).validateSelection("openai", ACCOUNT_ID), status);
+  });
+
+  it("rejects selection and default validation when the adapter is unavailable", async () => {
+    const value = policy(account(), null);
+
+    await expectPolicyError(value.validateSelection("openai", ACCOUNT_ID), 409);
+    await expectPolicyError(value.validateDefault("openai", ACCOUNT_ID), 409);
+  });
+
+  it("returns the active matching account for selections and defaults", async () => {
+    const value = account();
+    const validator = policy(value);
+
+    await expect(validator.validateSelection("openai", ACCOUNT_ID)).resolves.toBe(value);
+    await expect(validator.validateDefault("openai", ACCOUNT_ID)).resolves.toBe(value);
+  });
+});

--- a/packages/control-plane/src/model-provider-accounts/selection-policy.ts
+++ b/packages/control-plane/src/model-provider-accounts/selection-policy.ts
@@ -1,0 +1,82 @@
+import { MODEL_PROVIDER_ACCOUNT_ID_PATTERN } from "@open-inspect/shared/types/provider-accounts";
+import type {
+  ModelProviderAccount,
+  ModelProviderAccountStore,
+} from "../db/model-provider-accounts";
+import type { ModelProviderId } from "./provider-auth-contracts";
+
+type ProviderAccountPolicyStatus = 400 | 404 | 409;
+
+export interface ProviderAccountAdapterLookup {
+  get(provider: ModelProviderId): unknown | undefined;
+}
+
+export class ProviderAccountSelectionPolicyError extends Error {
+  constructor(
+    message: string,
+    readonly status: ProviderAccountPolicyStatus
+  ) {
+    super(message);
+  }
+}
+
+export class ProviderAccountSelectionPolicy {
+  constructor(
+    private readonly accounts: Pick<ModelProviderAccountStore, "getById">,
+    private readonly adapters: ProviderAccountAdapterLookup
+  ) {}
+
+  validateSelection(
+    provider: ModelProviderId,
+    providerAccountId: string
+  ): Promise<ModelProviderAccount> {
+    return this.validateActiveAccount(provider, providerAccountId, "Selected");
+  }
+
+  validateDefault(
+    provider: ModelProviderId,
+    providerAccountId: string
+  ): Promise<ModelProviderAccount> {
+    return this.validateActiveAccount(provider, providerAccountId, "Default");
+  }
+
+  private async validateActiveAccount(
+    provider: ModelProviderId,
+    providerAccountId: string,
+    source: "Selected" | "Default"
+  ): Promise<ModelProviderAccount> {
+    if (!MODEL_PROVIDER_ACCOUNT_ID_PATTERN.test(providerAccountId)) {
+      throw new ProviderAccountSelectionPolicyError(
+        `${source} provider account ID is invalid`,
+        400
+      );
+    }
+    if (!this.adapters.get(provider)) {
+      throw new ProviderAccountSelectionPolicyError(
+        `${provider} provider account adapter is unavailable`,
+        409
+      );
+    }
+
+    const account = await this.accounts.getById(providerAccountId);
+    if (!account) {
+      throw new ProviderAccountSelectionPolicyError(
+        `${source} ${provider} provider account was not found`,
+        404
+      );
+    }
+    if (account.provider !== provider) {
+      throw new ProviderAccountSelectionPolicyError(
+        `${source} provider account does not belong to ${provider}`,
+        400
+      );
+    }
+    if (account.status !== "active" || account.archivedAt !== null) {
+      throw new ProviderAccountSelectionPolicyError(
+        `${source} ${provider} provider account is unavailable`,
+        409
+      );
+    }
+    return account;
+  }
+}

--- a/packages/control-plane/src/model-provider-accounts/selection-policy.ts
+++ b/packages/control-plane/src/model-provider-accounts/selection-policy.ts
@@ -9,7 +9,7 @@ import { providerAccountIneligibility } from "./account-lifecycle-policy";
 type ProviderAccountPolicyStatus = 400 | 404 | 409;
 
 export interface ProviderAccountAdapterLookup {
-  get(provider: ModelProviderId): unknown | undefined;
+  get(provider: ModelProviderId): object | undefined;
 }
 
 export class ProviderAccountSelectionPolicyError extends Error {

--- a/packages/control-plane/src/model-provider-accounts/selection-policy.ts
+++ b/packages/control-plane/src/model-provider-accounts/selection-policy.ts
@@ -4,6 +4,7 @@ import type {
   ModelProviderAccountStore,
 } from "../db/model-provider-accounts";
 import type { ModelProviderId } from "./provider-auth-contracts";
+import { providerAccountIneligibility } from "./account-lifecycle-policy";
 
 type ProviderAccountPolicyStatus = 400 | 404 | 409;
 
@@ -71,7 +72,7 @@ export class ProviderAccountSelectionPolicy {
         400
       );
     }
-    if (account.status !== "active" || account.archivedAt !== null) {
+    if (providerAccountIneligibility(account, "active_use")) {
       throw new ProviderAccountSelectionPolicyError(
         `${source} ${provider} provider account is unavailable`,
         409

--- a/packages/control-plane/src/model-provider-accounts/service.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.test.ts
@@ -49,7 +49,7 @@ function adapter(
       if (accountId) validateExternalIdentity(result.externalAccountId, accountId);
       return result;
     }),
-    parseCredential: (value) => value as Credential,
+    parseCredential: vi.fn((value) => value as Credential),
     refresh: vi.fn(
       async () =>
         options.refresh ?? {
@@ -398,6 +398,55 @@ describe("ModelProviderAccountService", () => {
     expect(store.credentials.readCredentialState).not.toHaveBeenCalled();
   });
 
+  it("maps only the default-account constraint for status and archive writes", async () => {
+    const store = stores();
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+    vi.mocked(store.accounts.setStatus).mockRejectedValueOnce(
+      new Error("provider default account must remain active")
+    );
+    vi.mocked(store.accounts.archive).mockRejectedValueOnce(
+      new Error("provider default account must remain active")
+    );
+
+    await expect(service.setStatus(ACCOUNT_ID, "disabled", "user-1")).rejects.toMatchObject({
+      status: 409,
+      message: "A default account must remain active",
+    });
+    await expect(service.archive(ACCOUNT_ID, "user-1")).rejects.toMatchObject({
+      status: 409,
+      message: "A default account cannot be archived",
+    });
+  });
+
+  it("preserves unexpected status and archive storage failures", async () => {
+    const store = stores();
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+    const statusFailure = new Error("D1 unavailable while updating status");
+    const archiveFailure = new Error("D1 unavailable while archiving");
+    vi.mocked(store.accounts.setStatus).mockRejectedValueOnce(statusFailure);
+    vi.mocked(store.accounts.archive).mockRejectedValueOnce(archiveFailure);
+
+    await expect(service.setStatus(ACCOUNT_ID, "disabled", "user-1")).rejects.toBe(statusFailure);
+    await expect(service.archive(ACCOUNT_ID, "user-1")).rejects.toBe(archiveFailure);
+  });
+
+  it("keeps archive idempotent when no row changes", async () => {
+    const store = stores();
+    vi.mocked(store.accounts.archive).mockResolvedValue(false);
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    await expect(service.archive(ACCOUNT_ID, "user-1")).resolves.toBeUndefined();
+  });
+
   it("safely reconnects an existing account with the trusted external identity", async () => {
     const existing = providerAccount({ id: "22222222222222222222222222222222" });
     const store = stores(existing);
@@ -520,9 +569,10 @@ describe("ModelProviderAccountService", () => {
         { generateId: () => ACCOUNT_ID, now: () => 1_000 }
       );
 
-      await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toBeInstanceOf(
-        ProviderRefreshError
-      );
+      await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toMatchObject({
+        status: 409,
+        message: "Provider account requires reconnection",
+      });
       expect(store.atomicWriter.fenceExchangeAndRequireReconnect).toHaveBeenCalledWith({
         providerAccountId: ACCOUNT_ID,
         credentialVersion: 1,
@@ -532,6 +582,43 @@ describe("ModelProviderAccountService", () => {
       });
     }
   );
+
+  it("maps retry-safe verification refresh failure without requiring reconnect", async () => {
+    const store = stores();
+    const providerAdapter = adapter();
+    vi.mocked(providerAdapter.refresh).mockRejectedValue(
+      new ProviderRefreshError("refresh failed", "retry_safe")
+    );
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toMatchObject({
+      status: 502,
+      message: "Provider credential verification failed safely; retry the operation",
+    });
+    expect(store.atomicWriter.fenceExchangeAndRequireReconnect).not.toHaveBeenCalled();
+  });
+
+  it("maps an invalid stored verification credential to a stable conflict", async () => {
+    const store = stores();
+    const providerAdapter = adapter();
+    vi.mocked(providerAdapter.parseCredential).mockImplementation(() => {
+      throw new Error("secret parse detail");
+    });
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toMatchObject({
+      status: 409,
+      message: "Stored provider credential is invalid",
+    });
+  });
 
   it("uses authoritative account state when verification terminal fencing loses its claim", async () => {
     const store = stores();

--- a/packages/control-plane/src/model-provider-accounts/service.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   ModelProviderAccountAdapterRegistry,
+  ProviderIdentityError,
   ProviderRefreshError,
   type ModelProviderAccountAdapter,
   type ProviderConnectionResult,
@@ -24,19 +25,30 @@ function adapter(
     refresh?: ProviderRefreshResult<Credential>;
   } = {}
 ): ModelProviderAccountAdapter<Credential, unknown> {
+  const validateExternalIdentity = (actual: string | undefined, expected: string | null) => {
+    if (!actual) {
+      throw new ProviderIdentityError("OpenAI account identity could not be verified");
+    }
+    if (!expected || actual !== expected) {
+      throw new ProviderIdentityError("OpenAI account identity did not match");
+    }
+  };
   return {
     provider: "openai",
     credentialSchemaVersion: 1,
     refreshBufferMs: 300_000,
     parseConnectInput: (input) => input,
-    connect: vi.fn(
-      async () =>
-        options.connect ?? {
-          credential: { refreshToken: "rotated-secret", accessToken: "access-secret" },
-          externalAccountId: "acct-1",
-          accessTokenExpiresAt: 2_000,
-        }
-    ),
+    connect: vi.fn(async (input) => {
+      const result = options.connect ?? {
+        credential: { refreshToken: "rotated-secret", accessToken: "access-secret" },
+        externalAccountId: "acct-1",
+        accessTokenExpiresAt: 2_000,
+      };
+      const accountId =
+        input && typeof input === "object" && "accountId" in input ? String(input.accountId) : null;
+      if (accountId) validateExternalIdentity(result.externalAccountId, accountId);
+      return result;
+    }),
     parseCredential: (value) => value as Credential,
     refresh: vi.fn(
       async () =>
@@ -49,6 +61,7 @@ function adapter(
     ),
     cachedAccess: vi.fn(() => null),
     runtimeMetadata: vi.fn(() => ({})),
+    validateExternalIdentity,
   };
 }
 
@@ -317,6 +330,20 @@ describe("ModelProviderAccountService", () => {
     expect(providerAdapter.refresh).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch verification for an account that requires reconnect", async () => {
+    const store = stores(providerAccount({ status: "reconnect_required" }));
+    const providerAdapter = adapter();
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toMatchObject({ status: 409 });
+    expect(providerAdapter.refresh).not.toHaveBeenCalled();
+    expect(store.credentials.readCredentialState).not.toHaveBeenCalled();
+  });
+
   it("reconnects credential and account identity in one persistence operation", async () => {
     const store = stores();
     const service = createService(
@@ -351,7 +378,27 @@ describe("ModelProviderAccountService", () => {
     expect(store.accounts.setStatus).not.toHaveBeenCalled();
   });
 
-  it("preflights duplicate identity and safely reconnects the existing account", async () => {
+  it("rejects archived reconnects before consuming the submitted credential", async () => {
+    const store = stores(providerAccount({ archivedAt: 999, status: "reconnect_required" }));
+    const providerAdapter = adapter();
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(
+      service.reconnect(
+        ACCOUNT_ID,
+        { provider: "openai", refreshToken: "submitted-secret", accountId: "acct-1" },
+        "user-1"
+      )
+    ).rejects.toMatchObject({ status: 409 });
+    expect(providerAdapter.connect).not.toHaveBeenCalled();
+    expect(store.credentials.readCredentialState).not.toHaveBeenCalled();
+  });
+
+  it("safely reconnects an existing account with the trusted external identity", async () => {
     const existing = providerAccount({ id: "22222222222222222222222222222222" });
     const store = stores(existing);
     vi.mocked(store.accounts.findByExternalIdentity).mockResolvedValue(existing);
@@ -381,7 +428,6 @@ describe("ModelProviderAccountService", () => {
     const winner = providerAccount({ id: "22222222222222222222222222222222" });
     const store = stores(winner);
     vi.mocked(store.accounts.findByExternalIdentity)
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(winner);
     vi.mocked(store.atomicWriter.createAccountWithCredential).mockRejectedValue(
@@ -486,4 +532,26 @@ describe("ModelProviderAccountService", () => {
       });
     }
   );
+
+  it("uses authoritative account state when verification terminal fencing loses its claim", async () => {
+    const store = stores();
+    const providerAdapter = adapter();
+    vi.mocked(providerAdapter.refresh).mockRejectedValue(
+      new ProviderRefreshError("refresh failed", "ambiguous")
+    );
+    vi.mocked(store.atomicWriter.fenceExchangeAndRequireReconnect).mockResolvedValue(false);
+    vi.mocked(store.accounts.getById)
+      .mockResolvedValueOnce(providerAccount())
+      .mockResolvedValue(providerAccount({ status: "disabled" }));
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    const error = await service.verify(ACCOUNT_ID, "user-1").catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({ status: 409 });
+    expect((error as Error).message).toMatch(/not active/i);
+  });
 });

--- a/packages/control-plane/src/model-provider-accounts/service.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.test.ts
@@ -1,0 +1,489 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ModelProviderAccountAdapterRegistry,
+  ProviderRefreshError,
+  type ModelProviderAccountAdapter,
+  type ProviderConnectionResult,
+  type ProviderRefreshResult,
+} from "../auth/model-provider-account-adapters";
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+import type { ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
+import {
+  ModelProviderAccountService,
+  type ModelProviderAccountServiceAccountStore,
+  type ModelProviderAccountServiceCredentialStore,
+} from "./service";
+
+const ACCOUNT_ID = "11111111111111111111111111111111";
+
+type Credential = { refreshToken: string; accessToken?: string };
+
+function adapter(
+  options: {
+    connect?: ProviderConnectionResult<Credential>;
+    refresh?: ProviderRefreshResult<Credential>;
+  } = {}
+): ModelProviderAccountAdapter<Credential, unknown> {
+  return {
+    provider: "openai",
+    credentialSchemaVersion: 1,
+    refreshBufferMs: 300_000,
+    parseConnectInput: (input) => input,
+    connect: vi.fn(
+      async () =>
+        options.connect ?? {
+          credential: { refreshToken: "rotated-secret", accessToken: "access-secret" },
+          externalAccountId: "acct-1",
+          accessTokenExpiresAt: 2_000,
+        }
+    ),
+    parseCredential: (value) => value as Credential,
+    refresh: vi.fn(
+      async () =>
+        options.refresh ?? {
+          credential: { refreshToken: "verified-secret", accessToken: "verified-access" },
+          accessToken: "verified-access",
+          accessTokenExpiresAt: 3_000,
+          externalAccountId: "acct-1",
+        }
+    ),
+    cachedAccess: vi.fn(() => null),
+    runtimeMetadata: vi.fn(() => ({})),
+  };
+}
+
+function providerAccount(overrides: Partial<ModelProviderAccount> = {}): ModelProviderAccount {
+  return {
+    id: ACCOUNT_ID,
+    provider: "openai",
+    displayName: "Team ChatGPT",
+    externalAccountId: "acct-1",
+    status: "active",
+    createdBy: "user-1",
+    updatedBy: "user-1",
+    lastVerifiedAt: 1,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function stores(account: ModelProviderAccount | null = providerAccount()): {
+  accounts: ModelProviderAccountServiceAccountStore;
+  credentials: ModelProviderAccountServiceCredentialStore;
+  atomicWriter: ModelProviderAccountAtomicWriter;
+} {
+  return {
+    accounts: {
+      list: vi.fn(async () => []),
+      getById: vi.fn(async () => account),
+      findByExternalIdentity: vi.fn(async () => null),
+      updateDetails: vi.fn(async () => true),
+      setStatus: vi.fn(async () => true),
+      archive: vi.fn(async () => true),
+    },
+    credentials: {
+      tryBeginExchange: vi.fn(async () => ({ acquired: true as const, generation: 1 })),
+      clearSafeFailure: vi.fn(async () => true),
+      readCredentialState: vi.fn(async () => ({
+        payload: { refreshToken: "stored-secret" },
+        credentialSchemaVersion: 1,
+        credentialVersion: 1,
+        exchangeGeneration: 0,
+        exchangeState: "idle" as const,
+        exchangeOwner: null,
+        exchangeStartedAt: null,
+        accessTokenExpiresAt: null,
+        updatedAt: 1,
+      })),
+    },
+    atomicWriter: {
+      createAccountWithCredential: vi.fn(async (input) => ({
+        id: input.id,
+        provider: input.provider,
+        displayName: input.displayName,
+        externalAccountId: input.externalAccountId,
+        status: "active" as const,
+        createdBy: input.actorId,
+        updatedBy: input.actorId,
+        lastVerifiedAt: input.now,
+        lastUsedAt: null,
+        createdAt: input.now,
+        updatedAt: input.now,
+        archivedAt: null,
+      })),
+      reconnectCredentialAndAccount: vi.fn(async () => true),
+      completeVerificationCredentialAndAccount: vi.fn(async () => true),
+      fenceExchangeAndRequireReconnect: vi.fn(async () => true),
+    },
+  };
+}
+
+function createService(
+  store: ReturnType<typeof stores>,
+  registry: ModelProviderAccountAdapterRegistry,
+  dependencies: { generateId: () => string; now: () => number }
+) {
+  return new ModelProviderAccountService(
+    store.accounts,
+    store.credentials,
+    store.atomicWriter,
+    registry,
+    dependencies
+  );
+}
+
+describe("ModelProviderAccountService", () => {
+  it("connects through the adapter and never returns credentials", async () => {
+    const store = stores();
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    const account = await service.create(
+      {
+        provider: "openai",
+        displayName: "Team ChatGPT",
+        refreshToken: "submitted-secret",
+        accountId: "acct-1",
+      },
+      "user-1"
+    );
+
+    expect(account).toMatchObject({
+      account: { id: ACCOUNT_ID, provider: "openai", status: "active" },
+      reconnectedExisting: false,
+    });
+    expect(JSON.stringify(account)).not.toContain("secret");
+    expect(store.atomicWriter.createAccountWithCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ACCOUNT_ID,
+        provider: "openai",
+        credential: expect.objectContaining({
+          payload: { refreshToken: "rotated-secret", accessToken: "access-secret" },
+        }),
+      })
+    );
+  });
+
+  it.each([
+    [undefined, "could not be verified"],
+    ["acct-other", "did not match"],
+  ] as const)(
+    "rejects an untrusted OpenAI create identity %s",
+    async (externalAccountId, message) => {
+      const store = stores(null);
+      const service = createService(
+        store,
+        new ModelProviderAccountAdapterRegistry([
+          adapter({
+            connect: {
+              credential: { refreshToken: "rotated-secret" },
+              externalAccountId,
+            },
+          }),
+        ]),
+        { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+      );
+
+      await expect(
+        service.create(
+          {
+            provider: "openai",
+            displayName: "Team ChatGPT",
+            refreshToken: "submitted-secret",
+            accountId: "acct-1",
+          },
+          "user-1"
+        )
+      ).rejects.toThrow(message);
+      expect(store.atomicWriter.createAccountWithCredential).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([undefined, "acct-other"] as const)(
+    "rejects an untrusted OpenAI reconnect identity %s before persistence",
+    async (externalAccountId) => {
+      const store = stores();
+      const service = createService(
+        store,
+        new ModelProviderAccountAdapterRegistry([
+          adapter({
+            connect: {
+              credential: { refreshToken: "rotated-secret" },
+              externalAccountId,
+            },
+          }),
+        ]),
+        { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+      );
+
+      await expect(
+        service.reconnect(
+          ACCOUNT_ID,
+          {
+            provider: "openai",
+            refreshToken: "submitted-secret",
+            accountId: "acct-1",
+          },
+          "user-1"
+        )
+      ).rejects.toThrow(/identity/);
+      expect(store.credentials.readCredentialState).not.toHaveBeenCalled();
+      expect(store.atomicWriter.reconnectCredentialAndAccount).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([undefined, "acct-other"] as const)(
+    "rejects an untrusted OpenAI verify identity %s before persistence",
+    async (externalAccountId) => {
+      const store = stores();
+      const service = createService(
+        store,
+        new ModelProviderAccountAdapterRegistry([
+          adapter({
+            refresh: {
+              credential: { refreshToken: "verified-secret" },
+              accessToken: "verified-access",
+              accessTokenExpiresAt: 3_000,
+              externalAccountId,
+            },
+          }),
+        ]),
+        { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+      );
+
+      await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toThrow(/identity/);
+      expect(store.atomicWriter.completeVerificationCredentialAndAccount).not.toHaveBeenCalled();
+    }
+  );
+
+  it("claims verification before dispatch and atomically commits credential and account state", async () => {
+    const store = stores();
+    const providerAdapter = adapter({
+      refresh: {
+        credential: { refreshToken: "verified-secret", accessToken: "verified-access" },
+        accessToken: "verified-access",
+        accessTokenExpiresAt: 3_000,
+        externalAccountId: "acct-1",
+      },
+    });
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await service.verify(ACCOUNT_ID, "user-1");
+
+    expect(store.credentials.tryBeginExchange).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      1,
+      ACCOUNT_ID,
+      "active",
+      1_000
+    );
+    expect(providerAdapter.refresh).toHaveBeenCalledTimes(1);
+    expect(store.atomicWriter.completeVerificationCredentialAndAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerAccountId: ACCOUNT_ID,
+        expectedCredentialVersion: 1,
+        exchangeGeneration: 1,
+        exchangeOwner: ACCOUNT_ID,
+        externalAccountId: "acct-1",
+        status: "active",
+        actorId: "user-1",
+        lastVerifiedAt: 1_000,
+        payload: expect.objectContaining({ refreshToken: "verified-secret" }),
+      })
+    );
+    expect(store.accounts.setStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch verification when another worker owns the durable claim", async () => {
+    const store = stores();
+    vi.mocked(store.credentials.tryBeginExchange).mockResolvedValue({ acquired: false });
+    const providerAdapter = adapter();
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([providerAdapter]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toMatchObject({ status: 409 });
+    expect(providerAdapter.refresh).not.toHaveBeenCalled();
+  });
+
+  it("reconnects credential and account identity in one persistence operation", async () => {
+    const store = stores();
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([
+        adapter({
+          connect: {
+            credential: { refreshToken: "rotated-secret", accessToken: "new-access" },
+            externalAccountId: "acct-1",
+            accessTokenExpiresAt: 3_000,
+          },
+        }),
+      ]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await service.reconnect(
+      ACCOUNT_ID,
+      { provider: "openai", refreshToken: "submitted-secret", accountId: "acct-1" },
+      "user-1"
+    );
+
+    expect(store.atomicWriter.reconnectCredentialAndAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerAccountId: ACCOUNT_ID,
+        expectedCredentialVersion: 1,
+        externalAccountId: "acct-1",
+        status: "active",
+        actorId: "user-1",
+      })
+    );
+    expect(store.accounts.setStatus).not.toHaveBeenCalled();
+  });
+
+  it("preflights duplicate identity and safely reconnects the existing account", async () => {
+    const existing = providerAccount({ id: "22222222222222222222222222222222" });
+    const store = stores(existing);
+    vi.mocked(store.accounts.findByExternalIdentity).mockResolvedValue(existing);
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    const result = await service.create(
+      {
+        provider: "openai",
+        displayName: "Duplicate",
+        refreshToken: "submitted-secret",
+        accountId: "acct-1",
+      },
+      "user-1"
+    );
+
+    expect(result).toMatchObject({ account: { id: existing.id }, reconnectedExisting: true });
+    expect(store.atomicWriter.createAccountWithCredential).not.toHaveBeenCalled();
+    expect(store.atomicWriter.reconnectCredentialAndAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ providerAccountId: existing.id })
+    );
+  });
+
+  it("recovers a post-exchange uniqueness race through safe reconnect", async () => {
+    const winner = providerAccount({ id: "22222222222222222222222222222222" });
+    const store = stores(winner);
+    vi.mocked(store.accounts.findByExternalIdentity)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(winner);
+    vi.mocked(store.atomicWriter.createAccountWithCredential).mockRejectedValue(
+      new Error("UNIQUE constraint failed: model_provider_accounts.provider")
+    );
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    await expect(
+      service.create(
+        {
+          provider: "openai",
+          displayName: "Racing duplicate",
+          refreshToken: "submitted-secret",
+          accountId: "acct-1",
+        },
+        "user-1"
+      )
+    ).resolves.toMatchObject({ account: { id: winner.id }, reconnectedExisting: true });
+    expect(store.atomicWriter.reconnectCredentialAndAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ providerAccountId: winner.id })
+    );
+  });
+
+  it("returns consumed-credential guidance when duplicate recovery cannot persist safely", async () => {
+    const existing = providerAccount({ id: "22222222222222222222222222222222" });
+    const store = stores(existing);
+    vi.mocked(store.accounts.findByExternalIdentity).mockResolvedValue(existing);
+    vi.mocked(store.atomicWriter.reconnectCredentialAndAccount).mockResolvedValue(false);
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    const error = await service
+      .create(
+        {
+          provider: "openai",
+          displayName: "Duplicate",
+          refreshToken: "submitted-secret",
+          accountId: "acct-1",
+        },
+        "user-1"
+      )
+      .catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({ status: 409 });
+    expect((error as Error).message).toMatch(/may have been consumed.*fresh credential/i);
+    expect((error as Error).message).not.toContain("submitted-secret");
+    expect(store.atomicWriter.createAccountWithCredential).not.toHaveBeenCalled();
+  });
+
+  it("fences a consumed verification result when its atomic commit fails", async () => {
+    const store = stores();
+    vi.mocked(store.atomicWriter.completeVerificationCredentialAndAccount).mockRejectedValue(
+      new Error("D1 unavailable")
+    );
+    const service = createService(store, new ModelProviderAccountAdapterRegistry([adapter()]), {
+      generateId: () => ACCOUNT_ID,
+      now: () => 1_000,
+    });
+
+    const error = await service.verify(ACCOUNT_ID, "user-1").catch((cause: unknown) => cause);
+
+    expect(store.atomicWriter.fenceExchangeAndRequireReconnect).toHaveBeenCalledWith({
+      providerAccountId: ACCOUNT_ID,
+      credentialVersion: 1,
+      exchangeGeneration: 1,
+      exchangeOwner: ACCOUNT_ID,
+      now: 1_000,
+    });
+    expect(error).toMatchObject({ status: 409 });
+    expect((error as Error).message).toMatch(/may have been consumed.*fresh credential/i);
+    expect((error as Error).message).not.toContain("verified-secret");
+  });
+
+  it.each(["ambiguous", "unauthorized"] as const)(
+    "atomically requires reconnect after a %s verification refresh failure",
+    async (classification) => {
+      const store = stores();
+      const providerAdapter = adapter();
+      vi.mocked(providerAdapter.refresh).mockRejectedValue(
+        new ProviderRefreshError("refresh failed", classification)
+      );
+      const service = createService(
+        store,
+        new ModelProviderAccountAdapterRegistry([providerAdapter]),
+        { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+      );
+
+      await expect(service.verify(ACCOUNT_ID, "user-1")).rejects.toBeInstanceOf(
+        ProviderRefreshError
+      );
+      expect(store.atomicWriter.fenceExchangeAndRequireReconnect).toHaveBeenCalledWith({
+        providerAccountId: ACCOUNT_ID,
+        credentialVersion: 1,
+        exchangeGeneration: 1,
+        exchangeOwner: ACCOUNT_ID,
+        now: 1_000,
+      });
+    }
+  );
+});

--- a/packages/control-plane/src/model-provider-accounts/service.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.ts
@@ -1,0 +1,354 @@
+import type {
+  ConnectModelProviderAccountRequest,
+  ReconnectModelProviderAccountRequest,
+} from "@open-inspect/shared/types/provider-accounts";
+import type {
+  ModelProviderAccount,
+  ModelProviderAccountStatus,
+  ModelProviderAccountStore,
+} from "../db/model-provider-accounts";
+import type {
+  ProviderCredentialExchangeAccountStatus,
+  ProviderCredentialState,
+  ProviderCredentialStore,
+} from "../db/provider-account-credentials";
+import type { ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
+import type { ModelProviderId } from "./provider-auth-contracts";
+import {
+  type ModelProviderAccountAdapter,
+  type ModelProviderAccountAdapterRegistry,
+  type ProviderConnectionResult,
+} from "../auth/model-provider-account-adapters";
+import {
+  ClaimedProviderCredentialExchange,
+  ClaimedProviderCredentialExchangeError,
+} from "../auth/claimed-provider-credential-exchange";
+
+type ErasedProviderAccountAdapter = ModelProviderAccountAdapter<unknown, unknown>;
+
+export type ModelProviderAccountServiceAccountStore = Pick<
+  ModelProviderAccountStore,
+  "list" | "getById" | "findByExternalIdentity" | "updateDetails" | "setStatus" | "archive"
+>;
+
+export type ModelProviderAccountServiceCredentialStore = Pick<
+  ProviderCredentialStore,
+  "tryBeginExchange" | "clearSafeFailure"
+> & {
+  readCredentialState(
+    providerAccountId: string,
+    provider: ModelProviderId
+  ): Promise<ProviderCredentialState | null>;
+};
+
+export class ProviderAccountServiceError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+  }
+}
+
+export class ModelProviderAccountService {
+  private readonly exchange: ClaimedProviderCredentialExchange;
+
+  constructor(
+    private readonly accounts: ModelProviderAccountServiceAccountStore,
+    private readonly credentials: ModelProviderAccountServiceCredentialStore,
+    private readonly atomicWriter: ModelProviderAccountAtomicWriter,
+    private readonly adapters: ModelProviderAccountAdapterRegistry,
+    private readonly dependencies: { generateId: () => string; now: () => number }
+  ) {
+    this.exchange = new ClaimedProviderCredentialExchange(
+      credentials,
+      atomicWriter.fenceExchangeAndRequireReconnect.bind(atomicWriter)
+    );
+  }
+
+  list(provider?: ModelProviderId, includeArchived = false): Promise<ModelProviderAccount[]> {
+    return this.accounts.list(provider, includeArchived);
+  }
+
+  async get(id: string): Promise<ModelProviderAccount> {
+    const account = await this.accounts.getById(id);
+    if (!account) throw new ProviderAccountServiceError("Provider account not found", 404);
+    return account;
+  }
+
+  async create(
+    input: ConnectModelProviderAccountRequest,
+    actorId: string
+  ): Promise<{ account: ModelProviderAccount; reconnectedExisting: boolean }> {
+    const adapter = this.requireAdapter(input.provider);
+    const preflight =
+      input.provider === "openai"
+        ? await this.accounts.findByExternalIdentity(input.provider, input.accountId)
+        : null;
+    const connected = await adapter.connect(adapter.parseConnectInput(input));
+    if (input.provider === "openai") {
+      this.requireTrustedOpenAIIdentity(
+        input.provider,
+        connected.externalAccountId,
+        input.accountId
+      );
+    }
+    const now = this.dependencies.now();
+    const externalAccountId = connected.externalAccountId ?? null;
+    let existing = preflight;
+    if (!existing && externalAccountId) {
+      try {
+        existing = await this.accounts.findByExternalIdentity(input.provider, externalAccountId);
+      } catch (cause) {
+        throw this.consumedCredentialError(cause);
+      }
+    }
+    if (existing) {
+      return {
+        account: await this.persistConnectedCredential(existing, connected, adapter, actorId, now),
+        reconnectedExisting: true,
+      };
+    }
+
+    try {
+      return {
+        account: await this.atomicWriter.createAccountWithCredential({
+          id: this.dependencies.generateId(),
+          provider: input.provider,
+          displayName: input.displayName,
+          externalAccountId,
+          actorId,
+          now,
+          credential: {
+            credentialSchemaVersion: adapter.credentialSchemaVersion,
+            payload: connected.credential,
+            accessTokenExpiresAt: connected.accessTokenExpiresAt,
+          },
+        }),
+        reconnectedExisting: false,
+      };
+    } catch (cause) {
+      let winner: ModelProviderAccount | null = null;
+      if (externalAccountId) {
+        try {
+          winner = await this.accounts.findByExternalIdentity(input.provider, externalAccountId);
+        } catch {
+          throw this.consumedCredentialError(cause);
+        }
+      }
+      if (winner) {
+        return {
+          account: await this.persistConnectedCredential(winner, connected, adapter, actorId, now),
+          reconnectedExisting: true,
+        };
+      }
+      throw this.consumedCredentialError(cause);
+    }
+  }
+
+  async rename(id: string, displayName: string, actorId: string): Promise<ModelProviderAccount> {
+    const account = await this.accounts.getById(id);
+    if (
+      !account ||
+      !(await this.accounts.updateDetails(id, {
+        displayName,
+        actorId,
+        now: this.dependencies.now(),
+      }))
+    ) {
+      throw new ProviderAccountServiceError("Provider account not found", 404);
+    }
+    return this.get(id);
+  }
+
+  async setStatus(
+    id: string,
+    status: Extract<ModelProviderAccountStatus, "active" | "disabled">,
+    actorId: string
+  ): Promise<ModelProviderAccount> {
+    const account = await this.get(id);
+    if (account.status === status) return account;
+    if (status === "active" && account.status !== "disabled") {
+      throw new ProviderAccountServiceError("Provider account requires reconnection", 409);
+    }
+    try {
+      if (!(await this.accounts.setStatus(id, status, actorId, this.dependencies.now()))) {
+        throw new ProviderAccountServiceError("Provider account not found", 404);
+      }
+    } catch (cause) {
+      if (cause instanceof ProviderAccountServiceError) throw cause;
+      throw new ProviderAccountServiceError("A default account must remain active", 409);
+    }
+    return this.get(id);
+  }
+
+  async archive(id: string, actorId: string): Promise<void> {
+    try {
+      await this.accounts.archive(id, actorId, this.dependencies.now());
+    } catch {
+      throw new ProviderAccountServiceError("A default account cannot be archived", 409);
+    }
+  }
+
+  async verify(id: string, actorId: string): Promise<ModelProviderAccount> {
+    const account = await this.getUsableAccount(id);
+    const adapter = this.requireAdapter(account.provider);
+    const current = await this.credentials.readCredentialState(account.id, account.provider);
+    if (!current) throw new ProviderAccountServiceError("Provider credential not found", 409);
+    if (current.exchangeState !== "idle") {
+      throw new ProviderAccountServiceError(
+        "Provider credential verification is already in progress",
+        409
+      );
+    }
+    const owner = this.dependencies.generateId();
+    const now = this.dependencies.now();
+    try {
+      const result = await this.exchange.run({
+        providerAccountId: account.id,
+        provider: account.provider,
+        state: current,
+        expectedAccountStatus: account.status,
+        adapter,
+        owner,
+        now: this.dependencies.now,
+        complete: ({ write, refreshed }) => {
+          this.requireTrustedOpenAIIdentity(
+            account.provider,
+            refreshed.externalAccountId,
+            account.externalAccountId
+          );
+          return this.atomicWriter.completeVerificationCredentialAndAccount({
+            ...write,
+            externalAccountId: refreshed.externalAccountId ?? account.externalAccountId,
+            status: "active",
+            actorId,
+            lastVerifiedAt: now,
+          });
+        },
+      });
+      if (result.kind === "claim_unavailable") {
+        throw new ProviderAccountServiceError(
+          "Provider credential verification is already in progress",
+          409
+        );
+      }
+    } catch (cause) {
+      if (!(cause instanceof ClaimedProviderCredentialExchangeError)) throw cause;
+      if (cause.phase !== "completion") throw cause.cause;
+      if (cause.cause instanceof ProviderAccountServiceError) throw cause.cause;
+      throw this.consumedCredentialError(cause);
+    }
+    return this.get(id);
+  }
+
+  async reconnect(
+    id: string,
+    input: ReconnectModelProviderAccountRequest,
+    actorId: string
+  ): Promise<ModelProviderAccount> {
+    const account = await this.get(id);
+    if (account.provider !== input.provider) {
+      throw new ProviderAccountServiceError("Provider account does not match provider", 400);
+    }
+    const adapter = this.requireAdapter(account.provider);
+    const connected = await adapter.connect(adapter.parseConnectInput(input));
+    if (input.provider === "openai") {
+      this.requireTrustedOpenAIIdentity(
+        input.provider,
+        connected.externalAccountId,
+        input.accountId
+      );
+      this.requireTrustedOpenAIIdentity(
+        input.provider,
+        connected.externalAccountId,
+        account.externalAccountId
+      );
+    } else if (
+      account.externalAccountId &&
+      connected.externalAccountId &&
+      connected.externalAccountId !== account.externalAccountId
+    ) {
+      throw new ProviderAccountServiceError("Provider account identity did not match", 409);
+    }
+    return this.persistConnectedCredential(
+      account,
+      connected,
+      adapter,
+      actorId,
+      this.dependencies.now()
+    );
+  }
+
+  private async getUsableAccount(
+    id: string
+  ): Promise<ModelProviderAccount & { status: ProviderCredentialExchangeAccountStatus }> {
+    const account = await this.get(id);
+    if (account.archivedAt !== null) {
+      throw new ProviderAccountServiceError("Provider account is not active", 409);
+    }
+    if (account.status === "disabled") {
+      throw new ProviderAccountServiceError("Provider account is not active", 409);
+    }
+    return { ...account, status: account.status };
+  }
+
+  private async persistConnectedCredential(
+    account: ModelProviderAccount,
+    connected: ProviderConnectionResult<unknown>,
+    adapter: ErasedProviderAccountAdapter,
+    actorId: string,
+    now: number
+  ): Promise<ModelProviderAccount> {
+    const current = await this.credentials.readCredentialState(account.id, account.provider);
+    if (!current) throw this.consumedCredentialError();
+    try {
+      const replaced = await this.atomicWriter.reconnectCredentialAndAccount({
+        providerAccountId: account.id,
+        provider: account.provider,
+        credentialSchemaVersion: adapter.credentialSchemaVersion,
+        expectedCredentialVersion: current.credentialVersion,
+        payload: connected.credential,
+        accessTokenExpiresAt: connected.accessTokenExpiresAt,
+        externalAccountId: connected.externalAccountId ?? account.externalAccountId,
+        status: "active",
+        actorId,
+        lastVerifiedAt: now,
+        now,
+      });
+      if (!replaced) throw new Error("Provider credential changed concurrently");
+    } catch (cause) {
+      throw this.consumedCredentialError(cause);
+    }
+    return this.get(account.id);
+  }
+
+  private consumedCredentialError(cause?: unknown): ProviderAccountServiceError {
+    return new ProviderAccountServiceError(
+      "The submitted credential may have been consumed and could not be saved safely. Obtain a fresh credential and reconnect.",
+      409,
+      cause === undefined ? undefined : { cause }
+    );
+  }
+
+  private requireAdapter(provider: ModelProviderId) {
+    const adapter = this.adapters.get(provider);
+    if (!adapter) throw new ProviderAccountServiceError(`${provider} is unavailable`, 409);
+    return adapter;
+  }
+
+  private requireTrustedOpenAIIdentity(
+    provider: ModelProviderId,
+    actual: string | undefined,
+    expected: string | null
+  ): void {
+    if (provider !== "openai") return;
+    if (!actual) {
+      throw new ProviderAccountServiceError("OpenAI account identity could not be verified", 409);
+    }
+    if (!expected || actual !== expected) {
+      throw new ProviderAccountServiceError("OpenAI account identity did not match", 409);
+    }
+  }
+}

--- a/packages/control-plane/src/model-provider-accounts/service.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.ts
@@ -8,7 +8,6 @@ import type {
   ModelProviderAccountStore,
 } from "../db/model-provider-accounts";
 import type {
-  ProviderCredentialExchangeAccountStatus,
   ProviderCredentialState,
   ProviderCredentialStore,
 } from "../db/provider-account-credentials";
@@ -18,11 +17,16 @@ import {
   type ModelProviderAccountAdapter,
   type ModelProviderAccountAdapterRegistry,
   type ProviderConnectionResult,
+  ProviderIdentityError,
 } from "../auth/model-provider-account-adapters";
 import {
   ClaimedProviderCredentialExchange,
   ClaimedProviderCredentialExchangeError,
 } from "../auth/claimed-provider-credential-exchange";
+import {
+  providerAccountIneligibility,
+  type ProviderAccountOperation,
+} from "./account-lifecycle-policy";
 
 type ErasedProviderAccountAdapter = ModelProviderAccountAdapter<unknown, unknown>;
 
@@ -82,22 +86,11 @@ export class ModelProviderAccountService {
     actorId: string
   ): Promise<{ account: ModelProviderAccount; reconnectedExisting: boolean }> {
     const adapter = this.requireAdapter(input.provider);
-    const preflight =
-      input.provider === "openai"
-        ? await this.accounts.findByExternalIdentity(input.provider, input.accountId)
-        : null;
-    const connected = await adapter.connect(adapter.parseConnectInput(input));
-    if (input.provider === "openai") {
-      this.requireTrustedOpenAIIdentity(
-        input.provider,
-        connected.externalAccountId,
-        input.accountId
-      );
-    }
+    const connected = await this.connect(adapter, input);
     const now = this.dependencies.now();
     const externalAccountId = connected.externalAccountId ?? null;
-    let existing = preflight;
-    if (!existing && externalAccountId) {
+    let existing: ModelProviderAccount | null = null;
+    if (externalAccountId) {
       try {
         existing = await this.accounts.findByExternalIdentity(input.provider, externalAccountId);
       } catch (cause) {
@@ -192,7 +185,7 @@ export class ModelProviderAccountService {
   }
 
   async verify(id: string, actorId: string): Promise<ModelProviderAccount> {
-    const account = await this.getUsableAccount(id);
+    const account = await this.getAccountForOperation(id, "active_use");
     const adapter = this.requireAdapter(account.provider);
     const current = await this.credentials.readCredentialState(account.id, account.provider);
     if (!current) throw new ProviderAccountServiceError("Provider credential not found", 409);
@@ -209,13 +202,13 @@ export class ModelProviderAccountService {
         providerAccountId: account.id,
         provider: account.provider,
         state: current,
-        expectedAccountStatus: account.status,
+        expectedAccountStatus: "active",
         adapter,
         owner,
         now: this.dependencies.now,
         complete: ({ write, refreshed }) => {
-          this.requireTrustedOpenAIIdentity(
-            account.provider,
+          this.validateExternalIdentity(
+            adapter,
             refreshed.externalAccountId,
             account.externalAccountId
           );
@@ -236,6 +229,9 @@ export class ModelProviderAccountService {
       }
     } catch (cause) {
       if (!(cause instanceof ClaimedProviderCredentialExchangeError)) throw cause;
+      if (cause.terminalFence === "lost") {
+        return this.reconcileVerificationFenceLoss(account, current);
+      }
       if (cause.phase !== "completion") throw cause.cause;
       if (cause.cause instanceof ProviderAccountServiceError) throw cause.cause;
       throw this.consumedCredentialError(cause);
@@ -248,30 +244,13 @@ export class ModelProviderAccountService {
     input: ReconnectModelProviderAccountRequest,
     actorId: string
   ): Promise<ModelProviderAccount> {
-    const account = await this.get(id);
+    const account = await this.getAccountForOperation(id, "reconnect");
     if (account.provider !== input.provider) {
       throw new ProviderAccountServiceError("Provider account does not match provider", 400);
     }
     const adapter = this.requireAdapter(account.provider);
-    const connected = await adapter.connect(adapter.parseConnectInput(input));
-    if (input.provider === "openai") {
-      this.requireTrustedOpenAIIdentity(
-        input.provider,
-        connected.externalAccountId,
-        input.accountId
-      );
-      this.requireTrustedOpenAIIdentity(
-        input.provider,
-        connected.externalAccountId,
-        account.externalAccountId
-      );
-    } else if (
-      account.externalAccountId &&
-      connected.externalAccountId &&
-      connected.externalAccountId !== account.externalAccountId
-    ) {
-      throw new ProviderAccountServiceError("Provider account identity did not match", 409);
-    }
+    const connected = await this.connect(adapter, input);
+    this.validateExternalIdentity(adapter, connected.externalAccountId, account.externalAccountId);
     return this.persistConnectedCredential(
       account,
       connected,
@@ -281,17 +260,15 @@ export class ModelProviderAccountService {
     );
   }
 
-  private async getUsableAccount(
-    id: string
-  ): Promise<ModelProviderAccount & { status: ProviderCredentialExchangeAccountStatus }> {
+  private async getAccountForOperation(
+    id: string,
+    operation: ProviderAccountOperation
+  ): Promise<ModelProviderAccount> {
     const account = await this.get(id);
-    if (account.archivedAt !== null) {
+    if (providerAccountIneligibility(account, operation)) {
       throw new ProviderAccountServiceError("Provider account is not active", 409);
     }
-    if (account.status === "disabled") {
-      throw new ProviderAccountServiceError("Provider account is not active", 409);
-    }
-    return { ...account, status: account.status };
+    return account;
   }
 
   private async persistConnectedCredential(
@@ -324,6 +301,27 @@ export class ModelProviderAccountService {
     return this.get(account.id);
   }
 
+  private async reconcileVerificationFenceLoss(
+    previousAccount: ModelProviderAccount,
+    previousState: ProviderCredentialState
+  ): Promise<ModelProviderAccount> {
+    const account = await this.get(previousAccount.id);
+    const ineligibility = providerAccountIneligibility(account, "active_use");
+    if (ineligibility === "reconnect_required") {
+      throw new ProviderAccountServiceError("Provider account requires reconnection", 409);
+    }
+    if (ineligibility) {
+      throw new ProviderAccountServiceError("Provider account is not active", 409);
+    }
+    const state = await this.credentials.readCredentialState(account.id, account.provider);
+    if (!state) throw new ProviderAccountServiceError("Provider credential not found", 409);
+    if (state.credentialVersion !== previousState.credentialVersion) return account;
+    throw new ProviderAccountServiceError(
+      "Provider credential verification lost its durable claim",
+      409
+    );
+  }
+
   private consumedCredentialError(cause?: unknown): ProviderAccountServiceError {
     return new ProviderAccountServiceError(
       "The submitted credential may have been consumed and could not be saved safely. Obtain a fresh credential and reconnect.",
@@ -338,17 +336,32 @@ export class ModelProviderAccountService {
     return adapter;
   }
 
-  private requireTrustedOpenAIIdentity(
-    provider: ModelProviderId,
+  private async connect(
+    adapter: ErasedProviderAccountAdapter,
+    input: ConnectModelProviderAccountRequest | ReconnectModelProviderAccountRequest
+  ): Promise<ProviderConnectionResult<unknown>> {
+    try {
+      return await adapter.connect(adapter.parseConnectInput(input));
+    } catch (cause) {
+      if (cause instanceof ProviderIdentityError) {
+        throw new ProviderAccountServiceError(cause.message, 409, { cause });
+      }
+      throw cause;
+    }
+  }
+
+  private validateExternalIdentity(
+    adapter: ErasedProviderAccountAdapter,
     actual: string | undefined,
     expected: string | null
   ): void {
-    if (provider !== "openai") return;
-    if (!actual) {
-      throw new ProviderAccountServiceError("OpenAI account identity could not be verified", 409);
-    }
-    if (!expected || actual !== expected) {
-      throw new ProviderAccountServiceError("OpenAI account identity did not match", 409);
+    try {
+      adapter.validateExternalIdentity(actual, expected);
+    } catch (cause) {
+      if (cause instanceof ProviderIdentityError) {
+        throw new ProviderAccountServiceError(cause.message, 409, { cause });
+      }
+      throw cause;
     }
   }
 }

--- a/packages/control-plane/src/model-provider-accounts/service.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.ts
@@ -18,6 +18,7 @@ import {
   type ModelProviderAccountAdapterRegistry,
   type ProviderConnectionResult,
   ProviderIdentityError,
+  ProviderRefreshError,
 } from "../auth/model-provider-account-adapters";
 import {
   ClaimedProviderCredentialExchange,
@@ -53,6 +54,16 @@ export class ProviderAccountServiceError extends Error {
   ) {
     super(message, options);
   }
+}
+
+function mapDefaultAccountConstraint(cause: unknown, message: string): never {
+  if (
+    !(cause instanceof Error) ||
+    !/provider default account must remain active/i.test(cause.message)
+  ) {
+    throw cause;
+  }
+  throw new ProviderAccountServiceError(message, 409, { cause });
 }
 
 export class ModelProviderAccountService {
@@ -171,7 +182,7 @@ export class ModelProviderAccountService {
       }
     } catch (cause) {
       if (cause instanceof ProviderAccountServiceError) throw cause;
-      throw new ProviderAccountServiceError("A default account must remain active", 409);
+      mapDefaultAccountConstraint(cause, "A default account must remain active");
     }
     return this.get(id);
   }
@@ -179,8 +190,8 @@ export class ModelProviderAccountService {
   async archive(id: string, actorId: string): Promise<void> {
     try {
       await this.accounts.archive(id, actorId, this.dependencies.now());
-    } catch {
-      throw new ProviderAccountServiceError("A default account cannot be archived", 409);
+    } catch (cause) {
+      mapDefaultAccountConstraint(cause, "A default account cannot be archived");
     }
   }
 
@@ -232,7 +243,26 @@ export class ModelProviderAccountService {
       if (cause.terminalFence === "lost") {
         return this.reconcileVerificationFenceLoss(account, current);
       }
-      if (cause.phase !== "completion") throw cause.cause;
+      if (cause.phase === "parse") {
+        throw new ProviderAccountServiceError("Stored provider credential is invalid", 409, {
+          cause: cause.cause,
+        });
+      }
+      if (cause.phase === "refresh") {
+        if (
+          cause.cause instanceof ProviderRefreshError &&
+          cause.cause.classification === "retry_safe"
+        ) {
+          throw new ProviderAccountServiceError(
+            "Provider credential verification failed safely; retry the operation",
+            502,
+            { cause: cause.cause }
+          );
+        }
+        throw new ProviderAccountServiceError("Provider account requires reconnection", 409, {
+          cause: cause.cause,
+        });
+      }
       if (cause.cause instanceof ProviderAccountServiceError) throw cause.cause;
       throw this.consumedCredentialError(cause);
     }

--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -26,6 +26,11 @@ describe("route policy table", () => {
     ["POST", "/image-builds/build-failed", "handler-authenticated"],
     ["GET", "/api/auth/get-session", "web-service"],
     ["GET", "/internal/auth/sign-in-providers", "web-service"],
+    ["GET", "/model-provider-accounts", "user"],
+    ["POST", "/model-provider-accounts", "user"],
+    ["GET", "/model-provider-accounts/legacy-credentials", "user"],
+    ["GET", "/model-provider-account-defaults", "user"],
+    ["PUT", "/model-provider-account-defaults/openai", "user"],
   ])("owns the auth policy for %s %s", (method, path, expectedKind) => {
     expect(routeFor(method, path)?.authentication.kind).toBe(expectedKind);
   });
@@ -87,6 +92,10 @@ describe("route policy table", () => {
     expect(routeFor("POST", "/sessions/session-1/diff/retry")?.authentication.kind).toBe(
       "user-or-service"
     );
+  });
+
+  it("marks provider account management routes as non-cacheable", () => {
+    expect(routeFor("GET", "/model-provider-accounts")?.cacheControl).toBe("private, no-store");
   });
 
   it.each([

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -44,6 +44,7 @@ import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
 import { skillRoutes } from "./routes/skills";
 import { sessionRoutes } from "./routes/sessions";
+import { modelProviderAccountRoutes } from "./routes/model-provider-accounts";
 import { handleSlackNotify } from "./routes/slack-notify";
 import { webhookRoutes } from "./webhooks";
 
@@ -54,6 +55,17 @@ function withCorsAndTraceHeaders(response: Response, ctx: RequestContext): Respo
   headers.set("Access-Control-Allow-Origin", "*");
   headers.set("x-request-id", ctx.request_id);
   headers.set("x-trace-id", ctx.trace_id);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function withRouteCachePolicy(response: Response, route: Route): Response {
+  if (!route.cacheControl) return response;
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", route.cacheControl);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -197,6 +209,26 @@ async function verifySandboxAuth(
   return null; // Auth passed
 }
 
+async function verifySandboxAuthSafely(
+  request: Request,
+  env: Env,
+  sessionId: string,
+  ctx: RequestContext
+): Promise<Response | null> {
+  try {
+    return await verifySandboxAuth(request, env, sessionId, ctx);
+  } catch (cause) {
+    logger.error("Sandbox authentication unavailable", {
+      event: "auth.sandbox_unavailable",
+      session_id: sessionId,
+      error: cause instanceof Error ? cause : String(cause),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Sandbox authentication unavailable", 503);
+  }
+}
+
 /**
  * Emit the per-request `auth.principal` line: who is acting, as a verified
  * identity — never token material.
@@ -301,6 +333,9 @@ export const routes: Route[] = [
 
   // Model preferences
   ...modelPreferencesRoutes,
+
+  // Subscription provider account management and sandbox access broker
+  ...modelProviderAccountRoutes,
 
   // Integration settings
   ...integrationSettingsRoutes,
@@ -410,7 +445,7 @@ export async function handleRequest(
 
     if (authentication.kind === "sandbox") {
       authError = sandboxSessionId
-        ? await verifySandboxAuth(request, env, sandboxSessionId, ctx)
+        ? await verifySandboxAuthSafely(request, env, sandboxSessionId, ctx)
         : error("Unauthorized: Invalid session path", 401);
     } else {
       const authResult = await authenticate(request, env, ctx, {
@@ -428,7 +463,7 @@ export async function handleRequest(
           authentication.kind === "user-or-service-with-sandbox-fallback" &&
           sandboxSessionId
         ) {
-          authError = await verifySandboxAuth(request, env, sandboxSessionId, ctx);
+          authError = await verifySandboxAuthSafely(request, env, sandboxSessionId, ctx);
         }
       } else {
         authError = null;
@@ -444,7 +479,7 @@ export async function handleRequest(
         logPrincipal(ctx.principal, ctx, path);
         logRequest(authError, ctx, method, path, startTime);
       }
-      return withCorsAndTraceHeaders(authError, ctx);
+      return withCorsAndTraceHeaders(withRouteCachePolicy(authError, matchedRoute.route), ctx);
     }
 
     if (ctx.principal) {
@@ -454,7 +489,7 @@ export async function handleRequest(
 
   const providerCheck = enforceImplementedScmProvider(matchedRoute.route, path, env, ctx);
   if (providerCheck) {
-    return providerCheck;
+    return withRouteCachePolicy(providerCheck, matchedRoute.route);
   }
 
   let response: Response;
@@ -477,11 +512,14 @@ export async function handleRequest(
         error: e instanceof Error ? e : String(e),
         ...ctx.metrics.summarize(),
       });
-      return withCorsAndTraceHeaders(error("Internal server error", 500), ctx);
+      return withCorsAndTraceHeaders(
+        withRouteCachePolicy(error("Internal server error", 500), matchedRoute.route),
+        ctx
+      );
     }
   }
 
   logRequest(response, ctx, method, path, startTime);
 
-  return withCorsAndTraceHeaders(response, ctx);
+  return withCorsAndTraceHeaders(withRouteCachePolicy(response, matchedRoute.route), ctx);
 }

--- a/packages/control-plane/src/routes/model-provider-accounts.ts
+++ b/packages/control-plane/src/routes/model-provider-accounts.ts
@@ -1,6 +1,7 @@
 import {
   MODEL_PROVIDER_ACCOUNT_ID_PATTERN,
   connectModelProviderAccountRequestSchema,
+  modelProviderAccountDisplayNameSchema,
   modelProviderAccountDefaultRequestSchema,
   modelProviderAccountStatusSchema,
   reconnectModelProviderAccountRequestSchema,
@@ -38,7 +39,7 @@ import {
 } from "./shared";
 
 const PRIVATE_NO_STORE = "private, no-store" as const;
-const renameSchema = z.strictObject({ displayName: z.string().trim().min(1).max(100) });
+const renameSchema = z.strictObject({ displayName: modelProviderAccountDisplayNameSchema });
 const logger = createLogger("router:model-provider-accounts");
 
 function service(env: Env, ctx: RequestContext): ModelProviderAccountService {

--- a/packages/control-plane/src/routes/model-provider-accounts.ts
+++ b/packages/control-plane/src/routes/model-provider-accounts.ts
@@ -1,0 +1,245 @@
+import {
+  MODEL_PROVIDER_ACCOUNT_ID_PATTERN,
+  connectModelProviderAccountRequestSchema,
+  modelProviderAccountDefaultRequestSchema,
+  modelProviderAccountStatusSchema,
+  reconnectModelProviderAccountRequestSchema,
+  subscriptionProviderIdSchema,
+  type SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
+import { z } from "zod";
+import { generateId } from "../auth/crypto";
+import { modelProviderAccountAdapterRegistry } from "../auth/model-provider-account-default-adapters";
+import { ModelProviderAccountStore } from "../db/model-provider-accounts";
+import { D1ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
+import { ProviderCredentialStore } from "../db/provider-account-credentials";
+import { ProviderDefaultStore } from "../db/provider-account-defaults";
+import { listLegacyProviderCredentials } from "../model-provider-accounts/legacy-provider-credentials";
+import {
+  ModelProviderAccountService,
+  ProviderAccountServiceError,
+} from "../model-provider-accounts/service";
+import {
+  ProviderAccountSelectionPolicy,
+  ProviderAccountSelectionPolicyError,
+} from "../model-provider-accounts/selection-policy";
+import type { Env } from "../types";
+import {
+  defineRoute,
+  error,
+  json,
+  parseJsonBody,
+  parsePattern,
+  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
+  type RequestContext,
+  type Route,
+  type UserRouteContext,
+} from "./shared";
+
+const PRIVATE_NO_STORE = "private, no-store" as const;
+const renameSchema = z.strictObject({ displayName: z.string().trim().min(1).max(100) });
+
+function service(env: Env, ctx: RequestContext): ModelProviderAccountService {
+  const accounts = new ModelProviderAccountStore(ctx.db);
+  const credentials = new ProviderCredentialStore(ctx.db, env.PROVIDER_ACCOUNTS_ENCRYPTION_KEY);
+  return new ModelProviderAccountService(
+    accounts,
+    credentials,
+    new D1ModelProviderAccountAtomicWriter(ctx.db, env.PROVIDER_ACCOUNTS_ENCRYPTION_KEY),
+    modelProviderAccountAdapterRegistry,
+    { generateId: () => generateId(), now: () => Date.now() }
+  );
+}
+
+function provider(value: string | undefined): SubscriptionProviderId | Response {
+  if (!value) return error("Provider required", 400);
+  const parsed = subscriptionProviderIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : error("Unsupported model provider", 400);
+}
+
+function accountId(match: RegExpMatchArray): string | Response {
+  const id = match.groups?.id;
+  return id && MODEL_PROVIDER_ACCOUNT_ID_PATTERN.test(id)
+    ? id
+    : error("Invalid provider account ID", 400);
+}
+
+async function accountOperation(operation: () => Promise<Response>): Promise<Response> {
+  try {
+    return await operation();
+  } catch (cause) {
+    if (cause instanceof ProviderAccountServiceError) return error(cause.message, cause.status);
+    const message = cause instanceof Error ? cause.message : "Provider account operation failed";
+    if (/UNIQUE constraint|default account/i.test(message)) return error(message, 409);
+    return error("Provider account operation failed", 502);
+  }
+}
+
+function managementRoute(
+  method: string,
+  path: string,
+  handler: (
+    request: Request,
+    env: Env,
+    match: RegExpMatchArray,
+    ctx: UserRouteContext
+  ) => Promise<Response>
+): Route {
+  return defineRoute(SCM_AGNOSTIC_HUMAN_USER_ROUTE, {
+    method,
+    pattern: parsePattern(path),
+    cacheControl: PRIVATE_NO_STORE,
+    handler,
+  });
+}
+
+const managementRoutes: Route[] = [
+  managementRoute(
+    "GET",
+    "/model-provider-accounts/legacy-credentials",
+    async (_request, _env, _match, ctx) =>
+      json({ legacyKeys: await listLegacyProviderCredentials(ctx.db) })
+  ),
+  managementRoute("GET", "/model-provider-accounts", async (request, env, _match, ctx) => {
+    const accounts = service(env, ctx);
+    const url = new URL(request.url);
+    const providerFilter = url.searchParams.get("provider");
+    let parsedProvider: SubscriptionProviderId | undefined;
+    if (providerFilter) {
+      const result = provider(providerFilter);
+      if (result instanceof Response) return result;
+      parsedProvider = result;
+    }
+    const includeArchived = url.searchParams.get("archived") === "true";
+    const status = url.searchParams.get("status");
+    if (status !== null && !modelProviderAccountStatusSchema.safeParse(status).success) {
+      return error("Unsupported provider account status", 400);
+    }
+    const listed = await accounts.list(parsedProvider, includeArchived);
+    return json({
+      accounts: status ? listed.filter((account) => account.status === status) : listed,
+    });
+  }),
+  managementRoute("POST", "/model-provider-accounts", async (request, env, _match, ctx) => {
+    const body = await parseJsonBody<unknown>(request);
+    if (body instanceof Response) return body;
+    const parsed = connectModelProviderAccountRequestSchema.safeParse(body);
+    if (!parsed.success) return error("Invalid provider account", 400);
+    const accounts = service(env, ctx);
+    return accountOperation(async () => {
+      const result = await accounts.create(parsed.data, ctx.principal.userId);
+      return json(result, result.reconnectedExisting ? 200 : 201);
+    });
+  }),
+  managementRoute("GET", "/model-provider-accounts/:id", async (_request, env, match, ctx) => {
+    const id = accountId(match);
+    if (id instanceof Response) return id;
+    const accounts = service(env, ctx);
+    return accountOperation(async () => json({ account: await accounts.get(id) }));
+  }),
+  managementRoute("PATCH", "/model-provider-accounts/:id", async (request, env, match, ctx) => {
+    const id = accountId(match);
+    if (id instanceof Response) return id;
+    const body = await parseJsonBody<unknown>(request);
+    if (body instanceof Response) return body;
+    const parsed = renameSchema.safeParse(body);
+    if (!parsed.success) return error("Invalid provider account name", 400);
+    const accounts = service(env, ctx);
+    return accountOperation(async () =>
+      json({ account: await accounts.rename(id, parsed.data.displayName, ctx.principal.userId) })
+    );
+  }),
+  ...(["verify", "disable", "enable"] as const).map((action) =>
+    managementRoute(
+      "POST",
+      `/model-provider-accounts/:id/${action}`,
+      async (_request, env, match, ctx) => {
+        const id = accountId(match);
+        if (id instanceof Response) return id;
+        const accounts = service(env, ctx);
+        return accountOperation(async () => {
+          const account =
+            action === "verify"
+              ? await accounts.verify(id, ctx.principal.userId)
+              : await accounts.setStatus(
+                  id,
+                  action === "enable" ? "active" : "disabled",
+                  ctx.principal.userId
+                );
+          return json({ account });
+        });
+      }
+    )
+  ),
+  managementRoute(
+    "POST",
+    "/model-provider-accounts/:id/reconnect",
+    async (request, env, match, ctx) => {
+      const id = accountId(match);
+      if (id instanceof Response) return id;
+      const body = await parseJsonBody<unknown>(request);
+      if (body instanceof Response) return body;
+      const parsed = reconnectModelProviderAccountRequestSchema.safeParse(body);
+      if (!parsed.success) return error("Invalid provider account reconnect request", 400);
+      const accounts = service(env, ctx);
+      return accountOperation(async () =>
+        json({ account: await accounts.reconnect(id, parsed.data, ctx.principal.userId) })
+      );
+    }
+  ),
+  managementRoute("DELETE", "/model-provider-accounts/:id", async (_request, env, match, ctx) => {
+    const id = accountId(match);
+    if (id instanceof Response) return id;
+    const accounts = service(env, ctx);
+    return accountOperation(async () => {
+      await accounts.archive(id, ctx.principal.userId);
+      return new Response(null, { status: 204 });
+    });
+  }),
+  managementRoute("GET", "/model-provider-account-defaults", async (_request, _env, _match, ctx) =>
+    json({ defaults: await new ProviderDefaultStore(ctx.db).list() })
+  ),
+  managementRoute(
+    "PUT",
+    "/model-provider-account-defaults/:provider",
+    async (request, _env, match, ctx) => {
+      const parsedProvider = provider(match.groups?.provider);
+      if (parsedProvider instanceof Response) return parsedProvider;
+      const body = await parseJsonBody<unknown>(request);
+      if (body instanceof Response) return body;
+      const parsed = modelProviderAccountDefaultRequestSchema.safeParse(body);
+      if (!parsed.success) return error("Invalid provider default", 400);
+      const defaults = new ProviderDefaultStore(ctx.db);
+      try {
+        await new ProviderAccountSelectionPolicy(
+          new ModelProviderAccountStore(ctx.db),
+          modelProviderAccountAdapterRegistry
+        ).validateDefault(parsedProvider, parsed.data.providerAccountId);
+        await defaults.set(
+          parsedProvider,
+          parsed.data.providerAccountId,
+          parsed.data.unattendedMode,
+          ctx.principal.userId
+        );
+        return json({ default: await defaults.get(parsedProvider) });
+      } catch (cause) {
+        if (cause instanceof ProviderAccountSelectionPolicyError) {
+          return error(cause.message, cause.status);
+        }
+        return error(cause instanceof Error ? cause.message : "Invalid provider default", 409);
+      }
+    }
+  ),
+  managementRoute(
+    "DELETE",
+    "/model-provider-account-defaults/:provider",
+    async (_request, _env, match, ctx) => {
+      const parsedProvider = provider(match.groups?.provider);
+      if (parsedProvider instanceof Response) return parsedProvider;
+      await new ProviderDefaultStore(ctx.db).remove(parsedProvider);
+      return new Response(null, { status: 204 });
+    }
+  ),
+];
+
+export const modelProviderAccountRoutes: Route[] = managementRoutes;

--- a/packages/control-plane/src/routes/model-provider-accounts.ts
+++ b/packages/control-plane/src/routes/model-provider-accounts.ts
@@ -8,6 +8,7 @@ import {
   type SubscriptionProviderId,
 } from "@open-inspect/shared/types/provider-accounts";
 import { z } from "zod";
+import { createLogger } from "../logger";
 import { generateId } from "../auth/crypto";
 import { modelProviderAccountAdapterRegistry } from "../auth/model-provider-account-default-adapters";
 import { ModelProviderAccountStore } from "../db/model-provider-accounts";
@@ -38,6 +39,7 @@ import {
 
 const PRIVATE_NO_STORE = "private, no-store" as const;
 const renameSchema = z.strictObject({ displayName: z.string().trim().min(1).max(100) });
+const logger = createLogger("router:model-provider-accounts");
 
 function service(env: Env, ctx: RequestContext): ModelProviderAccountService {
   const accounts = new ModelProviderAccountStore(ctx.db);
@@ -64,13 +66,27 @@ function accountId(match: RegExpMatchArray): string | Response {
     : error("Invalid provider account ID", 400);
 }
 
-async function accountOperation(operation: () => Promise<Response>): Promise<Response> {
+async function accountOperation(
+  ctx: RequestContext,
+  operation: () => Promise<Response>
+): Promise<Response> {
   try {
     return await operation();
   } catch (cause) {
     if (cause instanceof ProviderAccountServiceError) return error(cause.message, cause.status);
     const message = cause instanceof Error ? cause.message : "Provider account operation failed";
-    if (/UNIQUE constraint|default account/i.test(message)) return error(message, 409);
+    logger.error("provider_account.operation_failed", {
+      event: "provider_account.operation_failed",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+      error: cause instanceof Error ? cause : String(cause),
+    });
+    if (/UNIQUE constraint/i.test(message)) {
+      return error("Provider account conflicts with an existing account", 409);
+    }
+    if (/default account/i.test(message)) {
+      return error("A default provider account cannot be changed", 409);
+    }
     return error("Provider account operation failed", 502);
   }
 }
@@ -126,7 +142,7 @@ const managementRoutes: Route[] = [
     const parsed = connectModelProviderAccountRequestSchema.safeParse(body);
     if (!parsed.success) return error("Invalid provider account", 400);
     const accounts = service(env, ctx);
-    return accountOperation(async () => {
+    return accountOperation(ctx, async () => {
       const result = await accounts.create(parsed.data, ctx.principal.userId);
       return json(result, result.reconnectedExisting ? 200 : 201);
     });
@@ -135,7 +151,7 @@ const managementRoutes: Route[] = [
     const id = accountId(match);
     if (id instanceof Response) return id;
     const accounts = service(env, ctx);
-    return accountOperation(async () => json({ account: await accounts.get(id) }));
+    return accountOperation(ctx, async () => json({ account: await accounts.get(id) }));
   }),
   managementRoute("PATCH", "/model-provider-accounts/:id", async (request, env, match, ctx) => {
     const id = accountId(match);
@@ -145,7 +161,7 @@ const managementRoutes: Route[] = [
     const parsed = renameSchema.safeParse(body);
     if (!parsed.success) return error("Invalid provider account name", 400);
     const accounts = service(env, ctx);
-    return accountOperation(async () =>
+    return accountOperation(ctx, async () =>
       json({ account: await accounts.rename(id, parsed.data.displayName, ctx.principal.userId) })
     );
   }),
@@ -157,7 +173,7 @@ const managementRoutes: Route[] = [
         const id = accountId(match);
         if (id instanceof Response) return id;
         const accounts = service(env, ctx);
-        return accountOperation(async () => {
+        return accountOperation(ctx, async () => {
           const account =
             action === "verify"
               ? await accounts.verify(id, ctx.principal.userId)
@@ -182,7 +198,7 @@ const managementRoutes: Route[] = [
       const parsed = reconnectModelProviderAccountRequestSchema.safeParse(body);
       if (!parsed.success) return error("Invalid provider account reconnect request", 400);
       const accounts = service(env, ctx);
-      return accountOperation(async () =>
+      return accountOperation(ctx, async () =>
         json({ account: await accounts.reconnect(id, parsed.data, ctx.principal.userId) })
       );
     }
@@ -191,7 +207,7 @@ const managementRoutes: Route[] = [
     const id = accountId(match);
     if (id instanceof Response) return id;
     const accounts = service(env, ctx);
-    return accountOperation(async () => {
+    return accountOperation(ctx, async () => {
       await accounts.archive(id, ctx.principal.userId);
       return new Response(null, { status: 204 });
     });
@@ -226,7 +242,13 @@ const managementRoutes: Route[] = [
         if (cause instanceof ProviderAccountSelectionPolicyError) {
           return error(cause.message, cause.status);
         }
-        return error(cause instanceof Error ? cause.message : "Invalid provider default", 409);
+        logger.error("provider_account.default_update_failed", {
+          event: "provider_account.default_update_failed",
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+          error: cause instanceof Error ? cause : String(cause),
+        });
+        return error("Provider default could not be updated", 409);
       }
     }
   ),

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -52,6 +52,7 @@ export type RequestContext = CorrelationContext & {
 export interface RouteDefinition<Context extends RequestContext = RequestContext> {
   method: string;
   pattern: RegExp;
+  cacheControl?: "no-store" | "private, no-store";
   handler: (request: Request, env: Env, match: RegExpMatchArray, ctx: Context) => Promise<Response>;
 }
 

--- a/packages/control-plane/test/integration/provider-account-atomicity.test.ts
+++ b/packages/control-plane/test/integration/provider-account-atomicity.test.ts
@@ -214,7 +214,7 @@ describe("provider account atomic persistence", () => {
     ).resolves.toEqual({ acquired: false });
   });
 
-  it("does not overwrite an operator disable while fencing a failed exchange", async () => {
+  it("reports a lost fence without clearing the lease after an operator disable", async () => {
     const { accounts, credentials, writer } = await seedAccount(
       "disabled-during-exchange",
       "active"
@@ -244,7 +244,7 @@ describe("provider account atomic persistence", () => {
         exchangeOwner: "owner-a",
         now: NOW + 4,
       })
-    ).resolves.toBe(true);
+    ).resolves.toBe(false);
     await expect(accounts.getById("disabled-during-exchange")).resolves.toMatchObject({
       status: "disabled",
       updatedBy: "user-1",
@@ -253,9 +253,39 @@ describe("provider account atomic persistence", () => {
     await expect(
       credentials.readCredentialState("disabled-during-exchange", "openai")
     ).resolves.toMatchObject({
-      exchangeState: "idle",
-      exchangeGeneration: 2,
-      exchangeOwner: null,
+      exchangeState: "in_flight",
+      exchangeGeneration: 1,
+      exchangeOwner: "owner-a",
+    });
+  });
+
+  it("reports a lost fence without clearing the lease after archival", async () => {
+    const { accounts, credentials, writer } = await seedAccount(
+      "archived-during-exchange",
+      "active"
+    );
+    await credentials.tryBeginExchange("archived-during-exchange", 1, "owner-a", "active", NOW + 1);
+    await accounts.archive("archived-during-exchange", "user-1", NOW + 2);
+
+    await expect(
+      writer.fenceExchangeAndRequireReconnect({
+        providerAccountId: "archived-during-exchange",
+        credentialVersion: 1,
+        exchangeGeneration: 1,
+        exchangeOwner: "owner-a",
+        now: NOW + 3,
+      })
+    ).resolves.toBe(false);
+    await expect(accounts.getById("archived-during-exchange")).resolves.toMatchObject({
+      status: "active",
+      archivedAt: NOW + 2,
+    });
+    await expect(
+      credentials.readCredentialState("archived-during-exchange", "openai")
+    ).resolves.toMatchObject({
+      exchangeState: "in_flight",
+      exchangeGeneration: 1,
+      exchangeOwner: "owner-a",
     });
   });
 

--- a/packages/control-plane/test/integration/provider-account-routes.test.ts
+++ b/packages/control-plane/test/integration/provider-account-routes.test.ts
@@ -229,7 +229,7 @@ describe("provider account management routes", () => {
       env.DB.prepare(
         `INSERT INTO repo_secrets
          (repo_id, repo_owner, repo_name, key, encrypted_value, created_at, updated_at)
-         VALUES (7, 'acme', 'repo', 'XAI_OAUTH_ACCESS_TOKEN', 'ciphertext', ?, ?)`
+         VALUES (7, 'acme/platform', 'repo', 'XAI_OAUTH_ACCESS_TOKEN', 'ciphertext', ?, ?)`
       ).bind(now, now),
       env.DB.prepare(
         `INSERT INTO environments (id, name, created_at, updated_at)
@@ -251,7 +251,7 @@ describe("provider account management routes", () => {
       {
         scope: "repository",
         scopeId: "7",
-        repository: "acme/repo",
+        repository: "acme/platform/repo",
         key: "XAI_OAUTH_ACCESS_TOKEN",
       },
     ]);

--- a/packages/control-plane/test/integration/provider-account-routes.test.ts
+++ b/packages/control-plane/test/integration/provider-account-routes.test.ts
@@ -1,0 +1,260 @@
+import { SELF, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanD1Tables } from "./cleanup";
+import { serviceFetch } from "./helpers";
+
+const OPENAI_ACCOUNT_ID = "11111111111111111111111111111111";
+
+async function managementFetch(path: string, init?: { method?: string; body?: unknown }) {
+  return serviceFetch(`https://test.local${path}`, {
+    method: init?.method,
+    body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+}
+
+function expectPrivateNoStore(response: Response): void {
+  expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+}
+
+describe("provider account management routes", () => {
+  beforeEach(cleanD1Tables);
+  afterEach(cleanD1Tables);
+
+  it("requires a human principal and marks even auth failures private/no-store", async () => {
+    const response = await SELF.fetch("https://test.local/model-provider-accounts");
+    expect(response.status).toBe(401);
+    expectPrivateNoStore(response);
+
+    const serviceResponse = await serviceFetch("https://test.local/model-provider-accounts", {
+      service: "linear-bot",
+    });
+    expect(serviceResponse.status).toBe(403);
+    expectPrivateNoStore(serviceResponse);
+  });
+
+  it("does not expose a provider catalog and performs credential-free account CRUD", async () => {
+    const catalog = await managementFetch("/model-subscription-providers");
+    expect(catalog.status).toBe(404);
+
+    const created = await managementFetch("/model-provider-accounts", {
+      method: "POST",
+      body: {
+        provider: "openai",
+        displayName: "Team ChatGPT",
+        refreshToken: "integration-openai-refresh",
+        accountId: "acct-integration",
+      },
+    });
+    expect(created.status).toBe(201);
+    expectPrivateNoStore(created);
+    const createdBody = await created.json<{ account: { id: string } }>();
+    expect(createdBody.account.id).toMatch(/^[0-9a-f]{32}$/);
+    expect(JSON.stringify(createdBody)).not.toContain("refresh");
+    expect(JSON.stringify(createdBody)).not.toContain("access-token");
+
+    const list = await managementFetch("/model-provider-accounts?provider=openai");
+    expect(list.status).toBe(200);
+    expectPrivateNoStore(list);
+    await expect(list.json()).resolves.toMatchObject({
+      accounts: [{ id: createdBody.account.id, displayName: "Team ChatGPT", status: "active" }],
+    });
+
+    const renamed = await managementFetch(`/model-provider-accounts/${createdBody.account.id}`, {
+      method: "PATCH",
+      body: { displayName: "Primary ChatGPT" },
+    });
+    expect(renamed.status).toBe(200);
+    await expect(renamed.json()).resolves.toMatchObject({
+      account: { displayName: "Primary ChatGPT" },
+    });
+
+    const fetched = await managementFetch(`/model-provider-accounts/${createdBody.account.id}`);
+    expect(fetched.status).toBe(200);
+    await expect(fetched.json()).resolves.toMatchObject({
+      account: { displayName: "Primary ChatGPT" },
+    });
+
+    const reconnected = await managementFetch(
+      `/model-provider-accounts/${createdBody.account.id}/reconnect`,
+      {
+        method: "POST",
+        body: {
+          provider: "openai",
+          refreshToken: "integration-openai-refresh-reconnect",
+          accountId: "acct-integration",
+        },
+      }
+    );
+    expect(reconnected.status).toBe(200);
+    expectPrivateNoStore(reconnected);
+    expect(JSON.stringify(await reconnected.json())).not.toContain("refresh");
+
+    for (const action of ["disable", "enable", "verify"] as const) {
+      const response = await managementFetch(
+        `/model-provider-accounts/${createdBody.account.id}/${action}`,
+        { method: "POST" }
+      );
+      expect(response.status, action).toBe(200);
+      expectPrivateNoStore(response);
+      expect(JSON.stringify(await response.json())).not.toContain("refresh");
+    }
+
+    const archived = await managementFetch(`/model-provider-accounts/${createdBody.account.id}`, {
+      method: "DELETE",
+    });
+    expect(archived.status).toBe(204);
+    expectPrivateNoStore(archived);
+  });
+
+  it("creates, updates, lists, and deletes provider defaults", async () => {
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO model_provider_accounts
+        (id, provider, display_name, status, created_at, updated_at)
+        VALUES (?, 'openai', 'Default OpenAI', 'active', ?, ?)`
+    )
+      .bind(OPENAI_ACCOUNT_ID, now, now)
+      .run();
+
+    const put = await managementFetch("/model-provider-account-defaults/openai", {
+      method: "PUT",
+      body: { providerAccountId: OPENAI_ACCOUNT_ID, unattendedMode: "api_key" },
+    });
+    expect(put.status).toBe(200);
+    expectPrivateNoStore(put);
+    await expect(put.json()).resolves.toMatchObject({
+      default: { provider: "openai", unattendedMode: "api_key" },
+    });
+
+    const list = await managementFetch("/model-provider-account-defaults");
+    await expect(list.json()).resolves.toMatchObject({ defaults: [{ provider: "openai" }] });
+
+    const removed = await managementFetch("/model-provider-account-defaults/openai", {
+      method: "DELETE",
+    });
+    expect(removed.status).toBe(204);
+    expectPrivateNoStore(removed);
+  });
+
+  it("preflights a duplicate identity through an atomic reconnect", async () => {
+    const first = await managementFetch("/model-provider-accounts", {
+      method: "POST",
+      body: {
+        provider: "openai",
+        displayName: "Original",
+        refreshToken: "integration-openai-duplicate-original",
+        accountId: "acct-integration",
+      },
+    });
+    const original = await first.json<{ account: { id: string } }>();
+
+    const duplicate = await managementFetch("/model-provider-accounts", {
+      method: "POST",
+      body: {
+        provider: "openai",
+        displayName: "Must not create another row",
+        refreshToken: "integration-openai-duplicate-reconnect",
+        accountId: "acct-integration",
+      },
+    });
+
+    expect(duplicate.status).toBe(200);
+    const body = await duplicate.json<{
+      account: { id: string; displayName: string };
+      reconnectedExisting: boolean;
+    }>();
+    expect(body).toMatchObject({
+      account: { id: original.account.id, displayName: "Original" },
+      reconnectedExisting: true,
+    });
+    expect(JSON.stringify(body)).not.toContain("refresh");
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM model_provider_accounts WHERE external_account_id = 'acct-integration'"
+    ).first<{ count: number }>();
+    expect(count?.count).toBe(1);
+  });
+
+  it.each([
+    ["missing", "22222222222222222222222222222222", 404],
+    ["provider mismatch", OPENAI_ACCOUNT_ID, 400],
+  ] as const)("rejects a %s default account with %i", async (kind, accountId, status) => {
+    if (kind === "provider mismatch") {
+      const now = Date.now();
+      await env.DB.prepare(
+        `INSERT INTO model_provider_accounts
+          (id, provider, display_name, status, created_at, updated_at)
+          VALUES (?, 'xai', 'xAI account', 'active', ?, ?)`
+      )
+        .bind(accountId, now, now)
+        .run();
+    }
+
+    const response = await managementFetch("/model-provider-account-defaults/openai", {
+      method: "PUT",
+      body: { providerAccountId: accountId, unattendedMode: "provider_account" },
+    });
+
+    expect(response.status).toBe(status);
+    expectPrivateNoStore(response);
+  });
+
+  it.each([
+    ["inactive", "disabled", null],
+    ["archived", "active", 1],
+  ] as const)("rejects an %s default account with 409", async (_kind, status, archivedAt) => {
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO model_provider_accounts
+        (id, provider, display_name, status, created_at, updated_at, archived_at)
+        VALUES (?, 'openai', 'OpenAI account', ?, ?, ?, ?)`
+    )
+      .bind(OPENAI_ACCOUNT_ID, status, now, now, archivedAt)
+      .run();
+
+    const response = await managementFetch("/model-provider-account-defaults/openai", {
+      method: "PUT",
+      body: { providerAccountId: OPENAI_ACCOUNT_ID, unattendedMode: "provider_account" },
+    });
+
+    expect(response.status).toBe(409);
+    expectPrivateNoStore(response);
+  });
+
+  it("inventories legacy keys in every scope without exposing ciphertext", async () => {
+    const now = Date.now();
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO global_secrets (key, encrypted_value, created_at, updated_at) VALUES ('OPENAI_OAUTH_REFRESH_TOKEN', 'ciphertext', ?, ?)"
+      ).bind(now, now),
+      env.DB.prepare(
+        `INSERT INTO repo_secrets
+         (repo_id, repo_owner, repo_name, key, encrypted_value, created_at, updated_at)
+         VALUES (7, 'acme', 'repo', 'XAI_OAUTH_ACCESS_TOKEN', 'ciphertext', ?, ?)`
+      ).bind(now, now),
+      env.DB.prepare(
+        `INSERT INTO environments (id, name, created_at, updated_at)
+         VALUES ('env-1', 'Environment', ?, ?)`
+      ).bind(now, now),
+      env.DB.prepare(
+        `INSERT INTO environment_secrets
+         (environment_id, key, encrypted_value, created_at, updated_at)
+         VALUES ('env-1', 'XAI_OAUTH_REFRESH_TOKEN', 'ciphertext', ?, ?)`
+      ).bind(now, now),
+    ]);
+
+    const read = await managementFetch("/model-provider-accounts/legacy-credentials");
+    expect(read.status).toBe(200);
+    const readBody = await read.json<{ legacyKeys: unknown[] }>();
+    expect(readBody.legacyKeys).toEqual([
+      { scope: "environment", scopeId: "env-1", key: "XAI_OAUTH_REFRESH_TOKEN" },
+      { scope: "global", key: "OPENAI_OAUTH_REFRESH_TOKEN" },
+      {
+        scope: "repository",
+        scopeId: "7",
+        repository: "acme/repo",
+        key: "XAI_OAUTH_ACCESS_TOKEN",
+      },
+    ]);
+    expect(JSON.stringify(readBody)).not.toContain("ciphertext");
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -197,7 +197,11 @@ export {
   sessionModelProviderAuthResponseSchema,
   legacyProviderKeyLocationSchema,
   legacyProviderCredentialsResponseSchema,
+  connectOpenAIModelProviderAccountRequestSchema,
+  connectXaiModelProviderAccountRequestSchema,
   connectModelProviderAccountRequestSchema,
+  reconnectOpenAIModelProviderAccountRequestSchema,
+  reconnectXaiModelProviderAccountRequestSchema,
   reconnectModelProviderAccountRequestSchema,
 } from "./provider-accounts";
 export type {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -192,6 +192,7 @@ export {
   modelProviderAccountsResponseSchema,
   modelProviderAccountDefaultSchema,
   modelProviderAccountDefaultRequestSchema,
+  modelProviderAccountDisplayNameSchema,
   modelProviderAccountDefaultsResponseSchema,
   sessionModelProviderAuthSchema,
   sessionModelProviderAuthResponseSchema,

--- a/packages/shared/src/types/provider-accounts.ts
+++ b/packages/shared/src/types/provider-accounts.ts
@@ -153,33 +153,37 @@ const displayNameSchema = z.string().trim().min(1).max(100);
 const credentialStringSchema = z.string().min(1).max(65_536);
 const externalAccountIdSchema = z.string().trim().min(1).max(512);
 
+export const connectOpenAIModelProviderAccountRequestSchema = z.strictObject({
+  provider: z.literal("openai"),
+  displayName: displayNameSchema,
+  refreshToken: credentialStringSchema,
+  accountId: externalAccountIdSchema,
+});
+export const connectXaiModelProviderAccountRequestSchema = z.strictObject({
+  provider: z.literal("xai"),
+  displayName: displayNameSchema,
+  refreshToken: credentialStringSchema,
+});
 export const connectModelProviderAccountRequestSchema = z.discriminatedUnion("provider", [
-  z.strictObject({
-    provider: z.literal("openai"),
-    displayName: displayNameSchema,
-    refreshToken: credentialStringSchema,
-    accountId: externalAccountIdSchema,
-  }),
-  z.strictObject({
-    provider: z.literal("xai"),
-    displayName: displayNameSchema,
-    refreshToken: credentialStringSchema,
-  }),
+  connectOpenAIModelProviderAccountRequestSchema,
+  connectXaiModelProviderAccountRequestSchema,
 ]);
 export type ConnectModelProviderAccountRequest = z.infer<
   typeof connectModelProviderAccountRequestSchema
 >;
 
+export const reconnectOpenAIModelProviderAccountRequestSchema = z.strictObject({
+  provider: z.literal("openai"),
+  refreshToken: credentialStringSchema,
+  accountId: externalAccountIdSchema,
+});
+export const reconnectXaiModelProviderAccountRequestSchema = z.strictObject({
+  provider: z.literal("xai"),
+  refreshToken: credentialStringSchema,
+});
 export const reconnectModelProviderAccountRequestSchema = z.discriminatedUnion("provider", [
-  z.strictObject({
-    provider: z.literal("openai"),
-    refreshToken: credentialStringSchema,
-    accountId: externalAccountIdSchema,
-  }),
-  z.strictObject({
-    provider: z.literal("xai"),
-    refreshToken: credentialStringSchema,
-  }),
+  reconnectOpenAIModelProviderAccountRequestSchema,
+  reconnectXaiModelProviderAccountRequestSchema,
 ]);
 export type ReconnectModelProviderAccountRequest = z.infer<
   typeof reconnectModelProviderAccountRequestSchema

--- a/packages/shared/src/types/provider-accounts.ts
+++ b/packages/shared/src/types/provider-accounts.ts
@@ -149,19 +149,19 @@ export type LegacyProviderCredentialsResponse = z.infer<
   typeof legacyProviderCredentialsResponseSchema
 >;
 
-const displayNameSchema = z.string().trim().min(1).max(100);
+export const modelProviderAccountDisplayNameSchema = z.string().trim().min(1).max(100);
 const credentialStringSchema = z.string().min(1).max(65_536);
 const externalAccountIdSchema = z.string().trim().min(1).max(512);
 
 export const connectOpenAIModelProviderAccountRequestSchema = z.strictObject({
   provider: z.literal("openai"),
-  displayName: displayNameSchema,
+  displayName: modelProviderAccountDisplayNameSchema,
   refreshToken: credentialStringSchema,
   accountId: externalAccountIdSchema,
 });
 export const connectXaiModelProviderAccountRequestSchema = z.strictObject({
   provider: z.literal("xai"),
-  displayName: displayNameSchema,
+  displayName: modelProviderAccountDisplayNameSchema,
   refreshToken: credentialStringSchema,
 });
 export const connectModelProviderAccountRequestSchema = z.discriminatedUnion("provider", [


### PR DESCRIPTION
## Summary
- add provider adapters, credential exchange, and refresh fencing
- add account lifecycle and default-selection services
- expose human-only management routes with private no-store responses
- retain legacy credential discovery for migration

## Stack
Stack 2 of 7. Base: #1524. The next branch is `feat/provider-accounts-runtime`.

## Validation
- workspace typecheck
- focused control-plane: 7 files, 136 tests
- management API integration: 9 tests
- combined stack validation is recorded on the final PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model provider account management, including creation, listing, renaming, verification, reconnection, status changes, archiving, and provider defaults.
  - Added OpenAI and xAI account connections, token refresh, identity validation, and legacy credential discovery.
  - Added validation for provider accounts, request data, lifecycle states, and default selections.

- **Bug Fixes**
  - Improved concurrent refresh handling and recovery from expired or invalid credentials.
  - Added safer authentication error responses and private, no-store caching for account routes.
  - Improved handling of archived, disabled, reconnect-required, and unavailable accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->