### PR TITLE
feat: route sessions through provider accounts

### DIFF
--- a/packages/control-plane/src/automation/hydrate.ts
+++ b/packages/control-plane/src/automation/hydrate.ts
@@ -1,0 +1,15 @@
+import type { Automation } from "@open-inspect/shared/types/automations";
+import { AutomationStore, toAutomation, type AutomationRow } from "../db/automation-store";
+import { AutomationModelProviderAuthStore } from "../db/automation-model-provider-auth";
+import type { SqlDatabase } from "../db/sql-database";
+
+export async function hydrateAutomation(db: SqlDatabase, row: AutomationRow): Promise<Automation> {
+  const store = new AutomationStore(db);
+  const providerAuthStore = new AutomationModelProviderAuthStore(db);
+  const [repositories, environments, providerAuth] = await Promise.all([
+    store.getRepositoriesForAutomation(row.id),
+    store.getEnvironmentsForAutomation(row.id),
+    providerAuthStore.list(row.id),
+  ]);
+  return toAutomation(row, repositories, environments, providerAuth);
+}

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -81,11 +81,10 @@ export interface ImageBuildCallbackBuild {
  * Compatibility floor for prebuilt-image runtimes.
  *
  * Bumped ONLY on breaking runtime changes, never on routine CACHE_BUSTER
- * bumps. v56 is the managed-provider runtime — the first that consumes
- * provider-availability markers instead of durable OAuth credentials — so no
- * image baked by an earlier runtime may ever be selected for a session.
+ * bumps. v60 is the first runtime whose managed-provider plugins use the
+ * generic token broker, so no image baked by an earlier runtime may be selected.
  */
-export const MIN_COMPATIBLE_RUNTIME_VERSION = 56;
+export const MIN_COMPATIBLE_RUNTIME_VERSION = 60;
 
 /**
  * Parse the numeric prefix of a SANDBOX_VERSION ("v53-list-native-runtime"

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -17,6 +17,7 @@ import type {
   ImageBuildScopeKind,
   ImageBuildStatus,
 } from "@open-inspect/shared/types/image-builds";
+import { MIN_COMPATIBLE_RUNTIME_GENERATION } from "../sandbox/runtime-manifest";
 
 /**
  * Providers with image-build support: Modal images, Vercel snapshots,
@@ -84,7 +85,7 @@ export interface ImageBuildCallbackBuild {
  * bumps. v60 is the first runtime whose managed-provider plugins use the
  * generic token broker, so no image baked by an earlier runtime may be selected.
  */
-export const MIN_COMPATIBLE_RUNTIME_VERSION = 60;
+export const MIN_COMPATIBLE_RUNTIME_VERSION = MIN_COMPATIBLE_RUNTIME_GENERATION;
 
 /**
  * Parse the numeric prefix of a SANDBOX_VERSION ("v53-list-native-runtime"

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -2,7 +2,7 @@ import { resolveBuildTimeoutSeconds } from "@open-inspect/shared/types/integrati
 import { createLogger, type CorrelationContext } from "../logger";
 import { createSourceControlProviderFromEnv, resolveScmProviderFromEnv } from "../source-control";
 import { scmCloneIdentity } from "../sandbox/sandbox-env";
-import { prepareManagedProviderEnv } from "../sandbox/managed-provider-env";
+import { prepareLegacyManagedProviderEnv } from "../sandbox/managed-provider-env";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import {
@@ -90,7 +90,10 @@ export class ImageBuildPlanner {
       failureCallbackUrl: params.failureCallbackUrl,
       buildTimeoutMs: resolveBuildTimeoutSeconds(sandboxSettings) * MS_PER_SECOND,
       userEnvVars: userEnvVars
-        ? prepareManagedProviderEnv({ exposedSecrets: userEnvVars, brokerSecrets: userEnvVars })
+        ? prepareLegacyManagedProviderEnv({
+            exposedSecrets: userEnvVars,
+            brokerSecrets: userEnvVars,
+          })
         : undefined,
       correlation: {
         trace_id: params.correlation.trace_id,

--- a/packages/control-plane/src/image-builds/rebuild-policy.test.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.test.ts
@@ -71,9 +71,9 @@ describe("evaluateImageBuildRebuildPolicy", () => {
     }
 
     const current: Array<[ImageBuildProvider, string]> = [
-      ["modal", "v59-opencode-1-18-18"],
-      ["opencomputer", "v59-vnc-opencode-1-18-18"],
-      ["vercel", "v59-vnc-opencode-1-18-18"],
+      ["modal", "v60-provider-account-broker"],
+      ["opencomputer", "v60-provider-account-broker"],
+      ["vercel", "v60-provider-account-broker"],
     ];
     for (const [provider, runtime_version] of current) {
       expect(

--- a/packages/control-plane/src/image-builds/rebuild-policy.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.ts
@@ -2,11 +2,12 @@ import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-buil
 import { parseRuntimeVersionNumber, type ImageBuildProvider } from "./model";
 import { parseRepositoryShasJson, repositoryIdentityKey } from "./provenance";
 import type { EnabledScopeUnit } from "./scope";
+import { MIN_REBUILD_RUNTIME_GENERATION } from "../sandbox/runtime-manifest";
 
 // Runtime generations are one sequence shared by every image-build provider.
 // v60 carries the generic provider-account token broker plugin. Older images
 // cannot boot safely because their managed-provider plugins call legacy routes.
-export const MIN_REBUILD_RUNTIME_VERSION = 60;
+export const MIN_REBUILD_RUNTIME_VERSION = MIN_REBUILD_RUNTIME_GENERATION;
 
 export type ImageBuildRebuildDecision =
   | { type: "skip"; reason: "building" }

--- a/packages/control-plane/src/image-builds/rebuild-policy.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.ts
@@ -4,11 +4,9 @@ import { parseRepositoryShasJson, repositoryIdentityKey } from "./provenance";
 import type { EnabledScopeUnit } from "./scope";
 
 // Runtime generations are one sequence shared by every image-build provider.
-// v59 carries OpenCode past its message-ID wraparound (see
-// packages/modal-infra/src/images/base.py); v57 added the VNC/noVNC toolchain.
-// MIN_COMPATIBLE_RUNTIME_VERSION remains safe to boot while the scheduler
-// converges prebuilt images in the background.
-export const MIN_REBUILD_RUNTIME_VERSION = 59;
+// v60 carries the generic provider-account token broker plugin. Older images
+// cannot boot safely because their managed-provider plugins call legacy routes.
+export const MIN_REBUILD_RUNTIME_VERSION = 60;
 
 export type ImageBuildRebuildDecision =
   | { type: "skip"; reason: "building" }

--- a/packages/control-plane/src/model-provider-accounts/automation-provider-selection.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/automation-provider-selection.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseAndValidateAutomationProviderSelections } from "./automation-provider-selection";
+import { ProviderAccountSelectionPolicyError } from "./selection-policy";
+
+const mockGetById = vi.hoisted(() => vi.fn());
+const mockAdapterGet = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/model-provider-accounts", () => ({
+  ModelProviderAccountStore: vi.fn().mockImplementation(function () {
+    return { getById: mockGetById };
+  }),
+}));
+
+vi.mock("../auth/model-provider-account-default-adapters", () => ({
+  modelProviderAccountAdapterRegistry: { get: mockAdapterGet },
+}));
+
+describe("automation provider selections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapterGet.mockReturnValue({});
+    mockGetById.mockResolvedValue({
+      id: "0123456789abcdef0123456789abcdef",
+      provider: "openai",
+      status: "active",
+      archivedAt: null,
+    });
+  });
+
+  it("parses API-key and provider-account selections", async () => {
+    const selections = {
+      openai: {
+        mode: "provider_account" as const,
+        accountId: "0123456789abcdef0123456789abcdef",
+      },
+      xai: { mode: "api_key" as const },
+    };
+
+    await expect(
+      parseAndValidateAutomationProviderSelections({} as D1Database, selections)
+    ).resolves.toEqual(selections);
+    expect(mockGetById).toHaveBeenCalledOnce();
+  });
+
+  it("preserves schema issue paths in validation errors", async () => {
+    await expect(
+      parseAndValidateAutomationProviderSelections({} as D1Database, {
+        openai: { mode: "provider_account", accountId: "short" },
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "AutomationProviderSelectionError",
+        message: expect.stringMatching(/^providerSelections\.openai\.accountId:/),
+      })
+    );
+  });
+
+  it.each([
+    ["unavailable adapter", undefined, null, "openai provider account adapter is unavailable"],
+    ["missing account", {}, null, "Selected openai provider account was not found"],
+    [
+      "wrong provider",
+      {},
+      { provider: "xai", status: "active", archivedAt: null },
+      "Selected provider account does not belong to openai",
+    ],
+    [
+      "inactive account",
+      {},
+      { provider: "openai", status: "disabled", archivedAt: null },
+      "Selected openai provider account is unavailable",
+    ],
+    [
+      "archived account",
+      {},
+      { provider: "openai", status: "active", archivedAt: 1 },
+      "Selected openai provider account is unavailable",
+    ],
+  ])("rejects an %s", async (_label, adapter, account, message) => {
+    mockAdapterGet.mockReturnValue(adapter);
+    mockGetById.mockResolvedValue(account);
+
+    await expect(
+      parseAndValidateAutomationProviderSelections({} as D1Database, {
+        openai: {
+          mode: "provider_account",
+          accountId: "0123456789abcdef0123456789abcdef",
+        },
+      })
+    ).rejects.toEqual(expect.objectContaining({ name: "Error", message }));
+    await expect(
+      parseAndValidateAutomationProviderSelections({} as D1Database, {
+        openai: {
+          mode: "provider_account",
+          accountId: "0123456789abcdef0123456789abcdef",
+        },
+      })
+    ).rejects.toBeInstanceOf(ProviderAccountSelectionPolicyError);
+  });
+});

--- a/packages/control-plane/src/model-provider-accounts/automation-provider-selection.ts
+++ b/packages/control-plane/src/model-provider-accounts/automation-provider-selection.ts
@@ -1,0 +1,39 @@
+import {
+  modelProviderSelectionsSchema,
+  SUBSCRIPTION_PROVIDER_IDS,
+  type ModelProviderSelections,
+} from "@open-inspect/shared/types/provider-accounts";
+import { modelProviderAccountAdapterRegistry } from "../auth/model-provider-account-default-adapters";
+import { ModelProviderAccountStore } from "../db/model-provider-accounts";
+import type { SqlDatabase } from "../db/sql-database";
+import { ProviderAccountSelectionPolicy } from "./selection-policy";
+
+export class AutomationProviderSelectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AutomationProviderSelectionError";
+  }
+}
+
+export async function parseAndValidateAutomationProviderSelections(
+  db: SqlDatabase,
+  value: unknown
+): Promise<ModelProviderSelections> {
+  const parsed = modelProviderSelectionsSchema.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = ["providerSelections", ...(issue?.path ?? [])].join(".");
+    throw new AutomationProviderSelectionError(`${path}: ${issue?.message ?? "invalid"}`);
+  }
+
+  const policy = new ProviderAccountSelectionPolicy(
+    new ModelProviderAccountStore(db),
+    modelProviderAccountAdapterRegistry
+  );
+  for (const provider of SUBSCRIPTION_PROVIDER_IDS) {
+    const selection = parsed.data[provider];
+    if (!selection || selection.mode === "api_key") continue;
+    await policy.validateSelection(provider, selection.accountId);
+  }
+  return parsed.data;
+}

--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -12,6 +12,8 @@ import { sessionCreateRoutes } from "./routes/session-create";
 import { HttpError, resolveRepoOrError } from "./routes/shared";
 import { SessionInternalPaths } from "./session/contracts";
 import { resolveManagedSkills } from "./session/skill-resolution";
+import { resolveSessionProviderAuth } from "./session/provider-account-resolution";
+import { ProviderAccountSelectionPolicyError } from "./model-provider-accounts/selection-policy";
 
 vi.mock("./db/session-index", () => ({
   SessionIndexStore: vi.fn(),
@@ -27,6 +29,11 @@ vi.mock("./session/skill-resolution", async (importOriginal) => {
     ...actual,
     resolveManagedSkills: vi.fn(),
   };
+});
+
+vi.mock("./session/provider-account-resolution", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, resolveSessionProviderAuth: vi.fn() };
 });
 
 vi.mock("./routes/shared", async (importOriginal) => {
@@ -52,6 +59,10 @@ describe("handleCreateSession D1 ordering", () => {
       resolvedAt: 1,
       skills: [],
     });
+    vi.mocked(resolveSessionProviderAuth).mockResolvedValue([
+      { provider: "openai", authMode: "api_key", selectionSource: "fallback_api_key" },
+      { provider: "xai", authMode: "api_key", selectionSource: "fallback_api_key" },
+    ]);
     vi.mocked(resolveRepoOrError).mockResolvedValue({
       repoId: 12345,
       defaultBranch: "main",
@@ -289,6 +300,51 @@ describe("handleCreateSession D1 ordering", () => {
     expect(initFetch).toHaveBeenCalledOnce();
     expect(create.mock.invocationCallOrder[0]).toBeLessThan(initFetch.mock.invocationCallOrder[0]);
   });
+
+  it("resolves explicit provider selections for a user-created session", async () => {
+    const create = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return { create } as never;
+    });
+    const initFetch = vi.fn(async () => Response.json({ status: "created" }));
+    const explicit = {
+      openai: { mode: "provider_account" as const, accountId: "1".repeat(32) },
+    };
+
+    const response = await createSessionRequestWithBody(createEnv(initFetch), {
+      title: "Explicit provider",
+      providerSelections: explicit,
+    });
+
+    expect(response.status).toBe(201);
+    expect(resolveSessionProviderAuth).toHaveBeenCalledWith(expect.anything(), {
+      explicit,
+      unattended: true,
+    });
+  });
+
+  it.each([400, 404, 409] as const)(
+    "preserves provider account policy status %i",
+    async (status) => {
+      vi.mocked(resolveSessionProviderAuth).mockRejectedValueOnce(
+        new ProviderAccountSelectionPolicyError("Provider account rejected", status)
+      );
+      const create = vi.fn();
+      vi.mocked(SessionIndexStore).mockImplementation(function () {
+        return { create } as never;
+      });
+
+      const response = await createSessionRequestWithBody(createEnv(vi.fn()), {
+        title: "Rejected provider",
+        providerSelections: {
+          openai: { mode: "provider_account", accountId: "1".repeat(32) },
+        },
+      });
+
+      expect(response.status).toBe(status);
+      expect(create).not.toHaveBeenCalled();
+    }
+  );
 
   it("enriches SCM fields from the resolved user's linked GitHub identity", async () => {
     const create = vi.fn().mockResolvedValue(undefined);

--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -64,6 +64,7 @@ describe("route policy table", () => {
     ["POST", "/sessions/session-1/openai-token-refresh"],
     ["POST", "/sessions/session-1/xai-token-refresh"],
     ["GET", "/sessions/session-1/sandbox-skills"],
+    ["POST", "/sessions/session-1/provider-auth/openai/access-token"],
   ])("requires the bound sandbox for %s %s", (method, path) => {
     const route = routeFor(method, path);
     const match = path.match(route!.pattern)!;
@@ -94,8 +95,11 @@ describe("route policy table", () => {
     );
   });
 
-  it("marks provider account management routes as non-cacheable", () => {
+  it("marks management and broker routes as non-cacheable", () => {
     expect(routeFor("GET", "/model-provider-accounts")?.cacheControl).toBe("private, no-store");
+    expect(
+      routeFor("POST", "/sessions/session-1/provider-auth/openai/access-token")?.cacheControl
+    ).toBe("no-store");
   });
 
   it.each([
@@ -170,6 +174,31 @@ describe("route policy dispatch ordering", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Invalid SCM_PROVIDER value 'invalid'. Supported values: github, bitbucket, gitlab.",
     });
+  });
+
+  it("applies broker cache policy when sandbox authentication is unavailable", async () => {
+    const testEnv = env("github") as ReturnType<typeof env> & {
+      SESSION: {
+        idFromName: (name: string) => string;
+        get: () => { fetch: () => Promise<Response> };
+      };
+    };
+    testEnv.SESSION = {
+      idFromName: (name) => name,
+      get: () => ({ fetch: async () => Promise.reject(new Error("DO unavailable")) }),
+    };
+
+    const response = await handleRequest(
+      new Request("https://test.local/sessions/session-1/provider-auth/openai/access-token", {
+        method: "POST",
+        headers: { Authorization: "Bearer sandbox-token" },
+      }),
+      testEnv as never,
+      TEST_BACKGROUND_TASK_CONTEXT
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 });
 

--- a/packages/control-plane/src/router.scm-credentials.test.ts
+++ b/packages/control-plane/src/router.scm-credentials.test.ts
@@ -29,6 +29,7 @@ function createEnv() {
   return {
     fetch,
     idFromName,
+    statement,
     env: {
       ...TEST_SERVICE_SECRETS,
       SCM_PROVIDER: "gitlab",
@@ -65,7 +66,14 @@ describe("SCM credentials router provider gate", () => {
   );
 
   it("allows a matching sandbox token to reach the xAI broker", async () => {
-    const { env, fetch } = createEnv();
+    const { env, fetch, statement } = createEnv();
+    statement.first.mockResolvedValue({
+      provider: "xai",
+      auth_mode: "legacy_scoped_oauth",
+      provider_account_id: null,
+      selection_source: "legacy_migration",
+      inherited_from_session_id: null,
+    } as never);
     const response = await handleRequest(
       new Request("https://test.local/sessions/session-1/xai-token-refresh", {
         method: "POST",

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -49,6 +49,20 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     };
   };
 
+  const parentProviderAuth = [
+    {
+      provider: "openai" as const,
+      authMode: "provider_account" as const,
+      providerAccountId: "1".repeat(32),
+      selectionSource: "installation_default",
+    },
+    {
+      provider: "xai" as const,
+      authMode: "api_key" as const,
+      selectionSource: "fallback_api_key",
+    },
+  ];
+
   const spawnContext: TestSpawnContext = {
     repoOwner: "acme",
     repoName: "web-app",
@@ -81,6 +95,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
       environmentId: "env_parent",
     }),
     getSpawnDepth: vi.fn().mockResolvedValue(0),
+    getCompleteProviderAuth: vi.fn().mockResolvedValue(parentProviderAuth),
     countTotalChildren: vi.fn().mockResolvedValue(0),
     acquireChildAdmissionLease: vi.fn().mockResolvedValue({
       token: "lease-token",
@@ -98,6 +113,55 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     integrationSettingsMocks.resolveCodeServerEnabled.mockResolvedValue(false);
     integrationSettingsMocks.resolveVncEnabled.mockResolvedValue(false);
     integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({});
+  });
+
+  it("copies the exact parent provider auth snapshot with immediate inheritance", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    const { env } = makeSuccessfulEnv(spawnContext);
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(201);
+    expect(store.getCompleteProviderAuth).toHaveBeenCalledWith(parentId);
+    expect(store.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerAuth: [
+          {
+            provider: "openai",
+            authMode: "provider_account",
+            providerAccountId: "1".repeat(32),
+            selectionSource: "installation_default",
+            inheritedFromSessionId: parentId,
+          },
+          {
+            provider: "xai",
+            authMode: "api_key",
+            selectionSource: "fallback_api_key",
+            inheritedFromSessionId: parentId,
+          },
+        ],
+      })
+    );
+  });
+
+  it("fails closed when the parent D1 provider auth snapshot is unavailable", async () => {
+    const store = makeStore();
+    store.getCompleteProviderAuth.mockRejectedValue(new Error("D1 unavailable"));
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    const { env } = makeSuccessfulEnv(spawnContext);
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Parent provider auth unavailable",
+    });
+    expect(store.create).not.toHaveBeenCalled();
   });
 
   async function makeRequest(

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -14,6 +14,12 @@ import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import { TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
 
+const mockProviderAdapterGet = vi.hoisted(() => vi.fn());
+
+vi.mock("../auth/model-provider-account-default-adapters", () => ({
+  modelProviderAccountAdapterRegistry: { get: mockProviderAdapterGet },
+}));
+
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 const mockStore = {
@@ -37,6 +43,33 @@ const mockStore = {
   bindReplaceEnvironments: vi.fn(),
   listInvocations: vi.fn(),
 };
+
+const mockProviderAuthStore = {
+  list: vi.fn(),
+  listForAutomationIds: vi.fn(),
+  bindInserts: vi.fn(),
+  bindReplace: vi.fn(),
+};
+
+vi.mock("../db/automation-model-provider-auth", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    AutomationModelProviderAuthStore: vi.fn().mockImplementation(function () {
+      return mockProviderAuthStore;
+    }),
+  };
+});
+
+const mockProviderAccountStore = {
+  getById: vi.fn(),
+};
+
+vi.mock("../db/model-provider-accounts", () => ({
+  ModelProviderAccountStore: vi.fn().mockImplementation(function () {
+    return mockProviderAccountStore;
+  }),
+}));
 
 /** Shared D1 batch spy — createEnv wires it as env.DB.batch. */
 const mockBatch = vi.fn();
@@ -207,14 +240,25 @@ describe("automation route handlers", () => {
     mockStore.getRepositoriesForAutomationIds.mockResolvedValue(new Map());
     mockStore.getEnvironmentsForAutomation.mockResolvedValue([]);
     mockStore.getEnvironmentsForAutomationIds.mockResolvedValue(new Map());
+    mockProviderAuthStore.list.mockResolvedValue([]);
+    mockProviderAuthStore.listForAutomationIds.mockResolvedValue(new Map());
     mockStore.bindAutomationInsert.mockReturnValue({ sql: "insert-automation" });
     mockStore.bindAutomationUpdate.mockReturnValue({ sql: "update-automation" });
     mockStore.bindRepositoryInserts.mockReturnValue([{ sql: "insert-repositories" }]);
     mockStore.bindReplaceRepositories.mockReturnValue([{ sql: "replace-repositories" }]);
     mockStore.bindEnvironmentInserts.mockReturnValue([{ sql: "insert-environments" }]);
     mockStore.bindReplaceEnvironments.mockReturnValue([{ sql: "replace-environments" }]);
+    mockProviderAuthStore.bindInserts.mockReturnValue([{ sql: "insert-provider-auth" }]);
+    mockProviderAuthStore.bindReplace.mockReturnValue([{ sql: "replace-provider-auth" }]);
     mockBatch.mockResolvedValue([]);
     mockEnvironmentStore.getById.mockResolvedValue({ id: "env_1", name: "Fullstack" });
+    mockProviderAccountStore.getById.mockResolvedValue({
+      id: "0123456789abcdef0123456789abcdef",
+      provider: "openai",
+      status: "active",
+      archivedAt: null,
+    });
+    mockProviderAdapterGet.mockReturnValue({});
     vi.mocked(resolveRepoOrError).mockResolvedValue({
       repoId: 12345,
       repoOwner: "acme",
@@ -320,6 +364,79 @@ describe("automation route handlers", () => {
       expect(mockBatch).toHaveBeenCalledWith(
         expect.arrayContaining([{ sql: "insert-automation" }, { sql: "insert-repositories" }])
       );
+    });
+
+    it("persists a complete provider pin map in the create batch", async () => {
+      mockStore.getById.mockResolvedValue(sampleRow);
+      const providerSelections = {
+        openai: {
+          mode: "provider_account" as const,
+          accountId: "0123456789abcdef0123456789abcdef",
+        },
+        xai: { mode: "api_key" as const },
+      };
+
+      const res = await callRoute("POST", "/automations", {
+        body: { ...validBody, providerSelections },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockProviderAuthStore.bindInserts).toHaveBeenCalledWith(
+        "generated-id",
+        providerSelections,
+        expect.any(Number)
+      );
+      expect(mockBatch).toHaveBeenCalledWith(
+        expect.arrayContaining([{ sql: "insert-provider-auth" }])
+      );
+    });
+
+    it.each([
+      ["missing account", null, 404],
+      ["wrong provider", { provider: "xai", status: "active", archivedAt: null }, 400],
+      ["inactive account", { provider: "openai", status: "disabled", archivedAt: null }, 409],
+      ["archived account", { provider: "openai", status: "active", archivedAt: 123 }, 409],
+    ])("rejects a provider pin for a %s", async (_label, account, status) => {
+      mockProviderAccountStore.getById.mockResolvedValue({
+        id: "0123456789abcdef0123456789abcdef",
+        ...account,
+      });
+      if (!account) mockProviderAccountStore.getById.mockResolvedValue(null);
+
+      const res = await callRoute("POST", "/automations", {
+        body: {
+          ...validBody,
+          providerSelections: {
+            openai: {
+              mode: "provider_account",
+              accountId: "0123456789abcdef0123456789abcdef",
+            },
+          },
+        },
+      });
+
+      expect(res.status).toBe(status);
+      expect(mockBatch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a provider-account pin when its adapter is unavailable", async () => {
+      mockProviderAdapterGet.mockReturnValue(undefined);
+
+      const res = await callRoute("POST", "/automations", {
+        body: {
+          ...validBody,
+          providerSelections: {
+            openai: {
+              mode: "provider_account",
+              accountId: "0123456789abcdef0123456789abcdef",
+            },
+          },
+        },
+      });
+
+      expect(res.status).toBe(409);
+      expect(mockProviderAccountStore.getById).not.toHaveBeenCalled();
+      expect(mockBatch).not.toHaveBeenCalled();
     });
 
     it.each([{ triggerConfig: {} }, { triggerConfig: { conditions: null } }])(
@@ -822,6 +939,47 @@ describe("automation route handlers", () => {
         expect.arrayContaining([{ sql: "update-automation" }])
       );
     });
+
+    it("leaves provider pins unchanged when providerSelections is omitted", async () => {
+      mockStore.getById.mockResolvedValue(sampleRow);
+
+      const res = await callRoute("PUT", "/automations/auto-1", { body: { name: "Updated" } });
+
+      expect(res.status).toBe(200);
+      expect(mockProviderAuthStore.bindReplace).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        "replaces",
+        {
+          openai: {
+            mode: "provider_account" as const,
+            accountId: "0123456789abcdef0123456789abcdef",
+          },
+        },
+      ],
+      ["clears", {}],
+    ])(
+      "%s provider pins when providerSelections is present",
+      async (_label, providerSelections) => {
+        mockStore.getById.mockResolvedValue(sampleRow);
+
+        const res = await callRoute("PUT", "/automations/auto-1", {
+          body: { providerSelections },
+        });
+
+        expect(res.status).toBe(200);
+        expect(mockProviderAuthStore.bindReplace).toHaveBeenCalledWith(
+          "auto-1",
+          providerSelections,
+          expect.any(Number)
+        );
+        expect(mockBatch).toHaveBeenCalledWith(
+          expect.arrayContaining([{ sql: "replace-provider-auth" }])
+        );
+      }
+    );
 
     it.each([{ triggerConfig: {} }, { triggerConfig: { conditions: null } }])(
       "rejects malformed trigger config before updating",

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -14,6 +14,7 @@ import type {
   CreateAutomationRequest,
   UpdateAutomationRequest,
 } from "@open-inspect/shared/types/automations";
+import type { ModelProviderSelections } from "@open-inspect/shared/types/provider-accounts";
 import { listChannels } from "@open-inspect/shared/slack";
 import {
   getValidModelOrDefault,
@@ -35,10 +36,16 @@ import {
 import { EnvironmentStore } from "../db/environments";
 import { SlackChannelStore } from "../db/slack-channel-store";
 import { UserStore } from "../db/user-store";
+import { AutomationModelProviderAuthStore } from "../db/automation-model-provider-auth";
+import {
+  AutomationProviderSelectionError,
+  parseAndValidateAutomationProviderSelections,
+} from "../model-provider-accounts/automation-provider-selection";
 import { generateId } from "../auth/crypto";
 import { applyIdentityEnforcement, resolveCanonicalUserId } from "../auth/identity-enforcement";
 import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/webhook-key";
 import { createLogger } from "../logger";
+import { hydrateAutomation } from "../automation/hydrate";
 import {
   automationRepositoriesInputSchema,
   MAX_AUTOMATION_REPOSITORIES,
@@ -58,6 +65,7 @@ import {
 import type { Env } from "../types";
 import type { SqlDatabase, SqlStatement } from "../db/sql-database";
 import { z } from "zod";
+import { ProviderAccountSelectionPolicyError } from "../model-provider-accounts/selection-policy";
 
 const logger = createLogger("router:automations");
 
@@ -396,19 +404,22 @@ async function handleListAutomations(
   if (!parsed.ok) return error(parsed.error, 400);
 
   const store = new AutomationStore(ctx.db);
+  const providerAuthStore = new AutomationModelProviderAuthStore(ctx.db);
   const result = await store.list(parsed.options);
   const automationIds = result.automations.map((row) => row.id);
-  const [repositoriesByAutomation, environmentsByAutomation] = await Promise.all([
-    store.getRepositoriesForAutomationIds(automationIds),
-    store.getEnvironmentsForAutomationIds(automationIds),
-  ]);
+  const [repositoriesByAutomation, environmentsByAutomation, providerAuthByAutomation] =
+    await Promise.all([
+      store.getRepositoriesForAutomationIds(automationIds),
+      store.getEnvironmentsForAutomationIds(automationIds),
+      providerAuthStore.listForAutomationIds(automationIds),
+    ]);
 
   const automations = result.automations.map((row) =>
     toAutomation(
       row,
       repositoriesByAutomation.get(row.id) ?? [],
       environmentsByAutomation.get(row.id) ?? [],
-      []
+      providerAuthByAutomation.get(row.id) ?? []
     )
   );
   return json({
@@ -554,6 +565,18 @@ async function handleCreateAutomation(
 
   const newRepositories = await resolveRepositorySelection(env, requestedRepositories, ctx);
 
+  let providerSelections: ModelProviderSelections;
+  try {
+    providerSelections = await parseAndValidateAutomationProviderSelections(
+      ctx.db,
+      body.providerSelections ?? {}
+    );
+  } catch (e) {
+    if (e instanceof AutomationProviderSelectionError) return error(e.message, 400);
+    if (e instanceof ProviderAccountSelectionPolicyError) return error(e.message, e.status);
+    throw e;
+  }
+
   // Compute next run (only for schedule triggers)
   const nextRunAt = isSchedule
     ? nextCronOccurrence(body.scheduleCron!, body.scheduleTz!).getTime()
@@ -592,6 +615,7 @@ async function handleCreateAutomation(
 
   const db: SqlDatabase = ctx.db;
   const store = new AutomationStore(db);
+  const providerAuthStore = new AutomationModelProviderAuthStore(db);
   const row: AutomationRow = {
     id,
     name: body.name.trim(),
@@ -622,6 +646,7 @@ async function handleCreateAutomation(
     store.bindAutomationInsert(row),
     ...store.bindRepositoryInserts(id, newRepositories, now),
     ...store.bindEnvironmentInserts(id, requestedEnvironmentIds, now),
+    ...providerAuthStore.bindInserts(id, providerSelections, now),
   ];
   if (triggerType === "slack_event") {
     const slackStore = new SlackChannelStore(db);
@@ -631,12 +656,7 @@ async function handleCreateAutomation(
   }
   await db.batch(createStatements);
 
-  const automation = toAutomation(
-    (await store.getById(id))!,
-    await store.getRepositoriesForAutomation(id),
-    await store.getEnvironmentsForAutomation(id),
-    []
-  );
+  const automation = await hydrateAutomation(db, (await store.getById(id))!);
 
   logger.info("automation.created", {
     event: "automation.created",
@@ -686,14 +706,7 @@ async function handleGetAutomation(
   const row = await store.getById(id);
   if (!row) return error("Automation not found", 404);
 
-  return json({
-    automation: toAutomation(
-      row,
-      await store.getRepositoriesForAutomation(id),
-      await store.getEnvironmentsForAutomation(id),
-      []
-    ),
-  });
+  return json({ automation: await hydrateAutomation(ctx.db, row) });
 }
 
 async function handleUpdateAutomation(
@@ -707,6 +720,7 @@ async function handleUpdateAutomation(
 
   const db: SqlDatabase = ctx.db;
   const store = new AutomationStore(db);
+  const providerAuthStore = new AutomationModelProviderAuthStore(db);
   const existing = await store.getById(id);
   if (!existing) return error("Automation not found", 404);
 
@@ -720,6 +734,20 @@ async function handleUpdateAutomation(
       const parsedTriggerConfig = parseTriggerConfig(body.triggerConfig);
       if (!parsedTriggerConfig.ok) return error(parsedTriggerConfig.error, 400);
       body.triggerConfig = parsedTriggerConfig.triggerConfig;
+    }
+  }
+
+  let replacementProviderSelections: ModelProviderSelections | null = null;
+  if (body.providerSelections !== undefined) {
+    try {
+      replacementProviderSelections = await parseAndValidateAutomationProviderSelections(
+        ctx.db,
+        body.providerSelections
+      );
+    } catch (e) {
+      if (e instanceof AutomationProviderSelectionError) return error(e.message, 400);
+      if (e instanceof ProviderAccountSelectionPolicyError) return error(e.message, e.status);
+      throw e;
     }
   }
 
@@ -924,6 +952,11 @@ async function handleUpdateAutomation(
   if (replacementEnvironmentIds !== null) {
     statements.push(...store.bindReplaceEnvironments(id, replacementEnvironmentIds, Date.now()));
   }
+  if (replacementProviderSelections !== null) {
+    statements.push(
+      ...providerAuthStore.bindReplace(id, replacementProviderSelections, Date.now())
+    );
+  }
   if (resyncSlackChannels) {
     const slackStore = new SlackChannelStore(db);
     statements.push(
@@ -943,14 +976,7 @@ async function handleUpdateAutomation(
     trace_id: ctx.trace_id,
   });
 
-  return json({
-    automation: toAutomation(
-      updated,
-      await store.getRepositoriesForAutomation(id),
-      await store.getEnvironmentsForAutomation(id),
-      []
-    ),
-  });
+  return json({ automation: await hydrateAutomation(db, updated) });
 }
 
 async function handleDeleteAutomation(
@@ -998,14 +1024,7 @@ async function handlePauseAutomation(
 
   const row = await store.getById(id);
   return json({
-    automation: row
-      ? toAutomation(
-          row,
-          await store.getRepositoriesForAutomation(id),
-          await store.getEnvironmentsForAutomation(id),
-          []
-        )
-      : null,
+    automation: row ? await hydrateAutomation(ctx.db, row) : null,
   });
 }
 
@@ -1047,14 +1066,7 @@ async function handleResumeAutomation(
 
   const row = await store.getById(id);
   return json({
-    automation: row
-      ? toAutomation(
-          row,
-          await store.getRepositoriesForAutomation(id),
-          await store.getEnvironmentsForAutomation(id),
-          []
-        )
-      : null,
+    automation: row ? await hydrateAutomation(ctx.db, row) : null,
   });
 }
 

--- a/packages/control-plane/src/routes/model-provider-accounts.ts
+++ b/packages/control-plane/src/routes/model-provider-accounts.ts
@@ -12,10 +12,15 @@ import { z } from "zod";
 import { createLogger } from "../logger";
 import { generateId } from "../auth/crypto";
 import { modelProviderAccountAdapterRegistry } from "../auth/model-provider-account-default-adapters";
+import {
+  ModelProviderAccountBroker,
+  ModelProviderAccountBrokerError,
+} from "../auth/model-provider-account-broker";
 import { ModelProviderAccountStore } from "../db/model-provider-accounts";
 import { D1ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
 import { ProviderCredentialStore } from "../db/provider-account-credentials";
 import { ProviderDefaultStore } from "../db/provider-account-defaults";
+import { SessionIndexStore } from "../db/session-index";
 import { listLegacyProviderCredentials } from "../model-provider-accounts/legacy-provider-credentials";
 import {
   ModelProviderAccountService,
@@ -26,6 +31,8 @@ import {
   ProviderAccountSelectionPolicyError,
 } from "../model-provider-accounts/selection-policy";
 import type { Env } from "../types";
+import { SessionInternalPaths } from "../session/contracts";
+import { createSessionRuntimeClient } from "../session/runtime-client";
 import {
   defineRoute,
   error,
@@ -33,14 +40,26 @@ import {
   parseJsonBody,
   parsePattern,
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
+  SCM_AGNOSTIC_SANDBOX_ROUTE,
   type RequestContext,
   type Route,
+  type SandboxRouteContext,
   type UserRouteContext,
 } from "./shared";
 
 const PRIVATE_NO_STORE = "private, no-store" as const;
+const NO_STORE = "no-store" as const;
 const renameSchema = z.strictObject({ displayName: modelProviderAccountDisplayNameSchema });
 const logger = createLogger("router:model-provider-accounts");
+const legacyAccessSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().optional(),
+  account_id: z.string().optional(),
+});
+const LEGACY_REFRESH_PATH = {
+  openai: SessionInternalPaths.openaiTokenRefresh,
+  xai: SessionInternalPaths.xaiTokenRefresh,
+} as const;
 
 function service(env: Env, ctx: RequestContext): ModelProviderAccountService {
   const accounts = new ModelProviderAccountStore(ctx.db);
@@ -265,4 +284,86 @@ const managementRoutes: Route[] = [
   ),
 ];
 
-export const modelProviderAccountRoutes: Route[] = managementRoutes;
+async function handleLegacyProviderAccess(
+  env: Env,
+  ctx: SandboxRouteContext,
+  sessionId: string,
+  providerId: SubscriptionProviderId
+): Promise<Response> {
+  const response = await createSessionRuntimeClient(env, ctx).fetch(
+    sessionId,
+    LEGACY_REFRESH_PATH[providerId],
+    { method: "POST" }
+  );
+  if (!response.ok) return response;
+  const parsed = legacyAccessSchema.safeParse(await response.json().catch(() => null));
+  if (!parsed.success) return error("Provider access unavailable", 503);
+  return json({
+    accessToken: parsed.data.access_token,
+    ...(parsed.data.expires_in === undefined ? {} : { expiresIn: parsed.data.expires_in }),
+    providerMetadata:
+      providerId === "openai" && parsed.data.account_id
+        ? { accountId: parsed.data.account_id }
+        : {},
+  });
+}
+
+async function handleProviderAccess(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: SandboxRouteContext
+): Promise<Response> {
+  const sessionId = match.groups?.id;
+  const parsedProvider = provider(match.groups?.provider);
+  if (!sessionId) return error("Session ID required", 400);
+  if (parsedProvider instanceof Response) return parsedProvider;
+  let binding;
+  try {
+    binding = await new SessionIndexStore(ctx.db).getProviderAuthForProvider(
+      sessionId,
+      parsedProvider
+    );
+  } catch {
+    return error("Session provider auth unavailable", 503);
+  }
+  if (!binding) return error("Session provider account is not configured", 404);
+  if (binding.authMode === "legacy_scoped_oauth") {
+    return handleLegacyProviderAccess(env, ctx, sessionId, parsedProvider);
+  }
+  if (binding.authMode === "api_key") {
+    return error("Session uses API-key mode for this provider", 409);
+  }
+  const broker = new ModelProviderAccountBroker(
+    {
+      accounts: new ModelProviderAccountStore(ctx.db),
+      credentials: new ProviderCredentialStore(ctx.db, env.PROVIDER_ACCOUNTS_ENCRYPTION_KEY),
+      atomicWriter: new D1ModelProviderAccountAtomicWriter(
+        ctx.db,
+        env.PROVIDER_ACCOUNTS_ENCRYPTION_KEY
+      ),
+    },
+    modelProviderAccountAdapterRegistry,
+    { now: () => Date.now(), createOwner: () => generateId() }
+  );
+  try {
+    return json(await broker.getAccess(binding.providerAccountId, parsedProvider));
+  } catch (cause) {
+    if (cause instanceof ModelProviderAccountBrokerError) {
+      const status =
+        cause.code === "account_not_found" ? 404 : cause.code === "upstream_retry_safe" ? 502 : 409;
+      return error(cause.message, status);
+    }
+    return error("Provider access unavailable", 503);
+  }
+}
+
+export const modelProviderAccountRoutes: Route[] = [
+  ...managementRoutes,
+  defineRoute(SCM_AGNOSTIC_SANDBOX_ROUTE, {
+    method: "POST",
+    pattern: parsePattern("/sessions/:id/provider-auth/:provider/access-token"),
+    cacheControl: NO_STORE,
+    handler: handleProviderAccess,
+  }),
+];

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -175,6 +175,20 @@ async function handleSpawnChild(
       ? requestedReasoningEffort
       : null;
 
+  let providerAuth;
+  try {
+    providerAuth = await sessionStore.getCompleteProviderAuth(parentId);
+  } catch (cause) {
+    logger.error("Failed to load parent provider auth", {
+      event: "session.spawn_child_provider_auth_failed",
+      parent_id: parentId,
+      error: cause instanceof Error ? cause.message : String(cause),
+      trace_id: ctx.trace_id,
+      request_id: ctx.request_id,
+    });
+    return error("Parent provider auth unavailable", 503);
+  }
+
   const childDepth = parentDepth + 1;
   const childId = generateId();
 
@@ -228,6 +242,10 @@ async function handleSpawnChild(
     automationId: parentSession?.automationId ?? null,
     automationRunId: parentSession?.automationRunId ?? null,
     managedSkillsSourceSessionId: parentId,
+    providerAuth: providerAuth.map((auth) => ({
+      ...auth,
+      inheritedFromSessionId: parentId,
+    })),
   };
 
   const admissionLease = await sessionStore.acquireChildAdmissionLease(

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -15,6 +15,8 @@ import { resolveGitHubEnrichmentForRequest } from "../session/identity";
 import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
 import { resolveManagedSkills, SkillResolutionError } from "../session/skill-resolution";
 import type { Env } from "../types";
+import { resolveSessionProviderAuth } from "../session/provider-account-resolution";
+import { ProviderAccountSelectionPolicyError } from "../model-provider-accounts/selection-policy";
 import {
   normalizeOptionalRepositoryPair,
   RepositoryPairValidationError,
@@ -185,6 +187,16 @@ async function handleCreateSession(
   );
 
   const sessionId = generateId();
+  let providerAuth;
+  try {
+    providerAuth = await resolveSessionProviderAuth(ctx.db, {
+      explicit: body.providerSelections,
+      unattended: spawnSource !== undefined && spawnSource !== "user",
+    });
+  } catch (e) {
+    if (e instanceof ProviderAccountSelectionPolicyError) return error(e.message, e.status);
+    throw e;
+  }
 
   let managedSkillsManifest;
   try {
@@ -228,6 +240,7 @@ async function handleCreateSession(
     sandboxSettings,
     spawnSource,
     managedSkillsManifest,
+    providerAuth,
   };
 
   try {

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -5,6 +5,8 @@ import type {
 } from "@open-inspect/shared/types/sessions";
 import { z } from "zod";
 import { UserStore } from "../db/user-store";
+import { SessionIndexStore } from "../db/session-index";
+import type { SubscriptionProviderId } from "@open-inspect/shared/types/provider-accounts";
 import { SessionInternalPaths, type SessionInternalPath } from "../session/contracts";
 import type { Env } from "../types";
 import {
@@ -74,6 +76,32 @@ function simpleProxyRoute(config: SimpleProxyRouteConfig): Route {
         }
 
         return response;
+      },
+    })
+  );
+}
+
+function legacyTokenRefreshRoute(
+  provider: SubscriptionProviderId,
+  routePath: string,
+  internalPath: SessionInternalPath
+): Route {
+  return defineRoute(
+    SCM_AGNOSTIC_SANDBOX_ROUTE,
+    sessionRoute({
+      method: "POST",
+      pattern: parsePattern(routePath),
+      handler: async (_request, _env, match, ctx) => {
+        const sessionId = getSessionId(match);
+        if (sessionId instanceof Response) return sessionId;
+        const binding = await new SessionIndexStore(ctx.db).getProviderAuthForProvider(
+          sessionId,
+          provider
+        );
+        if (binding?.authMode !== "legacy_scoped_oauth") {
+          return error("Session does not use legacy scoped OAuth for this provider", 409);
+        }
+        return ctx.sessionRuntime.fetch(sessionId, internalPath, { method: "POST" });
       },
     })
   );
@@ -316,20 +344,16 @@ export const sessionRuntimeProxyRoutes: Route[] = [
       handler: handleCreatePR,
     })
   ),
-  simpleProxyRoute({
-    policy: SCM_AGNOSTIC_SANDBOX_ROUTE,
-    method: "POST",
-    routePath: "/sessions/:id/openai-token-refresh",
-    internalPath: SessionInternalPaths.openaiTokenRefresh,
-    runtimeMethod: "POST",
-  }),
-  simpleProxyRoute({
-    policy: SCM_AGNOSTIC_SANDBOX_ROUTE,
-    method: "POST",
-    routePath: "/sessions/:id/xai-token-refresh",
-    internalPath: SessionInternalPaths.xaiTokenRefresh,
-    runtimeMethod: "POST",
-  }),
+  legacyTokenRefreshRoute(
+    "openai",
+    "/sessions/:id/openai-token-refresh",
+    SessionInternalPaths.openaiTokenRefresh
+  ),
+  legacyTokenRefreshRoute(
+    "xai",
+    "/sessions/:id/xai-token-refresh",
+    SessionInternalPaths.xaiTokenRefresh
+  ),
   simpleProxyRoute({
     policy: SCM_CREDENTIALS_ROUTE,
     method: "POST",

--- a/packages/control-plane/src/sandbox/lifecycle/image-selection.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/image-selection.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import { evaluateImageBuildForSpawn, type ImageBuildSpawnRow } from "./image-selection";
 import { computeRepositoriesFingerprint } from "../../image-builds/fingerprint";
 import { COMPATIBLE_RUNTIME_VERSION } from "../../image-builds/test-helpers";
+import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../../image-builds/model";
 
 const SESSION_REPOSITORIES = [
   { repoOwner: "acme", repoName: "web", baseBranch: "main" },
@@ -84,17 +85,23 @@ describe("evaluateImageBuildForSpawn", () => {
     });
   });
 
-  it("preserves the v56 compatibility floor", async () => {
+  it("enforces the runtime compatibility floor", async () => {
     expect(
       (
         await evaluateImageBuildForSpawn(
-          await readyImage({ runtime_version: "v56-managed-provider-runtime" }),
+          await readyImage({
+            runtime_version: `v${MIN_COMPATIBLE_RUNTIME_VERSION}-compatible-runtime`,
+          }),
           SESSION_REPOSITORIES
         )
       ).outcome
     ).toBe("selected");
 
-    for (const runtimeVersion of ["v55-legacy-runtime", "dev", ""]) {
+    for (const runtimeVersion of [
+      `v${MIN_COMPATIBLE_RUNTIME_VERSION - 1}-legacy-runtime`,
+      "dev",
+      "",
+    ]) {
       const image = await readyImage({ runtime_version: runtimeVersion });
 
       expect(await evaluateImageBuildForSpawn(image, SESSION_REPOSITORIES)).toEqual({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1043,6 +1043,35 @@ describe("SandboxLifecycleManager", () => {
       expect(provider.createSandbox).not.toHaveBeenCalled();
     });
 
+    it("passes the current managed provider environment when restoring a snapshot", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const userEnvVars = {
+        OPENAI_OAUTH_MANAGED: "1",
+        XAI_API_KEY: "xai-key",
+      };
+      const storage = createMockStorage(createMockSession(), sandbox, userEnvVars);
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(storage.getUserEnvVars).toHaveBeenCalledOnce();
+      expect(provider.restoreFromSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ userEnvVars })
+      );
+    });
+
     it("logs one terminal sandbox.restore event for success", async () => {
       const sandbox = createMockSandbox({
         status: "stopped",

--- a/packages/control-plane/src/sandbox/managed-provider-env.test.ts
+++ b/packages/control-plane/src/sandbox/managed-provider-env.test.ts
@@ -47,4 +47,67 @@ describe("prepareManagedProviderEnv", () => {
       })
     ).toEqual({ USER_VALUE: "visible", OPENAI_OAUTH_MANAGED: "1" });
   });
+
+  it("makes provider-account mode override legacy OAuth and canonical API keys", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: {
+          OPENAI_API_KEY: "sk-openai",
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          OPENAI_OAUTH_MANAGED: "user-controlled",
+          XAI_API_KEY: "xai-key",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+          USER_VALUE: "visible",
+        },
+        brokerSecrets: {
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+        },
+        providerAuthModes: {
+          openai: "provider_account",
+          xai: "api_key",
+        },
+      })
+    ).toEqual({
+      OPENAI_OAUTH_MANAGED: "1",
+      XAI_API_KEY: "xai-key",
+      USER_VALUE: "visible",
+    });
+  });
+
+  it("retains canonical API keys and removes managed state in explicit API-key mode", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: {
+          OPENAI_API_KEY: "sk-openai",
+          OPENAI_OAUTH_ACCESS_TOKEN: "legacy-access",
+          OPENAI_OAUTH_MANAGED: "1",
+          XAI_API_KEY: "xai-key",
+          XAI_OAUTH_ACCESS_TOKEN: "legacy-access",
+          XAI_OAUTH_MANAGED: "1",
+        },
+        brokerSecrets: {
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+        },
+        providerAuthModes: {
+          openai: "api_key",
+          xai: "api_key",
+        },
+      })
+    ).toEqual({ OPENAI_API_KEY: "sk-openai", XAI_API_KEY: "xai-key" });
+  });
+
+  it("uses scoped OAuth only when a legacy-bound provider has a compatible refresh token", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: { OPENAI_API_KEY: "sk-openai", XAI_API_KEY: "xai-key" },
+        brokerSecrets: { OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai" },
+        providerAuthModes: {
+          openai: "legacy_scoped_oauth",
+          xai: "legacy_scoped_oauth",
+        },
+      })
+    ).toEqual({ OPENAI_OAUTH_MANAGED: "1", XAI_API_KEY: "xai-key" });
+  });
 });

--- a/packages/control-plane/src/sandbox/managed-provider-env.test.ts
+++ b/packages/control-plane/src/sandbox/managed-provider-env.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { prepareManagedProviderEnv } from "./managed-provider-env";
+import { prepareLegacyManagedProviderEnv, prepareManagedProviderEnv } from "./managed-provider-env";
 
-describe("prepareManagedProviderEnv", () => {
+describe("prepareLegacyManagedProviderEnv", () => {
   it("replaces durable OAuth credentials with provider markers", () => {
     expect(
-      prepareManagedProviderEnv({
+      prepareLegacyManagedProviderEnv({
         exposedSecrets: {
           USER_VALUE: "visible",
           OPENAI_OAUTH_REFRESH_TOKEN: "openai-refresh",
@@ -29,7 +29,7 @@ describe("prepareManagedProviderEnv", () => {
 
   it("does not advertise a provider without a refresh token", () => {
     expect(
-      prepareManagedProviderEnv({
+      prepareLegacyManagedProviderEnv({
         exposedSecrets: {
           XAI_OAUTH_ACCESS_TOKEN: "orphaned",
           XAI_OAUTH_MANAGED: "user-controlled",
@@ -41,13 +41,15 @@ describe("prepareManagedProviderEnv", () => {
 
   it("uses broker-compatible scopes to choose managed markers", () => {
     expect(
-      prepareManagedProviderEnv({
+      prepareLegacyManagedProviderEnv({
         exposedSecrets: { XAI_OAUTH_REFRESH_TOKEN: "secondary", USER_VALUE: "visible" },
         brokerSecrets: { OPENAI_OAUTH_REFRESH_TOKEN: "primary" },
       })
     ).toEqual({ USER_VALUE: "visible", OPENAI_OAUTH_MANAGED: "1" });
   });
+});
 
+describe("prepareManagedProviderEnv", () => {
   it("makes provider-account mode override legacy OAuth and canonical API keys", () => {
     expect(
       prepareManagedProviderEnv({

--- a/packages/control-plane/src/sandbox/managed-provider-env.ts
+++ b/packages/control-plane/src/sandbox/managed-provider-env.ts
@@ -1,3 +1,9 @@
+import {
+  SUBSCRIPTION_PROVIDER_IDS,
+  type SessionProviderAuthMode,
+  type SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
+
 const CONTROL_PLANE_OAUTH_KEYS = new Set([
   "OPENAI_OAUTH_REFRESH_TOKEN",
   "OPENAI_OAUTH_ACCESS_TOKEN",
@@ -13,16 +19,45 @@ const CONTROL_PLANE_OAUTH_KEYS = new Set([
 interface ManagedProviderEnvOptions {
   exposedSecrets: Record<string, string>;
   brokerSecrets: Record<string, string>;
+  providerAuthModes?: Partial<Record<SubscriptionProviderId, SessionProviderAuthMode>>;
 }
+
+const PROVIDER_ENV = {
+  openai: {
+    apiKey: "OPENAI_API_KEY",
+    marker: "OPENAI_OAUTH_MANAGED",
+    legacyRefreshToken: "OPENAI_OAUTH_REFRESH_TOKEN",
+  },
+  xai: {
+    apiKey: "XAI_API_KEY",
+    marker: "XAI_OAUTH_MANAGED",
+    legacyRefreshToken: "XAI_OAUTH_REFRESH_TOKEN",
+  },
+} as const satisfies Record<
+  SubscriptionProviderId,
+  { apiKey: string; marker: string; legacyRefreshToken: string }
+>;
 
 export function prepareManagedProviderEnv({
   exposedSecrets,
   brokerSecrets,
+  providerAuthModes,
 }: ManagedProviderEnvOptions): Record<string, string> {
   const env = Object.fromEntries(
     Object.entries(exposedSecrets).filter(([key]) => !CONTROL_PLANE_OAUTH_KEYS.has(key))
   );
-  if (brokerSecrets.OPENAI_OAUTH_REFRESH_TOKEN) env.OPENAI_OAUTH_MANAGED = "1";
-  if (brokerSecrets.XAI_OAUTH_REFRESH_TOKEN) env.XAI_OAUTH_MANAGED = "1";
+
+  for (const provider of SUBSCRIPTION_PROVIDER_IDS) {
+    const config = PROVIDER_ENV[provider];
+    const mode = providerAuthModes?.[provider];
+    const managed =
+      mode === "provider_account" ||
+      ((mode === "legacy_scoped_oauth" || mode === undefined) &&
+        Boolean(brokerSecrets[config.legacyRefreshToken]));
+    if (managed) {
+      delete env[config.apiKey];
+      env[config.marker] = "1";
+    }
+  }
   return env;
 }

--- a/packages/control-plane/src/sandbox/managed-provider-env.ts
+++ b/packages/control-plane/src/sandbox/managed-provider-env.ts
@@ -19,8 +19,10 @@ const CONTROL_PLANE_OAUTH_KEYS = new Set([
 interface ManagedProviderEnvOptions {
   exposedSecrets: Record<string, string>;
   brokerSecrets: Record<string, string>;
-  providerAuthModes?: Partial<Record<SubscriptionProviderId, SessionProviderAuthMode>>;
+  providerAuthModes: Record<SubscriptionProviderId, SessionProviderAuthMode>;
 }
+
+type LegacyManagedProviderEnvOptions = Omit<ManagedProviderEnvOptions, "providerAuthModes">;
 
 const PROVIDER_ENV = {
   openai: {
@@ -49,15 +51,37 @@ export function prepareManagedProviderEnv({
 
   for (const provider of SUBSCRIPTION_PROVIDER_IDS) {
     const config = PROVIDER_ENV[provider];
-    const mode = providerAuthModes?.[provider];
+    const mode = providerAuthModes[provider];
     const managed =
       mode === "provider_account" ||
-      ((mode === "legacy_scoped_oauth" || mode === undefined) &&
-        Boolean(brokerSecrets[config.legacyRefreshToken]));
+      (mode === "legacy_scoped_oauth" && Boolean(brokerSecrets[config.legacyRefreshToken]));
     if (managed) {
       delete env[config.apiKey];
       env[config.marker] = "1";
     }
   }
   return env;
+}
+
+/**
+ * Image builds predate session provider-routing snapshots. Infer legacy
+ * managed OAuth only in that compatibility path; live sessions must call
+ * prepareManagedProviderEnv with a complete providerAuthModes record.
+ */
+export function prepareLegacyManagedProviderEnv({
+  exposedSecrets,
+  brokerSecrets,
+}: LegacyManagedProviderEnvOptions): Record<string, string> {
+  return prepareManagedProviderEnv({
+    exposedSecrets,
+    brokerSecrets,
+    providerAuthModes: Object.fromEntries(
+      SUBSCRIPTION_PROVIDER_IDS.map((provider) => [
+        provider,
+        brokerSecrets[PROVIDER_ENV[provider].legacyRefreshToken]
+          ? "legacy_scoped_oauth"
+          : "api_key",
+      ])
+    ) as Record<SubscriptionProviderId, SessionProviderAuthMode>,
+  });
 }

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -45,7 +45,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v59-vnc-opencode-1-18-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v60-provider-account-broker");
   });
 
   it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
@@ -55,7 +55,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     await client.runRuntimeForeground("sb-1", 60);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v59-vnc-opencode-1-18-18");
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v60-provider-account-broker");
   });
 });
 

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -227,7 +227,7 @@ const RUNTIME_HOSTS_BOOTSTRAP =
 // runtime reports an empty version and the build-complete callback is rejected
 // (runtime-version floor check). Keep in sync with the value baked in
 // packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
-const OPENCOMPUTER_SANDBOX_VERSION = "v59-vnc-opencode-1-18-18";
+const OPENCOMPUTER_SANDBOX_VERSION = "v60-provider-account-broker";
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -8,6 +8,7 @@
 
 import { createLogger } from "../logger";
 import { z } from "zod";
+import { SANDBOX_RUNTIME_VERSION } from "./runtime-manifest";
 
 const log = createLogger("opencomputer-rest-client");
 
@@ -225,9 +226,8 @@ const RUNTIME_HOSTS_BOOTSTRAP =
 // OpenComputer launches the runtime via `exec`, which does NOT inherit the
 // image's baked env, so SANDBOX_VERSION must be re-exported here — otherwise the
 // runtime reports an empty version and the build-complete callback is rejected
-// (runtime-version floor check). Keep in sync with the value baked in
-// packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
-const OPENCOMPUTER_SANDBOX_VERSION = "v60-provider-account-broker";
+// (runtime-version floor check).
+export const OPENCOMPUTER_SANDBOX_VERSION = SANDBOX_RUNTIME_VERSION;
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -6,7 +6,7 @@
 
 export const VERCEL_PYTHON_BIN = "/usr/bin/python3.12";
 export const DEFAULT_VERCEL_RUNTIME = "node24";
-export const VERCEL_SANDBOX_VERSION = "v59-vnc-opencode-1-18-18";
+export const VERCEL_SANDBOX_VERSION = "v60-provider-account-broker";
 export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -4,9 +4,11 @@
  * Used by CI when building the managed Vercel base-runtime snapshot.
  */
 
+import { SANDBOX_RUNTIME_VERSION } from "../../runtime-manifest";
+
 export const VERCEL_PYTHON_BIN = "/usr/bin/python3.12";
 export const DEFAULT_VERCEL_RUNTIME = "node24";
-export const VERCEL_SANDBOX_VERSION = "v60-provider-account-broker";
+export const VERCEL_SANDBOX_VERSION = SANDBOX_RUNTIME_VERSION;
 export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 

--- a/packages/control-plane/src/sandbox/runtime-manifest.test.ts
+++ b/packages/control-plane/src/sandbox/runtime-manifest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../image-builds/model";
+import { MIN_REBUILD_RUNTIME_VERSION } from "../image-builds/rebuild-policy";
+import { OPENCOMPUTER_SANDBOX_VERSION } from "./opencomputer-rest-client";
+import { VERCEL_SANDBOX_VERSION } from "./providers/vercel/bootstrap";
+import {
+  MIN_COMPATIBLE_RUNTIME_GENERATION,
+  MIN_REBUILD_RUNTIME_GENERATION,
+  SANDBOX_RUNTIME_GENERATION,
+  SANDBOX_RUNTIME_VERSION,
+} from "./runtime-manifest";
+
+describe("sandbox runtime manifest", () => {
+  it("drives control-plane provider labels and compatibility floors", () => {
+    expect(OPENCOMPUTER_SANDBOX_VERSION).toBe(SANDBOX_RUNTIME_VERSION);
+    expect(VERCEL_SANDBOX_VERSION).toBe(SANDBOX_RUNTIME_VERSION);
+    expect(SANDBOX_RUNTIME_VERSION).toMatch(new RegExp(`^v${SANDBOX_RUNTIME_GENERATION}`));
+    expect(MIN_COMPATIBLE_RUNTIME_VERSION).toBe(MIN_COMPATIBLE_RUNTIME_GENERATION);
+    expect(MIN_REBUILD_RUNTIME_VERSION).toBe(MIN_REBUILD_RUNTIME_GENERATION);
+  });
+});

--- a/packages/control-plane/src/sandbox/runtime-manifest.ts
+++ b/packages/control-plane/src/sandbox/runtime-manifest.ts
@@ -1,0 +1,11 @@
+import runtimeManifest from "../../../sandbox-runtime/src/sandbox_runtime/runtime_manifest.json";
+
+const parsedGeneration = /^v(\d+)/.exec(runtimeManifest.runtimeVersion)?.[1];
+if (Number(parsedGeneration) !== runtimeManifest.generation) {
+  throw new Error("Sandbox runtime manifest version and generation disagree");
+}
+
+export const SANDBOX_RUNTIME_VERSION = runtimeManifest.runtimeVersion;
+export const SANDBOX_RUNTIME_GENERATION = runtimeManifest.generation;
+export const MIN_COMPATIBLE_RUNTIME_GENERATION = runtimeManifest.minimumCompatibleGeneration;
+export const MIN_REBUILD_RUNTIME_GENERATION = runtimeManifest.minimumRebuildGeneration;

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -641,6 +641,56 @@ describe("SchedulerDO", () => {
       ]);
     });
 
+    it("freezes provider routing before invocation admission", async () => {
+      mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
+      const firstAccountId = "a".repeat(32);
+      const editedAccountId = "b".repeat(32);
+      let selectedAccountId = firstAccountId;
+      mockProviderAuthList.mockReset();
+      mockProviderAuthList.mockImplementation(async () => [
+        {
+          automation_id: "auto-1",
+          provider: "openai",
+          auth_mode: "provider_account",
+          provider_account_id: selectedAccountId,
+          created_at: 1,
+          updated_at: 1,
+        },
+      ]);
+      mockResolveSessionProviderAuth.mockReset();
+      mockResolveSessionProviderAuth.mockImplementation(async (_db, options) => [
+        {
+          provider: "openai",
+          authMode: "provider_account",
+          providerAccountId: options.explicit.openai.accountId,
+          selectionSource: "explicit",
+        },
+        { provider: "xai", authMode: "api_key", selectionSource: "unattended_policy" },
+      ]);
+      mockStore.insertInvocationGuarded.mockImplementation(async (params: unknown) => {
+        capturedInvocationParams.push(
+          structuredClone(params) as { children: Array<Record<string, unknown>> }
+        );
+        // Simulate an automation edit racing immediately after the firing is
+        // admitted. The launched session must retain the pre-admission pin.
+        selectedAccountId = editedAccountId;
+        return { inserted: true };
+      });
+
+      const scheduler = createSchedulerDO();
+      const response = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockSessionStoreCreate.mock.calls[0][0].providerAuth).toContainEqual({
+        provider: "openai",
+        authMode: "provider_account",
+        providerAccountId: firstAccountId,
+        selectionSource: "automation_pin",
+      });
+    });
+
     it("starts later child launches before earlier child sessions finish initializing", async () => {
       mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
       selectRepositories("auto-1", [

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -24,11 +24,21 @@ vi.mock("cloudflare:workers", () => ({
 }));
 
 const mockCheckRepositoryAccess = vi.hoisted(() => vi.fn());
+const mockResolveSessionProviderAuth = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([
+    { provider: "openai", authMode: "api_key", selectionSource: "unattended_policy" },
+    { provider: "xai", authMode: "api_key", selectionSource: "unattended_policy" },
+  ])
+);
 
 vi.mock("../source-control", () => ({
   createSourceControlProviderFromEnv: vi.fn(() => ({
     checkRepositoryAccess: mockCheckRepositoryAccess,
   })),
+}));
+
+vi.mock("../session/provider-account-resolution", () => ({
+  resolveSessionProviderAuth: mockResolveSessionProviderAuth,
 }));
 
 vi.mock("../session/skill-resolution", () => ({
@@ -116,6 +126,17 @@ vi.mock("../db/automation-store", async (importOriginal) => {
   };
 });
 
+const mockProviderAuthList = vi.fn().mockResolvedValue([]);
+vi.mock("../db/automation-model-provider-auth", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    AutomationModelProviderAuthStore: vi.fn().mockImplementation(function () {
+      return { list: mockProviderAuthList };
+    }),
+  };
+});
+
 const mockSessionStoreCreate = vi.fn().mockResolvedValue(undefined);
 const mockSessionStoreUpdateStatus = vi.fn().mockResolvedValue(undefined);
 vi.mock("../db/session-index", () => ({
@@ -133,6 +154,18 @@ vi.mock("../db/user-store", () => ({
     return {
       getIdentity: mockUserStoreGetIdentity,
     };
+  }),
+}));
+
+vi.mock("../db/provider-account-defaults", () => ({
+  ProviderDefaultStore: vi.fn().mockImplementation(function () {
+    return { get: vi.fn().mockResolvedValue(null) };
+  }),
+}));
+
+vi.mock("../db/model-provider-accounts", () => ({
+  ModelProviderAccountStore: vi.fn().mockImplementation(function () {
+    return { getById: vi.fn().mockResolvedValue(null) };
   }),
 }));
 
@@ -444,6 +477,11 @@ function lastInsertedChildren(): Array<Record<string, unknown>> {
 describe("SchedulerDO", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockResolveSessionProviderAuth.mockResolvedValue([
+      { provider: "openai", authMode: "api_key", selectionSource: "unattended_policy" },
+      { provider: "xai", authMode: "api_key", selectionSource: "unattended_policy" },
+    ]);
+    mockProviderAuthList.mockResolvedValue([]);
     capturedInvocationParams = [];
     mockStore = createMockStore();
     mockGetSlackAutomationsForChannel.mockResolvedValue([]);
@@ -558,6 +596,51 @@ describe("SchedulerDO", () => {
       expect(mockStore.updateRun).toHaveBeenCalledTimes(2);
     });
 
+    it("resolves one provider auth snapshot for every child in a fan-out invocation", async () => {
+      mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
+      selectRepositories("auto-1", [
+        repositoryRow("auto-1", { repo_name: "web-app" }),
+        repositoryRow("auto-1", { repo_name: "api", base_branch: null }),
+      ]);
+      const invocationProviderAuth = [
+        {
+          provider: "openai" as const,
+          authMode: "provider_account" as const,
+          providerAccountId: "a".repeat(32),
+          selectionSource: "provider_default",
+        },
+        {
+          provider: "xai" as const,
+          authMode: "api_key" as const,
+          selectionSource: "unattended_policy",
+        },
+      ];
+      mockResolveSessionProviderAuth
+        .mockResolvedValueOnce(invocationProviderAuth)
+        .mockResolvedValueOnce([
+          {
+            provider: "openai",
+            authMode: "provider_account",
+            providerAccountId: "b".repeat(32),
+            selectionSource: "provider_default",
+          },
+          { provider: "xai", authMode: "api_key", selectionSource: "unattended_policy" },
+        ]);
+
+      const scheduler = createSchedulerDO();
+      const response = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockResolveSessionProviderAuth).toHaveBeenCalledTimes(1);
+      expect(mockSessionStoreCreate).toHaveBeenCalledTimes(2);
+      expect(mockSessionStoreCreate.mock.calls.map(([session]) => session.providerAuth)).toEqual([
+        invocationProviderAuth,
+        invocationProviderAuth,
+      ]);
+    });
+
     it("starts later child launches before earlier child sessions finish initializing", async () => {
       mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
       selectRepositories("auto-1", [
@@ -628,6 +711,7 @@ describe("SchedulerDO", () => {
       expect(res.status).toBe(200);
       const initBody = await getInitBody(fetchMock);
       expect(initBody.reasoningEffort).toBe("high");
+      expect(initBody).not.toHaveProperty("providerAuth");
     });
 
     it("snapshots the resolved repository onto the child and the session", async () => {

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -381,6 +381,24 @@ export class SchedulerDO extends DurableObject<Env> {
       children.push({ ...childBase(), status: "starting" });
     }
 
+    const launchCandidates = children.filter((child) => child.status === "starting");
+    // Resolve provider routing before admission, alongside the already-built
+    // target children. Together these values are the immutable launch snapshot
+    // for this firing: edits made after the guarded insert cannot change which
+    // account an admitted child uses.
+    let providerAuthSnapshot:
+      | { providerAuth: SessionModelProviderAuthInput[] }
+      | { error: unknown } = { providerAuth: [] };
+    if (launchCandidates.length > 0) {
+      try {
+        providerAuthSnapshot = {
+          providerAuth: await resolveAutomationProviderAuth(this.db, automation.id),
+        };
+      } catch (error) {
+        providerAuthSnapshot = { error };
+      }
+    }
+
     const invocation: AutomationInvocationRow = {
       id: invocationId,
       automation_id: automation.id,
@@ -445,27 +463,13 @@ export class SchedulerDO extends DurableObject<Env> {
       }
     }
 
-    const launchCandidates = children.filter((child) => child.status === "starting");
-    let providerAuthResolution:
-      | { providerAuth: SessionModelProviderAuthInput[] }
-      | { error: unknown } = { providerAuth: [] };
-    if (launchCandidates.length > 0) {
-      try {
-        providerAuthResolution = {
-          providerAuth: await resolveAutomationProviderAuth(this.db, automation.id),
-        };
-      } catch (error) {
-        providerAuthResolution = { error };
-      }
-    }
-
     const launchChild = async (child: AutomationRunRow): Promise<void> => {
       try {
-        if ("error" in providerAuthResolution) throw providerAuthResolution.error;
+        if ("error" in providerAuthSnapshot) throw providerAuthSnapshot.error;
         const { sessionId } = await this.createSessionForAutomationRun(
           automation,
           child,
-          providerAuthResolution.providerAuth
+          providerAuthSnapshot.providerAuth
         );
         const claimed = await store.updateRun(child.id, {
           status: "running",

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -38,6 +38,10 @@ import {
   type AutomationRepositoryInsert,
   type AutomationEnvironmentRow,
 } from "../db/automation-store";
+import {
+  AutomationModelProviderAuthStore,
+  toProviderSelections,
+} from "../db/automation-model-provider-auth";
 import { SlackChannelStore } from "../db/slack-channel-store";
 import { IntegrationSettingsStore } from "../db/integration-settings";
 import {
@@ -56,6 +60,9 @@ import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
 import { initializeSession } from "../session/initialize";
+import type { SessionInitInput } from "../session/initialize";
+import type { SessionModelProviderAuthInput } from "../model-provider-accounts/provider-auth-contracts";
+import { resolveSessionProviderAuth } from "../session/provider-account-resolution";
 import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
 import { resolveManagedSkills } from "../session/skill-resolution";
 import type { EnqueuePromptRequest } from "../session/enqueue-prompt-contract";
@@ -209,6 +216,21 @@ type SchedulerPromptRequest = Pick<
 > & {
   callbackContext: AutomationCallbackContext | SlackCallbackContext;
 };
+
+export async function resolveAutomationProviderAuth(
+  db: SqlDatabase,
+  automationId: string
+): Promise<SessionModelProviderAuthInput[]> {
+  const pinRows = await new AutomationModelProviderAuthStore(db).list(automationId);
+  const explicit = toProviderSelections(pinRows);
+  const resolved = await resolveSessionProviderAuth(db, { explicit, unattended: true });
+  const pinnedProviders = new Set(pinRows.map((pin) => pin.provider));
+  return resolved.map((auth) =>
+    pinnedProviders.has(auth.provider) && auth.selectionSource === "explicit"
+      ? { ...auth, selectionSource: "automation_pin" }
+      : auth
+  );
+}
 
 export class SchedulerDO extends DurableObject<Env> {
   private readonly log: Logger;
@@ -423,15 +445,37 @@ export class SchedulerDO extends DurableObject<Env> {
       }
     }
 
+    const launchCandidates = children.filter((child) => child.status === "starting");
+    let providerAuthResolution:
+      | { providerAuth: SessionModelProviderAuthInput[] }
+      | { error: unknown } = { providerAuth: [] };
+    if (launchCandidates.length > 0) {
+      try {
+        providerAuthResolution = {
+          providerAuth: await resolveAutomationProviderAuth(this.db, automation.id),
+        };
+      } catch (error) {
+        providerAuthResolution = { error };
+      }
+    }
+
     const launchChild = async (child: AutomationRunRow): Promise<void> => {
       try {
-        const { sessionId } = await this.createSessionForAutomationRun(automation, child);
-        await this.sendPromptToSession(sessionId, automation, child.id, instructionsOverride);
-        await store.updateRun(child.id, {
+        if ("error" in providerAuthResolution) throw providerAuthResolution.error;
+        const { sessionId } = await this.createSessionForAutomationRun(
+          automation,
+          child,
+          providerAuthResolution.providerAuth
+        );
+        const claimed = await store.updateRun(child.id, {
           status: "running",
           session_id: sessionId,
           started_at: Date.now(),
         });
+        if (!claimed) {
+          throw new Error("Automation run was recovered before launch completed");
+        }
+        await this.sendPromptToSession(sessionId, automation, child.id, instructionsOverride);
         child.status = "running";
         child.session_id = sessionId;
       } catch (e) {
@@ -463,7 +507,6 @@ export class SchedulerDO extends DurableObject<Env> {
       }
     };
 
-    const launchCandidates = children.filter((child) => child.status === "starting");
     let nextLaunchIndex = 0;
     const launchWorkerCount = Math.min(AUTOMATION_LAUNCH_CONCURRENCY, launchCandidates.length);
     await Promise.all(
@@ -1310,7 +1353,8 @@ export class SchedulerDO extends DurableObject<Env> {
 
   private async createSessionForAutomationRun(
     automation: AutomationRow,
-    run: AutomationRunRow
+    run: AutomationRunRow,
+    providerAuth: SessionModelProviderAuthInput[]
   ): Promise<{ sessionId: string }> {
     const sessionId = generateId();
 
@@ -1373,29 +1417,28 @@ export class SchedulerDO extends DurableObject<Env> {
       userId
     );
 
-    await initializeSession(
-      this.env,
-      {
-        sessionId,
-        ...target,
-        title: `[Auto] ${automation.name}`,
-        model: automation.model,
-        reasoningEffort: automation.reasoning_effort,
-        participantUserId: automation.created_by,
-        platformUserId: userId,
-        scmTokenEncrypted: null,
-        scmRefreshTokenEncrypted: null,
-        codeServerEnabled,
-        vncEnabled,
-        sandboxSettings,
-        spawnSource: "automation",
-        spawnDepth: 0,
-        automationId: automation.id,
-        automationRunId: run.id,
-        managedSkillsManifest,
-      },
-      ctx
-    );
+    const sessionInput: SessionInitInput = {
+      sessionId,
+      ...target,
+      title: `[Auto] ${automation.name}`,
+      model: automation.model,
+      reasoningEffort: automation.reasoning_effort,
+      participantUserId: automation.created_by,
+      platformUserId: userId,
+      scmTokenEncrypted: null,
+      scmRefreshTokenEncrypted: null,
+      codeServerEnabled,
+      vncEnabled,
+      sandboxSettings,
+      spawnSource: "automation",
+      spawnDepth: 0,
+      automationId: automation.id,
+      automationRunId: run.id,
+      managedSkillsManifest,
+      providerAuth,
+    };
+
+    await initializeSession(this.env, sessionInput, ctx);
 
     return { sessionId };
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -54,6 +54,10 @@ import {
   type GitPushSpec,
 } from "../source-control";
 import type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
+import type {
+  SessionProviderAuthMode,
+  SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
 import type { Env, ClientInfo } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
@@ -1839,7 +1843,7 @@ export class SessionDO extends DurableObject<Env> {
     );
     const providerAuthModes = Object.fromEntries(
       providerAuth.map(({ provider, authMode }) => [provider, authMode])
-    );
+    ) as Record<SubscriptionProviderId, SessionProviderAuthMode>;
 
     if (!this.env.REPO_SECRETS_ENCRYPTION_KEY) {
       this.log.debug("Ordinary secrets not configured, skipping secret loading", {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1832,21 +1832,34 @@ export class SessionDO extends DurableObject<Env> {
       return undefined;
     }
 
-    if (!this.db || !this.env.REPO_SECRETS_ENCRYPTION_KEY) {
-      this.log.debug("Secrets not configured, skipping", {
-        has_db: !!this.db,
+    const db = this.db;
+    if (!db) throw new Error("D1 is required to load session provider auth");
+    const providerAuth = await new SessionIndexStore(db).getCompleteProviderAuth(
+      this.getPublicSessionId(session)
+    );
+    const providerAuthModes = Object.fromEntries(
+      providerAuth.map(({ provider, authMode }) => [provider, authMode])
+    );
+
+    if (!this.env.REPO_SECRETS_ENCRYPTION_KEY) {
+      this.log.debug("Ordinary secrets not configured, skipping secret loading", {
         has_encryption_key: !!this.env.REPO_SECRETS_ENCRYPTION_KEY,
       });
-      return undefined;
+      const sandboxEnv = prepareManagedProviderEnv({
+        exposedSecrets: {},
+        brokerSecrets: {},
+        providerAuthModes,
+      });
+      return Object.keys(sandboxEnv).length === 0 ? undefined : sandboxEnv;
     }
 
     // Fail hard on secret loading — sandboxes must not silently lose secrets
     const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
-    const globalStore = new GlobalSecretsStore(this.db, encryptionKey);
+    const globalStore = new GlobalSecretsStore(db, encryptionKey);
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
-    const repoStore = new RepoSecretsStore(this.db, encryptionKey);
-    const environmentSecretsStore = new EnvironmentSecretsStore(this.db, encryptionKey);
+    const repoStore = new RepoSecretsStore(db, encryptionKey);
+    const environmentSecretsStore = new EnvironmentSecretsStore(db, encryptionKey);
     const members = this.sessionCoreRepository.getSessionRepositories();
     const sources = await buildSessionTargetSecretSources({
       environmentId: session.environment_id,
@@ -1875,7 +1888,6 @@ export class SessionDO extends DurableObject<Env> {
       });
     }
 
-    if (mergedCount === 0) return undefined;
     const primary = members.find((member) => member.isPrimary);
     const managedSources = session.environment_id
       ? sources
@@ -1888,6 +1900,7 @@ export class SessionDO extends DurableObject<Env> {
     const sandboxEnv = prepareManagedProviderEnv({
       exposedSecrets: merge.merged,
       brokerSecrets: managedSecrets,
+      providerAuthModes,
     });
     return Object.keys(sandboxEnv).length === 0 ? undefined : sandboxEnv;
   }

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -90,6 +90,7 @@ function createHandler() {
   const repository = {
     upsertSession: vi.fn(),
     replaceSessionRepositories: vi.fn(),
+    transaction: vi.fn((callback: () => void) => callback()),
     createParticipant: vi.fn(),
     getPendingOrProcessingCount: vi.fn(() => 0),
     getMessageCount: vi.fn(() => 0),
@@ -314,6 +315,7 @@ describe("createSessionLifecycleHandler", () => {
         baseBranch: "feature/work",
       },
     ]);
+    expect(repository.transaction).toHaveBeenCalledOnce();
     expect(scheduleWarmSandbox).toHaveBeenCalled();
     expect(log.info).toHaveBeenCalledWith("Triggering sandbox spawn for new session");
   });

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -239,69 +239,71 @@ export function createSessionLifecycleHandler(
         );
       }
 
-      deps.sessionCoreRepository.upsertSession({
-        id: sessionId,
-        sessionName,
-        title: body.title ?? null,
-        repoOwner,
-        repoName,
-        repoId: hasRepoOwner ? body.repoId : null,
-        baseBranch,
-        model,
-        reasoningEffort,
-        status: "created",
-        parentSessionId: body.parentSessionId ?? null,
-        spawnSource: body.spawnSource ?? "user",
-        spawnDepth: body.spawnDepth ?? 0,
-        codeServerEnabled: body.codeServerEnabled ?? false,
-        vncEnabled: body.vncEnabled ?? false,
-        sandboxSettings: body.sandboxSettings
-          ? JSON.stringify(normalizeSandboxSettings(body.sandboxSettings, { invalid: "omit" }))
-          : null,
-        environmentId: body.environmentId ?? null,
-        createdAt: now,
-        updatedAt: now,
-      });
+      deps.sessionCoreRepository.transaction(() => {
+        deps.sessionCoreRepository.upsertSession({
+          id: sessionId,
+          sessionName,
+          title: body.title ?? null,
+          repoOwner,
+          repoName,
+          repoId: hasRepoOwner ? body.repoId : null,
+          baseBranch,
+          model,
+          reasoningEffort,
+          status: "created",
+          parentSessionId: body.parentSessionId ?? null,
+          spawnSource: body.spawnSource ?? "user",
+          spawnDepth: body.spawnDepth ?? 0,
+          codeServerEnabled: body.codeServerEnabled ?? false,
+          vncEnabled: body.vncEnabled ?? false,
+          sandboxSettings: body.sandboxSettings
+            ? JSON.stringify(normalizeSandboxSettings(body.sandboxSettings, { invalid: "omit" }))
+            : null,
+          environmentId: body.environmentId ?? null,
+          createdAt: now,
+          updatedAt: now,
+        });
 
-      // Legacy scalar producers (spawn paths not yet list-aware) still get a
-      // member row so spawn/read paths have one source of truth.
-      const memberRepositories: RepositoryRef[] =
-        repositories.length > 0
-          ? repositories
-          : repoOwner !== null && repoName !== null && body.repoId != null && baseBranch !== null
-            ? [{ repoOwner, repoName, repoId: body.repoId, baseBranch }]
-            : [];
-      deps.sessionCoreRepository.replaceSessionRepositories(
-        memberRepositories.map((repo, position) => ({
-          position,
-          repoOwner: repo.repoOwner,
-          repoName: repo.repoName,
-          repoId: repo.repoId,
-          baseBranch: repo.baseBranch,
-        }))
-      );
-      const sandboxId = deps.generateId();
-      deps.sandboxRepository.createSandbox({
-        id: sandboxId,
-        status: "pending",
-        gitSyncStatus: "pending",
-        createdAt: 0,
-      });
+        // Legacy scalar producers (spawn paths not yet list-aware) still get a
+        // member row so spawn/read paths have one source of truth.
+        const memberRepositories: RepositoryRef[] =
+          repositories.length > 0
+            ? repositories
+            : repoOwner !== null && repoName !== null && body.repoId != null && baseBranch !== null
+              ? [{ repoOwner, repoName, repoId: body.repoId, baseBranch }]
+              : [];
+        deps.sessionCoreRepository.replaceSessionRepositories(
+          memberRepositories.map((repo, position) => ({
+            position,
+            repoOwner: repo.repoOwner,
+            repoName: repo.repoName,
+            repoId: repo.repoId,
+            baseBranch: repo.baseBranch,
+          }))
+        );
+        const sandboxId = deps.generateId();
+        deps.sandboxRepository.createSandbox({
+          id: sandboxId,
+          status: "pending",
+          gitSyncStatus: "pending",
+          createdAt: 0,
+        });
 
-      const participantId = deps.generateId();
-      deps.participantRepository.createParticipant({
-        id: participantId,
-        userId: body.userId,
-        ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
-        scmUserId: body.scmUserId ?? null,
-        scmLogin: body.scmLogin ?? null,
-        scmName: body.scmName ?? null,
-        scmEmail: body.scmEmail ?? null,
-        scmAccessTokenEncrypted: encryptedToken,
-        scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
-        scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
-        role: "owner",
-        joinedAt: now,
+        const participantId = deps.generateId();
+        deps.participantRepository.createParticipant({
+          id: participantId,
+          userId: body.userId,
+          ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
+          scmUserId: body.scmUserId ?? null,
+          scmLogin: body.scmLogin ?? null,
+          scmName: body.scmName ?? null,
+          scmEmail: body.scmEmail ?? null,
+          scmAccessTokenEncrypted: encryptedToken,
+          scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
+          scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
+          role: "owner",
+          joinedAt: now,
+        });
       });
 
       log.info("Triggering sandbox spawn for new session");

--- a/packages/control-plane/src/session/initialize.test.ts
+++ b/packages/control-plane/src/session/initialize.test.ts
@@ -35,6 +35,15 @@ describe("initializeSession", () => {
     sandboxSettings: {},
     automationId: null,
     automationRunId: null,
+    providerAuth: [
+      {
+        provider: "openai",
+        authMode: "provider_account",
+        providerAccountId: "1".repeat(32),
+        selectionSource: "installation_default",
+      },
+      { provider: "xai", authMode: "api_key", selectionSource: "fallback_api_key" },
+    ],
   };
 
   const ctx = {
@@ -191,6 +200,7 @@ describe("initializeSession", () => {
     expect(d1Entry.automationRunId).toBeNull();
     expect(d1Entry.scmLogin).toBe("acmedev");
     expect(d1Entry.userId).toBe("platform-user-1");
+    expect(d1Entry.providerAuth).toEqual(baseInput.providerAuth);
     expect(d1Entry.createdAt).toBeTypeOf("number");
     expect(d1Entry.updatedAt).toBeTypeOf("number");
   });
@@ -245,6 +255,7 @@ describe("initializeSession", () => {
     expect(body.parentSessionId).toBeNull();
     expect(body.spawnSource).toBe("user");
     expect(body.spawnDepth).toBe(0);
+    expect(body).not.toHaveProperty("providerAuth");
   });
 
   it("sets correlation headers on the DO init request", async () => {

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -7,6 +7,9 @@ import { SessionIndexStore } from "../db/session-index";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { createLogger } from "../logger";
 import type { SessionSkillManifestInput } from "./skill-resolution";
+import type { SessionModelProviderAuthInput } from "../model-provider-accounts/provider-auth-contracts";
+import type { ModelProviderSelections } from "@open-inspect/shared/types/provider-accounts";
+import { resolveSessionProviderAuth } from "./provider-account-resolution";
 
 const logger = createLogger("session-init");
 
@@ -71,6 +74,8 @@ export interface SessionInitInput {
   automationRunId?: string | null;
   managedSkillsManifest?: SessionSkillManifestInput;
   managedSkillsSourceSessionId?: string;
+  providerAuth?: SessionModelProviderAuthInput[];
+  providerSelections?: ModelProviderSelections;
 }
 
 /**
@@ -103,6 +108,12 @@ export async function initializeSession(
   const defaultBranch = hasRepoOwner ? input.defaultBranch : null;
 
   const now = Date.now();
+  const providerAuth =
+    input.providerAuth ??
+    (await resolveSessionProviderAuth(ctx.db, {
+      explicit: input.providerSelections,
+      unattended: input.spawnSource !== undefined && input.spawnSource !== "user",
+    }));
   const baseBranch = hasRepoOwner ? branch || defaultBranch || "main" : null;
 
   if (input.repositories?.length) {
@@ -153,6 +164,7 @@ export async function initializeSession(
     updatedAt: now,
     skillManifest: input.managedSkillsManifest,
     skillManifestSourceSessionId: input.managedSkillsSourceSessionId,
+    providerAuth,
   });
 
   // Step 2: DO init

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -8,8 +8,6 @@ import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { createLogger } from "../logger";
 import type { SessionSkillManifestInput } from "./skill-resolution";
 import type { SessionModelProviderAuthInput } from "../model-provider-accounts/provider-auth-contracts";
-import type { ModelProviderSelections } from "@open-inspect/shared/types/provider-accounts";
-import { resolveSessionProviderAuth } from "./provider-account-resolution";
 
 const logger = createLogger("session-init");
 
@@ -74,8 +72,8 @@ export interface SessionInitInput {
   automationRunId?: string | null;
   managedSkillsManifest?: SessionSkillManifestInput;
   managedSkillsSourceSessionId?: string;
-  providerAuth?: SessionModelProviderAuthInput[];
-  providerSelections?: ModelProviderSelections;
+  /** Complete, immutable provider routing snapshot resolved by the caller. */
+  providerAuth: SessionModelProviderAuthInput[];
 }
 
 /**
@@ -108,12 +106,6 @@ export async function initializeSession(
   const defaultBranch = hasRepoOwner ? input.defaultBranch : null;
 
   const now = Date.now();
-  const providerAuth =
-    input.providerAuth ??
-    (await resolveSessionProviderAuth(ctx.db, {
-      explicit: input.providerSelections,
-      unattended: input.spawnSource !== undefined && input.spawnSource !== "user",
-    }));
   const baseBranch = hasRepoOwner ? branch || defaultBranch || "main" : null;
 
   if (input.repositories?.length) {
@@ -164,7 +156,7 @@ export async function initializeSession(
     updatedAt: now,
     skillManifest: input.managedSkillsManifest,
     skillManifestSourceSessionId: input.managedSkillsSourceSessionId,
-    providerAuth,
+    providerAuth: input.providerAuth,
   });
 
   // Step 2: DO init

--- a/packages/control-plane/src/session/provider-account-resolution.test.ts
+++ b/packages/control-plane/src/session/provider-account-resolution.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModelProviderAccount } from "../db/model-provider-accounts";
+import type { ProviderDefault } from "../db/provider-account-defaults";
+import { resolveProviderAccountSelections } from "./provider-account-resolution";
+import { ProviderAccountSelectionPolicyError } from "../model-provider-accounts/selection-policy";
+
+const OPENAI_ACCOUNT_ID = "1".repeat(32);
+const XAI_ACCOUNT_ID = "2".repeat(32);
+
+function account(
+  id: string,
+  provider: "openai" | "xai",
+  overrides: Partial<ModelProviderAccount> = {}
+): ModelProviderAccount {
+  return {
+    id,
+    provider,
+    displayName: provider,
+    externalAccountId: null,
+    status: "active",
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function providerDefault(
+  provider: "openai" | "xai",
+  providerAccountId: string,
+  unattendedMode: "provider_account" | "api_key" = "provider_account"
+): ProviderDefault {
+  return {
+    provider,
+    providerAccountId,
+    unattendedMode,
+    createdBy: null,
+    updatedBy: null,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function stores(
+  options: {
+    defaults?: ProviderDefault[];
+    accounts?: ModelProviderAccount[];
+  } = {}
+) {
+  const defaults = new Map((options.defaults ?? []).map((item) => [item.provider, item]));
+  const accounts = new Map((options.accounts ?? []).map((item) => [item.id, item]));
+  return {
+    defaults: { get: vi.fn(async (provider: "openai" | "xai") => defaults.get(provider) ?? null) },
+    accounts: { getById: vi.fn(async (id: string) => accounts.get(id) ?? null) },
+    adapters: { get: vi.fn(() => ({})) },
+  };
+}
+
+describe("resolveProviderAccountSelections", () => {
+  it("uses legacy scoped OAuth when no explicit choice or default exists", async () => {
+    await expect(
+      resolveProviderAccountSelections({ unattended: false }, stores())
+    ).resolves.toEqual([
+      { provider: "openai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+      { provider: "xai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+    ]);
+  });
+
+  it("resolves every provider using explicit choices before defaults", async () => {
+    const result = await resolveProviderAccountSelections(
+      {
+        explicit: {
+          openai: { mode: "provider_account", accountId: OPENAI_ACCOUNT_ID },
+          xai: { mode: "api_key" },
+        },
+        unattended: false,
+      },
+      stores({
+        defaults: [
+          providerDefault("openai", XAI_ACCOUNT_ID),
+          providerDefault("xai", XAI_ACCOUNT_ID),
+        ],
+        accounts: [account(OPENAI_ACCOUNT_ID, "openai"), account(XAI_ACCOUNT_ID, "xai")],
+      })
+    );
+
+    expect(result).toEqual([
+      {
+        provider: "openai",
+        authMode: "provider_account",
+        providerAccountId: OPENAI_ACCOUNT_ID,
+        selectionSource: "explicit",
+      },
+      { provider: "xai", authMode: "api_key", selectionSource: "explicit" },
+    ]);
+  });
+
+  it("applies unattended API-key policy before an active default", async () => {
+    const result = await resolveProviderAccountSelections(
+      { unattended: true },
+      stores({
+        defaults: [providerDefault("openai", OPENAI_ACCOUNT_ID, "api_key")],
+        accounts: [account(OPENAI_ACCOUNT_ID, "openai")],
+      })
+    );
+
+    expect(result[0]).toEqual({
+      provider: "openai",
+      authMode: "api_key",
+      selectionSource: "unattended_policy",
+    });
+    expect(result[1]).toEqual({
+      provider: "xai",
+      authMode: "legacy_scoped_oauth",
+      selectionSource: "legacy_fallback",
+    });
+  });
+
+  it("snapshots the active default account selection", async () => {
+    const defaults = [providerDefault("openai", OPENAI_ACCOUNT_ID)];
+    const deps = stores({ defaults, accounts: [account(OPENAI_ACCOUNT_ID, "openai")] });
+    const result = await resolveProviderAccountSelections({ unattended: false }, deps);
+
+    defaults[0] = providerDefault("openai", XAI_ACCOUNT_ID);
+
+    expect(result[0]).toEqual({
+      provider: "openai",
+      authMode: "provider_account",
+      providerAccountId: OPENAI_ACCOUNT_ID,
+      selectionSource: "installation_default",
+    });
+  });
+
+  it.each([
+    ["missing", null, 404],
+    ["mismatched", account(OPENAI_ACCOUNT_ID, "xai"), 400],
+    ["inactive", account(OPENAI_ACCOUNT_ID, "openai", { status: "disabled" }), 409],
+    ["archived", account(OPENAI_ACCOUNT_ID, "openai", { archivedAt: 2 }), 409],
+  ] as const)("rejects an explicit account that is %s", async (_label, selectedAccount, status) => {
+    const error = await resolveProviderAccountSelections(
+      {
+        explicit: {
+          openai: { mode: "provider_account", accountId: OPENAI_ACCOUNT_ID },
+        },
+        unattended: false,
+      },
+      stores({ accounts: selectedAccount ? [selectedAccount] : [] })
+    ).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ProviderAccountSelectionPolicyError);
+    expect(error).toMatchObject({ status });
+  });
+
+  it("treats a default selected by policy as a configuration error when unusable", async () => {
+    await expect(
+      resolveProviderAccountSelections(
+        { unattended: false },
+        stores({ defaults: [providerDefault("openai", OPENAI_ACCOUNT_ID)] })
+      )
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/packages/control-plane/src/session/provider-account-resolution.ts
+++ b/packages/control-plane/src/session/provider-account-resolution.ts
@@ -1,0 +1,90 @@
+import {
+  SUBSCRIPTION_PROVIDER_IDS,
+  type ModelProviderSelections,
+  type SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
+import { ProviderDefaultStore } from "../db/provider-account-defaults";
+import { ModelProviderAccountStore } from "../db/model-provider-accounts";
+import type { SessionModelProviderAuthInput } from "../model-provider-accounts/provider-auth-contracts";
+import type { SqlDatabase } from "../db/sql-database";
+import { modelProviderAccountAdapterRegistry } from "../auth/model-provider-account-default-adapters";
+import {
+  ProviderAccountSelectionPolicy,
+  type ProviderAccountAdapterLookup,
+} from "../model-provider-accounts/selection-policy";
+
+interface ProviderAccountResolutionStores {
+  defaults: Pick<ProviderDefaultStore, "get">;
+  accounts: Pick<ModelProviderAccountStore, "getById">;
+  adapters: ProviderAccountAdapterLookup;
+}
+
+function legacy(provider: SubscriptionProviderId): SessionModelProviderAuthInput {
+  return { provider, authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" };
+}
+
+export interface ProviderAccountResolutionInput {
+  explicit?: ModelProviderSelections;
+  unattended: boolean;
+}
+
+function apiKey(
+  provider: SubscriptionProviderId,
+  selectionSource: string
+): SessionModelProviderAuthInput {
+  return { provider, authMode: "api_key", selectionSource };
+}
+
+async function resolveProvider(
+  provider: SubscriptionProviderId,
+  input: ProviderAccountResolutionInput,
+  stores: ProviderAccountResolutionStores,
+  policy: ProviderAccountSelectionPolicy
+): Promise<SessionModelProviderAuthInput> {
+  const explicit = input.explicit?.[provider];
+  if (explicit?.mode === "api_key") return apiKey(provider, "explicit");
+  if (explicit?.mode === "provider_account") {
+    const account = await policy.validateSelection(provider, explicit.accountId);
+    return {
+      provider,
+      authMode: "provider_account",
+      providerAccountId: account.id,
+      selectionSource: "explicit",
+    };
+  }
+
+  const providerDefault = await stores.defaults.get(provider);
+  if (!providerDefault) return legacy(provider);
+  if (input.unattended && providerDefault.unattendedMode === "api_key") {
+    return apiKey(provider, "unattended_policy");
+  }
+
+  const account = await policy.validateDefault(provider, providerDefault.providerAccountId);
+  return {
+    provider,
+    authMode: "provider_account",
+    providerAccountId: account.id,
+    selectionSource: input.unattended ? "unattended_policy" : "installation_default",
+  };
+}
+
+export async function resolveProviderAccountSelections(
+  input: ProviderAccountResolutionInput,
+  stores: ProviderAccountResolutionStores
+): Promise<SessionModelProviderAuthInput[]> {
+  const policy = new ProviderAccountSelectionPolicy(stores.accounts, stores.adapters);
+  return Promise.all(
+    SUBSCRIPTION_PROVIDER_IDS.map((provider) => resolveProvider(provider, input, stores, policy))
+  );
+}
+
+export function resolveSessionProviderAuth(
+  db: SqlDatabase,
+  input: ProviderAccountResolutionInput
+): Promise<SessionModelProviderAuthInput[]> {
+  return resolveProviderAccountSelections(input, {
+    defaults: new ProviderDefaultStore(db),
+    accounts: new ModelProviderAccountStore(db),
+    adapters: modelProviderAccountAdapterRegistry,
+  });
+}

--- a/packages/control-plane/src/session/session-core-repository.ts
+++ b/packages/control-plane/src/session/session-core-repository.ts
@@ -50,6 +50,10 @@ export class SessionCoreRepository {
     return result.toArray() as T[];
   }
 
+  transaction<T>(callback: () => T): T {
+    return this.transactionSync(callback);
+  }
+
   getSession(): SessionRow | null {
     const result = this.sql.exec(`SELECT * FROM session LIMIT 1`);
     const rows = this.rows<SessionRow>(result);

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -27,6 +27,38 @@ describe("Child session operations (list, get, cancel)", () => {
     const pName = parentName();
     const childName = `child-ops-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
 
+    // Seed D1 before initializing the DOs because sandbox warming reads provider auth from D1.
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+    await store.create({
+      id: pName,
+      title: "Parent Session",
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: "anthropic/claude-sonnet-4-6",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "active",
+      spawnDepth: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await store.create({
+      id: childName,
+      title: "Child Session",
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: "anthropic/claude-sonnet-4-6",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: opts?.childStatus ?? "created",
+      parentSessionId: pName,
+      spawnSource: "agent",
+      spawnDepth: 1,
+      createdAt: now + 1,
+      updatedAt: now + 1,
+    });
+
     // Create parent DO
     const { stub: parentStub } = await initNamedSessionDO(pName, {
       repoOwner: "acme",
@@ -62,40 +94,6 @@ describe("Child session operations (list, get, cancel)", () => {
       parentSessionId: pName,
       spawnSource: "agent",
       spawnDepth: 1,
-    });
-
-    // Seed D1 rows for both parent and child
-    const store = new SessionIndexStore(env.DB);
-    const now = Date.now();
-
-    await store.create({
-      id: pName,
-      title: "Parent Session",
-      repoOwner: "acme",
-      repoName: "web-app",
-      model: "anthropic/claude-sonnet-4-6",
-      reasoningEffort: null,
-      baseBranch: null,
-      status: "active",
-      spawnDepth: 0,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    await store.create({
-      id: childName,
-      title: "Child Session",
-      repoOwner: "acme",
-      repoName: "web-app",
-      model: "anthropic/claude-sonnet-4-6",
-      reasoningEffort: null,
-      baseBranch: null,
-      status: opts?.childStatus ?? "created",
-      parentSessionId: pName,
-      spawnSource: "agent",
-      spawnDepth: 1,
-      createdAt: now + 1,
-      updatedAt: now + 1,
     });
 
     return { pName, childName, parentStub, childStub, sandboxToken, store };

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -5,6 +5,7 @@ import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import type { SessionDO } from "../../src/session/durable-object";
 import { hashToken } from "../../src/auth/crypto";
 import { SessionIndexStore } from "../../src/db/session-index";
+import type { SessionModelProviderAuthInput } from "../../src/model-provider-accounts/provider-auth-contracts";
 
 const DEFAULT_WAIT_FOR_SANDBOX_STATUS_TIMEOUT_MS = 3000;
 const TEST_BROWSER_USER_ID = "11111111111111111111111111111111";
@@ -19,6 +20,10 @@ const TEST_NAMED_SESSION_DEFAULTS = {
   repoId: 12345,
   userId: "user-1",
 } as const;
+const TEST_SESSION_PROVIDER_AUTH: SessionModelProviderAuthInput[] = [
+  { provider: "openai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+  { provider: "xai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+];
 
 async function signCookieValue(value: string, secret: string): Promise<string> {
   const key = await crypto.subtle.importKey(
@@ -138,9 +143,7 @@ export async function serviceFetch(
   });
 }
 
-/**
- * Create a fresh DO, call /internal/init, return the stub and id.
- */
+/** Create a production-shaped D1 session and DO, then return the stub and IDs. */
 export async function initSession(overrides?: {
   sessionName?: string;
   repoOwner?: string;
@@ -160,24 +163,43 @@ export async function initSession(overrides?: {
   sandboxSettings?: SandboxSettings;
   userId?: string;
   scmLogin?: string;
+  providerAuth?: SessionModelProviderAuthInput[];
 }) {
   const id = env.SESSION.newUniqueId();
   const stub = env.SESSION.get(id);
   const defaults = {
-    sessionName: `test-${Date.now()}`,
+    sessionName: `test-${Date.now()}-${crypto.randomUUID()}`,
     repoOwner: "acme",
     repoName: "web-app",
     repoId: 12345,
     userId: "user-1",
     ...overrides,
   };
+  const { providerAuth = TEST_SESSION_PROVIDER_AUTH, ...doDefaults } = defaults;
+  const now = Date.now();
+  await new SessionIndexStore(env.DB).create({
+    id: defaults.sessionName,
+    title: defaults.title ?? null,
+    repoOwner: defaults.repoOwner,
+    repoName: defaults.repoName,
+    model: defaults.model ?? "anthropic/claude-haiku-4-5",
+    reasoningEffort: defaults.reasoningEffort ?? null,
+    baseBranch: defaults.defaultBranch ?? "main",
+    repositories: defaults.repositories,
+    environmentId: defaults.environmentId ?? null,
+    status: "created",
+    userId: defaults.userId,
+    providerAuth,
+    createdAt: now,
+    updatedAt: now,
+  });
   const res = await stub.fetch("http://internal/internal/init", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(defaults),
+    body: JSON.stringify(doDefaults),
   });
   if (res.status !== 200) throw new Error(`Init failed: ${res.status}`);
-  return { stub, id };
+  return { stub, id, sessionName: defaults.sessionName };
 }
 
 /**
@@ -299,6 +321,7 @@ export async function initNamedSession(
     spawnSource?: "user" | "agent" | "automation";
     spawnDepth?: number;
     sandboxSettings?: Record<string, unknown>;
+    providerAuth?: SessionModelProviderAuthInput[];
   }
 ) {
   const defaults = {
@@ -306,6 +329,7 @@ export async function initNamedSession(
     ...TEST_NAMED_SESSION_DEFAULTS,
     ...overrides,
   };
+  const { providerAuth = TEST_SESSION_PROVIDER_AUTH, ...doDefaults } = defaults;
   const now = Date.now();
   await new SessionIndexStore(env.DB).create({
     id: sessionName,
@@ -320,11 +344,12 @@ export async function initNamedSession(
     spawnSource: defaults.spawnSource ?? "user",
     spawnDepth: defaults.spawnDepth ?? 0,
     userId: defaults.canonicalUserId ?? defaults.userId,
+    providerAuth,
     createdAt: now,
     updatedAt: now,
   });
 
-  return initNamedSessionDO(sessionName, defaults);
+  return initNamedSessionDO(sessionName, doDefaults);
 }
 
 /** Create only the named session DO for tests that manage the D1 row explicitly. */

--- a/packages/control-plane/test/integration/provider-account-routes.test.ts
+++ b/packages/control-plane/test/integration/provider-account-routes.test.ts
@@ -1,7 +1,9 @@
 import { SELF, env } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanD1Tables } from "./cleanup";
-import { serviceFetch } from "./helpers";
+import { initNamedSession, seedSandboxAuth, serviceFetch } from "./helpers";
+import { ProviderCredentialStore } from "../../src/db/provider-account-credentials";
+import { GlobalSecretsStore } from "../../src/db/global-secrets";
 
 const OPENAI_ACCOUNT_ID = "11111111111111111111111111111111";
 
@@ -256,5 +258,136 @@ describe("provider account management routes", () => {
       },
     ]);
     expect(JSON.stringify(readBody)).not.toContain("ciphertext");
+  });
+});
+
+describe("provider account sandbox broker route", () => {
+  beforeEach(cleanD1Tables);
+  afterEach(cleanD1Tables);
+
+  it("is sandbox-only and applies no-store to every outcome", async () => {
+    const sessionName = `provider-broker-${Date.now()}`;
+    const { stub } = await initNamedSession(sessionName);
+    await env.DB.prepare(
+      "DELETE FROM session_model_provider_auth WHERE session_id = ? AND provider = 'openai'"
+    )
+      .bind(sessionName)
+      .run();
+    const sandboxToken = "provider-broker-token";
+    await seedSandboxAuth(stub, { authToken: sandboxToken, sandboxId: "sandbox-1" });
+    const url = `https://test.local/sessions/${sessionName}/provider-auth/openai/access-token`;
+
+    const missing = await SELF.fetch(url, { method: "POST" });
+    expect(missing.status).toBe(401);
+    expect(missing.headers.get("Cache-Control")).toBe("no-store");
+
+    const service = await serviceFetch(url, { method: "POST", service: "web" });
+    expect(service.status).toBe(401);
+    expect(service.headers.get("Cache-Control")).toBe("no-store");
+
+    const absentBinding = await SELF.fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sandboxToken}` },
+    });
+    expect(absentBinding.status).toBe(404);
+    expect(absentBinding.headers.get("Cache-Control")).toBe("no-store");
+
+    const unsupportedProvider = await SELF.fetch(
+      `https://test.local/sessions/${sessionName}/provider-auth/anthropic/access-token`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sandboxToken}` },
+      }
+    );
+    expect(unsupportedProvider.status).toBe(400);
+    expect(unsupportedProvider.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("adapts legacy scoped OAuth to the generic provider access contract", async () => {
+    const sessionName = `provider-broker-legacy-${Date.now()}`;
+    await new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY!).setSecrets({
+      OPENAI_OAUTH_REFRESH_TOKEN: "integration-openai",
+    });
+    const { stub } = await initNamedSession(sessionName);
+    const sandboxToken = "provider-broker-legacy-token";
+    await seedSandboxAuth(stub, { authToken: sandboxToken, sandboxId: "sandbox-legacy" });
+
+    const response = await SELF.fetch(
+      `https://test.local/sessions/${sessionName}/provider-auth/openai/access-token`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sandboxToken}` },
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      accessToken: "integration-openai-access-token",
+      expiresIn: 3600,
+      providerMetadata: { accountId: "acct-integration" },
+    });
+  });
+
+  it("brokers only the account pinned to the trusted session auth row", async () => {
+    const sessionName = `provider-broker-success-${Date.now()}`;
+    const now = Date.now();
+    await env.DB.prepare(
+      `INSERT INTO model_provider_accounts
+        (id, provider, display_name, external_account_id, status, created_at, updated_at)
+        VALUES (?, 'openai', 'Pinned OpenAI', 'acct-pinned', 'active', ?, ?)`
+    )
+      .bind(OPENAI_ACCOUNT_ID, now, now)
+      .run();
+    await new ProviderCredentialStore(env.DB, env.PROVIDER_ACCOUNTS_ENCRYPTION_KEY!).create({
+      providerAccountId: OPENAI_ACCOUNT_ID,
+      provider: "openai",
+      credentialSchemaVersion: 1,
+      payload: {
+        refreshToken: "never-returned",
+        accessToken: "brokered-access-token",
+        accessTokenExpiresAt: now + 60 * 60 * 1000,
+        accountId: "acct-pinned",
+      },
+      accessTokenExpiresAt: now + 60 * 60 * 1000,
+      now,
+    });
+    const { stub } = await initNamedSession(sessionName, {
+      providerAuth: [
+        {
+          provider: "openai",
+          authMode: "provider_account",
+          providerAccountId: OPENAI_ACCOUNT_ID,
+          selectionSource: "explicit",
+        },
+        { provider: "xai", authMode: "api_key", selectionSource: "fallback_api_key" },
+      ],
+    });
+    const sandboxToken = "provider-broker-success-token";
+    await seedSandboxAuth(stub, { authToken: sandboxToken, sandboxId: "sandbox-success" });
+
+    const response = await SELF.fetch(
+      `https://test.local/sessions/${sessionName}/provider-auth/openai/access-token`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sandboxToken}` },
+      }
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    const body = await response.json<Record<string, unknown>>();
+    expect(body).toMatchObject({
+      accessToken: "brokered-access-token",
+      externalAccountId: "acct-pinned",
+    });
+    expect(JSON.stringify(body)).not.toContain("never-returned");
+    const legacyBypass = await SELF.fetch(
+      `https://test.local/sessions/${sessionName}/openai-token-refresh`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${sandboxToken}` },
+      }
+    );
+    expect(legacyBypass.status).toBe(409);
   });
 });

--- a/packages/control-plane/test/integration/scheduler.test.ts
+++ b/packages/control-plane/test/integration/scheduler.test.ts
@@ -3,6 +3,10 @@ import { env } from "cloudflare:test";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
 import { cleanD1Tables } from "./cleanup";
 import { makeRunRow, seedRun, fetchRuns } from "./run-helpers";
+import { resolveAutomationProviderAuth } from "../../src/scheduler/durable-object";
+import { AutomationModelProviderAuthStore } from "../../src/db/automation-model-provider-auth";
+import { ModelProviderAccountStore } from "../../src/db/model-provider-accounts";
+import { ProviderDefaultStore } from "../../src/db/provider-account-defaults";
 
 function getSchedulerStub() {
   const id = env.SCHEDULER.idFromName("global-scheduler");
@@ -36,7 +40,112 @@ function makeAutomation(overrides?: Partial<AutomationRow>): AutomationRow {
 }
 
 describe("SchedulerDO (integration)", () => {
-  beforeEach(cleanD1Tables);
+  beforeEach(async () => {
+    await cleanD1Tables();
+    await env.DB.exec(
+      "DELETE FROM model_provider_account_defaults; DELETE FROM model_provider_accounts;"
+    );
+  });
+
+  describe("automation provider auth resolution", () => {
+    const accountIds = {
+      openai: "00000000000000000000000000000001",
+      xai: "00000000000000000000000000000002",
+    } as const;
+
+    async function seedProviderAccounts(): Promise<void> {
+      const accounts = new ModelProviderAccountStore(env.DB);
+      const defaults = new ProviderDefaultStore(env.DB);
+      for (const provider of ["openai", "xai"] as const) {
+        await accounts.create({
+          id: accountIds[provider],
+          provider,
+          displayName: provider,
+        });
+        await defaults.set(provider, accountIds[provider], "provider_account", null);
+      }
+    }
+
+    it.each(["openai", "xai"] as const)("uses an account pin for %s", async (provider) => {
+      await seedProviderAccounts();
+      const automation = makeAutomation({ id: `auto-account-${provider}` });
+      await new AutomationStore(env.DB).create(automation);
+      const authStore = new AutomationModelProviderAuthStore(env.DB);
+      await env.DB.batch(
+        authStore.bindReplace(
+          automation.id,
+          {
+            [provider]: { mode: "provider_account", accountId: accountIds[provider] },
+          },
+          Date.now()
+        )
+      );
+
+      const resolved = await resolveAutomationProviderAuth(env.DB, automation.id);
+
+      expect(resolved).toContainEqual({
+        provider,
+        authMode: "provider_account",
+        providerAccountId: accountIds[provider],
+        selectionSource: "automation_pin",
+      });
+    });
+
+    it.each(["openai", "xai"] as const)("uses an API-key pin for %s", async (provider) => {
+      await seedProviderAccounts();
+      const automation = makeAutomation({ id: `auto-api-key-${provider}` });
+      await new AutomationStore(env.DB).create(automation);
+      const authStore = new AutomationModelProviderAuthStore(env.DB);
+      await env.DB.batch(
+        authStore.bindReplace(automation.id, { [provider]: { mode: "api_key" } }, Date.now())
+      );
+
+      const resolved = await resolveAutomationProviderAuth(env.DB, automation.id);
+
+      expect(resolved).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider,
+            authMode: "api_key",
+            selectionSource: "automation_pin",
+          }),
+        ])
+      );
+    });
+
+    it.each(["openai", "xai"] as const)(
+      "resolves the unattended policy on every unpinned %s run",
+      async (provider) => {
+        await seedProviderAccounts();
+        const automation = makeAutomation({ id: `auto-policy-${provider}` });
+        await new AutomationStore(env.DB).create(automation);
+        const defaults = new ProviderDefaultStore(env.DB);
+        await defaults.set(provider, accountIds[provider], "api_key", null);
+
+        await expect(resolveAutomationProviderAuth(env.DB, automation.id)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              provider,
+              authMode: "api_key",
+              selectionSource: "unattended_policy",
+            }),
+          ])
+        );
+
+        await defaults.set(provider, accountIds[provider], "provider_account", null);
+        await expect(resolveAutomationProviderAuth(env.DB, automation.id)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              provider,
+              authMode: "provider_account",
+              providerAccountId: accountIds[provider],
+              selectionSource: "unattended_policy",
+            }),
+          ])
+        );
+      }
+    );
+  });
 
   // ─── Health check ─────────────────────────────────────────────────────────
 

--- a/packages/control-plane/test/integration/session-provider-auth.test.ts
+++ b/packages/control-plane/test/integration/session-provider-auth.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { ModelProviderAccountStore } from "../../src/db/model-provider-accounts";
+import { ProviderDefaultStore } from "../../src/db/provider-account-defaults";
+import { SessionIndexStore } from "../../src/db/session-index";
+import { initializeSession } from "../../src/session/initialize";
+import { resolveSessionProviderAuth } from "../../src/session/provider-account-resolution";
+import { cleanD1Tables } from "./cleanup";
+
+const FIRST_ACCOUNT_ID = "1".repeat(32);
+const SECOND_ACCOUNT_ID = "2".repeat(32);
+
+describe("session provider auth persistence", () => {
+  beforeEach(async () => {
+    await cleanD1Tables();
+    await env.DB.exec(
+      "DELETE FROM model_provider_account_defaults; DELETE FROM model_provider_account_credentials; DELETE FROM model_provider_accounts;"
+    );
+  });
+
+  it("keeps the authoritative D1 snapshot when the installation default changes", async () => {
+    const accounts = new ModelProviderAccountStore(env.DB);
+    const defaults = new ProviderDefaultStore(env.DB);
+    await accounts.create({
+      id: FIRST_ACCOUNT_ID,
+      provider: "openai",
+      displayName: "First",
+      now: 10,
+    });
+    await accounts.create({
+      id: SECOND_ACCOUNT_ID,
+      provider: "openai",
+      displayName: "Second",
+      now: 20,
+    });
+    await defaults.set("openai", FIRST_ACCOUNT_ID, "provider_account", null, 30);
+
+    const providerAuth = await resolveSessionProviderAuth(env.DB, { unattended: false });
+    const sessionId = `provider-auth-${Date.now()}`;
+    await initializeSession(
+      env,
+      {
+        sessionId,
+        repoOwner: null,
+        repoName: null,
+        repoId: null,
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        participantUserId: "user-1",
+        platformUserId: null,
+        scmTokenEncrypted: null,
+        scmRefreshTokenEncrypted: null,
+        providerAuth,
+      },
+      {
+        db: env.DB,
+        trace_id: "provider-auth-trace",
+        request_id: "provider-auth-request",
+        metrics: { queries: [], totalQueryDurationMs: 0 },
+      } as never
+    );
+
+    await defaults.set("openai", SECOND_ACCOUNT_ID, "provider_account", null, 60);
+
+    await expect(new SessionIndexStore(env.DB).getCompleteProviderAuth(sessionId)).resolves.toEqual(
+      [
+        {
+          provider: "openai",
+          authMode: "provider_account",
+          providerAccountId: FIRST_ACCOUNT_ID,
+          selectionSource: "installation_default",
+        },
+        {
+          provider: "xai",
+          authMode: "legacy_scoped_oauth",
+          selectionSource: "legacy_fallback",
+        },
+      ]
+    );
+  });
+});

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -3,8 +3,10 @@ import { env, runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { RepoSecretsStore } from "../../src/db/repo-secrets";
+import { ModelProviderAccountStore } from "../../src/db/model-provider-accounts";
 import { cleanD1Tables } from "./cleanup";
-import { initSession } from "./helpers";
+import { initNamedSession, initSession } from "./helpers";
+import type { SessionProviderAuthMode } from "@open-inspect/shared/types/provider-accounts";
 
 const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
 
@@ -17,6 +19,38 @@ function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string>
       }
     ).getUserEnvVars()
   );
+}
+
+async function initSessionWithProviderAuth(
+  overrides: Parameters<typeof initNamedSession>[1] = {},
+  modes: Record<"openai" | "xai", SessionProviderAuthMode> = {
+    openai: "legacy_scoped_oauth",
+    xai: "legacy_scoped_oauth",
+  }
+) {
+  const sessionName = `provider-auth-env-${Date.now()}-${crypto.randomUUID()}`;
+  const accountIds = { openai: "1".repeat(32), xai: "2".repeat(32) } as const;
+  const accounts = new ModelProviderAccountStore(env.DB);
+  for (const provider of ["openai", "xai"] as const) {
+    if (modes[provider] === "provider_account") {
+      await accounts.create({
+        id: accountIds[provider],
+        provider,
+        displayName: `${provider} account`,
+      });
+    }
+  }
+  const providerAuth = (["openai", "xai"] as const).map((provider) =>
+    modes[provider] === "provider_account"
+      ? {
+          provider,
+          authMode: "provider_account" as const,
+          providerAccountId: accountIds[provider],
+          selectionSource: "explicit",
+        }
+      : { provider, authMode: modes[provider], selectionSource: "explicit" }
+  );
+  return initNamedSession(sessionName, { ...overrides, providerAuth });
 }
 
 describe("getUserEnvVars session-target fold", () => {
@@ -33,7 +67,7 @@ describe("getUserEnvVars session-target fold", () => {
       ONLY_BACKEND: "b",
     });
 
-    const { stub } = await initSession({
+    const { stub } = await initSessionWithProviderAuth({
       repoOwner: "acme",
       repoName: "web",
       repoId: 90101,
@@ -61,10 +95,72 @@ describe("getUserEnvVars session-target fold", () => {
       ONLY_REPO: "r",
     });
 
-    const { stub } = await initSession({ repoOwner: "acme", repoName: "solo", repoId: 90201 });
+    const { stub } = await initSessionWithProviderAuth({
+      repoOwner: "acme",
+      repoName: "solo",
+      repoId: 90201,
+    });
 
     const envVars = await getUserEnvVars(stub);
 
     expect(envVars).toMatchObject({ SHARED: "repo", ONLY_GLOBAL: "g", ONLY_REPO: "r" });
+  });
+
+  it("advertises provider accounts even when there are no ordinary secrets", async () => {
+    const { stub } = await initSessionWithProviderAuth(undefined, {
+      openai: "provider_account",
+      xai: "provider_account",
+    });
+
+    await expect(getUserEnvVars(stub)).resolves.toEqual({
+      OPENAI_OAUTH_MANAGED: "1",
+      XAI_OAUTH_MANAGED: "1",
+    });
+  });
+
+  it.each([
+    {
+      modes: { openai: "provider_account", xai: "api_key" } as const,
+      expected: { OPENAI_OAUTH_MANAGED: "1", XAI_API_KEY: "xai-key" },
+    },
+    {
+      modes: { openai: "api_key", xai: "provider_account" } as const,
+      expected: { OPENAI_API_KEY: "openai-key", XAI_OAUTH_MANAGED: "1" },
+    },
+  ])("uses authoritative D1 provider auth modes for $modes", async ({ modes, expected }) => {
+    await new GlobalSecretsStore(env.DB, KEY()).setSecrets({
+      OPENAI_API_KEY: "openai-key",
+      XAI_API_KEY: "xai-key",
+      OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+      XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+    });
+    const { stub } = await initSessionWithProviderAuth(undefined, modes);
+
+    await expect(getUserEnvVars(stub)).resolves.toEqual(expected);
+  });
+
+  it("preserves scoped OAuth for legacy-bound sessions", async () => {
+    await new GlobalSecretsStore(env.DB, KEY()).setSecrets({
+      OPENAI_API_KEY: "openai-key",
+      XAI_API_KEY: "xai-key",
+      OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+    });
+    const { stub } = await initSessionWithProviderAuth();
+
+    await expect(getUserEnvVars(stub)).resolves.toEqual({
+      OPENAI_OAUTH_MANAGED: "1",
+      XAI_API_KEY: "xai-key",
+    });
+  });
+
+  it("fails closed when the D1 provider auth snapshot is incomplete", async () => {
+    const { stub, sessionName } = await initSession();
+    await env.DB.prepare(
+      "DELETE FROM session_model_provider_auth WHERE session_id = ? AND provider = 'xai'"
+    )
+      .bind(sessionName)
+      .run();
+
+    await expect(getUserEnvVars(stub)).rejects.toThrow(/provider auth snapshot is incomplete/);
   });
 });

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -25,6 +25,32 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     reasoningEffort?: string | null;
   }) {
     const parentName = `parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+    await store.create({
+      id: parentName,
+      title: "Parent",
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: opts?.model ?? "anthropic/claude-sonnet-4-6",
+      reasoningEffort: opts?.reasoningEffort ?? null,
+      baseBranch: null,
+      status: "active",
+      parentSessionId: opts?.parentSessionId ?? null,
+      spawnSource: opts?.spawnSource ?? "user",
+      spawnDepth: opts?.spawnDepth ?? 0,
+      automationId: opts?.automationId ?? null,
+      automationRunId: opts?.automationRunId ?? null,
+      environmentId: opts?.environmentId ?? null,
+      userId: opts?.canonicalUserId ?? null,
+      providerAuth: [
+        { provider: "openai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+        { provider: "xai", authMode: "legacy_scoped_oauth", selectionSource: "legacy_fallback" },
+      ],
+      createdAt: now,
+      updatedAt: now,
+    });
+
     const { stub } = await initNamedSessionDO(parentName, {
       repoOwner: "acme",
       repoName: "web-app",
@@ -51,28 +77,6 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       status: "processing",
       createdAt: Date.now(),
       startedAt: Date.now(),
-    });
-
-    const store = new SessionIndexStore(env.DB);
-    const now = Date.now();
-    await store.create({
-      id: parentName,
-      title: "Parent",
-      repoOwner: "acme",
-      repoName: "web-app",
-      model: opts?.model ?? "anthropic/claude-sonnet-4-6",
-      reasoningEffort: opts?.reasoningEffort ?? null,
-      baseBranch: null,
-      status: "active",
-      parentSessionId: opts?.parentSessionId ?? null,
-      spawnSource: opts?.spawnSource ?? "user",
-      spawnDepth: opts?.spawnDepth ?? 0,
-      automationId: opts?.automationId ?? null,
-      automationRunId: opts?.automationRunId ?? null,
-      environmentId: opts?.environmentId ?? null,
-      userId: opts?.canonicalUserId ?? null,
-      createdAt: now,
-      updatedAt: now,
     });
 
     return { parentName, stub, sandboxToken, store, now };

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -48,7 +48,8 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # and MIN_REBUILD_RUNTIME_VERSION gates which prebuilt images get rebuilt onto
 # it, so bump every provider's label together.
 # v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
-CACHE_BUSTER = "v59-opencode-1-18-18"
+# v60: generic provider-account token broker plugin
+CACHE_BUSTER = "v60-provider-account-broker"
 
 # Base image with all development tools
 base_image = (

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import modal
 
 import sandbox_runtime
+from sandbox_runtime.runtime_manifest import RUNTIME_VERSION
 
 # Get the path to the sandbox runtime code (provider-agnostic)
 SANDBOX_RUNTIME_DIR = Path(sandbox_runtime.__file__).parent
@@ -49,7 +50,7 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # it, so bump every provider's label together.
 # v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
 # v60: generic provider-account token broker plugin
-CACHE_BUSTER = "v60-provider-account-broker"
+CACHE_BUSTER = RUNTIME_VERSION
 
 # Base image with all development tools
 base_image = (

--- a/packages/modal-infra/tests/test_runtime_manifest.py
+++ b/packages/modal-infra/tests/test_runtime_manifest.py
@@ -1,0 +1,9 @@
+from sandbox_runtime.runtime_manifest import RUNTIME_MANIFEST, RUNTIME_VERSION
+from src.images.base import CACHE_BUSTER
+
+
+def test_runtime_manifest_generation_matches_version() -> None:
+    assert RUNTIME_VERSION.startswith(f"v{RUNTIME_MANIFEST['generation']}")
+    assert CACHE_BUSTER == RUNTIME_VERSION
+    assert RUNTIME_MANIFEST["minimumCompatibleGeneration"] <= RUNTIME_MANIFEST["generation"]
+    assert RUNTIME_MANIFEST["minimumRebuildGeneration"] <= RUNTIME_MANIFEST["generation"]

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -167,6 +167,55 @@ async def test_restore_user_env_vars_override_order(monkeypatch):
     assert NOVNC_PORT_ENV_VAR not in env_vars
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("managed_marker", "suppressed_api_key"),
+    [
+        ("OPENAI_OAUTH_MANAGED", "OPENAI_API_KEY"),
+        ("XAI_OAUTH_MANAGED", "XAI_API_KEY"),
+    ],
+)
+async def test_create_preserves_managed_provider_env_isolation(
+    monkeypatch, managed_marker, suppressed_api_key
+):
+    captured = {}
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
+
+    await SandboxManager().create_sandbox(
+        SandboxConfig(
+            repo_owner="acme",
+            repo_name="repo",
+            user_env_vars={managed_marker: "1", "CUSTOM_SECRET": "value"},
+        )
+    )
+
+    assert captured["env"][managed_marker] == "1"
+    assert suppressed_api_key not in captured["env"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("managed_marker", "suppressed_api_key"),
+    [
+        ("OPENAI_OAUTH_MANAGED", "OPENAI_API_KEY"),
+        ("XAI_OAUTH_MANAGED", "XAI_API_KEY"),
+    ],
+)
+async def test_restore_preserves_managed_provider_env_isolation(
+    monkeypatch, managed_marker, suppressed_api_key
+):
+    captured = _fake_restore_setup(monkeypatch)
+
+    await SandboxManager().restore_from_snapshot(
+        snapshot_image_id="img-abc",
+        session_config={"session_id": "sess-1"},
+        user_env_vars={managed_marker: "1", "CUSTOM_SECRET": "value"},
+    )
+
+    assert captured["env"][managed_marker] == "1"
+    assert suppressed_api_key not in captured["env"]
+
+
 def test_generated_vnc_password_respects_protocol_limit():
     assert len(SandboxManager._generate_vnc_password().encode()) == VNC_PASSWORD_MAX_BYTES
 

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { Image, Snapshots } from "@opencomputer/sdk/node";
+import runtimeManifest from "../../sandbox-runtime/src/sandbox_runtime/runtime_manifest.json";
 
 // Never pin below 1.18.15 — see packages/modal-infra/src/images/base.py for why
 // (OpenCode's message-ID counter wraps and earlier releases order by ID string).
@@ -23,6 +24,7 @@ const UV_PYTHON_INSTALL_DIR = `${SANDBOX_HOME}/.local/share/uv/python`;
 const SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
 const OPENSANDBOX_PROXY_CA = "/usr/local/share/ca-certificates/opensandbox-proxy.crt";
 const LOCAL_NO_PROXY = "localhost,127.0.0.1,::1";
+export const OPENCOMPUTER_TEMPLATE_RUNTIME_VERSION = runtimeManifest.runtimeVersion;
 const HOSTS_BOOTSTRAP =
   "grep -Eq '^[[:space:]]*127\\.0\\.0\\.1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
   "printf '%s\\n' '127.0.0.1 localhost' | sudo tee -a /etc/hosts >/dev/null; " +
@@ -247,7 +249,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "v60-provider-account-broker",
+      SANDBOX_VERSION: OPENCOMPUTER_TEMPLATE_RUNTIME_VERSION,
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -247,7 +247,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "v59-vnc-opencode-1-18-18",
+      SANDBOX_VERSION: "v60-provider-account-broker",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
@@ -506,12 +506,18 @@ class OpenCodeServer:
             ("OPENAI_OAUTH_MANAGED", "codex-auth-plugin.js", "openai_oauth.plugin_deployed"),
             ("XAI_OAUTH_MANAGED", "xai-auth-plugin.js", "xai_oauth.plugin_deployed"),
         )
+        broker_client_deployed = False
         for marker, filename, log_event in managed_plugins:
             plugin_source = Path(f"/app/sandbox_runtime/plugins/{filename}")
             if not plugin_source.exists() or not os.environ.get(marker):
                 continue
             plugin_dir = opencode_dir / "plugins"
             plugin_dir.mkdir(parents=True, exist_ok=True)
+            if not broker_client_deployed:
+                broker_client = Path("/app/sandbox_runtime/plugins/provider-token-broker.js")
+                shutil.copy(broker_client, plugin_dir / broker_client.name)
+                installed_runtime_paths.add(f".opencode/plugins/{broker_client.name}")
+                broker_client_deployed = True
             shutil.copy(plugin_source, plugin_dir / filename)
             installed_runtime_paths.add(f".opencode/plugins/{filename}")
             self.log.info(log_event)

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -59,19 +59,34 @@ async function refreshViaControlPlane() {
     );
   }
 
-  const response = await fetch(`${controlPlaneUrl}/sessions/${sessionId}/openai-token-refresh`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${authToken}`,
-    },
-  });
+  const response = await fetch(
+    `${controlPlaneUrl}/sessions/${sessionId}/provider-auth/openai/access-token`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    }
+  );
 
   if (!response.ok) {
     const body = (await response.text()).slice(0, 200);
     throw new Error(`Token refresh failed (${response.status}): ${body}`);
   }
 
-  return response.json();
+  const result = await response.json();
+  if (
+    !result ||
+    typeof result.accessToken !== "string" ||
+    !result.accessToken.trim() ||
+    (result.expiresIn !== undefined &&
+      (typeof result.expiresIn !== "number" ||
+        !Number.isFinite(result.expiresIn) ||
+        result.expiresIn <= 0))
+  ) {
+    throw new Error("Invalid OpenAI token broker response");
+  }
+  return result;
 }
 
 async function ensureAccessToken(getAuth, setAuth) {
@@ -85,9 +100,9 @@ async function ensureAccessToken(getAuth, setAuth) {
   // Refresh via control plane
   const result = await refreshViaControlPlane();
 
-  cachedAccessToken = result.access_token;
-  cachedAccountId = result.account_id || null;
-  cachedExpiresAt = now + (result.expires_in ?? 3600) * 1000;
+  cachedAccessToken = result.accessToken;
+  cachedAccountId = result.providerMetadata?.accountId || null;
+  cachedExpiresAt = now + (result.expiresIn ?? 3600) * 1000;
 
   // Update OpenCode's auth state for consistency
   try {
@@ -95,7 +110,7 @@ async function ensureAccessToken(getAuth, setAuth) {
     await setAuth({
       type: "oauth",
       refresh: currentAuth?.refresh || "managed-by-control-plane",
-      access: result.access_token,
+      access: result.accessToken,
       expires: cachedExpiresAt,
       ...(cachedAccountId && { accountId: cachedAccountId }),
     });

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -10,9 +10,11 @@
  * and deduplicates by provider ID (last wins), so this replaces the built-in.
  */
 
+import { createProviderTokenBroker } from "./provider-token-broker.js";
+
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key";
-const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes before expiry
+const tokenBroker = createProviderTokenBroker({ provider: "openai", providerLabel: "OpenAI" });
 
 const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex-max",
@@ -27,98 +29,28 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex",
 ]);
 
-// In-memory token cache (reset on sandbox restart - fresh refresh via bridge)
-let cachedAccessToken = null;
-let cachedAccountId = null;
-let cachedExpiresAt = 0;
-
-function getSessionId() {
-  try {
-    const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
-    return config.sessionId || config.session_id || "";
-  } catch {
-    return "";
-  }
-}
-
-async function refreshViaControlPlane() {
-  const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
-  const authToken = process.env.SANDBOX_AUTH_TOKEN;
-  const sessionId = getSessionId();
-
-  if (!controlPlaneUrl || !authToken || !sessionId) {
-    throw new Error(
-      "Missing environment for token refresh: " +
-        [
-          !controlPlaneUrl && "CONTROL_PLANE_URL",
-          !authToken && "SANDBOX_AUTH_TOKEN",
-          !sessionId && "SESSION_CONFIG.sessionId",
-        ]
-          .filter(Boolean)
-          .join(", ")
-    );
-  }
-
-  const response = await fetch(
-    `${controlPlaneUrl}/sessions/${sessionId}/provider-auth/openai/access-token`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-      },
-    }
-  );
-
-  if (!response.ok) {
-    const body = (await response.text()).slice(0, 200);
-    throw new Error(`Token refresh failed (${response.status}): ${body}`);
-  }
-
-  const result = await response.json();
-  if (
-    !result ||
-    typeof result.accessToken !== "string" ||
-    !result.accessToken.trim() ||
-    (result.expiresIn !== undefined &&
-      (typeof result.expiresIn !== "number" ||
-        !Number.isFinite(result.expiresIn) ||
-        result.expiresIn <= 0))
-  ) {
-    throw new Error("Invalid OpenAI token broker response");
-  }
-  return result;
-}
-
 async function ensureAccessToken(getAuth, setAuth) {
-  const now = Date.now();
-
-  // Return cached token if still fresh
-  if (cachedAccessToken && cachedExpiresAt - now > REFRESH_BUFFER_MS) {
-    return { accessToken: cachedAccessToken, accountId: cachedAccountId };
-  }
-
-  // Refresh via control plane
-  const result = await refreshViaControlPlane();
-
-  cachedAccessToken = result.accessToken;
-  cachedAccountId = result.providerMetadata?.accountId || null;
-  cachedExpiresAt = now + (result.expiresIn ?? 3600) * 1000;
-
-  // Update OpenCode's auth state for consistency
-  try {
-    const currentAuth = await getAuth();
-    await setAuth({
-      type: "oauth",
-      refresh: currentAuth?.refresh || "managed-by-control-plane",
-      access: result.accessToken,
-      expires: cachedExpiresAt,
-      ...(cachedAccountId && { accountId: cachedAccountId }),
-    });
-  } catch {
-    // Non-fatal: the in-memory cache is the source of truth
-  }
-
-  return { accessToken: cachedAccessToken, accountId: cachedAccountId };
+  const result = await tokenBroker.getAccessToken(async (refreshed) => {
+    // Update OpenCode's auth state for consistency. The broker cache remains
+    // authoritative when the local auth store cannot be updated.
+    try {
+      const currentAuth = await getAuth();
+      const accountId = refreshed.providerMetadata?.accountId || null;
+      await setAuth({
+        type: "oauth",
+        refresh: currentAuth?.refresh || "managed-by-control-plane",
+        access: refreshed.accessToken,
+        expires: refreshed.expiresAt,
+        ...(accountId && { accountId }),
+      });
+    } catch {
+      // Non-fatal: the in-memory cache is the source of truth
+    }
+  });
+  return {
+    accessToken: result.accessToken,
+    accountId: result.providerMetadata?.accountId || null,
+  };
 }
 
 export const CodexAuthProxy = async (input) => {

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/provider-token-broker.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/provider-token-broker.js
@@ -1,0 +1,79 @@
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_EXPIRES_IN_SECONDS = 3600;
+
+function getSessionId() {
+  try {
+    const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
+    return config.sessionId || config.session_id || "";
+  } catch {
+    return "";
+  }
+}
+
+function validateBrokerResponse(result, providerLabel) {
+  if (
+    !result ||
+    typeof result.accessToken !== "string" ||
+    !result.accessToken.trim() ||
+    (result.expiresIn !== undefined &&
+      (typeof result.expiresIn !== "number" ||
+        !Number.isFinite(result.expiresIn) ||
+        result.expiresIn <= 0))
+  ) {
+    throw new Error(`Invalid ${providerLabel} token broker response`);
+  }
+}
+
+/**
+ * Create a provider-neutral, single-flight client for the session token broker.
+ * Each auth plugin owns one instance, so cached credentials never cross providers.
+ */
+export function createProviderTokenBroker({ provider, providerLabel }) {
+  let cachedResult = null;
+  let cachedExpiresAt = 0;
+  let refreshPromise = null;
+
+  async function refresh(onRefresh) {
+    const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
+    const authToken = process.env.SANDBOX_AUTH_TOKEN;
+    const sessionId = getSessionId();
+    if (!controlPlaneUrl || !authToken || !sessionId) {
+      throw new Error(`Missing environment for ${providerLabel} token refresh`);
+    }
+
+    const response = await fetch(
+      `${controlPlaneUrl}/sessions/${sessionId}/provider-auth/${provider}/access-token`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+        signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+      }
+    );
+    if (!response.ok) {
+      const body = (await response.text()).slice(0, 200);
+      throw new Error(`${providerLabel} token refresh failed (${response.status}): ${body}`);
+    }
+
+    const result = await response.json();
+    validateBrokerResponse(result, providerLabel);
+    cachedResult = result;
+    cachedExpiresAt = Date.now() + (result.expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS) * 1000;
+    await onRefresh?.({ ...result, expiresAt: cachedExpiresAt });
+    return { ...result, expiresAt: cachedExpiresAt };
+  }
+
+  return {
+    async getAccessToken(onRefresh) {
+      if (cachedResult && cachedExpiresAt - Date.now() > REFRESH_BUFFER_MS) {
+        return { ...cachedResult, expiresAt: cachedExpiresAt };
+      }
+      if (!refreshPromise) {
+        refreshPromise = refresh(onRefresh).finally(() => {
+          refreshPromise = null;
+        });
+      }
+      return refreshPromise;
+    },
+  };
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
@@ -30,11 +30,14 @@ async function refreshViaControlPlane() {
     throw new Error("Missing environment for xAI token refresh");
   }
 
-  const response = await fetch(`${controlPlaneUrl}/sessions/${sessionId}/xai-token-refresh`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${authToken}` },
-    signal: AbortSignal.timeout(CONTROL_PLANE_TOKEN_REQUEST_TIMEOUT_MS),
-  });
+  const response = await fetch(
+    `${controlPlaneUrl}/sessions/${sessionId}/provider-auth/xai/access-token`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${authToken}` },
+      signal: AbortSignal.timeout(CONTROL_PLANE_TOKEN_REQUEST_TIMEOUT_MS),
+    }
+  );
   if (!response.ok) {
     const body = (await response.text()).slice(0, 200);
     throw new Error(`xAI token refresh failed (${response.status}): ${body}`);
@@ -42,11 +45,12 @@ async function refreshViaControlPlane() {
   const result = await response.json();
   if (
     !result ||
-    typeof result.access_token !== "string" ||
-    !result.access_token.trim() ||
-    typeof result.expires_in !== "number" ||
-    !Number.isFinite(result.expires_in) ||
-    result.expires_in <= 0
+    typeof result.accessToken !== "string" ||
+    !result.accessToken.trim() ||
+    (result.expiresIn !== undefined &&
+      (typeof result.expiresIn !== "number" ||
+        !Number.isFinite(result.expiresIn) ||
+        result.expiresIn <= 0))
   ) {
     throw new Error("Invalid xAI token broker response");
   }
@@ -60,8 +64,8 @@ async function ensureAccessToken() {
   if (!refreshPromise) {
     refreshPromise = refreshViaControlPlane()
       .then((result) => {
-        cachedAccessToken = result.access_token;
-        cachedExpiresAt = Date.now() + result.expires_in * 1000;
+        cachedAccessToken = result.accessToken;
+        cachedExpiresAt = Date.now() + (result.expiresIn ?? 3600) * 1000;
         return cachedAccessToken;
       })
       .finally(() => {

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/xai-auth-plugin.js
@@ -5,75 +5,10 @@
  * only short-lived access tokens to the ephemeral sandbox.
  */
 
+import { createProviderTokenBroker } from "./provider-token-broker.js";
+
 const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key";
-const REFRESH_BUFFER_MS = 5 * 60 * 1000;
-const CONTROL_PLANE_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
-
-let cachedAccessToken = null;
-let cachedExpiresAt = 0;
-let refreshPromise = null;
-
-function getSessionId() {
-  try {
-    const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
-    return config.sessionId || config.session_id || "";
-  } catch {
-    return "";
-  }
-}
-
-async function refreshViaControlPlane() {
-  const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
-  const authToken = process.env.SANDBOX_AUTH_TOKEN;
-  const sessionId = getSessionId();
-  if (!controlPlaneUrl || !authToken || !sessionId) {
-    throw new Error("Missing environment for xAI token refresh");
-  }
-
-  const response = await fetch(
-    `${controlPlaneUrl}/sessions/${sessionId}/provider-auth/xai/access-token`,
-    {
-      method: "POST",
-      headers: { Authorization: `Bearer ${authToken}` },
-      signal: AbortSignal.timeout(CONTROL_PLANE_TOKEN_REQUEST_TIMEOUT_MS),
-    }
-  );
-  if (!response.ok) {
-    const body = (await response.text()).slice(0, 200);
-    throw new Error(`xAI token refresh failed (${response.status}): ${body}`);
-  }
-  const result = await response.json();
-  if (
-    !result ||
-    typeof result.accessToken !== "string" ||
-    !result.accessToken.trim() ||
-    (result.expiresIn !== undefined &&
-      (typeof result.expiresIn !== "number" ||
-        !Number.isFinite(result.expiresIn) ||
-        result.expiresIn <= 0))
-  ) {
-    throw new Error("Invalid xAI token broker response");
-  }
-  return result;
-}
-
-async function ensureAccessToken() {
-  if (cachedAccessToken && cachedExpiresAt - Date.now() > REFRESH_BUFFER_MS) {
-    return cachedAccessToken;
-  }
-  if (!refreshPromise) {
-    refreshPromise = refreshViaControlPlane()
-      .then((result) => {
-        cachedAccessToken = result.accessToken;
-        cachedExpiresAt = Date.now() + (result.expiresIn ?? 3600) * 1000;
-        return cachedAccessToken;
-      })
-      .finally(() => {
-        refreshPromise = null;
-      });
-  }
-  return refreshPromise;
-}
+const tokenBroker = createProviderTokenBroker({ provider: "xai", providerLabel: "xAI" });
 
 export const XaiAuthProxy = async () => ({
   provider: {
@@ -137,7 +72,8 @@ export const XaiAuthProxy = async () => ({
               if (value !== undefined) headers.set(key, String(value));
             }
           }
-          headers.set("authorization", `Bearer ${await ensureAccessToken()}`);
+          const { accessToken } = await tokenBroker.getAccessToken();
+          headers.set("authorization", `Bearer ${accessToken}`);
           return fetch(requestInput, { ...init, headers });
         },
       };

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,0 +1,6 @@
+{
+  "runtimeVersion": "v60-provider-account-broker",
+  "generation": 60,
+  "minimumCompatibleGeneration": 60,
+  "minimumRebuildGeneration": 60
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.py
@@ -1,0 +1,22 @@
+"""Validated sandbox runtime compatibility manifest."""
+
+import json
+import re
+from pathlib import Path
+from typing import TypedDict, cast
+
+
+class RuntimeManifest(TypedDict):
+    runtimeVersion: str
+    generation: int
+    minimumCompatibleGeneration: int
+    minimumRebuildGeneration: int
+
+
+_MANIFEST_PATH = Path(__file__).with_name("runtime_manifest.json")
+RUNTIME_MANIFEST = cast("RuntimeManifest", json.loads(_MANIFEST_PATH.read_text()))
+RUNTIME_VERSION = RUNTIME_MANIFEST["runtimeVersion"]
+_VERSION_MATCH = re.match(r"^v(\d+)", RUNTIME_VERSION)
+
+if not _VERSION_MATCH or int(_VERSION_MATCH.group(1)) != RUNTIME_MANIFEST["generation"]:
+    raise RuntimeError("Sandbox runtime manifest version and generation disagree")

--- a/packages/sandbox-runtime/tests/provider-token-broker.test.mjs
+++ b/packages/sandbox-runtime/tests/provider-token-broker.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createProviderTokenBroker } from "../src/sandbox_runtime/plugins/provider-token-broker.js";
+
+function configureSession() {
+  process.env.CONTROL_PLANE_URL = "https://control.test";
+  process.env.SANDBOX_AUTH_TOKEN = "sandbox-token";
+  process.env.SESSION_CONFIG = JSON.stringify({ sessionId: "session-1" });
+}
+
+test("uses the generic broker route, validates the response, and caches fresh tokens", async () => {
+  configureSession();
+  const requests = [];
+  globalThis.fetch = async (url, init) => {
+    requests.push({ url, init });
+    return Response.json({ accessToken: "access-1", expiresIn: 3600 });
+  };
+  const broker = createProviderTokenBroker({ provider: "openai", providerLabel: "OpenAI" });
+
+  const first = await broker.getAccessToken();
+  const second = await broker.getAccessToken();
+
+  assert.equal(first.accessToken, "access-1");
+  assert.equal(second.accessToken, "access-1");
+  assert.equal(requests.length, 1);
+  assert.equal(
+    requests[0].url,
+    "https://control.test/sessions/session-1/provider-auth/openai/access-token"
+  );
+  assert.equal(requests[0].init.headers.Authorization, "Bearer sandbox-token");
+  assert.ok(requests[0].init.signal instanceof AbortSignal);
+});
+
+test("deduplicates concurrent refreshes", async () => {
+  configureSession();
+  let resolveResponse;
+  let requestCount = 0;
+  globalThis.fetch = () => {
+    requestCount++;
+    return new Promise((resolve) => {
+      resolveResponse = resolve;
+    });
+  };
+  const broker = createProviderTokenBroker({ provider: "xai", providerLabel: "xAI" });
+
+  const first = broker.getAccessToken();
+  const second = broker.getAccessToken();
+  assert.equal(requestCount, 1);
+  resolveResponse(Response.json({ accessToken: "shared", expiresIn: 3600 }));
+
+  assert.deepEqual(
+    (await Promise.all([first, second])).map(({ accessToken }) => accessToken),
+    ["shared", "shared"]
+  );
+});
+
+test("clears a failed in-flight refresh so a later request can retry", async () => {
+  configureSession();
+  let requestCount = 0;
+  globalThis.fetch = async () => {
+    requestCount++;
+    return requestCount === 1
+      ? Response.json({ accessToken: "" })
+      : Response.json({ accessToken: "recovered", expiresIn: 3600 });
+  };
+  const broker = createProviderTokenBroker({ provider: "xai", providerLabel: "xAI" });
+
+  await assert.rejects(broker.getAccessToken(), /Invalid xAI token broker response/);
+  assert.equal((await broker.getAccessToken()).accessToken, "recovered");
+  assert.equal(requestCount, 2);
+});

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -57,6 +57,23 @@ class TestCodexAuthPluginSetup:
         for model in ("gpt-5.2", "gpt-5.2-codex"):
             assert f'"{model}"' not in plugin_source
 
+    def test_oauth_proxy_uses_generic_provider_broker_contract(self):
+        plugin_source = (
+            Path(__file__).parents[1]
+            / "src"
+            / "sandbox_runtime"
+            / "plugins"
+            / "codex-auth-plugin.js"
+        ).read_text()
+
+        assert "/provider-auth/openai/access-token" in plugin_source
+        assert "/openai-token-refresh" not in plugin_source
+        assert "result.accessToken" in plugin_source
+        assert "result.providerMetadata?.accountId" in plugin_source
+        assert "Invalid OpenAI token broker response" in plugin_source
+        assert "result.account_id" not in plugin_source
+        assert "result.externalAccountId" not in plugin_source
+
     def test_auth_json_uses_sentinel_token(self, tmp_path):
         """auth.json should contain the sentinel, not the real refresh token."""
         sup = _make_opencode_server()

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from sandbox_runtime.opencode_server import OpenCodeServer
 from tests.runtime_helpers import make_opencode_server
@@ -66,11 +66,9 @@ class TestCodexAuthPluginSetup:
             / "codex-auth-plugin.js"
         ).read_text()
 
-        assert "/provider-auth/openai/access-token" in plugin_source
+        assert 'provider: "openai"' in plugin_source
         assert "/openai-token-refresh" not in plugin_source
-        assert "result.accessToken" in plugin_source
         assert "result.providerMetadata?.accountId" in plugin_source
-        assert "Invalid OpenAI token broker response" in plugin_source
         assert "result.account_id" not in plugin_source
         assert "result.externalAccountId" not in plugin_source
 
@@ -125,6 +123,8 @@ class TestCodexAuthPluginSetup:
         plugin_source = tmp_path / "app" / "sandbox_runtime" / "plugins" / "codex-auth-plugin.js"
         plugin_source.parent.mkdir(parents=True)
         plugin_source.write_text("export const CodexAuthProxy = async () => ({});")
+        broker_source = plugin_source.parent / "provider-token-broker.js"
+        broker_source.write_text("export function createProviderTokenBroker() {}")
 
         fake_proc = MagicMock()
         fake_proc.stdout = None
@@ -145,11 +145,10 @@ class TestCodexAuthPluginSetup:
                 side_effect=lambda coro: coro.close(),
             ),
         ):
-            mock_path.side_effect = lambda p: (
-                plugin_source
-                if p == "/app/sandbox_runtime/plugins/codex-auth-plugin.js"
-                else original_path(p)
-            )
+            mock_path.side_effect = lambda p: {
+                "/app/sandbox_runtime/plugins/codex-auth-plugin.js": plugin_source,
+                "/app/sandbox_runtime/plugins/provider-token-broker.js": broker_source,
+            }.get(p, original_path(p))
             sup._setup_managed_oauth = MagicMock()
             sup._install_tools = MagicMock()
             sup._install_skills = MagicMock()
@@ -158,11 +157,20 @@ class TestCodexAuthPluginSetup:
 
             await sup.start((), sup.workspace_path)
 
-        mock_copy.assert_called_once_with(
-            plugin_source,
-            sup.workspace_path / ".opencode" / "plugins" / "codex-auth-plugin.js",
-        )
+        assert mock_copy.call_args_list == [
+            call(
+                broker_source,
+                sup.workspace_path / ".opencode" / "plugins" / "provider-token-broker.js",
+            ),
+            call(
+                plugin_source,
+                sup.workspace_path / ".opencode" / "plugins" / "codex-auth-plugin.js",
+            ),
+        ]
         mock_excludes.assert_called_once_with(
             sup.workspace_path,
-            {".opencode/plugins/codex-auth-plugin.js"},
+            {
+                ".opencode/plugins/codex-auth-plugin.js",
+                ".opencode/plugins/provider-token-broker.js",
+            },
         )

--- a/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
+++ b/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from sandbox_runtime.opencode_server import OpenCodeServer
 from tests.runtime_helpers import make_opencode_server
@@ -112,10 +112,7 @@ def test_xai_plugin_uses_broker_without_refresh_token_environment():
     ).read_text()
 
     assert 'provider: "xai"' in plugin
-    assert "/provider-auth/xai/access-token" in plugin
     assert "/xai-token-refresh" not in plugin
-    assert "result.accessToken" in plugin
-    assert "result.expiresIn" in plugin
     assert "providerMetadata" not in plugin
     assert "externalAccountId" not in plugin
     assert "XAI_OAUTH_REFRESH_TOKEN" not in plugin
@@ -131,6 +128,8 @@ async def test_start_deploys_xai_plugin_from_marker(tmp_path):
     plugin_source = tmp_path / "app" / "sandbox_runtime" / "plugins" / "xai-auth-plugin.js"
     plugin_source.parent.mkdir(parents=True)
     plugin_source.write_text("export const XaiAuthProxy = async () => ({});")
+    broker_source = plugin_source.parent / "provider-token-broker.js"
+    broker_source.write_text("export function createProviderTokenBroker() {}")
     fake_proc = MagicMock(stdout=None)
     original_path = Path
 
@@ -148,11 +147,10 @@ async def test_start_deploys_xai_plugin_from_marker(tmp_path):
             side_effect=lambda coro: coro.close(),
         ),
     ):
-        mock_path.side_effect = lambda value: (
-            plugin_source
-            if value == "/app/sandbox_runtime/plugins/xai-auth-plugin.js"
-            else original_path(value)
-        )
+        mock_path.side_effect = lambda value: {
+            "/app/sandbox_runtime/plugins/xai-auth-plugin.js": plugin_source,
+            "/app/sandbox_runtime/plugins/provider-token-broker.js": broker_source,
+        }.get(value, original_path(value))
         supervisor._setup_managed_oauth = MagicMock()
         supervisor._install_tools = MagicMock()
         supervisor._install_skills = MagicMock()
@@ -161,11 +159,20 @@ async def test_start_deploys_xai_plugin_from_marker(tmp_path):
 
         await supervisor.start((), supervisor.workspace_path)
 
-    mock_copy.assert_called_once_with(
-        plugin_source,
-        supervisor.workspace_path / ".opencode" / "plugins" / "xai-auth-plugin.js",
-    )
+    assert mock_copy.call_args_list == [
+        call(
+            broker_source,
+            supervisor.workspace_path / ".opencode" / "plugins" / "provider-token-broker.js",
+        ),
+        call(
+            plugin_source,
+            supervisor.workspace_path / ".opencode" / "plugins" / "xai-auth-plugin.js",
+        ),
+    ]
     mock_excludes.assert_called_once_with(
         supervisor.workspace_path,
-        {".opencode/plugins/xai-auth-plugin.js"},
+        {
+            ".opencode/plugins/provider-token-broker.js",
+            ".opencode/plugins/xai-auth-plugin.js",
+        },
     )

--- a/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
+++ b/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
@@ -112,7 +112,12 @@ def test_xai_plugin_uses_broker_without_refresh_token_environment():
     ).read_text()
 
     assert 'provider: "xai"' in plugin
-    assert "/xai-token-refresh" in plugin
+    assert "/provider-auth/xai/access-token" in plugin
+    assert "/xai-token-refresh" not in plugin
+    assert "result.accessToken" in plugin
+    assert "result.expiresIn" in plugin
+    assert "providerMetadata" not in plugin
+    assert "externalAccountId" not in plugin
     assert "XAI_OAUTH_REFRESH_TOKEN" not in plugin
     assert "reasoningEffort" not in plugin
 

--- a/packages/shared/src/types/automations.test.ts
+++ b/packages/shared/src/types/automations.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { listAutomationsResponseSchema } from "./automations";
+import {
+  createAutomationRequestSchema,
+  listAutomationsResponseSchema,
+  updateAutomationRequestSchema,
+} from "./automations";
+
+const ACCOUNT_ID = "0123456789abcdef0123456789abcdef";
 
 const automation = {
   id: "auto-1",
@@ -79,7 +85,17 @@ describe("listAutomationsResponseSchema", () => {
 });
 
 describe("automation provider selection contracts", () => {
-  it("returns selections in responses", () => {
+  it("accepts complete create selections and returns selections in responses", () => {
+    expect(
+      createAutomationRequestSchema.safeParse({
+        name: "Daily sync",
+        instructions: "Run the sync",
+        providerSelections: {
+          openai: { mode: "provider_account", accountId: ACCOUNT_ID },
+          xai: { mode: "api_key" },
+        },
+      }).success
+    ).toBe(true);
     expect(
       listAutomationsResponseSchema.safeParse({
         automations: [automation],
@@ -89,8 +105,25 @@ describe("automation provider selection contracts", () => {
     ).toBe(true);
   });
 
-  it("rejects unknown providers in response records", () => {
+  it("distinguishes omitted patch selections from an explicit clear", () => {
+    expect(updateAutomationRequestSchema.parse({ name: "Renamed" })).not.toHaveProperty(
+      "providerSelections"
+    );
+    expect(updateAutomationRequestSchema.parse({ providerSelections: {} })).toEqual({
+      providerSelections: {},
+    });
+  });
+
+  it("rejects unknown providers in create, update, and response records", () => {
     const providerSelections = { anthropic: { mode: "api_key" } };
+    expect(
+      createAutomationRequestSchema.safeParse({
+        name: "Daily sync",
+        instructions: "Run the sync",
+        providerSelections,
+      }).success
+    ).toBe(false);
+    expect(updateAutomationRequestSchema.safeParse({ providerSelections }).success).toBe(false);
     expect(
       listAutomationsResponseSchema.safeParse({
         automations: [{ ...automation, providerSelections }],

--- a/packages/shared/src/types/automations.ts
+++ b/packages/shared/src/types/automations.ts
@@ -103,6 +103,8 @@ export const createAutomationRequestSchema = z.object({
   repositories: automationRepositoriesInputSchema.optional(),
   /** Environments to fan out over, one workspace session each (design §13.3). */
   environmentIds: z.array(z.string()).optional(),
+  /** Complete pin set. Omission creates the automation without pins. */
+  providerSelections: modelProviderSelectionsSchema.optional(),
 });
 export type CreateAutomationRequest = z.input<typeof createAutomationRequestSchema>;
 
@@ -119,6 +121,8 @@ export const updateAutomationRequestSchema = z.object({
   repositories: automationRepositoriesInputSchema.optional(),
   /** Replaces the full environment selection when present (empty clears). */
   environmentIds: z.array(z.string()).optional(),
+  /** Replaces every provider pin when present; an empty map clears all pins. */
+  providerSelections: modelProviderSelectionsSchema.optional(),
 });
 export type UpdateAutomationRequest = z.input<typeof updateAutomationRequestSchema>;
 

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -4,6 +4,7 @@ import type { AgentResponse } from "./artifacts";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
 import { MAX_WEB_PROMPT_CHARS, promptContentSchema } from "./prompts";
+import { modelProviderSelectionsSchema } from "./provider-accounts";
 import {
   messageSourceSchema,
   sessionStatusSchema,
@@ -229,6 +230,8 @@ const createSessionRequestBaseSchema = z.object({
   environmentId: z.string().trim().min(1).nullish(),
   /** Managed skills are resolved and pinned when the session is created. */
   skillSelection: sessionSkillSelectionSchema.optional(),
+  /** Explicit account/API-key choices. Omission resolves provider policy. */
+  providerSelections: modelProviderSelectionsSchema.optional(),
 });
 
 export const createSessionRequestSchema = createSessionRequestBaseSchema

--- a/packages/shared/src/types/sessions.test.ts
+++ b/packages/shared/src/types/sessions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { sessionReadActionSchema, sessionReadResultSchema } from "./sessions";
+import { createSessionRequestSchema } from "./session-api";
+
+const ACCOUNT_ID = "0123456789abcdef0123456789abcdef";
 
 describe("session read contracts", () => {
   it("accepts only explicit exact and latest read actions", () => {
@@ -29,6 +32,29 @@ describe("session read contracts", () => {
         outcome: "no_terminal_message",
         unread: true,
         latestMessageId: null,
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("createSessionRequestSchema provider selections", () => {
+  it("accepts omitted, empty, and explicit provider selections", () => {
+    expect(createSessionRequestSchema.safeParse({}).success).toBe(true);
+    expect(createSessionRequestSchema.safeParse({ providerSelections: {} }).success).toBe(true);
+    expect(
+      createSessionRequestSchema.safeParse({
+        providerSelections: {
+          openai: { mode: "provider_account", accountId: ACCOUNT_ID },
+          xai: { mode: "api_key" },
+        },
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects malformed provider selections", () => {
+    expect(
+      createSessionRequestSchema.safeParse({
+        providerSelections: { anthropic: { mode: "api_key" } },
       }).success
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- resolve immutable provider-auth snapshots for sessions and automations
- route sandbox access through the trusted account broker
- propagate provider auth through child sessions, scheduling, and lifecycle paths
- configure managed provider credentials across Modal, OpenComputer, and sandbox-runtime

## Stack
Stack 3 of 7. Base: #1525. The next branch is `feat/openai-provider-device-auth`.

## Validation
- workspace typecheck
- focused control-plane: 6 files, 266 tests
- focused integration: 4 files, 48 tests
- focused sandbox-runtime: 11 tests
- focused Modal environment propagation: 33 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automations can now pin, update, and clear model-provider accounts.
  * Sessions and scheduled automation runs now resolve and preserve provider authentication settings.
  * Added secure provider-account access for sandbox sessions, including legacy OAuth support.
  * Added shared token brokering for OpenAI and xAI authentication.
* **Bug Fixes**
  * Improved authentication inheritance for child sessions and fail-closed behavior when credentials are unavailable.
  * Session setup now applies transactional persistence for improved consistency.
* **Chores**
  * Updated sandbox runtime to generation 60 with centralized compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->