### PR TITLE
feat: add xAI provider device authorization

### DIFF
--- a/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
+++ b/packages/control-plane/src/auth/claimed-provider-credential-exchange.test.ts
@@ -44,6 +44,7 @@ function adapter(
     parseCredential: vi.fn((value) => value as Credential),
     refresh,
     cachedAccess: vi.fn(() => null),
+    validateReconnectInputIdentity: vi.fn() as never,
     runtimeMetadata: vi.fn(() => ({})),
     validateExternalIdentity: vi.fn(),
   };

--- a/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.test.ts
@@ -138,13 +138,29 @@ describe("model provider account adapters", () => {
     const capability = modelProviderAccountAdapterRegistry.requireDeviceAuthorization("openai");
 
     await expect(async () =>
-      capability.pollPersisted({ deviceAuthId: "device" }, 1)
+      capability.pollPersisted({ deviceAuthId: "device" }, 1, 5_000)
     ).rejects.toThrow();
     await expect(async () =>
-      capability.pollPersisted({ deviceAuthId: "device", userCode: "CODE" }, 2)
+      capability.pollPersisted({ deviceAuthId: "device", userCode: "CODE" }, 2, 5_000)
     ).rejects.toThrow(/version/i);
     await expect(async () =>
-      capability.pollPersisted({ deviceAuthId: "device", userCode: "CODE", unexpected: true }, 1)
+      capability.pollPersisted(
+        { deviceAuthId: "device", userCode: "CODE", unexpected: true },
+        1,
+        5_000
+      )
+    ).rejects.toThrow();
+  });
+
+  it("registers and validates persisted xAI device authorization state", async () => {
+    const capability = modelProviderAccountAdapterRegistry.requireDeviceAuthorization("xai");
+
+    await expect(async () => capability.pollPersisted({}, 1, 5_000)).rejects.toThrow();
+    await expect(async () =>
+      capability.pollPersisted({ deviceCode: "device" }, 2, 5_000)
+    ).rejects.toThrow(/version/i);
+    await expect(async () =>
+      capability.pollPersisted({ deviceCode: "device", unexpected: true }, 1, 5_000)
     ).rejects.toThrow();
   });
 });

--- a/packages/control-plane/src/auth/model-provider-account-adapters.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.ts
@@ -26,7 +26,10 @@ export interface ProviderDeviceAuthorizationCapability<TCredential, TProviderSta
   readonly stateSchemaVersion: number;
   start(): Promise<ProviderDeviceAuthorizationStart<TProviderState>>;
   parseState(payload: unknown, schemaVersion: number): TProviderState;
-  poll(providerState: TProviderState): Promise<ProviderDeviceAuthorizationPollResult<TCredential>>;
+  poll(
+    providerState: TProviderState,
+    intervalMs: number
+  ): Promise<ProviderDeviceAuthorizationPollResult<TCredential>>;
 }
 
 interface ErasedProviderDeviceAuthorizationCapability {
@@ -34,7 +37,8 @@ interface ErasedProviderDeviceAuthorizationCapability {
   start(): Promise<ProviderDeviceAuthorizationStart<unknown>>;
   pollPersisted(
     payload: unknown,
-    schemaVersion: number
+    schemaVersion: number,
+    intervalMs: number
   ): Promise<ProviderDeviceAuthorizationPollResult<unknown>>;
 }
 
@@ -121,7 +125,7 @@ function eraseDeviceAuthorizationCapability<TCredential, TProviderState>(
   return {
     stateSchemaVersion: capability.stateSchemaVersion,
     start: () => capability.start(),
-    pollPersisted: (payload, schemaVersion) =>
-      capability.poll(capability.parseState(payload, schemaVersion)),
+    pollPersisted: (payload, schemaVersion, intervalMs) =>
+      capability.poll(capability.parseState(payload, schemaVersion), intervalMs),
   };
 }

--- a/packages/control-plane/src/auth/model-provider-account-adapters.ts
+++ b/packages/control-plane/src/auth/model-provider-account-adapters.ts
@@ -64,6 +64,10 @@ export interface ModelProviderAccountAdapter<TCredential, TConnectInput> {
   parseCredential(payload: unknown, schemaVersion: number): TCredential;
   refresh(credential: TCredential, now?: number): Promise<ProviderRefreshResult<TCredential>>;
   cachedAccess(credential: TCredential): CachedProviderAccess | null;
+  validateReconnectInputIdentity(
+    input: TConnectInput,
+    expectedExternalAccountId: string | null
+  ): void;
   runtimeMetadata(
     credential: TCredential,
     externalAccountId: string | null

--- a/packages/control-plane/src/auth/model-provider-account-broker.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-broker.test.ts
@@ -79,6 +79,7 @@ function adapter(
             accessTokenExpiresAt: credential.accessTokenExpiresAt,
           }
         : null,
+    validateReconnectInputIdentity: vi.fn() as never,
     runtimeMetadata: (_credential, externalAccountId): Record<string, string> =>
       externalAccountId ? { accountId: externalAccountId } : {},
     validateExternalIdentity: (actual, expected) => {

--- a/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-openai-adapter.ts
@@ -134,6 +134,15 @@ export class OpenAIModelProviderAccountAdapter implements ModelProviderAccountAd
       : null;
   }
 
+  validateReconnectInputIdentity(
+    input: OpenAIProviderConnectInput,
+    expectedExternalAccountId: string | null
+  ): void {
+    if (expectedExternalAccountId && input.accountId !== expectedExternalAccountId) {
+      throw new ProviderIdentityError("OpenAI account identity did not match");
+    }
+  }
+
   runtimeMetadata(
     credential: OpenAIProviderCredential,
     externalAccountId: string | null

--- a/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
@@ -14,8 +14,10 @@ import {
   ProviderRefreshError,
   type ModelProviderAccountAdapter,
   type ProviderConnectionResult,
+  type ProviderDeviceAuthorizationCapability,
   type ProviderRefreshResult,
 } from "./model-provider-account-adapters";
+import { XaiProviderDeviceAuthorization } from "./model-provider-account-xai-device-authorization";
 
 const credentialSchema = z.object({
   refreshToken: z.string().min(1),
@@ -42,7 +44,13 @@ export class XaiModelProviderAccountAdapter implements ModelProviderAccountAdapt
   readonly credentialSchemaVersion = 1;
   readonly refreshBufferMs = DEFAULT_PROVIDER_REFRESH_BUFFER_MS;
 
-  constructor(private readonly refreshToken: RefreshXai = refreshXaiToken) {}
+  constructor(
+    private readonly refreshToken: RefreshXai = refreshXaiToken,
+    readonly deviceAuthorization: ProviderDeviceAuthorizationCapability<
+      XaiProviderCredential,
+      unknown
+    > = new XaiProviderDeviceAuthorization()
+  ) {}
 
   parseConnectInput(input: unknown): XaiProviderConnectInput {
     return connectInputSchema.parse(input);

--- a/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-adapter.ts
@@ -118,6 +118,17 @@ export class XaiModelProviderAccountAdapter implements ModelProviderAccountAdapt
       : null;
   }
 
+  validateReconnectInputIdentity(
+    _input: XaiProviderConnectInput,
+    expectedExternalAccountId: string | null
+  ): void {
+    if (expectedExternalAccountId) {
+      throw new ProviderIdentityError(
+        "Identity-bound xAI accounts must reconnect through device authorization"
+      );
+    }
+  }
+
   runtimeMetadata(_credential: XaiProviderCredential, _externalAccountId: string | null) {
     return {};
   }

--- a/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.test.ts
@@ -46,4 +46,22 @@ describe("XaiProviderDeviceAuthorization", () => {
       "user info returned invalid data"
     );
   });
+
+  it("uses the canonical provider access-token lifetime when xAI omits expiry", async () => {
+    const authorization = new XaiProviderDeviceAuthorization({
+      start: vi.fn(),
+      check: vi.fn().mockResolvedValue({
+        status: "connected",
+        tokens: { access_token: "access", refresh_token: "refresh" },
+      }),
+      accountId: vi.fn().mockResolvedValue("xai-user"),
+      now: () => 1_000,
+    });
+
+    await expect(authorization.poll({ deviceCode: "device-secret" }, 5_000)).resolves.toMatchObject(
+      {
+        connection: { accessTokenExpiresAt: 3_601_000 },
+      }
+    );
+  });
 });

--- a/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.test.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { XaiProviderDeviceAuthorization } from "./model-provider-account-xai-device-authorization";
+
+describe("XaiProviderDeviceAuthorization", () => {
+  it("creates a trusted connection from a successful device token response", async () => {
+    const authorization = new XaiProviderDeviceAuthorization({
+      start: vi.fn(),
+      check: vi.fn().mockResolvedValue({
+        status: "connected",
+        tokens: {
+          access_token: "access",
+          refresh_token: "refresh",
+          expires_in: 120,
+        },
+      }),
+      accountId: vi.fn().mockResolvedValue("xai-user"),
+      now: () => 1_000,
+    });
+
+    await expect(authorization.poll({ deviceCode: "device-secret" }, 5_000)).resolves.toEqual({
+      status: "connected",
+      connection: {
+        credential: {
+          refreshToken: "refresh",
+          accessToken: "access",
+          accessTokenExpiresAt: 121_000,
+        },
+        externalAccountId: "xai-user",
+        accessTokenExpiresAt: 121_000,
+      },
+    });
+  });
+
+  it("fails closed when xAI does not return a trusted identity", async () => {
+    const authorization = new XaiProviderDeviceAuthorization({
+      start: vi.fn(),
+      check: vi.fn().mockResolvedValue({
+        status: "connected",
+        tokens: { access_token: "opaque", refresh_token: "refresh" },
+      }),
+      accountId: vi.fn().mockRejectedValue(new Error("xAI user info returned invalid data")),
+      now: () => 1_000,
+    });
+
+    await expect(authorization.poll({ deviceCode: "device-secret" }, 5_000)).rejects.toThrow(
+      "user info returned invalid data"
+    );
+  });
+});

--- a/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import type {
+  ProviderDeviceAuthorizationCapability,
+  ProviderDeviceAuthorizationPollResult,
+} from "./model-provider-account-adapters";
+import type { XaiProviderCredential } from "./model-provider-account-xai-adapter";
+import { checkXaiDeviceAuthorization, fetchXaiAccountId, startXaiDeviceAuthorization } from "./xai";
+
+const xaiDeviceAuthorizationStateSchema = z.strictObject({
+  deviceCode: z.string().min(1).max(4096),
+});
+
+export type XaiDeviceAuthorizationState = z.infer<typeof xaiDeviceAuthorizationStateSchema>;
+
+type XaiDeviceDependencies = {
+  start: typeof startXaiDeviceAuthorization;
+  check: typeof checkXaiDeviceAuthorization;
+  accountId: typeof fetchXaiAccountId;
+  now: () => number;
+};
+
+export class XaiProviderDeviceAuthorization implements ProviderDeviceAuthorizationCapability<
+  XaiProviderCredential,
+  XaiDeviceAuthorizationState
+> {
+  readonly stateSchemaVersion = 1;
+
+  constructor(
+    private readonly dependencies: XaiDeviceDependencies = {
+      start: startXaiDeviceAuthorization,
+      check: checkXaiDeviceAuthorization,
+      accountId: fetchXaiAccountId,
+      now: () => Date.now(),
+    }
+  ) {}
+
+  async start() {
+    const started = await this.dependencies.start();
+    return {
+      providerState: {
+        deviceCode: started.deviceCode,
+      },
+      userCode: started.userCode,
+      verificationUrl: started.verificationUrl,
+      expiresInMs: started.expiresInMs,
+      intervalMs: started.intervalMs,
+    };
+  }
+
+  parseState(payload: unknown, schemaVersion: number): XaiDeviceAuthorizationState {
+    if (schemaVersion !== this.stateSchemaVersion) {
+      throw new Error(`Unsupported xAI device authorization state version: ${schemaVersion}`);
+    }
+    return xaiDeviceAuthorizationStateSchema.parse(payload);
+  }
+
+  async poll(
+    state: XaiDeviceAuthorizationState,
+    intervalMs: number
+  ): Promise<ProviderDeviceAuthorizationPollResult<XaiProviderCredential>> {
+    const result = await this.dependencies.check(state.deviceCode, intervalMs);
+    if (result.status !== "connected") return result;
+
+    const externalAccountId = await this.dependencies.accountId(result.tokens.access_token);
+    const accessTokenExpiresAt =
+      this.dependencies.now() + (result.tokens.expires_in ?? 60 * 60) * 1000;
+    return {
+      status: "connected",
+      connection: {
+        credential: {
+          refreshToken: result.tokens.refresh_token,
+          accessToken: result.tokens.access_token,
+          accessTokenExpiresAt,
+        },
+        externalAccountId,
+        accessTokenExpiresAt,
+      },
+    };
+  }
+}

--- a/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.ts
+++ b/packages/control-plane/src/auth/model-provider-account-xai-device-authorization.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import type {
-  ProviderDeviceAuthorizationCapability,
-  ProviderDeviceAuthorizationPollResult,
+import {
+  DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS,
+  type ProviderDeviceAuthorizationCapability,
+  type ProviderDeviceAuthorizationPollResult,
 } from "./model-provider-account-adapters";
 import type { XaiProviderCredential } from "./model-provider-account-xai-adapter";
 import { checkXaiDeviceAuthorization, fetchXaiAccountId, startXaiDeviceAuthorization } from "./xai";
@@ -63,7 +64,8 @@ export class XaiProviderDeviceAuthorization implements ProviderDeviceAuthorizati
 
     const externalAccountId = await this.dependencies.accountId(result.tokens.access_token);
     const accessTokenExpiresAt =
-      this.dependencies.now() + (result.tokens.expires_in ?? 60 * 60) * 1000;
+      this.dependencies.now() +
+      (result.tokens.expires_in ?? DEFAULT_PROVIDER_ACCESS_TOKEN_LIFETIME_MS / 1000) * 1000;
     return {
       status: "connected",
       connection: {

--- a/packages/control-plane/src/auth/openai.ts
+++ b/packages/control-plane/src/auth/openai.ts
@@ -3,7 +3,12 @@
  */
 
 import { z } from "zod";
-import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
+import {
+  fetchProvider,
+  parseProviderResponse,
+  readBoundedProviderBody,
+  type ProviderResponseErrorFactory,
+} from "./provider-response";
 
 const OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token";
 const OPENAI_DEVICE_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode";
@@ -11,7 +16,6 @@ const OPENAI_DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth
 export const OPENAI_DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device";
 const OPENAI_DEVICE_REDIRECT_URL = "https://auth.openai.com/deviceauth/callback";
 const OPENAI_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const OPENAI_RESPONSE_MAX_BYTES = 64 * 1024;
 const DEFAULT_OPENAI_TOKEN_LIFETIME_SECONDS = 60 * 60;
 const MAX_OPENAI_TOKEN_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
 
@@ -88,66 +92,26 @@ export function openAIAccessTokenLifetimeMs(expiresIn?: number): number {
   );
 }
 
-async function readBoundedBody(response: Response): Promise<string> {
-  const declaredLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(declaredLength) && declaredLength > OPENAI_RESPONSE_MAX_BYTES) {
-    throw new OpenAIOAuthError("OpenAI returned an oversized response", 502);
-  }
-  const reader = response.body?.getReader();
-  if (!reader) return response.text();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    size += value.byteLength;
-    if (size > OPENAI_RESPONSE_MAX_BYTES) {
-      await reader.cancel();
-      throw new OpenAIOAuthError("OpenAI returned an oversized response", 502);
+function openAIResponseError(operation: string): ProviderResponseErrorFactory {
+  return (reason, status, invalidFields) => {
+    if (reason === "oversized") {
+      return new OpenAIOAuthError(`OpenAI ${operation} returned an oversized response`, 502);
     }
-    chunks.push(value);
-  }
-  const body = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(body);
-}
-
-async function parseProviderResponse<T>(
-  response: Response,
-  schema: z.ZodType<T>,
-  operation: string
-): Promise<T> {
-  const body = await readBoundedBody(response);
-  if (!response.ok) throw new OpenAIOAuthError(`OpenAI ${operation} failed`, response.status);
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    throw new OpenAIOAuthError(`OpenAI ${operation} returned invalid JSON`, 502);
-  }
-  const result = schema.safeParse(parsed);
-  if (!result.success) {
-    const fields = [
-      ...new Set(result.error.issues.map((issue) => String(issue.path[0] ?? "response"))),
-    ];
-    throw new OpenAIOAuthError(
-      `OpenAI ${operation} returned invalid data (${fields.join(", ")})`,
+    if (reason === "http") {
+      return new OpenAIOAuthError(`OpenAI ${operation} failed`, status);
+    }
+    if (reason === "invalid_json") {
+      return new OpenAIOAuthError(`OpenAI ${operation} returned invalid JSON`, 502);
+    }
+    return new OpenAIOAuthError(
+      `OpenAI ${operation} returned invalid data (${invalidFields?.join(", ")})`,
       502
     );
-  }
-  return result.data;
-}
-
-function providerFetch(url: string, init: RequestInit): Promise<Response> {
-  return fetch(url, { ...init, signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS) });
+  };
 }
 
 export async function startOpenAIDeviceAuthorization(): Promise<OpenAIDeviceAuthorization> {
-  const response = await providerFetch(OPENAI_DEVICE_CODE_URL, {
+  const response = await fetchProvider(OPENAI_DEVICE_CODE_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json", "User-Agent": "Open-Inspect" },
     body: JSON.stringify({ client_id: OPENAI_CLIENT_ID }),
@@ -155,7 +119,7 @@ export async function startOpenAIDeviceAuthorization(): Promise<OpenAIDeviceAuth
   const data = await parseProviderResponse(
     response,
     deviceAuthorizationSchema,
-    "device authorization"
+    openAIResponseError("device authorization")
   );
   return {
     deviceAuthId: data.device_auth_id,
@@ -168,16 +132,22 @@ export async function checkOpenAIDeviceAuthorization(
   deviceAuthId: string,
   userCode: string
 ): Promise<OpenAIDeviceStatus> {
-  const response = await providerFetch(OPENAI_DEVICE_TOKEN_URL, {
+  const response = await fetchProvider(OPENAI_DEVICE_TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json", "User-Agent": "Open-Inspect" },
     body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
   });
   if (response.status === 403 || response.status === 404) {
-    await readBoundedBody(response);
+    await readBoundedProviderBody(response, () =>
+      openAIResponseError("device status check")("oversized", response.status)
+    );
     return { status: "pending" };
   }
-  const data = await parseProviderResponse(response, deviceStatusSchema, "device status check");
+  const data = await parseProviderResponse(
+    response,
+    deviceStatusSchema,
+    openAIResponseError("device status check")
+  );
   return {
     status: "authorized",
     authorizationCode: data.authorization_code,
@@ -189,7 +159,7 @@ export async function exchangeOpenAIAuthorizationCode(
   authorizationCode: string,
   codeVerifier: string
 ): Promise<OpenAITokenResponse> {
-  const response = await providerFetch(OPENAI_TOKEN_URL, {
+  const response = await fetchProvider(OPENAI_TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -200,14 +170,18 @@ export async function exchangeOpenAIAuthorizationCode(
       code_verifier: codeVerifier,
     }).toString(),
   });
-  return parseProviderResponse(response, openAITokenResponseSchema, "token exchange");
+  return parseProviderResponse(
+    response,
+    openAITokenResponseSchema,
+    openAIResponseError("token exchange")
+  );
 }
 
 /**
  * Refresh an OpenAI OAuth access token using a refresh token.
  */
 export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAITokenResponse> {
-  const response = await providerFetch(OPENAI_TOKEN_URL, {
+  const response = await fetchProvider(OPENAI_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -220,7 +194,10 @@ export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAITo
   });
 
   if (!response.ok) {
-    const body = await readBoundedBody(response);
+    const body = await readBoundedProviderBody(
+      response,
+      () => new OpenAITokenRefreshError("OpenAI token refresh returned an oversized response", 502)
+    );
     let errorCode: string | undefined;
     try {
       const parsed = z.object({ error: z.string() }).safeParse(JSON.parse(body));
@@ -235,25 +212,15 @@ export async function refreshOpenAIToken(refreshToken: string): Promise<OpenAITo
     );
   }
 
-  const body = await readBoundedBody(response);
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    throw new OpenAITokenRefreshError(
-      `OpenAI token refresh returned invalid response: ${response.status}`,
-      response.status
-    );
-  }
-  const tokenResult = openAITokenResponseSchema.safeParse(parsed);
-  if (!tokenResult.success) {
-    throw new OpenAITokenRefreshError(
-      `OpenAI token refresh returned invalid response: ${response.status}`,
-      response.status
-    );
-  }
-
-  return tokenResult.data;
+  return parseProviderResponse(
+    response,
+    openAITokenResponseSchema,
+    (_reason, status) =>
+      new OpenAITokenRefreshError(
+        `OpenAI token refresh returned invalid response: ${status}`,
+        status
+      )
+  );
 }
 
 /**

--- a/packages/control-plane/src/auth/provider-response.ts
+++ b/packages/control-plane/src/auth/provider-response.ts
@@ -1,0 +1,78 @@
+import type { z } from "zod";
+import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
+
+const PROVIDER_RESPONSE_MAX_BYTES = 64 * 1024;
+
+type ProviderResponseErrorReason = "oversized" | "http" | "invalid_json" | "invalid_data";
+
+export type ProviderResponseErrorFactory = (
+  reason: ProviderResponseErrorReason,
+  status: number,
+  invalidFields?: readonly string[]
+) => Error;
+
+export function fetchProvider(url: string, init: RequestInit): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS),
+  });
+}
+
+export async function readBoundedProviderBody(
+  response: Response,
+  oversizedError: () => Error
+): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > PROVIDER_RESPONSE_MAX_BYTES) {
+    throw oversizedError();
+  }
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > PROVIDER_RESPONSE_MAX_BYTES) {
+      await reader.cancel();
+      throw oversizedError();
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+export async function parseProviderResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>,
+  createError: ProviderResponseErrorFactory,
+  options: { acceptErrorStatus?: boolean } = {}
+): Promise<T> {
+  const body = await readBoundedProviderBody(response, () =>
+    createError("oversized", response.status)
+  );
+  if (!response.ok && !options.acceptErrorStatus) {
+    throw createError("http", response.status);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw createError("invalid_json", response.status);
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    const fields = [
+      ...new Set(result.error.issues.map((issue) => String(issue.path[0] ?? "response"))),
+    ];
+    throw createError("invalid_data", response.status, fields);
+  }
+  return result.data;
+}

--- a/packages/control-plane/src/auth/xai.test.ts
+++ b/packages/control-plane/src/auth/xai.test.ts
@@ -169,6 +169,16 @@ describe("xAI device authorization", () => {
       Authorization: "Bearer access-secret",
     });
   });
+
+  it("uses the canonical bounded provider-response path", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("x", {
+        headers: { "Content-Length": String(64 * 1024 + 1) },
+      })
+    );
+
+    await expect(startXaiDeviceAuthorization()).rejects.toThrow("oversized response");
+  });
 });
 
 function makeJwt(payload: Record<string, unknown>): string {

--- a/packages/control-plane/src/auth/xai.test.ts
+++ b/packages/control-plane/src/auth/xai.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshXaiToken, XaiTokenRefreshError, type XaiTokenResponse } from "./xai";
+import {
+  checkXaiDeviceAuthorization,
+  fetchXaiAccountId,
+  refreshXaiToken,
+  startXaiDeviceAuthorization,
+  XaiTokenRefreshError,
+  type XaiTokenResponse,
+} from "./xai";
 
 describe("refreshXaiToken", () => {
   const originalFetch = globalThis.fetch;
@@ -14,11 +21,7 @@ describe("refreshXaiToken", () => {
       refresh_token: "refresh-new",
       expires_in: 3600,
     };
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve(JSON.stringify(tokens)),
-    } as Response);
+    globalThis.fetch = vi.fn().mockResolvedValue(Response.json(tokens));
 
     await expect(refreshXaiToken("refresh-old")).resolves.toEqual(tokens);
 
@@ -31,11 +34,7 @@ describe("refreshXaiToken", () => {
   });
 
   it("accepts responses without a replacement refresh token", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve('{"access_token":"access-new"}'),
-    } as Response);
+    globalThis.fetch = vi.fn().mockResolvedValue(Response.json({ access_token: "access-new" }));
 
     await expect(refreshXaiToken("refresh-old")).resolves.toEqual({
       access_token: "access-new",
@@ -43,11 +42,11 @@ describe("refreshXaiToken", () => {
   });
 
   it("accepts a rotated refresh token without expires_in", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve('{"access_token":"access-new","refresh_token":"refresh-new"}'),
-    } as Response);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ access_token: "access-new", refresh_token: "refresh-new" })
+      );
 
     await expect(refreshXaiToken("refresh-old")).resolves.toEqual({
       access_token: "access-new",
@@ -56,11 +55,9 @@ describe("refreshXaiToken", () => {
   });
 
   it("classifies invalid_grant refresh errors", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      text: () => Promise.resolve('{"error":"invalid_grant"}'),
-    } as Response);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(Response.json({ error: "invalid_grant" }, { status: 401 }));
 
     const error = await refreshXaiToken("stale").catch((cause) => cause);
     expect(error).toBeInstanceOf(XaiTokenRefreshError);
@@ -73,22 +70,107 @@ describe("refreshXaiToken", () => {
     '{"access_token":"access","expires_in":0}',
     '{"access_token":"access","expires_in":1.5}',
   ])("rejects unusable successful responses: %s", async (body) => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve(body),
-    } as Response);
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(body));
 
     await expect(refreshXaiToken("refresh")).rejects.toBeInstanceOf(XaiTokenRefreshError);
   });
 
   it("accepts provider lifetimes longer than one day", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => Promise.resolve('{"access_token":"access","expires_in":172800}'),
-    } as Response);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(Response.json({ access_token: "access", expires_in: 172_800 }));
 
     await expect(refreshXaiToken("refresh")).resolves.toMatchObject({ expires_in: 172_800 });
   });
 });
+
+describe("xAI device authorization", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("starts with the Grok CLI client and uses the complete verification URL", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json({
+        device_code: "device-secret",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://accounts.x.ai/oauth2/device",
+        verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=ABCD-EFGH",
+        expires_in: 300,
+        interval: 5,
+      })
+    );
+
+    await expect(startXaiDeviceAuthorization()).resolves.toEqual({
+      deviceCode: "device-secret",
+      userCode: "ABCD-EFGH",
+      verificationUrl: "https://accounts.x.ai/oauth2/device?user_code=ABCD-EFGH",
+      expiresInMs: 300_000,
+      intervalMs: 5_000,
+    });
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(url).toBe("https://auth.x.ai/oauth2/device/code");
+    expect(new URLSearchParams(String(init?.body))).toEqual(
+      new URLSearchParams({
+        client_id: "b1a00492-073a-47ea-816f-4c329264a828",
+        scope: "openid profile email offline_access grok-cli:access api:access",
+        referrer: "opencode",
+      })
+    );
+  });
+
+  it.each([
+    ["authorization_pending", { status: "pending" }],
+    ["slow_down", { status: "pending", intervalMs: 10_000 }],
+    ["access_denied", { status: "denied" }],
+    ["authorization_denied", { status: "denied" }],
+    ["expired_token", { status: "expired" }],
+    ["invalid_grant", { status: "failed" }],
+  ])("maps %s token responses", async (error, expected) => {
+    globalThis.fetch = vi.fn().mockResolvedValue(Response.json({ error }, { status: 400 }));
+
+    await expect(checkXaiDeviceAuthorization("device-secret", 5_000)).resolves.toEqual(expected);
+  });
+
+  it("exchanges a device code without exposing it in the result state", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json({
+        id_token: makeJwt({ sub: "xai-user" }),
+        access_token: "access",
+        refresh_token: "refresh",
+        expires_in: 3600,
+      })
+    );
+
+    await expect(checkXaiDeviceAuthorization("device-secret", 5_000)).resolves.toMatchObject({
+      status: "connected",
+      tokens: { access_token: "access", refresh_token: "refresh" },
+    });
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(new URLSearchParams(String(init?.body))).toEqual(
+      new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        client_id: "b1a00492-073a-47ea-816f-4c329264a828",
+        device_code: "device-secret",
+      })
+    );
+  });
+
+  it("fetches the stable OIDC subject from xAI", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(Response.json({ sub: "xai-user" }));
+
+    await expect(fetchXaiAccountId("access-secret")).resolves.toBe("xai-user");
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(url).toBe("https://auth.x.ai/oauth2/userinfo");
+    expect(init?.headers).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer access-secret",
+    });
+  });
+});
+
+function makeJwt(payload: Record<string, unknown>): string {
+  return `${btoa(JSON.stringify({ alg: "none" }))}.${btoa(JSON.stringify(payload))}.`;
+}

--- a/packages/control-plane/src/auth/xai.ts
+++ b/packages/control-plane/src/auth/xai.ts
@@ -2,15 +2,48 @@ import { z } from "zod";
 import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
 
 const XAI_TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const XAI_DEVICE_CODE_URL = "https://auth.x.ai/oauth2/device/code";
+const XAI_USERINFO_URL = "https://auth.x.ai/oauth2/userinfo";
 const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_DEVICE_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const XAI_RESPONSE_MAX_BYTES = 64 * 1024;
 
 const xaiTokenResponseSchema = z.object({
+  id_token: z.string().min(1).max(16_384).optional(),
   access_token: z.string().min(1),
   refresh_token: z.string().optional(),
   expires_in: z.number().int().positive().optional(),
 });
 
+const xaiDeviceTokenResponseSchema = xaiTokenResponseSchema.extend({
+  refresh_token: z.string().min(1),
+});
+
+const xaiDeviceAuthorizationSchema = z.object({
+  device_code: z.string().min(1).max(4096),
+  user_code: z.string().min(1).max(128),
+  verification_uri: z.url(),
+  verification_uri_complete: z.url().optional(),
+  expires_in: z.number().int().positive().optional(),
+  interval: z.number().int().min(1).max(60).optional(),
+});
+
+const xaiOAuthErrorSchema = z.object({ error: z.string().min(1) });
+const xaiUserInfoSchema = z.object({ sub: z.string().min(1).max(512) });
+
 export type XaiTokenResponse = z.infer<typeof xaiTokenResponseSchema>;
+export type XaiDeviceAuthorization = {
+  deviceCode: string;
+  userCode: string;
+  verificationUrl: string;
+  expiresInMs?: number;
+  intervalMs: number;
+};
+export type XaiDeviceStatus =
+  | { status: "pending"; intervalMs?: number }
+  | { status: "connected"; tokens: XaiTokenResponse & { refresh_token: string } }
+  | { status: "denied" | "expired" | "failed" };
 
 type XaiTokenRefreshErrorReason = "invalid_grant" | "unauthorized" | "invalid_response" | "other";
 
@@ -22,6 +55,120 @@ export class XaiTokenRefreshError extends Error {
   ) {
     super(message);
   }
+}
+
+async function readBoundedBody(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > XAI_RESPONSE_MAX_BYTES) {
+    throw new Error("xAI returned an oversized response");
+  }
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > XAI_RESPONSE_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error("xAI returned an oversized response");
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function providerFetch(url: string, init: RequestInit): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS) });
+}
+
+function parseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error("xAI returned invalid JSON");
+  }
+}
+
+export async function startXaiDeviceAuthorization(): Promise<XaiDeviceAuthorization> {
+  const response = await providerFetch(XAI_DEVICE_CODE_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "User-Agent": "Open-Inspect",
+    },
+    body: new URLSearchParams({
+      client_id: XAI_CLIENT_ID,
+      scope: XAI_DEVICE_SCOPE,
+      referrer: "opencode",
+    }).toString(),
+  });
+  const body = await readBoundedBody(response);
+  if (!response.ok) throw new Error(`xAI device authorization failed: ${response.status}`);
+  const result = xaiDeviceAuthorizationSchema.safeParse(parseJson(body));
+  if (!result.success) throw new Error("xAI device authorization returned invalid data");
+  return {
+    deviceCode: result.data.device_code,
+    userCode: result.data.user_code,
+    verificationUrl: result.data.verification_uri_complete ?? result.data.verification_uri,
+    expiresInMs: result.data.expires_in ? result.data.expires_in * 1000 : undefined,
+    intervalMs: (result.data.interval ?? 5) * 1000,
+  };
+}
+
+export async function checkXaiDeviceAuthorization(
+  deviceCode: string,
+  intervalMs: number
+): Promise<XaiDeviceStatus> {
+  const response = await providerFetch(XAI_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      "User-Agent": "Open-Inspect",
+    },
+    body: new URLSearchParams({
+      grant_type: XAI_DEVICE_GRANT_TYPE,
+      client_id: XAI_CLIENT_ID,
+      device_code: deviceCode,
+    }).toString(),
+  });
+  const body = await readBoundedBody(response);
+  const parsed = parseJson(body);
+  if (response.ok) {
+    const tokens = xaiDeviceTokenResponseSchema.safeParse(parsed);
+    if (!tokens.success) throw new Error("xAI device token exchange returned invalid data");
+    return { status: "connected", tokens: tokens.data };
+  }
+  const error = xaiOAuthErrorSchema.safeParse(parsed);
+  if (!error.success) throw new Error(`xAI device token exchange failed: ${response.status}`);
+  if (error.data.error === "authorization_pending") return { status: "pending" };
+  if (error.data.error === "slow_down")
+    return { status: "pending", intervalMs: Math.min(intervalMs + 5_000, 60_000) };
+  if (error.data.error === "access_denied" || error.data.error === "authorization_denied") {
+    return { status: "denied" };
+  }
+  if (error.data.error === "expired_token") return { status: "expired" };
+  return { status: "failed" };
+}
+
+export async function fetchXaiAccountId(accessToken: string): Promise<string> {
+  const response = await providerFetch(XAI_USERINFO_URL, {
+    headers: { Accept: "application/json", Authorization: `Bearer ${accessToken}` },
+  });
+  const body = await readBoundedBody(response);
+  if (!response.ok) throw new Error(`xAI user info request failed: ${response.status}`);
+  const result = xaiUserInfoSchema.safeParse(parseJson(body));
+  if (!result.success) throw new Error("xAI user info returned invalid data");
+  return result.data.sub;
 }
 
 function classifyRefreshError(status: number, body: string): XaiTokenRefreshErrorReason {
@@ -42,9 +189,8 @@ function classifyRefreshError(status: number, body: string): XaiTokenRefreshErro
 }
 
 export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenResponse> {
-  const response = await fetch(XAI_TOKEN_URL, {
+  const response = await providerFetch(XAI_TOKEN_URL, {
     method: "POST",
-    signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS),
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       Accept: "application/json",
@@ -55,7 +201,7 @@ export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenRes
       client_id: XAI_CLIENT_ID,
     }).toString(),
   });
-  const body = await response.text();
+  const body = await readBoundedBody(response);
 
   if (!response.ok) {
     throw new XaiTokenRefreshError(

--- a/packages/control-plane/src/auth/xai.ts
+++ b/packages/control-plane/src/auth/xai.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { PROVIDER_TOKEN_REFRESH_TIMEOUT_MS } from "./provider-token-timeouts";
+import {
+  fetchProvider,
+  parseProviderResponse,
+  readBoundedProviderBody,
+  type ProviderResponseErrorFactory,
+} from "./provider-response";
 
 const XAI_TOKEN_URL = "https://auth.x.ai/oauth2/token";
 const XAI_DEVICE_CODE_URL = "https://auth.x.ai/oauth2/device/code";
@@ -7,7 +12,6 @@ const XAI_USERINFO_URL = "https://auth.x.ai/oauth2/userinfo";
 const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 const XAI_DEVICE_SCOPE = "openid profile email offline_access grok-cli:access api:access";
 const XAI_DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
-const XAI_RESPONSE_MAX_BYTES = 64 * 1024;
 
 const xaiTokenResponseSchema = z.object({
   id_token: z.string().min(1).max(16_384).optional(),
@@ -30,6 +34,10 @@ const xaiDeviceAuthorizationSchema = z.object({
 });
 
 const xaiOAuthErrorSchema = z.object({ error: z.string().min(1) });
+const xaiDeviceTokenExchangeResponseSchema = z.union([
+  xaiDeviceTokenResponseSchema,
+  xaiOAuthErrorSchema,
+]);
 const xaiUserInfoSchema = z.object({ sub: z.string().min(1).max(512) });
 
 export type XaiTokenResponse = z.infer<typeof xaiTokenResponseSchema>;
@@ -57,48 +65,18 @@ export class XaiTokenRefreshError extends Error {
   }
 }
 
-async function readBoundedBody(response: Response): Promise<string> {
-  const declaredLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(declaredLength) && declaredLength > XAI_RESPONSE_MAX_BYTES) {
-    throw new Error("xAI returned an oversized response");
-  }
-  const reader = response.body?.getReader();
-  if (!reader) return response.text();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    size += value.byteLength;
-    if (size > XAI_RESPONSE_MAX_BYTES) {
-      await reader.cancel();
-      throw new Error("xAI returned an oversized response");
-    }
-    chunks.push(value);
-  }
-  const body = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(body);
-}
-
-function providerFetch(url: string, init: RequestInit): Promise<Response> {
-  return fetch(url, { ...init, signal: AbortSignal.timeout(PROVIDER_TOKEN_REFRESH_TIMEOUT_MS) });
-}
-
-function parseJson(body: string): unknown {
-  try {
-    return JSON.parse(body);
-  } catch {
-    throw new Error("xAI returned invalid JSON");
-  }
+function xaiResponseError(operation: string): ProviderResponseErrorFactory {
+  return (reason, status, invalidFields) => {
+    if (reason === "oversized") return new Error(`xAI ${operation} returned an oversized response`);
+    if (reason === "http") return new Error(`xAI ${operation} failed: ${status}`);
+    if (reason === "invalid_json") return new Error(`xAI ${operation} returned invalid JSON`);
+    const fieldSuffix = invalidFields?.length ? ` (${invalidFields.join(", ")})` : "";
+    return new Error(`xAI ${operation} returned invalid data${fieldSuffix}`);
+  };
 }
 
 export async function startXaiDeviceAuthorization(): Promise<XaiDeviceAuthorization> {
-  const response = await providerFetch(XAI_DEVICE_CODE_URL, {
+  const response = await fetchProvider(XAI_DEVICE_CODE_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -111,16 +89,17 @@ export async function startXaiDeviceAuthorization(): Promise<XaiDeviceAuthorizat
       referrer: "opencode",
     }).toString(),
   });
-  const body = await readBoundedBody(response);
-  if (!response.ok) throw new Error(`xAI device authorization failed: ${response.status}`);
-  const result = xaiDeviceAuthorizationSchema.safeParse(parseJson(body));
-  if (!result.success) throw new Error("xAI device authorization returned invalid data");
+  const result = await parseProviderResponse(
+    response,
+    xaiDeviceAuthorizationSchema,
+    xaiResponseError("device authorization")
+  );
   return {
-    deviceCode: result.data.device_code,
-    userCode: result.data.user_code,
-    verificationUrl: result.data.verification_uri_complete ?? result.data.verification_uri,
-    expiresInMs: result.data.expires_in ? result.data.expires_in * 1000 : undefined,
-    intervalMs: (result.data.interval ?? 5) * 1000,
+    deviceCode: result.device_code,
+    userCode: result.user_code,
+    verificationUrl: result.verification_uri_complete ?? result.verification_uri,
+    expiresInMs: result.expires_in ? result.expires_in * 1000 : undefined,
+    intervalMs: (result.interval ?? 5) * 1000,
   };
 }
 
@@ -128,7 +107,7 @@ export async function checkXaiDeviceAuthorization(
   deviceCode: string,
   intervalMs: number
 ): Promise<XaiDeviceStatus> {
-  const response = await providerFetch(XAI_TOKEN_URL, {
+  const response = await fetchProvider(XAI_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -141,34 +120,41 @@ export async function checkXaiDeviceAuthorization(
       device_code: deviceCode,
     }).toString(),
   });
-  const body = await readBoundedBody(response);
-  const parsed = parseJson(body);
+  const parsed = await parseProviderResponse(
+    response,
+    xaiDeviceTokenExchangeResponseSchema,
+    xaiResponseError("device token exchange"),
+    { acceptErrorStatus: true }
+  );
   if (response.ok) {
-    const tokens = xaiDeviceTokenResponseSchema.safeParse(parsed);
-    if (!tokens.success) throw new Error("xAI device token exchange returned invalid data");
-    return { status: "connected", tokens: tokens.data };
+    if ("error" in parsed) {
+      throw xaiResponseError("device token exchange")("invalid_data", response.status);
+    }
+    return { status: "connected", tokens: parsed };
   }
-  const error = xaiOAuthErrorSchema.safeParse(parsed);
-  if (!error.success) throw new Error(`xAI device token exchange failed: ${response.status}`);
-  if (error.data.error === "authorization_pending") return { status: "pending" };
-  if (error.data.error === "slow_down")
+  if (!("error" in parsed)) {
+    throw xaiResponseError("device token exchange")("invalid_data", response.status);
+  }
+  if (parsed.error === "authorization_pending") return { status: "pending" };
+  if (parsed.error === "slow_down")
     return { status: "pending", intervalMs: Math.min(intervalMs + 5_000, 60_000) };
-  if (error.data.error === "access_denied" || error.data.error === "authorization_denied") {
+  if (parsed.error === "access_denied" || parsed.error === "authorization_denied") {
     return { status: "denied" };
   }
-  if (error.data.error === "expired_token") return { status: "expired" };
+  if (parsed.error === "expired_token") return { status: "expired" };
   return { status: "failed" };
 }
 
 export async function fetchXaiAccountId(accessToken: string): Promise<string> {
-  const response = await providerFetch(XAI_USERINFO_URL, {
+  const response = await fetchProvider(XAI_USERINFO_URL, {
     headers: { Accept: "application/json", Authorization: `Bearer ${accessToken}` },
   });
-  const body = await readBoundedBody(response);
-  if (!response.ok) throw new Error(`xAI user info request failed: ${response.status}`);
-  const result = xaiUserInfoSchema.safeParse(parseJson(body));
-  if (!result.success) throw new Error("xAI user info returned invalid data");
-  return result.data.sub;
+  const result = await parseProviderResponse(
+    response,
+    xaiUserInfoSchema,
+    xaiResponseError("user info request")
+  );
+  return result.sub;
 }
 
 function classifyRefreshError(status: number, body: string): XaiTokenRefreshErrorReason {
@@ -189,7 +175,7 @@ function classifyRefreshError(status: number, body: string): XaiTokenRefreshErro
 }
 
 export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenResponse> {
-  const response = await providerFetch(XAI_TOKEN_URL, {
+  const response = await fetchProvider(XAI_TOKEN_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -201,9 +187,17 @@ export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenRes
       client_id: XAI_CLIENT_ID,
     }).toString(),
   });
-  const body = await readBoundedBody(response);
 
   if (!response.ok) {
+    const body = await readBoundedProviderBody(
+      response,
+      () =>
+        new XaiTokenRefreshError(
+          "xAI token refresh returned an oversized response",
+          502,
+          "invalid_response"
+        )
+    );
     throw new XaiTokenRefreshError(
       `xAI token refresh failed: ${response.status}`,
       response.status,
@@ -211,23 +205,14 @@ export async function refreshXaiToken(refreshToken: string): Promise<XaiTokenRes
     );
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    throw new XaiTokenRefreshError(
-      "xAI token refresh returned invalid JSON",
-      response.status,
-      "invalid_response"
-    );
-  }
-  const result = xaiTokenResponseSchema.safeParse(parsed);
-  if (!result.success) {
-    throw new XaiTokenRefreshError(
-      `xAI token refresh returned invalid response: ${response.status}`,
-      response.status,
-      "invalid_response"
-    );
-  }
-  return result.data;
+  return parseProviderResponse(
+    response,
+    xaiTokenResponseSchema,
+    (_reason, status) =>
+      new XaiTokenRefreshError(
+        `xAI token refresh returned invalid response: ${status}`,
+        status,
+        "invalid_response"
+      )
+  );
 }

--- a/packages/control-plane/src/model-provider-accounts/device-authorization-service.ts
+++ b/packages/control-plane/src/model-provider-accounts/device-authorization-service.ts
@@ -211,7 +211,11 @@ export class ProviderDeviceAuthorizationService {
         }
       );
       const capability = this.adapters.requireDeviceAuthorization(provider);
-      const result = await capability.pollPersisted(providerState, row.providerStateVersion);
+      const result = await capability.pollPersisted(
+        providerState,
+        row.providerStateVersion,
+        row.intervalMs
+      );
       now = this.dependencies.now();
       if (result.status === "pending") {
         const intervalMs = result.intervalMs ?? row.intervalMs;

--- a/packages/control-plane/src/model-provider-accounts/service.test.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../auth/model-provider-account-adapters";
 import type { ModelProviderAccount } from "../db/model-provider-accounts";
 import type { ModelProviderAccountAtomicWriter } from "../db/model-provider-account-atomic-writer";
+import { XaiModelProviderAccountAdapter } from "../auth/model-provider-account-xai-adapter";
 import {
   ModelProviderAccountService,
   type ModelProviderAccountServiceAccountStore,
@@ -60,6 +61,13 @@ function adapter(
         }
     ),
     cachedAccess: vi.fn(() => null),
+    validateReconnectInputIdentity: vi.fn((input, expectedExternalAccountId) => {
+      const accountId =
+        input && typeof input === "object" && "accountId" in input ? String(input.accountId) : null;
+      if (expectedExternalAccountId && accountId !== expectedExternalAccountId) {
+        throw new ProviderIdentityError("OpenAI account identity did not match");
+      }
+    }),
     runtimeMetadata: vi.fn(() => ({})),
     validateExternalIdentity,
   };
@@ -378,6 +386,50 @@ describe("ModelProviderAccountService", () => {
       })
     );
     expect(store.accounts.setStatus).not.toHaveBeenCalled();
+  });
+
+  it("rejects identity-bound xAI reconnects through the adapter before consuming credentials", async () => {
+    const store = stores(providerAccount({ provider: "xai", externalAccountId: "xai-account" }));
+    const refresh = vi.fn();
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([new XaiModelProviderAccountAdapter(refresh)]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await expect(
+      service.reconnect(ACCOUNT_ID, { provider: "xai", refreshToken: "submitted-secret" }, "user-1")
+    ).rejects.toMatchObject({
+      status: 409,
+      message: "Identity-bound xAI accounts must reconnect through device authorization",
+    });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(store.credentials.readCredentialState).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy identity-unbound xAI reconnects compatible", async () => {
+    const store = stores(providerAccount({ provider: "xai", externalAccountId: null }));
+    const refresh = vi.fn().mockResolvedValue({
+      access_token: "new-access",
+      refresh_token: "rotated-secret",
+      expires_in: 120,
+    });
+    const service = createService(
+      store,
+      new ModelProviderAccountAdapterRegistry([new XaiModelProviderAccountAdapter(refresh)]),
+      { generateId: () => ACCOUNT_ID, now: () => 1_000 }
+    );
+
+    await service.reconnect(
+      ACCOUNT_ID,
+      { provider: "xai", refreshToken: "submitted-secret" },
+      "user-1"
+    );
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(store.atomicWriter.reconnectCredentialAndAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "xai", externalAccountId: null })
+    );
   });
 
   it("rejects archived reconnects before consuming the submitted credential", async () => {

--- a/packages/control-plane/src/model-provider-accounts/service.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.ts
@@ -279,6 +279,12 @@ export class ModelProviderAccountService {
     if (account.provider !== input.provider) {
       throw new ProviderAccountServiceError("Provider account does not match provider", 400);
     }
+    if (account.provider === "xai" && account.externalAccountId) {
+      throw new ProviderAccountServiceError(
+        "Identity-bound xAI accounts must reconnect through device authorization",
+        409
+      );
+    }
     const adapter = this.requireAdapter(account.provider);
     const connected = await this.connect(adapter, input);
     this.validateExternalIdentity(adapter, connected.externalAccountId, account.externalAccountId);

--- a/packages/control-plane/src/model-provider-accounts/service.ts
+++ b/packages/control-plane/src/model-provider-accounts/service.ts
@@ -279,14 +279,10 @@ export class ModelProviderAccountService {
     if (account.provider !== input.provider) {
       throw new ProviderAccountServiceError("Provider account does not match provider", 400);
     }
-    if (account.provider === "xai" && account.externalAccountId) {
-      throw new ProviderAccountServiceError(
-        "Identity-bound xAI accounts must reconnect through device authorization",
-        409
-      );
-    }
     const adapter = this.requireAdapter(account.provider);
-    const connected = await this.connect(adapter, input);
+    const parsedInput = adapter.parseConnectInput(input);
+    this.validateReconnectInputIdentity(adapter, parsedInput, account.externalAccountId);
+    const connected = await this.connectParsed(adapter, parsedInput);
     this.validateExternalIdentity(adapter, connected.externalAccountId, account.externalAccountId);
     return this.persistConnectedCredential(
       account,
@@ -377,8 +373,30 @@ export class ModelProviderAccountService {
     adapter: ErasedProviderAccountAdapter,
     input: ConnectModelProviderAccountRequest | ReconnectModelProviderAccountRequest
   ): Promise<ProviderConnectionResult<unknown>> {
+    return this.connectParsed(adapter, adapter.parseConnectInput(input));
+  }
+
+  private async connectParsed(
+    adapter: ErasedProviderAccountAdapter,
+    input: unknown
+  ): Promise<ProviderConnectionResult<unknown>> {
     try {
-      return await adapter.connect(adapter.parseConnectInput(input));
+      return await adapter.connect(input);
+    } catch (cause) {
+      if (cause instanceof ProviderIdentityError) {
+        throw new ProviderAccountServiceError(cause.message, 409, { cause });
+      }
+      throw cause;
+    }
+  }
+
+  private validateReconnectInputIdentity(
+    adapter: ErasedProviderAccountAdapter,
+    input: unknown,
+    expectedExternalAccountId: string | null
+  ): void {
+    try {
+      adapter.validateReconnectInputIdentity(input, expectedExternalAccountId);
     } catch (cause) {
       if (cause instanceof ProviderIdentityError) {
         throw new ProviderAccountServiceError(cause.message, 409, { cause });

--- a/packages/control-plane/test/integration/provider-account-device-authorizations.test.ts
+++ b/packages/control-plane/test/integration/provider-account-device-authorizations.test.ts
@@ -311,10 +311,12 @@ describe("provider account device authorization routes", () => {
 
   it("expires locally without allowing a provider completion", async () => {
     const { result } = await start();
+    const expiredAt = Date.now() - 1;
     await env.DB.prepare(
-      "UPDATE model_provider_account_authorizations SET expires_at = ? WHERE id = ?"
+      `UPDATE model_provider_account_authorizations
+       SET created_at = ?, expires_at = ? WHERE id = ?`
     )
-      .bind(Date.now() - 1, result.transactionId)
+      .bind(expiredAt - 1, expiredAt, result.transactionId)
       .run();
     const response = await request(
       `/model-provider-accounts/openai/device-authorizations/${result.transactionId}/poll`,

--- a/packages/control-plane/test/integration/provider-account-device-authorizations.test.ts
+++ b/packages/control-plane/test/integration/provider-account-device-authorizations.test.ts
@@ -115,6 +115,49 @@ describe("provider account device authorization routes", () => {
     expect(transaction).toEqual({ state: "connected", encrypted_provider_data: null });
   });
 
+  it("connects an xAI account through device authorization", async () => {
+    const started = await request("/model-provider-accounts/xai/device-authorizations", "POST", {
+      operation: "create",
+      displayName: "Primary SuperGrok",
+    });
+    expect(started.status).toBe(201);
+    const startBody = await started.json<{
+      transactionId: string;
+      userCode: string;
+      verificationUrl: string;
+    }>();
+    expect(startBody).toMatchObject({
+      userCode: "XAI-CODE",
+      verificationUrl: "https://accounts.x.ai/oauth2/device?user_code=XAI-CODE",
+    });
+
+    await makeDue(startBody.transactionId);
+    const connected = await request(
+      `/model-provider-accounts/xai/device-authorizations/${startBody.transactionId}/poll`,
+      "POST"
+    );
+    const connectedBody = await connected.json<{ account: { id: string } }>();
+    expect(connectedBody).toMatchObject({
+      status: "connected",
+      account: {
+        provider: "xai",
+        displayName: "Primary SuperGrok",
+        externalAccountId: "xai-integration",
+      },
+      reconnectedExisting: false,
+    });
+
+    const legacyReconnect = await request(
+      `/model-provider-accounts/${connectedBody.account.id}/reconnect`,
+      "POST",
+      { provider: "xai", refreshToken: "integration-xai-manual-reconnect" }
+    );
+    expect(legacyReconnect.status).toBe(409);
+    await expect(legacyReconnect.json()).resolves.toMatchObject({
+      error: "Identity-bound xAI accounts must reconnect through device authorization",
+    });
+  });
+
   it("reconnects only the same trusted identity and preserves the display name", async () => {
     await ensureAuthenticatedUser();
     await seedAccount();

--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -83,16 +83,37 @@ export default defineConfig({
                 expires_in: 3600,
               });
             }
+            if (url.href === "https://auth.x.ai/oauth2/device/code") {
+              return Response.json({
+                device_code: "integration-xai-device",
+                user_code: "XAI-CODE",
+                verification_uri: "https://accounts.x.ai/oauth2/device",
+                verification_uri_complete: "https://accounts.x.ai/oauth2/device?user_code=XAI-CODE",
+                expires_in: 300,
+                interval: 1,
+              });
+            }
+            if (url.href === "https://auth.x.ai/oauth2/userinfo") {
+              return Response.json({ sub: "xai-integration" });
+            }
             if (url.href === "https://auth.x.ai/oauth2/token") {
               const body = await request.text();
-              if (!body.includes("integration-xai")) {
-                throw new Error("Unexpected xAI integration-test credential");
+              if (body.includes("integration-xai-device")) {
+                return Response.json({
+                  id_token: "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4YWktaW50ZWdyYXRpb24ifQ.",
+                  access_token: "integration-xai-access-token",
+                  refresh_token: "integration-xai-refresh-token",
+                  expires_in: 3600,
+                });
               }
-              return Response.json({
-                access_token: "integration-xai-access-token",
-                refresh_token: "integration-xai-rotated-refresh",
-                expires_in: 3600,
-              });
+              if (body.includes("integration-xai")) {
+                return Response.json({
+                  access_token: "integration-xai-access-token",
+                  refresh_token: "integration-xai-rotated-refresh",
+                  expires_in: 3600,
+                });
+              }
+              throw new Error("Unexpected xAI integration-test credential");
             }
             throw new Error(`Unexpected outbound request: ${request.url}`);
           },


### PR DESCRIPTION
## Summary
- add xAI device-code issuance, polling, and identity verification
- register xAI device authorization through the generic provider adapter contract
- support xAI account creation and reconnect while retaining legacy compatibility
- extend integration fixtures and transaction coverage

## Stack
Stack 5 of 7. Base: #1527. The next branch is `feat/provider-accounts-web`.

## Validation
- workspace typecheck
- focused control-plane: 3 files, 28 tests
- device-authorization integration: 17 tests
- combined stack validation is recorded on the final PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added xAI device authorization, including sign-in, polling, account lookup, token handling, and expiration support.
  * Added safer reconnect validation to prevent connecting an account to an unexpected external identity.
  * Improved provider authentication response handling with timeouts, response-size limits, and clearer error reporting.
* **Bug Fixes**
  * Preserved pending authorization states during provider polling.
  * Improved handling of malformed, oversized, expired, and unsuccessful authentication responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->