### PR TITLE
fix: align E2B OpenCode version

### DIFF
--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -14,7 +14,7 @@
 FROM python:3.12-slim-bookworm
 
 # Pinned toolchain versions (keep in sync with daytona-infra/src/toolchain.py).
-ARG OPENCODE_VERSION=1.18.11
+ARG OPENCODE_VERSION=1.18.18
 ARG CODE_SERVER_VERSION=4.109.5
 ARG AGENT_BROWSER_VERSION=0.21.2
 


### PR DESCRIPTION
## Summary
- bump the E2B OpenCode CLI and plugin version from 1.18.11 to 1.18.18
- align E2B with Modal, Daytona, Vercel, and OpenComputer
- ensure rebuilt E2B templates include the post-message-ID-wraparound fix

## Verification
- `git diff --check`
- confirmed all five sandbox providers now pin OpenCode 1.18.18

## Known issue
- repository-wide `npm run lint -- --no-fix` currently reports 45 pre-existing errors under `.opencode/`; the changed Dockerfile is not involved

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1e474ca0a2ebc396c9cb8fd786253e17)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenCode version to 1.18.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->