### PR TITLE
fix(web): surface the sandbox failure reason in the UI

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -75,6 +75,7 @@ export default function SessionPage() {
     authError,
     connectionError,
     sessionState,
+    sandboxError,
     events,
     participants,
     artifacts,
@@ -392,6 +393,7 @@ export default function SessionPage() {
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-clip">
       <SessionHeader
         sessionState={sessionState}
+        sandboxError={sandboxError}
         fallbackSessionInfo={fallbackSessionInfo}
         connected={connected && ready}
         connecting={connecting || (connected && !ready)}

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -214,6 +214,63 @@ describe("SessionHeader", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Connected");
   });
 
+  it("shows the provider's reason inside the failed sandbox popover", async () => {
+    render(
+      <SessionHeader
+        sessionState={createSessionState({ sandboxStatus: "failed" })}
+        sandboxError={
+          'Failed to create E2B sandbox: {"code":400,"message":"Timeout cannot be greater than 1 hours"}'
+        }
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Failed sandbox" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        isDesktopDetailsOpen
+        showDesktopDetailsToggle
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={vi.fn()}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sandbox status: Failed" }));
+
+    // The generic label is not actionable on its own; the provider's message is
+    // what tells someone the plan cap was exceeded.
+    expect(await screen.findByText("The sandbox could not start or recover.")).toBeInTheDocument();
+    expect(screen.getByText(/Timeout cannot be greater than 1 hours/)).toBeInTheDocument();
+  });
+
+  it("omits the error block when the control plane reported no reason", async () => {
+    render(
+      <SessionHeader
+        sessionState={createSessionState({ sandboxStatus: "failed" })}
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Failed sandbox" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        isDesktopDetailsOpen
+        showDesktopDetailsToggle
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={vi.fn()}
+        onToggleDesktopDetails={vi.fn()}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sandbox status: Failed" }));
+
+    expect(await screen.findByText("The sandbox could not start or recover.")).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to create/)).not.toBeInTheDocument();
+  });
+
   it("reveals the connection label on keyboard focus", async () => {
     render(
       <SessionHeader

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -93,6 +93,8 @@ const SANDBOX_STATUS_PRESENTATION: Record<
 
 export type SessionHeaderProps = {
   sessionState: SessionSocketState["sessionState"];
+  /** Why the sandbox last failed; shown in the status popover. */
+  sandboxError?: SessionSocketState["sandboxError"];
   fallbackSessionInfo: {
     repoOwner: string | null;
     repoName: string | null;
@@ -115,6 +117,7 @@ export type SessionHeaderProps = {
 
 export function SessionHeader({
   sessionState,
+  sandboxError,
   fallbackSessionInfo,
   connected,
   connecting,
@@ -240,6 +243,7 @@ export function SessionHeader({
             <SandboxStatusIcon
               status={sessionState?.sandboxStatus}
               dashboardUrl={sessionState?.sandboxDashboardUrl}
+              error={sandboxError}
             />
           </div>
           {showDesktopDetailsToggle && (
@@ -295,9 +299,17 @@ function ConnectionStatusIcon({
 function SandboxStatusIcon({
   status,
   dashboardUrl,
+  error,
 }: {
   status?: SandboxStatusValue;
   dashboardUrl?: string | null;
+  /**
+   * The control plane's reason for the current failure, when it has one.
+   * Rendered verbatim: it is usually the sandbox provider's own message (quota
+   * exceeded, rate limited, timeout above the plan cap), which is the only part
+   * that tells someone what to actually change.
+   */
+  error?: string | null;
 }) {
   if (!status) return null;
 
@@ -329,6 +341,11 @@ function SandboxStatusIcon({
             Sandbox {presentation.label}
           </div>
           <p className="mt-1.5 text-xs leading-5 text-muted-foreground">{presentation.detail}</p>
+          {error && (
+            <p className="mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap break-words rounded-sm bg-muted p-2 font-mono text-[11px] leading-4 text-destructive">
+              {error}
+            </p>
+          )}
         </div>
         {safeDashboardUrl && (
           <a

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -46,6 +46,8 @@ interface UseSessionSocketReturn {
   authError: string | null;
   connectionError: string | null;
   sessionState: SessionState | null;
+  /** Why the sandbox last failed, when the control plane reported a reason. */
+  sandboxError: string | null;
   messages: Message[];
   events: SandboxEvent[];
   participants: ParticipantPresence[];
@@ -187,9 +189,6 @@ export function useSessionSocket(
         console.log("WebSocket subscribed to session");
         pendingTextRef.current = null;
         void refreshSandboxAccess();
-        if (message.spawnError && message.session.sandboxStatus === "failed") {
-          console.error("Sandbox spawn error:", message.spawnError);
-        }
       } else if (message.type === "sandbox_access_changed") {
         void refreshSandboxAccess();
       } else if (message.type === "sandbox_error") {
@@ -410,6 +409,7 @@ export function useSessionSocket(
     authError: transport.authError,
     connectionError: transport.connectionError,
     sessionState,
+    sandboxError: state.sandboxError,
     messages: NO_MESSAGES,
     events: state.events,
     participants: state.participants,

--- a/packages/web/src/lib/session-socket/reducer.test.ts
+++ b/packages/web/src/lib/session-socket/reducer.test.ts
@@ -190,6 +190,55 @@ describe("sessionSocketReducer", () => {
     expect(state.promptQueue).toEqual(initial.promptQueue);
   });
 
+  describe("sandboxError", () => {
+    it("hydrates the spawn error from the snapshot and from subscribed", () => {
+      const reason =
+        'Failed to create E2B sandbox: {"code":400,"message":"Timeout cannot be greater than 1 hours"}';
+
+      expect(createSessionSocketState(createSnapshot({ spawnError: reason })).sandboxError).toBe(
+        reason
+      );
+      expect(subscribedState({ spawnError: reason }).sandboxError).toBe(reason);
+      expect(subscribedState().sandboxError).toBeNull();
+    });
+
+    it("records the reason a live sandbox_error carries", () => {
+      const state = reduce(
+        subscribedState(),
+        serverMessage({ type: "sandbox_error", error: "E2B quota exceeded" })
+      );
+
+      expect(state.sessionState?.sandboxStatus).toBe("failed");
+      expect(state.sandboxError).toBe("E2B quota exceeded");
+    });
+
+    it("clears the reason once a fresh attempt starts or succeeds", () => {
+      const failed = reduce(
+        subscribedState(),
+        serverMessage({ type: "sandbox_error", error: "E2B quota exceeded" })
+      );
+
+      // A retry supersedes the previous failure, so the stale reason must not
+      // linger next to a spawning or ready sandbox.
+      expect(reduce(failed, serverMessage({ type: "sandbox_spawning" })).sandboxError).toBeNull();
+      expect(reduce(failed, serverMessage({ type: "sandbox_warming" })).sandboxError).toBeNull();
+      expect(reduce(failed, serverMessage({ type: "sandbox_ready" })).sandboxError).toBeNull();
+      expect(
+        reduce(failed, serverMessage({ type: "sandbox_status", status: "ready" })).sandboxError
+      ).toBeNull();
+    });
+
+    it("keeps the reason when sandbox_status merely re-asserts failed", () => {
+      const failed = reduce(
+        subscribedState(),
+        serverMessage({ type: "sandbox_error", error: "E2B quota exceeded" }),
+        serverMessage({ type: "sandbox_status", status: "failed" })
+      );
+
+      expect(failed.sandboxError).toBe("E2B quota exceeded");
+    });
+  });
+
   describe("subscribed", () => {
     it("hydrates the authoritative projection", () => {
       const state = subscribedState({

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -33,6 +33,14 @@ export interface SessionSocketState {
   loadingHistory: boolean;
   cursor: HistoryCursor | null;
   promptQueue: PromptQueueItem[];
+  /**
+   * Why the sandbox last failed, as reported by the control plane — the
+   * provider's own message (quota, rate limit, bad config), not a status label.
+   * Set from `sandbox_error` and from the spawn error carried by the snapshot /
+   * `subscribed`, and cleared as soon as a fresh attempt starts or succeeds, so
+   * it never outlives the failure it explains.
+   */
+  sandboxError: string | null;
 }
 
 export const initialSessionSocketState: SessionSocketState = {
@@ -47,6 +55,7 @@ export const initialSessionSocketState: SessionSocketState = {
   loadingHistory: false,
   cursor: null,
   promptQueue: [],
+  sandboxError: null,
 };
 
 export type SessionSocketAction =
@@ -93,6 +102,7 @@ export function createSessionSocketState(snapshot: SessionSnapshot): SessionSock
     hasMoreHistory: snapshot.timeline.hasMore,
     cursor: snapshot.timeline.cursor,
     promptQueue: snapshot.promptQueue,
+    sandboxError: snapshot.spawnError ?? null,
   };
 }
 
@@ -187,6 +197,7 @@ function reduceServerMessage(
         // stuck true and block loadOlderEvents after the reconnect.
         loadingHistory: false,
         promptQueue: message.promptQueue,
+        sandboxError: message.spawnError ?? null,
       };
     }
 
@@ -213,10 +224,14 @@ function reduceServerMessage(
       };
 
     case "sandbox_warming":
-      return updateSessionState(state, (prev) => ({ ...prev, sandboxStatus: "warming" }));
+      return updateSessionState({ ...state, sandboxError: null }, (prev) => ({
+        ...prev,
+        sandboxStatus: "warming",
+      }));
 
     case "sandbox_spawning":
-      return updateSessionState(state, (prev) => ({
+      // A new attempt supersedes whatever the last one failed with.
+      return updateSessionState({ ...state, sandboxError: null }, (prev) => ({
         ...prev,
         sandboxStatus: "spawning",
         ...CLEARED_SANDBOX_RUNTIME_STATE,
@@ -229,19 +244,25 @@ function reduceServerMessage(
         message.status === "stale" ||
         message.status === "stopped" ||
         message.status === "failed";
-      return updateSessionState(state, (prev) => ({
-        ...prev,
-        sandboxStatus: message.status,
-        ...(shouldClearAccessState && CLEARED_SANDBOX_RUNTIME_STATE),
-        ...(isReplacementStart && { sandboxDashboardUrl: undefined }),
-      }));
+      return updateSessionState(
+        message.status === "failed" ? state : { ...state, sandboxError: null },
+        (prev) => ({
+          ...prev,
+          sandboxStatus: message.status,
+          ...(shouldClearAccessState && CLEARED_SANDBOX_RUNTIME_STATE),
+          ...(isReplacementStart && { sandboxDashboardUrl: undefined }),
+        })
+      );
     }
 
     case "sandbox_ready":
-      return updateSessionState(state, (prev) => ({ ...prev, sandboxStatus: "ready" }));
+      return updateSessionState({ ...state, sandboxError: null }, (prev) => ({
+        ...prev,
+        sandboxStatus: "ready",
+      }));
 
     case "sandbox_error":
-      return updateSessionState(state, (prev) => ({
+      return updateSessionState({ ...state, sandboxError: message.error }, (prev) => ({
         ...prev,
         sandboxStatus: "failed",
         ...CLEARED_SANDBOX_RUNTIME_STATE,


### PR DESCRIPTION
A failed sandbox showed only "Sandbox Failed — The sandbox could not start or recover." That sentence is true of every failure and actionable for none, so diagnosing one meant reading Cloudflare worker logs.

Hit while evaluating the E2B provider: a spawn failed with

```
Failed to create E2B sandbox: {"code":400,"message":"Timeout cannot be greater than 1 hours"}
```

which names the exact thing to change — and was invisible in the product.

## The reason was already in the browser

The control plane reports it on both channels and the client discarded both:

- `manager.ts` persists `last_spawn_error` and broadcasts `sandbox_error` with the message on spawn failure.
- `durable-object.ts:1684` puts it in the session snapshot as `spawnError`; `subscribed` carries it too, and `sessionSnapshotSchema` has had the field all along.
- `use-session-socket.ts` passed each to `console.error` and dropped them. `createSessionSocketState` ignored `snapshot.spawnError` entirely, so even a full page load had it and threw it away.

So this is not a new data path — it stops discarding one. Nothing crosses the trust boundary that wasn't already crossing it.

## Change

`SessionSocketState.sandboxError` holds the reason, set from `sandbox_error` and from the snapshot / `subscribed` spawn error. The status popover renders it under the existing detail line, monospace and scroll-capped so a long provider payload can't blow out the layout.

It is cleared on `sandbox_spawning`, `sandbox_warming`, `sandbox_ready`, and any `sandbox_status` that isn't `failed` — a retry supersedes the previous failure, and a stale reason next to a healthy sandbox is worse than none. A `sandbox_status: failed` that merely re-asserts the current state keeps it.

The redundant `console.error` branch in the `subscribed` handler is removed; the live `sandbox_error` console line stays, since it is still useful with devtools open.

## Testing

Reducer: hydration from both the snapshot and `subscribed`, capture from a live `sandbox_error`, clearing on each of the four recovery transitions, and retention on a repeated `failed`. Component: the popover renders the provider message for a failed sandbox, and omits the block when the control plane reported no reason.

`npm run typecheck` clean; web suite 1141 passing; ESLint and Prettier clean.

## Not addressed

The E2B error itself is configuration, not a bug: `resolveSandboxTimeoutSeconds` passes `sandboxSettings.sandboxTimeoutMs` straight through, and E2B's Hobby plan caps a sandbox at 1 hour. A deployment carrying a longer timeout from another provider hits this on every spawn. The fix is Settings → Sandbox → timeout at 60 minutes or less (or a larger E2B plan); with the setting unset, the provider falls back to `E2B_SANDBOX_TIMEOUT_SECONDS`. Worth considering separately whether providers should advertise a maximum timeout so this is rejected at save time with a clear message rather than at spawn — but that is a different change, and this PR is what makes the current failure legible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sandbox startup failures now display the provider’s specific error message in the sandbox status popover when available.
  - Error details are presented in a readable, scrollable format.

- **Bug Fixes**
  - Sandbox error messages are cleared when the sandbox retries or becomes ready.
  - Generic failure messaging remains available when no detailed reason is provided.

- **Tests**
  - Added coverage for displaying, omitting, preserving, and clearing sandbox error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->