### PR TITLE
test: repair the red control-plane suite on main

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1063,6 +1063,7 @@ describe("SandboxLifecycleManager", () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "img-abc123",
+        snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const userEnvVars = {
         OPENAI_OAUTH_MANAGED: "1",


### PR DESCRIPTION
`main` is red. `Test (control-plane unit)` fails on every PR opened against it:

```
FAIL src/sandbox/lifecycle/manager.test.ts > SandboxLifecycleManager > spawnSandbox
  > passes the current managed provider environment when restoring a snapshot
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
Number of calls: 0
```

## Cause

A semantic merge conflict — both sides were green alone.

#1518 made restore fail closed on snapshot runtime version: `isSnapshotRuntimeCompatible` (`decisions.ts:209`) returns false when `snapshotRuntimeVersion` is null, so `evaluateSpawnDecision` returns `spawn` rather than `restore` and `provider.restoreFromSnapshot` is never called. It updated every restore case it could see — 386, 529, 587, 1039, 1129, 1172, 1214, 1247, 1408 all set `snapshot_runtime_version`.

This case is the one it could not see: it arrived on `main` from a different PR in the same window, so #1518's branch never had it to update. Neither PR's CI could observe the pair.

## Fix

The gate is behaving as designed, so the fixture is what is wrong. The case exists to prove `userEnvVars` reaches `restoreFromSnapshot`, and it cannot prove that while the snapshot is retired before the call — it was asserting against a code path it no longer reached, which is a passing-looking test with no subject.

Adds `snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION` to the fixture, matching every other restore case in the file.

## Testing

control-plane unit suite: 2984 passing, 194 files. Verified the failure reproduces on `origin/main` before the change and is gone after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot restoration test coverage to use a compatible runtime version, improving validation of restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->