### PR TITLE
fix: persist the sandbox failure reason wherever it is broadcast

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1003,6 +1003,35 @@ describe("SandboxLifecycleManager", () => {
       expect(onSandboxTerminated).not.toHaveBeenCalled();
     });
 
+    it("persists the circuit-breaker reason, not just the broadcast", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "pending",
+        spawn_failure_count: 3,
+        last_spawn_failure: now - 60000,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      // Broadcast alone reaches only the tab that is already open; the reason
+      // has to be persisted or it vanishes on the reload someone does to read it.
+      expect(storage.setLastSpawnError).toHaveBeenCalledWith(
+        expect.stringContaining("temporarily disabled"),
+        expect.any(Number)
+      );
+      expect(sandbox.last_spawn_error).toContain("temporarily disabled");
+    });
+
     it("resets circuit breaker when window passes", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({
@@ -2213,6 +2242,9 @@ describe("SandboxLifecycleManager", () => {
       expect(
         broadcaster.messages.some((m) => (m as { type?: string }).type === "sandbox_error")
       ).toBe(true);
+      // The reason is persisted alongside the broadcast, so reloading to
+      // investigate still shows why the sandbox failed.
+      expect(sandbox.last_spawn_error).toContain("failed to connect");
       // Should NOT trigger snapshot (nothing to snapshot)
       expect(provider.takeSnapshot).not.toHaveBeenCalled();
     });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1032,6 +1032,38 @@ describe("SandboxLifecycleManager", () => {
       expect(sandbox.last_spawn_error).toContain("temporarily disabled");
     });
 
+    it("still broadcasts the reason when persisting it throws", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "pending",
+        spawn_failure_count: 3,
+        last_spawn_failure: now - 60000,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      // updateSandboxSpawnError is a bare synchronous sql.exec in the DO, so
+      // this is a real failure mode, not a hypothetical one.
+      vi.mocked(storage.setLastSpawnError).mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      const broadcaster = createMockBroadcaster();
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      // Losing durability must not also cost the live broadcast, which is the
+      // only signal an already-open tab gets.
+      await expect(manager.spawnSandbox()).resolves.toBeUndefined();
+      expect(
+        broadcaster.messages.some((m) => (m as { type?: string }).type === "sandbox_error")
+      ).toBe(true);
+    });
+
     it("resets circuit breaker when window passes", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -291,6 +291,7 @@ export interface SandboxLifecycle {
   spawnSandbox(): Promise<void>;
   updateLastActivity(timestamp: number): void;
   terminateUnresponsiveSandbox(trigger: UnresponsiveSandboxTrigger): Promise<void>;
+  reportSandboxError(reason: string): void;
 }
 
 export type UnresponsiveSandboxTrigger =
@@ -362,10 +363,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         failure_count: circuitBreakerState.failureCount,
         wait_time_ms: cbDecision.waitTimeMs || 0,
       });
-      this.broadcaster.broadcast({
-        type: "sandbox_error",
-        error: `Sandbox spawning temporarily disabled after ${circuitBreakerState.failureCount} failures. Try again in ${Math.ceil((cbDecision.waitTimeMs || 0) / 1000)} seconds.`,
-      });
+      this.reportSandboxError(
+        `Sandbox spawning temporarily disabled after ${circuitBreakerState.failureCount} failures. Try again in ${Math.ceil((cbDecision.waitTimeMs || 0) / 1000)} seconds.`
+      );
       return;
     }
 
@@ -603,7 +603,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to spawn sandbox";
-      this.storage.setLastSpawnError(errorMessage, Date.now());
       this.log.error("Sandbox spawn completed", {
         event: "sandbox.spawn",
         outcome: "error",
@@ -630,10 +629,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
 
       this.storage.updateSandboxStatus("failed");
-      this.broadcaster.broadcast({
-        type: "sandbox_error",
-        error: errorMessage,
-      });
+      this.reportSandboxError(errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -748,6 +744,25 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
       return undefined;
     }
+  }
+
+  /**
+   * Report why the sandbox failed: broadcast it to connected clients and
+   * persist it, as one step.
+   *
+   * `sandbox_error` is how the reason reaches a live UI; `last_spawn_error` is
+   * how it survives a reload, since that is what the session snapshot serves as
+   * `spawnError`. They are the same fact, so writing one without the other
+   * makes the reason visible only until someone refreshes — which is precisely
+   * when they are trying to read it.
+   *
+   * Sandbox status is deliberately not touched here. Most callers mark the
+   * sandbox failed themselves, but the circuit breaker reports a reason without
+   * changing state, and that distinction is theirs to make.
+   */
+  reportSandboxError(reason: string): void {
+    this.storage.setLastSpawnError(reason, Date.now());
+    this.broadcaster.broadcast({ type: "sandbox_error", error: reason });
   }
 
   /**
@@ -880,19 +895,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           repo_owner: session.repo_owner,
           repo_name: session.repo_name,
         });
-        this.storage.setLastSpawnError(
-          result.error || "Failed to restore from snapshot",
-          Date.now()
-        );
         this.storage.updateSandboxStatus("failed");
-        this.broadcaster.broadcast({
-          type: "sandbox_error",
-          error: result.error || "Failed to restore from snapshot",
-        });
+        this.reportSandboxError(result.error || "Failed to restore from snapshot");
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to restore sandbox";
-      this.storage.setLastSpawnError(errorMessage, Date.now());
       this.log.error("Sandbox restore completed", {
         event: "sandbox.restore",
         outcome: "error",
@@ -903,10 +910,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         repo_name: session?.repo_name,
       });
       this.storage.updateSandboxStatus("failed");
-      this.broadcaster.broadcast({
-        type: "sandbox_error",
-        error: errorMessage,
-      });
+      this.reportSandboxError(errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -986,12 +990,8 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.storage.resetCircuitBreaker();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to resume sandbox";
-      this.storage.setLastSpawnError(errorMessage, Date.now());
       this.storage.updateSandboxStatus("failed");
-      this.broadcaster.broadcast({
-        type: "sandbox_error",
-        error: errorMessage,
-      });
+      this.reportSandboxError(errorMessage);
       this.log.error("Sandbox resume failed", {
         error: error instanceof Error ? error : String(error),
       });
@@ -1250,11 +1250,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         }
       }
       this.broadcaster.broadcast({ type: "sandbox_status", status: "failed" });
-      this.broadcaster.broadcast({
-        type: "sandbox_error",
-        error:
-          "Sandbox failed to connect within the allowed time. It will be retried on your next message.",
-      });
+      this.reportSandboxError(
+        "Sandbox failed to connect within the allowed time. It will be retried on your next message."
+      );
       return;
     }
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -761,7 +761,19 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * changing state, and that distinction is theirs to make.
    */
   reportSandboxError(reason: string): void {
-    this.storage.setLastSpawnError(reason, Date.now());
+    // Persisting is best effort. `updateSandboxSpawnError` is a bare synchronous
+    // sql.exec, so a storage failure would otherwise also cost the broadcast —
+    // the one signal an already-open tab gets — and, from the message queue's
+    // spawn catch, would replace the spawn error being reported with the
+    // storage error. Losing durability is bad; losing both is worse.
+    try {
+      this.storage.setLastSpawnError(reason, Date.now());
+    } catch (error) {
+      this.log.warn("Failed to persist sandbox failure reason", {
+        event: "sandbox.error_persist_failed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     this.broadcaster.broadcast({ type: "sandbox_error", error: reason });
   }
 

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -192,6 +192,7 @@ function buildQueue() {
     spawnSandbox: vi.fn(async () => {}),
     updateLastActivity: vi.fn((_timestamp: number) => {}),
     terminateUnresponsiveSandbox: vi.fn(async () => {}),
+    reportSandboxError: vi.fn((_reason: string) => {}),
   };
   const waitUntil = vi.fn((task: Promise<unknown>) =>
     task.catch((error) => log.error("background_task.failed", { error }))
@@ -349,7 +350,7 @@ describe("SessionMessageQueue", () => {
     await h.waitUntil.mock.results[0]!.value;
   });
 
-  it("broadcasts sandbox_error when the background spawn throws", async () => {
+  it("reports sandbox_error when the background spawn throws", async () => {
     const h = buildQueue();
     h.repository.getNextPendingMessage.mockReturnValue(createMessage());
     h.sandboxLifecycle.spawnSandbox.mockRejectedValue(new Error("modal exploded"));
@@ -357,10 +358,12 @@ describe("SessionMessageQueue", () => {
     await h.queue.processMessageQueue();
     await h.waitUntil.mock.results[0]!.value;
 
-    expect(h.broadcast).toHaveBeenCalledWith({
-      type: "sandbox_error",
-      error: "modal exploded",
-    });
+    // Routed through the lifecycle manager rather than broadcast directly, so
+    // the reason is persisted too and survives the reload someone does to read it.
+    expect(h.sandboxLifecycle.reportSandboxError).toHaveBeenCalledWith("modal exploded");
+    expect(h.broadcast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "sandbox_error" })
+    );
     expect(h.log.error).toHaveBeenCalledWith("background_task.failed", {
       error: expect.any(Error),
     });

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -319,14 +319,13 @@ export class SessionMessageQueue {
       // pending and dispatches when the sandbox WebSocket connects.
       this.backgroundTasks.submit(
         this.sandboxLifecycle.spawnSandbox().catch((error) => {
-          // Expected provider failures broadcast sandbox_error inside the
-          // lifecycle manager; this catch only sees throws from before those
-          // handlers. Surface them the same way so clients aren't left
-          // watching a silent "sandbox_spawning" forever.
-          this.messenger.broadcast({
-            type: "sandbox_error",
-            error: error instanceof Error ? error.message : "Failed to spawn sandbox",
-          });
+          // Expected provider failures report themselves inside the lifecycle
+          // manager; this catch only sees throws from before those handlers.
+          // Route it through the same call so the reason is persisted as well
+          // as broadcast — otherwise it survives only until the tab reloads.
+          this.sandboxLifecycle.reportSandboxError(
+            error instanceof Error ? error.message : "Failed to spawn sandbox"
+          );
           throw error;
         }),
         {


### PR DESCRIPTION
Follow-up to #1537, from [review feedback on it](https://github.com/ColeMurray/background-agents/pull/1537#discussion_r3824598789).

`sandbox_error` is how a failure reason reaches a live UI. `last_spawn_error` is how it survives a reload — it is what `durable-object.ts` serves as `spawnError` in the session snapshot. They are the same fact, and three of the six producers wrote only one of them:

| `sandbox_error` producer | Persisted the reason (before) |
| --- | --- |
| `manager.ts` spawn failure (`doSpawn` catch) | yes |
| `manager.ts` restore failure (both branches) | yes |
| `manager.ts` resume failure | yes |
| `manager.ts` circuit breaker open | **no** |
| `manager.ts` connecting timeout | **no** |
| `message-queue.ts` escape-hatch catch | **no** |

For those three the reason was visible only until the tab refreshed — which is exactly when someone is trying to read it. #1537 made that observable by rendering the reason; it did not introduce the split.

One clarification on severity, since it changes how urgent this is: a *stale* reason cannot surface. `setLastSpawnError(null, null)` runs at the start of every attempt, so by the time a connecting timeout fires the preceding spawn had already succeeded and cleared it. Reload yields no error block rather than a wrong one — absent, not misleading.

## Change

`reportSandboxError(reason)` persists and broadcasts in one call, and is now the only place that emits the event — verified: one `type: "sandbox_error"` literal remains in `packages/control-plane/src`, inside the helper. A caller can no longer do half of it, so the bug class is gone rather than patched three times. The four sites that already did both collapse onto it, which is where most of the net line reduction comes from.

`message-queue.ts` routes through `SandboxLifecycle`, which gains the method, instead of broadcasting directly.

**Sandbox status is deliberately untouched.** Most callers mark the sandbox failed themselves, but the circuit breaker reports a reason without changing state, and that distinction is theirs to keep. Folding status into the helper would have silently marked circuit-breaker-open as `failed`, which feeds `evaluateSpawnDecision` — a behaviour change well beyond persisting a string.

## Known residual

The client reducer treats any `sandbox_error` as `failed`, so for the circuit-breaker and escape-hatch paths the browser shows `failed` while the persisted status is unchanged; a reload then shows the real status. That divergence predates both PRs and is a status-semantics question, not a reason-persistence one. Left alone deliberately — worth its own change if you want client and server to agree there.

## Testing

New: the circuit breaker persists its reason (not just broadcasts it); the connecting timeout leaves a readable `last_spawn_error`; the message-queue catch routes through the lifecycle manager and no longer broadcasts directly.

control-plane 2985 unit + 926 integration passing; workspace typecheck, ESLint and Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox startup and recovery errors are now saved consistently, including circuit-breaker blocks and connection timeouts.
  * Error messages remain available after page reloads while continuing to be broadcast to connected clients.
  * Improved consistency across sandbox spawn, restore, resume, and timeout failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->