### PR TITLE
fix(e2b): start the launcher at spawn time for prebuilt-image boots

### DIFF
--- a/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
@@ -20,6 +20,26 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+/** Build a Connect streaming body: each message is flags + big-endian length + JSON. */
+function connectStream(messages: Array<{ flags: number; body: unknown }>): Uint8Array {
+  const chunks = messages.map(({ flags, body }) => {
+    const payload = new TextEncoder().encode(JSON.stringify(body));
+    const framed = new Uint8Array(5 + payload.length);
+    framed[0] = flags;
+    new DataView(framed.buffer).setUint32(1, payload.length);
+    framed.set(payload, 5);
+    return framed;
+  });
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
 let fetchSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -253,6 +273,68 @@ describe("E2BRestClient", () => {
     });
     await expect(client.createSnapshot("sb-1", { signal: caller.signal })).rejects.toThrow(
       /timeout/
+    );
+  });
+
+  it("startProcess frames the request as a Connect envelope", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    // envd's Process/Start is server-streaming: bare JSON gets a 415, so the body
+    // must be flags + big-endian length + payload.
+    const stream = connectStream([
+      { flags: 0, body: { event: { start: { pid: 42 } } } },
+      { flags: 0, body: { event: { end: { exited: true, status: "exit status 0" } } } },
+      { flags: 2, body: {} },
+    ]);
+    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
+
+    await client.startProcess("sb-1", "echo hi", { envdAccessToken: "tok" });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe("https://49983-sb-1.e2b.app/process.Process/Start");
+    expect(init.headers["Content-Type"]).toBe("application/connect+json");
+    expect(init.headers["X-Access-Token"]).toBe("tok");
+    const framed = new Uint8Array(init.body as ArrayBuffer);
+    expect(framed[0]).toBe(0);
+    const declaredLength = new DataView(framed.buffer).getUint32(1);
+    expect(declaredLength).toBe(framed.length - 5);
+    expect(JSON.parse(new TextDecoder().decode(framed.subarray(5)))).toEqual({
+      process: { cmd: "/bin/sh", args: ["-c", "echo hi"] },
+    });
+  });
+
+  it("startProcess fails on a non-zero exit reported inside a 200 stream", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    // envd reports command failures in-band, so the HTTP status proves nothing.
+    fetchSpy.mockResolvedValue(
+      new Response(
+        connectStream([
+          { flags: 0, body: { event: { start: { pid: 7 } } } },
+          { flags: 0, body: { event: { end: { exited: true, status: "exit status 127" } } } },
+          { flags: 2, body: {} },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(client.startProcess("sb-1", "nope", { envdAccessToken: "tok" })).rejects.toThrow(
+      /exit status 127/
+    );
+  });
+
+  it("startProcess surfaces a Connect end-of-stream error", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    fetchSpy.mockResolvedValue(
+      new Response(
+        connectStream([
+          { flags: 0, body: { event: { start: { pid: 7 } } } },
+          { flags: 2, body: { error: { message: "permission denied" } } },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(client.startProcess("sb-1", "nope", { envdAccessToken: "tok" })).rejects.toThrow(
+      /permission denied/
     );
   });
 

--- a/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.test.ts
@@ -338,6 +338,59 @@ describe("E2BRestClient", () => {
     );
   });
 
+  it("startProcess rejects a stream with no clean exit or end-of-stream", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    // A start event alone proves nothing ran to completion. Treating it as
+    // success would let an unconfirmed launcher through to a session that then
+    // dies silently on the connecting timeout.
+    fetchSpy.mockResolvedValue(
+      new Response(connectStream([{ flags: 0, body: { event: { start: { pid: 7 } } } }]), {
+        status: 200,
+      })
+    );
+    await expect(client.startProcess("sb-1", "cmd", { envdAccessToken: "tok" })).rejects.toThrow(
+      /stream incomplete/
+    );
+
+    // Clean exit but no Connect end-of-stream envelope: the protocol requires
+    // one on every completed stream, so its absence means the response is cut.
+    fetchSpy.mockResolvedValue(
+      new Response(
+        connectStream([
+          { flags: 0, body: { event: { start: { pid: 7 } } } },
+          { flags: 0, body: { event: { end: { exited: true, status: "exit status 0" } } } },
+        ]),
+        { status: 200 }
+      )
+    );
+    await expect(client.startProcess("sb-1", "cmd", { envdAccessToken: "tok" })).rejects.toThrow(
+      /stream incomplete/
+    );
+  });
+
+  it("startProcess rejects truncated and malformed streams", async () => {
+    const client = new E2BRestClient(defaultConfig);
+    const complete = connectStream([
+      { flags: 0, body: { event: { start: { pid: 7 } } } },
+      { flags: 0, body: { event: { end: { exited: true, status: "exit status 0" } } } },
+      { flags: 2, body: {} },
+    ]);
+    fetchSpy.mockResolvedValue(
+      new Response(complete.subarray(0, complete.length - 3), { status: 200 })
+    );
+    await expect(client.startProcess("sb-1", "cmd", { envdAccessToken: "tok" })).rejects.toThrow(
+      /truncated/
+    );
+
+    // Declared length 1, body "{" — parses as neither an event nor an error.
+    fetchSpy.mockResolvedValue(
+      new Response(new Uint8Array([0, 0, 0, 0, 1, 0x7b]), { status: 200 })
+    );
+    await expect(client.startProcess("sb-1", "cmd", { envdAccessToken: "tok" })).rejects.toThrow(
+      /malformed/
+    );
+  });
+
   it("deleteTemplate passes the full snapshot id to E2B", async () => {
     const client = new E2BRestClient(defaultConfig);
     fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -27,6 +27,12 @@ const TIMEOUT_WRITE_FILE_MS = 30_000;
 // larger than the other calls because it copies the whole prebuilt filesystem.
 const TIMEOUT_SNAPSHOT_MS = 180_000;
 const TIMEOUT_DELETE_TEMPLATE_MS = 30_000;
+const TIMEOUT_START_PROCESS_MS = 30_000;
+
+/** Connect envelope prefix: one flag byte plus a big-endian uint32 length. */
+const ENVELOPE_HEADER_BYTES = 5;
+/** Connect end-of-stream flag; that envelope carries `{}` or `{"error": ...}`. */
+const ENVELOPE_END_STREAM_FLAG = 0x02;
 
 const e2bSandboxDetailSchema = z.object({
   sandboxID: z.string(),
@@ -122,6 +128,59 @@ export class E2BApiError extends Error {
   ) {
     super(message);
     this.name = "E2BApiError";
+  }
+}
+
+/**
+ * Walk a Connect streaming response, yielding each envelope's flags and JSON.
+ * Truncated trailing bytes are ignored rather than throwing — the caller only
+ * asserts on the messages it did receive.
+ */
+function* decodeConnectEnvelopes(buffer: Uint8Array): Generator<{ flags: number; body: unknown }> {
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const decoder = new TextDecoder();
+  let offset = 0;
+  while (offset + ENVELOPE_HEADER_BYTES <= buffer.length) {
+    const flags = buffer[offset]!;
+    const length = view.getUint32(offset + 1);
+    const start = offset + ENVELOPE_HEADER_BYTES;
+    const end = start + length;
+    if (end > buffer.length) return;
+    let body: unknown;
+    try {
+      body = JSON.parse(decoder.decode(buffer.subarray(start, end)));
+    } catch {
+      return;
+    }
+    yield { flags, body };
+    offset = end;
+  }
+}
+
+/**
+ * Fail unless the stream reported a process that started and exited cleanly.
+ * envd reports command failures in-band (a normal 200 stream ending in a
+ * non-zero `exit status`), so the HTTP status alone proves nothing.
+ */
+function assertProcessStarted(buffer: Uint8Array): void {
+  let started = false;
+  for (const { flags, body } of decodeConnectEnvelopes(buffer)) {
+    const event = (body as { event?: Record<string, { status?: string }> }).event;
+    if (flags & ENVELOPE_END_STREAM_FLAG) {
+      const streamError = (body as { error?: { message?: string } }).error;
+      if (streamError) {
+        throw new Error(`envd process start failed: ${streamError.message ?? "stream error"}`);
+      }
+      continue;
+    }
+    if (event?.start) started = true;
+    const status = event?.end?.status;
+    if (status !== undefined && status !== "exit status 0") {
+      throw new Error(`envd process start exited non-zero: ${status}`);
+    }
+  }
+  if (!started) {
+    throw new Error("envd process start returned no start event");
   }
 }
 
@@ -262,6 +321,65 @@ export class E2BRestClient {
       body: { timeout: timeoutSeconds },
       signal,
     });
+  }
+
+  /**
+   * Start a detached process inside a sandbox through envd.
+   *
+   * envd speaks Connect RPC and `Process/Start` is server-streaming, so the
+   * request body must be a Connect *envelope* — one flag byte, then a
+   * big-endian uint32 length, then the JSON message. Posting bare JSON to this
+   * endpoint returns 415.
+   *
+   * The command is expected to detach and exit (the caller wants the spawned
+   * process to outlive this RPC), so a non-zero exit or a stream-level error is
+   * a real failure and throws.
+   */
+  async startProcess(
+    id: string,
+    shellCommand: string,
+    opts: { domain?: string | null; envdAccessToken: string; signal?: AbortSignal }
+  ): Promise<void> {
+    const domain = opts.domain || DEFAULT_SANDBOX_DOMAIN;
+    const url = `https://${ENVD_PORT}-${id}.${domain}/process.Process/Start`;
+    const message = JSON.stringify({
+      process: { cmd: "/bin/sh", args: ["-c", shellCommand] },
+    });
+    const payload = new TextEncoder().encode(message);
+    const framed = new Uint8Array(ENVELOPE_HEADER_BYTES + payload.length);
+    new DataView(framed.buffer).setUint32(1, payload.length);
+    framed.set(payload, ENVELOPE_HEADER_BYTES);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_START_PROCESS_MS);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        body: framed,
+        headers: {
+          "Content-Type": "application/connect+json",
+          "connect-protocol-version": "1",
+          "X-Access-Token": opts.envdAccessToken,
+        },
+        signal: opts.signal ? AbortSignal.any([controller.signal, opts.signal]) : controller.signal,
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new E2BApiError(
+          text || `envd process start failed (${response.status})`,
+          response.status,
+          text
+        );
+      }
+      assertProcessStarted(new Uint8Array(await response.arrayBuffer()));
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`E2B envd process start timeout after ${TIMEOUT_START_PROCESS_MS}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   async killSandbox(id: string, signal?: AbortSignal): Promise<void> {

--- a/packages/control-plane/src/sandbox/e2b-rest-client.ts
+++ b/packages/control-plane/src/sandbox/e2b-rest-client.ts
@@ -87,8 +87,10 @@ const DEFAULT_SANDBOX_DOMAIN = "e2b.app";
 /**
  * Path the per-session env file is written to. The template launcher
  * (packages/e2b-infra/oi-launch.py) polls this exact path — keep them in sync.
+ * Exported because the E2B provider's launcher start command waits on this
+ * file's consumption as its readiness handshake.
  */
-const SESSION_ENV_PATH = "/tmp/oi-session.env";
+export const SESSION_ENV_PATH = "/tmp/oi-session.env";
 
 export interface E2BCreateSandboxParams {
   templateID: string;
@@ -133,24 +135,30 @@ export class E2BApiError extends Error {
 
 /**
  * Walk a Connect streaming response, yielding each envelope's flags and JSON.
- * Truncated trailing bytes are ignored rather than throwing — the caller only
- * asserts on the messages it did receive.
+ * The response is fully buffered before decoding, so a truncated or malformed
+ * envelope means the stream is not trustworthy evidence — throw rather than
+ * silently dropping what did not parse.
  */
 function* decodeConnectEnvelopes(buffer: Uint8Array): Generator<{ flags: number; body: unknown }> {
   const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
   const decoder = new TextDecoder();
   let offset = 0;
-  while (offset + ENVELOPE_HEADER_BYTES <= buffer.length) {
+  while (offset < buffer.length) {
+    if (offset + ENVELOPE_HEADER_BYTES > buffer.length) {
+      throw new Error("envd stream truncated mid-envelope");
+    }
     const flags = buffer[offset]!;
     const length = view.getUint32(offset + 1);
     const start = offset + ENVELOPE_HEADER_BYTES;
     const end = start + length;
-    if (end > buffer.length) return;
+    if (end > buffer.length) {
+      throw new Error("envd stream truncated mid-envelope");
+    }
     let body: unknown;
     try {
       body = JSON.parse(decoder.decode(buffer.subarray(start, end)));
     } catch {
-      return;
+      throw new Error("envd stream contained a malformed envelope");
     }
     yield { flags, body };
     offset = end;
@@ -158,29 +166,43 @@ function* decodeConnectEnvelopes(buffer: Uint8Array): Generator<{ flags: number;
 }
 
 /**
- * Fail unless the stream reported a process that started and exited cleanly.
- * envd reports command failures in-band (a normal 200 stream ending in a
- * non-zero `exit status`), so the HTTP status alone proves nothing.
+ * Fail unless the stream proves the command ran to a clean exit: a start
+ * event, `end.status === "exit status 0"`, and a healthy Connect end-of-stream
+ * envelope (the protocol requires one on every completed stream). envd reports
+ * command failures in-band (a normal 200 stream ending in a non-zero
+ * `exit status`), so the HTTP status alone proves nothing — and a stream
+ * missing any part of that shape is a failure, not a success: this guards the
+ * spawn path, where a false "started" becomes a session that dies silently on
+ * the connecting timeout.
  */
 function assertProcessStarted(buffer: Uint8Array): void {
   let started = false;
+  let exitedCleanly = false;
+  let endOfStream = false;
   for (const { flags, body } of decodeConnectEnvelopes(buffer)) {
-    const event = (body as { event?: Record<string, { status?: string }> }).event;
     if (flags & ENVELOPE_END_STREAM_FLAG) {
       const streamError = (body as { error?: { message?: string } }).error;
       if (streamError) {
         throw new Error(`envd process start failed: ${streamError.message ?? "stream error"}`);
       }
+      endOfStream = true;
       continue;
     }
+    const event = (body as { event?: Record<string, { status?: string }> }).event;
     if (event?.start) started = true;
     const status = event?.end?.status;
-    if (status !== undefined && status !== "exit status 0") {
-      throw new Error(`envd process start exited non-zero: ${status}`);
+    if (status !== undefined) {
+      if (status !== "exit status 0") {
+        throw new Error(`envd process start exited non-zero: ${status}`);
+      }
+      exitedCleanly = true;
     }
   }
-  if (!started) {
-    throw new Error("envd process start returned no start event");
+  if (!started || !exitedCleanly || !endOfStream) {
+    throw new Error(
+      `envd process start stream incomplete ` +
+        `(start=${started} clean_exit=${exitedCleanly} end_of_stream=${endOfStream})`
+    );
   }
 }
 

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -500,6 +500,12 @@ describe("E2BSandboxProvider prebuilt images / snapshots", () => {
       expect.stringContaining("oi-launch"),
       expect.objectContaining({ envdAccessToken: "envd-token" })
     );
+    // The command exits 0 only once the launcher has consumed the session env
+    // (launcher-owned liveness evidence — a detached launcher that dies
+    // instantly must fail the create, not surface as a silent timeout).
+    const [, command] = vi.mocked(client.startProcess).mock.calls[0];
+    expect(command).toContain("/tmp/oi-session.env");
+    expect(command).toContain("exit 1");
     // Env first, so the launcher consumes the file on its first poll.
     const writeOrder = vi.mocked(client.writeSessionEnv).mock.invocationCallOrder[0];
     const launchOrder = vi.mocked(client.startProcess).mock.invocationCallOrder[0];

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -39,12 +39,9 @@ function mockClient(overrides: Partial<E2BRestClient> = {}): E2BRestClient {
       })
     ),
     pauseSandbox: vi.fn(async () => {}),
-    connectSandbox: vi.fn(async () => ({
-      sandboxID: "e2b-id",
-      templateID: "tmpl",
-      envdAccessToken: "fresh-envd-token",
-    })),
+    connectSandbox: vi.fn(async () => {}),
     updateSandboxNetwork: vi.fn(async () => {}),
+    startProcess: vi.fn(async () => {}),
     killSandbox: vi.fn(async () => {}),
     setSandboxTimeout: vi.fn(async () => {}),
     createSnapshot: vi.fn(async () => ({ snapshotID: "snap-abc:default", names: ["oi/snap"] })),
@@ -488,6 +485,51 @@ describe("E2BSandboxProvider prebuilt images / snapshots", () => {
     expect(env.REPO_IMAGE_SHA).toBe("abc123");
   });
 
+  it("starts the launcher on a prebuilt boot, after the env is on disk", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).createSandbox({
+      ...baseCreateConfig,
+      prebuiltImageId: "snap-repo:default",
+    });
+    // A prebuilt image resumes quiet (its bake pause dropped all process memory,
+    // and a snapshot resume never re-runs the template start command), so the
+    // control plane must start oi-launch itself or nothing consumes the env and
+    // the session dies on the connecting timeout with no runtime logs.
+    expect(client.startProcess).toHaveBeenCalledWith(
+      "e2b-id",
+      expect.stringContaining("oi-launch"),
+      expect.objectContaining({ envdAccessToken: "envd-token" })
+    );
+    // Env first, so the launcher consumes the file on its first poll.
+    const writeOrder = vi.mocked(client.writeSessionEnv).mock.invocationCallOrder[0];
+    const launchOrder = vi.mocked(client.startProcess).mock.invocationCallOrder[0];
+    expect(writeOrder).toBeLessThan(launchOrder);
+  });
+
+  it("does not start a launcher on a base-template boot", async () => {
+    const client = mockClient();
+    await new E2BSandboxProvider(client, providerConfig).createSandbox(baseCreateConfig);
+    // Base templates resume the launcher E2B captured at template build;
+    // starting a second one would race it for the env file.
+    expect(client.startProcess).not.toHaveBeenCalled();
+  });
+
+  it("kills the sandbox and fails the create when the launcher cannot start", async () => {
+    const client = mockClient({
+      startProcess: vi.fn(async () => {
+        throw new Error("envd process start exited non-zero: exit status 127");
+      }),
+    });
+    await expect(
+      new E2BSandboxProvider(client, providerConfig).createSandbox({
+        ...baseCreateConfig,
+        prebuiltImageId: "snap-repo:default",
+      })
+    ).rejects.toThrow(/Failed to create E2B sandbox/);
+    // Without the kill the sandbox idles unbootable until its TTL.
+    expect(client.killSandbox).toHaveBeenCalledWith("e2b-id");
+  });
+
   it("takePrebuiltImageSnapshot sanitizes via pause(memory:false)+connect before snapshot", async () => {
     const client = mockClient();
     const provider = new E2BSandboxProvider(client, providerConfig);
@@ -499,6 +541,10 @@ describe("E2BSandboxProvider prebuilt images / snapshots", () => {
     expect(client.pauseSandbox).toHaveBeenCalledWith("build-sbx", { memory: false }, undefined);
     expect(client.connectSandbox).toHaveBeenCalledWith("build-sbx", expect.any(Number), undefined);
     expect(client.createSnapshot).toHaveBeenCalledWith("build-sbx", { signal: undefined });
+    // The image's contract is its filesystem: the bake starts nothing inside the
+    // sandbox, and every spawn from the image starts the launcher itself. Baking
+    // a waiting launcher in would make bootability depend on captured memory.
+    expect(client.startProcess).not.toHaveBeenCalled();
     const pauseOrder = vi.mocked(client.pauseSandbox).mock.invocationCallOrder[0];
     const connectOrder = vi.mocked(client.connectSandbox).mock.invocationCallOrder[0];
     const snapOrder = vi.mocked(client.createSnapshot).mock.invocationCallOrder[0];

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -13,10 +13,11 @@
  * once in a build sandbox (triggerImageBuild), then bakes its filesystem into a
  * reusable snapshot template (takePrebuiltImageSnapshot →
  * `POST /sandboxes/{id}/snapshots`). The snapshot id doubles as a `templateID`, so a
- * prebuilt spawn is just a create with that id in place of the base template. The
- * snapshot resumes oi-launch in its env wait loop, where it reads the freshly written
- * per-session env — so prebuilt boots reuse the baked filesystem while still getting
- * fresh session config.
+ * prebuilt spawn is a create with that id in place of the base template — plus an
+ * explicit launcher start: a snapshot resume never re-runs the template start command,
+ * so after writing the per-session env the control plane starts oi-launch itself
+ * (startLauncher). The image's contract is its filesystem; nothing captured in memory
+ * is relied on, mirroring how Modal repo images reboot their entrypoint on each spawn.
  */
 
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
@@ -73,11 +74,20 @@ export const DEFAULT_E2B_AUTO_PAUSE = true;
 export const E2B_SANDBOX_VERSION = SANDBOX_RUNTIME_VERSION;
 
 /**
- * TTL for the brief cold-boot between the sanitizing pause and createSnapshot
+ * TTL for the brief quiet resume between the sanitizing pause and createSnapshot
  * during an image build. Only needs to outlive the snapshot call; the build
  * sandbox is killed immediately afterwards.
  */
 const SNAPSHOT_CONNECT_TIMEOUT_SECONDS = 300;
+
+/**
+ * The template's start command (packages/e2b-infra/build-template.py START_CMD)
+ * — run by the control plane on every prebuilt-image boot, because a snapshot
+ * resume never re-runs it (see startLauncher). Keep in sync with that file.
+ */
+const E2B_LAUNCHER_COMMAND = "python /usr/local/bin/oi-launch";
+/** Where the control-plane-started launcher's output goes, for in-sandbox debugging. */
+const E2B_LAUNCHER_LOG_PATH = "/tmp/oi-launch.log";
 
 export interface E2BProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -163,7 +173,15 @@ export class E2BSandboxProvider implements SandboxProvider {
         autoResume: false,
       });
 
-      await this.deliverSessionEnv(sandbox, envVars);
+      const envd = await this.deliverSessionEnv(sandbox, envVars);
+      // A prebuilt image resumes quiet (the bake's sanitizing pause dropped all
+      // process memory, and snapshot resumes never re-run the template start
+      // command), so nothing inside is watching for the env file we just wrote.
+      // Base-template boots need no start: E2B captured their launcher mid-poll
+      // at template build, and starting a second one would race it for the file.
+      if (config.prebuiltImageId) {
+        await this.startLauncher(sandbox.sandboxID, envd);
+      }
 
       const { codeServerUrl, vncUrl, tunnelUrls } = this.buildTunnelUrls(
         sandbox.sandboxID,
@@ -189,19 +207,22 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * Bake an image-build sandbox into a reusable snapshot template, sanitized so
-   * the image is a clean, quiescent cold boot rather than a frozen build process.
+   * Bake an image-build sandbox into a reusable snapshot template whose only
+   * contract is its filesystem.
    *
-   * A reusable E2B snapshot (`POST /sandboxes/{id}/snapshots`) captures live
-   * process memory, so snapshotting the running build sandbox directly would (a)
-   * bake the build supervisor and its secret env into every image and (b) resume
-   * that stale process on spawn instead of a fresh launcher. To avoid both, we
-   * first `pause(keepMemory:false)` — which drops all memory and persists only
-   * the filesystem — then `connect`, which cold-boots the sandbox from disk,
-   * re-running the launcher fresh in its env-wait state. The snapshot then
-   * captures that clean state, so sandboxes spawned from it start a fresh
-   * supervisor with their own per-session env (and never inherit build secrets in
-   * memory).
+   * An E2B snapshot (`POST /sandboxes/{id}/snapshots`) always captures live
+   * memory: it requires a running sandbox (404 on a paused one) and has no
+   * filesystem-only variant. Snapshotting the build sandbox directly would bake
+   * the build supervisor and its secret env (clone token, build callback
+   * credentials) into every image and resume them on every spawn. So the bake
+   * first `pause(memory:false)` — dropping all process memory, keeping the disk
+   * — then `connect`s and snapshots the resumed, quiet sandbox: kernel and envd
+   * up, no userland processes.
+   *
+   * Nothing captured in memory is relied on. Sandboxes spawned from the image
+   * resume quiet, and createSandbox starts the launcher itself (startLauncher)
+   * — the same lifecycle as Modal repo images, whose entrypoint reboots on
+   * every spawn from a filesystem snapshot.
    *
    * This is the only snapshot path E2B exposes; there is no generic
    * `takeSnapshot` (see `capabilities.supportsSnapshots`).
@@ -209,8 +230,6 @@ export class E2BSandboxProvider implements SandboxProvider {
   async takePrebuiltImageSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
     try {
       await this.client.pauseSandbox(config.providerObjectId, { memory: false }, config.signal);
-      // Cold-boot from disk; connect returns once the template ready-check passes,
-      // i.e. once the launcher is back up and waiting — no readiness guesswork.
       await this.client.connectSandbox(
         config.providerObjectId,
         SNAPSHOT_CONNECT_TIMEOUT_SECONDS,
@@ -228,6 +247,37 @@ export class E2BSandboxProvider implements SandboxProvider {
       return { success: true, imageId: snapshot.snapshotID };
     } catch (error) {
       throw this.classifyError("Failed to bake E2B image snapshot", error, "snapshot");
+    }
+  }
+
+  /**
+   * Start the launcher in a sandbox booted from a prebuilt image.
+   *
+   * Without this, nothing ever consumes the session env: the control plane
+   * writes it, the supervisor never starts, and the session dies on the
+   * connecting timeout with no runtime logs to explain it (there is nothing
+   * inside to emit any). The env file is written before this runs, so the
+   * launcher consumes it on its first poll and execs the supervisor exactly as
+   * a base-template boot does. The command detaches, so the launcher outlives
+   * the RPC that started it.
+   *
+   * On failure the sandbox exists but can never boot — kill it rather than
+   * leak it until its TTL, then let the create fail loudly.
+   */
+  private async startLauncher(
+    e2bSandboxId: string,
+    envd: { domain?: string | null; envdAccessToken: string }
+  ): Promise<void> {
+    try {
+      await this.client.startProcess(
+        e2bSandboxId,
+        `nohup ${E2B_LAUNCHER_COMMAND} >${E2B_LAUNCHER_LOG_PATH} 2>&1 & echo started`,
+        envd
+      );
+      log.info("e2b.launcher_started", { sandbox_id: e2bSandboxId });
+    } catch (error) {
+      await this.cleanupSandbox(e2bSandboxId, "e2b.cleanup_kill_failed");
+      throw error;
     }
   }
 
@@ -494,14 +544,17 @@ export class E2BSandboxProvider implements SandboxProvider {
   /**
    * Deliver the per-session env to the supervisor via envd. E2B's template start
    * command runs once at build and never sees create-time env vars, so the
-   * launcher (oi-launch.py) waits for this file and starts the supervisor with it.
+   * launcher (oi-launch.py) reads this file and starts the supervisor with it.
    * On failure the sandbox exists but will never get its env — kill it rather
    * than leak a running launcher-only sandbox until its TTL.
+   *
+   * Returns the validated envd channel so callers can make follow-up envd calls
+   * (startLauncher) without re-checking the token.
    */
   private async deliverSessionEnv(
     sandbox: E2BSandboxCreated,
     envVars: Record<string, string>
-  ): Promise<void> {
+  ): Promise<{ domain?: string | null; envdAccessToken: string }> {
     try {
       const envdAccessToken = sandbox.envdAccessToken;
       if (!envdAccessToken) {
@@ -514,10 +567,9 @@ export class E2BSandboxProvider implements SandboxProvider {
           "permanent"
         );
       }
-      await this.client.writeSessionEnv(sandbox.sandboxID, envVars, {
-        domain: sandbox.domain,
-        envdAccessToken,
-      });
+      const envd = { domain: sandbox.domain, envdAccessToken };
+      await this.client.writeSessionEnv(sandbox.sandboxID, envVars, envd);
+      return envd;
     } catch (error) {
       try {
         await this.client.killSandbox(sandbox.sandboxID);

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -36,7 +36,12 @@ import { SANDBOX_RUNTIME_VERSION } from "../runtime-manifest";
 import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
 import type { SourceControlProviderName } from "../../source-control";
 import type { E2BRestClient, E2BSandboxCreated, E2BSandboxDetail } from "../e2b-rest-client";
-import { E2BApiError, E2BConflictError, E2BNotFoundError } from "../e2b-rest-client";
+import {
+  E2BApiError,
+  E2BConflictError,
+  E2BNotFoundError,
+  SESSION_ENV_PATH,
+} from "../e2b-rest-client";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
   SandboxProviderError,
@@ -88,6 +93,13 @@ const SNAPSHOT_CONNECT_TIMEOUT_SECONDS = 300;
 const E2B_LAUNCHER_COMMAND = "python /usr/local/bin/oi-launch";
 /** Where the control-plane-started launcher's output goes, for in-sandbox debugging. */
 const E2B_LAUNCHER_LOG_PATH = "/tmp/oi-launch.log";
+/**
+ * How many 0.2s in-shell polls the launcher start command waits for the
+ * launcher to consume the session env before reporting failure (4s total).
+ * The launcher polls the file at 100ms, so a healthy handshake completes in
+ * the first iteration or two.
+ */
+const LAUNCHER_HANDSHAKE_POLLS = 20;
 
 export interface E2BProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -251,15 +263,22 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * Start the launcher in a sandbox booted from a prebuilt image.
+   * Start the launcher in a sandbox booted from a prebuilt image, and wait for
+   * launcher-owned proof that it is alive.
    *
    * Without this, nothing ever consumes the session env: the control plane
    * writes it, the supervisor never starts, and the session dies on the
    * connecting timeout with no runtime logs to explain it (there is nothing
-   * inside to emit any). The env file is written before this runs, so the
-   * launcher consumes it on its first poll and execs the supervisor exactly as
-   * a base-template boot does. The command detaches, so the launcher outlives
-   * the RPC that started it.
+   * inside to emit any). The launcher detaches so it outlives the RPC, but a
+   * detached launcher that dies instantly (interpreter or launcher script
+   * broken — e.g. by the image's own setup.sh) would leave the shell exiting 0
+   * and reproduce exactly that silent timeout. So the foreground shell exits 0
+   * only once /tmp/oi-session.env is gone — the env file is written before
+   * this runs and only the launcher removes it (it unlinks after reading and
+   * fails closed if it can't), so consumption proves the whole handshake:
+   * env at the right path, launcher alive, launcher reading it. A process
+   * probe (kill -0 / pgrep) can't give that: an instantly-dead child is still
+   * a visible zombie of the shell.
    *
    * On failure the sandbox exists but can never boot — kill it rather than
    * leak it until its TTL, then let the create fail loudly.
@@ -268,12 +287,12 @@ export class E2BSandboxProvider implements SandboxProvider {
     e2bSandboxId: string,
     envd: { domain?: string | null; envdAccessToken: string }
   ): Promise<void> {
+    const command =
+      `nohup ${E2B_LAUNCHER_COMMAND} >${E2B_LAUNCHER_LOG_PATH} 2>&1 & ` +
+      `i=0; while [ $i -lt ${LAUNCHER_HANDSHAKE_POLLS} ]; do ` +
+      `[ ! -f ${SESSION_ENV_PATH} ] && exit 0; sleep 0.2; i=$((i+1)); done; exit 1`;
     try {
-      await this.client.startProcess(
-        e2bSandboxId,
-        `nohup ${E2B_LAUNCHER_COMMAND} >${E2B_LAUNCHER_LOG_PATH} 2>&1 & echo started`,
-        envd
-      );
+      await this.client.startProcess(e2bSandboxId, command, envd);
       log.info("e2b.launcher_started", { sandbox_id: e2bSandboxId });
     } catch (error) {
       await this.cleanupSandbox(e2bSandboxId, "e2b.cleanup_kill_failed");


### PR DESCRIPTION
## Problem

Every E2B prebuilt image built so far is unbootable. Sessions spawned from one create fine in ~2s, then nothing happens inside and the session dies on the 120s connecting timeout — with **zero runtime logs**, because the agent bridge that forwards logs is part of what never starts. Observed in prod: 10 consecutive prebuilt-image sessions, 0 reached `ready`; base-template sessions were fine throughout.

## Root cause

`takePrebuiltImageSnapshot` sanitizes the build sandbox with `pause(memory:false)` (correctly — otherwise the build supervisor and its secrets get baked into every image), then `connect`s and snapshots. The wrong assumption was that `connect` re-runs the template start command. It does not: a snapshot resume restores exactly the memory that was captured, and after the sanitizing pause that memory contains **no userland processes at all**. So every image captures a sandbox with no `oi-launch`, and a session spawned from it writes `/tmp/oi-session.env` that nothing will ever consume.

Verified against live E2B: an env file written into a sandbox spawned from a real prod image is untouched after 60s; the same write to a base-template sandbox is consumed within 20s.

## Fix: the quiet resume becomes the image's contract

Rather than baking a waiting launcher into the snapshot's memory (this PR's first iteration), the fix moves the launcher start to **spawn time**:

- **Bake is unchanged**: `pause(memory:false)` → `connect` → `createSnapshot`. The image's contract is its **filesystem**; nothing captured in memory is relied on. (E2B has no filesystem-only snapshot — `POST /sandboxes/{id}/snapshots` 404s on a paused sandbox — so memory is always captured; the design makes it irrelevant.)
- **Spawn from a prebuilt image**: after writing the session env, `createSandbox` execs `oi-launch` itself through envd (`Process/Start`). The env file is already on disk, so the launcher consumes it on its first poll and execs the supervisor exactly as a base-template boot does.
- **Base-template boots are untouched**: E2B resumes their captured launcher itself; starting a second one would race it for the env file.

This is the same lifecycle as Modal repo images, whose entrypoint reboots on every spawn from a filesystem snapshot: prebuild = filesystem state, first boot = processes started fresh, and pause/resume (which genuinely should resume running processes) stays the mid-session continuity mechanism.

Two consequences worth calling out:

1. **Every image baked so far is already valid.** The bake this PR keeps is byte-for-byte the bake that produced the "broken" images — they were quiet images all along; the spawn path just never started anything. No re-bake wave needed. Verified live: spawning from a prod-baked image and exec'ing the launcher through envd consumes the env and starts the supervisor normally.
2. **Failures are loud.** A launcher that fails to start kills the sandbox and fails the create with an attributable error (surfaced in the UI via #1537/#1539), instead of producing a session that silently times out after 120s with nothing in the logs.

## envd mechanics

envd speaks Connect RPC and `Process/Start` is server-streaming, so the request body is a Connect envelope (flag byte + big-endian uint32 length + JSON) — bare JSON returns 415. Failures are reported in-band inside a 200 stream (`exit status N` / end-of-stream error), so the exit status is asserted rather than trusting the HTTP status.

## Changes

- `e2b-provider.ts`: `createSandbox` starts the launcher for prebuilt boots (after the env write, kill-on-failure); bake docstring rewritten to state the filesystem contract; `deliverSessionEnv` returns the validated envd channel so the launcher start reuses it.
- `e2b-rest-client.ts`: adds `startProcess` (Connect-enveloped envd exec with in-band failure assertion). `connectSandbox` stays a `void` command.

## Testing

- Unit: prebuilt boot starts the launcher after the env write; base-template boot does not; launcher-start failure kills the sandbox and fails the create; bake performs pause → connect → snapshot and starts nothing; `startProcess` envelope framing and in-band failure assertions.
- Full control-plane suite: 2992 tests green; typecheck green.
- Live E2B acceptance (this exact code): baked a quiet image through `takePrebuiltImageSnapshot` (`qlzmilqs7djg8ahtxqqy:default`), spawned from it through `createSandbox`, and verified from inside the sandbox that the session env was consumed and the supervisor log existed **within 2s of spawn** — vs. an env file still unconsumed at t+60s on the broken path. Probe sandboxes and the test template were deleted afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox process startup reliability with stronger handling for timeouts, cancellations, incomplete responses, malformed data, and non-zero exits.
  - Prebuilt-image sandboxes now verify that startup environment setup completes before launching required services.
  - Failed launcher startup now cleans up the sandbox and reports the error clearly.
  - Base-template sandbox creation and snapshot operations no longer start an unnecessary launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->