### PR TITLE
feat(github-bot): emit applyable review suggestions

### DIFF
--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -211,6 +211,7 @@ Two prompt templates in `src/prompts.ts`:
 - Run `gh pr diff` for the full diff
 - Submit a review via `gh api .../reviews`
 - Post inline comments via `gh api .../comments`
+- Emit applyable `suggestion` fences in inline comment bodies (see below)
 
 **`buildCommentActionPrompt`** — Includes the user's request (with @mention stripped) and
 instructions to:
@@ -218,7 +219,26 @@ instructions to:
 - Check prior conversation via `gh pr view --comments`
 - Make code changes and push, or respond with analysis
 - Post a summary comment via `gh api .../issues/{n}/comments`
-- Reply to a specific review thread (when `commentId` is present)
+- Reply to a specific review thread (when `commentId` is present), optionally with an applyable
+  `suggestion` fence — the summary comment cannot carry one, since an issue comment has no line
+  anchor
+
+### Applyable Suggestions
+
+`buildSuggestionGuidelines` is shared by both prompts. A fenced `suggestion` block inside a
+**line-anchored** comment is what GitHub renders with a "Commit suggestion" button; the fence
+content replaces the anchored lines verbatim. Nothing in this package calls the GitHub API for it —
+the inline-comment command already carries `path`/`line`/`side` and a `commit_id`, so applyability
+is purely a property of the comment body. Bodies are therefore passed as `-F body=@<file>` rather
+than an inline `-f body="…"`: a fence contains backticks, and backticks inside a double-quoted shell
+argument are command substitution.
+
+The guidelines add `start_line`/`start_side` for range anchors and hold the agent to the constraints
+that make an applied suggestion safe: verbatim replacement, exact original indentation, no diff
+markers or placeholders, and range endpoints that both fall inside a diff hunk (an endpoint outside
+the diff rejects the comment with HTTP 422). Because the sandbox has the head branch checked out,
+the agent is required to print the anchored lines and validate the patched file before emitting a
+fence, and to fall back to prose when it cannot — an applied suggestion is one click from merge.
 
 The prompts embed only metadata from the webhook payload. The agent gathers everything else.
 

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -212,7 +212,8 @@ Two prompt templates in `src/prompts.ts`:
 
 - Run `gh pr diff` for the full diff
 - Submit a review via `gh api .../reviews`
-- Post inline comments via `gh api .../comments`
+- Post inline comments inside that same review's `comments` array
+- Emit applyable `suggestion` fences in the review's inline comment bodies (see below)
 
 **`buildCommentActionPrompt`** — Includes the user's request (with @mention stripped) and
 instructions to:
@@ -220,7 +221,46 @@ instructions to:
 - Check prior conversation via `gh pr view --comments`
 - Make code changes and push, or respond with analysis
 - Post a summary comment via `gh api .../issues/{n}/comments`
-- Reply to a specific review thread (when `commentId` is present)
+- Reply to a specific review thread when `commentId` is present. It offers an applyable `suggestion`
+  fence only when the payload also carries both a path and a non-empty diff hunk; the summary
+  comment cannot carry one, since an issue comment has no line anchor.
+
+### Applyable Suggestions
+
+`buildSuggestionGuidelines` serves both prompt paths. A fenced `suggestion` block inside a
+**line-anchored** comment is what GitHub renders with a "Commit suggestion" button; the fence
+content replaces the anchored lines verbatim. Nothing in this package calls a special suggestion
+API—the review's `comments` array and the thread-reply route already carry the markdown body.
+
+A fence contains backticks, so how the body reaches `gh` matters. Review bodies (summary and inline
+comments alike) ship inside the single JSON review payload, where each `body` is a JSON string and
+its line breaks are `\n`. Thread-reply and summary-comment bodies are passed as `-F body=@<file>`
+rather than an inline `-f body="…"` argument, since backticks inside a double-quoted shell argument
+are command substitution. Writing that file is a file-write-tool job. A heredoc needs a quoted
+delimiter, since an unquoted one substitutes commands out of untrusted review text, and it needs a
+delimiter proved absent from the body: a quoted heredoc still ends at the first line equal to its
+delimiter, and a fence quoting a script's own `EOF` is exactly such a line, which would hand the
+rest of the review to the shell.
+
+For a full review, the agent selects the anchor and must prove every selected line falls inside a
+diff hunk. For a thread reply with a supplied path and non-empty diff hunk, GitHub inherits the
+parent comment's anchor, so the agent instead checks that the supplied code-location hunk still
+matches the current head and emits no fence after a commit has moved those lines. A thread without
+that code location gets prose-only reply instructions and no suggestion contract. Both anchored
+paths require verbatim replacement, exact indentation, a scratch-copy check, and a prose fallback
+when the replacement cannot be proved safe. The anchored lines are read with the agent's file-read
+tool rather than a shell command, because a PR can add a file whose name is shell syntax and a path
+interpolated into shell source is command substitution.
+
+### Repository Identity in API Routes
+
+Every `gh api repos/...` route embedded in these prompts uses
+`encodeRepositoryPathSegments({ repoOwner: owner, repoName: repo })`
+(`@open-inspect/shared/types/repositories`) rather than maintaining another route-construction rule.
+GitHub login owners are currently single segments, so this is behavior-preserving for webhook
+traffic; using the shared helper keeps the prompt aligned with the repository-wide identity
+contract, which also permits nested namespaces on other source-control providers. Human-readable
+`${owner}/${repo}` prose stays unencoded.
 
 The prompts embed only metadata from the webhook payload. The agent gathers everything else.
 

--- a/packages/github-bot/src/prompts.ts
+++ b/packages/github-bot/src/prompts.ts
@@ -14,6 +14,41 @@ function buildCommentGuidelines(isPublicRepo: boolean): string {
 - Compose your full response before posting any comments.`;
 }
 
+function buildSuggestionGuidelines(): string {
+  return `
+## Applyable Suggestions
+A fenced \`suggestion\` block inside a line-anchored review comment renders in GitHub with a
+"Commit suggestion" button, so the author applies your fix in one click. Use one whenever the fix
+is a concrete, local edit you can state exactly:
+
+\`\`\`suggestion
+<the replacement lines>
+\`\`\`
+
+Hard rules — the fence content REPLACES the comment's anchored lines verbatim:
+- It is not a diff and not an excerpt. Never put \`+\`/\`-\` markers, \`...\`, placeholders, TODOs,
+  or prose inside the fence.
+- Reproduce the original leading whitespace exactly. A suggestion with wrong indentation still
+  applies cleanly and breaks the file.
+- Include only the anchored lines — no surrounding unchanged lines for context.
+- Prefer a single-line anchor (\`line\` only) even when the replacement is several lines: one
+  anchored line may be replaced by any number of lines. Use \`start_line\` only to replace a
+  contiguous range, and only when BOTH endpoints appear in a hunk of \`gh pr diff\` — an endpoint
+  outside the diff rejects that comment with HTTP 422 and the feedback is lost.
+- One suggestion per comment. The explanation goes above the fence, never inside it.
+
+Verify before you suggest. The repo is checked out on the PR head branch, so check instead of
+guessing:
+1. Print the exact anchored lines (\`sed -n 'START,ENDp' <path>\`) and confirm your fence is a
+   correct verbatim replacement for precisely those lines.
+2. Apply the replacement to a scratch copy and run the cheapest correctness check the repo
+   offers for that file (syntax parse, type check, or its linter).
+
+If either check fails, or the real fix spans multiple files, needs an import or declaration
+elsewhere, or turns on a judgment call, describe the fix in prose and post NO fence. A wrong
+suggestion is worse than none: it is one click away from being merged.`;
+}
+
 function buildUntrustedUserContentBlock(params: {
   source: string;
   author: string;
@@ -116,16 +151,26 @@ ${prDescriptionBlock}
 
    ${reviewEventGuidance}
 
-5. For inline comments on specific files:
+5. For inline comments on specific files, write the body to a file first — a suggestion fence
+   contains backticks, and backticks inside a double-quoted shell argument are command
+   substitution:
 
    gh api repos/${owner}/${repo}/pulls/${number}/comments \\
      --method POST \\
-     -f body="<comment>" \\
+     -F body=@/tmp/comment.md \\
      -f path="<file path>" \\
      -f commit_id="$(gh api repos/${owner}/${repo}/pulls/${number} --jq '.head.sha')" \\
-     -f line=<line number> \\
+     -F line=<line number> \\
      -f side="RIGHT"
 
+   \`line\` and \`start_line\` must go through \`-F\` (typed), not \`-f\` (raw string): the API rejects
+   a string line with \`"3" is not an integer\`. Add \`-F start_line=<first line>\` and
+   \`-f start_side="RIGHT"\` to anchor a contiguous range instead of a single line.
+
+   Prefer a suggestion over prose whenever the fix is a concrete, local edit — see
+   ## Applyable Suggestions below. It is the difference between a review the author has to
+   re-implement and one they can apply.
+${buildSuggestionGuidelines()}
 ${buildCustomInstructionsSection(codeReviewInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }
@@ -178,8 +223,10 @@ export function buildCommentActionPrompt(params: {
   }
 
   let replyInstruction = "";
+  let suggestionSection = "";
   if (commentId) {
-    replyInstruction = `\n5. If you need to reply to the specific review thread:\n\n   gh api repos/${owner}/${repo}/pulls/${number}/comments/${commentId}/replies \\\n     --method POST \\\n     -f body="<your reply>"`;
+    replyInstruction = `\n5. If you need to reply to the specific review thread, write the reply to a file first — a suggestion fence contains backticks, and backticks inside a double-quoted shell argument are command substitution:\n\n   gh api repos/${owner}/${repo}/pulls/${number}/comments/${commentId}/replies \\\n     --method POST \\\n     -F body=@/tmp/reply.md\n\n   A thread reply is anchored to the same lines as the comment it answers, so it can carry an\n   applyable suggestion. The summary comment cannot: an issue comment has no line anchor, and a\n   suggestion fence there renders as an inert code block. If you already pushed the fix, say so\n   in the reply instead of suggesting it.`;
+    suggestionSection = `\n${buildSuggestionGuidelines()}`;
   }
 
   return `${intro}${prDetails}${codeLocation}
@@ -201,7 +248,7 @@ ${buildUntrustedUserContentBlock({
 
    gh api repos/${owner}/${repo}/issues/${number}/comments \\
      --method POST \\
-     -f body="<summary of what you did or your response>"${replyInstruction}
+     -f body="<summary of what you did or your response>"${replyInstruction}${suggestionSection}
 ${buildCustomInstructionsSection(commentActionInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }

--- a/packages/github-bot/src/prompts.ts
+++ b/packages/github-bot/src/prompts.ts
@@ -16,6 +16,69 @@ function buildCommentGuidelines(isPublicRepo: boolean): string {
 - Compose your full response before posting any comments.`;
 }
 
+function buildSuggestionGuidelines(anchorMode: "selected" | "inherited"): string {
+  const anchorRules =
+    anchorMode === "selected"
+      ? `- Prefer a single-line anchor (\`line\` only) even when the replacement is several lines:
+  one anchored line may be replaced by any number of lines. Use \`start_line\` only to replace a
+  contiguous range.
+- EVERY anchor line must fall inside a hunk of \`gh pr diff\` — the single \`line\` of a
+  single-line anchor, and both \`start_line\` and \`line\` of a range. An anchor outside the diff
+  rejects the ENTIRE review with HTTP 422, so one bad anchor loses every comment in it.`
+      : `- A thread reply inherits the parent comment's anchor; do not send \`line\`, \`start_line\`,
+  or \`side\` fields on the reply request.
+- Verify the inherited anchor against the ## Code Location hunk and the current head. If any pushed
+  commit moved or replaced those lines, post prose and NO fence.`;
+  const verification =
+    anchorMode === "selected"
+      ? `1. Run \`gh pr diff\` (it accepts a PR number, URL, or branch — never a file path) and
+   confirm every anchor line — including a lone \`line\` anchor, not only range endpoints — falls
+   inside a hunk.
+2. Read the exact anchored lines with your file-read tool — never by interpolating the path into
+   shell source, since a PR can add a file whose name is shell syntax — and confirm your fence is
+   a correct verbatim replacement for precisely those lines.
+3. Apply the replacement to a scratch copy and run the cheapest correctness check the repo offers
+   for that file (syntax parse, type check, or its linter).`
+      : `1. Confirm the ## Code Location hunk still describes the current head and identify the exact
+   inherited lines it anchors.
+2. Apply the replacement to a scratch copy and run the cheapest correctness check the repo offers
+   for that file (syntax parse, type check, or its linter).`;
+
+  return `
+## Applyable Suggestions
+A fenced \`suggestion\` block inside a line-anchored review comment renders in GitHub with a
+"Commit suggestion" button, so the author applies your fix in one click. Use one whenever the fix
+is a concrete, local edit you can state exactly:
+
+\`\`\`suggestion
+<the replacement lines>
+\`\`\`
+
+Hard rules — the fence content REPLACES the comment's anchored lines verbatim:
+- It is not a diff and not an excerpt. Never put \`+\`/\`-\` markers, \`...\`, placeholders, TODOs,
+  or prose inside the fence.
+- Reproduce the original leading whitespace exactly. A suggestion with wrong indentation still
+  applies cleanly and breaks the file.
+- Include only the anchored lines — no surrounding unchanged lines for context.
+${anchorRules}
+- One suggestion per comment. The explanation goes above the fence, never inside it.
+
+Verify before you suggest. The repo is checked out on the PR head branch, so check instead of
+guessing:
+${verification}
+
+If any check fails, or the real fix spans multiple files, needs an import or declaration
+elsewhere, or turns on a judgment call, describe the fix in prose and post NO fence. A wrong
+suggestion is worse than none: it is one click away from being merged.`;
+}
+
+function writeBodyFileInstruction(path: string): string {
+  return `write \`${path}\` with your file-write tool. A body line equal to a heredoc delimiter
+   closes the heredoc early and hands the rest of your review to the shell, and an unquoted
+   delimiter substitutes commands out of untrusted review text — so if you use the shell instead,
+   quote the delimiter and confirm it appears on no line of the body`;
+}
+
 function buildUntrustedUserContentBlock(params: {
   source: string;
   author: string;
@@ -133,6 +196,12 @@ JSON
 
    ${reviewEventGuidance}
 
+   A comment may add \`"start_line": <first line>\` (with \`"start_side": "RIGHT"\`) to anchor a
+   contiguous range instead of a single line, and its \`"body"\` may carry an applyable fix — see
+   ## Applyable Suggestions below. Every \`"body"\` is a JSON string, so encode its newlines as
+   \`\\n\`. Prefer a suggestion over prose whenever the fix is a concrete, local edit: it is the
+   difference between a review the author has to re-implement and one they can apply.
+${buildSuggestionGuidelines("selected")}
 ${buildCustomInstructionsSection(codeReviewInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }
@@ -167,6 +236,7 @@ export function buildCommentActionPrompt(params: {
     commentId,
     commentActionInstructions,
   } = params;
+  const repositoryPath = encodeRepositoryPathSegments({ repoOwner: owner, repoName: repo });
 
   const intro = head
     ? `You are working on Pull Request #${number} in ${owner}/${repo}.\nThe repository has been cloned and you are on the ${head} branch.`
@@ -179,14 +249,32 @@ export function buildCommentActionPrompt(params: {
     if (base && head) prDetails += `\n- **Branch**: ${base} ← ${head}`;
   }
 
+  const hasCodeLocation = Boolean(filePath && diffHunk);
   let codeLocation = "";
-  if (filePath && diffHunk) {
+  if (hasCodeLocation) {
     codeLocation = `\n\n## Code Location\nThis comment is about \`${filePath}\`:\n\`\`\`\n${diffHunk}\n\`\`\``;
   }
 
   let replyInstruction = "";
+  let suggestionSection = "";
   if (commentId) {
-    replyInstruction = `\n5. If you need to reply to the specific review thread:\n\n   gh api repos/${owner}/${repo}/pulls/${number}/comments/${commentId}/replies \\\n     --method POST \\\n     -f body="<your reply>"`;
+    replyInstruction = `
+5. If you need to reply to the specific review thread, first ${writeBodyFileInstruction("/tmp/reply.md")}:
+
+   gh api repos/${repositoryPath}/pulls/${number}/comments/${commentId}/replies \\
+     --method POST \\
+     -F body=@/tmp/reply.md
+
+   ${
+     hasCodeLocation
+       ? `A thread reply inherits the parent comment's line anchor, so it can carry an applyable
+   suggestion. The summary comment cannot: an issue comment has no line anchor, and a suggestion
+   fence there renders as an inert code block.`
+       : `No Code Location was provided for this thread. Reply in prose and do not use a suggestion
+   fence because there is no anchor to validate. The summary comment cannot carry one either: an
+   issue comment has no line anchor, so a fence there renders as an inert code block.`
+   }`;
+    if (hasCodeLocation) suggestionSection = `\n${buildSuggestionGuidelines("inherited")}`;
   }
 
   return `${intro}${prDetails}${codeLocation}
@@ -204,11 +292,11 @@ ${buildUntrustedUserContentBlock({
 3. Address the request:
    - If code changes are needed, make them and push to the current branch
    - If it's a question, respond with your analysis
-4. When done, post a summary comment on the PR:
+4. When done, ${writeBodyFileInstruction("/tmp/summary.md")}. Then post it on the PR:
 
-   gh api repos/${owner}/${repo}/issues/${number}/comments \\
+   gh api repos/${repositoryPath}/issues/${number}/comments \\
      --method POST \\
-     -f body="<summary of what you did or your response>"${replyInstruction}
+     -F body=@/tmp/summary.md${replyInstruction}${suggestionSection}
 ${buildCustomInstructionsSection(commentActionInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }

--- a/packages/github-bot/test/prompts.test.ts
+++ b/packages/github-bot/test/prompts.test.ts
@@ -62,6 +62,45 @@ describe("buildCodeReviewPrompt", () => {
     expect(prompt).toContain("repos/acme/widgets/pulls/42/comments");
   });
 
+  it("teaches the applyable suggestion fence and its range anchors", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // The whole point: a `suggestion` fence in a line-anchored comment body is what GitHub
+    // renders with a "Commit suggestion" button, and start_line/start_side anchors a range.
+    expect(prompt).toContain("## Applyable Suggestions");
+    expect(prompt).toContain("```suggestion");
+    expect(prompt).toContain("-F start_line=<first line>");
+    expect(prompt).toContain('-f start_side="RIGHT"');
+  });
+
+  it("passes comment bodies through a file so a fence cannot be command-substituted", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // A suggestion fence contains backticks; inside `-f body="…"` the shell would execute them.
+    expect(prompt).toContain("-F body=@/tmp/comment.md");
+    expect(prompt).not.toContain('-f body="<comment>"');
+  });
+
+  it("sends line numbers as typed integers", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // `-f` is a raw string field, and the API rejects a string line with
+    // `For 'properties/line', "3" is not an integer` — verified live against the REST API.
+    expect(prompt).toContain("-F line=<line number>");
+    expect(prompt).not.toContain("-f line=<line number>");
+    expect(prompt).toContain('"3" is not an integer');
+  });
+
+  it("fences the suggestion contract against the ways an applied suggestion breaks code", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // A suggestion is one click from merge, so each of these is load-bearing: the fence replaces
+    // the anchored lines verbatim, so a diff marker, an ellipsis, or lost indentation applies
+    // cleanly and corrupts the file.
+    expect(prompt).toContain("REPLACES the comment's anchored lines verbatim");
+    expect(prompt).toContain("Reproduce the original leading whitespace exactly");
+    expect(prompt).toContain("HTTP 422");
+    expect(prompt).toContain("post NO fence");
+    // And the agent must check rather than guess — it has the head branch checked out.
+    expect(prompt).toContain("sed -n 'START,ENDp' <path>");
+  });
+
   it("limits self-reviews to comments", () => {
     const prompt = buildCodeReviewPrompt({ ...baseParams, isSelfReview: true });
     expect(prompt).toContain('-f event="COMMENT"');
@@ -187,6 +226,22 @@ describe("buildCommentActionPrompt", () => {
     const prompt = buildCommentActionPrompt(baseParams);
     expect(prompt).not.toContain("## Code Location");
     expect(prompt).not.toContain("reply to the specific review thread");
+  });
+
+  it("offers applyable suggestions only on the line-anchored reply path", () => {
+    const prompt = buildCommentActionPrompt({ ...baseParams, commentId: 999 });
+    expect(prompt).toContain("## Applyable Suggestions");
+    expect(prompt).toContain("```suggestion");
+    expect(prompt).toContain("-F body=@/tmp/reply.md");
+    // The summary lands on issues/{n}/comments, which has no line anchor, so a fence there is
+    // inert — the agent has to know which of its two posting paths can carry one.
+    expect(prompt).toContain("renders as an inert code block");
+  });
+
+  it("omits the suggestion contract when there is no thread to reply to", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).not.toContain("## Applyable Suggestions");
+    expect(prompt).not.toContain("```suggestion");
   });
 
   it("includes summary comment instruction with correct repo path", () => {

--- a/packages/github-bot/test/prompts.test.ts
+++ b/packages/github-bot/test/prompts.test.ts
@@ -74,6 +74,49 @@ describe("buildCodeReviewPrompt", () => {
     expect(prompt).not.toContain("gh api repos/group/subgroup/widgets/pulls/42/reviews");
   });
 
+  it("teaches the applyable suggestion fence and its range anchors", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // The whole point: a `suggestion` fence in a line-anchored comment body is what GitHub
+    // renders with a "Commit suggestion" button, and start_line/start_side anchors a range.
+    expect(prompt).toContain("## Applyable Suggestions");
+    expect(prompt).toContain("```suggestion");
+    expect(prompt).toContain('"start_line": <first line>');
+    expect(prompt).toContain('"start_side": "RIGHT"');
+    // A fence is multi-line, and every comment body ships as a JSON string in the review
+    // payload, so the agent has to be told how to encode the line breaks.
+    expect(prompt).toContain("is a JSON string, so encode its newlines");
+  });
+
+  it("fences the suggestion contract against the ways an applied suggestion breaks code", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // A suggestion is one click from merge, so each of these is load-bearing: the fence replaces
+    // the anchored lines verbatim, so a diff marker, an ellipsis, or lost indentation applies
+    // cleanly and corrupts the file.
+    expect(prompt).toContain("REPLACES the comment's anchored lines verbatim");
+    expect(prompt).toContain("Reproduce the original leading whitespace exactly");
+    expect(prompt).toContain("HTTP 422");
+    expect(prompt).toContain("post NO fence");
+    // And the agent must check rather than guess — it has the head branch checked out. It reads
+    // the anchored lines with its file-read tool: a PR can add a file whose name is shell syntax,
+    // so a path that reaches shell source is command substitution.
+    expect(prompt).toContain("Read the exact anchored lines with your file-read tool");
+    expect(prompt).not.toContain("sed -n");
+  });
+
+  it("requires every anchor — a lone line as much as a range endpoint — to sit inside a diff hunk", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    // Regression: this used to gate diff-hunk membership on start_line only, so a single-line
+    // `line` anchor outside the diff could still be suggested and would be rejected with 422.
+    expect(prompt).toContain("EVERY anchor line must fall inside a hunk of `gh pr diff`");
+    expect(prompt).toContain("single `line` of a");
+    expect(prompt).toContain("both `start_line` and `line`");
+    expect(prompt).toContain("including a lone `line`");
+    expect(prompt).toContain("not only range endpoints");
+    // Regression guard: the old wording scoped the requirement to range endpoints only.
+    expect(prompt).not.toContain("only when BOTH endpoints appear in a hunk");
+    expect(prompt).not.toContain("gh pr diff <path>");
+  });
+
   it("limits self-reviews to comments", () => {
     const prompt = buildCodeReviewPrompt({ ...baseParams, isSelfReview: true });
     expect(prompt).toContain('"event": "COMMENT"');
@@ -201,9 +244,78 @@ describe("buildCommentActionPrompt", () => {
     expect(prompt).not.toContain("reply to the specific review thread");
   });
 
+  it("offers applyable suggestions only on a validated inherited thread anchor", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      filePath: "src/cache.ts",
+      diffHunk: "@@ -10,3 +10,5 @@\n+const cache = new Map();",
+      commentId: 999,
+    });
+    expect(prompt).toContain("## Applyable Suggestions");
+    expect(prompt).toContain("```suggestion");
+    expect(prompt).toContain("-F body=@/tmp/reply.md");
+    expect(prompt).toContain("-F body=@/tmp/summary.md");
+    expect(prompt).toContain("inherits the parent comment's line anchor");
+    expect(prompt).toContain("do not send `line`, `start_line`,");
+    expect(prompt).toContain("If any pushed");
+    expect(prompt).not.toContain("EVERY anchor line");
+    expect(prompt).not.toContain("-F start_line=");
+    // The summary lands on issues/{n}/comments, which has no line anchor, so a fence there is
+    // inert — the agent has to know which of its two posting paths can carry one.
+    expect(prompt).toContain("renders as an inert code block");
+  });
+
+  it("requires code location context before offering an inherited suggestion", () => {
+    const prompt = buildCommentActionPrompt({ ...baseParams, commentId: 999 });
+    expect(prompt).toContain("Reply in prose");
+    expect(prompt).not.toContain("## Applyable Suggestions");
+    expect(prompt).not.toContain("```suggestion");
+  });
+
+  it("omits the suggestion contract when there is no thread to reply to", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).not.toContain("## Applyable Suggestions");
+    expect(prompt).not.toContain("```suggestion");
+  });
+
   it("includes summary comment instruction with correct repo path", () => {
     const prompt = buildCommentActionPrompt(baseParams);
     expect(prompt).toContain("repos/acme/widgets/issues/42/comments");
+  });
+
+  it("writes every posted body to a file and offers no fixed heredoc delimiter", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      filePath: "src/cache.ts",
+      diffHunk: "@@ -10,3 +10,5 @@\n+const cache = new Map();",
+      commentId: 999,
+    });
+    // A suggestion fence carries backticks, and backticks inside a double-quoted shell argument
+    // are command substitution, so no body is ever inlined into the gh call.
+    expect(prompt).not.toContain("-f body=");
+    // A quoted heredoc stops expansion but still ends at the first line equal to the delimiter,
+    // and a fence quoting a script's own `EOF` is exactly such a line — so no fixed delimiter is
+    // offered, and the shell fallback has to prove the delimiter is absent from the body.
+    expect(prompt).toContain("A body line equal to a heredoc delimiter");
+    expect(prompt).toContain("confirm it appears on no line of the body");
+    expect(prompt).not.toContain("<<'EOF'");
+    expect(prompt).not.toContain("<<EOF");
+  });
+
+  it("encodes a nested-namespace owner as a single route segment in every API call", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      owner: "group/platform",
+      filePath: "src/cache.ts",
+      diffHunk: "@@ -10,3 +10,5 @@\n+const cache = new Map();",
+      commentId: 999,
+    });
+    // Route construction stays aligned with the shared repository-identity contract.
+    expect(prompt).toContain("repos/group%2Fplatform/widgets/issues/42/comments");
+    expect(prompt).toContain("repos/group%2Fplatform/widgets/pulls/42/comments/999/replies");
+    expect(prompt).not.toContain("repos/group/platform/widgets");
+    // The human-readable intro line is prose, not a route, and stays unencoded.
+    expect(prompt).toContain("Pull Request #42 in group/platform/widgets.");
   });
 
   it("escapes embedded closing user_content tags in comment body", () => {


### PR DESCRIPTION
## What

Teach the PR-review agent to emit GitHub **suggested changes** — a fenced ` ```suggestion ` block inside a line-anchored review comment, which GitHub renders with an *Apply suggestion* / *Add suggestion to batch* control. The author applies the fix in one click instead of re-implementing it from prose.

This is what CodeRabbit and similar reviewers do, and it needs no new endpoint: the existing inline-comment command already carries `path`/`line`/`side` and a `commit_id`, so applyability is purely a property of the comment **body**.

## Changes

`packages/github-bot/src/prompts.ts` — a new `buildSuggestionGuidelines()` shared by both prompts:

- **`buildCodeReviewPrompt`** — documents range anchors (`start_line`/`start_side`) and is told to prefer a suggestion over prose whenever the fix is a concrete, local edit.
- **`buildCommentActionPrompt`** — gets the contract **only** when `commentId` is present. A thread reply is line-anchored so it can carry a fence; the summary comment goes to `issues/{n}/comments`, which has no line anchor, so a fence there renders as an inert code block. The prompt says so explicitly rather than letting the agent waste one.

### Two mechanical fixes the feature required

Both verified live against the REST API on a throwaway PR:

1. **Comment bodies now use `-F body=@<file>` instead of inline `-f body=\"…\"`.** A suggestion fence contains backticks, and backticks inside a double-quoted shell argument are command substitution. There is no safe way to inline one.

2. **`line` and `start_line` now use `-F` (typed), not `-f` (raw string).** This is a pre-existing bug: `-f` sends `\"3\"` and the API rejects it —

   \`\`\`
   POST /repos/{o}/{r}/pulls/{n}/comments
   422: For 'properties/line', \"3\" is not an integer.
        \"line\" is not a permitted key.
   \`\`\`

   The current `-f line=<line number>` instruction could not have produced an inline comment. With `-F line=3` the same request succeeds and round-trips `{\"line\":3,\"side\":\"RIGHT\",\"subject_type\":\"line\"}`.

### Why the contract is strict

An applied suggestion is one click from merge, so a wrong one is worse than none. The fence content **replaces the anchored lines verbatim**, which means wrong indentation applies *cleanly* and breaks the file. The guidelines therefore forbid diff markers, ellipses, placeholders, and surrounding context lines; require exact original whitespace; and prefer a single-line anchor with a multi-line fence body (one anchored line may be replaced by any number of lines) over a range whose endpoints might fall outside a diff hunk.

They also exploit something a hosted reviewer cannot: the sandbox has the PR head branch checked out. The agent must print the anchored lines (`sed -n 'START,ENDp'`), confirm the fence is a correct verbatim replacement, apply it to a scratch copy, and run the file's cheapest correctness check — falling back to prose if any of that fails or if the real fix spans multiple files.

## Verification

- **Live API probe** on a throwaway PR: a single-line suggestion (`line=3`) and a multi-line range suggestion (`start_line=2, line=3`) both posted successfully via `-F body=@file`; bodies round-tripped byte-exact including leading whitespace; the rendered page contains `js-suggested-changes-blob`, *Apply suggestion*, and *Add suggestion to batch*, i.e. both render as genuinely applyable.
- `npm test -w @open-inspect/github-bot` — **141 passed** (7 new tests pinning the contract: fence present, typed line flags, file-based body, the verbatim/indentation/422/`post NO fence` rules, and reply-path-only gating with its negative case).
- `tsc --noEmit -p packages/github-bot` clean; eslint clean; prettier applied.

Prompt-text only — no runtime, API-client, or schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for applyable GitHub code suggestions in inline review comments and eligible review-thread replies.
  - Added line and range anchoring guidance, replacement formatting, and safer comment submission.
  - Improved handling of nested and URL-encoded repository paths.
  - Clarified that threads without code-location context receive prose replies and that summary comments do not support active suggestions.

- **Documentation**
  - Expanded guidance on suggestion formatting, validation, and submission requirements.

- **Tests**
  - Added coverage for suggestions, anchoring, comment bodies, repository paths, and safety validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->