### PR TITLE
feat: page the managed-skill installation and pack its persistence writes

### DIFF
--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -336,26 +336,30 @@ is not portable to the second `SqlDatabase` engine.
 
 ### Bounds that remain implicit
 
-Removing the count cap left three resources still linear in skill count. None is enforced, so each
-surfaces as an engine error rather than a validation message. They are recorded here so the removed
-limit does not become invisible; making them count-independent is tracked separately.
+Removing the count cap left three resources scaling with skill count rather than content. None is
+enforced, so each surfaces as an engine error rather than a validation message. They are recorded
+here so the removed limit does not become invisible.
 
-| Resource                     | Shape                                                       | Approximate cliff       |
-| ---------------------------- | ----------------------------------------------------------- | ----------------------- |
-| Installation payload         | JSON framing per file is excluded from `totalBytes`         | ~900–2,400 skills       |
-| Session manifest persistence | One `session_skill_revisions` INSERT per skill in one batch | engine statement budget |
-| Profile membership writes    | One `skill_profile_items` INSERT per skill in one batch     | engine statement budget |
+| Resource                     | Shape                                               | Approximate cliff |
+| ---------------------------- | --------------------------------------------------- | ----------------- |
+| Installation payload         | JSON framing per file is excluded from `totalBytes` | ~2,400 skills     |
+| Session manifest persistence | 10 `session_skill_revisions` rows per INSERT        | ~9,900 skills     |
+| Profile membership writes    | 50 `skill_profile_items` rows per INSERT            | ~49,900 skills    |
 
 The payload figure assumes the worst realistic shape: `MAX_SKILL_FILES` near-empty files per skill,
 where roughly 134 bytes plus the path length of framing per file counts against the runtime's
 `MAX_MANAGED_SKILL_RESPONSE_BYTES` but contributes nothing to the 5 MiB content aggregate. Because
 resolution checks only content bytes, such a manifest is accepted and persisted, then fails closed
-at sandbox boot — the one case where an accepted manifest is not installable. A transport-safe
-aggregate needs a per-revision file count available at resolution time.
+at sandbox boot — the one case where an accepted manifest is not installable. This is the binding
+constraint, and it is a transport shape rather than a storage bound: the runtime fetches the whole
+installation as one response, so the ceiling is per-response rather than per-session. Paging that
+fetch removes it without introducing a count limit.
 
-The two write paths are bounded by the engine's per-invocation statement budget, not by content.
-`bindManifestCopy` is already set-based (`INSERT … SELECT`) and therefore count-independent; the
-create path and profile writes are the outliers, and both must keep their current atomicity.
+The two write paths are bounded by D1's 1,000 queries per Worker invocation. Both pack rows into
+multi-row `INSERT`s sized to the 100-parameter ceiling (`bulkInsertStatements`), which divides the
+statement count by rows-per-statement and keeps the write inside its caller's atomic `batch()`.
+Multi-row `VALUES` is standard SQL, so neither path needs an engine branch. `bindManifestCopy` is
+set-based (`INSERT … SELECT`) and stays fully count-independent.
 
 Paths must be normalized relative POSIX paths. Reject absolute paths, empty segments, `.`, `..`,
 backslashes, NUL/control characters, duplicate normalized paths, symlinks, hard links, and reserved

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -336,24 +336,27 @@ is not portable to the second `SqlDatabase` engine.
 
 ### Bounds that remain implicit
 
-Removing the count cap left three resources scaling with skill count rather than content. None is
-enforced, so each surfaces as an engine error rather than a validation message. They are recorded
-here so the removed limit does not become invisible.
+Removing the count cap exposed three resources scaling with skill count rather than content. None
+was enforced, so each surfaced as an engine error rather than a validation message. What each cost
+and what it costs now:
 
-| Resource                     | Shape                                               | Approximate cliff |
-| ---------------------------- | --------------------------------------------------- | ----------------- |
-| Installation payload         | JSON framing per file is excluded from `totalBytes` | ~2,400 skills     |
-| Session manifest persistence | 10 `session_skill_revisions` rows per INSERT        | ~9,900 skills     |
-| Profile membership writes    | 50 `skill_profile_items` rows per INSERT            | ~49,900 skills    |
+| Resource                     | Was                            | Now                                          | Cliff          |
+| ---------------------------- | ------------------------------ | -------------------------------------------- | -------------- |
+| Installation payload         | Whole manifest in one response | `MANAGED_SKILLS_PAGE_SIZE` per response      | none           |
+| Session manifest persistence | One INSERT per skill           | 10 `session_skill_revisions` rows per INSERT | ~9,900 skills  |
+| Profile membership writes    | One INSERT per skill           | 50 `skill_profile_items` rows per INSERT     | ~49,900 skills |
 
-The payload figure assumes the worst realistic shape: `MAX_SKILL_FILES` near-empty files per skill,
-where roughly 134 bytes plus the path length of framing per file counts against the runtime's
-`MAX_MANAGED_SKILL_RESPONSE_BYTES` but contributes nothing to the 5 MiB content aggregate. Because
-resolution checks only content bytes, such a manifest is accepted and persisted, then fails closed
-at sandbox boot — the one case where an accepted manifest is not installable. This is the binding
-constraint, and it is a transport shape rather than a storage bound: the runtime fetches the whole
-installation as one response, so the ceiling is per-response rather than per-session. Paging that
-fetch removes it without introducing a count limit.
+The payload was the binding constraint at roughly 2,400 skills, assuming the worst realistic shape:
+`MAX_SKILL_FILES` near-empty files per skill, where roughly 134 bytes plus the path length of
+framing per file counts against the runtime's `MAX_MANAGED_SKILL_RESPONSE_BYTES` but contributes
+nothing to the 5 MiB content aggregate. Because resolution checks only content bytes, such a
+manifest was accepted and persisted, then failed closed at sandbox boot — the one case where an
+accepted manifest was not installable. That is a transport shape rather than a storage bound, so the
+runtime pages the fetch instead of resolution rejecting the manifest: a fixed number of skills per
+response keeps every response far below the ceiling however wide the manifest is, and the runtime
+writes each page into the staging tree as it arrives, so peak memory is one page rather than the
+whole installation. Duplicate names and the content aggregate accumulate across pages, because they
+are properties of the installation and not of a response.
 
 The two write paths are bounded by D1's 1,000 queries per Worker invocation. Both pack rows into
 multi-row `INSERT`s sized to the 100-parameter ceiling (`bulkInsertStatements`), which divides the
@@ -673,7 +676,7 @@ Add `GET /sessions/:id/skills` for authenticated human-readable provenance.
 Add a sandbox-authenticated endpoint:
 
 ```text
-GET /sessions/:id/sandbox-skills
+GET /sessions/:id/sandbox-skills[?limit=<1..200>&cursor=<position>]
 ```
 
 The session-specific sandbox bearer token, validated by the Session Durable Object, must
@@ -698,9 +701,21 @@ narrow installation DTO containing the pinned manifest digest and bounded UTF-8 
         }
       ]
     }
-  ]
+  ],
+  "nextCursor": null
 }
 ```
+
+`limit` is optional. Without it the response is the whole installation and `nextCursor` is null,
+which is the only shape sandbox runtimes predating paging understand — they ignore the field, so
+this route must keep serving unpaged requests for as long as older snapshots can be restored. With
+it, the response holds at most `limit` skills and `nextCursor` carries the last position returned,
+or null at the end. Pinned revisions are immutable, so position is a stable cursor and every page of
+one installation reports the same `manifestSha256`; a runtime must reject a page whose digest
+differs from the first page's.
+
+Only an unpaged response carries an `ETag`. The digest covers the whole manifest, so it cannot
+identify a page.
 
 All integer fields in digest encodings are unsigned big-endian. `str(value)` means a 32-bit byte
 length followed by the exact UTF-8 bytes. A SHA-256 field contributes its raw 32 bytes, not hex.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -340,11 +340,11 @@ Removing the count cap exposed three resources scaling with skill count rather t
 was enforced, so each surfaced as an engine error rather than a validation message. What each cost
 and what it costs now:
 
-| Resource                     | Was                            | Now                                          | Cliff          |
-| ---------------------------- | ------------------------------ | -------------------------------------------- | -------------- |
-| Installation payload         | Whole manifest in one response | `MANAGED_SKILLS_PAGE_SIZE` per response      | none           |
-| Session manifest persistence | One INSERT per skill           | 10 `session_skill_revisions` rows per INSERT | ~9,900 skills  |
-| Profile membership writes    | One INSERT per skill           | 50 `skill_profile_items` rows per INSERT     | ~49,900 skills |
+| Resource                     | Was                            | Now                                          | Cliff         |
+| ---------------------------- | ------------------------------ | -------------------------------------------- | ------------- |
+| Installation payload         | Whole manifest in one response | `MANAGED_SKILLS_PAGE_SIZE` per response      | none          |
+| Session manifest persistence | One INSERT per skill           | 10 `session_skill_revisions` rows per INSERT | 9,041 skills  |
+| Profile membership writes    | One INSERT per skill           | 50 `skill_profile_items` rows per INSERT     | 33,251 skills |
 
 The payload was the binding constraint at roughly 2,400 skills, assuming the worst realistic shape:
 `MAX_SKILL_FILES` near-empty files per skill, where roughly 134 bytes plus the path length of
@@ -363,6 +363,23 @@ multi-row `INSERT`s sized to the 100-parameter ceiling (`bulkInsertStatements`),
 statement count by rows-per-statement and keeps the write inside its caller's atomic `batch()`.
 Multi-row `VALUES` is standard SQL, so neither path needs an engine branch. `bindManifestCopy` is
 set-based (`INSERT … SELECT`) and stays fully count-independent.
+
+Packing lowers the constant; it does not remove the linear term, and the budget is spent by the
+whole invocation rather than by the write alone. The cliffs above are the minimum end-to-end cost
+for `N` skills, so any additional per-request work lowers them further:
+
+| Path           | Reads                                                   | Writes                                    | Total     |
+| -------------- | ------------------------------------------------------- | ----------------------------------------- | --------- |
+| Session create | 2 generation + 1 catalog + ⌈N/100⌉ assignment hydration | 1 session + 1 manifest + ⌈N/10⌉ revisions | 5 + 0.11N |
+| Profile create | ⌈N/100⌉ `validateSkillIds`                              | 1 profile + ⌈N/50⌉ items + 1 generation   | 2 + 0.03N |
+
+Session create excludes repository and provider-auth statements and assumes resolution does not
+retry; a generation change retries the read phase up to `MAX_CATALOG_READ_ATTEMPTS` times, and
+profile-mode selection adds two more reads. Profile create excludes authentication and routing.
+Making either genuinely count-independent needs a set-based bulk write behind the database boundary
+— `json_each`-style expansion of a single parameter — which the `SqlDatabase` port cannot express
+today because it is types-only and erased at build time, leaving no runtime dispatch point for an
+engine branch.
 
 Paths must be normalized relative POSIX paths. Reject absolute paths, empty segments, `.`, `..`,
 backslashes, NUL/control characters, duplicate normalized paths, symlinks, hard links, and reserved

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -753,7 +753,8 @@ those six values with `str`, using the empty string for fields not applicable to
 The control plane owns the canonical provenance digest. The sandbox independently verifies every
 delivered file's path, size, content hash, permissions, and generated `SKILL.md` identity.
 Selection, revision metadata, and assignment provenance remain available from
-`GET /sessions/:id/skills`. Return `ETag: "<manifestSha256>"` for diagnostics and future caching.
+`GET /sessions/:id/skills`. The unpaged `ETag` described above exists for diagnostics and future
+caching.
 
 The response is intentionally not placed in `SESSION_CONFIG`, environment variables, or the Modal
 create request. Content can exceed environment limits, executable instructions should not appear in

--- a/packages/control-plane/src/db/bulk-insert.test.ts
+++ b/packages/control-plane/src/db/bulk-insert.test.ts
@@ -31,28 +31,25 @@ function recordingDb(): { db: SqlDatabase; recorded: Recorded[] } {
   return { db, recorded };
 }
 
-function rows(count: number, width: number): unknown[][] {
+function rows(count: number, width: number): Record<string, unknown>[] {
   return Array.from({ length: count }, (_, row) =>
-    Array.from({ length: width }, (_, column) => `r${row}c${column}`)
+    Object.fromEntries(
+      Array.from({ length: width }, (_, column) => [`c${column}`, `r${row}c${column}`])
+    )
   );
 }
 
 describe("bulkInsertStatements", () => {
   it("emits nothing for an empty row list", () => {
     const { db, recorded } = recordingDb();
-    expect(bulkInsertStatements(db, "t", ["a", "b"], [])).toEqual([]);
+    expect(bulkInsertStatements(db, "t", [])).toEqual([]);
     expect(recorded).toHaveLength(0);
   });
 
   it("packs one statement per full parameter budget", () => {
     const { db, recorded } = recordingDb();
     // 10 columns => 10 rows per statement; 101 rows is one full set past ten.
-    const statements = bulkInsertStatements(
-      db,
-      "session_skill_revisions",
-      Array.from({ length: 10 }, (_, index) => `c${index}`),
-      rows(101, 10)
-    );
+    const statements = bulkInsertStatements(db, "session_skill_revisions", rows(101, 10));
 
     expect(statements).toHaveLength(11);
     expect(recorded.slice(0, 10).map((entry) => entry.values.length)).toEqual(Array(10).fill(100));
@@ -62,12 +59,7 @@ describe("bulkInsertStatements", () => {
   it("keeps every statement within the engine parameter ceiling", () => {
     for (const width of [1, 2, 3, 7, 10, 33, 100]) {
       const { db, recorded } = recordingDb();
-      bulkInsertStatements(
-        db,
-        "t",
-        Array.from({ length: width }, (_, index) => `c${index}`),
-        rows(257, width)
-      );
+      bulkInsertStatements(db, "t", rows(257, width));
       for (const entry of recorded) {
         expect(entry.values.length).toBeLessThanOrEqual(MAX_D1_QUERY_PARAMETERS);
         expect(entry.sql.split("?")).toHaveLength(entry.values.length + 1);
@@ -78,15 +70,10 @@ describe("bulkInsertStatements", () => {
 
   it("binds values in row-major order under a multi-row VALUES clause", () => {
     const { db, recorded } = recordingDb();
-    bulkInsertStatements(
-      db,
-      "skill_profile_items",
-      ["profile_id", "skill_id"],
-      [
-        ["p1", "s1"],
-        ["p1", "s2"],
-      ]
-    );
+    bulkInsertStatements(db, "skill_profile_items", [
+      { profile_id: "p1", skill_id: "s1" },
+      { profile_id: "p1", skill_id: "s2" },
+    ]);
 
     expect(recorded).toHaveLength(1);
     expect(recorded[0]?.sql.replace(/\s+/g, " ")).toBe(
@@ -95,17 +82,38 @@ describe("bulkInsertStatements", () => {
     expect(recorded[0]?.values).toEqual(["p1", "s1", "p1", "s2"]);
   });
 
-  it("rejects a row whose arity does not match the column list", () => {
+  it("reads each row by column name rather than by insertion order", () => {
+    const { db, recorded } = recordingDb();
+    bulkInsertStatements(db, "t", [
+      { a: 1, b: 2 },
+      { b: 4, a: 3 },
+    ]);
+
+    expect(recorded[0]?.sql).toContain("(a, b)");
+    expect(recorded[0]?.values).toEqual([1, 2, 3, 4]);
+  });
+
+  it("rejects rows with no columns", () => {
     const { db } = recordingDb();
-    expect(() => bulkInsertStatements(db, "t", ["a", "b"], [["only-one"]])).toThrow(
-      /row has 1 values for 2 columns/
+    expect(() => bulkInsertStatements(db, "t", [{}, {}])).toThrow(/rows have no columns/);
+  });
+
+  it("rejects a row whose columns disagree with the first row", () => {
+    const { db } = recordingDb();
+    expect(() => bulkInsertStatements(db, "t", [{ a: 1, b: 2 }, { a: 3 }])).toThrow(
+      /rows disagree on columns/
     );
+    expect(() =>
+      bulkInsertStatements(db, "t", [
+        { a: 1, b: 2 },
+        { a: 3, c: 4 },
+      ])
+    ).toThrow(/rows disagree on columns/);
   });
 
   it("rejects a table too wide to insert even one row", () => {
     const { db } = recordingDb();
-    const columns = Array.from({ length: MAX_D1_QUERY_PARAMETERS + 1 }, (_, i) => `c${i}`);
-    expect(() => bulkInsertStatements(db, "t", columns, [columns])).toThrow(
+    expect(() => bulkInsertStatements(db, "t", rows(1, MAX_D1_QUERY_PARAMETERS + 1))).toThrow(
       /exceeds the parameter ceiling/
     );
   });

--- a/packages/control-plane/src/db/bulk-insert.test.ts
+++ b/packages/control-plane/src/db/bulk-insert.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { bulkInsertStatements } from "./bulk-insert";
+import { MAX_D1_QUERY_PARAMETERS } from "./query-limits";
+import type { SqlDatabase, SqlStatement } from "./sql-database";
+
+interface Recorded {
+  sql: string;
+  values: unknown[];
+}
+
+/** Capture prepared SQL and bound values without an engine. */
+function recordingDb(): { db: SqlDatabase; recorded: Recorded[] } {
+  const recorded: Recorded[] = [];
+  const db: SqlDatabase = {
+    prepare(sql: string): SqlStatement {
+      const entry: Recorded = { sql, values: [] };
+      recorded.push(entry);
+      const statement: SqlStatement = {
+        bind(...values: unknown[]) {
+          entry.values = values;
+          return statement;
+        },
+        first: async () => null,
+        run: async () => ({ results: [], meta: { changes: 0 } }),
+        all: async () => ({ results: [], meta: { changes: 0 } }),
+      };
+      return statement;
+    },
+    batch: async () => [],
+  };
+  return { db, recorded };
+}
+
+function rows(count: number, width: number): unknown[][] {
+  return Array.from({ length: count }, (_, row) =>
+    Array.from({ length: width }, (_, column) => `r${row}c${column}`)
+  );
+}
+
+describe("bulkInsertStatements", () => {
+  it("emits nothing for an empty row list", () => {
+    const { db, recorded } = recordingDb();
+    expect(bulkInsertStatements(db, "t", ["a", "b"], [])).toEqual([]);
+    expect(recorded).toHaveLength(0);
+  });
+
+  it("packs one statement per full parameter budget", () => {
+    const { db, recorded } = recordingDb();
+    // 10 columns => 10 rows per statement; 101 rows is one full set past ten.
+    const statements = bulkInsertStatements(
+      db,
+      "session_skill_revisions",
+      Array.from({ length: 10 }, (_, index) => `c${index}`),
+      rows(101, 10)
+    );
+
+    expect(statements).toHaveLength(11);
+    expect(recorded.slice(0, 10).map((entry) => entry.values.length)).toEqual(Array(10).fill(100));
+    expect(recorded[10]?.values).toHaveLength(10);
+  });
+
+  it("keeps every statement within the engine parameter ceiling", () => {
+    for (const width of [1, 2, 3, 7, 10, 33, 100]) {
+      const { db, recorded } = recordingDb();
+      bulkInsertStatements(
+        db,
+        "t",
+        Array.from({ length: width }, (_, index) => `c${index}`),
+        rows(257, width)
+      );
+      for (const entry of recorded) {
+        expect(entry.values.length).toBeLessThanOrEqual(MAX_D1_QUERY_PARAMETERS);
+        expect(entry.sql.split("?")).toHaveLength(entry.values.length + 1);
+      }
+      expect(recorded.reduce((total, entry) => total + entry.values.length, 0)).toBe(257 * width);
+    }
+  });
+
+  it("binds values in row-major order under a multi-row VALUES clause", () => {
+    const { db, recorded } = recordingDb();
+    bulkInsertStatements(
+      db,
+      "skill_profile_items",
+      ["profile_id", "skill_id"],
+      [
+        ["p1", "s1"],
+        ["p1", "s2"],
+      ]
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.sql.replace(/\s+/g, " ")).toBe(
+      "INSERT INTO skill_profile_items (profile_id, skill_id) VALUES (?, ?), (?, ?)"
+    );
+    expect(recorded[0]?.values).toEqual(["p1", "s1", "p1", "s2"]);
+  });
+
+  it("rejects a row whose arity does not match the column list", () => {
+    const { db } = recordingDb();
+    expect(() => bulkInsertStatements(db, "t", ["a", "b"], [["only-one"]])).toThrow(
+      /row has 1 values for 2 columns/
+    );
+  });
+
+  it("rejects a table too wide to insert even one row", () => {
+    const { db } = recordingDb();
+    const columns = Array.from({ length: MAX_D1_QUERY_PARAMETERS + 1 }, (_, i) => `c${i}`);
+    expect(() => bulkInsertStatements(db, "t", columns, [columns])).toThrow(
+      /exceeds the parameter ceiling/
+    );
+  });
+});

--- a/packages/control-plane/src/db/bulk-insert.ts
+++ b/packages/control-plane/src/db/bulk-insert.ts
@@ -1,0 +1,55 @@
+import { MAX_D1_QUERY_PARAMETERS } from "./query-limits";
+import type { SqlDatabase, SqlStatement } from "./sql-database";
+
+/**
+ * Build multi-row INSERTs for a row list whose length the caller does not control.
+ *
+ * One statement per row makes a write linear in row count against the engine's
+ * per-invocation query budget; one statement covering every row blows the
+ * bound-parameter ceiling. Packing floor(ceiling / columns) rows into each
+ * statement keeps every statement legal and divides the statement count by that
+ * factor, which is what moves the write off the critical path.
+ *
+ * The result is ordinary parameterized SQL, so callers splice it into an
+ * existing batch() and keep the surrounding write atomic. Multi-row VALUES is
+ * standard SQL, so this needs no engine branch.
+ *
+ * `table` and `columns` are interpolated into the statement text: pass literals,
+ * never anything derived from a request.
+ */
+export function bulkInsertStatements(
+  db: SqlDatabase,
+  table: string,
+  columns: readonly string[],
+  rows: readonly (readonly unknown[])[]
+): SqlStatement[] {
+  const rowsPerStatement = Math.floor(MAX_D1_QUERY_PARAMETERS / columns.length);
+  if (rowsPerStatement < 1) {
+    throw new Error(
+      `Cannot bulk insert into ${table}: ${columns.length} columns exceeds the parameter ceiling`
+    );
+  }
+  const rowPlaceholder = `(${columns.map(() => "?").join(", ")})`;
+  const statements: SqlStatement[] = [];
+  for (let start = 0; start < rows.length; start += rowsPerStatement) {
+    const chunk = rows.slice(start, start + rowsPerStatement);
+    const values: unknown[] = [];
+    for (const row of chunk) {
+      if (row.length !== columns.length) {
+        throw new Error(
+          `Cannot bulk insert into ${table}: row has ${row.length} values for ${columns.length} columns`
+        );
+      }
+      values.push(...row);
+    }
+    statements.push(
+      db
+        .prepare(
+          `INSERT INTO ${table} (${columns.join(", ")})
+           VALUES ${chunk.map(() => rowPlaceholder).join(", ")}`
+        )
+        .bind(...values)
+    );
+  }
+  return statements;
+}

--- a/packages/control-plane/src/db/bulk-insert.ts
+++ b/packages/control-plane/src/db/bulk-insert.ts
@@ -7,40 +7,55 @@ import type { SqlDatabase, SqlStatement } from "./sql-database";
  * One statement per row makes a write linear in row count against the engine's
  * per-invocation query budget; one statement covering every row blows the
  * bound-parameter ceiling. Packing floor(ceiling / columns) rows into each
- * statement keeps every statement legal and divides the statement count by that
- * factor, which is what moves the write off the critical path.
+ * statement divides the statement count by that factor.
+ *
+ * That is a smaller constant, not count-independence: this returns as many
+ * statements as the rows require and knows nothing about the caller's other
+ * queries, so the end-to-end invocation budget stays the caller's problem. See
+ * the bounds table in docs/plans/managed-skills.md for the surviving cliffs.
+ *
+ * Rows are column-keyed objects rather than positional tuples so a column can
+ * never drift from its value: the column list comes from the rows themselves,
+ * and each row is read back by key rather than by position.
  *
  * The result is ordinary parameterized SQL, so callers splice it into an
  * existing batch() and keep the surrounding write atomic. Multi-row VALUES is
  * standard SQL, so this needs no engine branch.
  *
- * `table` and `columns` are interpolated into the statement text: pass literals,
- * never anything derived from a request.
+ * `table` and the row keys are interpolated into the statement text: pass
+ * literals, never anything derived from a request.
  */
 export function bulkInsertStatements(
   db: SqlDatabase,
   table: string,
-  columns: readonly string[],
-  rows: readonly (readonly unknown[])[]
+  rows: readonly Readonly<Record<string, unknown>>[]
 ): SqlStatement[] {
+  const [first] = rows;
+  if (!first) return [];
+  const columns = Object.keys(first);
+  if (columns.length === 0) {
+    throw new Error(`Cannot bulk insert into ${table}: rows have no columns`);
+  }
   const rowsPerStatement = Math.floor(MAX_D1_QUERY_PARAMETERS / columns.length);
   if (rowsPerStatement < 1) {
     throw new Error(
       `Cannot bulk insert into ${table}: ${columns.length} columns exceeds the parameter ceiling`
     );
   }
+  const expected = new Set(columns);
   const rowPlaceholder = `(${columns.map(() => "?").join(", ")})`;
   const statements: SqlStatement[] = [];
   for (let start = 0; start < rows.length; start += rowsPerStatement) {
     const chunk = rows.slice(start, start + rowsPerStatement);
     const values: unknown[] = [];
     for (const row of chunk) {
-      if (row.length !== columns.length) {
+      const keys = Object.keys(row);
+      if (keys.length !== expected.size || keys.some((key) => !expected.has(key))) {
         throw new Error(
-          `Cannot bulk insert into ${table}: row has ${row.length} values for ${columns.length} columns`
+          `Cannot bulk insert into ${table}: rows disagree on columns (${keys.join(", ")})`
         );
       }
-      values.push(...row);
+      for (const column of columns) values.push(row[column]);
     }
     statements.push(
       db

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -48,20 +48,6 @@ const TERMINAL_STATUS_SQL = TERMINAL_STATUSES.map((status) => `'${status}'`).joi
 
 const CHILD_ADMISSION_LEASE_TTL_MS = 5 * 60 * 1000;
 
-/** Column order for pinned-manifest inserts; must match bindManifestCopy's SELECT. */
-const SESSION_SKILL_REVISION_COLUMNS = [
-  "session_id",
-  "position",
-  "skill_id",
-  "revision_id",
-  "skill_name",
-  "description",
-  "revision_number",
-  "revision_sha256",
-  "total_bytes",
-  "assignment_sources",
-] as const;
-
 export interface ChildAdmissionLease {
   token: string;
   childSessionId: string;
@@ -407,19 +393,18 @@ export class SessionIndexStore {
       ...bulkInsertStatements(
         this.db,
         "session_skill_revisions",
-        SESSION_SKILL_REVISION_COLUMNS,
-        manifest.skills.map((skill, position) => [
-          sessionId,
+        manifest.skills.map((skill, position) => ({
+          session_id: sessionId,
           position,
-          skill.skillId,
-          skill.revisionId,
-          skill.name,
-          skill.description,
-          skill.revisionNumber,
-          skill.revisionSha256,
-          skill.totalBytes,
-          JSON.stringify(skill.assignmentSources),
-        ])
+          skill_id: skill.skillId,
+          revision_id: skill.revisionId,
+          skill_name: skill.name,
+          description: skill.description,
+          revision_number: skill.revisionNumber,
+          revision_sha256: skill.revisionSha256,
+          total_bytes: skill.totalBytes,
+          assignment_sources: JSON.stringify(skill.assignmentSources),
+        }))
       ),
     ];
   }

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -21,6 +21,7 @@ import {
   type ModelProviderId,
   type SessionModelProviderAuthInput,
 } from "../model-provider-accounts/provider-auth-contracts";
+import { bulkInsertStatements } from "./bulk-insert";
 import { attachSessionListMetadata } from "./session-list-metadata";
 import {
   SessionInboxStore,
@@ -46,6 +47,20 @@ const TERMINAL_STATUSES = [
 const TERMINAL_STATUS_SQL = TERMINAL_STATUSES.map((status) => `'${status}'`).join(", ");
 
 const CHILD_ADMISSION_LEASE_TTL_MS = 5 * 60 * 1000;
+
+/** Column order for pinned-manifest inserts; must match bindManifestCopy's SELECT. */
+const SESSION_SKILL_REVISION_COLUMNS = [
+  "session_id",
+  "position",
+  "skill_id",
+  "revision_id",
+  "skill_name",
+  "description",
+  "revision_number",
+  "revision_sha256",
+  "total_bytes",
+  "assignment_sources",
+] as const;
 
 export interface ChildAdmissionLease {
   token: string;
@@ -363,6 +378,10 @@ export class SessionIndexStore {
    * Build manifest statements for the session-creation batch. The caller owns
    * execution so the session, repository snapshot, and pinned skills commit
    * atomically rather than leaving a partially initialized session.
+   *
+   * Revisions are packed into multi-row INSERTs: the pinned set is as wide as
+   * the applicable catalog, and a statement per skill would spend the
+   * invocation's whole query budget on one session create.
    */
   private bindManifestInserts(
     sessionId: string,
@@ -385,26 +404,22 @@ export class SessionIndexStore {
           manifest.manifestSha256,
           manifest.resolvedAt
         ),
-      ...manifest.skills.map((skill, position) =>
-        this.db
-          .prepare(
-            `INSERT INTO session_skill_revisions
-             (session_id, position, skill_id, revision_id, skill_name, description,
-              revision_number, revision_sha256, total_bytes, assignment_sources)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-          )
-          .bind(
-            sessionId,
-            position,
-            skill.skillId,
-            skill.revisionId,
-            skill.name,
-            skill.description,
-            skill.revisionNumber,
-            skill.revisionSha256,
-            skill.totalBytes,
-            JSON.stringify(skill.assignmentSources)
-          )
+      ...bulkInsertStatements(
+        this.db,
+        "session_skill_revisions",
+        SESSION_SKILL_REVISION_COLUMNS,
+        manifest.skills.map((skill, position) => [
+          sessionId,
+          position,
+          skill.skillId,
+          skill.revisionId,
+          skill.name,
+          skill.description,
+          skill.revisionNumber,
+          skill.revisionSha256,
+          skill.totalBytes,
+          JSON.stringify(skill.assignmentSources),
+        ])
       ),
     ];
   }

--- a/packages/control-plane/src/db/session-skills.ts
+++ b/packages/control-plane/src/db/session-skills.ts
@@ -49,21 +49,34 @@ export class SessionSkillStore {
   /**
    * Project the pinned snapshot into the narrow sandbox installation contract.
    * Persisted revisions fail closed if their generated SKILL.md is missing.
+   *
+   * `page` narrows the response to one window of manifest positions. Pinned
+   * revisions are immutable, so paging by position is stable and every page
+   * carries the same `manifestSha256`; omitting `page` returns the whole
+   * installation, which is the contract older sandbox runtimes expect.
    */
-  async getSandboxInstallation(sessionId: string): Promise<SandboxSkillInstallation | null> {
-    const loaded = await this.load(sessionId);
+  async getSandboxInstallation(
+    sessionId: string,
+    page?: { after: number; limit: number }
+  ): Promise<SandboxSkillInstallation | null> {
+    // One extra row distinguishes "page is full" from "more remain" without a
+    // second count query.
+    const loaded = await this.load(sessionId, page && { ...page, limit: page.limit + 1 });
     if (!loaded) return null;
-    const filesByRevision = await new SkillStore(this.db).filesForSessionRevisions(sessionId);
+    const hasMore = page !== undefined && loaded.revisions.length > page.limit;
+    const revisions = hasMore ? loaded.revisions.slice(0, page.limit) : loaded.revisions;
+    const filesByRevision = await new SkillStore(this.db).filesForSessionRevisions(sessionId, page);
     const installation = {
       schemaVersion: 1,
       manifestSha256: loaded.manifest.manifest_sha256,
-      skills: loaded.revisions.map((row) => {
+      skills: revisions.map((row) => {
         const files = filesByRevision.get(row.revision_id);
         if (!files?.some((file) => file.path === "SKILL.md")) {
           throw new Error(`Missing files for session skill revision ${row.revision_id}`);
         }
         return { name: row.skill_name, files };
       }),
+      nextCursor: hasMore ? String(revisions[revisions.length - 1]?.position) : null,
     };
     const parsed = sandboxSkillInstallationSchema.safeParse(installation);
     if (!parsed.success) {
@@ -75,7 +88,8 @@ export class SessionSkillStore {
   }
 
   private async load(
-    sessionId: string
+    sessionId: string,
+    page?: { after: number; limit: number }
   ): Promise<{ manifest: ManifestRow; revisions: RevisionRow[] } | null> {
     const manifest = await this.db
       .prepare("SELECT * FROM session_skill_manifests WHERE session_id = ?")
@@ -83,8 +97,13 @@ export class SessionSkillStore {
       .first<ManifestRow>();
     if (!manifest) return null;
     const revisions = await this.db
-      .prepare("SELECT * FROM session_skill_revisions WHERE session_id = ? ORDER BY position")
-      .bind(sessionId)
+      .prepare(
+        page
+          ? `SELECT * FROM session_skill_revisions
+             WHERE session_id = ? AND position > ? ORDER BY position LIMIT ?`
+          : "SELECT * FROM session_skill_revisions WHERE session_id = ? ORDER BY position"
+      )
+      .bind(...(page ? [sessionId, page.after, page.limit] : [sessionId]))
       .all<RevisionRow>();
     return { manifest, revisions: revisions.results ?? [] };
   }

--- a/packages/control-plane/src/db/skill-profiles.ts
+++ b/packages/control-plane/src/db/skill-profiles.ts
@@ -171,8 +171,7 @@ export class SkillProfileStore {
     return bulkInsertStatements(
       this.db,
       "skill_profile_items",
-      ["profile_id", "skill_id"],
-      [...new Set(skillIds)].map((skillId) => [profileId, skillId])
+      [...new Set(skillIds)].map((skillId) => ({ profile_id: profileId, skill_id: skillId }))
     );
   }
 

--- a/packages/control-plane/src/db/skill-profiles.ts
+++ b/packages/control-plane/src/db/skill-profiles.ts
@@ -1,5 +1,6 @@
 import type { SkillProfile } from "@open-inspect/shared/types/skills";
 import { generateId } from "../auth/crypto";
+import { bulkInsertStatements } from "./bulk-insert";
 import { MAX_D1_QUERY_PARAMETERS } from "./query-limits";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
 
@@ -161,11 +162,17 @@ export class SkillProfileStore {
     }
   }
 
+  /**
+   * Pack membership rows into multi-row INSERTs. Profile size is caller-chosen,
+   * so a statement per member would let one profile write exhaust the
+   * invocation's query budget; the statements stay batchable either way.
+   */
   private itemStatements(profileId: string, skillIds: string[]): SqlStatement[] {
-    return [...new Set(skillIds)].map((skillId) =>
-      this.db
-        .prepare("INSERT INTO skill_profile_items (profile_id, skill_id) VALUES (?, ?)")
-        .bind(profileId, skillId)
+    return bulkInsertStatements(
+      this.db,
+      "skill_profile_items",
+      ["profile_id", "skill_id"],
+      [...new Set(skillIds)].map((skillId) => [profileId, skillId])
     );
   }
 

--- a/packages/control-plane/src/db/skills.ts
+++ b/packages/control-plane/src/db/skills.ts
@@ -378,24 +378,31 @@ export class SkillStore {
   }
 
   /**
-   * Load installation files for every revision a session pinned.
+   * Load installation files for the revisions a session pinned, optionally
+   * narrowed to one page of manifest positions.
    *
    * Keyed by session rather than by a revision-ID list on purpose: the IDs
    * already live in `session_skill_revisions`, so passing them back as bound
    * parameters would cap the manifest at the engine's parameter ceiling for no
-   * gain. One statement, one parameter, no chunking, no ceiling.
+   * gain. Narrowing by position keeps that property — three parameters whether
+   * the page holds one revision or a thousand.
    */
-  async filesForSessionRevisions(sessionId: string): Promise<Map<string, SkillFile[]>> {
+  async filesForSessionRevisions(
+    sessionId: string,
+    page?: { after: number; limit: number }
+  ): Promise<Map<string, SkillFile[]>> {
+    const pinnedRevisions = page
+      ? `SELECT revision_id FROM session_skill_revisions
+         WHERE session_id = ? AND position > ? ORDER BY position LIMIT ?`
+      : "SELECT revision_id FROM session_skill_revisions WHERE session_id = ?";
     const result = await this.db
       .prepare(
         `SELECT f.revision_id, f.path, f.content, f.content_sha256, f.size_bytes, f.executable
          FROM skill_revision_files f
-         WHERE f.revision_id IN (
-           SELECT revision_id FROM session_skill_revisions WHERE session_id = ?
-         )
+         WHERE f.revision_id IN (${pinnedRevisions})
          ORDER BY f.revision_id, f.path`
       )
-      .bind(sessionId)
+      .bind(...(page ? [sessionId, page.after, page.limit] : [sessionId]))
       .all<FileRow & { revision_id: string }>();
     const files = new Map<string, SkillFile[]>();
     for (const row of result.results ?? []) {

--- a/packages/control-plane/src/routes/session-skills.ts
+++ b/packages/control-plane/src/routes/session-skills.ts
@@ -1,3 +1,4 @@
+import { MAX_SANDBOX_SKILL_PAGE_SIZE } from "@open-inspect/shared/types/skills";
 import { SessionIndexStore } from "../db/session-index";
 import { SessionSkillStore } from "../db/session-skills";
 import { hashSessionSkillManifest } from "../skills/content-addressing";
@@ -36,15 +37,40 @@ async function handleSessionSkillsView(
   return response;
 }
 
+/**
+ * Read the optional page window. Absent `limit` means the caller wants the whole
+ * installation in one response, which is how sandbox runtimes predating paging
+ * call this endpoint.
+ */
+function installationPage(request: Request): { after: number; limit: number } | Response | null {
+  const params = new URL(request.url).searchParams;
+  const rawLimit = params.get("limit");
+  if (rawLimit === null) return null;
+  const limit = Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_SANDBOX_SKILL_PAGE_SIZE) {
+    return error(`limit must be an integer between 1 and ${MAX_SANDBOX_SKILL_PAGE_SIZE}`, 400);
+  }
+  const rawCursor = params.get("cursor");
+  if (rawCursor === null) return { after: -1, limit };
+  const after = Number(rawCursor);
+  if (!Number.isInteger(after) || after < 0) return error("cursor is not a valid position", 400);
+  return { after, limit };
+}
+
 async function handleSandboxInstallation(
-  _request: Request,
+  request: Request,
   _env: Env,
   match: RegExpMatchArray,
   ctx: SandboxRouteContext
 ): Promise<Response> {
   const id = sessionId(match);
   if (id instanceof Response) return id;
-  const manifest = await new SessionSkillStore(ctx.db).getSandboxInstallation(id);
+  const page = installationPage(request);
+  if (page instanceof Response) return page;
+  const manifest = await new SessionSkillStore(ctx.db).getSandboxInstallation(
+    id,
+    page ?? undefined
+  );
   // Sessions created before managed-skills shipped have no pinned row. Treat
   // them as an empty legacy manifest so snapshot restores remain bootable.
   const resolvedManifest =
@@ -54,11 +80,14 @@ async function handleSandboxInstallation(
           schemaVersion: 1 as const,
           manifestSha256: await hashSessionSkillManifest({ mode: "all" }, []),
           skills: [],
+          nextCursor: null,
         }
       : null);
   if (!resolvedManifest) return error("Session skill manifest not found", 404);
   const response = json(resolvedManifest);
-  response.headers.set("ETag", `"${resolvedManifest.manifestSha256}"`);
+  // The digest covers the whole manifest, so it is stable across pages and
+  // cannot identify one. Only tag a response that is the entire installation.
+  if (page === null) response.headers.set("ETag", `"${resolvedManifest.manifestSha256}"`);
   response.headers.set("Cache-Control", "private, no-store");
   return response;
 }

--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -381,14 +381,25 @@ describe("managed skills persistence and resolution", () => {
     const installation = await new SessionSkillStore(env.DB).getSandboxInstallation("wide");
     expect(installation?.skills).toHaveLength(101);
     expect(installation?.skills.every((skill) => skill.files.length === 2)).toBe(true);
+    // Revisions are written in multi-row chunks, so prove `position` survives the
+    // chunk boundaries rather than only that the right number of rows landed.
+    expect(installation?.skills.map((skill) => skill.name)).toEqual(
+      manifest.skills.map((skill) => skill.name)
+    );
 
     // validateSkillIds chunks the same way, and profiles no longer cap length.
-    const profile = await new SkillProfileStore(env.DB).create(
+    const profiles = new SkillProfileStore(env.DB);
+    const profile = await profiles.create(
       "user_1",
       "Everything",
       catalog.map(({ id }) => id)
     );
     expect(profile.skillIds).toHaveLength(101);
+    // create() returns its own input, so read membership back to prove the
+    // chunked item inserts committed every row.
+    await expect(profiles.getOwned(profile.id, "user_1")).resolves.toMatchObject({
+      skillIds: catalog.map(({ id }) => id).sort(),
+    });
   });
 
   it("maps typed profile validation and conflict failures", async () => {

--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -402,6 +402,72 @@ describe("managed skills persistence and resolution", () => {
     });
   });
 
+  it("pages the sandbox installation without changing the unpaged contract", async () => {
+    await seedGlobalCatalog(101);
+    const manifest = await resolveManagedSkills(
+      env.DB,
+      { repositories: [], environmentId: null },
+      { mode: "all" },
+      "user_1"
+    );
+    await new SessionIndexStore(env.DB).create({
+      id: "paged",
+      title: null,
+      repoOwner: null,
+      repoName: null,
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "created" as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      skillManifest: manifest,
+    });
+    const { stub } = await initNamedSessionDO("paged");
+    await seedSandboxAuthHash(stub, { authToken: "paged-token", sandboxId: "sandbox-paged" });
+    const fetchPage = (query: string) =>
+      SELF.fetch(`https://test.local/sessions/paged/sandbox-skills${query}`, {
+        headers: { Authorization: "Bearer paged-token" },
+      });
+
+    const names: string[] = [];
+    const digests = new Set<string>();
+    let cursor: string | null = null;
+    let requests = 0;
+    do {
+      const response = await fetchPage(`?limit=25${cursor === null ? "" : `&cursor=${cursor}`}`);
+      expect(response.status).toBe(200);
+      // The digest covers the whole manifest, so a page must not claim it.
+      expect(response.headers.get("ETag")).toBeNull();
+      const page = await response.json<{
+        manifestSha256: string;
+        skills: { name: string }[];
+        nextCursor: string | null;
+      }>();
+      expect(page.skills.length).toBeLessThanOrEqual(25);
+      digests.add(page.manifestSha256);
+      names.push(...page.skills.map((skill) => skill.name));
+      cursor = page.nextCursor;
+      requests += 1;
+    } while (cursor !== null);
+
+    expect(requests).toBe(5);
+    expect(names).toEqual(manifest.skills.map((skill) => skill.name));
+    // Pinned revisions are immutable, so every page describes one installation.
+    expect([...digests]).toEqual([manifest.manifestSha256]);
+
+    // A runtime that predates paging sends no limit and must still get all of it.
+    const whole = await fetchPage("");
+    expect(whole.headers.get("ETag")).toBe(`"${manifest.manifestSha256}"`);
+    const unpaged = await whole.json<{ skills: { name: string }[]; nextCursor: string | null }>();
+    expect(unpaged.nextCursor).toBeNull();
+    expect(unpaged.skills.map((skill) => skill.name)).toEqual(names);
+
+    await expect(fetchPage("?limit=0").then((r) => r.status)).resolves.toBe(400);
+    await expect(fetchPage("?limit=201").then((r) => r.status)).resolves.toBe(400);
+    await expect(fetchPage("?limit=25&cursor=nope").then((r) => r.status)).resolves.toBe(400);
+  });
+
   it("maps typed profile validation and conflict failures", async () => {
     const first = await serviceFetch("https://test.local/skill-profiles", {
       method: "POST",

--- a/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
@@ -38,9 +38,6 @@ MANAGED_SKILLS_RETRY_BASE_SECONDS = 0.25
 # even while passing resolution. Requesting a fixed window keeps every response
 # far below MAX_MANAGED_SKILL_RESPONSE_BYTES regardless of how wide it is.
 MANAGED_SKILLS_PAGE_SIZE = 50
-# Backstop against a control plane that keeps handing back a cursor. Sized well
-# past any real catalog: exceeding it is a bug, not a large installation.
-MANAGED_SKILLS_MAX_PAGES = 1000
 
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -361,6 +358,17 @@ def validate_installation_page(
             "managed skills content exceeds the session size limit", code="installation_too_large"
         )
 
+    # A page that promises more must deliver something. Without this a control
+    # plane could hand back empty pages and an advancing cursor forever; with
+    # it, every non-final page adds at least one skill, every skill adds a
+    # non-empty SKILL.md to the content aggregate, and the 5 MiB check above
+    # therefore terminates the traversal. A repeated page terminates earlier
+    # still, on the duplicate-name check.
+    if next_cursor is not None and not skills:
+        raise ManagedSkillsError(
+            "managed skills page is empty but claims more", code="installation_invalid"
+        )
+
     page = ManagedSkillInstallationPage(manifest_sha256, tuple(skills), next_cursor)
     return page, installation_content_bytes
 
@@ -585,12 +593,18 @@ class ManagedSkillsMaterializer:
         Nothing outside the staging tree is touched until the caller commits, so
         a failure part-way through a paged fetch leaves the previous
         installation in place.
+
+        The loop has no page-count bound on purpose. A fixed one would cap the
+        installation at pages times page size, reintroducing exactly the kind of
+        invented skill limit this work removed; the session contract bounds
+        aggregate content, not count. Termination comes from that contract
+        instead — see validate_installation_page.
         """
         names: set[str] = set()
         content_bytes = 0
         manifest_sha256: str | None = None
         cursor: str | None = None
-        for _ in range(MANAGED_SKILLS_MAX_PAGES):
+        while True:
             raw = await self.client.fetch_installation(
                 cursor=cursor, limit=MANAGED_SKILLS_PAGE_SIZE
             )
@@ -605,9 +619,6 @@ class ManagedSkillsMaterializer:
             if page.next_cursor is None:
                 return manifest_sha256, names
             cursor = page.next_cursor
-        raise ManagedSkillsError(
-            "managed skills installation did not finish paging", code="installation_invalid"
-        )
 
     async def materialize(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
         """Fetch, validate, collision-check, and install skills before OpenCode starts."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
@@ -18,6 +18,7 @@ import httpx
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Set as AbstractSet
 
     from .repo_config import RepoEntry
 
@@ -32,6 +33,14 @@ MAX_MANAGED_SKILL_RESPONSE_BYTES = 32 * 1024 * 1024
 MANAGED_SKILLS_FETCH_TIMEOUT_SECONDS = 15.0
 MANAGED_SKILLS_REQUEST_ATTEMPTS = 3
 MANAGED_SKILLS_RETRY_BASE_SECONDS = 0.25
+# Skills per request. Per-file JSON framing does not count against the manifest's
+# content aggregate, so a wide manifest can exceed a single response's ceiling
+# even while passing resolution. Requesting a fixed window keeps every response
+# far below MAX_MANAGED_SKILL_RESPONSE_BYTES regardless of how wide it is.
+MANAGED_SKILLS_PAGE_SIZE = 50
+# Backstop against a control plane that keeps handing back a cursor. Sized well
+# past any real catalog: exceeding it is a bug, not a large installation.
+MANAGED_SKILLS_MAX_PAGES = 1000
 
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -70,6 +79,15 @@ class ManagedSkillInstallation:
     skills: tuple[ManagedSkill, ...]
 
 
+@dataclass(frozen=True)
+class ManagedSkillInstallationPage:
+    """One response's worth of an installation, plus where to resume."""
+
+    manifest_sha256: str
+    skills: tuple[ManagedSkill, ...]
+    next_cursor: str | None
+
+
 class ManagedSkillsClient:
     """Provider-neutral async client for the sandbox-only skills endpoints."""
 
@@ -91,8 +109,20 @@ class ManagedSkillsClient:
         session_id = quote(self._session_id, safe="")
         return f"{self._base_url}/sessions/{session_id}/sandbox-skills"
 
-    async def fetch_installation(self) -> bytes:
-        """Fetch the session-bound installation DTO with bounded retries and response size."""
+    async def fetch_installation(
+        self, *, cursor: str | None = None, limit: int | None = None
+    ) -> bytes:
+        """Fetch one page of the session-bound installation DTO.
+
+        Omitting `limit` requests the whole installation in one response, which
+        is the shape a control plane predating paging returns either way.
+        """
+        url = self._skills_url
+        if limit is not None:
+            query = f"limit={limit}"
+            if cursor is not None:
+                query += f"&cursor={quote(cursor, safe='')}"
+            url = f"{url}?{query}"
         last_error: Exception | None = None
         for attempt in range(MANAGED_SKILLS_REQUEST_ATTEMPTS):
             try:
@@ -100,7 +130,7 @@ class ManagedSkillsClient:
                     httpx.AsyncClient(transport=self._transport) as client,
                     client.stream(
                         "GET",
-                        self._skills_url,
+                        url,
                         headers=self._headers,
                         timeout=MANAGED_SKILLS_FETCH_TIMEOUT_SECONDS,
                     ) as response,
@@ -187,11 +217,35 @@ def _validate_path(value: Any) -> str:
 
 
 def validate_installation(raw: bytes) -> ManagedSkillInstallation:
+    """Validate a complete installation delivered as a single response."""
+    page, _ = validate_installation_page(
+        raw, names=set(), content_bytes=0, expected_manifest_sha256=None
+    )
+    if page.next_cursor is not None:
+        raise ManagedSkillsError(
+            "managed skills installation is paged but was read whole",
+            code="installation_invalid",
+        )
+    return ManagedSkillInstallation(page.manifest_sha256, page.skills)
+
+
+def validate_installation_page(
+    raw: bytes,
+    *,
+    names: set[str],
+    content_bytes: int,
+    expected_manifest_sha256: str | None,
+) -> tuple[ManagedSkillInstallationPage, int]:
     """Validate untrusted installation bytes independently of the control plane.
 
     The narrow DTO omits selection and assignment provenance, so manifest_sha256
     is an opaque identifier here. File hashes, paths, sizes, names, and modes are
     validated locally before any content reaches an OpenCode discovery path.
+
+    Duplicate skill names and the content aggregate are properties of the whole
+    installation, not of one response, so `names` is read and extended in place
+    and `content_bytes` carries forward. `expected_manifest_sha256` pins every
+    page after the first to the installation the first page described.
     """
     if len(raw) > MAX_MANAGED_SKILL_RESPONSE_BYTES:
         raise ManagedSkillsError(
@@ -213,13 +267,19 @@ def validate_installation(raw: bytes) -> ManagedSkillInstallation:
             "unsupported managed skills schema version", code="installation_invalid"
         )
     manifest_sha256 = _validate_sha256(installation["manifestSha256"], "manifest SHA-256")
+    if expected_manifest_sha256 is not None and manifest_sha256 != expected_manifest_sha256:
+        raise ManagedSkillsError(
+            "managed skills pages describe different manifests", code="installation_invalid"
+        )
+    next_cursor = installation.get("nextCursor")
+    if next_cursor is not None:
+        next_cursor = _require_string(next_cursor, "managed skills cursor")
     raw_skills = installation["skills"]
     if not isinstance(raw_skills, list):
         raise ManagedSkillsError("invalid managed skills list", code="installation_invalid")
 
     skills: list[ManagedSkill] = []
-    names: set[str] = set()
-    installation_content_bytes = 0
+    installation_content_bytes = content_bytes
     for raw_skill in raw_skills:
         skill = _require_object(
             raw_skill,
@@ -301,7 +361,8 @@ def validate_installation(raw: bytes) -> ManagedSkillInstallation:
             "managed skills content exceeds the session size limit", code="installation_too_large"
         )
 
-    return ManagedSkillInstallation(manifest_sha256, tuple(skills))
+    page = ManagedSkillInstallationPage(manifest_sha256, tuple(skills), next_cursor)
+    return page, installation_content_bytes
 
 
 def _canonical_frontmatter_name(markdown: str) -> str | None:
@@ -390,12 +451,11 @@ class ManagedSkillsMaterializer:
 
     def _check_collisions(
         self,
-        installation: ManagedSkillInstallation,
+        selected: AbstractSet[str],
         repositories: Sequence[RepoEntry],
         workdir: Path,
     ) -> None:
         """Reject ambiguous names across every OpenCode skill discovery root."""
-        selected = {skill.name for skill in installation.skills}
         for root in self._collision_roots(repositories, workdir):
             if not root.is_dir():
                 continue
@@ -456,12 +516,8 @@ class ManagedSkillsMaterializer:
         finally:
             os.close(descriptor)
 
-    def _install(self, installation: ManagedSkillInstallation) -> None:
-        """Replace the complete managed tree using a recoverable same-filesystem swap.
-
-        The durable marker must precede moving the current tree. Recovery keeps
-        an installed destination when present, or restores the backup otherwise.
-        """
+    def _begin_staging(self) -> tuple[Path, Path, Path]:
+        """Recover any interrupted swap and open an empty staging tree."""
         parent = self.destination.parent
         parent.mkdir(parents=True, exist_ok=True)
         staging = parent / ".managed-skills-staging"
@@ -474,37 +530,96 @@ class ManagedSkillsMaterializer:
             raise ManagedSkillsError(
                 "managed skills destination is not a directory", code="install_failed"
             )
-
         staging.mkdir(mode=0o700)
+        return staging, backup, journal
+
+    def _stage_skills(self, staging: Path, skills: Sequence[ManagedSkill]) -> None:
+        """Write one batch of validated skills into the staging tree.
+
+        Called once per fetched page, so peak memory is a page rather than the
+        whole installation. Skill directories are created exclusively, which
+        makes a duplicate name that slipped past validation fail here too.
+        """
+        for skill in sorted(skills, key=lambda item: item.name.encode("utf-8")):
+            skill_dir = staging / skill.name
+            skill_dir.mkdir(mode=0o700)
+            for file in sorted(skill.files, key=lambda item: item.path.encode("utf-8")):
+                self._write_file(skill_dir / PurePosixPath(file.path), file)
+
+    def _commit_staging(self, staging: Path, backup: Path, journal: Path) -> None:
+        """Swap the staged tree in, recoverably.
+
+        The durable marker must precede moving the current tree. Recovery keeps
+        an installed destination when present, or restores the backup otherwise.
+        """
+        parent = self.destination.parent
+        self._write_journal(journal)
+        if self.destination.exists():
+            self.destination.rename(backup)
+            self._fsync_directory(parent)
+        staging.rename(self.destination)
+        self._fsync_directory(parent)
+        self._remove_path(backup)
+        journal.unlink(missing_ok=True)
+        self._fsync_directory(parent)
+
+    def _abort_staging(self, staging: Path, backup: Path, journal: Path) -> None:
+        if not self.destination.exists() and backup.exists():
+            backup.rename(self.destination)
+        self._remove_path(staging)
+        journal.unlink(missing_ok=True)
+
+    def _install(self, installation: ManagedSkillInstallation) -> None:
+        """Replace the complete managed tree from an already-assembled installation."""
+        staging, backup, journal = self._begin_staging()
         try:
-            for skill in sorted(installation.skills, key=lambda item: item.name.encode("utf-8")):
-                skill_dir = staging / skill.name
-                skill_dir.mkdir(mode=0o700)
-                for file in sorted(skill.files, key=lambda item: item.path.encode("utf-8")):
-                    self._write_file(skill_dir / PurePosixPath(file.path), file)
-            self._write_journal(journal)
-            if self.destination.exists():
-                self.destination.rename(backup)
-                self._fsync_directory(parent)
-            staging.rename(self.destination)
-            self._fsync_directory(parent)
-            self._remove_path(backup)
-            journal.unlink(missing_ok=True)
-            self._fsync_directory(parent)
+            self._stage_skills(staging, installation.skills)
+            self._commit_staging(staging, backup, journal)
         except Exception:
-            if not self.destination.exists() and backup.exists():
-                backup.rename(self.destination)
-            self._remove_path(staging)
-            journal.unlink(missing_ok=True)
+            self._abort_staging(staging, backup, journal)
             raise
+
+    async def _fetch_into_staging(self, staging: Path) -> tuple[str, set[str]]:
+        """Stream every page into staging, returning the digest and installed names.
+
+        Nothing outside the staging tree is touched until the caller commits, so
+        a failure part-way through a paged fetch leaves the previous
+        installation in place.
+        """
+        names: set[str] = set()
+        content_bytes = 0
+        manifest_sha256: str | None = None
+        cursor: str | None = None
+        for _ in range(MANAGED_SKILLS_MAX_PAGES):
+            raw = await self.client.fetch_installation(
+                cursor=cursor, limit=MANAGED_SKILLS_PAGE_SIZE
+            )
+            page, content_bytes = validate_installation_page(
+                raw,
+                names=names,
+                content_bytes=content_bytes,
+                expected_manifest_sha256=manifest_sha256,
+            )
+            manifest_sha256 = page.manifest_sha256
+            self._stage_skills(staging, page.skills)
+            if page.next_cursor is None:
+                return manifest_sha256, names
+            cursor = page.next_cursor
+        raise ManagedSkillsError(
+            "managed skills installation did not finish paging", code="installation_invalid"
+        )
 
     async def materialize(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
         """Fetch, validate, collision-check, and install skills before OpenCode starts."""
         try:
-            raw = await self.client.fetch_installation()
-            installation = validate_installation(raw)
-            self._check_collisions(installation, repositories, workdir)
-            self._install(installation)
+            staging, backup, journal = self._begin_staging()
+            try:
+                manifest_sha256, names = await self._fetch_into_staging(staging)
+                self._check_collisions(names, repositories, workdir)
+                self._commit_staging(staging, backup, journal)
+            except Exception:
+                self._abort_staging(staging, backup, journal)
+                raise
         except ManagedSkillsError:
             raise
         except Exception as error:
@@ -514,6 +629,6 @@ class ManagedSkillsMaterializer:
 
         self.log.info(
             "managed_skills.materialized",
-            manifest_sha256=installation.manifest_sha256,
-            skill_count=len(installation.skills),
+            manifest_sha256=manifest_sha256,
+            skill_count=len(names),
         )

--- a/packages/sandbox-runtime/tests/test_managed_skills.py
+++ b/packages/sandbox-runtime/tests/test_managed_skills.py
@@ -197,6 +197,132 @@ async def test_materializer_ignores_invalid_utf8_during_collision_scan(tmp_path)
     assert (destination / "managed" / "SKILL.md").exists()
 
 
+def _page(names, *, next_cursor=None, manifest_sha256="a" * 64):
+    """A response carrying `names` as one page of a wider installation."""
+    document = {
+        "schemaVersion": 1,
+        "manifestSha256": manifest_sha256,
+        "skills": [_installation(name=name)["skills"][0] for name in names],
+        "nextCursor": next_cursor,
+    }
+    return json.dumps(document).encode()
+
+
+async def test_materializer_installs_every_page(tmp_path):
+    pages = [
+        _page(["alpha", "beta"], next_cursor="1"),
+        _page(["gamma"], next_cursor="2"),
+        _page(["delta"]),
+    ]
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(side_effect=pages)
+    destination = tmp_path / "global" / "skills"
+    materializer = ManagedSkillsMaterializer(
+        client,
+        destination,
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    await materializer.materialize((), tmp_path / "workspace")
+
+    assert sorted(entry.name for entry in destination.iterdir()) == [
+        "alpha",
+        "beta",
+        "delta",
+        "gamma",
+    ]
+    # Every request must carry a page size, and each one resumes from the
+    # previous response's cursor.
+    assert [call.kwargs for call in client.fetch_installation.await_args_list] == [
+        {"cursor": None, "limit": 50},
+        {"cursor": "1", "limit": 50},
+        {"cursor": "2", "limit": 50},
+    ]
+
+
+async def test_materializer_keeps_previous_install_when_a_later_page_fails(tmp_path):
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(
+        side_effect=[
+            _page(["alpha"], next_cursor="1"),
+            ManagedSkillsError("boom", code="fetch_failed"),
+        ]
+    )
+    destination = tmp_path / "global" / "skills"
+    destination.mkdir(parents=True)
+    (destination / "previous").mkdir()
+    materializer = ManagedSkillsMaterializer(
+        client,
+        destination,
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    with pytest.raises(ManagedSkillsError, match="boom"):
+        await materializer.materialize((), tmp_path / "workspace")
+
+    # A partial fetch must never be swapped in: the tree is all-or-nothing.
+    assert [entry.name for entry in destination.iterdir()] == ["previous"]
+    assert not (tmp_path / "global" / ".managed-skills-staging").exists()
+
+
+async def test_materializer_rejects_pages_from_different_manifests(tmp_path):
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(
+        side_effect=[
+            _page(["alpha"], next_cursor="1"),
+            _page(["beta"], manifest_sha256="b" * 64),
+        ]
+    )
+    materializer = ManagedSkillsMaterializer(
+        client,
+        tmp_path / "global" / "skills",
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    with pytest.raises(ManagedSkillsError, match="different manifests"):
+        await materializer.materialize((), tmp_path / "workspace")
+
+
+async def test_materializer_rejects_duplicate_names_across_pages(tmp_path):
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(
+        side_effect=[_page(["alpha"], next_cursor="1"), _page(["alpha"])]
+    )
+    materializer = ManagedSkillsMaterializer(
+        client,
+        tmp_path / "global" / "skills",
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    with pytest.raises(ManagedSkillsError, match="duplicate managed skill name"):
+        await materializer.materialize((), tmp_path / "workspace")
+
+
+async def test_materializer_stops_a_cursor_that_never_terminates(tmp_path):
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(
+        side_effect=lambda **_: _page([], next_cursor="always-more")
+    )
+    materializer = ManagedSkillsMaterializer(
+        client,
+        tmp_path / "global" / "skills",
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    with pytest.raises(ManagedSkillsError, match="did not finish paging"):
+        await materializer.materialize((), tmp_path / "workspace")
+
+
+def test_validate_installation_rejects_a_page_read_as_a_whole():
+    with pytest.raises(ManagedSkillsError, match="paged"):
+        validate_installation(_page(["alpha"], next_cursor="1"))
+
+
 def test_materializer_repairs_interrupted_swap(tmp_path):
     destination = tmp_path / "skills"
     backup = tmp_path / ".managed-skills-backup"

--- a/packages/sandbox-runtime/tests/test_managed_skills.py
+++ b/packages/sandbox-runtime/tests/test_managed_skills.py
@@ -302,7 +302,8 @@ async def test_materializer_rejects_duplicate_names_across_pages(tmp_path):
         await materializer.materialize((), tmp_path / "workspace")
 
 
-async def test_materializer_stops_a_cursor_that_never_terminates(tmp_path):
+async def test_materializer_rejects_an_empty_page_that_claims_more(tmp_path):
+    """A page promising more must deliver something, or traversal cannot terminate."""
     client = MagicMock()
     client.fetch_installation = AsyncMock(
         side_effect=lambda **_: _page([], next_cursor="always-more")
@@ -314,8 +315,31 @@ async def test_materializer_stops_a_cursor_that_never_terminates(tmp_path):
         bundled_skills_path=tmp_path / "missing-bundled",
     )
 
-    with pytest.raises(ManagedSkillsError, match="did not finish paging"):
+    with pytest.raises(ManagedSkillsError, match="empty but claims more"):
         await materializer.materialize((), tmp_path / "workspace")
+
+
+async def test_materializer_traversal_is_not_capped_by_a_page_count(tmp_path):
+    """Installation width is bounded by aggregate content, never by a page count."""
+    total = 1010
+    pages = [
+        _page([f"skill-{index:04d}"], next_cursor=None if index == total - 1 else str(index))
+        for index in range(total)
+    ]
+    client = MagicMock()
+    client.fetch_installation = AsyncMock(side_effect=pages)
+    destination = tmp_path / "global" / "skills"
+    materializer = ManagedSkillsMaterializer(
+        client,
+        destination,
+        MagicMock(),
+        bundled_skills_path=tmp_path / "missing-bundled",
+    )
+
+    await materializer.materialize((), tmp_path / "workspace")
+
+    assert len(list(destination.iterdir())) == total
+    assert client.fetch_installation.await_count == total
 
 
 def test_validate_installation_rejects_a_page_read_as_a_whole():

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -310,6 +310,13 @@ export const sessionSkillsViewSchema = z.strictObject({
 });
 
 /** Narrow sandbox DTO: installation files only; provenance stays on the user-facing view. */
+/**
+ * Per-file JSON framing is excluded from the manifest's content aggregate, so a
+ * wide manifest can be accepted at resolution and still exceed the runtime's
+ * per-response ceiling. Runtimes that ask for a page size receive `nextCursor`
+ * and fetch the rest; runtimes that do not still receive the whole installation
+ * with `nextCursor: null`, which is what keeps restored older sandboxes working.
+ */
 export const sandboxSkillInstallationSchema = z.object({
   schemaVersion: z.literal(1),
   manifestSha256: z.string(),
@@ -319,7 +326,11 @@ export const sandboxSkillInstallationSchema = z.object({
       files: z.array(skillFileSchema),
     })
   ),
+  nextCursor: z.string().nullable().default(null),
 });
+
+/** Bounds on the page size a sandbox may request from the installation endpoint. */
+export const MAX_SANDBOX_SKILL_PAGE_SIZE = 200;
 
 export type SkillFileInput = z.infer<typeof skillFileInputSchema>;
 export type SkillContentInput = z.infer<typeof skillContentInputSchema>;


### PR DESCRIPTION
Closes #1550. Three commits, reviewable separately.

Removing the 20-skill cap in #1549 exposed three resources that scaled with skill **count** rather than content. None was enforced, so each surfaced as an engine error rather than a validation message.

| Resource                     | Was                            | Now                                          | Cliff         |
| ---------------------------- | ------------------------------ | -------------------------------------------- | ------------- |
| Installation payload         | Whole manifest in one response | 50 skills per response                       | none          |
| Session manifest persistence | One INSERT per skill           | 10 `session_skill_revisions` rows per INSERT | 9,041 skills  |
| Profile membership writes    | One INSERT per skill           | 50 `skill_profile_items` rows per INSERT     | 33,251 skills |

Transport is genuinely count-independent. The two write paths are **cliff-raised, not count-independent** — the residual linear term is tracked in #1552. Cliffs are the minimum end-to-end invocation cost (`5 + 0.11N` and `2 + 0.03N`), counting the callers' preceding reads, not just the new INSERTs.

---

## 1. `perf:` pack the two write paths into multi-row inserts

`SessionIndexStore.bindManifestInserts` and `SkillProfileStore.itemStatements` each emitted one `INSERT` per skill into a single `batch()`, so both spent D1's [1,000 queries per Worker invocation](https://developers.cloudflare.com/d1/platform/limits/) in proportion to catalog size — failing outright at roughly 1,000 skills. The cap had been holding them ~50× clear of it.

New `bulkInsertStatements` packs rows into multi-row `VALUES` sized to the 100-bound-parameter ceiling. Three properties preserved:

- **Atomicity.** The helper returns ordinary prepared statements, so they splice into the callers' existing `batch()` unchanged. The transaction boundary does not move.
- **Portability.** Multi-row `VALUES` is standard SQL — no engine branch. This is why `json_each(?)` was not used despite being count-*independent*: it is SQLite-only, and `SqlDatabase` is a types-only port erased at build time, so there is no runtime dispatch point to hang a branch on. Tracked as #1552.
- **Positional results.** `session-index.ts` reads `results[0]` to detect a skipped session insert; the session statement is still first.

Rows are column-keyed objects, not positional tuples: the column list is derived from the rows and each row is read back by key, so a column cannot drift from its value and there is no second column list to keep in sync.

## 2. `feat:` page the sandbox installation fetch

Per-file JSON framing (~134 bytes plus path length) counts against the runtime's 32 MiB `MAX_MANAGED_SKILL_RESPONSE_BYTES` but **not** against the 5 MiB content aggregate resolution checks. Past roughly 2,400 skills a manifest was accepted, persisted, and then failed closed at sandbox boot — the only case where an accepted manifest was not installable.

That ceiling is per-*response*, not per-session, so the fix is to page the fetch rather than add a count limit:

```text
GET /sessions/:id/sandbox-skills[?limit=<1..200>&cursor=<position>]
```

- Pinned revisions are immutable, so **position is a stable cursor** and every page of one installation reports the same `manifestSha256`. The runtime rejects a page whose digest differs from the first page's.
- The runtime requests a fixed 50-skill window and **stages each page as it arrives**, so peak memory is a page rather than the whole installation. Duplicate names and the content aggregate accumulate across pages, since those are properties of the installation and not of a response.
- The staging→swap remains all-or-nothing: a failure part-way through a paged fetch leaves the previous installation in place, verified by a test.
- Paging costs no bound parameters — the file query narrows by position inside the existing session-keyed subquery, so it is 3 parameters whether the page holds one revision or a thousand.

**Backward compatibility.** A request without `limit` still returns the entire installation with `nextCursor: null`. That is what sandbox runtimes predating this change send, and snapshots restore old runtime code against the current control plane, so the unpaged shape has to keep working. Only unpaged responses carry an `ETag` — the digest covers the whole manifest and cannot identify a page. Nothing consumes that header today.

---

## Verification

- New `bulk-insert.test.ts` — no statement exceeds the 100-parameter ceiling across column widths 1–100, placeholder count matches bound-value count, row-major bind order, rows read by key rather than insertion order, and rejection of empty/mismatched column sets.
- Extended the 101-skill integration test (real D1) to read manifest ordering and profile membership **back** rather than trusting echoed input — `create()` returns its own argument, so it could not have caught a lost chunk.
- New integration test pages a 101-skill installation at `limit=25`, asserting 5 requests, exact name order, one digest across all pages, no `ETag` on pages, and that the unpaged request still returns all 101.
- New Python tests: multi-page install, mid-fetch failure leaving the previous tree intact, mismatched digests across pages, duplicate names across pages, and a cursor that never terminates.
- Full suites green: control-plane 3003 unit / 931 integration, web 1143, sandbox-runtime 759. Lint and typecheck clean.

Local `workerd` does not enforce the hosted per-invocation query limit, so the integration tests cannot fail on that cliff directly; the unit test asserts the statement-shape property instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated sandbox skill installations with configurable page size and continuation cursors.
  * Added safeguards for consistent manifests, duplicate names, content limits, and incomplete pages during multi-page installations.
  * Preserved compatibility for clients requesting complete, unpaged installations.

* **Bug Fixes**
  * Installations now remain intact if a later page fails validation.
  * Improved handling of large skill profiles through batched processing.

* **Tests**
  * Expanded coverage for pagination, validation, ordering, compatibility, and large profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->