### PR TITLE
fix(sandbox): put /usr/sbin on PATH and install the account helpers

### DIFF
--- a/packages/control-plane/src/image-builds/rebuild-policy.test.ts
+++ b/packages/control-plane/src/image-builds/rebuild-policy.test.ts
@@ -71,9 +71,9 @@ describe("evaluateImageBuildRebuildPolicy", () => {
     }
 
     const current: Array<[ImageBuildProvider, string]> = [
-      ["modal", "v60-provider-account-broker"],
-      ["opencomputer", "v60-provider-account-broker"],
-      ["vercel", "v60-provider-account-broker"],
+      ["modal", COMPATIBLE_RUNTIME_VERSION],
+      ["opencomputer", COMPATIBLE_RUNTIME_VERSION],
+      ["vercel", COMPATIBLE_RUNTIME_VERSION],
     ];
     for (const [provider, runtime_version] of current) {
       expect(

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -6,6 +6,7 @@ import {
   openComputerSandboxApiResponseSchema,
   openComputerSecretStoreResponseSchema,
 } from "./opencomputer-rest-client";
+import { SANDBOX_RUNTIME_VERSION } from "./runtime-manifest";
 
 const config = {
   apiUrl: "https://api.opencomputer.dev",
@@ -45,7 +46,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
     const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v60-provider-account-broker");
+    expect(body.args[1]).toContain(`SANDBOX_VERSION=${SANDBOX_RUNTIME_VERSION}`);
   });
 
   it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
@@ -55,7 +56,7 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     await client.runRuntimeForeground("sb-1", 60);
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
-    expect(body.args[1]).toContain("SANDBOX_VERSION=v60-provider-account-broker");
+    expect(body.args[1]).toContain(`SANDBOX_VERSION=${SANDBOX_RUNTIME_VERSION}`);
   });
 });
 

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -50,6 +50,7 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # it, so bump every provider's label together.
 # v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
 # v60: generic provider-account token broker plugin
+# v61: account/init helpers and /usr/sbin on PATH
 CACHE_BUSTER = RUNTIME_VERSION
 
 # Base image with all development tools
@@ -65,6 +66,13 @@ base_image = (
         "openssh-client",
         "jq",
         "unzip",  # Required for Bun installation
+        # Account and init helpers. debian_slim ships without them, so nothing in
+        # a sandbox can create a system user, and services that refuse to run as
+        # root (Elasticsearch, Postgres, nginx) have no account to drop to.
+        "passwd",
+        "adduser",
+        "sysvinit-utils",
+        "procps",
         "ffmpeg",
         "xvfb",
         "fluxbox",
@@ -215,7 +223,11 @@ base_image = (
             "HOME": "/root",
             "NODE_ENV": "development",
             "PNPM_HOME": "/root/.local/share/pnpm",
-            "PATH": "/root/.bun/bin:/root/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin",
+            # /usr/sbin and /sbin carry useradd, service, and daemons like nginx.
+            # Sandbox commands run in non-interactive, non-login shells that never
+            # source /etc/profile, so without them on PATH those commands fail with
+            # "command not found" rather than anything that names the real problem.
+            "PATH": "/root/.bun/bin:/root/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
             "PYTHONPATH": "/app",
             "SANDBOX_VERSION": CACHE_BUSTER,
             # NODE_PATH for globally installed modules (used by custom tools)

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "v60-provider-account-broker",
-  "generation": 60,
+  "runtimeVersion": "v61-sandbox-sbin-path",
+  "generation": 61,
   "minimumCompatibleGeneration": 60,
   "minimumRebuildGeneration": 60
 }


### PR DESCRIPTION
## Summary

- `debian_slim` ships without `passwd`/`adduser`, so nothing in a sandbox can create a system user, and services that refuse to run as root (Elasticsearch, Postgres, nginx) have no account to drop to. Adds `passwd`, `adduser`, `sysvinit-utils` and `procps`.
- Installing them is not sufficient on its own: `useradd` and `service` live in `/usr/sbin`, which the image's pinned `PATH` omits, and sandbox commands run in non-interactive, non-login shells that never source `/etc/profile`. Adds `/usr/sbin` and `/sbin` to the image `PATH`.
- Two tests pinned the runtime version as a literal string, so any generation bump broke them. They now derive it — `rebuild-policy.test.ts` uses the `COMPATIBLE_RUNTIME_VERSION` helper it already imports (which is what the assertion actually means: a runtime the scheduler treats as current), and `opencomputer-rest-client.test.ts` compares against `SANDBOX_RUNTIME_VERSION` from the manifest.

## Why the failure mode matters

Every one of these commands exits **127, "command not found"**, which reads as a missing package rather than a missing path — so the natural response is to `apt-get install` something that is in fact already installed. Bringing Postgres, Elasticsearch and nginx up inside a sandbox hit this twice, once on `useradd` and once on `nginx`, and each cost a full image-build cycle to diagnose because the build's own hook output is (deliberately) withheld.

It also produces a confusing asymmetry when reproducing: the same script passes in an ad-hoc sandbox and fails during an image build, because an interactive probe usually runs through `bash -lc` — a login shell, which sources `/etc/profile` and happens to pick up `/usr/sbin` — while a repository hook runs a plain `bash <script>`.

## Compatibility

`runtimeVersion` and `generation` go to 61, but `minimumCompatibleGeneration` and `minimumRebuildGeneration` deliberately stay at 60. v60 images boot perfectly well without these, so they pick the change up on their next natural rebuild instead of every prebuilt image being invalidated for a convenience fix. Happy to raise the floors instead if you would rather converge immediately.

## Test plan

- [x] `packages/modal-infra/src/images/base.py` parses; the manifest's own version/generation assertion holds in both the Python (`runtime_manifest.py`) and TypeScript (`runtime-manifest.ts`) guards
- [x] `vitest run` over `image-builds/rebuild-policy.test.ts`, `sandbox/runtime-manifest.test.ts`, `sandbox/opencomputer-rest-client.test.ts` — 27 passed
- [x] `grep` confirms no remaining hardcoded `v60-provider-account-broker` outside the manifest
- [ ] CI on this PR (full suite, ruff/mypy, typecheck)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandboxes now include additional system utilities and can access common administrative tools and services more reliably.
  * Improved support for creating system users and running initialization or service commands within sandboxes.

* **Bug Fixes**
  * Updated runtime version handling to keep sandbox startup and command execution aligned with the current runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->