### PR TITLE
feat: show recent automation activity

### DIFF
--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -421,22 +421,26 @@ export class AutomationStore {
     const placeholders = automationIds.map(() => "?").join(", ");
     const result = await this.db
       .prepare(
-        `WITH ranked AS (
+        `WITH ranked_invocations AS (
            SELECT i.id, i.automation_id, i.created_at,
-                  ${DERIVED_INVOCATION_STATUS_SQL} AS derived_status,
                   ROW_NUMBER() OVER (
                     PARTITION BY i.automation_id
                     ORDER BY i.created_at DESC, i.id DESC
                   ) AS position
            FROM automation_invocations i
-           LEFT JOIN automation_runs r ON r.invocation_id = i.id
            WHERE i.automation_id IN (${placeholders})
-           GROUP BY i.id
+         ),
+         recent_invocations AS (
+           SELECT id, automation_id, created_at
+           FROM ranked_invocations
+           WHERE position <= ?
          )
-         SELECT id, automation_id, created_at, derived_status
-         FROM ranked
-         WHERE position <= ?
-         ORDER BY automation_id, created_at DESC, id DESC`
+         SELECT i.id, i.automation_id, i.created_at,
+                ${DERIVED_INVOCATION_STATUS_SQL} AS derived_status
+         FROM recent_invocations i
+         LEFT JOIN automation_runs r ON r.invocation_id = i.id
+         GROUP BY i.id
+         ORDER BY i.automation_id, i.created_at DESC, i.id DESC`
       )
       .bind(...automationIds, limit)
       .all<{

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -7,6 +7,7 @@
 
 import type {
   Automation,
+  AutomationExecutionSummary,
   AutomationInvocation,
   AutomationInvocationSource,
   AutomationInvocationStatus,
@@ -407,6 +408,52 @@ export class AutomationStore {
         id: automations[automations.length - 1].id,
       },
     };
+  }
+
+  async listRecentExecutionsForAutomationIds(
+    automationIds: string[],
+    limit: number
+  ): Promise<Map<string, AutomationExecutionSummary[]>> {
+    const executionsByAutomation = new Map<string, AutomationExecutionSummary[]>();
+    for (const id of automationIds) executionsByAutomation.set(id, []);
+    if (automationIds.length === 0) return executionsByAutomation;
+
+    const placeholders = automationIds.map(() => "?").join(", ");
+    const result = await this.db
+      .prepare(
+        `WITH ranked AS (
+           SELECT i.id, i.automation_id, i.created_at,
+                  ${DERIVED_INVOCATION_STATUS_SQL} AS derived_status,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY i.automation_id
+                    ORDER BY i.created_at DESC, i.id DESC
+                  ) AS position
+           FROM automation_invocations i
+           LEFT JOIN automation_runs r ON r.invocation_id = i.id
+           WHERE i.automation_id IN (${placeholders})
+           GROUP BY i.id
+         )
+         SELECT id, automation_id, created_at, derived_status
+         FROM ranked
+         WHERE position <= ?
+         ORDER BY automation_id, created_at DESC, id DESC`
+      )
+      .bind(...automationIds, limit)
+      .all<{
+        id: string;
+        automation_id: string;
+        created_at: number;
+        derived_status: AutomationInvocationStatus;
+      }>();
+
+    for (const row of result.results ?? []) {
+      executionsByAutomation.get(row.automation_id)?.push({
+        id: row.id,
+        status: row.derived_status,
+        createdAt: row.created_at,
+      });
+    }
+    return executionsByAutomation;
   }
 
   /**

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -42,6 +42,7 @@ const mockStore = {
   bindEnvironmentInserts: vi.fn(),
   bindReplaceEnvironments: vi.fn(),
   listInvocations: vi.fn(),
+  listRecentExecutionsForAutomationIds: vi.fn(),
 };
 
 const mockProviderAuthStore = {
@@ -241,6 +242,7 @@ describe("automation route handlers", () => {
     mockStore.getRepositoriesForAutomationIds.mockResolvedValue(new Map());
     mockStore.getEnvironmentsForAutomation.mockResolvedValue([]);
     mockStore.getEnvironmentsForAutomationIds.mockResolvedValue(new Map());
+    mockStore.listRecentExecutionsForAutomationIds.mockResolvedValue(new Map());
     mockProviderAuthStore.list.mockResolvedValue([]);
     mockProviderAuthStore.listForAutomationIds.mockResolvedValue(new Map());
     mockStore.bindAutomationInsert.mockReturnValue({ sql: "insert-automation" });
@@ -291,6 +293,8 @@ describe("automation route handlers", () => {
       expect(body.hasMore).toBe(false);
       expect(body.nextCursor).toBeNull();
       expect(mockStore.list).toHaveBeenCalledWith({ limit: 25, cursor: null });
+      expect(mockStore.listRecentExecutionsForAutomationIds).toHaveBeenCalledWith(["auto-1"], 10);
+      expect(body.automations[0]).toMatchObject({ recentExecutions: [] });
     });
 
     it("passes name search and pagination params to the store", async () => {

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -79,6 +79,8 @@ const MAX_NAME_LENGTH = 200;
 /** Maximum instructions length. Keep in sync with INSTRUCTIONS_MAX_LENGTH in packages/web/src/components/automations/automation-form.tsx. */
 const MAX_INSTRUCTIONS_LENGTH = 15_000;
 
+const RECENT_EXECUTION_COUNT = 10;
+
 type ParseTriggerConfigResult =
   | { ok: true; triggerConfig: TriggerConfig }
   | { ok: false; error: string };
@@ -408,21 +410,27 @@ async function handleListAutomations(
   const providerAuthStore = new AutomationModelProviderAuthStore(ctx.db);
   const result = await store.list(parsed.options);
   const automationIds = result.automations.map((row) => row.id);
-  const [repositoriesByAutomation, environmentsByAutomation, providerAuthByAutomation] =
-    await Promise.all([
-      store.getRepositoriesForAutomationIds(automationIds),
-      store.getEnvironmentsForAutomationIds(automationIds),
-      providerAuthStore.listForAutomationIds(automationIds),
-    ]);
+  const [
+    repositoriesByAutomation,
+    environmentsByAutomation,
+    providerAuthByAutomation,
+    recentExecutionsByAutomation,
+  ] = await Promise.all([
+    store.getRepositoriesForAutomationIds(automationIds),
+    store.getEnvironmentsForAutomationIds(automationIds),
+    providerAuthStore.listForAutomationIds(automationIds),
+    store.listRecentExecutionsForAutomationIds(automationIds, RECENT_EXECUTION_COUNT),
+  ]);
 
-  const automations = result.automations.map((row) =>
-    toAutomation(
+  const automations = result.automations.map((row) => ({
+    ...toAutomation(
       row,
       repositoriesByAutomation.get(row.id) ?? [],
       environmentsByAutomation.get(row.id) ?? [],
       providerAuthByAutomation.get(row.id) ?? []
-    )
-  );
+    ),
+    recentExecutions: recentExecutionsByAutomation.get(row.id) ?? [],
+  }));
   return json({
     automations,
     hasMore: result.hasMore,

--- a/packages/control-plane/test/integration/automation-invocations.test.ts
+++ b/packages/control-plane/test/integration/automation-invocations.test.ts
@@ -809,5 +809,39 @@ describe("automation invocations (D1 integration)", () => {
       expect(single.status).toBe("completed");
       expect(single.runs.map((run) => run.id)).toEqual(["run-legacy"]);
     });
+
+    it("batches bounded recent execution summaries across automations", async () => {
+      const store = await seedMixedHistory("auto-recent-a");
+      await store.create(makeAutomation({ id: "auto-recent-b" }));
+      await store.insertInvocationGuarded({
+        invocation: makeInvocation("auto-recent-b", {
+          id: "inv-failed",
+          created_at: 4_000,
+          updated_at: 4_000,
+        }),
+        children: [
+          makeChild("auto-recent-b", {
+            status: "failed",
+            completed_at: 4_500,
+            created_at: 4_000,
+          }),
+        ],
+        overlapScope: { kind: "automation" },
+      });
+
+      const summaries = await store.listRecentExecutionsForAutomationIds(
+        ["auto-recent-a", "auto-recent-b", "auto-empty"],
+        2
+      );
+
+      expect(summaries.get("auto-recent-a")).toEqual([
+        { id: "inv-multi", status: "completed", createdAt: 3_000 },
+        { id: "inv-skip", status: "skipped", createdAt: 2_000 },
+      ]);
+      expect(summaries.get("auto-recent-b")).toEqual([
+        { id: "inv-failed", status: "failed", createdAt: 4_000 },
+      ]);
+      expect(summaries.get("auto-empty")).toEqual([]);
+    });
   });
 });

--- a/packages/shared/src/cron.test.ts
+++ b/packages/shared/src/cron.test.ts
@@ -72,6 +72,16 @@ describe("describeCron", () => {
   it("falls back to raw expression for complex patterns", () => {
     expect(describeCron("0 9 1,15 * *", "UTC")).toBe("0 9 1,15 * * (UTC)");
   });
+
+  it("provides compact descriptions without reparsing display text", () => {
+    expect(describeCron("0 9 * * *", "UTC", { compact: true })).toBe("Daily at 9 AM (UTC)");
+    expect(describeCron("30 14 * * 1-5", "America/New_York", { compact: true })).toBe(
+      "Weekdays at 2:30 PM (ET)"
+    );
+    expect(describeCron("0 9 * * 1", "America/Los_Angeles", { compact: true })).toBe(
+      "Mondays at 9 AM (PT)"
+    );
+  });
 });
 
 describe("cronIntervalMinutes", () => {

--- a/packages/shared/src/cron.ts
+++ b/packages/shared/src/cron.ts
@@ -77,43 +77,92 @@ export function cronIntervalMinutes(expression: string): number | null {
 
 interface CronPreset {
   pattern: RegExp;
-  describe: (match: RegExpMatchArray, tz: string) => string;
+  describe: (match: RegExpMatchArray, options: CronDescriptionOptions) => string;
+}
+
+interface CronDescriptionOptions {
+  timezone: string;
+  compact: boolean;
+}
+
+function withTimezone(description: string, { timezone, compact }: CronDescriptionOptions): string {
+  if (!compact) return `${description} (${timezone})`;
+  if (timezone === "UTC") return `${description} (UTC)`;
+
+  try {
+    const timeZoneName = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortGeneric",
+    })
+      .formatToParts(new Date("2025-01-01T00:00:00Z"))
+      .find((part) => part.type === "timeZoneName")?.value;
+    return `${description} (${timeZoneName ?? timezone})`;
+  } catch {
+    return `${description} (${timezone})`;
+  }
 }
 
 const PRESETS: CronPreset[] = [
   {
     // Every N minutes: */N * * * *
     pattern: /^\*\/(\d+) \* \* \* \*$/,
-    describe: (m, tz) => `Every ${m[1]} minutes (${tz})`,
+    describe: (m, options) => withTimezone(`Every ${m[1]} minutes`, options),
   },
   {
     // Every hour at minute M: M * * * *
     pattern: /^(\d+) \* \* \* \*$/,
-    describe: (m, tz) => `Every hour at :${m[1].padStart(2, "0")} (${tz})`,
+    describe: (m, options) =>
+      withTimezone(
+        `${options.compact ? "Hourly" : "Every hour"} at :${m[1].padStart(2, "0")}`,
+        options
+      ),
   },
   {
     // Every day at H:M: M H * * *
     pattern: /^(\d+) (\d+) \* \* \*$/,
-    describe: (m, tz) => `Every day at ${formatTime(parseInt(m[2]), parseInt(m[1]))} (${tz})`,
+    describe: (m, options) =>
+      withTimezone(
+        `${options.compact ? "Daily" : "Every day"} at ${formatTime(
+          parseInt(m[2]),
+          parseInt(m[1]),
+          options.compact
+        )}`,
+        options
+      ),
   },
   {
     // Every weekday at H:M: M H * * 1-5
     pattern: /^(\d+) (\d+) \* \* 1-5$/,
-    describe: (m, tz) => `Every weekday at ${formatTime(parseInt(m[2]), parseInt(m[1]))} (${tz})`,
+    describe: (m, options) =>
+      withTimezone(
+        `${options.compact ? "Weekdays" : "Every weekday"} at ${formatTime(
+          parseInt(m[2]),
+          parseInt(m[1]),
+          options.compact
+        )}`,
+        options
+      ),
   },
   {
     // Every specific day at H:M: M H * * D
     pattern: /^(\d+) (\d+) \* \* (\d)$/,
-    describe: (m, tz) =>
-      `Every ${DAY_NAMES[parseInt(m[3])]} at ${formatTime(parseInt(m[2]), parseInt(m[1]))} (${tz})`,
+    describe: (m, options) => {
+      const day = DAY_NAMES[parseInt(m[3])];
+      const frequency = options.compact ? `${day}s` : `Every ${day}`;
+      return withTimezone(
+        `${frequency} at ${formatTime(parseInt(m[2]), parseInt(m[1]), options.compact)}`,
+        options
+      );
+    },
   },
 ];
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
-function formatTime(hour: number, minute: number): string {
+function formatTime(hour: number, minute: number, compact = false): string {
   const suffix = hour >= 12 ? "PM" : "AM";
   const h = hour % 12 || 12;
+  if (compact && minute === 0) return `${h} ${suffix}`;
   return `${h}:${minute.toString().padStart(2, "0")} ${suffix}`;
 }
 
@@ -121,11 +170,16 @@ function formatTime(hour: number, minute: number): string {
  * Produce a human-readable description of a cron expression.
  * Uses preset detection with fallback to the raw expression.
  */
-export function describeCron(expression: string, timezone: string): string {
+export function describeCron(
+  expression: string,
+  timezone: string,
+  options: { compact?: boolean } = {}
+): string {
   const trimmed = expression.trim();
+  const descriptionOptions = { timezone, compact: options.compact ?? false };
   for (const preset of PRESETS) {
     const match = trimmed.match(preset.pattern);
-    if (match) return preset.describe(match, timezone);
+    if (match) return preset.describe(match, descriptionOptions);
   }
-  return `${trimmed} (${timezone})`;
+  return withTimezone(trimmed, descriptionOptions);
 }

--- a/packages/shared/src/types/automations.test.ts
+++ b/packages/shared/src/types/automations.test.ts
@@ -28,6 +28,7 @@ const automation = {
   repositories: [{ repoOwner: "acme", repoName: "web", repoId: 1, baseBranch: "main" }],
   environmentIds: [],
   providerSelections: {},
+  recentExecutions: [],
 };
 
 describe("listAutomationsResponseSchema", () => {
@@ -64,6 +65,23 @@ describe("listAutomationsResponseSchema", () => {
         nextCursor: null,
       }).success
     ).toBe(false);
+  });
+
+  it("validates recent execution summaries", () => {
+    const result = listAutomationsResponseSchema.parse({
+      automations: [
+        {
+          ...automation,
+          recentExecutions: [{ id: "inv-1", status: "partial_failed", createdAt: 123 }],
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    expect(result.automations[0].recentExecutions).toEqual([
+      { id: "inv-1", status: "partial_failed", createdAt: 123 },
+    ]);
   });
 
   it("rejects malformed trigger-condition records", () => {

--- a/packages/shared/src/types/automations.ts
+++ b/packages/shared/src/types/automations.ts
@@ -17,13 +17,16 @@ export type AutomationInvocationSource = "schedule" | "manual" | "event";
  * skipped; `partial_failed` means the runs finished terminal with a mix of
  * completed and failed.
  */
-export type AutomationInvocationStatus =
-  | "starting"
-  | "running"
-  | "completed"
-  | "failed"
-  | "partial_failed"
-  | "skipped";
+export const automationInvocationStatusSchema = z.enum([
+  "starting",
+  "running",
+  "completed",
+  "failed",
+  "partial_failed",
+  "skipped",
+]);
+
+export type AutomationInvocationStatus = z.infer<typeof automationInvocationStatusSchema>;
 
 /** Maximum repositories an automation can fan out across per invocation. */
 export const MAX_AUTOMATION_REPOSITORIES = MAX_TARGET_REPOSITORIES;
@@ -90,7 +93,7 @@ export type Automation = z.infer<typeof automationSchema>;
 
 const automationExecutionSummarySchema = z.object({
   id: z.string(),
-  status: z.enum(["starting", "running", "completed", "failed", "partial_failed", "skipped"]),
+  status: automationInvocationStatusSchema,
   createdAt: z.number(),
 });
 

--- a/packages/shared/src/types/automations.ts
+++ b/packages/shared/src/types/automations.ts
@@ -88,6 +88,20 @@ const automationSchema = z.object({
 
 export type Automation = z.infer<typeof automationSchema>;
 
+const automationExecutionSummarySchema = z.object({
+  id: z.string(),
+  status: z.enum(["starting", "running", "completed", "failed", "partial_failed", "skipped"]),
+  createdAt: z.number(),
+});
+
+export type AutomationExecutionSummary = z.infer<typeof automationExecutionSummarySchema>;
+
+const automationListItemSchema = automationSchema.extend({
+  recentExecutions: z.array(automationExecutionSummarySchema),
+});
+
+export type AutomationListItem = z.infer<typeof automationListItemSchema>;
+
 export const createAutomationRequestSchema = z.object({
   name: z.string(),
   instructions: z.string(),
@@ -158,12 +172,12 @@ export interface AutomationRun {
 
 export const listAutomationsResponseSchema = z.discriminatedUnion("hasMore", [
   z.object({
-    automations: z.array(automationSchema),
+    automations: z.array(automationListItemSchema),
     hasMore: z.literal(false),
     nextCursor: z.null(),
   }),
   z.object({
-    automations: z.array(automationSchema),
+    automations: z.array(automationListItemSchema),
     hasMore: z.literal(true),
     nextCursor: z.string().min(1),
   }),

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -168,6 +168,8 @@ export type {
   AutomationRepository,
   AutomationRepositoryInput,
   Automation,
+  AutomationExecutionSummary,
+  AutomationListItem,
   CreateAutomationRequest,
   UpdateAutomationRequest,
   AutomationRun,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -163,6 +163,7 @@ export {
   createAutomationRequestSchema,
   updateAutomationRequestSchema,
   listAutomationsResponseSchema,
+  automationInvocationStatusSchema,
 } from "./automations";
 export type {
   AutomationRepository,

--- a/packages/web/src/components/automations/automations-list.test.tsx
+++ b/packages/web/src/components/automations/automations-list.test.tsx
@@ -112,7 +112,7 @@ describe("AutomationsList schedule metadata", () => {
     );
 
     expect(screen.getByText("Next: in 2h")).toBeInTheDocument();
-    expect(screen.getByText("Daily at 9 AM")).toBeInTheDocument();
+    expect(screen.getByText("Daily at 9 AM (UTC)")).toBeInTheDocument();
   });
 });
 
@@ -192,6 +192,9 @@ describe("AutomationsList execution activity", () => {
       expect.stringContaining("Completed")
     );
     expect(activity.children[1]).toHaveAttribute("aria-label", expect.stringContaining("Failed"));
+    expect(activity.children[0]).toHaveAttribute("data-status-shape", "completed");
+    expect(activity.children[1]).toHaveAttribute("data-status-shape", "failed");
+    expect(activity.children[0]).toHaveAttribute("tabindex", "0");
   });
 
   it("shows an explicit empty history state", () => {

--- a/packages/web/src/components/automations/automations-list.test.tsx
+++ b/packages/web/src/components/automations/automations-list.test.tsx
@@ -2,10 +2,10 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ComponentProps } from "react";
-import type { Automation } from "@open-inspect/shared/types/automations";
+import type { AutomationListItem } from "@open-inspect/shared/types/automations";
 import { AutomationsList } from "./automations-list";
 
 expect.extend(matchers);
@@ -27,7 +27,7 @@ vi.mock("@/hooks/use-environments", () => ({
 
 const noop = () => {};
 
-function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+function makeAutomation(overrides: Partial<AutomationListItem> = {}): AutomationListItem {
   return {
     id: "auto-1",
     name: "Nightly review",
@@ -49,12 +49,13 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
     repositories: [{ repoOwner: "acme", repoName: "web-app", repoId: 1, baseBranch: "main" }],
     environmentIds: [],
     providerSelections: {},
+    recentExecutions: [],
     ...overrides,
   };
 }
 
 describe("AutomationsList repository labels", () => {
-  const renderList = (automations: Automation[]) =>
+  const renderList = (automations: AutomationListItem[]) =>
     render(
       <AutomationsList
         automations={automations}
@@ -111,6 +112,101 @@ describe("AutomationsList schedule metadata", () => {
     );
 
     expect(screen.getByText("Next: in 2h")).toBeInTheDocument();
+    expect(screen.getByText("Daily at 9 AM")).toBeInTheDocument();
+  });
+});
+
+describe("AutomationsList actions", () => {
+  it("offers row actions from the compact menu", async () => {
+    const onTrigger = vi.fn();
+    render(
+      <AutomationsList
+        automations={[makeAutomation()]}
+        emptyState={{ kind: "no-automations" }}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={onTrigger}
+        onDelete={noop}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Actions for Nightly review" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Trigger now" }));
+
+    expect(onTrigger).toHaveBeenCalledWith("auto-1");
+  });
+
+  it("confirms deletion selected from the compact menu", async () => {
+    const onDelete = vi.fn();
+    render(
+      <AutomationsList
+        automations={[makeAutomation()]}
+        emptyState={{ kind: "no-automations" }}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={noop}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Actions for Nightly review" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Delete" }));
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledWith("auto-1");
+  });
+});
+
+describe("AutomationsList execution activity", () => {
+  it("shows recent execution statuses from oldest to newest", () => {
+    render(
+      <AutomationsList
+        automations={[
+          makeAutomation({
+            recentExecutions: [
+              { id: "inv-new", status: "failed", createdAt: 200 },
+              { id: "inv-old", status: "completed", createdAt: 100 },
+            ],
+          }),
+        ]}
+        emptyState={{ kind: "no-automations" }}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={noop}
+        onDelete={noop}
+      />
+    );
+
+    const activity = screen.getByRole("list", {
+      name: "Last 2 executions, oldest to newest",
+    });
+    expect(activity.children[0]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Completed")
+    );
+    expect(activity.children[1]).toHaveAttribute("aria-label", expect.stringContaining("Failed"));
+  });
+
+  it("shows an explicit empty history state", () => {
+    render(
+      <AutomationsList
+        automations={[makeAutomation()]}
+        emptyState={{ kind: "no-automations" }}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={noop}
+        onDelete={noop}
+      />
+    );
+
+    expect(screen.getByText("No runs")).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -79,13 +79,7 @@ function describeCompactTrigger(automation: Automation): string {
     return describeTrigger(automation);
   }
 
-  const description = describeCron(automation.scheduleCron, automation.scheduleTz);
-  return description
-    .replace(/^Every day at /, "Daily at ")
-    .replace(/^Every weekday at /, "Weekdays at ")
-    .replace(/^Every (Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) at /, "$1s at ")
-    .replace(":00 ", " ")
-    .replace(/ \([^)]+\)$/, "");
+  return describeCron(automation.scheduleCron, automation.scheduleTz, { compact: true });
 }
 
 export function AutomationsList({

--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -4,16 +4,33 @@ import { useState } from "react";
 import Link from "next/link";
 import { describeCron } from "@open-inspect/shared/cron";
 import { GITHUB_WEBHOOK_EVENT_CATALOG } from "@open-inspect/shared/triggers";
-import type { Automation } from "@open-inspect/shared/types/automations";
+import type { Automation, AutomationListItem } from "@open-inspect/shared/types/automations";
 import { AutomationStatusBadge } from "@/components/automations/automation-status-badge";
+import { ExecutionActivity } from "@/components/automations/execution-activity";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { FolderIcon, BoxIcon, ClockIcon, BoltIcon } from "@/components/ui/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { FolderIcon, BoxIcon, ClockIcon, BoltIcon, MoreIcon } from "@/components/ui/icons";
 import { useEnvironments } from "@/hooks/use-environments";
 import { formatFutureRelativeTime } from "@/lib/time";
 import { formatAutomationTargetsLabel } from "@/lib/repo-label";
 
 interface AutomationsListProps {
-  automations: Automation[];
+  automations: AutomationListItem[];
   emptyState: { kind: "no-automations" } | { kind: "no-search-results"; nameSearch: string };
   onPause: (id: string) => void;
   onResume: (id: string) => void;
@@ -57,6 +74,20 @@ function describeTrigger(automation: Automation): string {
   return label;
 }
 
+function describeCompactTrigger(automation: Automation): string {
+  if (automation.triggerType !== "schedule" || !automation.scheduleCron) {
+    return describeTrigger(automation);
+  }
+
+  const description = describeCron(automation.scheduleCron, automation.scheduleTz);
+  return description
+    .replace(/^Every day at /, "Daily at ")
+    .replace(/^Every weekday at /, "Weekdays at ")
+    .replace(/^Every (Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday) at /, "$1s at ")
+    .replace(":00 ", " ")
+    .replace(/ \([^)]+\)$/, "");
+}
+
 export function AutomationsList({
   automations,
   emptyState,
@@ -67,6 +98,7 @@ export function AutomationsList({
 }: AutomationsListProps) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const { environments } = useEnvironments();
+  const automationToDelete = automations.find((automation) => automation.id === confirmDeleteId);
 
   if (automations.length === 0) {
     if (emptyState.kind === "no-search-results") {
@@ -99,53 +131,38 @@ export function AutomationsList({
   }
 
   return (
-    <div className="border border-border-muted rounded-md bg-card divide-y divide-border-muted">
-      {automations.map((automation) => (
-        <div key={automation.id} className="px-4 py-4">
-          {/* Header: Name + badge | Actions */}
-          <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-            <div className="flex w-full min-w-0 items-center gap-2 sm:w-auto">
-              <Link
-                href={`/automations/${automation.id}`}
-                className="font-medium text-foreground hover:text-accent transition truncate"
-              >
-                {automation.name}
-              </Link>
-              <AutomationStatusBadge automation={automation} />
-            </div>
-            <div className="flex w-full flex-shrink-0 items-center justify-end gap-1 sm:w-auto">
-              {automation.enabled ? (
-                <Button variant="ghost" size="xs" onClick={() => onPause(automation.id)}>
-                  Pause
-                </Button>
-              ) : (
-                <Button variant="ghost" size="xs" onClick={() => onResume(automation.id)}>
-                  Resume
-                </Button>
-              )}
-              <Button variant="ghost" size="xs" onClick={() => onTrigger(automation.id)}>
-                <span className="flex items-center gap-1">
-                  <BoltIcon className="w-3 h-3" aria-hidden="true" />
-                  Trigger
-                </span>
-              </Button>
-              {confirmDeleteId === automation.id ? (
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="destructive"
-                    size="xs"
-                    onClick={() => {
-                      onDelete(automation.id);
-                      setConfirmDeleteId(null);
-                    }}
-                  >
-                    Confirm
+    <>
+      <div className="border border-border-muted rounded-md bg-card divide-y divide-border-muted">
+        {automations.map((automation) => (
+          <div key={automation.id} className="px-4 py-4">
+            {/* Header: Name + badge | Actions */}
+            <div className="flex items-start justify-between gap-3 sm:items-center sm:gap-4">
+              <div className="flex min-w-0 items-center gap-2">
+                <Link
+                  href={`/automations/${automation.id}`}
+                  className="font-medium text-foreground hover:text-accent transition truncate"
+                >
+                  {automation.name}
+                </Link>
+                <AutomationStatusBadge automation={automation} />
+                <ExecutionActivity executions={automation.recentExecutions} />
+              </div>
+              <div className="hidden flex-shrink-0 items-center gap-1 sm:flex">
+                {automation.enabled ? (
+                  <Button variant="ghost" size="xs" onClick={() => onPause(automation.id)}>
+                    Pause
                   </Button>
-                  <Button variant="ghost" size="xs" onClick={() => setConfirmDeleteId(null)}>
-                    Cancel
+                ) : (
+                  <Button variant="ghost" size="xs" onClick={() => onResume(automation.id)}>
+                    Resume
                   </Button>
-                </div>
-              ) : (
+                )}
+                <Button variant="ghost" size="xs" onClick={() => onTrigger(automation.id)}>
+                  <span className="flex items-center gap-1">
+                    <BoltIcon className="w-3 h-3" aria-hidden="true" />
+                    Trigger
+                  </span>
+                </Button>
                 <Button
                   variant="destructive"
                   size="xs"
@@ -153,32 +170,98 @@ export function AutomationsList({
                 >
                   Delete
                 </Button>
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`Actions for ${automation.name}`}
+                    className="-mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition hover:bg-muted hover:text-foreground sm:hidden"
+                  >
+                    <MoreIcon className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="sm:hidden">
+                  <DropdownMenuItem
+                    onSelect={() =>
+                      automation.enabled ? onPause(automation.id) : onResume(automation.id)
+                    }
+                  >
+                    {automation.enabled ? "Pause" : "Resume"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => onTrigger(automation.id)}>
+                    <BoltIcon aria-hidden="true" />
+                    Trigger now
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onSelect={() => setConfirmDeleteId(automation.id)}
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+
+            {/* Metadata: icon-paired items */}
+            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                {automation.environmentIds.length > 0 && automation.repositories.length === 0 ? (
+                  <BoxIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                ) : (
+                  <FolderIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                )}
+                {formatAutomationTargetsLabel(automation, environments)}
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <ClockIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                <span
+                  className="sm:hidden"
+                  title={describeTrigger(automation)}
+                  aria-label={describeTrigger(automation)}
+                >
+                  {describeCompactTrigger(automation)}
+                </span>
+                <span className="hidden sm:inline">{describeTrigger(automation)}</span>
+              </span>
+              {automation.triggerType === "schedule" && automation.nextRunAt && (
+                <span className="inline-flex items-center gap-1">
+                  Next: {formatFutureRelativeTime(automation.nextRunAt)}
+                </span>
               )}
             </div>
           </div>
-
-          {/* Metadata: icon-paired items */}
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-muted-foreground">
-            <span className="inline-flex items-center gap-1">
-              {automation.environmentIds.length > 0 && automation.repositories.length === 0 ? (
-                <BoxIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
-              ) : (
-                <FolderIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
-              )}
-              {formatAutomationTargetsLabel(automation, environments)}
-            </span>
-            <span className="inline-flex items-center gap-1">
-              <ClockIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
-              {describeTrigger(automation)}
-            </span>
-            {automation.triggerType === "schedule" && automation.nextRunAt && (
-              <span className="inline-flex items-center gap-1">
-                Next: {formatFutureRelativeTime(automation.nextRunAt)}
-              </span>
-            )}
-          </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+      <AlertDialog
+        open={automationToDelete !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDeleteId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete automation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {automationToDelete
+                ? `This will permanently delete "${automationToDelete.name}".`
+                : "This will permanently delete the automation."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                if (automationToDelete) onDelete(automationToDelete.id);
+                setConfirmDeleteId(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/packages/web/src/components/automations/execution-activity.tsx
+++ b/packages/web/src/components/automations/execution-activity.tsx
@@ -1,0 +1,44 @@
+import type {
+  AutomationExecutionSummary,
+  AutomationInvocationStatus,
+} from "@open-inspect/shared/types/automations";
+
+const STATUS_PRESENTATION: Record<
+  AutomationInvocationStatus,
+  { label: string; className: string }
+> = {
+  starting: { label: "Starting", className: "bg-info/60 motion-safe:animate-pulse" },
+  running: { label: "Running", className: "bg-info motion-safe:animate-pulse" },
+  completed: { label: "Completed", className: "bg-success" },
+  failed: { label: "Failed", className: "bg-destructive" },
+  partial_failed: { label: "Partial failure", className: "bg-warning" },
+  skipped: { label: "Skipped", className: "bg-muted-foreground/40" },
+};
+
+export function ExecutionActivity({ executions }: { executions: AutomationExecutionSummary[] }) {
+  if (executions.length === 0) {
+    return <span className="text-[10px] text-muted-foreground">No runs</span>;
+  }
+
+  const chronologicalExecutions = [...executions].reverse();
+
+  return (
+    <ol
+      className="flex shrink-0 items-center gap-0.5"
+      aria-label={`Last ${executions.length} executions, oldest to newest`}
+    >
+      {chronologicalExecutions.map((execution) => {
+        const presentation = STATUS_PRESENTATION[execution.status];
+        const occurredAt = new Date(execution.createdAt).toLocaleString();
+        return (
+          <li
+            key={execution.id}
+            className={`h-3 w-1 rounded-[1px] ${presentation.className}`}
+            title={`${presentation.label} - ${occurredAt}`}
+            aria-label={`${presentation.label}, ${occurredAt}`}
+          />
+        );
+      })}
+    </ol>
+  );
+}

--- a/packages/web/src/components/automations/execution-activity.tsx
+++ b/packages/web/src/components/automations/execution-activity.tsx
@@ -2,18 +2,39 @@ import type {
   AutomationExecutionSummary,
   AutomationInvocationStatus,
 } from "@open-inspect/shared/types/automations";
+import {
+  AUTOMATION_INVOCATION_STATUS,
+  type AutomationInvocationTone,
+} from "@/lib/automation-invocation-status";
 
-const STATUS_PRESENTATION: Record<
-  AutomationInvocationStatus,
-  { label: string; className: string }
-> = {
-  starting: { label: "Starting", className: "bg-info/60 motion-safe:animate-pulse" },
-  running: { label: "Running", className: "bg-info motion-safe:animate-pulse" },
-  completed: { label: "Completed", className: "bg-success" },
-  failed: { label: "Failed", className: "bg-destructive" },
-  partial_failed: { label: "Partial failure", className: "bg-warning" },
-  skipped: { label: "Skipped", className: "bg-muted-foreground/40" },
+const TONE_CLASSES: Record<AutomationInvocationTone, string> = {
+  neutral: "text-muted-foreground",
+  info: "text-info",
+  success: "text-success",
+  danger: "text-destructive",
+  warning: "text-warning",
 };
+
+const SHAPE_CLASSES: Record<Exclude<AutomationInvocationStatus, "failed">, string> = {
+  starting: "h-2 w-2 rounded-full border border-current motion-safe:animate-pulse",
+  running: "h-2 w-2 rounded-full bg-current motion-safe:animate-pulse",
+  completed: "h-3 w-1 rounded-[1px] bg-current",
+  partial_failed: "h-3 w-1 border border-dashed border-current",
+  skipped: "h-px w-2 bg-current",
+};
+
+function StatusShape({ status }: { status: AutomationInvocationStatus }) {
+  if (status === "failed") {
+    return (
+      <span className="relative h-2 w-2" aria-hidden="true">
+        <span className="absolute left-1 top-0 h-2 w-px rotate-45 bg-current" />
+        <span className="absolute left-1 top-0 h-2 w-px -rotate-45 bg-current" />
+      </span>
+    );
+  }
+
+  return <span className={SHAPE_CLASSES[status]} aria-hidden="true" />;
+}
 
 export function ExecutionActivity({ executions }: { executions: AutomationExecutionSummary[] }) {
   if (executions.length === 0) {
@@ -28,15 +49,19 @@ export function ExecutionActivity({ executions }: { executions: AutomationExecut
       aria-label={`Last ${executions.length} executions, oldest to newest`}
     >
       {chronologicalExecutions.map((execution) => {
-        const presentation = STATUS_PRESENTATION[execution.status];
+        const presentation = AUTOMATION_INVOCATION_STATUS[execution.status];
         const occurredAt = new Date(execution.createdAt).toLocaleString();
         return (
           <li
             key={execution.id}
-            className={`h-3 w-1 rounded-[1px] ${presentation.className}`}
+            className={`flex h-4 w-2 items-center justify-center rounded-sm outline-none focus-visible:ring-1 focus-visible:ring-ring ${TONE_CLASSES[presentation.tone]}`}
             title={`${presentation.label} - ${occurredAt}`}
             aria-label={`${presentation.label}, ${occurredAt}`}
-          />
+            data-status-shape={execution.status}
+            tabIndex={0}
+          >
+            <StatusShape status={execution.status} />
+          </li>
         );
       })}
     </ol>

--- a/packages/web/src/components/automations/run-history.tsx
+++ b/packages/web/src/components/automations/run-history.tsx
@@ -8,6 +8,18 @@ import { Button } from "@/components/ui/button";
 import { ChevronDownIcon, ChevronRightIcon } from "@/components/ui/icons";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { useEnvironments } from "@/hooks/use-environments";
+import {
+  AUTOMATION_INVOCATION_STATUS,
+  type AutomationInvocationTone,
+} from "@/lib/automation-invocation-status";
+
+const BADGE_TONE_CLASSES: Record<AutomationInvocationTone, string> = {
+  neutral: "bg-muted text-muted-foreground",
+  info: "bg-info-muted text-info",
+  success: "bg-success-muted text-success",
+  danger: "bg-destructive-muted text-destructive",
+  warning: "bg-warning-muted text-warning",
+};
 
 // The UI keeps "run" vocabulary while the API speaks invocations: each history
 // row is one invocation (a single firing). A firing with one repository renders
@@ -15,20 +27,8 @@ import { useEnvironments } from "@/hooks/use-environments";
 // repository row per child run.
 
 function statusBadge(status: AutomationInvocation["status"] | AutomationRun["status"]) {
-  switch (status) {
-    case "starting":
-      return <Badge className="bg-muted text-muted-foreground">Starting</Badge>;
-    case "running":
-      return <Badge variant="info">Running</Badge>;
-    case "completed":
-      return <Badge className="bg-success-muted text-success">Completed</Badge>;
-    case "failed":
-      return <Badge className="bg-destructive-muted text-destructive">Failed</Badge>;
-    case "partial_failed":
-      return <Badge className="bg-warning-muted text-warning">Partial failure</Badge>;
-    case "skipped":
-      return <Badge className="bg-warning-muted text-warning">Skipped</Badge>;
-  }
+  const presentation = AUTOMATION_INVOCATION_STATUS[status];
+  return <Badge className={BADGE_TONE_CLASSES[presentation.tone]}>{presentation.label}</Badge>;
 }
 
 function formatDuration(startedAt: number | null, completedAt: number | null): string | null {

--- a/packages/web/src/hooks/use-automations.test.tsx
+++ b/packages/web/src/hooks/use-automations.test.tsx
@@ -4,14 +4,14 @@ import type { ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Automation, ListAutomationsResponse } from "@open-inspect/shared";
+import type { AutomationListItem, ListAutomationsResponse } from "@open-inspect/shared";
 import { useAutomations } from "./use-automations";
 
 vi.mock("@/lib/auth-session", () => ({
   useAuthSession: () => ({ data: { user: { id: "user-1" } }, status: "authenticated" }),
 }));
 
-function automation(id: string, name: string): Automation {
+function automation(id: string, name: string): AutomationListItem {
   return {
     id,
     name,
@@ -33,6 +33,7 @@ function automation(id: string, name: string): Automation {
     repositories: [],
     environmentIds: [],
     providerSelections: {},
+    recentExecutions: [],
   };
 }
 

--- a/packages/web/src/lib/automation-invocation-status.ts
+++ b/packages/web/src/lib/automation-invocation-status.ts
@@ -1,0 +1,15 @@
+import type { AutomationInvocationStatus } from "@open-inspect/shared/types/automations";
+
+export type AutomationInvocationTone = "neutral" | "info" | "success" | "danger" | "warning";
+
+export const AUTOMATION_INVOCATION_STATUS: Record<
+  AutomationInvocationStatus,
+  { label: string; tone: AutomationInvocationTone }
+> = {
+  starting: { label: "Starting", tone: "neutral" },
+  running: { label: "Running", tone: "info" },
+  completed: { label: "Completed", tone: "success" },
+  failed: { label: "Failed", tone: "danger" },
+  partial_failed: { label: "Partial failure", tone: "warning" },
+  skipped: { label: "Skipped", tone: "warning" },
+};


### PR DESCRIPTION
## Summary
- add the latest 10 execution summaries to automation list responses using one batched D1 query
- show compact, accessible status ticks beside each automation title
- improve the mobile row with concise schedule labels and a kebab actions menu
- use a confirmation dialog for automation deletion

## Testing
- `npm run typecheck`
- `npm test -w @open-inspect/shared -- src/types/automations.test.ts src/types/type-contracts.test.ts`
- `npm test -w @open-inspect/web -- src/components/automations/automations-list.test.tsx src/hooks/use-automations.test.tsx`
- `npm test -w @open-inspect/control-plane -- src/routes/automations.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/automation-invocations.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/37ede0412b24f2743c06e88adde1ad22)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation lists now display recent execution activity, including statuses and timestamps.
  * Added visual execution history indicators, including “No runs” for automations without history.
  * Improved responsive layouts with compact schedule details and mobile action menus.
  * Added confirmation dialogs for deleting automations.
  * Added clearer status indicators for completed, skipped, and failed executions.

* **Bug Fixes**
  * Automation execution histories are now loaded consistently across multiple automations.
  * Execution statuses are displayed in chronological order.
  * Improved compact schedule descriptions with timezone information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->