### PR TITLE
Fix two D1 width bugs in managed-skill assignment validation and profile listing

### DIFF
--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -329,10 +329,19 @@ outright rather than degrading, and the count cap was previously masking them. C
 bind one parameter per skill within a chunk; what matters is that no one statement is handed the
 whole list. Prefer keying off an ID the database already holds — the session installation query
 filters `skill_revision_files` by a subquery on `session_skill_revisions`, so a wider manifest costs
-no additional parameters. Where the list genuinely originates outside the database (profile
-membership, which arrives in the request body), chunk by the engine's bound-parameter ceiling
-(`MAX_D1_QUERY_PARAMETERS`). A JSON-array parameter with `json_each` would also work on SQLite but
-is not portable to the second `SqlDatabase` engine.
+no additional parameters. Where the list genuinely originates outside the database — profile
+membership and skill assignments, both of which arrive in the request body — chunk by the engine's
+bound-parameter ceiling (`MAX_D1_QUERY_PARAMETERS`). A JSON-array parameter with `json_each` would
+also work on SQLite but is not portable to the second `SqlDatabase` engine.
+
+The same applies to aggregates on the read side, which are easier to miss because they fail on a
+byte ceiling rather than a parameter count. `SkillProfileStore.list` used to build a profile's whole
+membership into one `json_group_array` value, capped at 2 MB or roughly fifty thousand ids; nothing
+bounds profile width, and that ceiling was only out of reach because profile writes give out first
+at about 33,000 members. Making the write cheaper would have moved the write cliff past the read one
+and left profiles that could be saved and never loaded. It reads membership as its own query and
+groups in memory instead. When a limit is removed or a write is made cheaper, check what the read
+path was quietly relying on that limit to keep small.
 
 ### Bounds that remain implicit
 

--- a/packages/control-plane/src/db/skill-profiles.ts
+++ b/packages/control-plane/src/db/skill-profiles.ts
@@ -26,19 +26,40 @@ export class SkillProfileValidationError extends Error {}
 export class SkillProfileStore {
   constructor(private readonly db: SqlDatabase) {}
 
+  /**
+   * Read every profile this user owns, with its membership.
+   *
+   * Two statements rather than one `json_group_array` aggregate. The aggregate
+   * builds a profile's whole membership into a single value, which the engine
+   * caps at 2 MB — roughly fifty thousand ids. Nothing bounds profile width, so
+   * that ceiling is only out of reach because the write path gives out first,
+   * at about 33,000 members. Anything that makes profile writes cheaper moves
+   * the write cliff past the read one and turns this into a profile that can be
+   * saved and then never loaded, so the read should not depend on the write
+   * staying expensive. Grouping in memory has no such ceiling, matches what
+   * `getOwned` already does, and drops a SQLite-only aggregate.
+   */
   async list(userId: string): Promise<SkillProfile[]> {
-    const result = await this.db
+    const profiles = await this.db
+      .prepare("SELECT * FROM skill_profiles WHERE user_id = ? ORDER BY lower(name), id")
+      .bind(userId)
+      .all<ProfileRow>();
+    const rows = profiles.results ?? [];
+    if (rows.length === 0) return [];
+
+    // Keyed by a subquery rather than by the ids just read, so this costs one
+    // parameter however many profiles or members the user has.
+    const items = await this.db
       .prepare(
-        `SELECT p.*, COALESCE(json_group_array(i.skill_id) FILTER (WHERE i.skill_id IS NOT NULL), '[]') AS skill_ids
-         FROM skill_profiles p
-         LEFT JOIN skill_profile_items i ON i.profile_id = p.id
-         WHERE p.user_id = ?
-         GROUP BY p.id
-         ORDER BY lower(p.name), p.id`
+        `SELECT profile_id, skill_id FROM skill_profile_items
+         WHERE profile_id IN (SELECT id FROM skill_profiles WHERE user_id = ?)`
       )
       .bind(userId)
-      .all<ProfileRow & { skill_ids: string }>();
-    return (result.results ?? []).map((row) => this.toProfile(row, JSON.parse(row.skill_ids)));
+      .all<{ profile_id: string; skill_id: string }>();
+
+    const membership = new Map<string, string[]>(rows.map((row) => [row.id, []]));
+    for (const item of items.results ?? []) membership.get(item.profile_id)?.push(item.skill_id);
+    return rows.map((row) => this.toProfile(row, membership.get(row.id) ?? []));
   }
 
   /** Return a profile only when it belongs to the canonical user. */

--- a/packages/control-plane/src/db/skills.ts
+++ b/packages/control-plane/src/db/skills.ts
@@ -524,12 +524,22 @@ export class SkillStore {
       ),
     ];
     if (environmentIds.length === 0) return;
-    const placeholders = environmentIds.map(() => "?").join(", ");
-    const row = await this.db
-      .prepare(`SELECT COUNT(*) AS count FROM environments WHERE id IN (${placeholders})`)
-      .bind(...environmentIds)
-      .first<{ count: number }>();
-    if ((row?.count ?? 0) !== environmentIds.length) {
+    // `assignments` is request input and carries no length bound, so this
+    // cannot bind a parameter per environment: past the engine ceiling it
+    // fails outright with `too many SQL variables` instead of reporting a
+    // validation error, which made a skill assigned to more than
+    // MAX_D1_QUERY_PARAMETERS environments impossible to create.
+    let found = 0;
+    for (let start = 0; start < environmentIds.length; start += MAX_D1_QUERY_PARAMETERS) {
+      const chunk = environmentIds.slice(start, start + MAX_D1_QUERY_PARAMETERS);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const row = await this.db
+        .prepare(`SELECT COUNT(*) AS count FROM environments WHERE id IN (${placeholders})`)
+        .bind(...chunk)
+        .first<{ count: number }>();
+      found += row?.count ?? 0;
+    }
+    if (found !== environmentIds.length) {
       throw new SkillValidationError("One or more assigned environments do not exist");
     }
   }

--- a/packages/control-plane/test/integration/managed-skills.test.ts
+++ b/packages/control-plane/test/integration/managed-skills.test.ts
@@ -568,6 +568,81 @@ describe("managed skills persistence and resolution", () => {
     expect((await skills.get(skill.id))?.assignments).toMatchObject([{ type: "global" }]);
   });
 
+  it("validates more assigned environments than the engine has parameter slots", async () => {
+    // `assignments` is request input with no length bound. Validating it with
+    // one parameter per environment failed outright past the engine ceiling, so
+    // a skill assigned to more than MAX_D1_QUERY_PARAMETERS environments could
+    // not be created at all.
+    const environments = new EnvironmentStore(env.DB);
+    const ids = Array.from({ length: 101 }, (_, index) => `env_${String(index).padStart(3, "0")}`);
+    for (const id of ids) {
+      await environments.create(
+        {
+          id,
+          name: id,
+          description: null,
+          prebuild_enabled: 0,
+          channel_associations: null,
+          created_at: 1,
+          updated_at: 1,
+        },
+        []
+      );
+    }
+
+    const skills = new SkillStore(env.DB);
+    const skill = await skills.create(
+      {
+        name: "widely-assigned",
+        content,
+        assignments: ids.map((environmentId) => ({ type: "environment" as const, environmentId })),
+      },
+      "user_1"
+    );
+    expect(skill.assignments).toHaveLength(101);
+
+    // A missing environment among many must still be rejected rather than
+    // passing because the per-chunk counts happened to sum correctly.
+    await expect(
+      skills.create(
+        {
+          name: "partly-assigned",
+          content,
+          assignments: [...ids, "env_missing"].map((environmentId) => ({
+            type: "environment" as const,
+            environmentId,
+          })),
+        },
+        "user_1"
+      )
+    ).rejects.toThrow(/environments do not exist/);
+  });
+
+  it("groups membership per profile when listing, including empty ones", async () => {
+    // list() groups in memory rather than with a json_group_array aggregate.
+    // The aggregate also supplied the empty-membership case through a FILTER,
+    // so that has to survive the change.
+    const catalog = await seedGlobalCatalog(3);
+    const profiles = new SkillProfileStore(env.DB);
+    await profiles.create("user_1", "Two", [catalog[0].id, catalog[1].id]);
+    await profiles.create("user_1", "One", [catalog[2].id]);
+    await profiles.create("user_1", "Empty", []);
+    await profiles.create("user_2", "Other user", [catalog[0].id]);
+
+    // Ordered by lower(name), and each profile keeps only its own members.
+    await expect(profiles.list("user_1")).resolves.toEqual([
+      expect.objectContaining({ name: "Empty", skillIds: [] }),
+      expect.objectContaining({ name: "One", skillIds: [catalog[2].id] }),
+      expect.objectContaining({
+        name: "Two",
+        skillIds: [catalog[0].id, catalog[1].id].sort(),
+      }),
+    ]);
+    await expect(profiles.list("user_2")).resolves.toMatchObject([
+      { name: "Other user", skillIds: [catalog[0].id] },
+    ]);
+  });
+
   it("tracks environment assignment provenance changes through database-owned triggers", async () => {
     const environments = new EnvironmentStore(env.DB);
     await environments.create(


### PR DESCRIPTION
Two D1 width bugs in the managed-skill layer, both of the class the removed 20-skill cap had been masking.

## 1. A skill cannot be assigned to more than 100 environments

`SkillStore.validateAssignments` built `IN (?, ?, …)` from request-supplied environment ids with no chunking, and `assignments` carries no length bound. Past `MAX_D1_QUERY_PARAMETERS` the statement fails with `too many SQL variables`, so creating or editing such a skill fails outright rather than reporting anything useful.

This is reachable today. It now chunks by the parameter ceiling, matching `validateSkillIds`, `assignmentsForSkills`, and `session-list-metadata`. The regression test was verified to fail against the unfixed code with the real `D1_ERROR`.

## 2. The profile read was relying on the profile write being expensive

`SkillProfileStore.list` built a profile's whole membership into one `json_group_array` value. The engine caps a string at 2 MB, or roughly fifty thousand ids.

Nothing bounds profile width. That ceiling is currently out of reach only because profile writes give out first, at about 33,000 members — so the read is safe by accident. Anything that makes profile writes cheaper moves the write cliff past the read one and produces profiles that can be saved and then never loaded.

To be clear about severity: this is **latent, not live**. You cannot reach it today. It is fixed here because #1552 proposes exactly the change that would expose it, and because the fix is small: `list()` reads membership as its own query keyed by a subquery on `skill_profiles` and groups in memory, which is what `getOwned` already did. It also removes a SQLite-only aggregate, which helps the Postgres work. `list()` had no test coverage at all; it does now.

## What this PR no longer does

Earlier revisions rewrote both managed-skill write paths to expand a single JSON parameter with `json_each`, closing #1552. That is dropped, and #1552 stays open.

The reasoning: the cliff it removed sits at ~9,000 skills, which nobody will reach, while the change rewrote the write path of session creation and added `json_each` to five statements under an active dual-engine mandate — more Postgres migration surface, for a benefit that is unreachable in practice. The two bugs above do not need it.

That implementation is preserved at `0c78d83a8` if #1552 is picked up later; it was reviewed and green (3,008 unit + 934 integration), so it is a working starting point rather than a sketch. Note that fix 2 in this PR is a prerequisite for it.

## Verification

3,010 unit + 934 integration tests pass; typecheck and lint clean. The diff is 4 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed skill installation when skill names collide, preserving discovered skills and continuing installation with warnings.
  * Fixed profile listing and skill assignment validation for large sets of environments or memberships.
  * Empty profiles and missing environments are now handled more reliably.
  * Profile results maintain user isolation, consistent ordering, and correctly sorted memberships.

* **Tests**
  * Added coverage for large environment assignments, missing environments, profile isolation, ordering, and empty profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->