### PR TITLE
Persist homepage provider account selections

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -59,6 +59,7 @@ const mocks = vi.hoisted(() => ({
     updatedAt: number;
     archivedAt: null;
   }>,
+  providerAccountsLoadingValue: false,
   skillPreview: {
     skills: [
       {
@@ -134,7 +135,7 @@ vi.mock("@/hooks/use-provider-accounts", () => ({
     providers: [],
     accounts: mocks.providerAccountsValue,
     defaults: [],
-    loading: false,
+    loading: mocks.providerAccountsLoadingValue,
     error: undefined,
     refresh: vi.fn(),
   }),
@@ -167,6 +168,7 @@ beforeEach(() => {
     },
   ];
   mocks.providerAccountsValue = [];
+  mocks.providerAccountsLoadingValue = false;
   mocks.routerPush.mockReset();
   mocks.mutateMock.mockReset();
   vi.stubGlobal(
@@ -477,6 +479,27 @@ describe("Home", () => {
       model: openAiModel,
       providerSelections: { openai: { mode: "provider_account", accountId } },
     });
+  });
+
+  it("waits for provider accounts and removes a stale stored selection", async () => {
+    const staleAccountId = "b".repeat(32);
+    localStorage.setItem(
+      "open-inspect-last-provider-selections",
+      JSON.stringify({ xai: { mode: "provider_account", accountId: staleAccountId } })
+    );
+    mocks.providerAccountsLoadingValue = true;
+    const user = userEvent.setup();
+    const view = render(<Home />);
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Continue work");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalledWith("/api/sessions", expect.anything());
+
+    mocks.providerAccountsLoadingValue = false;
+    view.rerender(<Home />);
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(sessionCreateBody()).toMatchObject({ providerSelections: {} }));
+    expect(localStorage.getItem("open-inspect-last-provider-selections")).toBe("{}");
   });
 
   it("waits for environments to load before restoring a stored environment", async () => {

--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { DEFAULT_MODEL } from "@open-inspect/shared/models";
@@ -39,6 +39,25 @@ const mocks = vi.hoisted(() => ({
       repoId: number | null;
       baseBranch: string;
     }>;
+  }>,
+  enabledModelsValue: [] as string[],
+  enabledModelOptionsValue: [] as Array<{
+    category: string;
+    models: Array<{ id: string; name: string; description: string }>;
+  }>,
+  providerAccountsValue: [] as Array<{
+    id: string;
+    provider: "openai" | "xai";
+    displayName: string;
+    externalAccountId: string | null;
+    status: "active";
+    createdBy: null;
+    updatedBy: null;
+    lastVerifiedAt: null;
+    lastUsedAt: null;
+    createdAt: number;
+    updatedAt: number;
+    archivedAt: null;
   }>,
   skillPreview: {
     skills: [
@@ -104,14 +123,20 @@ vi.mock("@/hooks/use-branches", () => ({
 
 vi.mock("@/hooks/use-enabled-models", () => ({
   useEnabledModels: () => ({
-    enabledModels: [DEFAULT_MODEL],
-    enabledModelOptions: [
-      {
-        category: "Anthropic",
-        models: [{ id: DEFAULT_MODEL, name: "Claude Sonnet 4.6", description: "" }],
-      },
-    ],
+    enabledModels: mocks.enabledModelsValue,
+    enabledModelOptions: mocks.enabledModelOptionsValue,
     loading: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-provider-accounts", () => ({
+  useProviderAccounts: () => ({
+    providers: [],
+    accounts: mocks.providerAccountsValue,
+    defaults: [],
+    loading: false,
+    error: undefined,
+    refresh: vi.fn(),
   }),
 }));
 
@@ -134,6 +159,14 @@ beforeEach(() => {
   mocks.loadingReposValue = false;
   mocks.environmentsLoadingValue = false;
   mocks.environmentsValue = [];
+  mocks.enabledModelsValue = [DEFAULT_MODEL];
+  mocks.enabledModelOptionsValue = [
+    {
+      category: "Anthropic",
+      models: [{ id: DEFAULT_MODEL, name: "Claude Sonnet 4.6", description: "" }],
+    },
+  ];
+  mocks.providerAccountsValue = [];
   mocks.routerPush.mockReset();
   mocks.mutateMock.mockReset();
   vi.stubGlobal(
@@ -388,6 +421,62 @@ describe("Home", () => {
     await user.click(screen.getByRole("button", { name: /send/i }));
     await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
     expect(sessionCreateBody()).toMatchObject({ environmentId: "env-1" });
+  });
+
+  it("persists provider authentication and restores it on the next visit", async () => {
+    const openAiModel = "openai/gpt-5.4";
+    const accountId = "a".repeat(32);
+    mocks.enabledModelsValue = [DEFAULT_MODEL, openAiModel];
+    mocks.enabledModelOptionsValue.push({
+      category: "OpenAI",
+      models: [{ id: openAiModel, name: "GPT-5.4", description: "" }],
+    });
+    mocks.providerAccountsValue = [
+      {
+        id: accountId,
+        provider: "openai",
+        displayName: "Team ChatGPT",
+        externalAccountId: "acct_public",
+        status: "active",
+        createdBy: null,
+        updatedBy: null,
+        lastVerifiedAt: null,
+        lastUsedAt: null,
+        createdAt: 1,
+        updatedAt: 1,
+        archivedAt: null,
+      },
+    ];
+    localStorage.setItem("open-inspect-last-selected-model", openAiModel);
+    const first = render(<Home />);
+
+    const authenticationTrigger = await screen.findByRole("button", {
+      name: "OpenAI authentication options",
+    });
+    fireEvent.pointerDown(authenticationTrigger, { button: 0, ctrlKey: false });
+    const authenticationMenu = await screen.findByRole("menuitem", {
+      name: "OpenAI authentication",
+    });
+    authenticationMenu.focus();
+    fireEvent.keyDown(authenticationMenu, { key: "ArrowRight" });
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "Team ChatGPT" }));
+
+    expect(localStorage.getItem("open-inspect-last-provider-selections")).toBe(
+      JSON.stringify({ openai: { mode: "provider_account", accountId } })
+    );
+
+    first.unmount();
+    render(<Home />);
+    const user = userEvent.setup();
+    await screen.findByRole("button", { name: "OpenAI authentication options" });
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Continue work");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    expect(sessionCreateBody()).toMatchObject({
+      model: openAiModel,
+      providerSelections: { openai: { mode: "provider_account", accountId } },
+    });
   });
 
   it("waits for environments to load before restoring a stored environment", async () => {

--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -492,7 +492,11 @@ describe("Home", () => {
     const view = render(<Home />);
 
     await user.type(screen.getByPlaceholderText("What do you want to build?"), "Continue work");
+    const send = screen.getByRole("button", { name: /send/i });
+    expect(send).toBeDisabled();
+    fireEvent.click(send);
     expect(vi.mocked(fetch)).not.toHaveBeenCalledWith("/api/sessions", expect.anything());
+    expect(screen.queryByText("Failed to create session")).not.toBeInTheDocument();
 
     mocks.providerAccountsLoadingValue = false;
     view.rerender(<Home />);

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -48,14 +48,19 @@ import {
 } from "@/hooks/use-managed-skills";
 import type { SessionTargetRequestFields } from "@/lib/session-target";
 import type { PromptSkillSuggestionSource } from "@/lib/prompt-skill-completion";
-import type { ModelProviderSelections } from "@open-inspect/shared/types/provider-accounts";
+import type {
+  ModelProviderSelections,
+  ProviderAuthSelection,
+  SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
 import { ProviderAuthControls } from "@/components/provider-auth-controls";
 import { useProviderAccounts } from "@/hooks/use-provider-accounts";
 import { useWarmDraftSession } from "@/hooks/use-warm-draft-session";
-import { setProviderSelection } from "@/lib/provider-selection";
+import { parseStoredProviderSelections, setProviderSelection } from "@/lib/provider-selection";
 
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
+const LAST_PROVIDER_SELECTIONS_STORAGE_KEY = "open-inspect-last-provider-selections";
 
 function skillPreviewTarget(
   fields: SessionTargetRequestFields | null
@@ -108,10 +113,14 @@ export default function Home() {
 
     const storedModel = localStorage.getItem(LAST_SELECTED_MODEL_STORAGE_KEY);
     const storedReasoningEffort = localStorage.getItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
+    const storedProviderSelections = parseStoredProviderSelections(
+      localStorage.getItem(LAST_PROVIDER_SELECTIONS_STORAGE_KEY)
+    );
     setStoredPreference({
       model: storedModel ?? DEFAULT_MODEL,
       reasoningEffort: storedReasoningEffort ?? undefined,
     });
+    if (storedProviderSelections) setProviderSelections(storedProviderSelections);
     hasHydratedModelPreferencesRef.current = true;
   }, []);
 
@@ -159,6 +168,15 @@ export default function Home() {
       saveModelPreferenceDraft({ model: selectedModel, reasoningEffort: nextReasoningEffort });
     },
     [saveModelPreferenceDraft, selectedModel]
+  );
+
+  const handleProviderSelectionChange = useCallback(
+    (provider: SubscriptionProviderId, selection: ProviderAuthSelection | undefined) => {
+      const next = setProviderSelection(providerSelections, provider, selection);
+      setProviderSelections(next);
+      localStorage.setItem(LAST_PROVIDER_SELECTIONS_STORAGE_KEY, JSON.stringify(next));
+    },
+    [providerSelections]
   );
 
   const handlePromptChange = (value: string) => {
@@ -280,7 +298,7 @@ export default function Home() {
       skillPreviewLoading={skillPreviewLoading}
       skillSuggestions={skillSuggestions}
       providerSelections={providerSelections}
-      setProviderSelections={setProviderSelections}
+      onProviderSelectionChange={handleProviderSelectionChange}
       providerAccounts={providerAccounts}
     />
   );
@@ -308,7 +326,7 @@ function HomeContent({
   skillPreviewLoading,
   skillSuggestions,
   providerSelections,
-  setProviderSelections,
+  onProviderSelectionChange,
   providerAccounts,
 }: {
   isAuthenticated: boolean;
@@ -338,7 +356,10 @@ function HomeContent({
   skillPreviewLoading: boolean;
   skillSuggestions: PromptSkillSuggestionSource;
   providerSelections: ModelProviderSelections;
-  setProviderSelections: React.Dispatch<React.SetStateAction<ModelProviderSelections>>;
+  onProviderSelectionChange: (
+    provider: SubscriptionProviderId,
+    selection: ProviderAuthSelection | undefined
+  ) => void;
   providerAccounts: ReturnType<typeof useProviderAccounts>;
 }) {
   const { isOpen } = useSidebarContext();
@@ -517,9 +538,7 @@ function HomeContent({
                         )}
                         value={providerSelections[selectedProvider]}
                         onChange={(selection) =>
-                          setProviderSelections((current) =>
-                            setProviderSelection(current, selectedProvider, selection)
-                          )
+                          onProviderSelectionChange(selectedProvider, selection)
                         }
                       />
                     )}

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -56,7 +56,11 @@ import type {
 import { ProviderAuthControls } from "@/components/provider-auth-controls";
 import { useProviderAccounts } from "@/hooks/use-provider-accounts";
 import { useWarmDraftSession } from "@/hooks/use-warm-draft-session";
-import { parseStoredProviderSelections, setProviderSelection } from "@/lib/provider-selection";
+import {
+  parseStoredProviderSelections,
+  reconcileProviderSelections,
+  setProviderSelection,
+} from "@/lib/provider-selection";
 
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
@@ -93,6 +97,7 @@ export default function Home() {
   const [prompt, setPrompt] = useState("");
   const [skillSelection, setSkillSelection] = useState<SessionSkillSelection>({ mode: "all" });
   const [providerSelections, setProviderSelections] = useState<ModelProviderSelections>({});
+  const [providerSelectionsHydrated, setProviderSelectionsHydrated] = useState(false);
   const providerAccounts = useProviderAccounts();
   const sessionAttachments = useSessionAttachments();
   const [creating, setCreating] = useState(false);
@@ -121,8 +126,34 @@ export default function Home() {
       reasoningEffort: storedReasoningEffort ?? undefined,
     });
     if (storedProviderSelections) setProviderSelections(storedProviderSelections);
+    setProviderSelectionsHydrated(true);
     hasHydratedModelPreferencesRef.current = true;
   }, []);
+
+  const availableProviderSelections = providerAccounts.loading
+    ? providerSelections
+    : reconcileProviderSelections(providerSelections, providerAccounts.accounts);
+
+  useEffect(() => {
+    if (
+      !providerSelectionsHydrated ||
+      providerAccounts.loading ||
+      availableProviderSelections === providerSelections
+    ) {
+      return;
+    }
+
+    setProviderSelections(availableProviderSelections);
+    localStorage.setItem(
+      LAST_PROVIDER_SELECTIONS_STORAGE_KEY,
+      JSON.stringify(availableProviderSelections)
+    );
+  }, [
+    availableProviderSelections,
+    providerAccounts.loading,
+    providerSelections,
+    providerSelectionsHydrated,
+  ]);
 
   const { model: selectedModel, reasoningEffort } = resolveModelPreference(
     modelPreferenceDraft ?? storedPreference,
@@ -130,13 +161,17 @@ export default function Home() {
   );
 
   const warmRequest =
-    session && !loadingEnabledModels && targetRequestFields
+    session &&
+    providerSelectionsHydrated &&
+    !providerAccounts.loading &&
+    !loadingEnabledModels &&
+    targetRequestFields
       ? {
           ...targetRequestFields,
           model: selectedModel,
           reasoningEffort,
           skillSelection,
-          providerSelections,
+          providerSelections: availableProviderSelections,
         }
       : null;
   const {
@@ -172,11 +207,11 @@ export default function Home() {
 
   const handleProviderSelectionChange = useCallback(
     (provider: SubscriptionProviderId, selection: ProviderAuthSelection | undefined) => {
-      const next = setProviderSelection(providerSelections, provider, selection);
+      const next = setProviderSelection(availableProviderSelections, provider, selection);
       setProviderSelections(next);
       localStorage.setItem(LAST_PROVIDER_SELECTIONS_STORAGE_KEY, JSON.stringify(next));
     },
-    [providerSelections]
+    [availableProviderSelections]
   );
 
   const handlePromptChange = (value: string) => {
@@ -297,7 +332,7 @@ export default function Home() {
       skillPreview={skillPreview}
       skillPreviewLoading={skillPreviewLoading}
       skillSuggestions={skillSuggestions}
-      providerSelections={providerSelections}
+      providerSelections={availableProviderSelections}
       onProviderSelectionChange={handleProviderSelectionChange}
       providerAccounts={providerAccounts}
     />

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -238,7 +238,14 @@ export default function Home() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (submitInFlightRef.current || sessionAttachments.isUploading || loadingEnabledModels) return;
+    if (
+      submitInFlightRef.current ||
+      sessionAttachments.isUploading ||
+      providerAccounts.loading ||
+      loadingEnabledModels
+    ) {
+      return;
+    }
     const hasAttachments = sessionAttachments.attachments.length > 0;
     if (!prompt.trim() && !hasAttachments) return;
     if (!isLaunchable) {
@@ -509,6 +516,7 @@ function HomeContent({
                       disabled={
                         (!prompt.trim() && attachments.items.length === 0) ||
                         attachmentsLocked ||
+                        providerAccounts.loading ||
                         !isLaunchable
                       }
                       className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"

--- a/packages/web/src/lib/provider-selection.test.ts
+++ b/packages/web/src/lib/provider-selection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { setProviderSelection, type ProviderSelectionDrafts } from "./provider-selection";
+import {
+  parseStoredProviderSelections,
+  setProviderSelection,
+  type ProviderSelectionDrafts,
+} from "./provider-selection";
 
 describe("provider selection state", () => {
   it("retains explicit state for every provider while another provider changes", () => {
@@ -26,4 +30,25 @@ describe("provider selection state", () => {
       xai: { mode: "provider_account", accountId: "b".repeat(32) },
     });
   });
+
+  it("parses valid stored selections", () => {
+    expect(
+      parseStoredProviderSelections(
+        JSON.stringify({
+          openai: { mode: "provider_account", accountId: "a".repeat(32) },
+          xai: { mode: "api_key" },
+        })
+      )
+    ).toEqual({
+      openai: { mode: "provider_account", accountId: "a".repeat(32) },
+      xai: { mode: "api_key" },
+    });
+  });
+
+  it.each([null, "not json", JSON.stringify({ openai: { mode: "unknown" } })])(
+    "ignores invalid stored selections: %s",
+    (value) => {
+      expect(parseStoredProviderSelections(value)).toBeNull();
+    }
+  );
 });

--- a/packages/web/src/lib/provider-selection.test.ts
+++ b/packages/web/src/lib/provider-selection.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
   parseStoredProviderSelections,
+  reconcileProviderSelections,
   setProviderSelection,
   type ProviderSelectionDrafts,
 } from "./provider-selection";
 
 describe("provider selection state", () => {
+  const account = {
+    id: "a".repeat(32),
+    provider: "openai" as const,
+    displayName: "Team ChatGPT",
+    externalAccountId: null,
+    status: "active" as const,
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+  };
+
   it("retains explicit state for every provider while another provider changes", () => {
     let state: ProviderSelectionDrafts = {};
     state = setProviderSelection(state, "openai", {
@@ -51,4 +67,24 @@ describe("provider selection state", () => {
       expect(parseStoredProviderSelections(value)).toBeNull();
     }
   );
+
+  it("removes unavailable accounts while preserving API-key selections", () => {
+    expect(
+      reconcileProviderSelections(
+        {
+          openai: { mode: "provider_account", accountId: account.id },
+          xai: { mode: "api_key" },
+        },
+        [{ ...account, status: "disabled" }]
+      )
+    ).toEqual({ xai: { mode: "api_key" } });
+  });
+
+  it("retains selections for active matching accounts", () => {
+    const selections: ProviderSelectionDrafts = {
+      openai: { mode: "provider_account", accountId: account.id },
+    };
+
+    expect(reconcileProviderSelections(selections, [account])).toBe(selections);
+  });
 });

--- a/packages/web/src/lib/provider-selection.ts
+++ b/packages/web/src/lib/provider-selection.ts
@@ -1,10 +1,24 @@
-import type {
-  ModelProviderSelections,
-  ProviderAuthSelection,
-  SubscriptionProviderId,
+import {
+  modelProviderSelectionsSchema,
+  type ModelProviderSelections,
+  type ProviderAuthSelection,
+  type SubscriptionProviderId,
 } from "@open-inspect/shared/types/provider-accounts";
 
 export type ProviderSelectionDrafts = ModelProviderSelections;
+
+export function parseStoredProviderSelections(
+  value: string | null
+): ModelProviderSelections | null {
+  if (!value) return null;
+
+  try {
+    const parsed = modelProviderSelectionsSchema.safeParse(JSON.parse(value));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
 
 export function setProviderSelection(
   selections: ProviderSelectionDrafts,

--- a/packages/web/src/lib/provider-selection.ts
+++ b/packages/web/src/lib/provider-selection.ts
@@ -1,5 +1,7 @@
 import {
   modelProviderSelectionsSchema,
+  SUBSCRIPTION_PROVIDER_IDS,
+  type ModelProviderAccount,
   type ModelProviderSelections,
   type ProviderAuthSelection,
   type SubscriptionProviderId,
@@ -18,6 +20,33 @@ export function parseStoredProviderSelections(
   } catch {
     return null;
   }
+}
+
+export function reconcileProviderSelections(
+  selections: ModelProviderSelections,
+  accounts: ModelProviderAccount[]
+): ModelProviderSelections {
+  let changed = false;
+  const next: ModelProviderSelections = {};
+
+  for (const provider of SUBSCRIPTION_PROVIDER_IDS) {
+    const selection = selections[provider];
+    if (!selection) continue;
+
+    const available =
+      selection.mode === "api_key" ||
+      accounts.some(
+        (account) =>
+          account.id === selection.accountId &&
+          account.provider === provider &&
+          account.status === "active" &&
+          !account.archivedAt
+      );
+    if (available) next[provider] = selection;
+    else changed = true;
+  }
+
+  return changed ? next : selections;
 }
 
 export function setProviderSelection(


### PR DESCRIPTION
## Summary
- persist homepage provider authentication selections in `localStorage`
- restore separate OpenAI and xAI selections when the homepage remounts or reloads
- validate stored JSON with the shared provider-selection schema before using it
- cover selecting and restoring an actual ChatGPT provider account through session creation

## Testing
- `npm test -w @open-inspect/web -- --run 'src/app/(app)/page.test.tsx' 'src/lib/provider-selection.test.ts'`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- Prettier check for changed files
- Full web suite: 1,146 tests passed; two ESLint-boundary tests timed out under parallel load and both passed when rerun directly (`12/12`)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/035cec10e954095dd9d3777dfe437637)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider and model selections are restored from storage, reconciled with available accounts, and saved when updated.
  * API-key selections and active account selections are preserved automatically.
* **Bug Fixes**
  * Unavailable or archived account selections are removed before submission.
  * Session creation and sending wait until provider accounts finish loading.
  * Sending is disabled during loading, preventing premature requests and errors.
* **Tests**
  * Added coverage for selection persistence, reconciliation, loading behavior, and delayed session creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->