### PR TITLE
fix(skills): drop colliding managed skills

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/managed_skills.py
@@ -457,26 +457,23 @@ class ManagedSkillsMaterializer:
                 seen.add(root)
                 yield root
 
-    def _check_collisions(
+    def _find_collisions(
         self,
         selected: AbstractSet[str],
         repositories: Sequence[RepoEntry],
         workdir: Path,
-    ) -> None:
-        """Reject ambiguous names across every OpenCode skill discovery root."""
+    ) -> dict[str, set[Path]]:
+        """Collect managed names shadowed by an existing discovered skill."""
+        found: dict[str, set[Path]] = {}
         for root in self._collision_roots(repositories, workdir):
             if not root.is_dir():
                 continue
             for child in root.iterdir():
                 if not child.is_dir():
                     continue
-                collisions = self._skill_names(child) & selected
-                if collisions:
-                    name = sorted(collisions)[0]
-                    raise ManagedSkillsError(
-                        f"managed skill {name!r} collides with discovered skill at {child}",
-                        code="name_collision",
-                    )
+                for name in self._skill_names(child) & selected:
+                    found.setdefault(name, set()).add(child)
+        return found
 
     @staticmethod
     def _write_journal(journal: Path) -> None:
@@ -626,7 +623,21 @@ class ManagedSkillsMaterializer:
             staging, backup, journal = self._begin_staging()
             try:
                 manifest_sha256, names = await self._fetch_into_staging(staging)
-                self._check_collisions(names, repositories, workdir)
+                collisions = self._find_collisions(names, repositories, workdir)
+                if collisions:
+                    for name in collisions:
+                        self._remove_path(staging / name)
+                    names.difference_update(collisions)
+                    self.log.warn(
+                        "managed_skills.collisions_dropped",
+                        collisions=[
+                            {
+                                "name": name,
+                                "paths": sorted(str(path) for path in collisions[name]),
+                            }
+                            for name in sorted(collisions)
+                        ],
+                    )
                 self._commit_staging(staging, backup, journal)
             except Exception:
                 self._abort_staging(staging, backup, journal)

--- a/packages/sandbox-runtime/tests/test_managed_skills.py
+++ b/packages/sandbox-runtime/tests/test_managed_skills.py
@@ -159,22 +159,43 @@ async def test_materializer_replaces_destination(tmp_path):
     assert (destination / "managed" / "SKILL.md").stat().st_mode & 0o777 == 0o400
 
 
-async def test_materializer_rejects_bundled_name_collision(tmp_path):
+async def test_materializer_drops_only_managed_skills_that_collide_with_discovered_skills(tmp_path):
     document = _installation(name="conflict")
+    document["skills"].append(_installation(name="alias")["skills"][0])
+    document["skills"].append(_installation(name="bundled")["skills"][0])
+    document["skills"].append(_installation(name="kept")["skills"][0])
     client = MagicMock()
     client.fetch_installation = AsyncMock(return_value=json.dumps(document).encode())
-    bundled = tmp_path / "bundled" / "conflict"
-    bundled.mkdir(parents=True)
-    (bundled / "SKILL.md").write_text("---\nname: conflict\n---\n")
+    repository = tmp_path / "repository"
+    discovered = repository / ".claude" / "skills" / "conflict"
+    discovered.mkdir(parents=True)
+    (discovered / "SKILL.md").write_text("---\nname: conflict\n---\n")
+    alias_discovered = repository / ".agents" / "skills" / "different-directory"
+    alias_discovered.mkdir(parents=True)
+    (alias_discovered / "SKILL.md").write_text("---\nname: alias\n---\n")
+    bundled_discovered = tmp_path / "bundled" / "bundled"
+    bundled_discovered.mkdir(parents=True)
+    (bundled_discovered / "SKILL.md").write_text("---\nname: bundled\n---\n")
+    destination = tmp_path / "global" / "skills"
+    log = MagicMock()
     materializer = ManagedSkillsMaterializer(
         client,
-        tmp_path / "global" / "skills",
-        MagicMock(),
+        destination,
+        log,
         bundled_skills_path=tmp_path / "bundled",
     )
 
-    with pytest.raises(ManagedSkillsError, match="collides"):
-        await materializer.materialize((), tmp_path / "workspace")
+    await materializer.materialize((MagicMock(path=repository),), tmp_path / "workspace")
+
+    assert sorted(entry.name for entry in destination.iterdir()) == ["kept"]
+    log.warn.assert_called_once_with(
+        "managed_skills.collisions_dropped",
+        collisions=[
+            {"name": "alias", "paths": [str(alias_discovered)]},
+            {"name": "bundled", "paths": [str(bundled_discovered)]},
+            {"name": "conflict", "paths": [str(discovered)]},
+        ],
+    )
 
 
 async def test_materializer_ignores_invalid_utf8_during_collision_scan(tmp_path):


### PR DESCRIPTION
## Summary
- keep discovered repository, user, and bundled skills authoritative when their names collide with managed skills
- drop only the colliding managed entries from the atomic staging tree and emit a structured warning
- preserve installation of every non-colliding managed skill

## Problem
A single managed-skill name collision currently aborts materialization and prevents the sandbox from starting, even though a valid discovered skill with that name is already available. The failure also discards unrelated managed skills from the same installation.

## Testing
- `uv run --extra dev pytest tests/test_managed_skills.py -q` — 27 passed
- `uv run --extra dev pytest tests -q` — 760 passed
- `uv run --extra dev ruff check src tests` — passed
- `uv run --extra dev ruff format --check src tests` — 102 files already formatted
- `git diff --check` — passed

`mypy src/sandbox_runtime/managed_skills.py` still reports the same four pre-existing errors on both this branch and the base revision at lines 318–338.

Fixes #1545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Managed skill installation now continues when skill names conflict with already discovered skills.
  * Conflicting managed skills are skipped while non-conflicting skills are installed normally.
  * Collision details, including affected skill names and locations, are recorded in warning logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->