### PR TITLE
feat: add GLM 5.2 to OpenCode Zen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts.
 **Kimi K3 and GLM 5.3.** Adds `opencode/kimi-k3` to the opt-in OpenCode Zen catalog and
 `zai-coding-plan/glm-5.3` to the opt-in Z.AI Coding Plan catalog.
 
+**OpenCode Zen GLM 5.2.** Adds `opencode/glm-5.2` to the opt-in OpenCode Zen catalog.
+
 **Cancel queued prompts.** Pending web prompts can now be removed before they start processing,
 freeing queue capacity and restoring the removed text to an empty composer after server
 confirmation.

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider         | Models                                                              |
-| ---------------- | ------------------------------------------------------------------- |
-| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
-| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                        |
-| xAI / SuperGrok  | Grok models (opt-in)                                                |
-| OpenCode Zen     | Kimi K2.5/K2.6/K3, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)    |
-| Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                |
+| Provider         | Models                                                               |
+| ---------------- | -------------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5  |
+| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                         |
+| xAI / SuperGrok  | Grok models (opt-in)                                                 |
+| OpenCode Zen     | Kimi K2.5/K2.6/K3, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1/5.2 (opt-in) |
+| Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                 |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -64,6 +64,7 @@ instructions.
 | `opencode/qwen3.7-max`  | Qwen3.7 Max  | Alibaba Cloud | Not supported     | N/A            |
 | `opencode/glm-5`        | GLM 5        | Z.ai 744B MoE | Not supported     | N/A            |
 | `opencode/glm-5.1`      | GLM 5.1      | Z.ai          | Not supported     | N/A            |
+| `opencode/glm-5.2`      | GLM 5.2      | Z.ai          | Not supported     | N/A            |
 
 ## Z.AI Coding Plan
 

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -52,6 +52,7 @@ const ZEN_MODELS = [
   "opencode/qwen3.7-max",
   "opencode/glm-5",
   "opencode/glm-5.1",
+  "opencode/glm-5.2",
 ] as const;
 
 const DEEPSEEK_MODELS = ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"] as const;

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -198,6 +198,7 @@ export const MODEL_CATALOG = [
       { id: "opencode/qwen3.7-max", name: "Qwen3.7 Max", description: "Alibaba Cloud" },
       { id: "opencode/glm-5", name: "GLM 5", description: "Z.ai 744B MoE" },
       { id: "opencode/glm-5.1", name: "GLM 5.1", description: "Z.ai" },
+      { id: "opencode/glm-5.2", name: "GLM 5.2", description: "Z.ai" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- add `opencode/glm-5.2` to the opt-in OpenCode Zen model catalog
- cover the new model in the shared catalog assertions
- update the README, available-model documentation, and changelog

GLM 5.2 remains available separately as `zai-coding-plan/glm-5.2`; this adds the OpenCode Zen provider route without reasoning controls, consistent with the existing Zen GLM models.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (655 tests passed)
- `npm run typecheck`
- `npx prettier --check packages/shared/src/models.ts packages/shared/src/models.test.ts docs/AVAILABLE_MODELS.md README.md CHANGELOG.md`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/34371fbf9a3b6886cdc9f0e795cdee06)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GLM 5.2 to the OpenCode Zen model catalog.
  - GLM 5.2 is available as an opt-in model through the `opencode/glm-5.2` identifier.

- **Documentation**
  - Updated the supported-model list and provider documentation to include GLM 5.2.
  - Added a changelog entry announcing its availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->