### PR TITLE
fix: allow Enter shortcuts for sending prompts

### DIFF
--- a/packages/control-plane/test/integration/keyboard-shortcuts.test.ts
+++ b/packages/control-plane/test/integration/keyboard-shortcuts.test.ts
@@ -10,6 +10,7 @@ import { serviceFetch } from "./helpers";
 
 const customShortcuts = {
   ...DEFAULT_KEYBOARD_SHORTCUTS,
+  "send-prompt": { code: "Enter", primary: false, alt: false, shift: false },
   "open-command-menu": { code: "KeyP", primary: true, alt: false, shift: false },
 };
 

--- a/packages/shared/src/types/keyboard-shortcuts.test.ts
+++ b/packages/shared/src/types/keyboard-shortcuts.test.ts
@@ -25,11 +25,26 @@ describe("keyboard shortcut preferences", () => {
     ).toBe(false);
   });
 
-  it("requires primary or alt and a non-modifier key", () => {
+  it("allows Enter with or without Shift for sending prompts", () => {
+    expect(
+      keyboardShortcutPreferencesSchema.safeParse({
+        ...DEFAULT_KEYBOARD_SHORTCUTS,
+        "send-prompt": { code: "Enter", primary: false, alt: false, shift: false },
+      }).success
+    ).toBe(true);
     expect(
       keyboardShortcutPreferencesSchema.safeParse({
         ...DEFAULT_KEYBOARD_SHORTCUTS,
         "send-prompt": { code: "Enter", primary: false, alt: false, shift: true },
+      }).success
+    ).toBe(true);
+  });
+
+  it("requires primary or alt for other actions and a non-modifier key", () => {
+    expect(
+      keyboardShortcutPreferencesSchema.safeParse({
+        ...DEFAULT_KEYBOARD_SHORTCUTS,
+        "open-command-menu": { code: "Enter", primary: false, alt: false, shift: false },
       }).success
     ).toBe(false);
     expect(

--- a/packages/shared/src/types/keyboard-shortcuts.ts
+++ b/packages/shared/src/types/keyboard-shortcuts.ts
@@ -22,8 +22,8 @@ export const keyboardShortcutBindingSchema = z
     alt: z.boolean(),
     shift: z.boolean(),
   })
-  .refine(({ primary, alt }) => primary || alt, {
-    message: "A primary or Alt modifier is required",
+  .refine(({ code, primary, alt }) => primary || alt || code === "Enter", {
+    message: "A primary or Alt modifier is required unless the key is Enter",
   })
   .refine(({ code }) => !MODIFIER_CODES.has(code), {
     message: "A non-modifier key is required",
@@ -60,6 +60,13 @@ export type GlobalKeyboardShortcutAction = {
 }[KeyboardShortcutAction];
 export type KeyboardShortcutPreferences = Record<KeyboardShortcutAction, KeyboardShortcutBinding>;
 
+export function isKeyboardShortcutBindingAllowed(
+  action: KeyboardShortcutAction,
+  binding: KeyboardShortcutBinding
+): boolean {
+  return action === "send-prompt" || binding.primary || binding.alt;
+}
+
 export const KEYBOARD_SHORTCUT_ACTIONS = Object.keys(
   KEYBOARD_SHORTCUT_DEFINITIONS
 ) as KeyboardShortcutAction[];
@@ -89,6 +96,13 @@ export const keyboardShortcutPreferencesSchema: z.ZodType<KeyboardShortcutPrefer
     const seen = new Set<string>();
     for (const action of KEYBOARD_SHORTCUT_ACTIONS) {
       const binding = shortcuts[action];
+      if (!isKeyboardShortcutBindingAllowed(action, binding)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [action],
+          message: "A primary or Alt modifier is required for this action",
+        });
+      }
       const canonical = keyboardShortcutBindingKey(binding);
       if (seen.has(canonical)) {
         ctx.addIssue({

--- a/packages/web/src/components/settings/keyboard-shortcuts-settings.test.tsx
+++ b/packages/web/src/components/settings/keyboard-shortcuts-settings.test.tsx
@@ -42,6 +42,32 @@ describe("KeyboardShortcutsSettings", () => {
     });
   });
 
+  it.each([
+    ["{Enter}", "Enter", false, "Shift+Enter"],
+    ["{Shift>}{Enter}{/Shift}", "Shift+Enter", true, "Enter"],
+  ])("records %s for sending prompts", async (keys, label, shift, newlineLabel) => {
+    const user = userEvent.setup();
+    render(<KeyboardShortcutsSettings />);
+
+    await user.click(screen.getByRole("button", { name: /Record shortcut for Send prompt/ }));
+    await user.keyboard(keys);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName === "P" &&
+          element.textContent ===
+            `In the composer, ${label} sends and ${newlineLabel} creates a newline.`
+      )
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(save).toHaveBeenCalledWith({
+      ...DEFAULT_KEYBOARD_SHORTCUTS,
+      "send-prompt": { code: "Enter", primary: false, alt: false, shift },
+    });
+  });
+
   it("cancels recording with Escape", async () => {
     const user = userEvent.setup();
     render(<KeyboardShortcutsSettings />);

--- a/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
+++ b/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
@@ -69,7 +69,7 @@ export function KeyboardShortcutsSettings() {
       setRecording(null);
       return;
     }
-    const binding = captureShortcut(event.nativeEvent);
+    const binding = captureShortcut(event.nativeEvent, action);
     if (!binding) return;
     event.preventDefault();
     event.stopPropagation();
@@ -95,6 +95,15 @@ export function KeyboardShortcutsSettings() {
   if (loading) {
     return <p className="text-sm text-muted-foreground">Loading keyboard shortcuts...</p>;
   }
+
+  const sendShortcut = draft["send-prompt"];
+  const newlineShortcut =
+    sendShortcut.code === "Enter" &&
+    !sendShortcut.primary &&
+    !sendShortcut.alt &&
+    !sendShortcut.shift
+      ? "Shift+Enter"
+      : "Enter";
 
   return (
     <div>
@@ -151,7 +160,8 @@ export function KeyboardShortcutsSettings() {
       </div>
 
       <p className="mt-4 text-sm text-muted-foreground">
-        In the composer, {formatShortcut(draft["send-prompt"])} sends and Enter creates a newline.
+        In the composer, {formatShortcut(sendShortcut)} sends and {newlineShortcut} creates a
+        newline.
       </p>
 
       <div className="mt-6 flex gap-3">

--- a/packages/web/src/hooks/use-prompt-input.test.tsx
+++ b/packages/web/src/hooks/use-prompt-input.test.tsx
@@ -101,4 +101,23 @@ describe("usePromptInput", () => {
     fireEvent.keyDown(input, { key: "j", code: "KeyJ", altKey: true });
     expect(mocks.sendPrompt).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    ["Enter", false],
+    ["Shift+Enter", true],
+  ])("submits with %s when configured", (_label, shiftKey) => {
+    mocks.sendPrompt.mockResolvedValue({ ok: true });
+    render(
+      <PromptHarness
+        canSubmit
+        sendShortcut={{ code: "Enter", primary: false, alt: false, shift: shiftKey }}
+      />
+    );
+    const input = screen.getByRole("textbox", { name: "Prompt" });
+    fireEvent.change(input, { target: { value: "Ship it" } });
+
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter", shiftKey });
+
+    expect(mocks.sendPrompt).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/web/src/lib/keyboard-shortcuts.test.ts
+++ b/packages/web/src/lib/keyboard-shortcuts.test.ts
@@ -82,14 +82,19 @@ describe("matchGlobalShortcut", () => {
 describe("shortcut capture and display", () => {
   it("captures Meta and Control as the portable primary modifier", () => {
     expect(
-      captureShortcut(createKeyEvent({ code: "KeyJ", metaKey: true, shiftKey: true }))
+      captureShortcut(
+        createKeyEvent({ code: "KeyJ", metaKey: true, shiftKey: true }),
+        "open-command-menu"
+      )
     ).toEqual({
       code: "KeyJ",
       primary: true,
       alt: false,
       shift: true,
     });
-    expect(captureShortcut(createKeyEvent({ code: "KeyJ", ctrlKey: true }))).toEqual({
+    expect(
+      captureShortcut(createKeyEvent({ code: "KeyJ", ctrlKey: true }), "open-command-menu")
+    ).toEqual({
       code: "KeyJ",
       primary: true,
       alt: false,
@@ -98,8 +103,25 @@ describe("shortcut capture and display", () => {
   });
 
   it("ignores modifiers and combinations without primary or Alt", () => {
-    expect(captureShortcut(createKeyEvent({ code: "ShiftLeft", shiftKey: true }))).toBeNull();
-    expect(captureShortcut(createKeyEvent({ code: "KeyJ", shiftKey: true }))).toBeNull();
+    expect(
+      captureShortcut(createKeyEvent({ code: "ShiftLeft", shiftKey: true }), "open-command-menu")
+    ).toBeNull();
+    expect(
+      captureShortcut(createKeyEvent({ code: "KeyJ", shiftKey: true }), "open-command-menu")
+    ).toBeNull();
+  });
+
+  it("captures Enter with or without Shift only for sending prompts", () => {
+    expect(captureShortcut(createKeyEvent({ code: "Enter" }), "send-prompt")).toEqual({
+      code: "Enter",
+      primary: false,
+      alt: false,
+      shift: false,
+    });
+    expect(
+      captureShortcut(createKeyEvent({ code: "Enter", shiftKey: true }), "send-prompt")
+    ).toEqual({ code: "Enter", primary: false, alt: false, shift: true });
+    expect(captureShortcut(createKeyEvent({ code: "Enter" }), "open-command-menu")).toBeNull();
   });
 
   it("formats common physical key codes", () => {

--- a/packages/web/src/lib/keyboard-shortcuts.ts
+++ b/packages/web/src/lib/keyboard-shortcuts.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_KEYBOARD_SHORTCUTS,
   GLOBAL_KEYBOARD_SHORTCUT_ACTIONS,
   KEYBOARD_SHORTCUT_ACTIONS,
+  isKeyboardShortcutBindingAllowed,
   keyboardShortcutBindingKey,
   keyboardShortcutBindingSchema,
   type KeyboardShortcutAction,
@@ -40,7 +41,10 @@ export function matchesShortcut(event: KeyboardEvent, binding: KeyboardShortcutB
   );
 }
 
-export function captureShortcut(event: KeyboardEvent): KeyboardShortcutBinding | null {
+export function captureShortcut(
+  event: KeyboardEvent,
+  action: KeyboardShortcutAction
+): KeyboardShortcutBinding | null {
   const binding = {
     code: event.code,
     primary: event.metaKey || event.ctrlKey,
@@ -48,7 +52,9 @@ export function captureShortcut(event: KeyboardEvent): KeyboardShortcutBinding |
     shift: event.shiftKey,
   };
   const parsed = keyboardShortcutBindingSchema.safeParse(binding);
-  return parsed.success ? parsed.data : null;
+  return parsed.success && isKeyboardShortcutBindingAllowed(action, parsed.data)
+    ? parsed.data
+    : null;
 }
 
 export function formatShortcut(binding: KeyboardShortcutBinding): string {


### PR DESCRIPTION
## Summary
- allow bare `Enter` and `Shift+Enter` bindings for the Send prompt action
- retain the `Cmd/Ctrl` or `Alt` modifier requirement for global shortcut actions
- update the settings hint to show the correct newline shortcut
- add validation, recorder, submission, and persistence regression coverage

## Testing
- `npm test -w @open-inspect/shared -- --run src/types/keyboard-shortcuts.test.ts`
- `npm test -w @open-inspect/web -- --run src/lib/keyboard-shortcuts.test.ts src/components/settings/keyboard-shortcuts-settings.test.tsx src/hooks/use-prompt-input.test.tsx`
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/keyboard-shortcuts.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ba52038fd76b084072ca59aec465b2ff)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send prompt can now be assigned to Enter or Shift+Enter.
  * Shortcut settings provide updated guidance when Enter is used for sending prompts.
  * Prompt submission works with the configured Enter shortcut, with or without Shift.

* **Bug Fixes**
  * Other actions continue to reject Enter-only and modifier-only shortcuts.
  * Shortcut recording now correctly applies action-specific validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->