### PR TITLE
Shorten recent session timestamps to "now"

### DIFF
--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -101,7 +101,7 @@ function dateLabel(timestamp: number | null) {
 function relativeDateLabel(timestamp: number | null) {
   if (!timestamp) return "Never";
   const relative = formatRelativeTime(timestamp);
-  return relative === "just now" ? relative : `${relative} ago`;
+  return relative === "now" ? relative : `${relative} ago`;
 }
 
 function ProviderIcon({

--- a/packages/web/src/lib/time.test.ts
+++ b/packages/web/src/lib/time.test.ts
@@ -11,6 +11,10 @@ afterEach(() => {
 });
 
 describe("formatRelativeTime", () => {
+  it("formats timestamps less than one minute old as now", () => {
+    expect(formatRelativeTime(Date.now() - 30 * 1000)).toBe("now");
+  });
+
   it("keeps formatting past timestamps without future-time wording", () => {
     expect(formatRelativeTime(Date.now() - 2 * 60 * 60 * 1000)).toBe("2h");
   });

--- a/packages/web/src/lib/time.ts
+++ b/packages/web/src/lib/time.ts
@@ -16,7 +16,7 @@ export function formatSessionEventTime(timestampSeconds: number): string {
 
 /**
  * Format a timestamp as a relative time string (e.g., "2d", "3h", "5m").
- * Returns "just now" for very recent timestamps.
+ * Returns "now" for very recent timestamps.
  */
 export function formatRelativeTime(timestamp: number): string {
   const now = Date.now();
@@ -36,7 +36,7 @@ export function formatRelativeTime(timestamp: number): string {
   if (minutes > 0) {
     return `${minutes}m`;
   }
-  return "just now";
+  return "now";
 }
 
 /**


### PR DESCRIPTION
## Summary
- display `now` instead of `just now` for timestamps less than one minute old
- keep provider account relative-date labels grammatically correct
- add regression coverage for the compact timestamp

## Testing
- `npm test -w @open-inspect/web -- src/lib/time.test.ts`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8a028e050e0355e21bbc0b3fa982cc15)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated relative timestamps from “just now” to the more concise “now” for events occurring within the past minute.
  * Provider account settings now consistently display the updated relative time label.

* **Tests**
  * Added coverage confirming timestamps from 30 seconds ago display as “now.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->