### PR TITLE
docs: add recent changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## August 22, 2026
+
+**Unified model and reasoning selection.** New-session and follow-up composers now combine model and
+reasoning-effort selection in one responsive control, with nested desktop menus and an in-place
+mobile drill-down.
+
+## August 21, 2026
+
+**Configurable keyboard shortcuts.** Set per-user shortcuts for sending prompts, opening search or a
+new session, and toggling the sidebar. Settings can record, validate, reset, and persist bindings,
+including Enter or Shift+Enter for sending.
+
+**Recent automation activity.** Automation rows now show the latest execution outcomes at a glance,
+alongside clearer compact schedules, responsive mobile actions, and confirmation before deletion.
+
+**Managed skills at larger scale.** Sessions and profiles are no longer limited to 20 managed
+skills. Large manifests are installed page by page and persisted in batches, while name collisions
+skip only the conflicting managed skill instead of preventing the sandbox from starting.
+
+**OpenCode Zen GLM 5.2.** Adds `opencode/glm-5.2` to the opt-in OpenCode Zen catalog.
+
+**Better support for system services in sandboxes.** Sandbox images now include account and init
+helpers and expose system administration paths, allowing setup hooks to create users and start
+services such as PostgreSQL, Elasticsearch, and nginx.
+
+## August 20, 2026
+
+**Managed provider accounts.** Connect and manage multiple ChatGPT and SuperGrok subscription
+accounts from Settings using device authorization, choose accounts for sessions and automations, and
+configure defaults for unattended runs. Sandboxes receive short-lived access without exposing stored
+refresh credentials.
+
+**Prebuilt images for E2B.** E2B can now build, snapshot, reuse, and delete repository and
+environment images, with reliable startup from prebuilt snapshots and configurable template CPU and
+memory.
+
+**Actionable sandbox failures.** Session status now shows the provider's actual startup or recovery
+error and preserves it across reloads, while clearing stale details when a retry begins.
+
+**Automatic retirement of stale sandbox snapshots.** Session snapshots now record their runtime
+version and restore only when compatible; old or unknown snapshots trigger a fresh sandbox instead
+of repeatedly reviving a broken runtime.
+
+## August 16, 2026
+
+**Session attention inbox.** The sidebar now groups session trees into Needs attention, In progress,
+and Recent, prioritizing unread terminal outcomes. Each section has independent pagination and retry
+behavior while preserving parent and child-session grouping.
+
+**Managed skill autocomplete.** Type `/skill-name` or `$skill-name` in new-session and follow-up
+prompts to search applicable skills, with keyboard and pointer selection. Existing sessions suggest
+from their pinned skill manifest so completions stay reproducible.
+
 ## August 15, 2026
 
 **Managed skills.** Create and edit reusable Agent Skills in Settings, assign them globally or to
@@ -25,8 +78,6 @@ to the opt-in xAI / SuperGrok catalog with low, medium, and high efforts.
 
 **Kimi K3 and GLM 5.3.** Adds `opencode/kimi-k3` to the opt-in OpenCode Zen catalog and
 `zai-coding-plan/glm-5.3` to the opt-in Z.AI Coding Plan catalog.
-
-**OpenCode Zen GLM 5.2.** Adds `opencode/glm-5.2` to the opt-in OpenCode Zen catalog.
 
 **Cancel queued prompts.** Pending web prompts can now be removed before they start processing,
 freeing queue capacity and restoring the removed text to an empty composer after server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ mobile drill-down.
 ## August 21, 2026
 
 **Configurable keyboard shortcuts.** Set per-user shortcuts for sending prompts, opening search or a
-new session, and toggling the sidebar. Settings can record, validate, reset, and persist bindings,
-including Enter or Shift+Enter for sending.
+new session, and toggling the sidebar. Settings can record, validate, reset, and persist bindings.
 
 **Recent automation activity.** Automation rows now show the latest execution outcomes at a glance,
 alongside clearer compact schedules, responsive mobile actions, and confirmation before deletion.
@@ -23,19 +22,20 @@ alongside clearer compact schedules, responsive mobile actions, and confirmation
 
 **Managed provider accounts.** Connect and manage multiple ChatGPT and SuperGrok subscription
 accounts from Settings using device authorization, choose accounts for sessions and automations, and
-configure defaults for unattended runs. Sandboxes receive short-lived access without exposing stored
-refresh credentials.
+configure defaults for unattended runs. These installation-wide accounts and defaults are available
+to every admitted user, while sandboxes receive short-lived access without exposing stored refresh
+credentials.
 
 **Prebuilt images for E2B.** E2B can now build, snapshot, reuse, and delete repository and
 environment images, with reliable startup from prebuilt snapshots and configurable template CPU and
 memory.
 
-**Actionable sandbox failures.** Session status now shows the provider's actual startup or recovery
-error and preserves it across reloads, while clearing stale details when a retry begins.
+**Actionable sandbox failures.** Session status now shows the provider's startup or recovery error
+when available and preserves it across reloads, while clearing stale details when a retry begins.
 
 **Automatic retirement of stale sandbox snapshots.** Session snapshots now record their runtime
-version and restore only when compatible; old or unknown snapshots trigger a fresh sandbox instead
-of repeatedly reviving a broken runtime.
+version and restore only when compatible. Incompatible or unknown snapshots trigger a fresh sandbox
+instead of repeatedly reviving a broken runtime, which may discard uncommitted filesystem state.
 
 ## August 16, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,7 @@ including Enter or Shift+Enter for sending.
 **Recent automation activity.** Automation rows now show the latest execution outcomes at a glance,
 alongside clearer compact schedules, responsive mobile actions, and confirmation before deletion.
 
-**Managed skills at larger scale.** Sessions and profiles are no longer limited to 20 managed
-skills. Large manifests are installed page by page and persisted in batches, while name collisions
-skip only the conflicting managed skill instead of preventing the sandbox from starting.
-
 **OpenCode Zen GLM 5.2.** Adds `opencode/glm-5.2` to the opt-in OpenCode Zen catalog.
-
-**Better support for system services in sandboxes.** Sandbox images now include account and init
-helpers and expose system administration paths, allowing setup hooks to create users and start
-services such as PostgreSQL, Elasticsearch, and nginx.
 
 ## August 20, 2026
 


### PR DESCRIPTION
## Summary

- document user-facing features and notable improvements merged from August 16 through August 22
- add entries for provider accounts, session inbox organization, managed-skill improvements, E2B prebuilt images, keyboard shortcuts, automation activity, sandbox diagnostics, and model selection
- move the OpenCode Zen GLM 5.2 entry to its actual August 21 merge date

## Validation

- `npm exec prettier -- --check CHANGELOG.md`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/b0e92dcd6a322300f6b85199a95390ec)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified model and reasoning selection.
  * Added configurable keyboard shortcuts and automation activity visibility.
  * Added managed provider accounts and managed-skill autocomplete.
  * Added E2B image support, sandbox snapshots, and session attention indicators.

* **Bug Fixes**
  * Improved sandbox failure handling and clarified snapshot compatibility behavior.

* **Documentation**
  * Updated release notes for August 16, 20, 21, and 22, 2026.
  * Clarified provider account availability and sandbox error conditions.
  * Removed the OpenCode Zen GLM 5.2 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->