### PR TITLE
Keep default reasoning effort controls visible

### DIFF
--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -282,7 +282,9 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("anthropic/claude-fable-5")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
-    expect(getDefaultReasoningEffort("openai/gpt-5.6-luna")).toBeUndefined();
+    expect(getDefaultReasoningEffort("openai/gpt-5.6-sol")).toBe("medium");
+    expect(getDefaultReasoningEffort("openai/gpt-5.6-terra")).toBe("medium");
+    expect(getDefaultReasoningEffort("openai/gpt-5.6-luna")).toBe("medium");
     expect(getDefaultReasoningEffort("xai/grok-build-0.1")).toBeUndefined();
     expect(getDefaultReasoningEffort("deepseek/deepseek-v4-pro")).toBeUndefined();
   });
@@ -314,11 +316,15 @@ describe("model utilities", () => {
     });
     expect(getReasoningConfig("openai/gpt-5.6-sol")).toEqual({
       efforts: ["none", "low", "medium", "high", "xhigh"],
-      default: undefined,
+      default: "medium",
+    });
+    expect(getReasoningConfig("openai/gpt-5.6-terra")).toEqual({
+      efforts: ["none", "low", "medium", "high", "xhigh"],
+      default: "medium",
     });
     expect(getReasoningConfig("openai/gpt-5.6-luna")).toEqual({
       efforts: ["none", "low", "medium", "high", "xhigh", "max"],
-      default: undefined,
+      default: "medium",
     });
     expect(getReasoningConfig("openai/gpt-5.3-codex")).toEqual({
       efforts: ["low", "medium", "high", "xhigh"],

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -16,6 +16,8 @@ import { SUBSCRIPTION_PROVIDER_IDS, type SubscriptionProviderId } from "./types/
  */
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 
+const GPT_5_6_DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+
 export interface ModelReasoningConfig {
   efforts: ReasoningEffort[];
   default: ReasoningEffort | undefined;
@@ -152,7 +154,7 @@ export const MODEL_CATALOG = [
         description: "Frontier model for complex professional work",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh"],
-          default: "medium",
+          default: GPT_5_6_DEFAULT_REASONING_EFFORT,
         },
       },
       {
@@ -161,7 +163,7 @@ export const MODEL_CATALOG = [
         description: "Balanced, cost-efficient everyday work",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh"],
-          default: "medium",
+          default: GPT_5_6_DEFAULT_REASONING_EFFORT,
         },
       },
       {
@@ -170,7 +172,7 @@ export const MODEL_CATALOG = [
         description: "Fast, cost-efficient high-volume workloads",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh", "max"],
-          default: "medium",
+          default: GPT_5_6_DEFAULT_REASONING_EFFORT,
         },
       },
       {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -152,7 +152,7 @@ export const MODEL_CATALOG = [
         description: "Frontier model for complex professional work",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh"],
-          default: undefined,
+          default: "medium",
         },
       },
       {
@@ -161,7 +161,7 @@ export const MODEL_CATALOG = [
         description: "Balanced, cost-efficient everyday work",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh"],
-          default: undefined,
+          default: "medium",
         },
       },
       {
@@ -170,7 +170,7 @@ export const MODEL_CATALOG = [
         description: "Fast, cost-efficient high-volume workloads",
         reasoning: {
           efforts: ["none", "low", "medium", "high", "xhigh", "max"],
-          default: undefined,
+          default: "medium",
         },
       },
       {

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -206,7 +206,7 @@ export default function Home() {
   );
 
   const handleReasoningEffortChange = useCallback(
-    (nextReasoningEffort: ReasoningEffort) => {
+    (nextReasoningEffort: ReasoningEffort | undefined) => {
       saveModelPreferenceDraft({ model: selectedModel, reasoningEffort: nextReasoningEffort });
     },
     [saveModelPreferenceDraft, selectedModel]
@@ -386,7 +386,7 @@ function HomeContent({
   selectedModel: ValidModel;
   setSelectedModel: (value: ValidModel) => void;
   reasoningEffort: ReasoningEffort | undefined;
-  setReasoningEffort: (value: ReasoningEffort) => void;
+  setReasoningEffort: (value: ReasoningEffort | undefined) => void;
   prompt: string;
   handlePromptChange: (value: string) => void;
   attachments: {

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -621,7 +621,7 @@ function useModelSelection(sessionState: SessionState) {
   }, []);
 
   const setReasoningEffort = useCallback(
-    (nextReasoningEffort: ReasoningEffort) => {
+    (nextReasoningEffort: ReasoningEffort | undefined) => {
       setModelPreferenceDraft({ model: selectedModel, reasoningEffort: nextReasoningEffort });
     },
     [selectedModel]

--- a/packages/web/src/components/model-reasoning-selector.test.tsx
+++ b/packages/web/src/components/model-reasoning-selector.test.tsx
@@ -37,6 +37,11 @@ const items = [
         name: "GPT 5.6 Sol",
         description: "Frontier model",
       },
+      {
+        id: "openai/gpt-5.5",
+        name: "GPT 5.5",
+        description: "Latest flagship model",
+      },
     ],
   },
   {
@@ -126,7 +131,47 @@ describe("ModelReasoningSelector", () => {
     const trigger = screen.getByRole("button", { name: /model and effort/i });
     expect(trigger).toHaveTextContent("gpt 5.6 solMedium");
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-    expect(await screen.findByRole("menuitem", { name: /effort.*medium/i })).toBeInTheDocument();
+    const effortMenu = await screen.findByRole("menuitem", { name: /effort.*medium/i });
+    effortMenu.focus();
+    fireEvent.keyDown(effortMenu, { key: "ArrowRight" });
+    expect(await screen.findByRole("menuitemradio", { name: "Default" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("allows returning to the default effort", async () => {
+    const onReasoningEffortChange = vi.fn();
+    const { rerender } = render(
+      <ModelReasoningSelector
+        selectedModel="openai/gpt-5.5"
+        reasoningEffort="high"
+        items={items}
+        onModelChange={vi.fn()}
+        onReasoningEffortChange={onReasoningEffortChange}
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: /model and effort/i });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    const effortMenu = await screen.findByRole("menuitem", { name: /effort/i });
+    effortMenu.focus();
+    fireEvent.keyDown(effortMenu, { key: "ArrowRight" });
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "Default" }));
+    expect(onReasoningEffortChange).toHaveBeenCalledWith(undefined);
+
+    rerender(
+      <ModelReasoningSelector
+        selectedModel="openai/gpt-5.5"
+        reasoningEffort={undefined}
+        items={items}
+        onModelChange={vi.fn()}
+        onReasoningEffortChange={onReasoningEffortChange}
+      />
+    );
+    expect(screen.getByRole("button", { name: /model and effort/i })).toHaveTextContent(
+      "gpt 5.5Default"
+    );
   });
 
   it("drills into model options without a clipped side menu on mobile", async () => {

--- a/packages/web/src/components/model-reasoning-selector.test.tsx
+++ b/packages/web/src/components/model-reasoning-selector.test.tsx
@@ -30,12 +30,22 @@ const items = [
     ],
   },
   {
-    category: "Other",
+    category: "OpenAI",
     models: [
       {
-        id: "xai/grok-build-0.1",
-        name: "Grok Build 0.1",
-        description: "Coding model",
+        id: "openai/gpt-5.6-sol",
+        name: "GPT 5.6 Sol",
+        description: "Frontier model",
+      },
+    ],
+  },
+  {
+    category: "xAI",
+    models: [
+      {
+        id: "xai/grok-4.6",
+        name: "Grok 4.6",
+        description: "Latest Grok model",
       },
     ],
   },
@@ -76,11 +86,11 @@ describe("ModelReasoningSelector", () => {
     const modelMenu = await screen.findByRole("menuitem", { name: /model/i });
     modelMenu.focus();
     fireEvent.keyDown(modelMenu, { key: "ArrowRight" });
-    const grokOption = await screen.findByRole("menuitemradio", { name: /grok build/i });
+    const grokOption = await screen.findByRole("menuitemradio", { name: /grok 4.6/i });
     expect(grokOption.closest('[role="menu"]')).toHaveClass("max-h-56", "overflow-y-auto");
     expect(grokOption.closest('[role="menu"]')).toHaveAttribute("data-align", "end");
     fireEvent.click(grokOption);
-    expect(onModelChange).toHaveBeenCalledWith("xai/grok-build-0.1");
+    expect(onModelChange).toHaveBeenCalledWith("xai/grok-4.6");
 
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
     const effortMenu = await screen.findByRole("menuitem", { name: /effort/i });
@@ -90,6 +100,33 @@ describe("ModelReasoningSelector", () => {
     expect(maxEffort.closest('[role="menu"]')).toHaveAttribute("data-align", "end");
     fireEvent.click(maxEffort);
     expect(onReasoningEffortChange).toHaveBeenCalledWith("max");
+  });
+
+  it("keeps effort controls visible when switching back from Grok to a model without a default", async () => {
+    const { rerender } = render(
+      <ModelReasoningSelector
+        selectedModel="xai/grok-4.6"
+        reasoningEffort="high"
+        items={items}
+        onModelChange={vi.fn()}
+        onReasoningEffortChange={vi.fn()}
+      />
+    );
+
+    rerender(
+      <ModelReasoningSelector
+        selectedModel="openai/gpt-5.6-sol"
+        reasoningEffort={undefined}
+        items={items}
+        onModelChange={vi.fn()}
+        onReasoningEffortChange={vi.fn()}
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: /model and effort/i });
+    expect(trigger).toHaveTextContent("gpt 5.6 solDefault");
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    expect(await screen.findByRole("menuitem", { name: /effort.*default/i })).toBeInTheDocument();
   });
 
   it("drills into model options without a clipped side menu on mobile", async () => {

--- a/packages/web/src/components/model-reasoning-selector.test.tsx
+++ b/packages/web/src/components/model-reasoning-selector.test.tsx
@@ -102,7 +102,7 @@ describe("ModelReasoningSelector", () => {
     expect(onReasoningEffortChange).toHaveBeenCalledWith("max");
   });
 
-  it("keeps effort controls visible when switching back from Grok to a model without a default", async () => {
+  it("shows the default effort when switching back from Grok", async () => {
     const { rerender } = render(
       <ModelReasoningSelector
         selectedModel="xai/grok-4.6"
@@ -124,9 +124,9 @@ describe("ModelReasoningSelector", () => {
     );
 
     const trigger = screen.getByRole("button", { name: /model and effort/i });
-    expect(trigger).toHaveTextContent("gpt 5.6 solDefault");
+    expect(trigger).toHaveTextContent("gpt 5.6 solMedium");
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-    expect(await screen.findByRole("menuitem", { name: /effort.*default/i })).toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: /effort.*medium/i })).toBeInTheDocument();
   });
 
   it("drills into model options without a clipped side menu on mobile", async () => {

--- a/packages/web/src/components/model-reasoning-selector.tsx
+++ b/packages/web/src/components/model-reasoning-selector.tsx
@@ -29,9 +29,11 @@ type ModelReasoningSelectorProps = {
   reasoningEffort: ReasoningEffort | undefined;
   items: ModelCategory[];
   onModelChange: (model: ValidModel) => void;
-  onReasoningEffortChange: (effort: ReasoningEffort) => void;
+  onReasoningEffortChange: (effort: ReasoningEffort | undefined) => void;
   disabled?: boolean;
 };
+
+const DEFAULT_EFFORT_VALUE = "__default__";
 
 function formatEffort(effort: string): string {
   return effort === "xhigh" ? "XHigh" : `${effort.charAt(0).toUpperCase()}${effort.slice(1)}`;
@@ -126,7 +128,7 @@ export function ModelReasoningSelector({
                 reasoningConfig && (
                   <EffortOptions
                     efforts={reasoningConfig.efforts}
-                    value={selectedEffort}
+                    value={reasoningEffort}
                     onChange={onReasoningEffortChange}
                   />
                 )
@@ -159,7 +161,7 @@ export function ModelReasoningSelector({
                 <DropdownMenuSubContent align="end" collisionPadding={8} className="w-40">
                   <EffortOptions
                     efforts={reasoningConfig.efforts}
-                    value={selectedEffort}
+                    value={reasoningEffort}
                     onChange={onReasoningEffortChange}
                   />
                 </DropdownMenuSubContent>
@@ -220,16 +222,21 @@ function EffortOptions({
 }: {
   efforts: readonly ReasoningEffort[];
   value: ReasoningEffort | undefined;
-  onChange: (effort: ReasoningEffort) => void;
+  onChange: (effort: ReasoningEffort | undefined) => void;
 }) {
   return (
     <DropdownMenuRadioGroup
-      value={value}
+      value={value ?? DEFAULT_EFFORT_VALUE}
       onValueChange={(nextValue) => {
+        if (nextValue === DEFAULT_EFFORT_VALUE) {
+          onChange(undefined);
+          return;
+        }
         const effort = efforts.find((candidate) => candidate === nextValue);
         if (effort) onChange(effort);
       }}
     >
+      <DropdownMenuRadioItem value={DEFAULT_EFFORT_VALUE}>Default</DropdownMenuRadioItem>
       {efforts.map((effort) => (
         <DropdownMenuRadioItem key={effort} value={effort}>
           {formatEffort(effort)}

--- a/packages/web/src/components/model-reasoning-selector.tsx
+++ b/packages/web/src/components/model-reasoning-selector.tsx
@@ -49,6 +49,7 @@ export function ModelReasoningSelector({
   const [mobileView, setMobileView] = useState<"main" | "model" | "effort">("main");
   const reasoningConfig = getReasoningConfig(selectedModel);
   const selectedEffort = reasoningEffort ?? reasoningConfig?.default;
+  const effortLabel = selectedEffort ? formatEffort(selectedEffort) : "Default";
   const modelLabel = formatModelNameLower(selectedModel);
 
   return (
@@ -58,14 +59,12 @@ export function ModelReasoningSelector({
           type="button"
           disabled={disabled}
           className="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-          aria-label={`Model and effort: ${modelLabel}${selectedEffort ? `, ${selectedEffort}` : ""}`}
+          aria-label={`Model and effort: ${modelLabel}${reasoningConfig ? `, ${effortLabel}` : ""}`}
         >
           <ModelIcon className="size-3.5 shrink-0" />
           <span className="max-w-[9rem] truncate sm:max-w-none">{modelLabel}</span>
-          {selectedEffort && (
-            <span className="shrink-0 text-secondary-foreground">
-              {formatEffort(selectedEffort)}
-            </span>
+          {reasoningConfig && (
+            <span className="shrink-0 text-secondary-foreground">{effortLabel}</span>
           )}
           <ChevronDownIcon className="size-3.5 shrink-0 text-secondary-foreground" />
         </button>
@@ -97,7 +96,7 @@ export function ModelReasoningSelector({
                   {modelLabel}
                 </span>
               </DropdownMenuItem>
-              {reasoningConfig && selectedEffort && (
+              {reasoningConfig && (
                 <DropdownMenuItem
                   onSelect={(event) => {
                     event.preventDefault();
@@ -105,9 +104,7 @@ export function ModelReasoningSelector({
                   }}
                 >
                   <span>Effort</span>
-                  <span className="ml-auto text-muted-foreground">
-                    {formatEffort(selectedEffort)}
-                  </span>
+                  <span className="ml-auto text-muted-foreground">{effortLabel}</span>
                 </DropdownMenuItem>
               )}
             </>
@@ -126,8 +123,7 @@ export function ModelReasoningSelector({
               {mobileView === "model" ? (
                 <ModelOptions items={items} value={selectedModel} onChange={onModelChange} />
               ) : (
-                reasoningConfig &&
-                selectedEffort && (
+                reasoningConfig && (
                   <EffortOptions
                     efforts={reasoningConfig.efforts}
                     value={selectedEffort}
@@ -154,13 +150,11 @@ export function ModelReasoningSelector({
                 <ModelOptions items={items} value={selectedModel} onChange={onModelChange} />
               </DropdownMenuSubContent>
             </DropdownMenuSub>
-            {reasoningConfig && selectedEffort && (
+            {reasoningConfig && (
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>
                   <span>Effort</span>
-                  <span className="ml-auto text-muted-foreground">
-                    {formatEffort(selectedEffort)}
-                  </span>
+                  <span className="ml-auto text-muted-foreground">{effortLabel}</span>
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent align="end" collisionPadding={8} className="w-40">
                   <EffortOptions
@@ -225,7 +219,7 @@ function EffortOptions({
   onChange,
 }: {
   efforts: readonly ReasoningEffort[];
-  value: ReasoningEffort;
+  value: ReasoningEffort | undefined;
   onChange: (effort: ReasoningEffort) => void;
 }) {
   return (

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -49,7 +49,7 @@ type SessionPromptComposerProps = {
     reasoningEffort: ReasoningEffort | undefined;
     items: ModelCategory[];
     onModelChange: (model: ValidModel) => void;
-    onReasoningEffortChange: (value: ReasoningEffort) => void;
+    onReasoningEffortChange: (value: ReasoningEffort | undefined) => void;
   };
 };
 

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -25,6 +25,12 @@ describe("resolveModelPreference", () => {
     ).toEqual({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
   });
 
+  it("preserves an omitted effort so the model default remains selectable", () => {
+    expect(resolveModelPreference({ model: "openai/gpt-5.6-sol" }, ["openai/gpt-5.6-sol"])).toEqual(
+      { model: "openai/gpt-5.6-sol", reasoningEffort: undefined }
+    );
+  });
+
   it("uses the default when the loaded enabled-model list is empty", () => {
     expect(
       resolveModelPreference({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" }, [])

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -32,7 +32,9 @@ export function resolveModelPreference(
   return {
     model,
     reasoningEffort:
-      reasoningConfig?.efforts.find((effort) => effort === preference.reasoningEffort) ??
-      reasoningConfig?.default,
+      preference.reasoningEffort === undefined
+        ? undefined
+        : (reasoningConfig?.efforts.find((effort) => effort === preference.reasoningEffort) ??
+          reasoningConfig?.default),
   };
 }


### PR DESCRIPTION
## Summary
- keep reasoning-effort controls visible for models such as GPT 5.6 Sol that support reasoning without defining a default effort
- display `Default` in the combined selector and effort menu when no explicit/default effort is selected
- add regression coverage for switching from Grok 4.6 back to GPT 5.6 Sol

## Verification
- `npm test -w @open-inspect/web -- --run src/components/model-reasoning-selector.test.tsx`
- `npx eslint src/components/model-reasoning-selector.tsx src/components/model-reasoning-selector.test.tsx` from `packages/web`
- `npm run typecheck -w @open-inspect/web`
- `git diff --check origin/main...HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f7e03835c70e356f8fd9c2dead0c1f66)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Default” option for reasoning effort, allowing users to clear a custom selection.
  * Reasoning effort settings now remain consistent when switching between models.
* **Bug Fixes**
  * Models without an explicitly selected effort now display “Default” correctly.
  * OpenAI GPT 5.6 models now use “Medium” as the default reasoning effort.
  * Updated model selection support for OpenAI GPT 5.6 Sol and xAI Grok 4.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->