### PR TITLE
Simplify new session composer controls

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -499,6 +499,10 @@ describe("Home", () => {
     const authenticationTrigger = await screen.findByRole("button", {
       name: /^OpenAI authentication options/,
     });
+    const skillTrigger = screen.getByRole("button", { name: /all skills/i });
+    expect(
+      skillTrigger.compareDocumentPosition(authenticationTrigger) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     fireEvent.pointerDown(authenticationTrigger, { button: 0, ctrlKey: false });
     const authenticationMenu = await screen.findByRole("menuitem", {
       name: "OpenAI authentication",
@@ -572,10 +576,20 @@ describe("Home", () => {
     await screen.findByRole("button", { name: /background-agents/i });
   });
 
-  it("keeps the composer footer compact", async () => {
+  it("shows the repository and branch above the composer", async () => {
     render(<Home />);
 
+    const repository = await screen.findByRole("button", { name: /background-agents/i });
     const branch = await screen.findByText("main");
+    const composer = screen.getByPlaceholderText("What do you want to build?");
+    expect(
+      repository.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      branch.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(repository.querySelectorAll("svg")).toHaveLength(1);
+    expect(branch.closest("button")?.querySelectorAll("svg")).toHaveLength(1);
     expect(branch).toHaveClass("max-w-[9rem]", "truncate");
     expect(screen.queryByText("build agent")).not.toBeInTheDocument();
   });

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -470,6 +470,10 @@ function HomeContent({
             <form onSubmit={handleSubmit}>
               {error && <ErrorBanner className="mb-4">{error}</ErrorBanner>}
 
+              <div className="mb-3 flex flex-wrap items-center gap-2 px-4 sm:gap-4">
+                <SessionTargetPicker {...picker.pickerProps} disabled={creating} />
+              </div>
+
               <div
                 className={`border border-border bg-input ${isDraggingOver ? "ring-2 ring-accent" : ""}`}
                 onPaste={handlePaste}
@@ -545,18 +549,24 @@ function HomeContent({
                   </div>
                 </div>
 
-                {/* Footer row with target and model controls */}
+                {/* Footer row with session controls */}
                 <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:gap-0">
-                  {/* Left side - Target selector + Model controls */}
                   <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
-                    <SessionTargetPicker {...picker.pickerProps} disabled={creating} />
-
                     <ModelReasoningSelector
                       selectedModel={selectedModel}
                       reasoningEffort={reasoningEffort}
                       items={modelOptions}
                       onModelChange={setSelectedModel}
                       onReasoningEffortChange={setReasoningEffort}
+                      disabled={creating}
+                    />
+
+                    <SessionSkillSelector
+                      value={skillSelection}
+                      onChange={setSkillSelection}
+                      target={skillPreviewTarget}
+                      preview={skillPreview}
+                      previewLoading={skillPreviewLoading}
                       disabled={creating}
                     />
 
@@ -575,15 +585,6 @@ function HomeContent({
                         }
                       />
                     )}
-
-                    <SessionSkillSelector
-                      value={skillSelection}
-                      onChange={setSkillSelection}
-                      target={skillPreviewTarget}
-                      preview={skillPreview}
-                      previewLoading={skillPreviewLoading}
-                      disabled={creating}
-                    />
                   </div>
                 </div>
               </div>

--- a/packages/web/src/components/model-reasoning-selector.test.tsx
+++ b/packages/web/src/components/model-reasoning-selector.test.tsx
@@ -53,9 +53,9 @@ describe("ModelReasoningSelector", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: /model and effort/i })).toHaveTextContent(
-      "claude sonnet 4.6High"
-    );
+    const trigger = screen.getByRole("button", { name: /model and effort/i });
+    expect(trigger).toHaveTextContent("claude sonnet 4.6High");
+    expect(trigger.querySelectorAll("svg")).toHaveLength(1);
   });
 
   it("selects model and effort through nested menus", async () => {

--- a/packages/web/src/components/model-reasoning-selector.tsx
+++ b/packages/web/src/components/model-reasoning-selector.tsx
@@ -8,7 +8,7 @@ import {
   type ValidModel,
 } from "@open-inspect/shared/models";
 import { formatModelNameLower } from "@/lib/format";
-import { BackIcon, ChevronDownIcon, ModelIcon } from "@/components/ui/icons";
+import { BackIcon, ChevronDownIcon } from "@/components/ui/icons";
 import { useIsMobile } from "@/hooks/use-media-query";
 import {
   DropdownMenu,
@@ -60,7 +60,6 @@ export function ModelReasoningSelector({
           className="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={`Model and effort: ${modelLabel}${selectedEffort ? `, ${selectedEffort}` : ""}`}
         >
-          <ModelIcon className="size-3.5 shrink-0" />
           <span className="max-w-[9rem] truncate sm:max-w-none">{modelLabel}</span>
           {selectedEffort && (
             <span className="shrink-0 text-secondary-foreground">

--- a/packages/web/src/components/provider-auth-controls.test.tsx
+++ b/packages/web/src/components/provider-auth-controls.test.tsx
@@ -41,7 +41,7 @@ describe("ProviderAuthControls menu", () => {
       name: "OpenAI authentication options, Team ChatGPT",
     });
     expect(trigger).toHaveAttribute("title", "OpenAI authentication");
-    expect(trigger).toHaveTextContent("OpenAI: Team ChatGPT");
+    expect(trigger).toHaveTextContent("");
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
 
     expect(await screen.findByText("Session options")).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("ProviderAuthControls menu", () => {
     await waitFor(() => expect(onChange).toHaveBeenCalledWith({ mode: "api_key" }));
   });
 
-  it("shows the effective default on the compact trigger", () => {
+  it("keeps the effective default in the compact trigger's accessible label", () => {
     render(
       <ProviderAuthControls
         variant="menu"
@@ -83,10 +83,10 @@ describe("ProviderAuthControls menu", () => {
       screen.getByRole("button", {
         name: "OpenAI authentication options, Team ChatGPT",
       })
-    ).toHaveTextContent("OpenAI: Team ChatGPT");
+    ).toHaveTextContent("");
   });
 
-  it("shows when the configured default account is unavailable", () => {
+  it("identifies an unavailable default account in the compact trigger's accessible label", () => {
     render(
       <ProviderAuthControls
         variant="menu"
@@ -109,7 +109,7 @@ describe("ProviderAuthControls menu", () => {
       screen.getByRole("button", {
         name: "OpenAI authentication options, Unavailable account",
       })
-    ).toHaveTextContent("OpenAI: Unavailable account");
+    ).toHaveTextContent("");
   });
 
   it("shows the effective unattended API-key default", () => {

--- a/packages/web/src/components/provider-auth-controls.tsx
+++ b/packages/web/src/components/provider-auth-controls.tsx
@@ -101,15 +101,12 @@ export function ProviderAuthControls({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className={`flex max-w-52 items-center gap-1.5 rounded px-2 py-1 text-xs transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${value ? "text-accent" : "text-muted-foreground"}`}
+            className={`rounded p-1 transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${value ? "text-accent" : "text-muted-foreground"}`}
             aria-label={`${providerName} authentication options, ${triggerSelectionLabel}`}
             title={`${providerName} authentication`}
             disabled={disabled}
           >
-            <span className="truncate">
-              {providerName}: {triggerSelectionLabel}
-            </span>
-            <MoreIcon className="size-3.5 shrink-0" />
+            <MoreIcon className="size-3.5" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="top" align="start" className="w-52 max-w-[calc(100vw-2rem)]">

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -2,7 +2,7 @@
 
 import { RepositoryMultiSelect } from "@/components/repository-multi-select";
 import { Combobox } from "@/components/ui/combobox";
-import { BranchIcon, ChevronDownIcon, RepoIcon } from "@/components/ui/icons";
+import { ChevronDownIcon } from "@/components/ui/icons";
 import type { SessionTargetPickerProps } from "@/hooks/use-session-target-picker";
 
 /**
@@ -39,12 +39,11 @@ export function SessionTargetPicker({
           (option.description?.toLowerCase().includes(query) ?? false) ||
           String(option.value).toLowerCase().includes(query)
         }
-        direction="up"
+        direction="down"
         dropdownWidth="w-72"
         disabled={disabled || loadingRepos}
         triggerClassName="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
       >
-        <RepoIcon className="w-4 h-4" />
         <span className="truncate max-w-[12rem] sm:max-w-none">
           {loadingRepos ? "Loading..." : displayTargetName}
         </span>
@@ -80,12 +79,11 @@ export function SessionTargetPicker({
           searchable
           searchPlaceholder="Search branches..."
           filterFn={(option, query) => option.label.toLowerCase().includes(query)}
-          direction="up"
+          direction="down"
           dropdownWidth="w-56"
           disabled={disabled || loadingBranches}
           triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
         >
-          <BranchIcon className="w-3.5 h-3.5" />
           <span className="max-w-[9rem] truncate">
             {loadingBranches ? "Loading..." : selectedBranch || "branch"}
           </span>


### PR DESCRIPTION
## Summary
- move repository and branch selectors above the new-session composer
- reduce provider authentication to a trailing kebab menu after skills
- remove decorative icons from repository, branch, and model selectors
- preserve accessible authentication selection labels and existing menu behavior

## Testing
- `npm test -w @open-inspect/web -- --run src/components/model-reasoning-selector.test.tsx src/components/session-prompt-composer.test.tsx 'src/app/(app)/page.test.tsx'`
- `npm run typecheck -w @open-inspect/web`
- Prettier and `git diff --check`

## Visual verification
- Desktop viewport, 1440x900: artifact `362591d2fcbb9424a10589b8810821c8`
- Mobile viewport with collapsed sidebar, 390x844: artifact `0a25ce8dec63a49935c0b17d16ed5da8`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/829d4fddb8b2482f43174a5cf858178c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Moved repository and branch selectors above the prompt composer for easier access.
  - Grouped skill, model, and provider options into the session controls area.
  - Simplified provider and model controls with cleaner, icon-focused triggers while preserving accessible labels.
  - Updated repository and branch menus to open downward.
  - Removed redundant leading icons from repository and branch selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->