### PR TITLE
feat: use provider logos in auth controls

### DIFF
--- a/packages/web/src/components/provider-auth-controls.test.tsx
+++ b/packages/web/src/components/provider-auth-controls.test.tsx
@@ -41,7 +41,8 @@ describe("ProviderAuthControls menu", () => {
       name: "OpenAI authentication options, Team ChatGPT",
     });
     expect(trigger).toHaveAttribute("title", "OpenAI authentication");
-    expect(trigger).toHaveTextContent("OpenAI: Team ChatGPT");
+    expect(trigger).toHaveTextContent("Team ChatGPT");
+    expect(screen.getByTitle("OpenAI")).toBeInTheDocument();
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
 
     expect(await screen.findByText("Session options")).toBeInTheDocument();
@@ -58,6 +59,24 @@ describe("ProviderAuthControls menu", () => {
 
     fireEvent.click(screen.getByRole("menuitemradio", { name: "No account" }));
     await waitFor(() => expect(onChange).toHaveBeenCalledWith({ mode: "api_key" }));
+  });
+
+  it("uses the Grok logo for xAI authentication", () => {
+    render(
+      <ProviderAuthControls
+        variant="menu"
+        provider="xai"
+        accounts={[{ ...account, provider: "xai", displayName: "SuperGrok" }]}
+        value={{ mode: "provider_account", accountId: account.id }}
+        onChange={vi.fn()}
+      />
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "xAI authentication options, SuperGrok",
+    });
+    expect(trigger).toHaveTextContent("SuperGrok");
+    expect(screen.getByTitle("Grok")).toBeInTheDocument();
   });
 
   it("shows the effective default on the compact trigger", () => {
@@ -83,7 +102,8 @@ describe("ProviderAuthControls menu", () => {
       screen.getByRole("button", {
         name: "OpenAI authentication options, Team ChatGPT",
       })
-    ).toHaveTextContent("OpenAI: Team ChatGPT");
+    ).toHaveTextContent("Team ChatGPT");
+    expect(screen.getByTitle("OpenAI")).toBeInTheDocument();
   });
 
   it("shows when the configured default account is unavailable", () => {
@@ -109,7 +129,8 @@ describe("ProviderAuthControls menu", () => {
       screen.getByRole("button", {
         name: "OpenAI authentication options, Unavailable account",
       })
-    ).toHaveTextContent("OpenAI: Unavailable account");
+    ).toHaveTextContent("Unavailable account");
+    expect(screen.getByTitle("OpenAI")).toBeInTheDocument();
   });
 
   it("shows the effective unattended API-key default", () => {

--- a/packages/web/src/components/provider-auth-controls.tsx
+++ b/packages/web/src/components/provider-auth-controls.tsx
@@ -8,7 +8,7 @@ import type {
 } from "@open-inspect/shared/types/provider-accounts";
 import { SUBSCRIPTION_PROVIDER_DISPLAY_METADATA } from "@open-inspect/shared/types/provider-accounts";
 import { Label } from "@/components/ui/label";
-import { MoreIcon } from "@/components/ui/icons";
+import { GrokIcon, MoreIcon, OpenAIIcon } from "@/components/ui/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,6 +36,17 @@ const DEFAULT_POLICY_LABEL = "Use default";
 const DEFAULT_UNATTENDED = false;
 const DEFAULT_VARIANT = "select";
 const DEFAULT_DISABLED = false;
+
+function ProviderIcon({
+  provider,
+  className = "size-3.5",
+}: {
+  provider: SubscriptionProviderId;
+  className?: string;
+}) {
+  const Icon = provider === "openai" ? OpenAIIcon : GrokIcon;
+  return <Icon aria-hidden="true" className={`${className} shrink-0`} />;
+}
 
 export function ProviderAuthControls({
   provider,
@@ -106,9 +117,8 @@ export function ProviderAuthControls({
             title={`${providerName} authentication`}
             disabled={disabled}
           >
-            <span className="truncate">
-              {providerName}: {triggerSelectionLabel}
-            </span>
+            <ProviderIcon provider={provider} />
+            <span className="truncate">{triggerSelectionLabel}</span>
             <MoreIcon className="size-3.5 shrink-0" />
           </button>
         </DropdownMenuTrigger>
@@ -116,8 +126,12 @@ export function ProviderAuthControls({
           <DropdownMenuLabel>Session options</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={disabled}>
-              {providerName} authentication
+            <DropdownMenuSubTrigger
+              disabled={disabled}
+              aria-label={`${providerName} authentication`}
+            >
+              <ProviderIcon provider={provider} />
+              authentication
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent
               collisionPadding={8}
@@ -149,9 +163,15 @@ export function ProviderAuthControls({
 
   return (
     <div className="space-y-1.5">
-      <Label htmlFor={`provider-auth-${provider}`}>{providerName} authentication</Label>
+      <Label htmlFor={`provider-auth-${provider}`} className="flex items-center gap-1.5">
+        <ProviderIcon provider={provider} className="size-4" />
+        authentication
+      </Label>
       <Select value={selected} onValueChange={handleChange} disabled={disabled}>
-        <SelectTrigger id={`provider-auth-${provider}`}>
+        <SelectTrigger
+          id={`provider-auth-${provider}`}
+          aria-label={`${providerName} authentication`}
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/packages/web/src/components/provider-auth-controls.tsx
+++ b/packages/web/src/components/provider-auth-controls.tsx
@@ -8,7 +8,7 @@ import type {
 } from "@open-inspect/shared/types/provider-accounts";
 import { SUBSCRIPTION_PROVIDER_DISPLAY_METADATA } from "@open-inspect/shared/types/provider-accounts";
 import { Label } from "@/components/ui/label";
-import { GrokIcon, OpenAIIcon } from "@/components/ui/icons";
+import { SubscriptionProviderIcon } from "@/components/subscription-provider-icon";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,17 +36,6 @@ const DEFAULT_POLICY_LABEL = "Use default";
 const DEFAULT_UNATTENDED = false;
 const DEFAULT_VARIANT = "select";
 const DEFAULT_DISABLED = false;
-
-function ProviderIcon({
-  provider,
-  className = "size-3.5",
-}: {
-  provider: SubscriptionProviderId;
-  className?: string;
-}) {
-  const Icon = provider === "openai" ? OpenAIIcon : GrokIcon;
-  return <Icon aria-hidden="true" className={`${className} shrink-0`} />;
-}
 
 export function ProviderAuthControls({
   provider,
@@ -117,7 +106,7 @@ export function ProviderAuthControls({
             title={`${providerName} authentication`}
             disabled={disabled}
           >
-            <ProviderIcon provider={provider} />
+            <SubscriptionProviderIcon provider={provider} className="size-3.5" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="top" align="start" className="w-52 max-w-[calc(100vw-2rem)]">
@@ -128,7 +117,7 @@ export function ProviderAuthControls({
               disabled={disabled}
               aria-label={`${providerName} authentication`}
             >
-              <ProviderIcon provider={provider} />
+              <SubscriptionProviderIcon provider={provider} className="size-3.5" />
               authentication
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent
@@ -162,7 +151,7 @@ export function ProviderAuthControls({
   return (
     <div className="space-y-1.5">
       <Label htmlFor={`provider-auth-${provider}`} className="flex items-center gap-1.5">
-        <ProviderIcon provider={provider} className="size-4" />
+        <SubscriptionProviderIcon provider={provider} className="size-4" />
         authentication
       </Label>
       <Select value={selected} onValueChange={handleChange} disabled={disabled}>

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -27,7 +27,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { GrokIcon, MoreIcon, OpenAIIcon, PlusIcon } from "@/components/ui/icons";
+import { MoreIcon, PlusIcon } from "@/components/ui/icons";
+import { SubscriptionProviderIcon } from "@/components/subscription-provider-icon";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -102,17 +103,6 @@ function relativeDateLabel(timestamp: number | null) {
   if (!timestamp) return "Never";
   const relative = formatRelativeTime(timestamp);
   return relative === "now" ? relative : `${relative} ago`;
-}
-
-function ProviderIcon({
-  provider,
-  className = "size-6",
-}: {
-  provider: SubscriptionProviderId;
-  className?: string;
-}) {
-  const Icon = provider === "openai" ? OpenAIIcon : GrokIcon;
-  return <Icon aria-hidden="true" className={`${className} shrink-0 text-primary`} />;
 }
 
 function legacyKeyLocationLabel(location: LegacyProviderKeyLocation): string {
@@ -277,7 +267,10 @@ export function ProviderAccountsSettings() {
                         beginConnection(CONNECTION_STRATEGIES[provider.provider].add())
                       }
                     >
-                      <ProviderIcon provider={provider.provider} className="size-5" />
+                      <SubscriptionProviderIcon
+                        provider={provider.provider}
+                        className="size-5 text-primary"
+                      />
                       <span>{provider.subscriptionName}</span>
                     </DropdownMenuItem>
                   ))}
@@ -303,7 +296,10 @@ export function ProviderAccountsSettings() {
                     >
                       <div className="flex min-w-0 items-start gap-3">
                         <div className="flex size-10 shrink-0 items-center justify-center text-foreground">
-                          <ProviderIcon provider={account.provider} className="size-6" />
+                          <SubscriptionProviderIcon
+                            provider={account.provider}
+                            className="size-6 text-primary"
+                          />
                         </div>
                         <div className="min-w-0">
                           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -490,7 +486,10 @@ export function ProviderAccountsSettings() {
                     className="grid gap-3 p-4 sm:grid-cols-[minmax(8rem,0.6fr)_1fr] sm:items-end"
                   >
                     <div className="flex items-center gap-2 self-center font-medium text-foreground">
-                      <ProviderIcon provider={provider.provider} className="size-5" />
+                      <SubscriptionProviderIcon
+                        provider={provider.provider}
+                        className="size-5 text-primary"
+                      />
                       {provider.subscriptionName}
                     </div>
                     <div>

--- a/packages/web/src/components/settings/provider-device-authorization-dialog.tsx
+++ b/packages/web/src/components/settings/provider-device-authorization-dialog.tsx
@@ -4,7 +4,8 @@ import { useState, type ReactNode } from "react";
 import type { ProviderDeviceAuthorizationStatusResponse } from "@open-inspect/shared/types/provider-accounts";
 import { useProviderDeviceAuthorization } from "@/hooks/use-provider-device-authorization";
 import { Button } from "@/components/ui/button";
-import { CheckIcon, CopyIcon, GrokIcon, OpenAIIcon } from "@/components/ui/icons";
+import { CheckIcon, CopyIcon } from "@/components/ui/icons";
+import { SubscriptionProviderIcon } from "@/components/subscription-provider-icon";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 
 export const CHATGPT_DEVICE_AUTHORIZATION_SETTINGS_URL =
@@ -25,14 +26,12 @@ const PROVIDER_CONTENT = {
     defaultDisplayName: "ChatGPT account",
     description:
       "Authorize Codex with OpenAI. Your credentials stay between OpenAI and the control plane.",
-    Icon: OpenAIIcon,
   },
   xai: {
     accountName: "SuperGrok",
     defaultDisplayName: "SuperGrok account",
     description:
       "Use your X Premium+ or SuperGrok subscription for Grok. Your credentials stay between xAI and the control plane.",
-    Icon: GrokIcon,
   },
 } as const;
 
@@ -55,7 +54,6 @@ export function ProviderDeviceAuthorizationDialog({
 }) {
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const content = PROVIDER_CONTENT[target.provider];
-  const ProviderIcon = content.Icon;
   const { authorization, failure, status, remainingMs, retry, cancel } =
     useProviderDeviceAuthorization(
       target.provider,
@@ -76,7 +74,10 @@ export function ProviderDeviceAuthorizationDialog({
         <div className="border-b border-border-muted bg-muted/30 px-5 py-5 sm:px-7">
           <div className="flex items-start gap-3">
             <div className="flex size-10 shrink-0 items-center justify-center rounded-full border border-border bg-background">
-              <ProviderIcon className="size-5 text-foreground" />
+              <SubscriptionProviderIcon
+                provider={target.provider}
+                className="size-5 text-foreground"
+              />
             </div>
             <div>
               <DialogTitle>

--- a/packages/web/src/components/subscription-provider-icon.tsx
+++ b/packages/web/src/components/subscription-provider-icon.tsx
@@ -1,0 +1,19 @@
+import type { SubscriptionProviderId } from "@open-inspect/shared/types/provider-accounts";
+import { GrokIcon, OpenAIIcon } from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+
+const SUBSCRIPTION_PROVIDER_ICONS = {
+  openai: OpenAIIcon,
+  xai: GrokIcon,
+} as const;
+
+export function SubscriptionProviderIcon({
+  provider,
+  className,
+}: {
+  provider: SubscriptionProviderId;
+  className?: string;
+}) {
+  const Icon = SUBSCRIPTION_PROVIDER_ICONS[provider];
+  return <Icon aria-hidden="true" className={cn("shrink-0", className)} />;
+}


### PR DESCRIPTION
Replace the visible "OpenAI" / "xAI" labels in provider authentication controls with the existing logos.

The compact composer trigger now shows the logo plus the selected account name. The session-options submenu and automations form labels use the same logos. Accessible names and titles still include the provider name.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f881c9167aa50bbaef1d2f73837eccde)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provider authentication controls now display the relevant OpenAI or Grok logo.
  - Added accessible labels to authentication menus and selectors for improved usability with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->