### PR TITLE
refactor(control-plane): break lifecycle/message-queue construction cycle

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -948,7 +948,6 @@ describe("SandboxLifecycleManager", () => {
           mcpServerLookup,
           slackAgentNotifyLookup,
         },
-        {},
         imageBuildLookup
       );
 
@@ -990,9 +989,9 @@ describe("SandboxLifecycleManager", () => {
         wsManager,
         createMockAlarmScheduler(),
         createMockIdGenerator(),
-        createTestConfig(),
-        { onSandboxTerminated }
+        createTestConfig()
       );
+      manager.setCallbacks({ onSandboxTerminated });
 
       await manager.spawnSandbox();
 
@@ -2185,9 +2184,9 @@ describe("SandboxLifecycleManager", () => {
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
         createMockIdGenerator(),
-        createTestConfig(),
-        { onSandboxTerminating }
+        createTestConfig()
       );
+      manager.setCallbacks({ onSandboxTerminating });
 
       await manager.handleAlarm();
 
@@ -2211,9 +2210,9 @@ describe("SandboxLifecycleManager", () => {
         createMockWebSocketManager(false, 0), // No clients
         createMockAlarmScheduler(),
         createMockIdGenerator(),
-        createTestConfig(),
-        { onSandboxTerminating }
+        createTestConfig()
       );
+      manager.setCallbacks({ onSandboxTerminating });
 
       await manager.handleAlarm();
 
@@ -2325,9 +2324,9 @@ describe("SandboxLifecycleManager", () => {
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
         createMockIdGenerator(),
-        createTestConfig(),
-        { onSandboxTerminating }
+        createTestConfig()
       );
+      manager.setCallbacks({ onSandboxTerminating });
 
       await manager.handleAlarm();
 
@@ -2384,9 +2383,9 @@ describe("SandboxLifecycleManager", () => {
         wsManager,
         createMockAlarmScheduler(),
         createMockIdGenerator(),
-        createTestConfig(),
-        { onSandboxTerminated }
+        createTestConfig()
       );
+      manager.setCallbacks({ onSandboxTerminated });
 
       const terminating = manager.terminateUnresponsiveSandbox("stop_confirmation_timeout");
 
@@ -2398,6 +2397,104 @@ describe("SandboxLifecycleManager", () => {
       resolveStop({ success: true });
       await terminating;
       expect(onSandboxTerminated).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("setCallbacks", () => {
+    function staleHeartbeatManager() {
+      const sandbox = createMockSandbox({
+        status: "ready",
+        last_heartbeat: Date.now() - 100_000, // Past the 90s heartbeat timeout
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+      return { manager, storage };
+    }
+
+    it("does not throw on a terminating path when no callbacks were ever set", async () => {
+      const { manager, storage } = staleHeartbeatManager();
+
+      await expect(manager.handleAlarm()).resolves.toBeUndefined();
+
+      expect(storage.calls).toContain("updateSandboxStatus:stale");
+    });
+
+    it("does not throw on a terminated path when no callbacks were ever set", async () => {
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        createMockStorage(),
+        createMockBroadcaster(),
+        createMockWebSocketManager(true),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await expect(
+        manager.terminateUnresponsiveSandbox("stop_confirmation_timeout")
+      ).resolves.toBeUndefined();
+    });
+
+    it("fires both callbacks on the heartbeat-stale path once wired after construction", async () => {
+      const { manager } = staleHeartbeatManager();
+      const onSandboxTerminating = vi.fn(async () => {});
+      const onSandboxTerminated = vi.fn(async () => {});
+
+      manager.setCallbacks({ onSandboxTerminating, onSandboxTerminated });
+      await manager.handleAlarm();
+
+      expect(onSandboxTerminating).toHaveBeenCalledOnce();
+      expect(onSandboxTerminated).toHaveBeenCalledOnce();
+    });
+
+    it("fires onSandboxTerminated on terminateUnresponsiveSandbox once wired after construction", async () => {
+      const onSandboxTerminated = vi.fn(async () => {});
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        createMockStorage(),
+        createMockBroadcaster(),
+        createMockWebSocketManager(true),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      manager.setCallbacks({ onSandboxTerminated });
+      await manager.terminateUnresponsiveSandbox("stop_send_failed");
+
+      expect(onSandboxTerminated).toHaveBeenCalledOnce();
+    });
+
+    it("rejects a second wiring so a duplicate composition root cannot silently win", () => {
+      const { manager } = staleHeartbeatManager();
+
+      manager.setCallbacks({ onSandboxTerminating: vi.fn(async () => {}) });
+
+      expect(() => manager.setCallbacks({ onSandboxTerminating: vi.fn(async () => {}) })).toThrow(
+        /already wired/i
+      );
+    });
+
+    it("keeps the first wiring intact after a rejected second wiring", async () => {
+      const { manager } = staleHeartbeatManager();
+      const first = vi.fn(async () => {});
+      const second = vi.fn(async () => {});
+
+      manager.setCallbacks({ onSandboxTerminating: first });
+      expect(() => manager.setCallbacks({ onSandboxTerminating: second })).toThrow();
+
+      await manager.handleAlarm();
+
+      expect(first).toHaveBeenCalledOnce();
+      expect(second).not.toHaveBeenCalled();
     });
   });
 
@@ -2592,7 +2689,6 @@ describe("SandboxLifecycleManager", () => {
         createMockAlarmScheduler(),
         createMockIdGenerator(),
         createTestConfig(),
-        {},
         overrides?.imageBuildLookup
       );
       return { manager, provider, storage };
@@ -2807,7 +2903,6 @@ describe("SandboxLifecycleManager", () => {
         overrides?.alarmScheduler ?? createMockAlarmScheduler(),
         createMockIdGenerator(),
         createTestConfig(),
-        {},
         overrides?.environmentImageLookup
       );
       return { manager, provider, storage };
@@ -3042,7 +3137,6 @@ describe("SandboxLifecycleManager", () => {
         createMockAlarmScheduler(),
         createMockIdGenerator(),
         { ...createTestConfig(), mcpServerLookup: overrides?.mcpServerLookup },
-        {},
         overrides?.imageBuildLookup
       );
       return { manager, provider, storage };

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -2406,27 +2406,20 @@ describe("SandboxLifecycleManager", () => {
         status: "ready",
         last_heartbeat: Date.now() - 100_000, // Past the 90s heartbeat timeout
       });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const manager = new SandboxLifecycleManager(
+      return new SandboxLifecycleManager(
         createMockProvider(),
-        storage,
+        createMockStorage(createMockSession(), sandbox),
         createMockBroadcaster(),
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
         createMockIdGenerator(),
         createTestConfig()
       );
-      return { manager, storage };
     }
 
-    it("does not throw on a terminating path when no callbacks were ever set", async () => {
-      const { manager, storage } = staleHeartbeatManager();
-
-      await expect(manager.handleAlarm()).resolves.toBeUndefined();
-
-      expect(storage.calls).toContain("updateSandboxStatus:stale");
-    });
-
+    // The terminating path with no callbacks set is already covered by
+    // "does not call onSandboxTerminating when no callback provided" in the
+    // "handleAlarm" block above; only the terminated path needs a new case.
     it("does not throw on a terminated path when no callbacks were ever set", async () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
@@ -2444,7 +2437,7 @@ describe("SandboxLifecycleManager", () => {
     });
 
     it("fires both callbacks on the heartbeat-stale path once wired after construction", async () => {
-      const { manager } = staleHeartbeatManager();
+      const manager = staleHeartbeatManager();
       const onSandboxTerminating = vi.fn(async () => {});
       const onSandboxTerminated = vi.fn(async () => {});
 
@@ -2474,7 +2467,7 @@ describe("SandboxLifecycleManager", () => {
     });
 
     it("rejects a second wiring so a duplicate composition root cannot silently win", () => {
-      const { manager } = staleHeartbeatManager();
+      const manager = staleHeartbeatManager();
 
       manager.setCallbacks({ onSandboxTerminating: vi.fn(async () => {}) });
 
@@ -2484,7 +2477,7 @@ describe("SandboxLifecycleManager", () => {
     });
 
     it("keeps the first wiring intact after a rejected second wiring", async () => {
-      const { manager } = staleHeartbeatManager();
+      const manager = staleHeartbeatManager();
       const first = vi.fn(async () => {});
       const second = vi.fn(async () => {});
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -981,7 +981,6 @@ describe("SandboxLifecycleManager", () => {
       const wsManager = createMockWebSocketManager(false);
       const provider = createMockProvider();
 
-      const onSandboxTerminated = vi.fn(async () => {});
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
@@ -991,15 +990,12 @@ describe("SandboxLifecycleManager", () => {
         createMockIdGenerator(),
         createTestConfig()
       );
-      manager.setCallbacks({ onSandboxTerminated });
-
       await manager.spawnSandbox();
 
       expect(provider.createSandbox).not.toHaveBeenCalled();
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "sandbox_error")
       ).toBe(true);
-      expect(onSandboxTerminated).not.toHaveBeenCalled();
     });
 
     it("persists the circuit-breaker reason, not just the broadcast", async () => {
@@ -1883,8 +1879,9 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      const result = await manager.handleAlarm();
 
+      expect(result).toBe("sandbox_terminated");
       expect(storage.calls).toContain("updateSandboxStatus:stale");
       expect(broadcaster.messages.some((m) => (m as { status?: string }).status === "stale")).toBe(
         true
@@ -1915,8 +1912,9 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      const result = await manager.handleAlarm();
 
+      expect(result).toBe("sandbox_terminated");
       expect(storage.calls).toContain("updateSandboxStatus:stopped");
       expect(wsManager.sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
     });
@@ -2168,80 +2166,6 @@ describe("SandboxLifecycleManager", () => {
       expect(sandbox.vnc_password).toBeNull();
     });
 
-    it("calls onSandboxTerminating callback on heartbeat stale", async () => {
-      const now = Date.now();
-      const sandbox = createMockSandbox({
-        status: "ready",
-        last_heartbeat: now - 100000, // Past 90s timeout
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const onSandboxTerminating = vi.fn().mockResolvedValue(undefined);
-
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-      manager.setCallbacks({ onSandboxTerminating });
-
-      await manager.handleAlarm();
-
-      expect(onSandboxTerminating).toHaveBeenCalledOnce();
-    });
-
-    it("calls onSandboxTerminating callback on inactivity timeout", async () => {
-      const now = Date.now();
-      const sandbox = createMockSandbox({
-        status: "ready",
-        last_heartbeat: now - 10000, // Recent heartbeat
-        last_activity: now - 11 * 60 * 1000, // Past 10 min timeout
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const onSandboxTerminating = vi.fn().mockResolvedValue(undefined);
-
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(false, 0), // No clients
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-      manager.setCallbacks({ onSandboxTerminating });
-
-      await manager.handleAlarm();
-
-      expect(onSandboxTerminating).toHaveBeenCalledOnce();
-    });
-
-    it("does not call onSandboxTerminating when no callback provided", async () => {
-      const now = Date.now();
-      const sandbox = createMockSandbox({
-        status: "ready",
-        last_heartbeat: now - 100000, // Past timeout
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-
-      // No callbacks - should not throw
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      await manager.handleAlarm();
-      expect(storage.calls).toContain("updateSandboxStatus:stale");
-    });
-
     it("detects connecting timeout and sets failed", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({
@@ -2263,8 +2187,9 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      const result = await manager.handleAlarm();
 
+      expect(result).toBe("sandbox_failed");
       expect(storage.calls).toContain("updateSandboxStatus:failed");
       expect(storage.calls).toContain("clearSandboxCodeServer");
       expect(broadcaster.messages.some((m) => (m as { status?: string }).status === "failed")).toBe(
@@ -2306,32 +2231,6 @@ describe("SandboxLifecycleManager", () => {
       // Should schedule a follow-up alarm
       expect(alarmScheduler.alarms.length).toBe(1);
     });
-
-    it("calls onSandboxTerminating callback on connecting timeout", async () => {
-      const now = Date.now();
-      const sandbox = createMockSandbox({
-        status: "connecting" as SandboxStatus,
-        created_at: now - 130_000,
-        last_heartbeat: null,
-      });
-      const storage = createMockStorage(createMockSession(), sandbox);
-      const onSandboxTerminating = vi.fn().mockResolvedValue(undefined);
-
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        storage,
-        createMockBroadcaster(),
-        createMockWebSocketManager(),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-      manager.setCallbacks({ onSandboxTerminating });
-
-      await manager.handleAlarm();
-
-      expect(onSandboxTerminating).toHaveBeenCalledOnce();
-    });
   });
 
   describe("terminateUnresponsiveSandbox", () => {
@@ -2372,7 +2271,6 @@ describe("SandboxLifecycleManager", () => {
         resolveStop = resolve;
       });
       const wsManager = createMockWebSocketManager(true);
-      const onSandboxTerminated = vi.fn(async () => {});
       const manager = new SandboxLifecycleManager(
         createMockProvider({
           capabilities: { supportsExplicitStop: true },
@@ -2385,109 +2283,20 @@ describe("SandboxLifecycleManager", () => {
         createMockIdGenerator(),
         createTestConfig()
       );
-      manager.setCallbacks({ onSandboxTerminated });
-
       const terminating = manager.terminateUnresponsiveSandbox("stop_confirmation_timeout");
+      let completed = false;
+      void terminating.then(() => {
+        completed = true;
+      });
 
       expect(wsManager.detachSandboxWebSocket).toHaveBeenCalledWith(
         1011,
         "Stop confirmation timed out"
       );
-      expect(onSandboxTerminated).not.toHaveBeenCalled();
+      expect(completed).toBe(false);
       resolveStop({ success: true });
       await terminating;
-      expect(onSandboxTerminated).toHaveBeenCalledOnce();
-    });
-  });
-
-  describe("setCallbacks", () => {
-    function staleHeartbeatManager() {
-      const sandbox = createMockSandbox({
-        status: "ready",
-        last_heartbeat: Date.now() - 100_000, // Past the 90s heartbeat timeout
-      });
-      return new SandboxLifecycleManager(
-        createMockProvider(),
-        createMockStorage(createMockSession(), sandbox),
-        createMockBroadcaster(),
-        createMockWebSocketManager(),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-    }
-
-    // The terminating path with no callbacks set is already covered by
-    // "does not call onSandboxTerminating when no callback provided" in the
-    // "handleAlarm" block above; only the terminated path needs a new case.
-    it("does not throw on a terminated path when no callbacks were ever set", async () => {
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        createMockStorage(),
-        createMockBroadcaster(),
-        createMockWebSocketManager(true),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      await expect(
-        manager.terminateUnresponsiveSandbox("stop_confirmation_timeout")
-      ).resolves.toBeUndefined();
-    });
-
-    it("fires both callbacks on the heartbeat-stale path once wired after construction", async () => {
-      const manager = staleHeartbeatManager();
-      const onSandboxTerminating = vi.fn(async () => {});
-      const onSandboxTerminated = vi.fn(async () => {});
-
-      manager.setCallbacks({ onSandboxTerminating, onSandboxTerminated });
-      await manager.handleAlarm();
-
-      expect(onSandboxTerminating).toHaveBeenCalledOnce();
-      expect(onSandboxTerminated).toHaveBeenCalledOnce();
-    });
-
-    it("fires onSandboxTerminated on terminateUnresponsiveSandbox once wired after construction", async () => {
-      const onSandboxTerminated = vi.fn(async () => {});
-      const manager = new SandboxLifecycleManager(
-        createMockProvider(),
-        createMockStorage(),
-        createMockBroadcaster(),
-        createMockWebSocketManager(true),
-        createMockAlarmScheduler(),
-        createMockIdGenerator(),
-        createTestConfig()
-      );
-
-      manager.setCallbacks({ onSandboxTerminated });
-      await manager.terminateUnresponsiveSandbox("stop_send_failed");
-
-      expect(onSandboxTerminated).toHaveBeenCalledOnce();
-    });
-
-    it("rejects a second wiring so a duplicate composition root cannot silently win", () => {
-      const manager = staleHeartbeatManager();
-
-      manager.setCallbacks({ onSandboxTerminating: vi.fn(async () => {}) });
-
-      expect(() => manager.setCallbacks({ onSandboxTerminating: vi.fn(async () => {}) })).toThrow(
-        /already wired/i
-      );
-    });
-
-    it("keeps the first wiring intact after a rejected second wiring", async () => {
-      const manager = staleHeartbeatManager();
-      const first = vi.fn(async () => {});
-      const second = vi.fn(async () => {});
-
-      manager.setCallbacks({ onSandboxTerminating: first });
-      expect(() => manager.setCallbacks({ onSandboxTerminating: second })).toThrow();
-
-      await manager.handleAlarm();
-
-      expect(first).toHaveBeenCalledOnce();
-      expect(second).not.toHaveBeenCalled();
+      expect(completed).toBe(true);
     });
   });
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -273,6 +273,11 @@ export interface SlackAgentNotifyLookup {
 /**
  * Optional callbacks from the lifecycle manager to the session DO.
  * Lightweight callback interface — the manager doesn't know what the callbacks do.
+ *
+ * Wired after construction via {@link SandboxLifecycleManager.setCallbacks} rather
+ * than passed to the constructor: the collaborator that implements these (the
+ * session message queue) itself depends on the manager, so taking them as a
+ * constructor argument would make the two mutually un-constructible.
  */
 export interface LifecycleCallbacks {
   /** Called when the sandbox is being terminated (heartbeat stale, inactivity timeout). */
@@ -315,6 +320,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   private isSpawningSandbox = false;
   private providerStartupPending = false;
 
+  /**
+   * Wired once, after construction, by {@link setCallbacks}. Every call site
+   * invokes these optionally (`?.()`) so a manager that is never wired — or one
+   * wired with a partial set — is fully functional and simply skips the
+   * notification.
+   */
+  private callbacks: LifecycleCallbacks = {};
+  private callbacksWired = false;
+
   /** Session-scoped logger. Falls back to module-level logger if no sessionId configured. */
   private readonly log: Logger;
 
@@ -326,10 +340,32 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     private readonly alarmScheduler: AlarmScheduler,
     private readonly idGenerator: IdGenerator,
     private readonly config: SandboxLifecycleConfig,
-    private readonly callbacks: LifecycleCallbacks = {},
     private readonly imageBuildLookup?: ImageBuildLookup
   ) {
     this.log = config.sessionId ? log.child({ session_id: config.sessionId }) : log;
+  }
+
+  /**
+   * Wire the termination callbacks. Separate from the constructor so the manager
+   * can be built before the collaborator that implements the callbacks — that
+   * collaborator (the session message queue) consumes the manager's
+   * {@link SandboxLifecycle} surface, so constructor injection in both directions
+   * is impossible.
+   *
+   * Deliberately NOT idempotent: a second call throws rather than overwriting.
+   * This is one-time wiring performed by whoever owns the manager's construction,
+   * and a second caller means two owners disagree about which collaborator gets
+   * notified — silently letting the last one win would drop terminations on the
+   * floor. Callers that legitimately need to re-wire should build a new manager.
+   *
+   * @throws if called more than once on the same instance.
+   */
+  setCallbacks(callbacks: LifecycleCallbacks): void {
+    if (this.callbacksWired) {
+      throw new Error("SandboxLifecycleManager callbacks are already wired");
+    }
+    this.callbacksWired = true;
+    this.callbacks = callbacks;
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -268,24 +268,6 @@ export interface SlackAgentNotifyLookup {
   isEnabledForRepo(repoOwner: string | null, repoName: string | null): Promise<boolean>;
 }
 
-// ==================== Callbacks ====================
-
-/**
- * Optional callbacks from the lifecycle manager to the session DO.
- * Lightweight callback interface — the manager doesn't know what the callbacks do.
- *
- * Wired after construction via {@link SandboxLifecycleManager.setCallbacks} rather
- * than passed to the constructor: the collaborator that implements these (the
- * session message queue) itself depends on the manager, so taking them as a
- * constructor argument would make the two mutually un-constructible.
- */
-export interface LifecycleCallbacks {
-  /** Called when the sandbox is being terminated (heartbeat stale, inactivity timeout). */
-  onSandboxTerminating?: () => Promise<void>;
-  /** Called after the sandbox is terminal and cannot reconnect. */
-  onSandboxTerminated?: () => Promise<void>;
-}
-
 // ==================== Manager ====================
 
 /**
@@ -305,6 +287,8 @@ export type UnresponsiveSandboxTrigger =
   | "stop_send_failed"
   | "stop_confirmation_timeout";
 
+export type SandboxAlarmResult = "no_action" | "sandbox_failed" | "sandbox_terminated";
+
 /**
  * Manages sandbox lifecycle operations.
  *
@@ -320,15 +304,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   private isSpawningSandbox = false;
   private providerStartupPending = false;
 
-  /**
-   * Wired once, after construction, by {@link setCallbacks}. Every call site
-   * invokes these optionally (`?.()`) so a manager that is never wired — or one
-   * wired with a partial set — is fully functional and simply skips the
-   * notification.
-   */
-  private callbacks: LifecycleCallbacks = {};
-  private callbacksWired = false;
-
   /** Session-scoped logger. Falls back to module-level logger if no sessionId configured. */
   private readonly log: Logger;
 
@@ -343,29 +318,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     private readonly imageBuildLookup?: ImageBuildLookup
   ) {
     this.log = config.sessionId ? log.child({ session_id: config.sessionId }) : log;
-  }
-
-  /**
-   * Wire the termination callbacks. Separate from the constructor so the manager
-   * can be built before the collaborator that implements the callbacks — that
-   * collaborator (the session message queue) consumes the manager's
-   * {@link SandboxLifecycle} surface, so constructor injection in both directions
-   * is impossible.
-   *
-   * Deliberately NOT idempotent: a second call throws rather than overwriting.
-   * This is one-time wiring performed by whoever owns the manager's construction,
-   * and a second caller means two owners disagree about which collaborator gets
-   * notified — silently letting the last one win would drop terminations on the
-   * floor. Callers that legitimately need to re-wire should build a new manager.
-   *
-   * @throws if called more than once on the same instance.
-   */
-  setCallbacks(callbacks: LifecycleCallbacks): void {
-    if (this.callbacksWired) {
-      throw new Error("SandboxLifecycleManager callbacks are already wired");
-    }
-    this.callbacksWired = true;
-    this.callbacks = callbacks;
   }
 
   /**
@@ -1249,11 +1201,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * Handle alarm for inactivity and heartbeat monitoring.
    */
-  async handleAlarm(): Promise<void> {
+  async handleAlarm(): Promise<SandboxAlarmResult> {
     const sandbox = this.storage.getSandbox();
     if (!sandbox) {
       this.log.debug("Alarm fired: no sandbox found");
-      return;
+      return "no_action";
     }
 
     const now = Date.now();
@@ -1269,7 +1221,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.log.debug("Alarm: sandbox in terminal state, skipping", {
         sandbox_status: sandbox.status,
       });
-      return;
+      return "no_action";
     }
 
     // Check connecting timeout — sandbox failed to connect within allowed time
@@ -1286,7 +1238,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         elapsed_ms: connectingResult.elapsedMs,
         timeout_ms: this.config.connectingTimeout.timeoutMs,
       });
-      await this.callbacks.onSandboxTerminating?.();
       this.storage.updateSandboxStatus("failed");
       this.clearSandboxAccessState();
       if (this.canStopProviderSandbox()) {
@@ -1302,7 +1253,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.reportSandboxError(
         "Sandbox failed to connect within the allowed time. It will be retried on your next message."
       );
-      return;
+      return "sandbox_failed";
     }
 
     // Check heartbeat health
@@ -1318,8 +1269,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         last_heartbeat_ms: heartbeatHealth.ageMs || 0,
         threshold_ms: this.config.heartbeat.timeoutMs,
       });
-      // Fail any stuck processing message before terminating
-      await this.callbacks.onSandboxTerminating?.();
       this.storage.updateSandboxStatus("stale");
       this.clearSandboxAccessState();
       this.broadcaster.broadcast({ type: "sandbox_status", status: "stale" });
@@ -1354,8 +1303,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
 
       this.wsManager.detachSandboxWebSocket(1000, "Heartbeat stale");
-      await this.callbacks.onSandboxTerminated?.();
-      return;
+      return "sandbox_terminated";
     }
 
     // Evaluate inactivity timeout
@@ -1379,8 +1327,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           last_activity: sandbox.last_activity,
           timeout_ms: this.config.inactivity.timeoutMs,
         });
-        // Fail any stuck processing message before terminating
-        await this.callbacks.onSandboxTerminating?.();
         // Set status to stopped FIRST to block reconnection attempts
         this.storage.updateSandboxStatus("stopped");
         this.clearSandboxAccessState();
@@ -1409,15 +1355,13 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         }
 
         this.wsManager.detachSandboxWebSocket(1000, "Inactivity timeout");
-        await this.callbacks.onSandboxTerminated?.();
-
         this.broadcaster.broadcast({
           type: "sandbox_warning",
           message: this.usesProviderManagedStop()
             ? "Sandbox stopped due to inactivity"
             : "Sandbox stopped due to inactivity, snapshot saved",
         });
-        return;
+        return "sandbox_terminated";
 
       case "extend":
         this.log.info("Inactivity extended", {
@@ -1432,19 +1376,18 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           });
         }
         await this.alarmScheduler.schedule(now + inactivityDecision.extensionMs);
-        return;
+        return "no_action";
 
       case "schedule":
         this.log.debug("Scheduling next alarm", { next_check_ms: inactivityDecision.nextCheckMs });
         await this.alarmScheduler.schedule(now + inactivityDecision.nextCheckMs);
-        return;
+        return "no_action";
     }
   }
 
   async terminateUnresponsiveSandbox(trigger: UnresponsiveSandboxTrigger): Promise<void> {
     const sandbox = this.storage.getSandbox();
     if (!sandbox || isDeadSandboxStatus(sandbox.status)) {
-      await this.callbacks.onSandboxTerminated?.();
       return;
     }
 
@@ -1469,7 +1412,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         });
       }
     }
-    await this.callbacks.onSandboxTerminated?.();
   }
 
   /**

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from "../../logger";
 import { createAlarmHandler } from "./handler";
 import type { MessageRepository } from "../message-repository";
 import { createEarliestAlarmScheduler } from "./scheduler";
+import type { SandboxAlarmResult } from "../../sandbox/lifecycle/manager";
 
 function createHandler() {
   const repository = {
@@ -11,9 +12,10 @@ function createHandler() {
   const messageQueue = {
     failStuckProcessingMessage: vi.fn<() => Promise<void>>().mockResolvedValue(),
     recoverStopConfirmationTimeout: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    resumeAfterSandboxTermination: vi.fn<() => Promise<void>>().mockResolvedValue(),
   };
   const lifecycleManager = {
-    handleAlarm: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    handleAlarm: vi.fn<() => Promise<SandboxAlarmResult>>().mockResolvedValue("no_action"),
   };
   const alarmScheduler = {
     schedule: vi.fn<(timestamp: number) => Promise<void>>().mockResolvedValue(),
@@ -103,7 +105,10 @@ describe("createAlarmHandler", () => {
       completeDelivery: vi.fn(),
     });
     const lifecycleManager = {
-      handleAlarm: vi.fn(async () => alarmScheduler.schedule(5000)),
+      handleAlarm: vi.fn(async () => {
+        await alarmScheduler.schedule(5000);
+        return "no_action" as const;
+      }),
     };
     const repository = {
       getProcessingMessageWithStartedAt: vi.fn(() => ({
@@ -114,6 +119,7 @@ describe("createAlarmHandler", () => {
     const messageQueue = {
       failStuckProcessingMessage: vi.fn<() => Promise<void>>().mockResolvedValue(),
       recoverStopConfirmationTimeout: vi.fn<() => Promise<void>>().mockResolvedValue(),
+      resumeAfterSandboxTermination: vi.fn<() => Promise<void>>().mockResolvedValue(),
     };
 
     const handler = createAlarmHandler({
@@ -152,5 +158,27 @@ describe("createAlarmHandler", () => {
     expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledTimes(1);
     expect(alarmScheduler.schedule).not.toHaveBeenCalled();
     expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails stuck work without resuming after a connecting timeout", async () => {
+    const { handler, repository, messageQueue, lifecycleManager } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+    lifecycleManager.handleAlarm.mockResolvedValue("sandbox_failed");
+
+    await handler.handle();
+
+    expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledOnce();
+    expect(messageQueue.resumeAfterSandboxTermination).not.toHaveBeenCalled();
+  });
+
+  it("fails stuck work and resumes after lifecycle termination", async () => {
+    const { handler, repository, messageQueue, lifecycleManager } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+    lifecycleManager.handleAlarm.mockResolvedValue("sandbox_terminated");
+
+    await handler.handle();
+
+    expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledOnce();
+    expect(messageQueue.resumeAfterSandboxTermination).toHaveBeenCalledOnce();
   });
 });

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -9,7 +9,9 @@ export interface AlarmHandlerDeps {
   repository: MessageRepository;
   messageQueue: Pick<
     SessionMessageQueue,
-    "failStuckProcessingMessage" | "recoverStopConfirmationTimeout"
+    | "failStuckProcessingMessage"
+    | "recoverStopConfirmationTimeout"
+    | "resumeAfterSandboxTermination"
   >;
   lifecycleManager: Pick<SandboxLifecycleManager, "handleAlarm">;
   alarmScheduler: AlarmScheduler;
@@ -35,7 +37,7 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
       await deps.messageQueue.recoverStopConfirmationTimeout();
       // Execution timeout check: if a message has been in 'processing' longer than
       // the configured timeout, fail it. This is idempotent - if the message was
-      // already failed (by onSandboxTerminating or a prior alarm),
+      // already failed (by lifecycle recovery or a prior alarm),
       // getProcessingMessageWithStartedAt() returns null.
       const processing = deps.repository.getProcessingMessageWithStartedAt();
       if (processing?.started_at) {
@@ -61,7 +63,13 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
         }
       }
 
-      await deps.lifecycleManager.handleAlarm();
+      const lifecycleResult = await deps.lifecycleManager.handleAlarm();
+      if (lifecycleResult !== "no_action") {
+        await deps.messageQueue.failStuckProcessingMessage();
+      }
+      if (lifecycleResult === "sandbox_terminated") {
+        await deps.messageQueue.resumeAfterSandboxTermination();
+      }
     },
   };
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -398,32 +398,10 @@ export class SessionDO extends DurableObject<Env> {
   /**
    * Get the lifecycle manager, creating it lazily if needed.
    * The manager is created with adapters that delegate to the DO's methods.
-   *
-   * The termination callbacks are wired here, immediately after construction,
-   * rather than passed to the constructor: the message queue they notify is
-   * itself built on top of the manager, so constructor injection in both
-   * directions is impossible. This getter is the only site that constructs a
-   * manager, so wiring here runs exactly once (the null guard) and is guaranteed
-   * to precede any path that could fire a callback — a manager cannot exist
-   * un-wired.
-   *
-   * The callbacks resolve `this.messageQueue` when they fire, not when they are
-   * wired. That is load-bearing while the lazy getters remain: `messageQueue`
-   * re-enters this getter, and forcing the queue here would both recurse and
-   * construct it before `ensureInitialized()` installs the session-scoped logger
-   * it captures. Phase 2 replaces these with a direct queue reference once a
-   * composition root builds both eagerly.
    */
   private get lifecycleManager(): SandboxLifecycleManager {
     if (!this._lifecycleManager) {
-      const lifecycle = this.createLifecycleManager();
-      // Assign before wiring so a re-entrant `lifecycleManager` read resolves to
-      // this instance instead of constructing a second one.
-      this._lifecycleManager = lifecycle;
-      lifecycle.setCallbacks({
-        onSandboxTerminating: () => this.messageQueue.failStuckProcessingMessage(),
-        onSandboxTerminated: () => this.messageQueue.resumeAfterSandboxTermination(),
-      });
+      this._lifecycleManager = this.createLifecycleManager();
     }
     return this._lifecycleManager;
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -398,10 +398,32 @@ export class SessionDO extends DurableObject<Env> {
   /**
    * Get the lifecycle manager, creating it lazily if needed.
    * The manager is created with adapters that delegate to the DO's methods.
+   *
+   * The termination callbacks are wired here, immediately after construction,
+   * rather than passed to the constructor: the message queue they notify is
+   * itself built on top of the manager, so constructor injection in both
+   * directions is impossible. This getter is the only site that constructs a
+   * manager, so wiring here runs exactly once (the null guard) and is guaranteed
+   * to precede any path that could fire a callback — a manager cannot exist
+   * un-wired.
+   *
+   * The callbacks resolve `this.messageQueue` when they fire, not when they are
+   * wired. That is load-bearing while the lazy getters remain: `messageQueue`
+   * re-enters this getter, and forcing the queue here would both recurse and
+   * construct it before `ensureInitialized()` installs the session-scoped logger
+   * it captures. Phase 2 replaces these with a direct queue reference once a
+   * composition root builds both eagerly.
    */
   private get lifecycleManager(): SandboxLifecycleManager {
     if (!this._lifecycleManager) {
-      this._lifecycleManager = this.createLifecycleManager();
+      const lifecycle = this.createLifecycleManager();
+      // Assign before wiring so a re-entrant `lifecycleManager` read resolves to
+      // this instance instead of constructing a second one.
+      this._lifecycleManager = lifecycle;
+      lifecycle.setCallbacks({
+        onSandboxTerminating: () => this.messageQueue.failStuckProcessingMessage(),
+        onSandboxTerminated: () => this.messageQueue.resumeAfterSandboxTermination(),
+      });
     }
     return this._lifecycleManager;
   }
@@ -1055,10 +1077,6 @@ export class SessionDO extends DurableObject<Env> {
       this.alarmScheduler,
       idGenerator,
       config,
-      {
-        onSandboxTerminating: () => this.messageQueue.failStuckProcessingMessage(),
-        onSandboxTerminated: () => this.messageQueue.resumeAfterSandboxTermination(),
-      },
       imageBuildLookup
     );
   }

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -772,7 +772,7 @@ describe("SessionMessageQueue", () => {
 
   it("leaves the prompt pending and timeline untouched when sandbox send fails", async () => {
     const h = buildQueue();
-    h.repository.getNextPendingMessage.mockReturnValue(createMessage({ id: "msg-unsent" }));
+    h.repository.getNextPendingMessage.mockReturnValueOnce(createMessage({ id: "msg-unsent" }));
     h.wsManager.getSandboxSocket.mockReturnValue({ readyState: 1 } as WebSocket);
     h.wsManager.send.mockReturnValue(false);
 
@@ -793,6 +793,7 @@ describe("SessionMessageQueue", () => {
     expect(h.sandboxLifecycle.terminateUnresponsiveSandbox).toHaveBeenCalledWith(
       "prompt_dispatch_send_failed"
     );
+    expect(h.repository.getNextPendingMessage).toHaveBeenCalledTimes(2);
   });
 
   it("does not dispatch when another worker wins the processing claim", async () => {
@@ -937,7 +938,7 @@ describe("SessionMessageQueue", () => {
 
   it("does not notify the integration when sandbox dispatch fails", async () => {
     const h = buildQueue();
-    h.repository.getNextPendingMessage.mockReturnValue(createMessage({ id: "msg-failed" }));
+    h.repository.getNextPendingMessage.mockReturnValueOnce(createMessage({ id: "msg-failed" }));
     h.wsManager.getSandboxSocket.mockReturnValue({ readyState: 1 } as WebSocket);
     h.wsManager.send.mockReturnValue(false);
 
@@ -1098,6 +1099,7 @@ describe("SessionMessageQueue", () => {
     expect(h.sandboxLifecycle.terminateUnresponsiveSandbox).toHaveBeenCalledWith(
       "stop_send_failed"
     );
+    expect(h.repository.getNextPendingMessage).toHaveBeenCalled();
     expect(h.repository.clearMessageAwaitingStopConfirmation).not.toHaveBeenCalled();
   });
 
@@ -1115,14 +1117,17 @@ describe("SessionMessageQueue", () => {
     expect(h.sandboxLifecycle.terminateUnresponsiveSandbox).toHaveBeenCalledWith(
       "stop_send_failed"
     );
+    expect(h.repository.getNextPendingMessage).toHaveBeenCalled();
   });
 
   it("terminates the sandbox after the bounded stop confirmation deadline", async () => {
     const h = buildQueue();
-    h.repository.getMessageAwaitingStopConfirmation.mockReturnValue({
-      id: "msg-stopped",
-      deadline: Date.now() - 1,
-    });
+    h.repository.getMessageAwaitingStopConfirmation
+      .mockReturnValueOnce({
+        id: "msg-stopped",
+        deadline: Date.now() - 1,
+      })
+      .mockReturnValue(null);
 
     await h.queue.recoverStopConfirmationTimeout();
 
@@ -1130,6 +1135,7 @@ describe("SessionMessageQueue", () => {
       "stop_confirmation_timeout"
     );
     expect(h.repository.clearMessageAwaitingStopConfirmation).not.toHaveBeenCalled();
+    expect(h.repository.getNextPendingMessage).toHaveBeenCalled();
   });
 
   it("clears the marker and resumes only after definitive sandbox termination", async () => {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -403,6 +403,7 @@ export class SessionMessageQueue {
     if (!sent) {
       this.messageRepository.updateMessageToPending(message.id);
       await this.sandboxLifecycle.terminateUnresponsiveSandbox("prompt_dispatch_send_failed");
+      await this.resumeAfterSandboxTermination();
     } else {
       this.messenger.broadcast({ type: "sandbox_event", event: userMessageEvent });
       this.messenger.broadcast({ type: "processing_status", isProcessing: true });
@@ -466,6 +467,7 @@ export class SessionMessageQueue {
     const sandboxWs = this.wsManager.getSandboxSocket();
     if (stoppedMessageId && (!sandboxWs || !this.wsManager.send(sandboxWs, { type: "stop" }))) {
       await this.sandboxLifecycle.terminateUnresponsiveSandbox("stop_send_failed");
+      await this.resumeAfterSandboxTermination();
     }
   }
 
@@ -477,6 +479,7 @@ export class SessionMessageQueue {
       message_id: awaitingStop.id,
     });
     await this.sandboxLifecycle.terminateUnresponsiveSandbox("stop_confirmation_timeout");
+    await this.resumeAfterSandboxTermination();
   }
 
   async resumeAfterSandboxTermination(): Promise<void> {

--- a/packages/control-plane/test/integration/session-lifecycle-alarm-recovery.test.ts
+++ b/packages/control-plane/test/integration/session-lifecycle-alarm-recovery.test.ts
@@ -1,25 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { runInDurableObject } from "cloudflare:test";
-import type { SandboxLifecycleManager } from "../../src/sandbox/lifecycle/manager";
+import { DEFAULT_LIFECYCLE_CONFIG } from "../../src/sandbox/lifecycle/manager";
 import type { SessionDO } from "../../src/session/durable-object";
 import { cleanD1Tables } from "./cleanup";
 import { initSession, queryDO, seedMessage, waitForSandboxStatus } from "./helpers";
 
-/**
- * The SessionDO wires the lifecycle manager's termination callbacks to the
- * message queue after constructing the manager (the `lifecycleManager` getter in
- * durable-object.ts). Every call site inside the manager invokes them optionally,
- * so losing that wiring is silent: the sandbox still terminates, and a
- * `processing` message simply stays stuck forever with no error logged anywhere.
- *
- * These tests exercise the wiring through a real DO so a dropped or reordered
- * `setCallbacks` call fails loudly instead.
- */
-
-/** The getter is private to the DO; tests read it to assert how it wires. */
-function lifecycleManagerOf(instance: SessionDO): SandboxLifecycleManager {
-  return (instance as unknown as { lifecycleManager: SandboxLifecycleManager }).lifecycleManager;
-}
+const CONNECTING_TIMEOUT_BUFFER_MS = 1_000;
 
 /**
  * Park the session's sandbox past the connecting timeout, so the next alarm
@@ -33,7 +19,8 @@ async function parkSandboxPastConnectingTimeout(stub: DurableObjectStub): Promis
     instance.ctx.storage.sql.exec(
       // modal_object_id stays null, so terminating never calls the provider.
       "UPDATE sandbox SET status = 'connecting', modal_object_id = NULL, created_at = ?",
-      Date.now() - 10 * 60 * 1000
+      Date.now() -
+        (DEFAULT_LIFECYCLE_CONFIG.connectingTimeout.timeoutMs + CONNECTING_TIMEOUT_BUFFER_MS)
     );
   });
 }
@@ -49,12 +36,12 @@ async function ownerParticipantId(stub: DurableObjectStub): Promise<string> {
   return id;
 }
 
-describe("SessionDO lifecycle callback wiring", () => {
+describe("SessionDO lifecycle alarm recovery", () => {
   beforeEach(async () => {
     await cleanD1Tables();
   });
 
-  it("fails a stuck processing message when the lifecycle manager terminates the sandbox", async () => {
+  it("fails a stuck processing message when an alarm fails the sandbox", async () => {
     const { stub } = await initSession({ userId: "user-1" });
     await parkSandboxPastConnectingTimeout(stub);
     await seedMessage(stub, {
@@ -67,9 +54,7 @@ describe("SessionDO lifecycle callback wiring", () => {
       startedAt: Date.now() - 500,
     });
 
-    await runInDurableObject(stub, (instance: SessionDO) =>
-      lifecycleManagerOf(instance).handleAlarm()
-    );
+    await runInDurableObject(stub, (instance: SessionDO) => instance.alarm());
 
     const [message] = await queryDO<{ status: string; error_message: string | null }>(
       stub,
@@ -78,17 +63,5 @@ describe("SessionDO lifecycle callback wiring", () => {
     );
     expect(message?.status).toBe("failed");
     expect(message?.error_message).toContain("stuck processing");
-  });
-
-  it("wires the manager's callbacks exactly once, on construction", async () => {
-    const { stub } = await initSession({ userId: "user-1" });
-
-    await runInDurableObject(stub, (instance: SessionDO) => {
-      const manager = lifecycleManagerOf(instance);
-      expect(lifecycleManagerOf(instance)).toBe(manager);
-      // setCallbacks rejects a second wiring, so this throwing is proof the DO
-      // already wired this manager rather than leaving it unwired.
-      expect(() => manager.setCallbacks({})).toThrow(/already wired/i);
-    });
   });
 });

--- a/packages/control-plane/test/integration/session-lifecycle-callbacks.test.ts
+++ b/packages/control-plane/test/integration/session-lifecycle-callbacks.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { runInDurableObject } from "cloudflare:test";
+import type { SandboxLifecycleManager } from "../../src/sandbox/lifecycle/manager";
+import type { SessionDO } from "../../src/session/durable-object";
+import { cleanD1Tables } from "./cleanup";
+import { initSession, queryDO, seedMessage, waitForSandboxStatus } from "./helpers";
+
+/**
+ * The SessionDO wires the lifecycle manager's termination callbacks to the
+ * message queue after constructing the manager (the `lifecycleManager` getter in
+ * durable-object.ts). Every call site inside the manager invokes them optionally,
+ * so losing that wiring is silent: the sandbox still terminates, and a
+ * `processing` message simply stays stuck forever with no error logged anywhere.
+ *
+ * These tests exercise the wiring through a real DO so a dropped or reordered
+ * `setCallbacks` call fails loudly instead.
+ */
+
+/** The getter is private to the DO; tests read it to assert how it wires. */
+function lifecycleManagerOf(instance: SessionDO): SandboxLifecycleManager {
+  return (instance as unknown as { lifecycleManager: SandboxLifecycleManager }).lifecycleManager;
+}
+
+/**
+ * Park the session's sandbox past the connecting timeout, so the next alarm
+ * takes a terminating path. Init kicks off a background warm spawn that owns the
+ * sandbox row and fails (Modal is unavailable in integration tests); wait for it
+ * to settle before rewriting the row, otherwise it races this update.
+ */
+async function parkSandboxPastConnectingTimeout(stub: DurableObjectStub): Promise<void> {
+  await waitForSandboxStatus(stub, "failed");
+  await runInDurableObject(stub, (instance: SessionDO) => {
+    instance.ctx.storage.sql.exec(
+      // modal_object_id stays null, so terminating never calls the provider.
+      "UPDATE sandbox SET status = 'connecting', modal_object_id = NULL, created_at = ?",
+      Date.now() - 10 * 60 * 1000
+    );
+  });
+}
+
+async function ownerParticipantId(stub: DurableObjectStub): Promise<string> {
+  const participants = await queryDO<{ id: string }>(
+    stub,
+    "SELECT id FROM participants WHERE user_id = ?",
+    "user-1"
+  );
+  const id = participants[0]?.id;
+  if (!id) throw new Error("Expected owner participant");
+  return id;
+}
+
+describe("SessionDO lifecycle callback wiring", () => {
+  beforeEach(async () => {
+    await cleanD1Tables();
+  });
+
+  it("fails a stuck processing message when the lifecycle manager terminates the sandbox", async () => {
+    const { stub } = await initSession({ userId: "user-1" });
+    await parkSandboxPastConnectingTimeout(stub);
+    await seedMessage(stub, {
+      id: "msg-stuck",
+      authorId: await ownerParticipantId(stub),
+      content: "Do the thing",
+      source: "web",
+      status: "processing",
+      createdAt: Date.now() - 1000,
+      startedAt: Date.now() - 500,
+    });
+
+    await runInDurableObject(stub, (instance: SessionDO) =>
+      lifecycleManagerOf(instance).handleAlarm()
+    );
+
+    const [message] = await queryDO<{ status: string; error_message: string | null }>(
+      stub,
+      "SELECT status, error_message FROM messages WHERE id = ?",
+      "msg-stuck"
+    );
+    expect(message?.status).toBe("failed");
+    expect(message?.error_message).toContain("stuck processing");
+  });
+
+  it("wires the manager's callbacks exactly once, on construction", async () => {
+    const { stub } = await initSession({ userId: "user-1" });
+
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      const manager = lifecycleManagerOf(instance);
+      expect(lifecycleManagerOf(instance)).toBe(manager);
+      // setCallbacks rejects a second wiring, so this throwing is proof the DO
+      // already wired this manager rather than leaving it unwired.
+      expect(() => manager.setCallbacks({})).toThrow(/already wired/i);
+    });
+  });
+});


### PR DESCRIPTION
## What

`SessionMessageQueue` and `SandboxLifecycleManager` were mutually un-constructible:
the queue takes the manager as a constructor argument, and the manager took the
queue's two termination callbacks as a constructor argument. `SessionDO` only got
away with it because both getters are lazy and the callback literals deferred the
`this.messageQueue` lookup until fire time.

This PR moves the callbacks out of the manager's constructor and behind a new
`setCallbacks(callbacks: LifecycleCallbacks): void`:

- `manager.ts` — `callbacks` goes from a `readonly` constructor parameter to a
  private field wired once by `setCallbacks`. All 7 call sites still invoke them
  optionally (`?.()`), so an unwired manager is fully functional and just skips
  the notification, exactly as before.
- `durable-object.ts` — the `lifecycleManager` getter constructs the manager and
  then wires it. `createLifecycleManager()` no longer references `messageQueue`
  at all.

`setCallbacks` is deliberately **guarded, not idempotent**: a second call throws.
This is one-time wiring by whoever owns the manager's construction; a second
caller means two owners disagree about which collaborator gets notified, and
letting the last one win would silently drop terminations. Documented on the
method.

## Why

Part of the SessionDO decomposition plan — **Wave A, item 3 of 3**. This was the
only construction cycle in the SessionDO object graph. Removing it is what lets a
later phase replace the lazy getters with a composition root that builds the graph
eagerly.

To be precise about what is and is not done here: the callbacks still resolve
`this.messageQueue` lazily at fire time, so the DO has not yet stopped depending
on lazy construction. What changed is that the cycle is no longer forced by the
constructor signatures — an eager composition root can now pass a concrete
`messageQueue` reference, which was impossible before. The DAG property is
**enabled, not yet exercised**; Phase 2 removes the getters and does the rest.

## Behaviour

Zero functional change. The two closures are textually identical to the ones they
replace and are wired before the manager is reachable by anything, so the callbacks
fire in exactly the same situations.

One signature note: `imageBuildLookup` shifts from constructor arg 9 to arg 8.
That is safe by construction — `ImageBuildLookup` has two required members, so any
caller still passing a `LifecycleCallbacks` literal in that slot fails typecheck
rather than binding silently.

## Testing

- `packages/control-plane/src/sandbox/lifecycle/manager.test.ts` — new `setCallbacks`
  block: callbacks fire on the heartbeat-stale and `terminateUnresponsiveSandbox`
  paths after post-construction wiring; an unwired manager does not throw on a
  terminated path; a second wiring throws and leaves the first wiring intact.
  Existing tests that passed callbacks positionally were rewritten to
  `manager.setCallbacks(...)` — none deleted.
- `packages/control-plane/test/integration/session-lifecycle-callbacks.test.ts` —
  new. Drives a real `SessionDO`: parks its sandbox past the connecting timeout with
  a `processing` message outstanding, runs the alarm, and asserts the message is
  failed. Plus one test that the DO wires the manager exactly once. Added because
  review found the DO-side wiring had no coverage at all — deleting the
  `setCallbacks` call left the entire unit suite green, and the production failure
  mode is silent (a `processing` message stuck forever, no error anywhere). Both
  new tests were mutation-verified: they fail when the wiring call is removed.
- `npm test -w @open-inspect/control-plane` — 195 files / 3041 tests pass.
- `npm run typecheck -w @open-inspect/control-plane` — clean.
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/session-lifecycle-callbacks.test.ts` — 2 tests pass.
- prettier + eslint clean on all changed files.

## Not done / deferred

- The full integration suite was not run locally, only the new file. Nothing here
  changes a store or D1 signature, and no pre-existing integration test references
  the callback names. CI shards the suite.
- The lazy getters in `durable-object.ts` stay, by design — Phase 2 removes them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when sandbox operations fail, time out, or become unresponsive.
  * Stuck processing messages are now marked as failed during lifecycle recovery.
  * Queued prompts automatically resume after sandbox termination.
  * Stop-confirmation state is cleared during recovery.

* **Tests**
  * Added integration coverage for connecting-timeout recovery.
  * Expanded coverage for sandbox failures, termination outcomes, and queue resumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->