### PR TITLE
Terminate fatal commit-signing initialization retries

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -350,7 +350,9 @@ class AgentBridge:
                 except Exception as e:
                     error_str = str(e)
                     # Check for fatal HTTP errors that shouldn't trigger retry
-                    if self._is_fatal_connection_error(error_str):
+                    if (
+                        isinstance(e, GitSigningError) and not e.retryable
+                    ) or self._is_fatal_connection_error(error_str):
                         run_outcome = "fatal_error"
                         self.shutdown_event.set()
                         break

--- a/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
@@ -34,6 +34,17 @@ UNSIGNED_GIT_USER = GitUser(name="OpenInspect", email="open-inspect@noreply.gith
 class GitSigningError(RuntimeError):
     """Bounded runtime error that never includes secret configuration values."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retryable = retryable
+
 
 class DisabledCommitSigningConfiguration(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
@@ -129,7 +140,18 @@ class GitSigningRuntime:
                 )
                 response.raise_for_status()
                 payload = response.json()
-        except (httpx.HTTPError, ValueError):
+        except httpx.HTTPStatusError as error:
+            status_code = error.response.status_code
+            raise GitSigningError(
+                "Commit signing configuration unavailable",
+                status_code=status_code,
+                retryable=status_code not in {401, 403, 404, 410},
+            ) from None
+        except httpx.HTTPError:
+            raise GitSigningError(
+                "Commit signing configuration unavailable", retryable=True
+            ) from None
+        except ValueError:
             raise GitSigningError("Commit signing configuration unavailable") from None
 
         return parse_commit_signing_configuration(payload)

--- a/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/git_signing.py
@@ -145,7 +145,7 @@ class GitSigningRuntime:
             raise GitSigningError(
                 "Commit signing configuration unavailable",
                 status_code=status_code,
-                retryable=status_code not in {401, 403, 404, 410},
+                retryable=status_code in {408, 429} or status_code >= 500,
             ) from None
         except httpx.HTTPError:
             raise GitSigningError(

--- a/packages/sandbox-runtime/tests/test_bridge_reconnection.py
+++ b/packages/sandbox-runtime/tests/test_bridge_reconnection.py
@@ -149,7 +149,10 @@ class TestIsFatalConnectionError:
 
         bridge.log = MagicMock()
         bridge.git_signing.initialize = AsyncMock(
-            side_effect=[GitSigningError("Commit signing configuration unavailable"), None]
+            side_effect=[
+                GitSigningError("Commit signing configuration unavailable", retryable=True),
+                None,
+            ]
         )
         bridge._load_session_id = AsyncMock()
         bridge._connect_and_run = AsyncMock(side_effect=connect_and_run)
@@ -161,6 +164,52 @@ class TestIsFatalConnectionError:
         assert bridge.git_signing.initialize.await_count == 2
         bridge._connect_and_run.assert_awaited_once()
         sleep.assert_awaited_once_with(bridge.RECONNECT_BACKOFF_BASE)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403, 404, 410])
+    async def test_run_exits_on_terminal_signing_configuration_status(
+        self, bridge, monkeypatch, status
+    ):
+        bridge.log = MagicMock()
+        bridge.git_signing.initialize = AsyncMock(
+            side_effect=GitSigningError(
+                "Commit signing configuration unavailable", status_code=status
+            )
+        )
+        bridge._load_session_id = AsyncMock()
+        bridge._connect_and_run = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr("sandbox_runtime.bridge.asyncio.sleep", sleep)
+
+        await bridge.run()
+
+        bridge._connect_and_run.assert_not_awaited()
+        sleep.assert_not_awaited()
+        assert bridge.shutdown_event.is_set()
+        bridge.log.info.assert_any_call(
+            "bridge.run_complete",
+            outcome="fatal_error",
+            connection_count=0,
+            reconnect_count=0,
+            reconnect_attempt_count=0,
+            total_connected_duration_seconds=0.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_exits_on_nonretryable_payload_failure(self, bridge, monkeypatch):
+        bridge.log = MagicMock()
+        bridge.git_signing.initialize = AsyncMock(
+            side_effect=GitSigningError("Invalid commit signing configuration")
+        )
+        bridge._load_session_id = AsyncMock()
+        bridge._connect_and_run = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr("sandbox_runtime.bridge.asyncio.sleep", sleep)
+
+        await bridge.run()
+
+        bridge._connect_and_run.assert_not_awaited()
+        sleep.assert_not_awaited()
 
 
 class TestSessionTerminatedError:

--- a/packages/sandbox-runtime/tests/test_git_signing.py
+++ b/packages/sandbox-runtime/tests/test_git_signing.py
@@ -4,7 +4,7 @@ import textwrap
 import httpx
 import pytest
 
-from sandbox_runtime.git_signing import GitSigningRuntime
+from sandbox_runtime.git_signing import GitSigningError, GitSigningRuntime
 from sandbox_runtime.repo_config import RepoEntry, dump_repo_manifest
 from sandbox_runtime.types import GitUser
 
@@ -414,6 +414,59 @@ async def test_refresh_blocks_on_non_success_or_malformed_broker_results(
 
     with pytest.raises(RuntimeError, match=r"commit signing configuration|Commit signing"):
         await runtime.refresh(GitUser(name="OpenInspect", email="open-inspect@example.com"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403, 404, 410, 503])
+async def test_refresh_preserves_broker_http_status_without_response_details(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, status: int
+):
+    manifest = create_manifest(tmp_path)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, text="secret upstream details")
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "sandbox_runtime.git_signing.httpx.AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    runtime = create_runtime(tmp_path, manifest)
+
+    with pytest.raises(GitSigningError) as exc_info:
+        await runtime.refresh(None)
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.retryable is (status not in {401, 403, 404, 410})
+    assert str(exc_info.value) == "Commit signing configuration unavailable"
+    assert "secret upstream details" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_network_failure_has_no_http_status_or_secret_details(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    manifest = create_manifest(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("sandbox-token", request=request)
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "sandbox_runtime.git_signing.httpx.AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    runtime = create_runtime(tmp_path, manifest)
+
+    with pytest.raises(GitSigningError) as exc_info:
+        await runtime.refresh(None)
+
+    assert exc_info.value.status_code is None
+    assert exc_info.value.retryable is True
+    assert str(exc_info.value) == "Commit signing configuration unavailable"
+    assert "sandbox-token" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/packages/sandbox-runtime/tests/test_git_signing.py
+++ b/packages/sandbox-runtime/tests/test_git_signing.py
@@ -417,9 +417,21 @@ async def test_refresh_blocks_on_non_success_or_malformed_broker_results(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", [401, 403, 404, 410, 503])
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [
+        (400, False),
+        (401, False),
+        (403, False),
+        (404, False),
+        (408, True),
+        (410, False),
+        (429, True),
+        (503, True),
+    ],
+)
 async def test_refresh_preserves_broker_http_status_without_response_details(
-    tmp_path, monkeypatch: pytest.MonkeyPatch, status: int
+    tmp_path, monkeypatch: pytest.MonkeyPatch, status: int, retryable: bool
 ):
     manifest = create_manifest(tmp_path)
 
@@ -438,7 +450,7 @@ async def test_refresh_preserves_broker_http_status_without_response_details(
         await runtime.refresh(None)
 
     assert exc_info.value.status_code == status
-    assert exc_info.value.retryable is (status not in {401, 403, 404, 410})
+    assert exc_info.value.retryable is retryable
     assert str(exc_info.value) == "Commit signing configuration unavailable"
     assert "secret upstream details" not in str(exc_info.value)
 


### PR DESCRIPTION
## Context

This is the commit-signing half of closed PR #1580.

The bridge initializes commit signing before opening its WebSocket. The configuration fetch previously collapsed every `httpx.HTTPError` into one status-less `GitSigningError`, so terminal 401/403/404/410 responses were treated like transient network failures and retried indefinitely.

## Changes

- preserve the HTTP response status on redacted commit-signing fetch errors
- make retryability explicit on `GitSigningError`
- classify network and non-terminal HTTP failures as retryable
- classify terminal authorization/not-found responses, malformed payloads, invalid manifests, and local Git configuration failures as non-retryable
- let the bridge consume the signing boundary’s retryability decision instead of owning broker-specific status policy
- retain fixed error messages without response bodies, URLs, authorization headers, or secret details

## Validation

- `PYTHONPATH=src uv run --extra dev ruff check src tests`
- `PYTHONPATH=src uv run --extra dev pytest tests/test_git_signing.py tests/test_bridge_reconnection.py -q` (43 passed)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1ce4e4cf0c1f19445af1d3d28ba283f3)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git signing error handling to distinguish temporary failures from terminal failures.
  * Authentication, authorization, and unavailable signing responses now stop processing immediately instead of repeatedly reconnecting.
  * Temporary network and service errors continue to support retry behavior.
  * Error messages remain sanitized and do not expose sensitive upstream details.

* **Tests**
  * Added coverage for terminal HTTP statuses, retryable failures, and non-retryable signing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->