### PR TITLE
Show skill creator attribution in settings list

### DIFF
--- a/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
@@ -93,7 +93,7 @@ describe("SkillsCatalog", () => {
     const withDisplayName = skill("1", "first-skill");
     const withIdFallback = {
       ...skill("2", "second-skill"),
-      creatorDisplayName: null,
+      creatorDisplayName: "",
       createdBy: "user-2",
     };
     useSkillCatalogPageMock.mockReturnValue({

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.test.tsx
@@ -89,6 +89,27 @@ describe("SkillsCatalog", () => {
     expect(useSkillCatalogPageMock).toHaveBeenLastCalledWith(null);
   });
 
+  it("shows the skill creator with an ID fallback", () => {
+    const withDisplayName = skill("1", "first-skill");
+    const withIdFallback = {
+      ...skill("2", "second-skill"),
+      creatorDisplayName: null,
+      createdBy: "user-2",
+    };
+    useSkillCatalogPageMock.mockReturnValue({
+      skills: [withDisplayName, withIdFallback],
+      hasMore: false,
+      nextCursor: null,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<SkillsCatalog />);
+
+    expect(screen.getByText("· Created by User One")).toBeInTheDocument();
+    expect(screen.getByText("· Created by user-2")).toBeInTheDocument();
+  });
+
   it.each([
     [
       "empty",

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
@@ -136,8 +136,11 @@ export function SkillsCatalog() {
                 <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
                   {item.description}
                 </p>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
+                <p className="mt-2 flex flex-wrap gap-x-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
+                  </span>
+                  <span>· Created by {item.creatorDisplayName ?? item.createdBy}</span>
                 </p>
               </button>
               <Switch

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
@@ -140,7 +140,7 @@ export function SkillsCatalog() {
                   <span>
                     {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
                   </span>
-                  <span>· Created by {item.creatorDisplayName ?? item.createdBy}</span>
+                  <span>· Created by {item.creatorDisplayName || item.createdBy}</span>
                 </p>
               </button>
               <Switch

--- a/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
+++ b/packages/web/src/components/settings/skills-settings/skills-catalog.tsx
@@ -136,7 +136,7 @@ export function SkillsCatalog() {
                 <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
                   {item.description}
                 </p>
-                <p className="mt-2 flex flex-wrap gap-x-1.5 text-xs text-muted-foreground">
+                <p className="mt-2 flex flex-wrap gap-x-2.5 text-xs text-muted-foreground">
                   <span>
                     {item.assignments.length} assignment{item.assignments.length === 1 ? "" : "s"}
                   </span>


### PR DESCRIPTION
## Summary
- add understated creator attribution to each shared skill row
- fall back to the canonical creator ID when no display name is available
- keep assignment and creator metadata responsive on narrow screens
- add focused catalog coverage for display-name and ID rendering

## Verification
- `npm test -w @open-inspect/web -- src/components/settings/skills-settings/skills-catalog.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- src/components/settings/skills-settings/skills-catalog.tsx src/components/settings/skills-settings/skills-catalog.test.tsx`
- visually verified at 1440x900 and 390x844 viewports

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5a1e635f559acbad94fee85eab3dd77e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill catalog entries now display the creator’s name or ID alongside the assignment count.
  * Metadata wraps automatically for improved readability in narrow layouts.
  * When a creator name is unavailable, the catalog falls back to displaying the creator ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->