### PR TITLE
refactor(control-plane): extract UserEnvResolver from SessionDO

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -84,6 +84,7 @@ import { ParticipantService, getAvatarUrl } from "./participant-service";
 import { UserScmTokenStore } from "../db/user-scm-tokens";
 import { CallbackNotificationService } from "./callback-notification-service";
 import { UserEnvResolver } from "./user-env-resolver";
+import { resolveSessionRepoId } from "./repo-id-resolution";
 import { Scheduler } from "../scheduler/scheduler";
 import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
 import type { BackgroundTasks } from "../platform-ports";
@@ -412,7 +413,12 @@ export class SessionDO extends DurableObject<Env> {
       this._userEnvResolver = new UserEnvResolver({
         db: this.db,
         sessionCoreRepository: this.sessionCoreRepository,
-        getSourceControlProvider: () => this.sourceControlProvider,
+        resolveRepoId: (session) =>
+          resolveSessionRepoId(
+            session,
+            this.sessionCoreRepository,
+            () => this.sourceControlProvider
+          ),
         durableObjectId: this.ctx.id.toString(),
         repoSecretsEncryptionKey: this.env.REPO_SECRETS_ENCRYPTION_KEY,
         secretsCapEnforcement: this.env.SECRETS_CAP_ENFORCEMENT,
@@ -647,7 +653,12 @@ export class SessionDO extends DurableObject<Env> {
           const service = new OpenAITokenRefreshService(
             this.db!,
             this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) => this.userEnvResolver.ensureRepoId(sessionRow),
+            (sessionRow) =>
+              resolveSessionRepoId(
+                sessionRow,
+                this.sessionCoreRepository,
+                () => this.sourceControlProvider
+              ),
             log
           );
           return service.refresh(session);
@@ -656,7 +667,12 @@ export class SessionDO extends DurableObject<Env> {
           const service = new XaiTokenRefreshService(
             this.db!,
             this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) => this.userEnvResolver.ensureRepoId(sessionRow),
+            (sessionRow) =>
+              resolveSessionRepoId(
+                sessionRow,
+                this.sessionCoreRepository,
+                () => this.sourceControlProvider
+              ),
             log
           );
           return service.refresh(session);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -47,10 +47,6 @@ import {
   type SourceControlProvider,
 } from "../source-control";
 import type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
-import type {
-  SessionProviderAuthMode,
-  SubscriptionProviderId,
-} from "@open-inspect/shared/types/provider-accounts";
 import type { Env, ClientInfo } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, SandboxRow } from "./types";
@@ -80,27 +76,14 @@ import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
 import { refreshSessionPullRequests } from "./pull-request-refresh";
 import { findPrArtifactForRepo } from "./pr-artifacts";
-import { RepoSecretsStore } from "../db/repo-secrets";
-import { GlobalSecretsStore } from "../db/global-secrets";
-import { EnvironmentSecretsStore } from "../db/environment-secrets";
 import { EnvironmentStore } from "../db/environments";
-import {
-  auditSecretsMerge,
-  mergeSecretSources,
-  parseSecretsCapMode,
-} from "../db/secrets-validation";
-import { buildSessionTargetSecretSources } from "./session-target-secrets";
-import type { SessionRepositoryEntry } from "./repository-target";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { XaiTokenRefreshService } from "./xai-token-refresh-service";
-import {
-  getProviderAuthenticationError as resolveProviderAuthenticationError,
-  prepareManagedProviderEnv,
-} from "../sandbox/managed-provider-env";
 import { ScmCredentialsService } from "./scm-credentials-service";
 import { ParticipantService, getAvatarUrl } from "./participant-service";
 import { UserScmTokenStore } from "../db/user-scm-tokens";
 import { CallbackNotificationService } from "./callback-notification-service";
+import { UserEnvResolver } from "./user-env-resolver";
 import { Scheduler } from "../scheduler/scheduler";
 import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
 import type { BackgroundTasks } from "../platform-ports";
@@ -249,6 +232,7 @@ export class SessionDO extends DurableObject<Env> {
   // Session status service (lazily initialized)
   private _statusService: SessionStatusService | null = null;
   private _terminalMessageProjection: SessionTerminalMessageProjection | null = null;
+  private _userEnvResolver: UserEnvResolver | null = null;
   private readonly server: SessionServer<WebSocket, ClientInfo>;
 
   // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
@@ -423,6 +407,21 @@ export class SessionDO extends DurableObject<Env> {
     return this._sourceControlProvider;
   }
 
+  private get userEnvResolver(): UserEnvResolver {
+    if (!this._userEnvResolver) {
+      this._userEnvResolver = new UserEnvResolver({
+        db: this.db,
+        sessionCoreRepository: this.sessionCoreRepository,
+        getSourceControlProvider: () => this.sourceControlProvider,
+        durableObjectId: this.ctx.id.toString(),
+        repoSecretsEncryptionKey: this.env.REPO_SECRETS_ENCRYPTION_KEY,
+        secretsCapEnforcement: this.env.SECRETS_CAP_ENFORCEMENT,
+        log: () => this.log,
+      });
+    }
+    return this._userEnvResolver;
+  }
+
   /**
    * Get the participant service, creating it lazily if needed.
    */
@@ -549,7 +548,7 @@ export class SessionDO extends DurableObject<Env> {
         this.participantService,
         this.callbackService,
         this.statusService,
-        (model) => this.getProviderAuthenticationError(model),
+        (model) => this.userEnvResolver.getProviderAuthenticationError(model),
         (messageId, messageCreatedAt, completedAt) =>
           this.terminalMessageProjection.recordTerminalMessage({
             messageId,
@@ -648,7 +647,7 @@ export class SessionDO extends DurableObject<Env> {
           const service = new OpenAITokenRefreshService(
             this.db!,
             this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) => this.ensureRepoId(sessionRow),
+            (sessionRow) => this.userEnvResolver.ensureRepoId(sessionRow),
             log
           );
           return service.refresh(session);
@@ -657,7 +656,7 @@ export class SessionDO extends DurableObject<Env> {
           const service = new XaiTokenRefreshService(
             this.db!,
             this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) => this.ensureRepoId(sessionRow),
+            (sessionRow) => this.userEnvResolver.ensureRepoId(sessionRow),
             log
           );
           return service.refresh(session);
@@ -911,7 +910,7 @@ export class SessionDO extends DurableObject<Env> {
           baseBranch: entry.baseBranch ?? "main",
           baseSha: entry.row?.base_sha ?? null,
         })),
-      getUserEnvVars: () => this.getUserEnvVars(),
+      getUserEnvVars: () => this.userEnvResolver.getUserEnvVars(),
       updateSandboxStatus: (status) => this.sandboxRepository.updateSandboxStatus(status),
       updateSandboxForSpawn: (data) => this.sandboxRepository.updateSandboxForSpawn(data),
       updateSandboxForResume: (data) => this.sandboxRepository.updateSandboxForResume(data),
@@ -1700,151 +1699,5 @@ export class SessionDO extends DurableObject<Env> {
    */
   private getIsProcessing(): boolean {
     return this.messageRepository.getProcessingMessage() !== null;
-  }
-
-  private async ensureRepoId(session: SessionRow): Promise<number> {
-    if (session.repo_id) {
-      return session.repo_id;
-    }
-    if (!session.repo_owner || !session.repo_name) {
-      throw new Error("Session has no repository context");
-    }
-
-    const result = await this.sourceControlProvider.checkRepositoryAccess({
-      owner: session.repo_owner,
-      name: session.repo_name,
-    });
-    if (!result) {
-      throw new Error("Repository is not accessible for the configured SCM provider");
-    }
-
-    this.sessionCoreRepository.updateSessionRepoId(result.repoId);
-    return result.repoId;
-  }
-
-  private async getUserEnvVars(): Promise<Record<string, string> | undefined> {
-    const context = await this.loadUserEnvContext();
-    if (!context) return undefined;
-    return Object.keys(context.sandboxEnv).length === 0 ? undefined : context.sandboxEnv;
-  }
-
-  private async getProviderAuthenticationError(model: string): Promise<string | null> {
-    const context = await this.loadUserEnvContext();
-    if (!context) return null;
-    const issue = resolveProviderAuthenticationError(
-      model,
-      context.sandboxEnv,
-      context.providerAuthModes
-    );
-    if (!issue) return null;
-    this.log.error("provider_auth.unavailable", {
-      event: "provider_auth.unavailable",
-      provider: issue.provider,
-      auth_mode: context.providerAuthModes[issue.provider],
-    });
-    return issue.message;
-  }
-
-  private async loadUserEnvContext(): Promise<{
-    sandboxEnv: Record<string, string>;
-    providerAuthModes: Record<SubscriptionProviderId, SessionProviderAuthMode>;
-  } | null> {
-    const session = this.sessionCoreRepository.getSession();
-    if (!session) {
-      this.log.warn("Cannot load secrets: no session");
-      return null;
-    }
-
-    const db = this.db;
-    if (!db) throw new Error("D1 is required to load session provider auth");
-    const providerAuth = await new SessionIndexStore(db).getCompleteProviderAuth(
-      resolvePublicSessionId(session, this.ctx.id.toString())
-    );
-    const providerAuthModes = Object.fromEntries(
-      providerAuth.map(({ provider, authMode }) => [provider, authMode])
-    ) as Record<SubscriptionProviderId, SessionProviderAuthMode>;
-
-    if (!this.env.REPO_SECRETS_ENCRYPTION_KEY) {
-      this.log.debug("Ordinary secrets not configured, skipping secret loading", {
-        has_encryption_key: !!this.env.REPO_SECRETS_ENCRYPTION_KEY,
-      });
-      const sandboxEnv = prepareManagedProviderEnv({
-        exposedSecrets: {},
-        brokerSecrets: {},
-        providerAuthModes,
-      });
-      return { sandboxEnv, providerAuthModes };
-    }
-
-    // Fail hard on secret loading — sandboxes must not silently lose secrets
-    const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
-    const globalStore = new GlobalSecretsStore(db, encryptionKey);
-    const globalSecrets = await globalStore.getDecryptedSecrets();
-
-    const repoStore = new RepoSecretsStore(db, encryptionKey);
-    const environmentSecretsStore = new EnvironmentSecretsStore(db, encryptionKey);
-    const members = this.sessionCoreRepository.getSessionRepositories();
-    const sources = await buildSessionTargetSecretSources({
-      environmentId: session.environment_id,
-      globalSecrets,
-      members,
-      loadMemberSecrets: (member) => this.loadMemberRepoSecrets(session, member, repoStore),
-      loadEnvironmentSecrets: (environmentId) =>
-        environmentSecretsStore.getDecryptedSecrets(environmentId),
-    });
-
-    const merge = mergeSecretSources(sources);
-    auditSecretsMerge({
-      merge,
-      mode: parseSecretsCapMode(this.env.SECRETS_CAP_ENFORCEMENT),
-      log: this.log,
-      context: { session_id: session.id },
-    });
-
-    const mergedCount = Object.keys(merge.merged).length;
-    if (mergedCount > 0) {
-      this.log.info("Secrets merged for sandbox", {
-        source_count: sources.length,
-        merged_count: mergedCount,
-        payload_bytes: merge.totalBytes,
-        exceeds_limit: merge.exceedsLimit,
-      });
-    }
-
-    const primary = members.find((member) => member.isPrimary);
-    const managedSources = session.environment_id
-      ? sources
-      : sources.filter(
-          (source) =>
-            source.label === "global" ||
-            (primary && source.label === `${primary.repoOwner}/${primary.repoName}`)
-        );
-    const managedSecrets = mergeSecretSources(managedSources).merged;
-    const sandboxEnv = prepareManagedProviderEnv({
-      exposedSecrets: merge.merged,
-      brokerSecrets: managedSecrets,
-      providerAuthModes,
-    });
-    return { sandboxEnv, providerAuthModes };
-  }
-
-  /**
-   * Decrypt one member repo's secrets — the injected leaf loader for
-   * buildSessionTargetSecretSources. The member row carries the repo id; a
-   * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
-   * A member without a resolvable id (a secondary with a null row id) can't be
-   * keyed, so it contributes nothing.
-   */
-  private async loadMemberRepoSecrets(
-    session: SessionRow,
-    member: SessionRepositoryEntry,
-    repoStore: RepoSecretsStore
-  ): Promise<Record<string, string>> {
-    const repoId =
-      member.row?.repo_id ?? (member.isPrimary ? await this.ensureRepoId(session) : null);
-    if (repoId === null) {
-      return {};
-    }
-    return repoStore.getDecryptedSecrets(repoId);
   }
 }

--- a/packages/control-plane/src/session/repo-id-resolution.test.ts
+++ b/packages/control-plane/src/session/repo-id-resolution.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { resolveSessionRepoId } from "./repo-id-resolution";
+import { SessionCoreRepository } from "./session-core-repository";
+import type { SqlResult, SqlStorage } from "./sql-storage";
+import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
+import type { SessionRow } from "./types";
+
+function notUsedHere(member: string): never {
+  throw new Error(`${member} is not exercised by the repo-id-resolution suite`);
+}
+
+/** Full-interface stub so no test needs an unsafe cast. */
+function stubProvider(
+  checkRepositoryAccess: SourceControlProvider["checkRepositoryAccess"]
+): SourceControlProvider {
+  return {
+    name: "github",
+    getRepository: () => notUsedHere("getRepository"),
+    createPullRequest: () => notUsedHere("createPullRequest"),
+    checkRepositoryAccess,
+    listRepositories: () => notUsedHere("listRepositories"),
+    listBranches: () => notUsedHere("listBranches"),
+    getBranchHead: () => notUsedHere("getBranchHead"),
+    resolveCommit: () => notUsedHere("resolveCommit"),
+    listTree: () => notUsedHere("listTree"),
+    readBlob: () => notUsedHere("readBlob"),
+    getPullRequest: () => notUsedHere("getPullRequest"),
+    generatePushAuth: () => notUsedHere("generatePushAuth"),
+    generateCredentialHelperAuth: () => notUsedHere("generateCredentialHelperAuth"),
+    buildManualPullRequestUrl: () => notUsedHere("buildManualPullRequestUrl"),
+    buildGitPushSpec: () => notUsedHere("buildGitPushSpec"),
+  };
+}
+
+function sessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "sess-1",
+    session_name: "sess-public-1",
+    title: null,
+    repo_owner: "acme",
+    repo_name: "web",
+    repo_id: 90101,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "anthropic/claude-sonnet-4-5",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    code_server_enabled: 0,
+    vnc_enabled: 0,
+    total_cost: 0,
+    sandbox_settings: null,
+    environment_id: null,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+function makeHarness(
+  checkRepositoryAccess: SourceControlProvider["checkRepositoryAccess"] = () =>
+    notUsedHere("checkRepositoryAccess")
+) {
+  const updates: Array<{ query: string; params: unknown[] }> = [];
+  const sql: SqlStorage = {
+    exec(query: string, ...params: unknown[]): SqlResult {
+      if (!query.startsWith("UPDATE session SET repo_id")) {
+        throw new Error(`Unexpected DO storage query: ${query}`);
+      }
+      updates.push({ query, params });
+      return { toArray: () => [], one: () => null, rowsWritten: 1 };
+    },
+  };
+  const repository = new SessionCoreRepository(sql, (closure) => closure());
+  const provider = stubProvider(checkRepositoryAccess);
+  let providerThunkCalls = 0;
+  const getProvider = () => {
+    providerThunkCalls += 1;
+    return provider;
+  };
+  return {
+    resolve: (session: SessionRow) => resolveSessionRepoId(session, repository, getProvider),
+    updates,
+    providerThunkCalls: () => providerThunkCalls,
+  };
+}
+
+describe("resolveSessionRepoId", () => {
+  it("short-circuits on an existing repo_id without touching the provider or persisting", async () => {
+    const h = makeHarness();
+
+    await expect(h.resolve(sessionRow())).resolves.toBe(90101);
+
+    expect(h.providerThunkCalls()).toBe(0);
+    expect(h.updates).toEqual([]);
+  });
+
+  it("throws when the session has no repository context", async () => {
+    const h = makeHarness();
+
+    await expect(
+      h.resolve(sessionRow({ repo_id: null, repo_owner: null, repo_name: null }))
+    ).rejects.toThrow("Session has no repository context");
+  });
+
+  it("throws when the repository is not accessible", async () => {
+    const h = makeHarness(async () => null);
+
+    await expect(h.resolve(sessionRow({ repo_id: null }))).rejects.toThrow(
+      "Repository is not accessible for the configured SCM provider"
+    );
+    expect(h.updates).toEqual([]);
+  });
+
+  it("resolves via the provider and persists the repo id for legacy rows", async () => {
+    const checked: Array<{ owner: string; name: string }> = [];
+    const access: RepositoryAccessResult = {
+      repoId: 777,
+      repoOwner: "acme",
+      repoName: "web",
+      defaultBranch: "main",
+    };
+    const h = makeHarness(async ({ owner, name }) => {
+      checked.push({ owner, name });
+      return access;
+    });
+
+    await expect(h.resolve(sessionRow({ repo_id: null }))).resolves.toBe(777);
+
+    expect(checked).toEqual([{ owner: "acme", name: "web" }]);
+    expect(h.updates).toHaveLength(1);
+    expect(h.updates[0]?.params).toEqual([777]);
+  });
+});

--- a/packages/control-plane/src/session/repo-id-resolution.ts
+++ b/packages/control-plane/src/session/repo-id-resolution.ts
@@ -1,0 +1,33 @@
+import type { SourceControlProvider } from "../source-control";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionRow } from "./types";
+
+/**
+ * Resolve the session's primary repo id, looking it up via the SCM provider
+ * and persisting it for legacy rows that predate `repo_id`. The provider is
+ * taken as a thunk so rows that already carry an id never construct it —
+ * `createSourceControlProviderFromEnv` throws on misconfigured SCM env.
+ */
+export async function resolveSessionRepoId(
+  session: SessionRow,
+  sessionCoreRepository: SessionCoreRepository,
+  getSourceControlProvider: () => SourceControlProvider
+): Promise<number> {
+  if (session.repo_id) {
+    return session.repo_id;
+  }
+  if (!session.repo_owner || !session.repo_name) {
+    throw new Error("Session has no repository context");
+  }
+
+  const result = await getSourceControlProvider().checkRepositoryAccess({
+    owner: session.repo_owner,
+    name: session.repo_name,
+  });
+  if (!result) {
+    throw new Error("Repository is not accessible for the configured SCM provider");
+  }
+
+  sessionCoreRepository.updateSessionRepoId(result.repoId);
+  return result.repoId;
+}

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -9,13 +9,18 @@
 
 import { describe, it, expect } from "vitest";
 import { UserEnvResolver } from "./user-env-resolver";
-import { SecretsCapExceededError } from "../db/secrets-validation";
+import { resolveSessionRepoId } from "./repo-id-resolution";
+import {
+  MAX_COMBINED_SECRETS_BYTES,
+  MAX_TOTAL_VALUE_SIZE,
+  MAX_VALUE_SIZE,
+  SecretsCapExceededError,
+} from "../db/secrets-validation";
 import { SessionCoreRepository } from "./session-core-repository";
 import { encryptToken, generateEncryptionKey } from "../auth/crypto";
 import type { Logger } from "../logger";
 import type { SqlDatabase, SqlResult, SqlStatement } from "../db/sql-database";
 import type { SqlResult as StorageSqlResult, SqlStorage } from "./sql-storage";
-import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
 import type { SessionProviderAuthMode } from "@open-inspect/shared/types/provider-accounts";
 import type { SessionRepositoryRow, SessionRow } from "./types";
 
@@ -46,29 +51,6 @@ function recordingLogger(entries: LogEntry[]): Logger {
 
 function notUsedHere(member: string): never {
   throw new Error(`${member} is not exercised by the user-env-resolver suite`);
-}
-
-/** Full-interface stub so no test needs an unsafe cast. */
-function stubProvider(
-  checkRepositoryAccess: SourceControlProvider["checkRepositoryAccess"]
-): SourceControlProvider {
-  return {
-    name: "github",
-    getRepository: () => notUsedHere("getRepository"),
-    createPullRequest: () => notUsedHere("createPullRequest"),
-    checkRepositoryAccess,
-    listRepositories: () => notUsedHere("listRepositories"),
-    listBranches: () => notUsedHere("listBranches"),
-    getBranchHead: () => notUsedHere("getBranchHead"),
-    resolveCommit: () => notUsedHere("resolveCommit"),
-    listTree: () => notUsedHere("listTree"),
-    readBlob: () => notUsedHere("readBlob"),
-    getPullRequest: () => notUsedHere("getPullRequest"),
-    generatePushAuth: () => notUsedHere("generatePushAuth"),
-    generateCredentialHelperAuth: () => notUsedHere("generateCredentialHelperAuth"),
-    buildManualPullRequestUrl: () => notUsedHere("buildManualPullRequestUrl"),
-    buildGitPushSpec: () => notUsedHere("buildGitPushSpec"),
-  };
 }
 
 /** DO-embedded SQLite fake backing a real SessionCoreRepository. */
@@ -237,7 +219,7 @@ function makeHarness(
     encryptionKey?: string;
     /** Omit to model an unset SECRETS_CAP_ENFORCEMENT (fail-closed enforce). */
     capEnforcement?: string;
-    checkRepositoryAccess?: SourceControlProvider["checkRepositoryAccess"];
+    resolveRepoId?: (session: SessionRow) => Promise<number>;
   } = {}
 ) {
   const session = options.session === undefined ? sessionRow() : options.session;
@@ -245,17 +227,24 @@ function makeHarness(
   const db = new FakeSqlDatabase();
   const logs: LogEntry[] = [];
   let currentLogger = recordingLogger(logs);
-  let providerThunkCalls = 0;
-  const provider = stubProvider(
-    options.checkRepositoryAccess ?? (() => notUsedHere("checkRepositoryAccess"))
-  );
+  const sessionCoreRepository = new SessionCoreRepository(storage.sql, (closure) => closure());
+  let resolveRepoIdCalls = 0;
+  // Default mirrors production wiring: the real resolution function over a
+  // provider thunk that throws, so short-circuits work and any path that
+  // would construct the SCM provider fails the test loudly.
+  const resolveRepoId =
+    options.resolveRepoId ??
+    ((sessionForRepoId: SessionRow) =>
+      resolveSessionRepoId(sessionForRepoId, sessionCoreRepository, () =>
+        notUsedHere("sourceControlProvider")
+      ));
 
   const resolver = new UserEnvResolver({
     db: options.withoutDb ? null : db,
-    sessionCoreRepository: new SessionCoreRepository(storage.sql, (closure) => closure()),
-    getSourceControlProvider: () => {
-      providerThunkCalls += 1;
-      return provider;
+    sessionCoreRepository,
+    resolveRepoId: (sessionForRepoId) => {
+      resolveRepoIdCalls += 1;
+      return resolveRepoId(sessionForRepoId);
     },
     durableObjectId: "do-id-fallback",
     repoSecretsEncryptionKey: options.encryptionKey,
@@ -268,7 +257,7 @@ function makeHarness(
     db,
     logs,
     sqlCalls: storage.calls,
-    providerThunkCalls: () => providerThunkCalls,
+    resolveRepoIdCalls: () => resolveRepoIdCalls,
     setLogger(logger: Logger) {
       currentLogger = logger;
     },
@@ -421,12 +410,28 @@ describe("UserEnvResolver", () => {
       });
 
       // The id-less secondary contributes nothing: exactly one repo_secrets read
-      // (the primary's) and no lazy ensureRepoId resolution via the provider.
+      // (the primary's) and no lazy repo-id resolution.
       expect(h.db.queries.filter((query) => query.includes("repo_secrets"))).toHaveLength(1);
-      expect(h.providerThunkCalls()).toBe(0);
+      expect(h.resolveRepoIdCalls()).toBe(0);
     });
 
-    it("never constructs the source control provider on a secrets-only load", async () => {
+    it("resolves the repo id lazily for a legacy primary member row", async () => {
+      const h = makeHarness({
+        memberRows: [memberRow(0, "acme", "web", null)],
+        encryptionKey: ENCRYPTION_KEY,
+        resolveRepoId: async () => 90101,
+      });
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+      h.db.repoSecretRowsByRepoId.set(90101, await secretRows({ ONLY_WEB: "w" }));
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({ ONLY_WEB: "w" });
+
+      // The primary's null row id routes through the injected capability, and
+      // the id it returns keys the repo-secrets read.
+      expect(h.resolveRepoIdCalls()).toBe(1);
+    });
+
+    it("resolves repo secrets without constructing the source control provider", async () => {
       const h = makeHarness({ encryptionKey: ENCRYPTION_KEY });
       h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
       h.db.globalSecretRows = await secretRows({ FOO: "bar" });
@@ -434,19 +439,41 @@ describe("UserEnvResolver", () => {
 
       await expect(h.resolver.getUserEnvVars()).resolves.toEqual({ FOO: "bar", BAZ: "qux" });
 
-      expect(h.providerThunkCalls()).toBe(0);
+      // The synthesized primary (no member rows) routes through the capability
+      // once, which short-circuits on the session's repo_id; the harness
+      // default throws if the provider thunk is ever invoked.
+      expect(h.resolveRepoIdCalls()).toBe(1);
     });
   });
 
   describe("secrets cap", () => {
+    // Every scope must be reachable through the production write path: each
+    // value within MAX_VALUE_SIZE and each scope within MAX_TOTAL_VALUE_SIZE.
+    // Three individually valid scopes together exceed the combined cap.
+    const CAP_VALUE = "x".repeat(MAX_VALUE_SIZE / 2);
+    const PER_SCOPE_COUNT = 6;
+    const SCOPE_COUNT = 3;
+    const TOTAL_KEYS = PER_SCOPE_COUNT * SCOPE_COUNT;
+
+    function bulkScope(prefix: string): Record<string, string> {
+      return Object.fromEntries(
+        Array.from({ length: PER_SCOPE_COUNT }, (_, i) => [`${prefix}_${i}`, CAP_VALUE])
+      );
+    }
+
     async function overCapHarness(capEnforcement?: string) {
-      const h = makeHarness({ encryptionKey: ENCRYPTION_KEY, capEnforcement });
+      expect(PER_SCOPE_COUNT * CAP_VALUE.length).toBeLessThanOrEqual(MAX_TOTAL_VALUE_SIZE);
+      expect(TOTAL_KEYS * CAP_VALUE.length).toBeGreaterThan(MAX_COMBINED_SECRETS_BYTES);
+
+      const h = makeHarness({
+        memberRows: [memberRow(0, "acme", "web", 90101), memberRow(1, "acme", "backend", 90102)],
+        encryptionKey: ENCRYPTION_KEY,
+        capEnforcement,
+      });
       h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
-      const bulk: Record<string, string> = {};
-      for (let i = 0; i < 9; i += 1) {
-        bulk[`BULK_${i}`] = "x".repeat(16384);
-      }
-      h.db.globalSecretRows = await secretRows(bulk);
+      h.db.globalSecretRows = await secretRows(bulkScope("BULK_G"));
+      h.db.repoSecretRowsByRepoId.set(90101, await secretRows(bulkScope("BULK_A")));
+      h.db.repoSecretRowsByRepoId.set(90102, await secretRows(bulkScope("BULK_B")));
       return h;
     }
 
@@ -465,7 +492,7 @@ describe("UserEnvResolver", () => {
 
       const env = await h.resolver.getUserEnvVars();
 
-      expect(Object.keys(env ?? {})).toHaveLength(9);
+      expect(Object.keys(env ?? {})).toHaveLength(TOTAL_KEYS);
       expect(h.logs).toContainEqual(
         expect.objectContaining({ level: "warn", msg: "secrets.cap_exceeded" })
       );
@@ -502,57 +529,6 @@ describe("UserEnvResolver", () => {
       await expect(
         h.resolver.getProviderAuthenticationError("anthropic/claude-sonnet-4-5")
       ).resolves.toBeNull();
-    });
-  });
-
-  describe("ensureRepoId", () => {
-    it("short-circuits on an existing repo_id without touching the provider or persisting", async () => {
-      const h = makeHarness();
-
-      await expect(h.resolver.ensureRepoId(sessionRow())).resolves.toBe(90101);
-
-      expect(h.providerThunkCalls()).toBe(0);
-      expect(h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"))).toEqual([]);
-    });
-
-    it("throws when the session has no repository context", async () => {
-      const h = makeHarness();
-
-      await expect(
-        h.resolver.ensureRepoId(sessionRow({ repo_id: null, repo_owner: null, repo_name: null }))
-      ).rejects.toThrow("Session has no repository context");
-    });
-
-    it("throws when the repository is not accessible", async () => {
-      const h = makeHarness({ checkRepositoryAccess: async () => null });
-
-      await expect(h.resolver.ensureRepoId(sessionRow({ repo_id: null }))).rejects.toThrow(
-        "Repository is not accessible for the configured SCM provider"
-      );
-      expect(h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"))).toEqual([]);
-    });
-
-    it("resolves via the provider and persists the repo id for legacy rows", async () => {
-      const checked: Array<{ owner: string; name: string }> = [];
-      const access: RepositoryAccessResult = {
-        repoId: 777,
-        repoOwner: "acme",
-        repoName: "web",
-        defaultBranch: "main",
-      };
-      const h = makeHarness({
-        checkRepositoryAccess: async ({ owner, name }) => {
-          checked.push({ owner, name });
-          return access;
-        },
-      });
-
-      await expect(h.resolver.ensureRepoId(sessionRow({ repo_id: null }))).resolves.toBe(777);
-
-      expect(checked).toEqual([{ owner: "acme", name: "web" }]);
-      const updates = h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"));
-      expect(updates).toHaveLength(1);
-      expect(updates[0]?.params).toEqual([777]);
     });
   });
 

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Unit tests for UserEnvResolver.
+ *
+ * The resolver is exercised against a real SessionCoreRepository over a fake
+ * DO SqlStorage and real secret stores over a fake SqlDatabase (real AES-GCM
+ * round-trips via encryptToken), so these tests pin the observable throw and
+ * return surface rather than the fakes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { UserEnvResolver } from "./user-env-resolver";
+import { SecretsCapExceededError } from "../db/secrets-validation";
+import { SessionCoreRepository } from "./session-core-repository";
+import { encryptToken, generateEncryptionKey } from "../auth/crypto";
+import type { Logger } from "../logger";
+import type { SqlDatabase, SqlResult, SqlStatement } from "../db/sql-database";
+import type { SqlResult as StorageSqlResult, SqlStorage } from "./sql-storage";
+import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
+import type { SessionProviderAuthMode } from "@open-inspect/shared/types/provider-accounts";
+import type { SessionRepositoryRow, SessionRow } from "./types";
+
+const ENCRYPTION_KEY = generateEncryptionKey();
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+interface LogEntry {
+  level: "debug" | "info" | "warn" | "error";
+  msg: string;
+  data?: Record<string, unknown>;
+}
+
+function recordingLogger(entries: LogEntry[]): Logger {
+  const push = (level: LogEntry["level"]) => (msg: string, data?: Record<string, unknown>) => {
+    entries.push({ level, msg, data });
+  };
+  return {
+    debug: push("debug"),
+    info: push("info"),
+    warn: push("warn"),
+    error: push("error"),
+    child: () => recordingLogger(entries),
+  };
+}
+
+function notUsedHere(member: string): never {
+  throw new Error(`${member} is not exercised by the user-env-resolver suite`);
+}
+
+/** Full-interface stub so no test needs an unsafe cast. */
+function stubProvider(
+  checkRepositoryAccess: SourceControlProvider["checkRepositoryAccess"]
+): SourceControlProvider {
+  return {
+    name: "github",
+    getRepository: () => notUsedHere("getRepository"),
+    createPullRequest: () => notUsedHere("createPullRequest"),
+    checkRepositoryAccess,
+    listRepositories: () => notUsedHere("listRepositories"),
+    listBranches: () => notUsedHere("listBranches"),
+    getBranchHead: () => notUsedHere("getBranchHead"),
+    resolveCommit: () => notUsedHere("resolveCommit"),
+    listTree: () => notUsedHere("listTree"),
+    readBlob: () => notUsedHere("readBlob"),
+    getPullRequest: () => notUsedHere("getPullRequest"),
+    generatePushAuth: () => notUsedHere("generatePushAuth"),
+    generateCredentialHelperAuth: () => notUsedHere("generateCredentialHelperAuth"),
+    buildManualPullRequestUrl: () => notUsedHere("buildManualPullRequestUrl"),
+    buildGitPushSpec: () => notUsedHere("buildGitPushSpec"),
+  };
+}
+
+/** DO-embedded SQLite fake backing a real SessionCoreRepository. */
+function fakeSqlStorage(state: { session: SessionRow | null; memberRows: SessionRepositoryRow[] }) {
+  const calls: Array<{ query: string; params: unknown[] }> = [];
+  const sql: SqlStorage = {
+    exec(query: string, ...params: unknown[]): StorageSqlResult {
+      calls.push({ query, params });
+      let rows: unknown[] = [];
+      if (query === "SELECT * FROM session LIMIT 1") {
+        rows = state.session ? [state.session] : [];
+      } else if (query === "SELECT * FROM session_repositories ORDER BY position") {
+        rows = state.memberRows;
+      } else if (!query.startsWith("UPDATE session SET repo_id")) {
+        throw new Error(`Unexpected DO storage query: ${query}`);
+      }
+      return { toArray: () => rows, one: () => rows[0] ?? null, rowsWritten: 1 };
+    },
+  };
+  return { sql, calls };
+}
+
+type D1Row = Record<string, unknown>;
+
+class FakeStatement implements SqlStatement {
+  private bound: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeSqlDatabase,
+    private readonly query: string
+  ) {}
+
+  bind(...values: unknown[]): SqlStatement {
+    this.bound = values;
+    return this;
+  }
+
+  first<T = Record<string, unknown>>(): Promise<T | null> {
+    return Promise.reject(new Error(`first() is not used by the resolver: ${this.query}`));
+  }
+
+  run<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
+    return Promise.reject(new Error(`run() is not used by the resolver: ${this.query}`));
+  }
+
+  async all<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
+    const rows: unknown[] = this.db.rowsFor(this.query, this.bound);
+    return { results: rows as T[], meta: { changes: 0 } };
+  }
+}
+
+/** Read-only D1 fake covering exactly the queries the resolver's stores run. */
+class FakeSqlDatabase implements SqlDatabase {
+  readonly queries: string[] = [];
+  readonly providerAuthBinds: unknown[] = [];
+  providerAuthRows: D1Row[] = [];
+  globalSecretRows: D1Row[] = [];
+  readonly repoSecretRowsByRepoId = new Map<number, D1Row[]>();
+  readonly environmentSecretRowsById = new Map<string, D1Row[]>();
+
+  prepare(query: string): SqlStatement {
+    return new FakeStatement(this, query.replace(/\s+/g, " ").trim());
+  }
+
+  batch<T = unknown>(): Promise<SqlResult<T>[]> {
+    return Promise.reject(new Error("batch() is not used by the resolver"));
+  }
+
+  rowsFor(query: string, bound: unknown[]): D1Row[] {
+    this.queries.push(query);
+    if (query.startsWith("SELECT provider, auth_mode")) {
+      this.providerAuthBinds.push(bound[0]);
+      return this.providerAuthRows;
+    }
+    if (query === "SELECT key, encrypted_value FROM global_secrets") {
+      return this.globalSecretRows;
+    }
+    if (query === "SELECT key, encrypted_value FROM repo_secrets WHERE repo_id = ?") {
+      return this.repoSecretRowsByRepoId.get(bound[0] as number) ?? [];
+    }
+    if (query === "SELECT key, encrypted_value FROM environment_secrets WHERE environment_id = ?") {
+      return this.environmentSecretRowsById.get(bound[0] as string) ?? [];
+    }
+    throw new Error(`Unexpected D1 query: ${query}`);
+  }
+}
+
+async function secretRows(secrets: Record<string, string>): Promise<D1Row[]> {
+  const rows: D1Row[] = [];
+  for (const [key, value] of Object.entries(secrets)) {
+    rows.push({ key, encrypted_value: await encryptToken(value, ENCRYPTION_KEY) });
+  }
+  return rows;
+}
+
+function providerAuthRows(modes: {
+  openai: SessionProviderAuthMode;
+  xai: SessionProviderAuthMode;
+}): D1Row[] {
+  return (["openai", "xai"] as const).map((provider) => ({
+    provider,
+    auth_mode: modes[provider],
+    provider_account_id: modes[provider] === "provider_account" ? "1".repeat(32) : null,
+    selection_source: "explicit",
+    inherited_from_session_id: null,
+  }));
+}
+
+const API_KEY_MODES = { openai: "api_key", xai: "api_key" } as const;
+
+function sessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "sess-1",
+    session_name: "sess-public-1",
+    title: null,
+    repo_owner: "acme",
+    repo_name: "web",
+    repo_id: 90101,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "anthropic/claude-sonnet-4-5",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    code_server_enabled: 0,
+    vnc_enabled: 0,
+    total_cost: 0,
+    sandbox_settings: null,
+    environment_id: null,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+function memberRow(
+  position: number,
+  repoOwner: string,
+  repoName: string,
+  repoId: number | null
+): SessionRepositoryRow {
+  return {
+    position,
+    repo_owner: repoOwner,
+    repo_name: repoName,
+    repo_id: repoId,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+  };
+}
+
+function makeHarness(
+  options: {
+    session?: SessionRow | null;
+    memberRows?: SessionRepositoryRow[];
+    /** Model a deployment where the DB binding is missing. */
+    withoutDb?: boolean;
+    /** Omit to model a deployment without REPO_SECRETS_ENCRYPTION_KEY. */
+    encryptionKey?: string;
+    /** Omit to model an unset SECRETS_CAP_ENFORCEMENT (fail-closed enforce). */
+    capEnforcement?: string;
+    checkRepositoryAccess?: SourceControlProvider["checkRepositoryAccess"];
+  } = {}
+) {
+  const session = options.session === undefined ? sessionRow() : options.session;
+  const storage = fakeSqlStorage({ session, memberRows: options.memberRows ?? [] });
+  const db = new FakeSqlDatabase();
+  const logs: LogEntry[] = [];
+  let currentLogger = recordingLogger(logs);
+  let providerThunkCalls = 0;
+  const provider = stubProvider(
+    options.checkRepositoryAccess ?? (() => notUsedHere("checkRepositoryAccess"))
+  );
+
+  const resolver = new UserEnvResolver({
+    db: options.withoutDb ? null : db,
+    sessionCoreRepository: new SessionCoreRepository(storage.sql, (closure) => closure()),
+    getSourceControlProvider: () => {
+      providerThunkCalls += 1;
+      return provider;
+    },
+    durableObjectId: "do-id-fallback",
+    repoSecretsEncryptionKey: options.encryptionKey,
+    secretsCapEnforcement: options.capEnforcement,
+    log: () => currentLogger,
+  });
+
+  return {
+    resolver,
+    db,
+    logs,
+    sqlCalls: storage.calls,
+    providerThunkCalls: () => providerThunkCalls,
+    setLogger(logger: Logger) {
+      currentLogger = logger;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UserEnvResolver", () => {
+  describe("missing session row", () => {
+    it("returns undefined from getUserEnvVars after a warn, without touching D1", async () => {
+      const h = makeHarness({ session: null });
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toBeUndefined();
+
+      expect(h.logs).toContainEqual({
+        level: "warn",
+        msg: "Cannot load secrets: no session",
+        data: undefined,
+      });
+      expect(h.db.queries).toEqual([]);
+    });
+
+    it("returns null from getProviderAuthenticationError", async () => {
+      const h = makeHarness({ session: null });
+
+      await expect(h.resolver.getProviderAuthenticationError("openai/gpt-5")).resolves.toBeNull();
+    });
+  });
+
+  it("throws when a session exists but D1 is unavailable", async () => {
+    const h = makeHarness({ withoutDb: true });
+
+    await expect(h.resolver.getUserEnvVars()).rejects.toThrow(
+      "D1 is required to load session provider auth"
+    );
+  });
+
+  describe("without REPO_SECRETS_ENCRYPTION_KEY", () => {
+    it("skips secret loading and derives env from provider auth modes only", async () => {
+      const h = makeHarness();
+      h.db.providerAuthRows = providerAuthRows({ openai: "provider_account", xai: "api_key" });
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({ OPENAI_OAUTH_MANAGED: "1" });
+
+      expect(h.logs.some((entry) => entry.level === "debug")).toBe(true);
+      // Provider auth is resolved by the session's public id; no secrets table is read.
+      expect(h.db.providerAuthBinds).toEqual(["sess-public-1"]);
+      expect(h.db.queries).toHaveLength(1);
+    });
+
+    it("returns undefined (not {}) when no provider is managed", async () => {
+      const h = makeHarness();
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("session-target secret fold", () => {
+    async function foldHarness(
+      secondarySecrets: Record<string, string>,
+      primarySecrets: Record<string, string>
+    ) {
+      const h = makeHarness({
+        memberRows: [memberRow(0, "acme", "web", 90101), memberRow(1, "acme", "backend", 90102)],
+        encryptionKey: ENCRYPTION_KEY,
+      });
+      h.db.providerAuthRows = providerAuthRows({ openai: "api_key", xai: "legacy_scoped_oauth" });
+      h.db.globalSecretRows = await secretRows({ SHARED: "global", ONLY_GLOBAL: "g" });
+      h.db.repoSecretRowsByRepoId.set(90101, await secretRows(primarySecrets));
+      h.db.repoSecretRowsByRepoId.set(90102, await secretRows(secondarySecrets));
+      return h;
+    }
+
+    it("folds members with the primary winning, and excludes secondary repos from the managed broker env", async () => {
+      const h = await foldHarness(
+        { SHARED: "backend", ONLY_BACKEND: "b", XAI_OAUTH_REFRESH_TOKEN: "legacy-xai" },
+        { SHARED: "web", ONLY_WEB: "w" }
+      );
+
+      // The secondary's legacy OAuth token is stripped from the exposed env and,
+      // because only global + primary feed broker secrets, does NOT mark xai managed.
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({
+        SHARED: "web",
+        ONLY_GLOBAL: "g",
+        ONLY_WEB: "w",
+        ONLY_BACKEND: "b",
+      });
+    });
+
+    it("marks a provider managed when the legacy token comes from the primary repo", async () => {
+      const h = await foldHarness(
+        { SHARED: "backend", ONLY_BACKEND: "b" },
+        { SHARED: "web", ONLY_WEB: "w", XAI_OAUTH_REFRESH_TOKEN: "legacy-xai" }
+      );
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({
+        SHARED: "web",
+        ONLY_GLOBAL: "g",
+        ONLY_WEB: "w",
+        ONLY_BACKEND: "b",
+        XAI_OAUTH_MANAGED: "1",
+      });
+    });
+
+    it("returns undefined (not {}) when every source is empty", async () => {
+      const h = makeHarness({ encryptionKey: ENCRYPTION_KEY });
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toBeUndefined();
+    });
+
+    it("sources environment secrets without the member filter and never reads repo secrets", async () => {
+      const h = makeHarness({
+        session: sessionRow({ environment_id: "env-1" }),
+        encryptionKey: ENCRYPTION_KEY,
+      });
+      h.db.providerAuthRows = providerAuthRows({ openai: "api_key", xai: "legacy_scoped_oauth" });
+      h.db.globalSecretRows = await secretRows({ SHARED: "global", ONLY_GLOBAL: "g" });
+      h.db.environmentSecretRowsById.set(
+        "env-1",
+        await secretRows({ SHARED: "env", FROM_ENV: "e", XAI_OAUTH_REFRESH_TOKEN: "legacy-xai" })
+      );
+
+      // Environment sources also feed the broker env, so the legacy token marks xai managed.
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({
+        SHARED: "env",
+        ONLY_GLOBAL: "g",
+        FROM_ENV: "e",
+        XAI_OAUTH_MANAGED: "1",
+      });
+      expect(h.db.queries.some((query) => query.includes("repo_secrets"))).toBe(false);
+    });
+
+    it("skips a secondary member with no resolvable repo id without touching the provider", async () => {
+      const h = makeHarness({
+        memberRows: [memberRow(0, "acme", "web", 90101), memberRow(1, "acme", "backend", null)],
+        encryptionKey: ENCRYPTION_KEY,
+      });
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+      h.db.globalSecretRows = await secretRows({ ONLY_GLOBAL: "g" });
+      h.db.repoSecretRowsByRepoId.set(90101, await secretRows({ ONLY_WEB: "w" }));
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({
+        ONLY_GLOBAL: "g",
+        ONLY_WEB: "w",
+      });
+
+      // The id-less secondary contributes nothing: exactly one repo_secrets read
+      // (the primary's) and no lazy ensureRepoId resolution via the provider.
+      expect(h.db.queries.filter((query) => query.includes("repo_secrets"))).toHaveLength(1);
+      expect(h.providerThunkCalls()).toBe(0);
+    });
+
+    it("never constructs the source control provider on a secrets-only load", async () => {
+      const h = makeHarness({ encryptionKey: ENCRYPTION_KEY });
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+      h.db.globalSecretRows = await secretRows({ FOO: "bar" });
+      h.db.repoSecretRowsByRepoId.set(90101, await secretRows({ BAZ: "qux" }));
+
+      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({ FOO: "bar", BAZ: "qux" });
+
+      expect(h.providerThunkCalls()).toBe(0);
+    });
+  });
+
+  describe("secrets cap", () => {
+    async function overCapHarness(capEnforcement?: string) {
+      const h = makeHarness({ encryptionKey: ENCRYPTION_KEY, capEnforcement });
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+      const bulk: Record<string, string> = {};
+      for (let i = 0; i < 9; i += 1) {
+        bulk[`BULK_${i}`] = "x".repeat(16384);
+      }
+      h.db.globalSecretRows = await secretRows(bulk);
+      return h;
+    }
+
+    it("rejects an over-cap payload when enforcement is unset (fail closed)", async () => {
+      const h = await overCapHarness();
+
+      await expect(h.resolver.getUserEnvVars()).rejects.toThrow(SecretsCapExceededError);
+
+      expect(h.logs).toContainEqual(
+        expect.objectContaining({ level: "error", msg: "secrets.cap_exceeded" })
+      );
+    });
+
+    it("resolves the oversized payload in warn mode and logs the breach", async () => {
+      const h = await overCapHarness("warn");
+
+      const env = await h.resolver.getUserEnvVars();
+
+      expect(Object.keys(env ?? {})).toHaveLength(9);
+      expect(h.logs).toContainEqual(
+        expect.objectContaining({ level: "warn", msg: "secrets.cap_exceeded" })
+      );
+    });
+  });
+
+  describe("getProviderAuthenticationError", () => {
+    it("returns the provider message and logs when authentication is unavailable", async () => {
+      const h = makeHarness();
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+
+      await expect(
+        h.resolver.getProviderAuthenticationError("openai/gpt-5-codex")
+      ).resolves.toMatch(/No OpenAI authentication is configured/);
+
+      expect(h.logs).toContainEqual({
+        level: "error",
+        msg: "provider_auth.unavailable",
+        data: { event: "provider_auth.unavailable", provider: "openai", auth_mode: "api_key" },
+      });
+    });
+
+    it("returns null when the provider is authenticated", async () => {
+      const h = makeHarness();
+      h.db.providerAuthRows = providerAuthRows({ openai: "provider_account", xai: "api_key" });
+
+      await expect(h.resolver.getProviderAuthenticationError("openai/gpt-5")).resolves.toBeNull();
+    });
+
+    it("returns null for non-subscription providers", async () => {
+      const h = makeHarness();
+      h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);
+
+      await expect(
+        h.resolver.getProviderAuthenticationError("anthropic/claude-sonnet-4-5")
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe("ensureRepoId", () => {
+    it("short-circuits on an existing repo_id without touching the provider or persisting", async () => {
+      const h = makeHarness();
+
+      await expect(h.resolver.ensureRepoId(sessionRow())).resolves.toBe(90101);
+
+      expect(h.providerThunkCalls()).toBe(0);
+      expect(h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"))).toEqual([]);
+    });
+
+    it("throws when the session has no repository context", async () => {
+      const h = makeHarness();
+
+      await expect(
+        h.resolver.ensureRepoId(sessionRow({ repo_id: null, repo_owner: null, repo_name: null }))
+      ).rejects.toThrow("Session has no repository context");
+    });
+
+    it("throws when the repository is not accessible", async () => {
+      const h = makeHarness({ checkRepositoryAccess: async () => null });
+
+      await expect(h.resolver.ensureRepoId(sessionRow({ repo_id: null }))).rejects.toThrow(
+        "Repository is not accessible for the configured SCM provider"
+      );
+      expect(h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"))).toEqual([]);
+    });
+
+    it("resolves via the provider and persists the repo id for legacy rows", async () => {
+      const checked: Array<{ owner: string; name: string }> = [];
+      const access: RepositoryAccessResult = {
+        repoId: 777,
+        repoOwner: "acme",
+        repoName: "web",
+        defaultBranch: "main",
+      };
+      const h = makeHarness({
+        checkRepositoryAccess: async ({ owner, name }) => {
+          checked.push({ owner, name });
+          return access;
+        },
+      });
+
+      await expect(h.resolver.ensureRepoId(sessionRow({ repo_id: null }))).resolves.toBe(777);
+
+      expect(checked).toEqual([{ owner: "acme", name: "web" }]);
+      const updates = h.sqlCalls.filter((call) => call.query.startsWith("UPDATE"));
+      expect(updates).toHaveLength(1);
+      expect(updates[0]?.params).toEqual([777]);
+    });
+  });
+
+  describe("thunk contracts", () => {
+    it("logs through the logger current at call time, not construction time", async () => {
+      const h = makeHarness({ session: null });
+      const swappedEntries: LogEntry[] = [];
+
+      await h.resolver.getUserEnvVars();
+      expect(h.logs).toHaveLength(1);
+
+      h.setLogger(recordingLogger(swappedEntries));
+      await h.resolver.getUserEnvVars();
+
+      // The swapped-in logger received the second warn; the original saw only the first.
+      expect(swappedEntries).toContainEqual({
+        level: "warn",
+        msg: "Cannot load secrets: no session",
+        data: undefined,
+      });
+      expect(h.logs).toHaveLength(1);
+    });
+  });
+});

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -2,9 +2,9 @@
  * Resolves the user-defined environment a session's sandbox receives: decrypts
  * and folds global/repo/environment secrets, derives the managed-provider env
  * from the session's provider auth modes, and answers whether a model's
- * provider has usable authentication in that environment. Also resolves (and
- * persists) the primary repo id for legacy session rows, which the repo-scoped
- * secrets lookup needs.
+ * provider has usable authentication in that environment. Legacy session rows
+ * that predate `repo_id` resolve it through the injected `resolveRepoId`
+ * capability when the repo-scoped secrets lookup needs it.
  */
 
 import { SessionIndexStore } from "../db/session-index";
@@ -26,7 +26,6 @@ import type {
 } from "@open-inspect/shared/types/provider-accounts";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Logger } from "../logger";
-import type { SourceControlProvider } from "../source-control";
 import { resolvePublicSessionId } from "./public-session-id";
 import { buildSessionTargetSecretSources } from "./session-target-secrets";
 import type { SessionRepositoryEntry } from "./repository-target";
@@ -40,12 +39,11 @@ export interface UserEnvResolverDeps {
   db: SqlDatabase | null;
   sessionCoreRepository: SessionCoreRepository;
   /**
-   * Thunk, deliberately: the provider is only needed when a legacy session
-   * row lacks `repo_id`. Taking a constructed provider would force provider
-   * construction on every secrets load, changing the throw surface for
-   * deployments with broken SCM env.
+   * Resolves (and persists) the session's primary repo id for legacy rows
+   * that predate `repo_id` — see `resolveSessionRepoId`. Injected as a
+   * capability so this class carries no SCM-provider dependency.
    */
-  getSourceControlProvider: () => SourceControlProvider;
+  resolveRepoId: (session: SessionRow) => Promise<number>;
   /** The owning Durable Object's id; the resolvePublicSessionId fallback. */
   durableObjectId: string;
   repoSecretsEncryptionKey: string | undefined;
@@ -66,7 +64,7 @@ interface UserEnvContext {
 export class UserEnvResolver {
   private readonly db: SqlDatabase | null;
   private readonly sessionCoreRepository: SessionCoreRepository;
-  private readonly getSourceControlProvider: () => SourceControlProvider;
+  private readonly resolveRepoId: (session: SessionRow) => Promise<number>;
   private readonly durableObjectId: string;
   private readonly repoSecretsEncryptionKey: string | undefined;
   private readonly secretsCapEnforcement: string | undefined;
@@ -75,35 +73,11 @@ export class UserEnvResolver {
   constructor(deps: UserEnvResolverDeps) {
     this.db = deps.db;
     this.sessionCoreRepository = deps.sessionCoreRepository;
-    this.getSourceControlProvider = deps.getSourceControlProvider;
+    this.resolveRepoId = deps.resolveRepoId;
     this.durableObjectId = deps.durableObjectId;
     this.repoSecretsEncryptionKey = deps.repoSecretsEncryptionKey;
     this.secretsCapEnforcement = deps.secretsCapEnforcement;
     this.log = deps.log;
-  }
-
-  /**
-   * Resolve the session's primary repo id, looking it up via the SCM
-   * provider and persisting it for legacy rows that predate `repo_id`.
-   */
-  async ensureRepoId(session: SessionRow): Promise<number> {
-    if (session.repo_id) {
-      return session.repo_id;
-    }
-    if (!session.repo_owner || !session.repo_name) {
-      throw new Error("Session has no repository context");
-    }
-
-    const result = await this.getSourceControlProvider().checkRepositoryAccess({
-      owner: session.repo_owner,
-      name: session.repo_name,
-    });
-    if (!result) {
-      throw new Error("Repository is not accessible for the configured SCM provider");
-    }
-
-    this.sessionCoreRepository.updateSessionRepoId(result.repoId);
-    return result.repoId;
   }
 
   /**
@@ -220,9 +194,9 @@ export class UserEnvResolver {
   /**
    * Decrypt one member repo's secrets — the injected leaf loader for
    * buildSessionTargetSecretSources. The member row carries the repo id; a
-   * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
-   * A member without a resolvable id (a secondary with a null row id) can't be
-   * keyed, so it contributes nothing.
+   * synthesized primary (legacy scalar row) resolves it lazily via the
+   * injected resolveRepoId. A member without a resolvable id (a secondary
+   * with a null row id) can't be keyed, so it contributes nothing.
    */
   private async loadMemberRepoSecrets(
     session: SessionRow,
@@ -230,7 +204,7 @@ export class UserEnvResolver {
     repoStore: RepoSecretsStore
   ): Promise<Record<string, string>> {
     const repoId =
-      member.row?.repo_id ?? (member.isPrimary ? await this.ensureRepoId(session) : null);
+      member.row?.repo_id ?? (member.isPrimary ? await this.resolveRepoId(session) : null);
     if (repoId === null) {
       return {};
     }

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -1,0 +1,239 @@
+/**
+ * Resolves the user-defined environment a session's sandbox receives: decrypts
+ * and folds global/repo/environment secrets, derives the managed-provider env
+ * from the session's provider auth modes, and answers whether a model's
+ * provider has usable authentication in that environment. Also resolves (and
+ * persists) the primary repo id for legacy session rows, which the repo-scoped
+ * secrets lookup needs.
+ */
+
+import { SessionIndexStore } from "../db/session-index";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import { RepoSecretsStore } from "../db/repo-secrets";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
+import {
+  auditSecretsMerge,
+  mergeSecretSources,
+  parseSecretsCapMode,
+} from "../db/secrets-validation";
+import {
+  getProviderAuthenticationError as resolveProviderAuthenticationError,
+  prepareManagedProviderEnv,
+} from "../sandbox/managed-provider-env";
+import type {
+  SessionProviderAuthMode,
+  SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
+import type { SqlDatabase } from "../db/sql-database";
+import type { Logger } from "../logger";
+import type { SourceControlProvider } from "../source-control";
+import { resolvePublicSessionId } from "./public-session-id";
+import { buildSessionTargetSecretSources } from "./session-target-secrets";
+import type { SessionRepositoryEntry } from "./repository-target";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionRow } from "./types";
+
+/**
+ * Dependencies injected into UserEnvResolver.
+ */
+export interface UserEnvResolverDeps {
+  db: SqlDatabase | null;
+  sessionCoreRepository: SessionCoreRepository;
+  /**
+   * Thunk, deliberately: the provider is only needed when a legacy session
+   * row lacks `repo_id`. Taking a constructed provider would force provider
+   * construction on every secrets load, changing the throw surface for
+   * deployments with broken SCM env.
+   */
+  getSourceControlProvider: () => SourceControlProvider;
+  /** The owning Durable Object's id; the resolvePublicSessionId fallback. */
+  durableObjectId: string;
+  repoSecretsEncryptionKey: string | undefined;
+  secretsCapEnforcement: string | undefined;
+  /**
+   * Thunk, deliberately: the owner replaces its logger with a session-scoped
+   * one during initialization, so a by-value capture would pin whichever
+   * logger existed at construction.
+   */
+  log: () => Logger;
+}
+
+interface UserEnvContext {
+  sandboxEnv: Record<string, string>;
+  providerAuthModes: Record<SubscriptionProviderId, SessionProviderAuthMode>;
+}
+
+export class UserEnvResolver {
+  private readonly db: SqlDatabase | null;
+  private readonly sessionCoreRepository: SessionCoreRepository;
+  private readonly getSourceControlProvider: () => SourceControlProvider;
+  private readonly durableObjectId: string;
+  private readonly repoSecretsEncryptionKey: string | undefined;
+  private readonly secretsCapEnforcement: string | undefined;
+  private readonly log: () => Logger;
+
+  constructor(deps: UserEnvResolverDeps) {
+    this.db = deps.db;
+    this.sessionCoreRepository = deps.sessionCoreRepository;
+    this.getSourceControlProvider = deps.getSourceControlProvider;
+    this.durableObjectId = deps.durableObjectId;
+    this.repoSecretsEncryptionKey = deps.repoSecretsEncryptionKey;
+    this.secretsCapEnforcement = deps.secretsCapEnforcement;
+    this.log = deps.log;
+  }
+
+  /**
+   * Resolve the session's primary repo id, looking it up via the SCM
+   * provider and persisting it for legacy rows that predate `repo_id`.
+   */
+  async ensureRepoId(session: SessionRow): Promise<number> {
+    if (session.repo_id) {
+      return session.repo_id;
+    }
+    if (!session.repo_owner || !session.repo_name) {
+      throw new Error("Session has no repository context");
+    }
+
+    const result = await this.getSourceControlProvider().checkRepositoryAccess({
+      owner: session.repo_owner,
+      name: session.repo_name,
+    });
+    if (!result) {
+      throw new Error("Repository is not accessible for the configured SCM provider");
+    }
+
+    this.sessionCoreRepository.updateSessionRepoId(result.repoId);
+    return result.repoId;
+  }
+
+  /**
+   * The user-defined environment for the sandbox, or undefined when the
+   * session is missing or the assembled environment is empty.
+   */
+  async getUserEnvVars(): Promise<Record<string, string> | undefined> {
+    const context = await this.loadUserEnvContext();
+    if (!context) return undefined;
+    return Object.keys(context.sandboxEnv).length === 0 ? undefined : context.sandboxEnv;
+  }
+
+  /**
+   * A user-facing error message when the model's provider has no usable
+   * authentication in the assembled environment, or null when authenticated.
+   */
+  async getProviderAuthenticationError(model: string): Promise<string | null> {
+    const context = await this.loadUserEnvContext();
+    if (!context) return null;
+    const issue = resolveProviderAuthenticationError(
+      model,
+      context.sandboxEnv,
+      context.providerAuthModes
+    );
+    if (!issue) return null;
+    this.log().error("provider_auth.unavailable", {
+      event: "provider_auth.unavailable",
+      provider: issue.provider,
+      auth_mode: context.providerAuthModes[issue.provider],
+    });
+    return issue.message;
+  }
+
+  private async loadUserEnvContext(): Promise<UserEnvContext | null> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      this.log().warn("Cannot load secrets: no session");
+      return null;
+    }
+
+    const db = this.db;
+    if (!db) throw new Error("D1 is required to load session provider auth");
+    const providerAuth = await new SessionIndexStore(db).getCompleteProviderAuth(
+      resolvePublicSessionId(session, this.durableObjectId)
+    );
+    const providerAuthModes = Object.fromEntries(
+      providerAuth.map(({ provider, authMode }) => [provider, authMode])
+    ) as Record<SubscriptionProviderId, SessionProviderAuthMode>;
+
+    if (!this.repoSecretsEncryptionKey) {
+      this.log().debug("Ordinary secrets not configured, skipping secret loading", {
+        has_encryption_key: !!this.repoSecretsEncryptionKey,
+      });
+      const sandboxEnv = prepareManagedProviderEnv({
+        exposedSecrets: {},
+        brokerSecrets: {},
+        providerAuthModes,
+      });
+      return { sandboxEnv, providerAuthModes };
+    }
+
+    // Fail hard on secret loading — sandboxes must not silently lose secrets
+    const encryptionKey = this.repoSecretsEncryptionKey;
+    const globalStore = new GlobalSecretsStore(db, encryptionKey);
+    const globalSecrets = await globalStore.getDecryptedSecrets();
+
+    const repoStore = new RepoSecretsStore(db, encryptionKey);
+    const environmentSecretsStore = new EnvironmentSecretsStore(db, encryptionKey);
+    const members = this.sessionCoreRepository.getSessionRepositories();
+    const sources = await buildSessionTargetSecretSources({
+      environmentId: session.environment_id,
+      globalSecrets,
+      members,
+      loadMemberSecrets: (member) => this.loadMemberRepoSecrets(session, member, repoStore),
+      loadEnvironmentSecrets: (environmentId) =>
+        environmentSecretsStore.getDecryptedSecrets(environmentId),
+    });
+
+    const merge = mergeSecretSources(sources);
+    auditSecretsMerge({
+      merge,
+      mode: parseSecretsCapMode(this.secretsCapEnforcement),
+      log: this.log(),
+      context: { session_id: session.id },
+    });
+
+    const mergedCount = Object.keys(merge.merged).length;
+    if (mergedCount > 0) {
+      this.log().info("Secrets merged for sandbox", {
+        source_count: sources.length,
+        merged_count: mergedCount,
+        payload_bytes: merge.totalBytes,
+        exceeds_limit: merge.exceedsLimit,
+      });
+    }
+
+    const primary = members.find((member) => member.isPrimary);
+    const managedSources = session.environment_id
+      ? sources
+      : sources.filter(
+          (source) =>
+            source.label === "global" ||
+            (primary && source.label === `${primary.repoOwner}/${primary.repoName}`)
+        );
+    const managedSecrets = mergeSecretSources(managedSources).merged;
+    const sandboxEnv = prepareManagedProviderEnv({
+      exposedSecrets: merge.merged,
+      brokerSecrets: managedSecrets,
+      providerAuthModes,
+    });
+    return { sandboxEnv, providerAuthModes };
+  }
+
+  /**
+   * Decrypt one member repo's secrets — the injected leaf loader for
+   * buildSessionTargetSecretSources. The member row carries the repo id; a
+   * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
+   * A member without a resolvable id (a secondary with a null row id) can't be
+   * keyed, so it contributes nothing.
+   */
+  private async loadMemberRepoSecrets(
+    session: SessionRow,
+    member: SessionRepositoryEntry,
+    repoStore: RepoSecretsStore
+  ): Promise<Record<string, string>> {
+    const repoId =
+      member.row?.repo_id ?? (member.isPrimary ? await this.ensureRepoId(session) : null);
+    if (repoId === null) {
+      return {};
+    }
+    return repoStore.getDecryptedSecrets(repoId);
+  }
+}

--- a/packages/control-plane/test/integration/session-do-access.ts
+++ b/packages/control-plane/test/integration/session-do-access.ts
@@ -1,0 +1,20 @@
+import { runInDurableObject } from "cloudflare:test";
+import type { SessionDO } from "../../src/session/durable-object";
+import type { UserEnvResolver } from "../../src/session/user-env-resolver";
+
+/**
+ * Invoke the DO's real (private) user-env resolver. The single place secrets
+ * tests reach past SessionDO's encapsulation; `Pick` ties the cast to the real
+ * class so a rename breaks this helper instead of silently passing.
+ */
+export function getUserEnvVars(
+  stub: DurableObjectStub
+): Promise<Record<string, string> | undefined> {
+  return runInDurableObject(stub, (instance: SessionDO) =>
+    (
+      instance as unknown as {
+        userEnvResolver: Pick<UserEnvResolver, "getUserEnvVars">;
+      }
+    ).userEnvResolver.getUserEnvVars()
+  );
+}

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -20,6 +20,7 @@ import { RepoSecretsStore } from "../../src/db/repo-secrets";
 import { resolveEnvironmentTarget } from "../../src/repos/resolve";
 import { cleanD1Tables } from "./cleanup";
 import { initSession, queryDO } from "./helpers";
+import { getUserEnvVars } from "./session-do-access";
 
 const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
 
@@ -49,19 +50,6 @@ async function seedEnvironment(id: string, name: string, repos: RepoSpec[]): Pro
       repo_id: repo.repoId,
       base_branch: repo.baseBranch,
     }))
-  );
-}
-
-/** Invoke the DO's real (private) sandbox env resolver, exercising the session secret fold. */
-function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
-  return runInDurableObject(stub, (instance: SessionDO) =>
-    (
-      instance as unknown as {
-        userEnvResolver: {
-          getUserEnvVars(): Promise<Record<string, string> | undefined>;
-        };
-      }
-    ).userEnvResolver.getUserEnvVars()
   );
 }
 

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -7,12 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { env, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:test";
 import {
   sessionSnapshotSchema,
   type SessionState,
 } from "@open-inspect/shared/types/server-messages";
-import type { SessionDO } from "../../src/session/durable-object";
 import { EnvironmentStore } from "../../src/db/environments";
 import { EnvironmentSecretsStore } from "../../src/db/environment-secrets";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -52,14 +52,16 @@ async function seedEnvironment(id: string, name: string, repos: RepoSpec[]): Pro
   );
 }
 
-/** Invoke the DO's real (private) getUserEnvVars, exercising the session secret fold. */
+/** Invoke the DO's real (private) sandbox env resolver, exercising the session secret fold. */
 function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
   return runInDurableObject(stub, (instance: SessionDO) =>
     (
       instance as unknown as {
-        getUserEnvVars(): Promise<Record<string, string> | undefined>;
+        userEnvResolver: {
+          getUserEnvVars(): Promise<Record<string, string> | undefined>;
+        };
       }
-    ).getUserEnvVars()
+    ).userEnvResolver.getUserEnvVars()
   );
 }
 

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { env, runInDurableObject } from "cloudflare:test";
-import type { SessionDO } from "../../src/session/durable-object";
+import { env } from "cloudflare:test";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { RepoSecretsStore } from "../../src/db/repo-secrets";
 import { ModelProviderAccountStore } from "../../src/db/model-provider-accounts";

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -6,22 +6,10 @@ import { RepoSecretsStore } from "../../src/db/repo-secrets";
 import { ModelProviderAccountStore } from "../../src/db/model-provider-accounts";
 import { cleanD1Tables } from "./cleanup";
 import { initNamedSession, initSession } from "./helpers";
+import { getUserEnvVars } from "./session-do-access";
 import type { SessionProviderAuthMode } from "@open-inspect/shared/types/provider-accounts";
 
 const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
-
-/** Invoke the DO's real (private) sandbox env resolver, exercising the session-target fold. */
-function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
-  return runInDurableObject(stub, (instance: SessionDO) =>
-    (
-      instance as unknown as {
-        userEnvResolver: {
-          getUserEnvVars(): Promise<Record<string, string> | undefined>;
-        };
-      }
-    ).userEnvResolver.getUserEnvVars()
-  );
-}
 
 async function initSessionWithProviderAuth(
   overrides: Parameters<typeof initNamedSession>[1] = {},

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -10,14 +10,16 @@ import type { SessionProviderAuthMode } from "@open-inspect/shared/types/provide
 
 const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
 
-/** Invoke the DO's real (private) getUserEnvVars, exercising the session-target fold. */
+/** Invoke the DO's real (private) sandbox env resolver, exercising the session-target fold. */
 function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
   return runInDurableObject(stub, (instance: SessionDO) =>
     (
       instance as unknown as {
-        getUserEnvVars(): Promise<Record<string, string> | undefined>;
+        userEnvResolver: {
+          getUserEnvVars(): Promise<Record<string, string> | undefined>;
+        };
       }
-    ).getUserEnvVars()
+    ).userEnvResolver.getUserEnvVars()
   );
 }
 


### PR DESCRIPTION
## What

Extracts the user-env responsibility (~145 lines, 5 methods) out of `SessionDO` into two focused units:

- **`UserEnvResolver`** (`session/user-env-resolver.ts`) — resolves the user-defined environment a session's sandbox receives (decrypted global/repo/environment secrets folded with precedence, plus the managed-provider env derived from the session's provider auth modes) and answers whether a model's provider has usable authentication in that environment. Public: `getUserEnvVars`, `getProviderAuthenticationError`.
- **`resolveSessionRepoId`** (`session/repo-id-resolution.ts`) — resolves (and persists) the primary repo id for legacy session rows that predate `repo_id`. Split out per review: it is repository identity, not environment assembly. The two token-refresh services and `UserEnvResolver` receive the same capability, so the resolver carries **no `SourceControlProvider` dependency**.

Behaviour-preserving; method bodies moved verbatim modulo dependency substitution. The name follows the codebase's existing vocabulary for exactly this data (`getUserEnvVars`, "user-defined secrets" vs system vars); "Env(ironment)" alone was avoided because capital-E Environments are a different feature (`environment_id`, `EnvironmentSecretsStore`), and `sandbox-env.ts` already names the SESSION_CONFIG wire contract.

This is the follow-on to #1577/#1578/#1579/#1583: `SessionDO` cannot shrink by extraction alone (each extraction historically left a `() => this.x` back-edge behind at ~1:1), so the plan is to build an eager composition root next — and this unit is the **only** domain responsibility that composition root itself depends on (`SandboxLifecycleManager` needs `getUserEnvVars`, `SessionMessageQueue` needs `getProviderAuthenticationError`). It jumps the queue so the root can be built without reaching back into the DO.

## Design notes

- **The SCM provider stays behind a thunk at the `resolveSessionRepoId` call sites, deliberately.** `createSourceControlProviderFromEnv` throws on reachable configs (invalid `SCM_PROVIDER`; `gitlab` without `GITLAB_ACCESS_TOKEN`; `bitbucket` unconditionally), and repo-id resolution only needs it for legacy rows — sessions that already carry `repo_id` never construct it. The composition-root PR is the right place to decide between upfront config validation + eager construction vs. keeping the deferral.
- **`log` is a thunk, deliberately.** The DO replaces `this.log` with a session-scoped logger inside `ensureInitialized()`; a by-value capture pins whichever logger existed at construction (`SandboxRepository` has exactly this live defect today — its `sandbox.status.unrecognized` warnings lack `session_id`).
- The DO gains one lazy getter (`userEnvResolver`) wired in the existing getter pattern; the four consumer edges (message-queue provider-auth error, two token-refresh repo-id edges, lifecycle `getUserEnvVars`) are rewired.
- Env is passed as two scalars (`repoSecretsEncryptionKey`, `secretsCapEnforcement`), not the whole `Env`.

## Metrics

- `durable-object.ts`: 1850 → 1719 lines.
- `=> this.` count: 118 → 119 (**expected to go up by one net**: the rewired edges still thunk through the DO getter for now; the composition-root PR is what deletes the getters and thunks wholesale. This PR's job is moving the logic, not the wiring).

## Tests

- **22 new unit tests** across `user-env-resolver.test.ts` (18) and `repo-id-resolution.test.ts` (4) — the first decomposition units testable without a Workers runtime. The resolver harness runs a **real** `SessionCoreRepository` over a fake DO `SqlStorage` and **real** secret stores over a fake `SqlDatabase` with real AES-GCM round-trips, so the tests pin the production throw/return surface, not the fakes. Its default `resolveRepoId` is the real function over a throwing provider thunk, mirroring production wiring. Coverage includes: the no-session and D1-missing surfaces, the no-encryption-key path, `undefined`-not-`{}` on empty env, the managed-broker source filter (secondary repos excluded unless environment-launched), all four repo-id branches, lazy repo-id resolution for a legacy primary member, an id-less secondary member contributing nothing, secrets-cap enforcement (fail-closed enforce → `SecretsCapExceededError`; `warn` mode proceeds and logs — fixture built from the exported size constants as three individually write-valid scopes whose sum exceeds the combined cap, with the arithmetic asserted inline), and both injection contracts (logger swap honored after construction; a secrets-only load never constructs the SCM provider).
- Integration safety net: full control-plane integration suite green (80 files / 995 tests), including `session-secrets-fold`, `session-from-environment`, `do-internal-routes`, and the collaborator-wiring guards.
- The two secrets integration files called the DO's (now deleted) private method directly via `runInDurableObject`; they now share one `Pick`-typed accessor helper (`test/integration/session-do-access.ts`) so a rename breaks the helper instead of silently passing. Every assertion is unchanged.

Follow-up tracked separately: #1588 (broker policy currently keyed on `SecretSource.label`; moved verbatim here, structural fix deferred deliberately).

Typecheck (both tsconfigs), full unit suite, and Prettier are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session environments now combine global, repository, and environment secrets consistently.
  * Managed-provider credentials and authentication errors are surfaced through session environments.
  * Missing repository identifiers can be resolved and saved automatically.
  * Unavailable secondary repositories are skipped safely.

* **Bug Fixes**
  * Improved handling of missing sessions and inaccessible repositories.

* **Tests**
  * Expanded coverage for secret merging, provider authentication, repository resolution, persistence, and environment limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->