### PR TITLE
fix(control-plane): re-check sandbox lifecycle state after WS token authentication

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1128,22 +1128,6 @@ export class SessionDO extends DurableObject<Env> {
       const sandbox = this.sandboxRepository.getSandbox();
       const expectedSandboxId = sandbox?.modal_sandbox_id;
 
-      // Reject connection if sandbox should be stopped (prevents reconnection after inactivity timeout).
-      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
-      // still connect — a slow boot that outlived the connecting watchdog
-      // self-heals here by flipping the status back to ready.
-      if (sandbox && isSandboxReconnectBlockedStatus(sandbox.status)) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "rejected",
-          reject_reason: "sandbox_stopped",
-          sandbox_status: sandbox.status,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Sandbox is stopped", { status: 410 });
-      }
-
       // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
       if (expectedSandboxId && sandboxId !== expectedSandboxId) {
         log.warn("ws.connect", {
@@ -1190,6 +1174,28 @@ export class SessionDO extends DurableObject<Env> {
           duration_ms: Date.now() - wsStartTime,
         });
         return new Response("Session is terminal", { status: 410 });
+      }
+
+      const currentSandbox = this.sandboxRepository.getSandbox();
+      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
+      // still connect after a slow boot and self-heal by becoming ready.
+      if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "rejected",
+          reject_reason: "sandbox_stopped",
+          sandbox_status: currentSandbox.status,
+          duration_ms: Date.now() - wsStartTime,
+        });
+        return new Response("Sandbox is stopped", { status: 410 });
+      }
+      if (
+        currentSandbox?.modal_sandbox_id !== expectedSandboxId ||
+        currentSandbox?.auth_token_hash !== sandbox?.auth_token_hash ||
+        currentSandbox?.auth_token !== sandbox?.auth_token
+      ) {
+        return new Response("Forbidden: Sandbox credentials changed", { status: 403 });
       }
 
       // Auth passed — continue to WebSocket accept below

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -894,7 +894,7 @@ describe("SessionSandboxEventProcessor", () => {
       expect(h.wsManager.send).not.toHaveBeenCalled();
     });
 
-    it("sends ACK on already_stopped path for execution_complete", async () => {
+    it("ACKs duplicate completions while safely repeating lifecycle reconciliation", async () => {
       const h = createProcessor();
       const sandboxWs = {} as WebSocket;
       h.wsManager.getSandboxSocket.mockReturnValue(sandboxWs);
@@ -917,6 +917,10 @@ describe("SessionSandboxEventProcessor", () => {
         ackId: "execution_complete:msg-1",
       });
       expect(h.repository.recordMessageCompletion).not.toHaveBeenCalled();
+      expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
+      expect(h.updateLastActivity).toHaveBeenCalledOnce();
+      expect(h.scheduleInactivityCheck).toHaveBeenCalledOnce();
+      expect(h.processMessageQueue).toHaveBeenCalledOnce();
     });
 
     it("does not send ACK for non-critical events even with ackId", async () => {

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -345,6 +345,7 @@ describe("SessionWebSocketManagerImpl", () => {
       mockRepo.setSandbox(createSandboxRow("correct-id"));
 
       expect(manager.getSandboxSocket()).toBeNull();
+      expect(wrongWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
     });
 
     it("returns null when cached socket is closed", () => {

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -348,6 +348,17 @@ describe("SessionWebSocketManagerImpl", () => {
       expect(wrongWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
     });
 
+    it("skips sockets without the expected sandbox ID tag during recovery", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const untaggedWs = createFakeWebSocket();
+
+      sockets.set(untaggedWs, ["sandbox"]);
+      mockRepo.setSandbox(createSandboxRow("correct-id"));
+
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(untaggedWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
+    });
+
     it("returns null when cached socket is closed", () => {
       const { manager } = createManager();
       const ws = createFakeWebSocket(WebSocket.CLOSED);

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -181,6 +181,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
           tag_sandbox_id: parsed.sandboxId,
           expected_sandbox_id: expectedSandboxId,
         });
+        this.close(ws, 1000, "Sandbox identity changed");
         continue;
       }
 

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -176,7 +176,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
       const parsed = this.classify(ws);
       if (parsed.kind !== "sandbox" || ws.readyState !== WebSocket.OPEN) continue;
 
-      if (expectedSandboxId && parsed.sandboxId && parsed.sandboxId !== expectedSandboxId) {
+      if (expectedSandboxId && parsed.sandboxId !== expectedSandboxId) {
         this.log.debug("Skipping WS with wrong sandbox ID", {
           tag_sandbox_id: parsed.sandboxId,
           expected_sandbox_id: expectedSandboxId,

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -130,6 +130,34 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     }
   );
 
+  /**
+   * Queue SQL mutations from the pre-authentication sandbox read so they land
+   * inside the token-hash await: the read runs to completion — so anything
+   * checked against its returned row sees the pre-mutation state — before the
+   * microtask fires, guaranteeing the mutation falls inside the
+   * `crypto.subtle.digest` suspension rather than before or after it.
+   */
+  async function mutateSandboxDuringAuth(
+    stub: DurableObjectStub,
+    ...statements: string[]
+  ): Promise<void> {
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      const repository = (
+        instance as unknown as { sandboxRepository: { getSandbox: () => unknown } }
+      ).sandboxRepository;
+      const readSandbox = repository.getSandbox.bind(repository);
+      vi.spyOn(repository, "getSandbox").mockImplementation(() => {
+        const sandbox = readSandbox();
+        queueMicrotask(() => {
+          for (const statement of statements) {
+            instance.ctx.storage.sql.exec(statement);
+          }
+        });
+        return sandbox;
+      });
+    });
+  }
+
   it("revalidates terminal state after asynchronous authentication", async () => {
     const name = `ws-session-auth-race-${Date.now()}`;
     const { stub } = await initNamedSession(name);
@@ -143,25 +171,11 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     // does not hold other events back while it runs. Cancelling mid-hash is the
     // real race: a status read taken before the await is already stale by the
     // time the upgrade is accepted.
-    //
-    // The cancel is queued as a microtask from the pre-authentication sandbox
-    // read. That read runs to completion — including the reconnect-blocked
-    // check, which therefore sees the pre-cancel row — before the microtask
-    // lands, so the mutation is guaranteed to fall inside the hash await.
-    await runInDurableObject(stub, (instance: SessionDO) => {
-      const repository = (
-        instance as unknown as { sandboxRepository: { getSandbox: () => unknown } }
-      ).sandboxRepository;
-      const readSandbox = repository.getSandbox.bind(repository);
-      vi.spyOn(repository, "getSandbox").mockImplementation(() => {
-        const sandbox = readSandbox();
-        queueMicrotask(() => {
-          instance.ctx.storage.sql.exec("UPDATE session SET status = 'cancelled'");
-          instance.ctx.storage.sql.exec("UPDATE sandbox SET status = 'stopped'");
-        });
-        return sandbox;
-      });
-    });
+    await mutateSandboxDuringAuth(
+      stub,
+      "UPDATE session SET status = 'cancelled'",
+      "UPDATE sandbox SET status = 'stopped'"
+    );
 
     const { ws, response } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,
@@ -169,14 +183,90 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     });
 
     expect(response.status).toBe(410);
-    // Pin the branch: the pre-authentication sandbox check saw a live row, so
-    // only the post-authentication session read can have rejected this.
+    // Pin the branch: after authentication the session guard runs before the
+    // sandbox guard, so the fresh session read must be what rejected this.
     expect(await response.text()).toBe("Session is terminal");
     expect(ws).toBeNull();
     // The rejected upgrade must not flip the sandbox back to `ready`.
     expect(await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox")).toEqual([
       { status: "stopped" },
     ]);
+  });
+
+  it("revalidates sandbox lifecycle state after asynchronous authentication", async () => {
+    const name = `ws-sandbox-stop-race-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "ready",
+    });
+
+    // Only the sandbox stops mid-hash; the session stays promptable, so only
+    // a fresh post-authentication sandbox read can reject this upgrade.
+    await mutateSandboxDuringAuth(stub, "UPDATE sandbox SET status = 'stopped'");
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(410);
+    expect(await response.text()).toBe("Sandbox is stopped");
+    expect(ws).toBeNull();
+    // The rejected upgrade must not flip the sandbox back to `ready`.
+    expect(await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox")).toEqual([
+      { status: "stopped" },
+    ]);
+  });
+
+  it("rejects credentials rotated during asynchronous authentication", async () => {
+    const name = `ws-sandbox-rotate-race-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "ready",
+    });
+
+    // A respawn rotates the auth token mid-hash. The presented token still
+    // matches the pre-rotation row captured before the await, so token
+    // validation alone would admit a bridge the current row no longer trusts.
+    await mutateSandboxDuringAuth(
+      stub,
+      "UPDATE sandbox SET auth_token_hash = 'rotated-token-hash'"
+    );
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("Forbidden: Sandbox credentials changed");
+    expect(ws).toBeNull();
+  });
+
+  it("returns 401, not 410, for a stopped sandbox with an invalid token (auth precedes state checks)", async () => {
+    const name = `ws-sandbox-stopped-badtoken-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "stopped",
+    });
+
+    // Contract change ported from prod: lifecycle state is only revealed to
+    // authenticated callers. An unauthenticated caller used to see 410 from
+    // the pre-auth stopped-sandbox guard; it now gets 401.
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: "wrong-token",
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("Unauthorized: Invalid auth token");
+    expect(ws).toBeNull();
   });
 
   it("sandbox connect sets status to ready", async () => {


### PR DESCRIPTION
## What

Completes the sandbox-WebSocket admission hardening started in #1577. `isValidSandboxToken` awaits `crypto.subtle.digest` — a **non-storage** await — so the Durable Object input gate does not hold other events across it: a cancel, archive, stop, or credential rotation can land mid-hash. #1577 moved the *session*-status guard behind authentication onto a fresh read; this PR does the same for the remaining state checks:

1. The sandbox-status guard (`410 Sandbox is stopped`) moves from pre-auth to post-auth and now operates on a **fresh** `sandboxRepository.getSandbox()` re-read.
2. New consistency check: if the sandbox row's `modal_sandbox_id`, `auth_token_hash`, or `auth_token` changed while the request was suspended in token hashing → `403 Forbidden: Sandbox credentials changed`.
3. `SessionWebSocketManagerImpl`'s hibernation-recovery loop now closes (`1000, "Sandbox identity changed"`) a cached socket whose tag doesn't match the persisted sandbox ID, instead of just skipping it.

Guard order after this PR: sandbox-ID mismatch `403` (pre-auth — pure synchronous comparison, nothing can go stale before it) → token `401` → fresh session read `410` → fresh sandbox read `410` → consistency `403`. Our production deployment has run exactly this ordering since Aug 18.

## Externally visible contract changes (both verified safe for the bridge)

- Stopped sandbox + **invalid token**: `410` → `401`.
- Stopped sandbox + **wrong X-Sandbox-ID**: `410` → `403 Wrong sandbox ID` (the stopped-check used to run before even the ID check).

The only in-repo consumer is the sandbox bridge (`packages/sandbox-runtime/src/sandbox_runtime/bridge.py`): a non-101 upgrade raises `InvalidStatus`, and `bridge.py` funnels 401/403/404/410 into the same terminal `SessionTerminatedError` — one attempt, no retry, clean shutdown (`test_bridge_reconnection.py` pins all four). No retry-forever risk.

Security-wise the unauthenticated surface **shrinks**: lifecycle state (`stopped`/`stale`) is no longer revealed to callers without a valid token; an unauthenticated probe now sees only `401`/`403`.

## Red-first evidence

The three new integration tests were written first and run against the unmodified base:

- sandbox stopped mid-auth → expected `410`, got `101` (pre-auth guard read the pre-flip row)
- credentials rotated mid-auth → expected `403`, got `101` (no consistency check existed)
- stopped sandbox + invalid token → expected `401`, got `410` (stopped-check ran pre-auth)

All three fail on base and pass with the change; the pre-existing session-terminal race test passes unchanged (its assertions are untouched — only two comments that described the old ordering were updated, and its inline spy was folded into the shared `mutateSandboxDuringAuth` helper). The new websocket-manager assertion was likewise red on base (`close` never called) and green now.

Also strengthened `sandbox-events.test.ts`'s duplicate-`execution_complete` test with four lifecycle-reconciliation assertions (snapshot trigger, activity bump, inactivity reschedule, queue drain) — pinning existing behavior.

## Review updates

- Per review, the recovery loop now also **skips and closes untagged sandbox sockets** when a persisted sandbox ID exists (`43b4d0f5c`, red-first verified) — matching the production recovery loop exactly. The cached-socket per-call identity re-validation remains deliberately out of scope.
- The deeper pre-persistence replacement race surfaced in review (a stale bridge authenticating between replacement start and `updateSandboxForSpawn` persisting) is **pre-existing** — the old pre-auth guard had the same window and production has run this exact ordering since Aug 18. This PR narrows admission races to that one window; closing it is a lifecycle-ordering change tracked as #1589 with two designed fixes.

## Known gaps, deliberate

- The credentials-changed `403` emits no `ws.connect` log event (parity with the production ordering as deployed; a follow-up can add a `reject_reason` for observability).

Typecheck, full unit suite, full integration suite (80 files / 998 tests), and Prettier are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox WebSocket reconnection handling when sandbox identity or credentials change during authentication.
  * Prevented stale or unidentified connections from being restored after sandbox identity changes.
  * Ensured stopped sandboxes and invalid credentials return the correct authentication response without exposing lifecycle details.
  * Improved reliability when sandboxes shut down during connection or authentication.
  * Duplicate execution completions now consistently trigger expected session updates and queued message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->