### PR TITLE
refactor(control-plane): BackgroundTasks.submit takes a task factory

### DIFF
--- a/packages/control-plane/src/background-tasks.test-support.test.ts
+++ b/packages/control-plane/src/background-tasks.test-support.test.ts
@@ -9,9 +9,12 @@ describe("createTestBackgroundTasks", () => {
     const boom = new Error("sync boom");
 
     expect(() =>
-      background.submit(() => {
-        throw boom;
-      }, { name: "test.sync_throw" })
+      background.submit(
+        () => {
+          throw boom;
+        },
+        { name: "test.sync_throw" }
+      )
     ).not.toThrow();
 
     expect(background.failures).toEqual([boom]);
@@ -22,9 +25,12 @@ describe("createTestBackgroundTasks", () => {
     const background = createTestBackgroundTasks();
     let ran = false;
 
-    background.submit(async () => {
-      ran = true;
-    }, { name: "test.task" });
+    background.submit(
+      async () => {
+        ran = true;
+      },
+      { name: "test.task" }
+    );
 
     expect(ran).toBe(true);
     expect(background.submissions).toHaveLength(1);

--- a/packages/control-plane/src/background-tasks.test-support.test.ts
+++ b/packages/control-plane/src/background-tasks.test-support.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { createTestBackgroundTasks } from "./background-tasks.test-support";
+
+// Pins the adapter to the production submit contract; see
+// cloudflare/background-tasks.test.ts for the implementation's own suite.
+describe("createTestBackgroundTasks", () => {
+  it("absorbs a synchronous factory throw and records it", () => {
+    const background = createTestBackgroundTasks();
+    const boom = new Error("sync boom");
+
+    expect(() =>
+      background.submit(() => {
+        throw boom;
+      }, { name: "test.sync_throw" })
+    ).not.toThrow();
+
+    expect(background.failures).toEqual([boom]);
+    expect(background.submissions).toEqual([{ name: "test.sync_throw" }]);
+  });
+
+  it("runs the factory synchronously and records the task in order", async () => {
+    const background = createTestBackgroundTasks();
+    let ran = false;
+
+    background.submit(async () => {
+      ran = true;
+    }, { name: "test.task" });
+
+    expect(ran).toBe(true);
+    expect(background.submissions).toHaveLength(1);
+    await background.settle();
+  });
+
+  it("absorbs rejections into failures so unawaited tasks cannot fail a run", async () => {
+    const background = createTestBackgroundTasks();
+
+    background.submit(() => Promise.reject(new Error("late boom")), { name: "test.reject" });
+
+    await expect(background.settle()).resolves.toBeUndefined();
+    expect(background.failures).toEqual([expect.objectContaining({ message: "late boom" })]);
+    await expect(background.submissions[0]?.task).rejects.toThrow("late boom");
+  });
+});

--- a/packages/control-plane/src/background-tasks.test-support.ts
+++ b/packages/control-plane/src/background-tasks.test-support.ts
@@ -1,0 +1,55 @@
+import type { BackgroundTasks } from "./platform-ports";
+
+/** One `submit` call: the task name and the factory's promise (absent when it threw). */
+export interface RecordedSubmission {
+  name: string;
+  task?: Promise<unknown>;
+}
+
+export interface TestBackgroundTasks extends BackgroundTasks {
+  /** Every submit in order. Assert on `.length` instead of spying on `submit`. */
+  readonly submissions: RecordedSubmission[];
+  /**
+   * Errors absorbed by the boundary — synchronous factory throws immediately,
+   * rejections once the task settles — exactly the set production logs as
+   * `background_task.failed`.
+   */
+  readonly failures: unknown[];
+  /** Await every recorded task, tolerating rejections (production absorbs them). */
+  settle(): Promise<void>;
+}
+
+/**
+ * Contract-faithful `BackgroundTasks` double, mirroring
+ * `createCloudflareBackgroundTasks`: the factory is invoked synchronously, a
+ * synchronous throw is absorbed, and rejections are absorbed; both land in
+ * `failures`. Tests drain deferred work via `settle()` (or an individual
+ * `submissions[i].task`). Keep this behaviourally identical to the production
+ * implementation — a fake with a different boundary makes collaborator tests
+ * exercise a contract production does not have.
+ */
+export function createTestBackgroundTasks(): TestBackgroundTasks {
+  const submissions: RecordedSubmission[] = [];
+  const failures: unknown[] = [];
+  return {
+    submissions,
+    failures,
+    submit(task, metadata) {
+      let pending: Promise<unknown>;
+      try {
+        pending = task();
+      } catch (error) {
+        failures.push(error);
+        submissions.push({ name: metadata.name });
+        return;
+      }
+      void pending.catch((error) => failures.push(error));
+      submissions.push({ name: metadata.name, task: pending });
+    },
+    async settle() {
+      for (const submission of submissions) {
+        await submission.task?.catch(() => {});
+      }
+    },
+  };
+}

--- a/packages/control-plane/src/cloudflare/background-tasks.test.ts
+++ b/packages/control-plane/src/cloudflare/background-tasks.test.ts
@@ -5,12 +5,29 @@ describe("createCloudflareBackgroundTasks", () => {
   it("extends the Durable Object lifetime for the spawned task", () => {
     const waitUntil = vi.fn();
     const background = createCloudflareBackgroundTasks({ waitUntil });
-    const job = Promise.resolve();
 
-    background.submit(job, { name: "test.task" });
+    background.submit(() => Promise.resolve(), { name: "test.task" });
 
     expect(waitUntil).toHaveBeenCalledOnce();
     expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise));
+  });
+
+  it("runs the factory synchronously exactly once", () => {
+    const waitUntil = vi.fn();
+    const background = createCloudflareBackgroundTasks({ waitUntil });
+    const runs: number[] = [];
+
+    background.submit(
+      () => {
+        runs.push(runs.length + 1);
+        return Promise.resolve();
+      },
+      { name: "test.task" }
+    );
+
+    // The side effect is observable before submit returns: the factory runs
+    // synchronously, with no microtask deferral.
+    expect(runs).toEqual([1]);
   });
 
   it("catches and logs rejected tasks", async () => {
@@ -18,7 +35,7 @@ describe("createCloudflareBackgroundTasks", () => {
     const logger = { error: vi.fn() };
     const background = createCloudflareBackgroundTasks({ waitUntil }, () => logger as never);
 
-    background.submit(Promise.reject(new Error("task failed")), {
+    background.submit(() => Promise.reject(new Error("task failed")), {
       name: "test.task",
       context: { session_id: "session-1" },
     });
@@ -28,6 +45,29 @@ describe("createCloudflareBackgroundTasks", () => {
       task_name: "test.task",
       session_id: "session-1",
       error: expect.objectContaining({ message: "task failed" }),
+    });
+  });
+
+  it("absorbs and logs a factory that throws synchronously", () => {
+    const waitUntil = vi.fn();
+    const logger = { error: vi.fn() };
+    const background = createCloudflareBackgroundTasks({ waitUntil }, () => logger as never);
+
+    expect(() =>
+      background.submit(
+        () => {
+          throw new Error("construction failed");
+        },
+        { name: "test.task", context: { session_id: "session-1" } }
+      )
+    ).not.toThrow();
+
+    // Nothing started, so there is no lifetime to extend.
+    expect(waitUntil).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("background_task.failed", {
+      task_name: "test.task",
+      session_id: "session-1",
+      error: expect.objectContaining({ message: "construction failed" }),
     });
   });
 });

--- a/packages/control-plane/src/cloudflare/background-tasks.ts
+++ b/packages/control-plane/src/cloudflare/background-tasks.ts
@@ -11,15 +11,21 @@ export function createCloudflareBackgroundTasks(
 ): BackgroundTasks {
   return {
     submit(task, metadata): void {
-      context.waitUntil(
-        task.catch((error) => {
-          getLogger().error("background_task.failed", {
-            task_name: metadata.name,
-            ...metadata.context,
-            error: error instanceof Error ? error : String(error),
-          });
-        })
-      );
+      const logFailure = (error: unknown): void => {
+        getLogger().error("background_task.failed", {
+          task_name: metadata.name,
+          ...metadata.context,
+          error: error instanceof Error ? error : String(error),
+        });
+      };
+      let pending: Promise<unknown>;
+      try {
+        pending = task();
+      } catch (error) {
+        logFailure(error);
+        return; // Nothing started, so there is no lifetime to extend.
+      }
+      context.waitUntil(pending.catch(logFailure));
     },
   };
 }

--- a/packages/control-plane/src/image-builds/save-hooks.ts
+++ b/packages/control-plane/src/image-builds/save-hooks.ts
@@ -32,32 +32,34 @@ export function scheduleImageBuildOnSave(
 ): void {
   if (!resolveImageBuildProvider(env.SANDBOX_PROVIDER)) return;
 
-  const task = createImageBuildWorkflowFromEnv(env, ctx.db)
-    .triggerBuildIfStale(scope, { request_id: ctx.request_id, trace_id: ctx.trace_id })
-    .then((result) => {
-      logger.info("image_build.save_hook_trigger", {
-        scope_kind: scope.kind,
-        scope_id: scope.id,
-        result: result.type,
-        build_id: result.type === "up_to_date" ? null : result.buildId,
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-    })
-    .catch((e) => {
-      logger.warn("image_build.save_hook_trigger_failed", {
-        scope_kind: scope.kind,
-        scope_id: scope.id,
-        error: e instanceof Error ? e.message : String(e),
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-    });
-
-  ctx.executionCtx.submit(task, {
-    name: "image_build.save_hook",
-    context: { scope_kind: scope.kind, scope_id: scope.id },
-  });
+  ctx.executionCtx.submit(
+    () =>
+      createImageBuildWorkflowFromEnv(env, ctx.db)
+        .triggerBuildIfStale(scope, { request_id: ctx.request_id, trace_id: ctx.trace_id })
+        .then((result) => {
+          logger.info("image_build.save_hook_trigger", {
+            scope_kind: scope.kind,
+            scope_id: scope.id,
+            result: result.type,
+            build_id: result.type === "up_to_date" ? null : result.buildId,
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+        })
+        .catch((e) => {
+          logger.warn("image_build.save_hook_trigger_failed", {
+            scope_kind: scope.kind,
+            scope_id: scope.id,
+            error: e instanceof Error ? e.message : String(e),
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+        }),
+    {
+      name: "image_build.save_hook",
+      context: { scope_kind: scope.kind, scope_id: scope.id },
+    }
+  );
 }
 
 /**

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -4,8 +4,14 @@ export type { FetchClient } from "@open-inspect/shared/service-auth";
 
 /** Capability consumed by application services that defer background work. */
 export interface BackgroundTasks {
+  /**
+   * Start `task` and let it run past the current request. The factory is
+   * invoked synchronously inside `submit`, and a synchronous throw is absorbed
+   * and logged exactly like a rejection — building the task can never fail the
+   * caller.
+   */
   submit(
-    task: Promise<unknown>,
+    task: () => Promise<unknown>,
     metadata: { name: string; context?: Record<string, unknown> }
   ): void;
 }

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -8,18 +8,11 @@
 
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
 import type { BackgroundTasks } from "./platform-ports";
+import { createTestBackgroundTasks } from "./background-tasks.test-support";
 
-export const TEST_BACKGROUND_TASK_CONTEXT: BackgroundTasks = {
-  // Match the real implementation: the factory runs synchronously and both a
-  // synchronous throw and a rejection are absorbed.
-  submit: (task) => {
-    try {
-      void task().catch(() => {});
-    } catch {
-      // Absorbed like background_task.failed.
-    }
-  },
-};
+// The single contract-faithful double lives in background-tasks.test-support;
+// this shared instance's recordings are unused by the router suites.
+export const TEST_BACKGROUND_TASK_CONTEXT: BackgroundTasks = createTestBackgroundTasks();
 
 /** Per-service secrets for unit-test env fixtures, mirrored by signedServiceRequest. */
 export const TEST_SERVICE_SECRETS = {

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -10,7 +10,15 @@ import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/
 import type { BackgroundTasks } from "./platform-ports";
 
 export const TEST_BACKGROUND_TASK_CONTEXT: BackgroundTasks = {
-  submit: () => {},
+  // Match the real implementation: the factory runs synchronously and both a
+  // synchronous throw and a rejection are absorbed.
+  submit: (task) => {
+    try {
+      void task().catch(() => {});
+    } catch {
+      // Absorbed like background_task.failed.
+    }
+  },
 };
 
 /** Per-service secrets for unit-test env fixtures, mirrored by signedServiceRequest. */

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -133,8 +133,14 @@ function createContext(waitUntilTasks?: Promise<unknown>[]): RequestContext {
     metrics: createRequestMetrics(),
     executionCtx: {
       submit: (task: () => Promise<unknown>) => {
-        const pending = task();
-        waitUntilTasks?.push(pending);
+        // Contract-faithful: run the factory even without a collector, and
+        // absorb synchronous throws like the production boundary does.
+        try {
+          const pending = task();
+          waitUntilTasks?.push(pending);
+        } catch {
+          // Absorbed like background_task.failed.
+        }
       },
     },
   };

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -132,8 +132,9 @@ function createContext(waitUntilTasks?: Promise<unknown>[]): RequestContext {
     db: {} as SqlDatabase,
     metrics: createRequestMetrics(),
     executionCtx: {
-      submit: (task: Promise<unknown>) => {
-        waitUntilTasks?.push(task);
+      submit: (task: () => Promise<unknown>) => {
+        const pending = task();
+        waitUntilTasks?.push(pending);
       },
     },
   };

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -116,7 +116,7 @@ describe("repository list route", () => {
     // CONTROL_PLANE_FETCH_TIMEOUT_MS, which cancels the worker — so unless the
     // refresh is registered with waitUntil, the KV write never lands and every
     // later request repeats the same slow path against an empty cache.
-    const waitUntil = vi.fn();
+    const waitUntil = vi.fn((task: () => Promise<unknown>) => task());
     const { handler, match } = getListHandler();
     const ctx = createContext();
 
@@ -133,7 +133,7 @@ describe("repository list route", () => {
     expect(response.status).toBe(200);
     expect(mockCachePut).toHaveBeenCalledTimes(1);
     expect(waitUntil).toHaveBeenCalledTimes(1);
-    await expect(waitUntil.mock.calls[0][0]).resolves.not.toThrow();
+    await expect(waitUntil.mock.results[0]!.value).resolves.not.toThrow();
   });
 });
 

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import { reposRoutes } from "./repos";
@@ -116,7 +117,7 @@ describe("repository list route", () => {
     // CONTROL_PLANE_FETCH_TIMEOUT_MS, which cancels the worker — so unless the
     // refresh is registered with waitUntil, the KV write never lands and every
     // later request repeats the same slow path against an empty cache.
-    const waitUntil = vi.fn((task: () => Promise<unknown>) => task());
+    const backgroundTasks = createTestBackgroundTasks();
     const { handler, match } = getListHandler();
     const ctx = createContext();
 
@@ -126,14 +127,15 @@ describe("repository list route", () => {
       match,
       {
         ...ctx,
-        executionCtx: { submit: waitUntil },
+        executionCtx: backgroundTasks,
       }
     );
 
     expect(response.status).toBe(200);
     expect(mockCachePut).toHaveBeenCalledTimes(1);
-    expect(waitUntil).toHaveBeenCalledTimes(1);
-    await expect(waitUntil.mock.results[0]!.value).resolves.not.toThrow();
+    expect(backgroundTasks.submissions).toHaveLength(1);
+    await backgroundTasks.settle();
+    expect(backgroundTasks.failures).toEqual([]);
   });
 });
 

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -164,7 +164,7 @@ async function handleListRepos(
         trace_id: ctx.trace_id,
         cached_at: cached.cachedAt,
       });
-      ctx.executionCtx.submit(refreshReposCache(env, ctx.db, ctx.trace_id), {
+      ctx.executionCtx.submit(() => refreshReposCache(env, ctx.db, ctx.trace_id), {
         name: "repos_cache.refresh",
         context: { trace_id: ctx.trace_id },
       });
@@ -183,10 +183,12 @@ async function handleListRepos(
   // cancel the Worker before the KV write, leaving the cache empty so the next
   // request repeats the same slow path — a miss that can never self-heal,
   // because the stale-while-revalidate branch above needs an entry to exist.
+  // The refresh promise is created once and shared: the factory hands it to
+  // waitUntil while the response below awaits the same run.
   const refresh = refreshReposCache(env, ctx.db, ctx.trace_id, (fn) =>
     ctx.metrics.time("scm_api", fn)
   );
-  ctx.executionCtx.submit(refresh, {
+  ctx.executionCtx.submit(() => refresh, {
     name: "repos_cache.refresh",
     context: { trace_id: ctx.trace_id },
   });

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -312,19 +312,20 @@ async function handleSpawnChild(
   }
 
   ctx.executionCtx.submit(
-    ctx.sessionRuntime
-      .fetch(parentId, SessionInternalPaths.childSessionUpdate, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          childSessionId: childId,
-          status: "created",
-          title: body.title,
+    () =>
+      ctx.sessionRuntime
+        .fetch(parentId, SessionInternalPaths.childSessionUpdate, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            childSessionId: childId,
+            status: "created",
+            title: body.title,
+          }),
+        })
+        .catch((err: unknown) => {
+          logger.error("session.notify_parent_spawn.failed", { error: err });
         }),
-      })
-      .catch((err: unknown) => {
-        logger.error("session.notify_parent_spawn.failed", { error: err });
-      }),
     {
       name: "session.notify_parent_spawn",
       context: { parent_id: parentId, child_id: childId, trace_id: ctx.trace_id },

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -148,15 +148,16 @@ export async function handlePromptChild(
       trace_id: ctx.trace_id,
     });
     ctx.executionCtx.submit(
-      sessionStore.touchUpdatedAt(childId).catch((error) => {
-        logger.error("session_index.touch_updated_at.background_error", {
-          parent_id: parentId,
-          child_id: childId,
-          request_id: ctx.request_id,
-          trace_id: ctx.trace_id,
-          error,
-        });
-      }),
+      () =>
+        sessionStore.touchUpdatedAt(childId).catch((error) => {
+          logger.error("session_index.touch_updated_at.background_error", {
+            parent_id: parentId,
+            child_id: childId,
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+            error,
+          });
+        }),
       {
         name: "session_index.touch_updated_at",
         context: {

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -159,14 +159,15 @@ async function handleSessionPrompt(
 
   const store = new SessionIndexStore(ctx.db);
   ctx.executionCtx.submit(
-    store.touchUpdatedAt(sessionId).catch((error) => {
-      logger.error("session_index.touch_updated_at.background_error", {
-        session_id: sessionId,
-        trace_id: ctx.trace_id,
-        request_id: ctx.request_id,
-        error,
-      });
-    }),
+    () =>
+      store.touchUpdatedAt(sessionId).catch((error) => {
+        logger.error("session_index.touch_updated_at.background_error", {
+          session_id: sessionId,
+          trace_id: ctx.trace_id,
+          request_id: ctx.request_id,
+          error,
+        });
+      }),
     {
       name: "session_index.touch_updated_at",
       context: { session_id: sessionId, trace_id: ctx.trace_id, request_id: ctx.request_id },

--- a/packages/control-plane/src/scheduler/scheduler.test.ts
+++ b/packages/control-plane/src/scheduler/scheduler.test.ts
@@ -323,7 +323,9 @@ function createEnv(overrides?: Partial<Env>): Env {
 }
 
 function createSchedulerDO(env = createEnv()) {
-  const scheduler = new Scheduler(env.DB, env, { submit: vi.fn() });
+  const scheduler = new Scheduler(env.DB, env, {
+    submit: vi.fn((task: () => Promise<unknown>) => void task().catch(() => {})),
+  });
   return Object.assign(scheduler, { fetch: (request: Request) => scheduler.dispatch(request) });
 }
 

--- a/packages/control-plane/src/scheduler/scheduler.test.ts
+++ b/packages/control-plane/src/scheduler/scheduler.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import type { InvocationRunAggregate } from "../db/automation-store";
@@ -323,9 +324,7 @@ function createEnv(overrides?: Partial<Env>): Env {
 }
 
 function createSchedulerDO(env = createEnv()) {
-  const scheduler = new Scheduler(env.DB, env, {
-    submit: vi.fn((task: () => Promise<unknown>) => void task().catch(() => {})),
-  });
+  const scheduler = new Scheduler(env.DB, env, createTestBackgroundTasks());
   return Object.assign(scheduler, { fetch: (request: Request) => scheduler.dispatch(request) });
 }
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -711,7 +711,9 @@ export class SessionDO extends DurableObject<Env> {
         generateId: (bytes) => generateId(bytes),
         now: () => Date.now(),
         scheduleWarmSandbox: () =>
-          this.backgroundTasks.submit(this.warmSandbox(), { name: "sandbox.warm" }),
+          this.backgroundTasks.submit(() => this.lifecycleManager.warmSandbox(), {
+            name: "sandbox.warm",
+          }),
         getSession: () => this.sessionCoreRepository.getSession(),
         getSandbox: () => this.sandboxRepository.getSandbox(),
         getPublicSessionId: (session) => resolvePublicSessionId(session, this.ctx.id.toString()),
@@ -775,27 +777,28 @@ export class SessionDO extends DurableObject<Env> {
   /** Fire a background read-through refresh. */
   private schedulePullRequestRefresh(trigger: "open" | "manual"): void {
     this.backgroundTasks.submit(
-      refreshSessionPullRequests(
-        this.sessionCoreRepository,
-        this.artifactRepository,
-        this.sourceControlProvider,
-        this.db ? new SessionPullRequestStore(this.db) : null
-      ).then(({ updated, failures }) => {
-        for (const artifact of updated) {
-          this.messenger.broadcast({ type: "artifact_updated", artifact });
-        }
-        for (const failure of failures) {
-          this.log.error("Pull request refresh failed for artifact", {
-            trigger,
-            reason: failure.reason,
-            artifact_id: failure.artifactId,
-            pr_number: failure.prNumber,
-            repo_owner: failure.repoOwner,
-            repo_name: failure.repoName,
-            error: failure.error instanceof Error ? failure.error : String(failure.error),
-          });
-        }
-      }),
+      () =>
+        refreshSessionPullRequests(
+          this.sessionCoreRepository,
+          this.artifactRepository,
+          this.sourceControlProvider,
+          this.db ? new SessionPullRequestStore(this.db) : null
+        ).then(({ updated, failures }) => {
+          for (const artifact of updated) {
+            this.messenger.broadcast({ type: "artifact_updated", artifact });
+          }
+          for (const failure of failures) {
+            this.log.error("Pull request refresh failed for artifact", {
+              trigger,
+              reason: failure.reason,
+              artifact_id: failure.artifactId,
+              pr_number: failure.prNumber,
+              repo_owner: failure.repoOwner,
+              repo_name: failure.repoName,
+              error: failure.error instanceof Error ? failure.error : String(failure.error),
+            });
+          }
+        }),
       {
         name: "pull_request.refresh",
         context: { trigger },
@@ -1055,21 +1058,6 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Warm the sandbox proactively.
-   *
-   * This is an async boundary, not a forwarder, and deleting it is a
-   * regression. `lifecycleManager` is a lazy getter that builds the sandbox
-   * provider, and that construction throws on a deployment missing provider
-   * credentials. Reading it inside an `async` method turns the synchronous
-   * throw into a rejected promise, which `backgroundTasks.submit` absorbs and
-   * logs. Inlined into the submit argument, the same throw escapes session
-   * creation and 500s `/internal/init` after its rows are already committed.
-   */
-  private async warmSandbox(): Promise<void> {
-    await this.lifecycleManager.warmSandbox();
-  }
-
-  /**
    * Initialize the session with required data.
    */
   private ensureInitialized(rehydrateAlarm = true): void {
@@ -1095,7 +1083,7 @@ export class SessionDO extends DurableObject<Env> {
     );
     this.diffsHandler = new SessionDiffsHandler(this.diffService);
     if (rehydrateAlarm) {
-      this.backgroundTasks.submit(this.alarmScheduler.rehydrate(), {
+      this.backgroundTasks.submit(() => this.alarmScheduler.rehydrate(), {
         name: "alarm.rehydrate",
       });
     }
@@ -1234,13 +1222,13 @@ export class SessionDO extends DurableObject<Env> {
         });
 
         // Process any pending messages now that sandbox is connected
-        this.backgroundTasks.submit(this.messageQueue.processMessageQueue(), {
+        this.backgroundTasks.submit(() => this.messageQueue.processMessageQueue(), {
           name: "message_queue.process",
         });
       } else {
         const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
         this.wsManager.acceptClientSocket(server, wsId);
-        this.backgroundTasks.submit(this.wsManager.enforceAuthTimeout(server, wsId), {
+        this.backgroundTasks.submit(() => this.wsManager.enforceAuthTimeout(server, wsId), {
           name: "websocket.enforce_auth_timeout",
           context: { ws_id: wsId },
         });
@@ -1470,10 +1458,13 @@ export class SessionDO extends DurableObject<Env> {
   private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
     if (!this.db) return;
     const sessionStore = new SessionIndexStore(this.db);
-    this.backgroundTasks.submit(sessionStore.updateTitleIfNewer(sessionId, title, updatedAt), {
-      name: "session_index.update_title",
-      context: { session_id: sessionId, updated_at: updatedAt },
-    });
+    this.backgroundTasks.submit(
+      () => sessionStore.updateTitleIfNewer(sessionId, title, updatedAt),
+      {
+        name: "session_index.update_title",
+        context: { session_id: sessionId, updated_at: updatedAt },
+      }
+    );
   }
 
   private applySessionTitleUpdate(

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import { fingerprintWebPrompt, SessionMessageQueue } from "./message-queue";
 import { AttachmentClaimConflictError } from "./session-attachment-repository";
 import type { SessionAttachmentRepository } from "./session-attachment-repository";
@@ -194,10 +195,7 @@ function buildQueue() {
     terminateUnresponsiveSandbox: vi.fn(async () => {}),
     reportSandboxError: vi.fn((_reason: string) => {}),
   };
-  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
-    task().catch((error) => log.error("background_task.failed", { error }))
-  );
-  const backgroundTasks = { submit: waitUntil };
+  const backgroundTasks = createTestBackgroundTasks();
   const getAlarm = vi.fn(async () => null as number | null);
   const setAlarm = vi.fn(async (_timestamp: number) => {});
   const projectTerminalMessage = vi.fn(async () => {});
@@ -245,7 +243,7 @@ function buildQueue() {
     broadcast,
     sessionStatus,
     sandboxLifecycle,
-    waitUntil,
+    backgroundTasks,
     getAlarm,
     setAlarm,
     callbackService,
@@ -345,12 +343,12 @@ describe("SessionMessageQueue", () => {
     );
 
     // Resolves immediately even though the spawn is still in flight; the
-    // spawn is handed to waitUntil so the prompt response is not held open.
+    // spawn is handed to backgroundTasks so the prompt response is not held open.
     await h.queue.processMessageQueue();
 
-    expect(h.waitUntil).toHaveBeenCalledTimes(1);
+    expect(h.backgroundTasks.submissions).toHaveLength(1);
     resolveSpawn();
-    await h.waitUntil.mock.results[0]!.value;
+    await h.backgroundTasks.settle();
   });
 
   it("reports sandbox_error when the background spawn throws", async () => {
@@ -359,7 +357,7 @@ describe("SessionMessageQueue", () => {
     h.sandboxLifecycle.spawnSandbox.mockRejectedValue(new Error("modal exploded"));
 
     await h.queue.processMessageQueue();
-    await h.waitUntil.mock.results[0]!.value;
+    await h.backgroundTasks.settle();
 
     // Routed through the lifecycle manager rather than broadcast directly, so
     // the reason is persisted too and survives the reload someone does to read it.
@@ -367,9 +365,8 @@ describe("SessionMessageQueue", () => {
     expect(h.broadcast).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "sandbox_error" })
     );
-    expect(h.log.error).toHaveBeenCalledWith("background_task.failed", {
-      error: expect.any(Error),
-    });
+    // The spawn failure is absorbed by the boundary, not thrown at the caller.
+    expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
   });
 
   it("marks session active when a prompt is enqueued", async () => {
@@ -933,7 +930,7 @@ describe("SessionMessageQueue", () => {
     await h.queue.processMessageQueue();
 
     expect(h.callbackService.notifyStarted).toHaveBeenCalledWith("msg-linear");
-    expect(h.waitUntil).toHaveBeenCalledOnce();
+    expect(h.backgroundTasks.submissions).toHaveLength(1);
   });
 
   it("does not notify the integration when sandbox dispatch fails", async () => {
@@ -945,7 +942,7 @@ describe("SessionMessageQueue", () => {
     await h.queue.processMessageQueue();
 
     expect(h.callbackService.notifyStarted).not.toHaveBeenCalled();
-    expect(h.waitUntil).not.toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).toHaveLength(0);
   });
 
   describe("execution timeout scheduling", () => {
@@ -1055,7 +1052,7 @@ describe("SessionMessageQueue", () => {
     });
 
     resolveProjection();
-    await h.waitUntil.mock.results[0]!.value;
+    await h.backgroundTasks.settle();
     expect(h.broadcast).toHaveBeenCalledWith({
       type: "sandbox_event",
       event: expect.objectContaining({ type: "execution_complete" }),

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -194,8 +194,8 @@ function buildQueue() {
     terminateUnresponsiveSandbox: vi.fn(async () => {}),
     reportSandboxError: vi.fn((_reason: string) => {}),
   };
-  const waitUntil = vi.fn((task: Promise<unknown>) =>
-    task.catch((error) => log.error("background_task.failed", { error }))
+  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
+    task().catch((error) => log.error("background_task.failed", { error }))
   );
   const backgroundTasks = { submit: waitUntil };
   const getAlarm = vi.fn(async () => null as number | null);
@@ -1055,7 +1055,7 @@ describe("SessionMessageQueue", () => {
     });
 
     resolveProjection();
-    await h.waitUntil.mock.calls[0][0];
+    await h.waitUntil.mock.results[0]!.value;
     expect(h.broadcast).toHaveBeenCalledWith({
       type: "sandbox_event",
       event: expect.objectContaining({ type: "execution_complete" }),

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -222,7 +222,7 @@ export class SessionMessageQueue {
       const session = this.repository.getSession();
       const sessionId = session?.session_name || session?.id;
       if (sessionId) {
-        this.backgroundTasks.submit(sessionIndex.touchUpdatedAt(sessionId), {
+        this.backgroundTasks.submit(() => sessionIndex.touchUpdatedAt(sessionId), {
           name: "session_index.touch_updated_at",
           context: { session_id: sessionId },
         });
@@ -322,16 +322,17 @@ export class SessionMessageQueue {
       // callers' request timeouts. The message is already persisted as
       // pending and dispatches when the sandbox WebSocket connects.
       this.backgroundTasks.submit(
-        this.sandboxLifecycle.spawnSandbox().catch((error) => {
-          // Expected provider failures report themselves inside the lifecycle
-          // manager; this catch only sees throws from before those handlers.
-          // Route it through the same call so the reason is persisted as well
-          // as broadcast — otherwise it survives only until the tab reloads.
-          this.sandboxLifecycle.reportSandboxError(
-            error instanceof Error ? error.message : "Failed to spawn sandbox"
-          );
-          throw error;
-        }),
+        () =>
+          this.sandboxLifecycle.spawnSandbox().catch((error) => {
+            // Expected provider failures report themselves inside the lifecycle
+            // manager; this catch only sees throws from before those handlers.
+            // Route it through the same call so the reason is persisted as well
+            // as broadcast — otherwise it survives only until the tab reloads.
+            this.sandboxLifecycle.reportSandboxError(
+              error instanceof Error ? error.message : "Failed to spawn sandbox"
+            );
+            throw error;
+          }),
         {
           name: "sandbox.spawn",
           context: { message_id: message.id },
@@ -402,7 +403,7 @@ export class SessionMessageQueue {
       const deadline = now + this.executionTimeoutMs;
       await this.alarmScheduler.schedule(deadline);
 
-      this.backgroundTasks.submit(this.callbackService.notifyStarted(message.id), {
+      this.backgroundTasks.submit(() => this.callbackService.notifyStarted(message.id), {
         name: "callback.notify_started",
         context: { message_id: message.id },
       });
@@ -551,26 +552,32 @@ export class SessionMessageQueue {
     );
     if (!completion) return false;
 
-    const projection = this.projectTerminalMessage(
-      completion.messageId,
-      completion.messageCreatedAt,
-      completion.completedAt
-    )
-      .catch((projectionError) => {
-        this.log.error("terminal_message.projection_failed", {
-          message_id: message.id,
-          error: projectionError,
-        });
-      })
-      .then(() => this.messenger.broadcast({ type: "sandbox_event", event }));
-    this.backgroundTasks.submit(projection, {
-      name: "terminal_message.project",
-      context: { message_id: message.id },
-    });
-    this.backgroundTasks.submit(this.callbackService.notifyComplete(message.id, false, error), {
-      name: "callback.notify_complete",
-      context: { message_id: message.id },
-    });
+    this.backgroundTasks.submit(
+      () =>
+        this.projectTerminalMessage(
+          completion.messageId,
+          completion.messageCreatedAt,
+          completion.completedAt
+        )
+          .catch((projectionError) => {
+            this.log.error("terminal_message.projection_failed", {
+              message_id: message.id,
+              error: projectionError,
+            });
+          })
+          .then(() => this.messenger.broadcast({ type: "sandbox_event", event })),
+      {
+        name: "terminal_message.project",
+        context: { message_id: message.id },
+      }
+    );
+    this.backgroundTasks.submit(
+      () => this.callbackService.notifyComplete(message.id, false, error),
+      {
+        name: "callback.notify_complete",
+        context: { message_id: message.id },
+      }
+    );
     return true;
   }
 

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import type { GitPushSpec } from "../source-control";
 import type { SandboxEvent } from "@open-inspect/shared/types/sandbox-events";
@@ -82,10 +83,7 @@ function createProcessor() {
     error: vi.fn(),
     child: vi.fn(),
   };
-  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
-    task().catch((error) => log.error("background_task.failed", { error }))
-  );
-  const backgroundTasks = { submit: waitUntil };
+  const backgroundTasks = createTestBackgroundTasks();
 
   const processor = new SessionSandboxEventProcessor(
     backgroundTasks,
@@ -126,7 +124,7 @@ function createProcessor() {
     broadcastPromptQueue,
     updateLastActivity,
     applySessionTitleUpdate,
-    waitUntil,
+    backgroundTasks,
     log,
   };
 }
@@ -161,11 +159,9 @@ describe("SessionSandboxEventProcessor", () => {
       timestamp: 2000,
     });
 
-    const settled = await Promise.allSettled(h.waitUntil.mock.results.map(({ value }) => value));
-    expect(settled.every(({ status }) => status === "fulfilled")).toBe(true);
-    expect(h.log.error).toHaveBeenCalledWith("background_task.failed", {
-      error: expect.any(Error),
-    });
+    await h.backgroundTasks.settle();
+    // The failed snapshot is absorbed by the boundary, not thrown at the caller.
+    expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
   });
 
   it("updates heartbeat without broadcasting", async () => {
@@ -469,7 +465,7 @@ describe("SessionSandboxEventProcessor", () => {
     expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
     expect(h.scheduleInactivityCheck).toHaveBeenCalledTimes(1);
     expect(h.processMessageQueue).toHaveBeenCalledTimes(1);
-    expect(h.waitUntil).toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).not.toHaveLength(0);
   });
 
   it("waits for terminal projection before snapshot, queue drain, and acknowledgement", async () => {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -82,8 +82,8 @@ function createProcessor() {
     error: vi.fn(),
     child: vi.fn(),
   };
-  const waitUntil = vi.fn((task: Promise<unknown>) =>
-    task.catch((error) => log.error("background_task.failed", { error }))
+  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
+    task().catch((error) => log.error("background_task.failed", { error }))
   );
   const backgroundTasks = { submit: waitUntil };
 

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -190,7 +190,7 @@ export class SessionSandboxEventProcessor {
       this.messenger.broadcast({ type: "sandbox_event", event });
 
       if (messageId) {
-        this.backgroundTasks.submit(this.callbackService.notifyToolCall(messageId, event), {
+        this.backgroundTasks.submit(() => this.callbackService.notifyToolCall(messageId, event), {
           name: "callback.notify_tool_call",
           context: { message_id: messageId },
         });
@@ -244,7 +244,7 @@ export class SessionSandboxEventProcessor {
         });
         this.broadcastPromptQueue();
         this.backgroundTasks.submit(
-          this.callbackService.notifyComplete(event.messageId, event.success, event.error),
+          () => this.callbackService.notifyComplete(event.messageId, event.success, event.error),
           {
             name: "callback.notify_complete",
             context: { message_id: event.messageId },
@@ -260,7 +260,7 @@ export class SessionSandboxEventProcessor {
         });
       }
 
-      this.backgroundTasks.submit(this.triggerSnapshot("execution_complete"), {
+      this.backgroundTasks.submit(() => this.triggerSnapshot("execution_complete"), {
         name: "snapshot.trigger",
         context: { reason: "execution_complete", message_id: event.messageId },
       });

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import { SessionStatusService } from "./session-status-service";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import type { Logger } from "../logger";
@@ -83,10 +84,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
     error: vi.fn(),
     child: vi.fn(),
   };
-  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
-    task().catch((error) => log.error("background_task.failed", { error }))
-  );
-  const backgroundTasks = { submit: waitUntil };
+  const backgroundTasks = createTestBackgroundTasks();
 
   const service = new SessionStatusService(
     backgroundTasks,
@@ -105,7 +103,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
     artifactRepository,
     broadcast,
     sessionIndex,
-    waitUntil,
+    backgroundTasks,
     parentSessions,
     parentFetch,
     log,
@@ -166,7 +164,7 @@ describe("SessionStatusService.transition", () => {
       messageCount: 3,
       prCount: 2,
     });
-    expect(h.waitUntil).toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).not.toHaveLength(0);
   });
 
   it("syncs metrics even when already in the terminal status", async () => {
@@ -211,7 +209,7 @@ describe("SessionStatusService.transition", () => {
     expect(await h.service.transition("completed")).toBe(true);
 
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
-    expect(h.waitUntil).not.toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).toHaveLength(0);
   });
 
   it("submits the parent notification as a background job", async () => {
@@ -231,7 +229,7 @@ describe("SessionStatusService.transition", () => {
       status: "completed",
       title: "Session title",
     });
-    expect(h.waitUntil).toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).not.toHaveLength(0);
   });
 
   it("does not notify a parent when the session has none", async () => {
@@ -407,7 +405,7 @@ describe("SessionStatusService.notifyParentOfChildUpdate", () => {
       status: "active",
       title: "New title",
     });
-    expect(h.waitUntil).toHaveBeenCalledTimes(1);
+    expect(h.backgroundTasks.submissions).toHaveLength(1);
   });
 
   it("logs (and does not throw) when the parent notification fails", async () => {
@@ -420,12 +418,11 @@ describe("SessionStatusService.notifyParentOfChildUpdate", () => {
       { status: "failed", title: null }
     );
 
-    // Drain the fire-and-forget promise handed to waitUntil.
-    await h.waitUntil.mock.results[0]!.value;
+    // Drain the fire-and-forget notification; its failure is absorbed by the
+    // boundary rather than thrown at the caller.
+    await h.backgroundTasks.settle();
 
-    expect(h.log.error).toHaveBeenCalledWith("background_task.failed", {
-      error: expect.any(Error),
-    });
+    expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
   });
 
   it("is a no-op without a parent session id", () => {
@@ -437,6 +434,6 @@ describe("SessionStatusService.notifyParentOfChildUpdate", () => {
     });
 
     expect(h.parentSessions.idFromName).not.toHaveBeenCalled();
-    expect(h.waitUntil).not.toHaveBeenCalled();
+    expect(h.backgroundTasks.submissions).toHaveLength(0);
   });
 });

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -83,8 +83,8 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
     error: vi.fn(),
     child: vi.fn(),
   };
-  const waitUntil = vi.fn((task: Promise<unknown>) =>
-    task.catch((error) => log.error("background_task.failed", { error }))
+  const waitUntil = vi.fn((task: () => Promise<unknown>) =>
+    task().catch((error) => log.error("background_task.failed", { error }))
   );
   const backgroundTasks = { submit: waitUntil };
 

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -190,17 +190,18 @@ export class SessionStatusService {
     const parentStub = this.parentSessions.get(parentDoId);
 
     this.backgroundTasks.submit(
-      parentStub.fetch(
-        new Request(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            childSessionId,
-            status: update.status,
-            title: update.title,
-          }),
-        })
-      ),
+      () =>
+        parentStub.fetch(
+          new Request(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              childSessionId,
+              status: update.status,
+              title: update.title,
+            }),
+          })
+        ),
       {
         name: "session.notify_parent",
         context: {
@@ -254,7 +255,8 @@ export class SessionStatusService {
   }
 
   private syncSessionMetrics(sessionId: string): void {
-    if (!this.sessionIndex) return;
+    const sessionIndex = this.sessionIndex;
+    if (!sessionIndex) return;
 
     const session = this.repository.getSession();
     if (!session) return;
@@ -265,12 +267,13 @@ export class SessionStatusService {
     const prCount = artifacts.filter((a) => a.type === "pr").length;
 
     this.backgroundTasks.submit(
-      this.sessionIndex.updateMetrics(sessionId, {
-        totalCost: session.total_cost ?? 0,
-        activeDurationMs,
-        messageCount,
-        prCount,
-      }),
+      () =>
+        sessionIndex.updateMetrics(sessionId, {
+          totalCost: session.total_cost ?? 0,
+          activeDurationMs,
+          messageCount,
+          prCount,
+        }),
       {
         name: "session_index.update_metrics",
         context: { session_id: sessionId },

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -117,8 +117,9 @@ async function handleGitHubAutomationEvent(
     return validated.response;
   }
 
-  const lifecycleWork = trackPullRequestLifecycle(env, validated.event, ctx);
-  ctx.executionCtx.submit(lifecycleWork, { name: "github_webhook.lifecycle" });
+  ctx.executionCtx.submit(() => trackPullRequestLifecycle(env, validated.event, ctx), {
+    name: "github_webhook.lifecycle",
+  });
 
   return forwardAutomationEventToScheduler(env, validated.event, ctx);
 }

--- a/packages/control-plane/test/integration/session-do-collaborator-wiring.test.ts
+++ b/packages/control-plane/test/integration/session-do-collaborator-wiring.test.ts
@@ -268,8 +268,9 @@ describe("SessionDO collaborator wiring", () => {
       // scheduling from init altogether also returns 200. The read count is
       // what pins that init still reaches the warm-spawn edge, so the 200 is
       // evidence the throw was absorbed rather than evidence it never happened.
-      // `warmSandbox()` is async, but an async body runs synchronously up to
-      // its first await, so the getter read lands before init responds.
+      // `submit` invokes the warm-spawn task factory synchronously inside its
+      // own try/catch, so the getter read still lands before init responds and
+      // the throw is logged as background_task.failed instead of escaping.
       const getterReads = await runInDurableObject(
         stub,
         (instance: SessionDO) => (instance as unknown as Record<string, number>)[GETTER_READS] ?? 0


### PR DESCRIPTION
## What

`BackgroundTasks.submit` now takes a **task factory** (`() => Promise<unknown>`) instead of an already-started promise, and invokes it synchronously inside try/catch. A synchronous throw while building the task — the canonical case being a lazy getter whose construction throws on missing provider env — becomes a logged `background_task.failed` instead of escaping the caller.

This is the follow-up promised in the #1583 review: that PR had to keep a named `warmSandbox()` method alive purely as an async boundary, because with `submit(promise)` the safety of the call depended on the call-site expression shape. With the factory signature the boundary is structural, so this PR **deletes that method** (and its 11-line justification comment) and inlines `() => this.lifecycleManager.warmSandbox()` at the one call site.

## Why synchronous invocation (not `Promise.resolve().then(task)`)

Under the old signature, the task expression always executed synchronously before `submit` was entered. Invoking the factory synchronously preserves that timing exactly at all 23 call sites; a microtask deferral would change execution order everywhere for zero benefit. The observable contract is identical either way: synchronous throws are absorbed and logged, `waitUntil` is only called with a real promise. A unit test pins the synchronous-execution semantics so a future "cleanup" to microtask deferral fails loudly.

## Scope

- 23 production call sites across 11 files converted to factories; 7 test fakes updated to invoke the factory (so background work still runs in tests with the same timing as before).
- Four sites passed a pre-created promise variable; three (`webhooks/github.ts`, `image-builds/save-hooks.ts`, `message-queue.ts`'s projection chain) moved creation inside the factory — for `save-hooks.ts` this also pulls the synchronous workflow construction inside the absorbed boundary, killing the exact bug class this refactor targets.
- The fourth, `routes/repos.ts`, deliberately keeps one shared promise: the HTTP response awaits the **same** refresh run that `submit` keeps alive past client disconnect, so moving creation inside the factory would double-execute the SCM refresh. `submit(() => refresh)` + a comment; safe because `refreshReposCache` is an `async function` and cannot throw synchronously.
- `test/integration/session-do-collaborator-wiring.test.ts` still passes both guards for the warm-spawn edge — the shadowed-getter read counter and the provider-env-throw test (`/internal/init` returns 200 with the throw absorbed and logged). Its mechanism comment now describes the new contract.

## Verification

Red-first on the implementation's unit tests (4/4 failed against the old code with `TypeError: task.catch is not a function`, green after). Typecheck (both tsconfigs — noting `test/integration/**` is not typechecked, the converted paths there were exercised by running 7 integration files), full unit suite, full integration suite (80 files / 995 tests), Prettier all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background operations by handling immediate and asynchronous failures.
  * Prevented background-task setup errors from interrupting primary request processing.
  * Preserved error logging across session, repository, image-build, webhook, and notification workflows.

* **Refactor**
  * Background work is now deferred until scheduled, avoiding unnecessary early execution.
  * Updated related workflows and test coverage to support consistent task scheduling and failure handling.
  * Added shared testing support for verifying submitted tasks and captured failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->