### PR TITLE
ci: skip checks for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- skip the main CI workflow when a pull request or push changes only Markdown files or content under `docs/`
- continue running full CI whenever documentation changes are mixed with code or configuration changes

## Motivation

PR #1571 changed only `CHANGELOG.md`, but triggered all 14 CI jobs. This is the first, narrowly scoped improvement in a broader effort to make CI package-aware.

## Validation

- `npx prettier --check .github/workflows/ci.yml`
- `git diff --check`

`actionlint` was not available in the local environment.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6a9584bdf48356904b0771920dcb9482)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration triggers to skip documentation-only changes, reducing unnecessary workflow runs for Markdown and documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->