### PR TITLE
fix(control-plane): select broker secret sources structurally

### DIFF
--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -115,7 +115,7 @@ describe("buildSessionTargetSecretSources", () => {
       "acme/backend": { B: "backend" },
     };
 
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true), member("acme", "backend", 1, false)],
@@ -125,12 +125,13 @@ describe("buildSessionTargetSecretSources", () => {
 
     // Primary (acme/web) is appended last so mergeSecretSources lets it win.
     expect(sources.map((s) => s.label)).toEqual(["global", "acme/backend", "acme/web"]);
+    expect(brokerSources.map((s) => s.label)).toEqual(["global", "acme/web"]);
   });
 
   it("folds global + environment for an environment-launched session — member repos never inherit", async () => {
     const loadMemberSecrets = vi.fn();
 
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: "env_flagship",
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true)],
@@ -140,12 +141,13 @@ describe("buildSessionTargetSecretSources", () => {
     });
 
     expect(sources.map((s) => s.label)).toEqual(["global", "environment"]);
+    expect(brokerSources.map((s) => s.label)).toEqual(["global", "environment"]);
     // Member repo secrets are never sourced for an environment session.
     expect(loadMemberSecrets).not.toHaveBeenCalled();
   });
 
   it("returns only global for an environment session with no environment secrets", async () => {
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: "env_empty",
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true)],
@@ -154,10 +156,11 @@ describe("buildSessionTargetSecretSources", () => {
     });
 
     expect(sources.map((s) => s.label)).toEqual(["global"]);
+    expect(brokerSources.map((s) => s.label)).toEqual(["global"]);
   });
 
   it("omits members that contribute no secrets", async () => {
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: {},
       members: [member("acme", "web", 0, true), member("acme", "empty", 1, false)],
@@ -167,10 +170,11 @@ describe("buildSessionTargetSecretSources", () => {
     });
 
     expect(sources.map((s) => s.label)).toEqual(["global", "acme/web"]);
+    expect(brokerSources.map((s) => s.label)).toEqual(["global", "acme/web"]);
   });
 
   it("returns only global when there are no members", async () => {
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: { G: "g" },
       members: [],
@@ -179,5 +183,6 @@ describe("buildSessionTargetSecretSources", () => {
     });
 
     expect(sources).toEqual([{ label: "global", secrets: { G: "g" } }]);
+    expect(brokerSources).toEqual(sources);
   });
 });

--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -128,6 +128,18 @@ describe("buildSessionTargetSecretSources", () => {
     expect(brokerSources.map((s) => s.label)).toEqual(["global", "acme/web"]);
   });
 
+  it("admits only the first member when duplicate entries are marked primary", async () => {
+    const { brokerSources } = await buildSessionTargetSecretSources({
+      environmentId: null,
+      globalSecrets: {},
+      members: [member("Acme", "Web", 0, true), member("acme", "web", 1, true)],
+      loadMemberSecrets: async (m) => ({ TOKEN: `${m.repoOwner}/${m.repoName}` }),
+      loadEnvironmentSecrets: noEnvironmentSecrets,
+    });
+
+    expect(brokerSources.map((s) => s.label)).toEqual(["global", "Acme/Web"]);
+  });
+
   it("folds global + environment for an environment-launched session — member repos never inherit", async () => {
     const loadMemberSecrets = vi.fn();
 

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -84,13 +84,14 @@ export async function buildSessionTargetSecretSources(
   }
 
   const brokerSources = [globalSource];
+  const primary = input.members.find((member) => member.isPrimary);
   // Reverse position order: the primary (position 0) merges last and wins.
   for (const member of [...input.members].reverse()) {
     const secrets = await input.loadMemberSecrets(member);
     if (Object.keys(secrets).length > 0) {
       const source = { label: `${member.repoOwner}/${member.repoName}`, secrets };
       sources.push(source);
-      if (member.isPrimary) brokerSources.push(source);
+      if (member === primary) brokerSources.push(source);
     }
   }
   return { sources, brokerSources };

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -51,6 +51,13 @@ export interface SessionTargetSecretSourcesInput {
   loadEnvironmentSecrets: (environmentId: string) => Promise<Record<string, string>>;
 }
 
+export interface SessionTargetSecretSources {
+  /** All sources exposed to the sandbox. */
+  sources: SecretSource[];
+  /** Sources permitted to feed managed-provider broker credentials. */
+  brokerSources: SecretSource[];
+}
+
 /**
  * Build the ordered secret sources for a session target, lowest
  * precedence first (design §6.4). Global is always the base; environment-
@@ -64,23 +71,27 @@ export interface SessionTargetSecretSourcesInput {
  */
 export async function buildSessionTargetSecretSources(
   input: SessionTargetSecretSourcesInput
-): Promise<SecretSource[]> {
-  const sources: SecretSource[] = [{ label: "global", secrets: input.globalSecrets }];
+): Promise<SessionTargetSecretSources> {
+  const globalSource: SecretSource = { label: "global", secrets: input.globalSecrets };
+  const sources: SecretSource[] = [globalSource];
 
   if (input.environmentId !== null) {
     const environmentSecrets = await input.loadEnvironmentSecrets(input.environmentId);
     if (Object.keys(environmentSecrets).length > 0) {
       sources.push({ label: "environment", secrets: environmentSecrets });
     }
-    return sources;
+    return { sources, brokerSources: sources };
   }
 
+  const brokerSources = [globalSource];
   // Reverse position order: the primary (position 0) merges last and wins.
   for (const member of [...input.members].reverse()) {
     const secrets = await input.loadMemberSecrets(member);
     if (Object.keys(secrets).length > 0) {
-      sources.push({ label: `${member.repoOwner}/${member.repoName}`, secrets });
+      const source = { label: `${member.repoOwner}/${member.repoName}`, secrets };
+      sources.push(source);
+      if (member.isPrimary) brokerSources.push(source);
     }
   }
-  return sources;
+  return { sources, brokerSources };
 }

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -147,7 +147,7 @@ export class UserEnvResolver {
     const repoStore = new RepoSecretsStore(db, encryptionKey);
     const environmentSecretsStore = new EnvironmentSecretsStore(db, encryptionKey);
     const members = this.sessionCoreRepository.getSessionRepositories();
-    const sources = await buildSessionTargetSecretSources({
+    const { sources, brokerSources } = await buildSessionTargetSecretSources({
       environmentId: session.environment_id,
       globalSecrets,
       members,
@@ -174,15 +174,7 @@ export class UserEnvResolver {
       });
     }
 
-    const primary = members.find((member) => member.isPrimary);
-    const managedSources = session.environment_id
-      ? sources
-      : sources.filter(
-          (source) =>
-            source.label === "global" ||
-            (primary && source.label === `${primary.repoOwner}/${primary.repoName}`)
-        );
-    const managedSecrets = mergeSecretSources(managedSources).merged;
+    const managedSecrets = mergeSecretSources(brokerSources).merged;
     const sandboxEnv = prepareManagedProviderEnv({
       exposedSecrets: merge.merged,
       brokerSecrets: managedSecrets,


### PR DESCRIPTION
## Summary
- return the managed-provider broker source set directly from session-target secret policy
- stop `UserEnvResolver` from treating `SecretSource.label` as a security-policy discriminator
- pin broker eligibility for repo, environment, empty-source, and ad-hoc session targets

## Testing
- `npm test -w @open-inspect/control-plane` (203 files, 3166 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint --workspace @open-inspect/control-plane`
- `git diff --check`

Closes #1588

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/796880ddefc566a1b39e3947bc6c367c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret handling for sessions launched from environments.
  * Managed-provider credentials now use only approved global and primary repository sources.
  * Preserved access to relevant member secrets while preventing secondary repository secrets from being used for broker credentials.
  * Ensured duplicate primary repository entries do not expand credential access unexpectedly.
  * Maintained consistent behavior when environments or repository members are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->