### PR TITLE
refactor(control-plane): make SessionDO an adapter over SessionRuntime

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,6 +139,34 @@ export default tseslint.config(
     },
   },
 
+  // The session composition root is the platform adapter's private wiring:
+  // only durable-object.ts may import it. This is what keeps "composition
+  // root" a governed invariant rather than a convention — services take their
+  // dependencies as constructor inputs, never by reaching into the root.
+  // (Uses the base rule so it stacks with the repo-wide
+  // @typescript-eslint/no-restricted-imports paths above.)
+  {
+    files: ["packages/control-plane/src/**/*.ts"],
+    ignores: [
+      "packages/control-plane/src/session/durable-object.ts",
+      "packages/control-plane/src/**/*.test.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/session/components", "./components"],
+              message:
+                "Only the platform adapter (session/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // React-specific configuration for web package
   {
     files: ["packages/web/**/*.{ts,tsx}"],

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -3674,3 +3674,57 @@ describe("SandboxLifecycleManager", () => {
     });
   });
 });
+
+describe("SandboxLifecycleManager log context", () => {
+  it("derives session_id from getSessionId per use, upgrading once the id changes", async () => {
+    let currentId = "do-fallback-id";
+    const manager = new SandboxLifecycleManager(
+      createMockProvider(),
+      createMockStorage(null),
+      createMockBroadcaster(),
+      createMockWebSocketManager(false),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      { ...createTestConfig(), getSessionId: () => currentId }
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    // The no-session spawn guard is the cheapest this.log-emitting operation.
+    await manager.spawnSandbox();
+    currentId = "public-session-name";
+    await manager.spawnSandbox();
+
+    const errorLogs = parseStructuredLogs(errorSpy);
+    errorSpy.mockRestore();
+
+    // A constructor-time capture (the pre-composition-root behavior) would
+    // stamp both lines with the first id; a latched-first-value memo would
+    // never upgrade. Each line must carry the id current at emit time.
+    const contexts = errorLogs
+      .filter((line) => line.msg === "Cannot spawn sandbox: no session")
+      .map((line) => line.session_id);
+    expect(contexts).toEqual(["do-fallback-id", "public-session-name"]);
+  });
+
+  it("omits session_id entirely when no getSessionId is configured", async () => {
+    const manager = new SandboxLifecycleManager(
+      createMockProvider(),
+      createMockStorage(null),
+      createMockBroadcaster(),
+      createMockWebSocketManager(false),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await manager.spawnSandbox();
+
+    const errorLogs = parseStructuredLogs(errorSpy);
+    errorSpy.mockRestore();
+
+    const line = errorLogs.find((entry) => entry.msg === "Cannot spawn sandbox: no session");
+    expect(line).toBeDefined();
+    expect(line).not.toHaveProperty("session_id");
+  });
+});

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -199,8 +199,13 @@ export interface SandboxLifecycleConfig {
   controlPlaneUrl: string;
   /** Default model ID used when the session has no model override. */
   model: string;
-  /** Session ID for log correlation. Optional — logs will omit sessionId if not provided. */
-  sessionId?: string;
+  /**
+   * Session ID for log correlation, resolved per use. Optional — logs will
+   * omit sessionId if not provided. A thunk rather than a value because the
+   * manager can be constructed during the init request, before the session
+   * row (and its public id) exists.
+   */
+  getSessionId?: () => string;
   /** MCP server lookup for injecting servers into sandboxes. */
   mcpServerLookup?: McpServerLookup;
   /** Resolves the spawn-time agent-slack-notify gate. */
@@ -304,8 +309,26 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   private isSpawningSandbox = false;
   private providerStartupPending = false;
 
-  /** Session-scoped logger. Falls back to module-level logger if no sessionId configured. */
-  private readonly log: Logger;
+  /** Memoized session-scoped logger, keyed by the resolved session id. */
+  private logMemo?: { sessionId: string | undefined; logger: Logger };
+
+  /**
+   * Session-scoped logger. Falls back to the module-level logger if no
+   * session id is configured. Re-derived when the resolved id changes, so a
+   * manager built before the session row exists picks up the public id.
+   */
+  private get log(): Logger {
+    const sessionId = this.config.getSessionId?.();
+    let memo = this.logMemo;
+    if (!memo || memo.sessionId !== sessionId) {
+      memo = {
+        sessionId,
+        logger: sessionId ? log.child({ session_id: sessionId }) : log,
+      };
+      this.logMemo = memo;
+    }
+    return memo.logger;
+  }
 
   constructor(
     private readonly provider: SandboxProvider,
@@ -316,9 +339,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     private readonly idGenerator: IdGenerator,
     private readonly config: SandboxLifecycleConfig,
     private readonly imageBuildLookup?: ImageBuildLookup
-  ) {
-    this.log = config.sessionId ? log.child({ session_id: config.sessionId }) : log;
-  }
+  ) {}
 
   /**
    * Spawn a sandbox (fresh or from snapshot).

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -36,7 +36,7 @@ function createHandler() {
     messageQueue,
     lifecycleManager,
     alarmScheduler,
-    executionTimeoutMs: 1000,
+    getExecutionTimeoutMs: () => 1000,
     now,
     log,
   });
@@ -127,7 +127,7 @@ describe("createAlarmHandler", () => {
       messageQueue,
       lifecycleManager,
       alarmScheduler,
-      executionTimeoutMs: 1000,
+      getExecutionTimeoutMs: () => 1000,
       now: () => 2000,
       log: createHandler().log,
     });

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -15,7 +15,8 @@ export interface AlarmHandlerDeps {
   >;
   lifecycleManager: Pick<SandboxLifecycleManager, "handleAlarm">;
   alarmScheduler: AlarmScheduler;
-  executionTimeoutMs: number;
+  /** Resolved per use so it honors settings persisted after construction. */
+  getExecutionTimeoutMs: () => number;
   now: () => number;
   /** Session-scoped logger — alarms run outside any request, so there is no request correlation. */
   log: Logger;
@@ -42,9 +43,10 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
       const processing = deps.repository.getProcessingMessageWithStartedAt();
       if (processing?.started_at) {
         const now = deps.now();
+        const executionTimeoutMs = deps.getExecutionTimeoutMs();
         const result = evaluateExecutionTimeout(
           processing.started_at,
-          { timeoutMs: deps.executionTimeoutMs },
+          { timeoutMs: executionTimeoutMs },
           now
         );
         if (result.isTimedOut) {
@@ -52,14 +54,14 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
             event: "execution.timeout",
             message_id: processing.id,
             elapsed_ms: result.elapsedMs,
-            timeout_ms: deps.executionTimeoutMs,
+            timeout_ms: executionTimeoutMs,
           });
           await deps.messageQueue.failStuckProcessingMessage();
         } else {
           // An earlier lifecycle alarm has consumed the Durable Object's single
           // alarm slot. Reassert this message's deadline before lifecycle handling
           // schedules its next check so stuck-message recovery cannot be delayed.
-          await deps.alarmScheduler.schedule(processing.started_at + deps.executionTimeoutMs);
+          await deps.alarmScheduler.schedule(processing.started_at + executionTimeoutMs);
         }
       }
 

--- a/packages/control-plane/src/session/components.test.ts
+++ b/packages/control-plane/src/session/components.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SandboxProvider } from "../sandbox/provider";
+import { createDeferredSandboxProvider } from "./components";
+
+function realProvider(overrides: Partial<SandboxProvider> = {}): SandboxProvider {
+  return {
+    name: "fake",
+    capabilities: {
+      supportsSnapshots: true,
+      supportsRestore: true,
+      supportsPersistentResume: false,
+      supportsExplicitStop: false,
+      supportsSandboxTimeout: false,
+    } as SandboxProvider["capabilities"],
+    createSandbox: vi.fn(async () => ({ sandboxId: "sb-1", status: "pending" }) as never),
+    takeSnapshot: vi.fn(async () => ({ success: true }) as never),
+    ...overrides,
+  };
+}
+
+describe("createDeferredSandboxProvider", () => {
+  it("does not invoke the factory until a member is touched, then memoizes", () => {
+    const create = vi.fn(() => realProvider());
+    const deferred = createDeferredSandboxProvider(create);
+
+    expect(create).not.toHaveBeenCalled();
+
+    expect(deferred.name).toBe("fake");
+    expect(deferred.capabilities.supportsSnapshots).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the construction error at first touch, not at adapter creation", () => {
+    const create = vi.fn((): SandboxProvider => {
+      throw new Error("MODAL_API_SECRET and MODAL_WORKSPACE are required");
+    });
+
+    const deferred = createDeferredSandboxProvider(create);
+    expect(create).not.toHaveBeenCalled();
+
+    expect(() => deferred.capabilities).toThrow("MODAL_API_SECRET and MODAL_WORKSPACE");
+    // A throwing factory is not latched: the next touch retries construction,
+    // matching the retry the lazy getter used to provide.
+    expect(() => deferred.name).toThrow("MODAL_API_SECRET and MODAL_WORKSPACE");
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("delegates calls to the single constructed provider", async () => {
+    const provider = realProvider();
+    const create = vi.fn(() => provider);
+    const deferred = createDeferredSandboxProvider(create);
+
+    await deferred.createSandbox({} as never);
+    await deferred.takeSnapshot!({} as never);
+
+    expect(provider.createSandbox).toHaveBeenCalledTimes(1);
+    expect(provider.takeSnapshot).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("mirrors optional-method presence so capability probes stay truthful", () => {
+    const withoutOptionals = createDeferredSandboxProvider(() =>
+      realProvider({ takeSnapshot: undefined, restoreFromSnapshot: undefined })
+    );
+    const withOptionals = createDeferredSandboxProvider(() =>
+      realProvider({ restoreFromSnapshot: vi.fn(async () => ({ success: true }) as never) })
+    );
+
+    // The lifecycle manager gates snapshot/restore/resume/stop on presence
+    // checks like `!this.provider.takeSnapshot` — the adapter must not turn an
+    // absent method into a present one.
+    expect(withoutOptionals.takeSnapshot).toBeUndefined();
+    expect(withoutOptionals.restoreFromSnapshot).toBeUndefined();
+    expect(withoutOptionals.resumeSandbox).toBeUndefined();
+    expect(withoutOptionals.stopSandbox).toBeUndefined();
+    expect(withOptionals.restoreFromSnapshot).toBeTypeOf("function");
+  });
+});

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -1,0 +1,910 @@
+/**
+ * Composition root for one session runtime.
+ *
+ * `createSessionComponents` builds the entire collaborator graph eagerly, in
+ * topological order, with exactly one session-scoped logger created before
+ * anything can capture it. `SessionDO.ensureInitialized()` is the single call
+ * site; the schema must already be applied when this runs, because the factory
+ * reads the session row to derive the logger's `session_id`.
+ *
+ * The only deferred constructions left are the two provider factories, both of
+ * which throw on reachable configurations (`createSandboxProviderFromEnv` on
+ * missing provider credentials, `createSourceControlProviderFromEnv` on an
+ * invalid `SCM_PROVIDER`, GitLab without a token, or Bitbucket). Deferring
+ * them — behind `once()` at this root, not behind lazy getters on the DO —
+ * keeps `/internal/init` succeeding on such deployments: the failure surfaces
+ * at the operation that needs the provider and is absorbed by the background
+ * task boundary, instead of failing every request at initialization.
+ */
+
+import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+import { resolveAppName } from "@open-inspect/shared/app-name";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
+import { generateId, hashToken, encryptToken } from "../auth/crypto";
+import { resolveSandboxBackendName, type SandboxBackendName } from "../sandbox/provider-name";
+import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
+import type { SandboxProvider } from "../sandbox/provider";
+import { DEFAULT_SANDBOX_TIMEOUT_SECONDS } from "../sandbox/provider";
+import { createImageBuildLookup } from "../image-builds/lookup";
+import { resolveImageBuildProvider } from "../image-builds/provider-policy";
+import { createLogger, parseLogLevel } from "../logger";
+import type { Logger } from "../logger";
+import {
+  SandboxLifecycleManager,
+  DEFAULT_LIFECYCLE_CONFIG,
+  type SandboxStorage,
+  type SandboxBroadcaster,
+  type WebSocketManager,
+  type IdGenerator,
+  type ImageBuildLookup,
+  type McpServerLookup,
+  type SlackAgentNotifyLookup,
+} from "../sandbox/lifecycle/manager";
+import { McpServerStore } from "../db/mcp-servers";
+import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
+import { SessionIndexStore } from "../db/session-index";
+import { parsePersistedSandboxSettings } from "../sandbox/settings";
+import {
+  createSourceControlProviderFromEnv,
+  resolveScmProviderFromEnv,
+  type SourceControlProvider,
+} from "../source-control";
+import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
+import { SessionCoreRepository } from "./session-core-repository";
+import { SandboxRepository } from "./sandbox-repository";
+import { SessionAttachmentRepository } from "./session-attachment-repository";
+import { ArtifactRepository } from "./artifact-repository";
+import { EventRepository } from "./event-repository";
+import { MessageRepository } from "./message-repository";
+import { ParticipantRepository } from "./participant-repository";
+import { WsClientMappingRepository } from "./ws-client-mapping-repository";
+import { resolvePublicSessionId } from "./public-session-id";
+import { resolveScmSettings } from "./scm-settings-resolution";
+import { validateReasoningEffort } from "./reasoning-effort";
+import {
+  isValidSandboxToken,
+  resolveSandboxDashboardUrl,
+  type SandboxDashboardSettings,
+} from "./sandbox-access";
+import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
+import { DurableObjectSessionConnections } from "./durable-object-session-connections";
+import { SessionPullRequestStore } from "../db/session-pull-request-store";
+import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
+import { refreshSessionPullRequests } from "./pull-request-refresh";
+import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
+import { XaiTokenRefreshService } from "./xai-token-refresh-service";
+import { ScmCredentialsService } from "./scm-credentials-service";
+import { ParticipantService } from "./participant-service";
+import { UserScmTokenStore } from "../db/user-scm-tokens";
+import { CallbackNotificationService } from "./callback-notification-service";
+import { UserEnvResolver } from "./user-env-resolver";
+import { resolveSessionRepoId } from "./repo-id-resolution";
+import { Scheduler } from "../scheduler/scheduler";
+import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
+import type { BackgroundTasks } from "../platform-ports";
+import { PresenceService } from "./presence-service";
+import { SessionMessageQueue } from "./message-queue";
+import { SessionSandboxEventProcessor } from "./sandbox-events";
+import { SessionTerminalMessageProjection } from "./terminal-message-projection";
+import { SessionEventStream } from "./event-stream";
+import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
+import {
+  createChildSessionsHandler,
+  type ChildSessionsHandler,
+} from "./http/handlers/child-sessions.handler";
+import { createSandboxHandler, type SandboxHandler } from "./http/handlers/sandbox.handler";
+import { AttachmentsHandler } from "./http/handlers/attachments.handler";
+import { createWsTokenHandler, type WsTokenHandler } from "./http/handlers/ws-token.handler";
+import {
+  createSessionLifecycleHandler,
+  type SessionLifecycleHandler,
+} from "./http/handlers/session-lifecycle.handler";
+import {
+  createPullRequestHandler,
+  type PullRequestHandler,
+} from "./http/handlers/pull-request.handler";
+import {
+  createParticipantsHandler,
+  type ParticipantsHandler,
+} from "./http/handlers/participants.handler";
+import { MessageService } from "./services/message.service";
+import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
+import {
+  createEarliestAlarmScheduler,
+  PersistedAlarmDeadlineStore,
+  type RehydratableAlarmScheduler,
+} from "./alarm/scheduler";
+import { SessionDiffStore } from "./diffs/store";
+import { SessionDiffService } from "./diffs/service";
+import { SessionDiffsHandler } from "./http/handlers/session-diffs.handler";
+import { SessionMessengerImpl, type SessionMessenger } from "./messenger";
+import { SessionStatusService } from "./session-status-service";
+import { SessionTitleService } from "./title-service";
+import { parseArtifactMetadata } from "./artifact-metadata";
+
+/**
+ * Timeout for WebSocket authentication (in milliseconds).
+ * Client WebSockets must send a valid 'subscribe' message within this time
+ * or the connection will be closed. This prevents resource abuse from
+ * unauthenticated connections that never complete the handshake.
+ */
+const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
+
+/** The platform surface the session graph is built over. */
+export interface SessionPlatform {
+  ctx: DurableObjectState;
+  sql: SqlStorage;
+  db: SqlDatabase | null;
+}
+
+export interface SessionComponents {
+  log: Logger;
+  backgroundTasks: BackgroundTasks;
+  // Repositories over the DO-embedded SQLite.
+  sessionCoreRepository: SessionCoreRepository;
+  sandboxRepository: SandboxRepository;
+  attachmentRepository: SessionAttachmentRepository;
+  artifactRepository: ArtifactRepository;
+  eventRepository: EventRepository;
+  messageRepository: MessageRepository;
+  participantRepository: ParticipantRepository;
+  wsClientMappingRepository: WsClientMappingRepository;
+  // Alarm persistence and scheduling.
+  alarmDeadlines: PersistedAlarmDeadlineStore;
+  alarmScheduler: RehydratableAlarmScheduler;
+  alarmHandler: AlarmHandler;
+  // Sockets and messaging.
+  wsManager: SessionWebSocketManager;
+  connections: DurableObjectSessionConnections;
+  messenger: SessionMessenger;
+  // Immutable env projection for the provider dashboard link.
+  sandboxDashboardSettings: SandboxDashboardSettings;
+  /** Deferred: `createSourceControlProviderFromEnv` throws on reachable configs. */
+  sourceControlProvider: () => SourceControlProvider;
+  // Domain services.
+  userEnvResolver: UserEnvResolver;
+  participantService: ParticipantService;
+  callbackService: CallbackNotificationService;
+  presenceService: PresenceService;
+  statusService: SessionStatusService;
+  titleService: SessionTitleService;
+  terminalMessageProjection: SessionTerminalMessageProjection;
+  diffService: SessionDiffService;
+  eventStream: SessionEventStream;
+  lifecycleManager: SandboxLifecycleManager;
+  messageQueue: SessionMessageQueue;
+  messageService: MessageService;
+  sandboxEventProcessor: SessionSandboxEventProcessor;
+  /** Fire a background read-through refresh of the session's PR artifacts. */
+  schedulePullRequestRefresh: (trigger: "open" | "manual") => void;
+  // Internal HTTP handlers.
+  messagesHandler: MessagesHandler;
+  childSessionsHandler: ChildSessionsHandler;
+  sandboxHandler: SandboxHandler;
+  attachmentsHandler: AttachmentsHandler;
+  wsTokenHandler: WsTokenHandler;
+  sessionLifecycleHandler: SessionLifecycleHandler;
+  pullRequestHandler: PullRequestHandler;
+  participantsHandler: ParticipantsHandler;
+  diffsHandler: SessionDiffsHandler;
+}
+
+/** `resolveSandboxBackendName` throws on unsupported values; graph-time uses need null instead. */
+function tryResolveSandboxBackendName(value: string | undefined): SandboxBackendName | null {
+  try {
+    return resolveSandboxBackendName(value);
+  } catch {
+    return null;
+  }
+}
+
+/** Memoize a factory so its (possibly throwing) construction runs at most once. */
+function once<T>(create: () => T): () => T {
+  let value: T | undefined;
+  let created = false;
+  return () => {
+    if (!created) {
+      value = create();
+      created = true;
+    }
+    return value as T;
+  };
+}
+
+/**
+ * Adapt a deferred provider factory to the `SandboxProvider` interface.
+ *
+ * The lifecycle manager takes a provider instance; constructing one throws on
+ * deployments missing provider credentials. Every member defers to the real
+ * provider on first touch, so the construction error surfaces inside the
+ * spawn/snapshot operation that needed it (an absorbed background-task
+ * rejection) rather than at graph construction.
+ */
+export function createDeferredSandboxProvider(create: () => SandboxProvider): SandboxProvider {
+  const resolve = once(create);
+  return {
+    get name() {
+      return resolve().name;
+    },
+    get capabilities() {
+      return resolve().capabilities;
+    },
+    createSandbox: (config) => resolve().createSandbox(config),
+    get restoreFromSnapshot() {
+      const provider = resolve();
+      const restore = provider.restoreFromSnapshot;
+      return restore && restore.bind(provider);
+    },
+    get resumeSandbox() {
+      const provider = resolve();
+      const resume = provider.resumeSandbox;
+      return resume && resume.bind(provider);
+    },
+    get takeSnapshot() {
+      const provider = resolve();
+      const snapshot = provider.takeSnapshot;
+      return snapshot && snapshot.bind(provider);
+    },
+    get stopSandbox() {
+      const provider = resolve();
+      const stop = provider.stopSandbox;
+      return stop && stop.bind(provider);
+    },
+  };
+}
+
+/**
+ * The execution watchdog deadline for the current session settings. Resolved
+ * per use (not at construction) so a deadline armed after `init` persists the
+ * session row honors that row's `sandbox_settings` override.
+ */
+function resolveExecutionTimeoutMs(
+  sessionCoreRepository: SessionCoreRepository,
+  env: Env,
+  log: Logger
+): number {
+  try {
+    const sandboxTimeoutMs = parsePersistedSandboxSettings(
+      sessionCoreRepository.getSession()?.sandbox_settings ?? null
+    ).sandboxTimeoutMs;
+    // This watchdog starts before bridge setup, so it must not race the
+    // bridge's earlier snapshot-reserved prompt deadline.
+    if (sandboxTimeoutMs !== undefined) return sandboxTimeoutMs;
+  } catch {
+    log.warn("Failed to parse sandbox_settings for execution timeout, using fallback");
+  }
+  return parseInt(env.EXECUTION_TIMEOUT_MS || String(DEFAULT_SANDBOX_TIMEOUT_SECONDS * 1000), 10);
+}
+
+export function createSessionComponents(platform: SessionPlatform, env: Env): SessionComponents {
+  const { ctx, sql, db } = platform;
+  const durableObjectId = ctx.id.toString();
+  const transaction = <T>(closure: () => T): T => ctx.storage.transactionSync(closure);
+
+  // Tier 1 — repositories and alarm persistence (leaves over SqlStorage).
+  const attachmentRepository = new SessionAttachmentRepository(sql);
+  const artifactRepository = new ArtifactRepository(sql);
+  const eventRepository = new EventRepository(sql, transaction);
+  const messageRepository = new MessageRepository(
+    sql,
+    transaction,
+    attachmentRepository,
+    eventRepository
+  );
+  const participantRepository = new ParticipantRepository(sql);
+  const wsClientMappingRepository = new WsClientMappingRepository(sql);
+  const sessionCoreRepository = new SessionCoreRepository(sql, transaction);
+  const alarmDeadlines = new PersistedAlarmDeadlineStore(sql);
+
+  // The session-scoped logger, created before anything can capture a logger at
+  // all. Before `init` writes the session row this resolves to the Durable
+  // Object id; the lifecycle manager re-derives its log context per use, so it
+  // picks up the public session id once the row exists.
+  const session = sessionCoreRepository.getSession();
+  const log = createLogger(
+    "session-do",
+    { session_id: resolvePublicSessionId(session, durableObjectId) },
+    parseLogLevel(env.LOG_LEVEL)
+  );
+  const backgroundTasks = createCloudflareBackgroundTasks(ctx, () => log);
+  // The sandbox repository validates the status it reads and warns on anything
+  // unmodelled, so it needs the session logger.
+  const sandboxRepository = new SandboxRepository(sql, log);
+
+  // Tier 2 — sockets and alarm scheduling.
+  const wsManager: SessionWebSocketManager = new SessionWebSocketManagerImpl(
+    ctx,
+    sandboxRepository,
+    wsClientMappingRepository,
+    log,
+    { authTimeoutMs: WS_AUTH_TIMEOUT_MS }
+  );
+  const alarmScheduler = createEarliestAlarmScheduler(ctx.storage, alarmDeadlines);
+
+  // Tier 3 — connection fan-out.
+  const connections = new DurableObjectSessionConnections(ctx, wsManager);
+  const messenger: SessionMessenger = new SessionMessengerImpl(connections);
+
+  // Deferred: `createSourceControlProviderFromEnv` throws on reachable configs.
+  // Consumers read it through the returned record rather than capturing the
+  // memo directly, so the collaborator-wiring suite can substitute a stub by
+  // replacing `components.sourceControlProvider`.
+  const scmProviderOnce = once(() => createSourceControlProviderFromEnv(env));
+  const sourceControlProvider = () => components.sourceControlProvider();
+
+  const sandboxDashboardSettings: SandboxDashboardSettings = {
+    sandboxProvider: env.SANDBOX_PROVIDER,
+    modalWorkspace: env.MODAL_WORKSPACE,
+    modalEnvironment: env.MODAL_ENVIRONMENT,
+  };
+
+  // Tier 4 — session-scoped domain services.
+  const userEnvResolver = new UserEnvResolver({
+    db,
+    sessionCoreRepository,
+    resolveRepoId: (sessionRow) =>
+      resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider),
+    durableObjectId,
+    repoSecretsEncryptionKey: env.REPO_SECRETS_ENCRYPTION_KEY,
+    secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
+    log,
+  });
+
+  const terminalMessageProjection = new SessionTerminalMessageProjection(
+    db ? new SessionIndexStore(db) : null,
+    () => {
+      const current = sessionCoreRepository.getSession();
+      return current ? resolvePublicSessionId(current, durableObjectId) : null;
+    },
+    log
+  );
+
+  const userScmTokenStore =
+    db && env.TOKEN_ENCRYPTION_KEY ? new UserScmTokenStore(db, env.TOKEN_ENCRYPTION_KEY) : null;
+  const participantService = new ParticipantService({
+    repository: participantRepository,
+    getProcessingMessageAuthor: () => messageRepository.getProcessingMessageAuthor(),
+    env,
+    log,
+    generateId: () => generateId(),
+    userScmTokenStore,
+  });
+
+  const scheduler = db ? new Scheduler(db, env, backgroundTasks) : undefined;
+  const callbackService = new CallbackNotificationService({
+    repository: sessionCoreRepository,
+    messageRepository,
+    env,
+    completeAutomationRun: scheduler
+      ? (completion) => scheduler.runComplete(completion)
+      : undefined,
+    log,
+    getSessionId: () => resolvePublicSessionId(sessionCoreRepository.getSession(), durableObjectId),
+  });
+
+  const statusService = new SessionStatusService(
+    backgroundTasks,
+    log,
+    sessionCoreRepository,
+    messageRepository,
+    artifactRepository,
+    messenger,
+    db ? new SessionIndexStore(db) : null,
+    env.SESSION ?? null
+  );
+
+  const titleService = new SessionTitleService({
+    sessionCoreRepository,
+    messenger,
+    statusService,
+    backgroundTasks,
+    sessionIndexStore: db ? new SessionIndexStore(db) : null,
+    durableObjectId,
+    now: () => Date.now(),
+  });
+
+  const diffService = new SessionDiffService(
+    new SessionDiffStore(sql),
+    sessionCoreRepository,
+    messenger,
+    log
+  );
+  const diffsHandler = new SessionDiffsHandler(diffService);
+  const eventStream = new SessionEventStream(eventRepository);
+
+  // Tier 5 — the lifecycle manager.
+  const lifecycleManager = createLifecycleManager({
+    env,
+    db,
+    durableObjectId,
+    sessionCoreRepository,
+    sandboxRepository,
+    userEnvResolver,
+    messenger,
+    wsManager,
+    alarmScheduler,
+    sandboxDashboardSettings,
+  });
+
+  // Tier 6 — the message queue.
+  const getExecutionTimeoutMs = () => resolveExecutionTimeoutMs(sessionCoreRepository, env, log);
+  const messageQueue = new SessionMessageQueue(
+    backgroundTasks,
+    log,
+    sessionCoreRepository,
+    messageRepository,
+    participantRepository,
+    attachmentRepository,
+    wsManager,
+    messenger,
+    participantService,
+    callbackService,
+    statusService,
+    (model) => userEnvResolver.getProviderAuthenticationError(model),
+    (messageId, messageCreatedAt, completedAt) =>
+      terminalMessageProjection.recordTerminalMessage({
+        messageId,
+        messageCreatedAt,
+        terminalMessageCompletedAt: completedAt,
+      }),
+    lifecycleManager,
+    db ? new SessionIndexStore(db) : null,
+    once(() => resolveScmProviderFromEnv(env.SCM_PROVIDER)),
+    alarmScheduler,
+    getExecutionTimeoutMs
+  );
+
+  // Tier 7 — services over the queue and lifecycle.
+  const presenceService = new PresenceService({
+    getAuthenticatedClients: () => wsManager.getAuthenticatedClients(),
+    messenger,
+    send: (ws, msg) => wsManager.send(ws, msg),
+    getSandboxSocket: () => wsManager.getSandboxSocket(),
+    isSpawning: () => lifecycleManager.isSpawning(),
+    spawnSandbox: () => lifecycleManager.spawnSandbox(),
+    log,
+  });
+
+  const messageService = new MessageService({
+    repository: messageRepository,
+    eventRepository,
+    artifactRepository,
+    messageQueue,
+    stopExecution: () => messageQueue.stopExecution(),
+    parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, log),
+  });
+
+  const sandboxEventProcessor = new SessionSandboxEventProcessor(
+    backgroundTasks,
+    () => log,
+    sessionCoreRepository,
+    sandboxRepository,
+    messageRepository,
+    eventRepository,
+    artifactRepository,
+    callbackService,
+    wsManager,
+    messenger,
+    diffService,
+    (title, options) => titleService.applySessionTitleUpdate(title, options),
+    (reason) => lifecycleManager.triggerSnapshot(reason),
+    (messageId, messageCreatedAt, completedAt) =>
+      terminalMessageProjection.recordTerminalMessage({
+        messageId,
+        messageCreatedAt,
+        terminalMessageCompletedAt: completedAt,
+      }),
+    statusService,
+    (timestamp) => lifecycleManager.updateLastActivity(timestamp),
+    () => lifecycleManager.scheduleInactivityCheck(),
+    () => messageQueue.processMessageQueue(),
+    () => messageQueue.broadcastPromptQueue()
+  );
+
+  const alarmHandler = createAlarmHandler({
+    repository: messageRepository,
+    messageQueue,
+    lifecycleManager,
+    alarmScheduler,
+    getExecutionTimeoutMs,
+    now: () => Date.now(),
+    log,
+  });
+
+  const schedulePullRequestRefresh = (trigger: "open" | "manual"): void => {
+    backgroundTasks.submit(
+      () =>
+        refreshSessionPullRequests(
+          sessionCoreRepository,
+          artifactRepository,
+          sourceControlProvider(),
+          db ? new SessionPullRequestStore(db) : null
+        ).then(({ updated, failures }) => {
+          for (const artifact of updated) {
+            messenger.broadcast({ type: "artifact_updated", artifact });
+          }
+          for (const failure of failures) {
+            log.error("Pull request refresh failed for artifact", {
+              trigger,
+              reason: failure.reason,
+              artifact_id: failure.artifactId,
+              pr_number: failure.prNumber,
+              repo_owner: failure.repoOwner,
+              repo_name: failure.repoName,
+              error: failure.error instanceof Error ? failure.error : String(failure.error),
+            });
+          }
+        }),
+      {
+        name: "pull_request.refresh",
+        context: { trigger },
+      }
+    );
+  };
+
+  // Tier 8 — internal HTTP handlers.
+  const messagesHandler = createMessagesHandler({
+    messageService,
+  });
+
+  const childSessionsHandler = createChildSessionsHandler({
+    messageRepository,
+    eventRepository,
+    participantRepository,
+    artifactRepository,
+    getSession: () => sessionCoreRepository.getSession(),
+    getSandbox: () => sandboxRepository.getSandbox(),
+    getPublicSessionId: (sessionRow) => resolvePublicSessionId(sessionRow, durableObjectId),
+    parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, log),
+    messenger,
+    messageService,
+  });
+
+  const sandboxHandler = createSandboxHandler({
+    messageRepository,
+    eventRepository,
+    participantRepository,
+    artifactRepository,
+    processSandboxEvent: (event) => sandboxEventProcessor.processSandboxEvent(event),
+    getSandbox: () => sandboxRepository.getSandbox(),
+    isValidSandboxToken: (token, sandbox) => isValidSandboxToken(token, sandbox),
+    getSession: () => sessionCoreRepository.getSession(),
+    refreshOpenAIToken: async (sessionRow, requestLog) => {
+      const service = new OpenAITokenRefreshService(
+        db!,
+        env.REPO_SECRETS_ENCRYPTION_KEY!,
+        (row) => resolveSessionRepoId(row, sessionCoreRepository, sourceControlProvider),
+        requestLog
+      );
+      return service.refresh(sessionRow);
+    },
+    refreshXaiToken: async (sessionRow, requestLog) => {
+      const service = new XaiTokenRefreshService(
+        db!,
+        env.REPO_SECRETS_ENCRYPTION_KEY!,
+        (row) => resolveSessionRepoId(row, sessionCoreRepository, sourceControlProvider),
+        requestLog
+      );
+      return service.refresh(sessionRow);
+    },
+    isManagedSecretsConfigured: () => Boolean(db && env.REPO_SECRETS_ENCRYPTION_KEY),
+    getScmCredentials: (requestLog) =>
+      new ScmCredentialsService(sourceControlProvider(), requestLog).getCredentials(),
+    messenger,
+    generateId: () => generateId(),
+    now: () => Date.now(),
+  });
+
+  const attachmentsHandler = new AttachmentsHandler(attachmentRepository, log);
+
+  const wsTokenHandler = createWsTokenHandler({
+    repository: participantRepository,
+    getParticipantByUserId: (userId) => participantService.getByUserId(userId),
+    generateId: (bytes) => generateId(bytes),
+    hashToken: (token) => hashToken(token),
+    now: () => Date.now(),
+  });
+
+  const sessionLifecycleHandler = createSessionLifecycleHandler({
+    sessionCoreRepository,
+    sandboxRepository,
+    messageRepository,
+    participantRepository,
+    getDurableObjectId: () => durableObjectId,
+    tokenEncryptionKey: env.TOKEN_ENCRYPTION_KEY,
+    encryptToken: (token, encryptionKey) => encryptToken(token, encryptionKey),
+    validateReasoningEffort: (model, effort) => validateReasoningEffort(model, effort, log),
+    generateId: (bytes) => generateId(bytes),
+    now: () => Date.now(),
+    scheduleWarmSandbox: () =>
+      backgroundTasks.submit(() => lifecycleManager.warmSandbox(), {
+        name: "sandbox.warm",
+      }),
+    getSession: () => sessionCoreRepository.getSession(),
+    getSandbox: () => sandboxRepository.getSandbox(),
+    getPublicSessionId: (sessionRow) => resolvePublicSessionId(sessionRow, durableObjectId),
+    getParticipantByUserId: (userId) => participantService.getByUserId(userId),
+    statusService,
+    applySessionTitleUpdate: (title, options) =>
+      titleService.applySessionTitleUpdate(title, options),
+    cancelSession: async () => {
+      await statusService.cancel(() => messageQueue.cancelExecution());
+    },
+    getSandboxSocket: () => wsManager.getSandboxSocket(),
+    sendToSandbox: (ws, message) => wsManager.send(ws, message),
+    updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
+  });
+
+  const prCreationClaims = new PullRequestCreationClaims();
+  const pullRequestHandler = createPullRequestHandler({
+    getSession: () => sessionCoreRepository.getSession(),
+    getSessionRepositories: () => sessionCoreRepository.getSessionRepositories(),
+    getPromptingParticipantForPR: () => participantService.getPromptingParticipantForPR(),
+    resolveAuthForPR: (participant) => participantService.resolveAuthForPR(participant),
+    getSessionUrl: (sessionRow) => {
+      const sessionId = sessionRow.session_name || sessionRow.id;
+      const webAppUrl = env.WEB_APP_URL || env.WORKER_URL || "";
+      return webAppUrl + "/session/" + sessionId;
+    },
+    createPullRequest: async (input, requestLog) => {
+      const pullRequestService = new SessionPullRequestService({
+        repository: sessionCoreRepository,
+        artifactRepository,
+        claims: prCreationClaims,
+        sourceControlProvider: sourceControlProvider(),
+        log: requestLog,
+        generateId: () => generateId(),
+        pushBranchToRemote: (pushSpec) => sandboxEventProcessor.pushBranchToRemote(pushSpec),
+        messenger,
+        appName: resolveAppName(env),
+        sessionPullRequests: db ? new SessionPullRequestStore(db) : undefined,
+        resolveScmSettings: (repo) => resolveScmSettings(db, repo),
+      });
+
+      return pullRequestService.createPullRequest(input);
+    },
+    getArtifactById: (artifactId) => artifactRepository.getArtifactById(artifactId),
+    updateArtifact: (artifactId, data) => artifactRepository.updateArtifact(artifactId, data),
+    messenger,
+    now: () => Date.now(),
+    triggerPullRequestRefresh: () => schedulePullRequestRefresh("manual"),
+  });
+
+  const participantsHandler = createParticipantsHandler({
+    repository: participantRepository,
+  });
+
+  const components: SessionComponents = {
+    log,
+    backgroundTasks,
+    sessionCoreRepository,
+    sandboxRepository,
+    attachmentRepository,
+    artifactRepository,
+    eventRepository,
+    messageRepository,
+    participantRepository,
+    wsClientMappingRepository,
+    alarmDeadlines,
+    alarmScheduler,
+    alarmHandler,
+    wsManager,
+    connections,
+    messenger,
+    sandboxDashboardSettings,
+    sourceControlProvider: scmProviderOnce,
+    userEnvResolver,
+    participantService,
+    callbackService,
+    presenceService,
+    statusService,
+    titleService,
+    terminalMessageProjection,
+    diffService,
+    eventStream,
+    lifecycleManager,
+    messageQueue,
+    messageService,
+    sandboxEventProcessor,
+    schedulePullRequestRefresh,
+    messagesHandler,
+    childSessionsHandler,
+    sandboxHandler,
+    attachmentsHandler,
+    wsTokenHandler,
+    sessionLifecycleHandler,
+    pullRequestHandler,
+    participantsHandler,
+    diffsHandler,
+  };
+  return components;
+}
+
+interface LifecycleManagerDeps {
+  env: Env;
+  db: SqlDatabase | null;
+  durableObjectId: string;
+  sessionCoreRepository: SessionCoreRepository;
+  sandboxRepository: SandboxRepository;
+  userEnvResolver: UserEnvResolver;
+  messenger: SessionMessenger;
+  wsManager: SessionWebSocketManager;
+  alarmScheduler: RehydratableAlarmScheduler;
+  sandboxDashboardSettings: SandboxDashboardSettings;
+}
+
+/** Create the lifecycle manager with all required adapters. */
+function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleManager {
+  const {
+    env,
+    db,
+    durableObjectId,
+    sessionCoreRepository,
+    sandboxRepository,
+    userEnvResolver,
+    messenger,
+    wsManager,
+    alarmScheduler,
+    sandboxDashboardSettings,
+  } = deps;
+  // Resolved leniently at graph time: an unsupported SANDBOX_PROVIDER must
+  // fail at the spawn that needs it (via the deferred provider below), not at
+  // graph construction — the same reachable-throw rule as the provider factory.
+  const sandboxBackend = tryResolveSandboxBackendName(env.SANDBOX_PROVIDER);
+
+  const provider = createDeferredSandboxProvider(() =>
+    createSandboxProviderFromEnv(env, resolveSandboxBackendName(env.SANDBOX_PROVIDER))
+  );
+
+  // Storage adapter
+  const storage: SandboxStorage = {
+    getSandbox: () => sandboxRepository.getSandbox(),
+    getSandboxWithCircuitBreaker: () => sandboxRepository.getSandboxWithCircuitBreaker(),
+    getSession: () => sessionCoreRepository.getSession(),
+    getSessionRepositories: () =>
+      sessionCoreRepository.getSessionRepositories().map((entry) => ({
+        repoOwner: entry.repoOwner,
+        repoName: entry.repoName,
+        baseBranch: entry.baseBranch ?? "main",
+        baseSha: entry.row?.base_sha ?? null,
+      })),
+    getUserEnvVars: () => userEnvResolver.getUserEnvVars(),
+    updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
+    updateSandboxForSpawn: (data) => sandboxRepository.updateSandboxForSpawn(data),
+    updateSandboxForResume: (data) => sandboxRepository.updateSandboxForResume(data),
+    updateSandboxModalObjectId: (id) => sandboxRepository.updateSandboxModalObjectId(id),
+    updateSandboxRuntimeVersion: (runtimeVersion) =>
+      sandboxRepository.updateSandboxRuntimeVersion(runtimeVersion),
+    updateSandboxSnapshotImageId: (sandboxId, imageId, runtimeVersion) =>
+      sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion),
+    updateSandboxLastActivity: (timestamp) =>
+      sandboxRepository.updateSandboxLastActivity(timestamp),
+    incrementCircuitBreakerFailure: (timestamp) =>
+      sandboxRepository.incrementCircuitBreakerFailure(timestamp),
+    resetCircuitBreaker: () => sandboxRepository.resetCircuitBreaker(),
+    setLastSpawnError: (error, timestamp) =>
+      sandboxRepository.updateSandboxSpawnError(error, timestamp),
+    updateSandboxCodeServer: async (url, password) => {
+      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
+        ? await encryptToken(password, env.REPO_SECRETS_ENCRYPTION_KEY)
+        : password;
+      sandboxRepository.updateSandboxCodeServer(url, encrypted);
+    },
+    clearSandboxCodeServer: () => sandboxRepository.clearSandboxCodeServer(),
+    clearSandboxCodeServerUrl: () => sandboxRepository.clearSandboxCodeServerUrl(),
+    updateSandboxVnc: async (url, password) => {
+      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
+        ? await encryptToken(password, env.REPO_SECRETS_ENCRYPTION_KEY)
+        : password;
+      sandboxRepository.updateSandboxVnc(url, encrypted);
+    },
+    clearSandboxVnc: () => sandboxRepository.clearSandboxVnc(),
+    clearSandboxVncUrl: () => sandboxRepository.clearSandboxVncUrl(),
+    updateSandboxTunnelUrls: (urls) => sandboxRepository.updateSandboxTunnelUrls(urls),
+    clearSandboxTunnelUrls: () => sandboxRepository.clearSandboxTunnelUrls(),
+    updateSandboxTtyd: async (url, token) => {
+      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
+        ? await encryptToken(token, env.REPO_SECRETS_ENCRYPTION_KEY)
+        : token;
+      sandboxRepository.updateSandboxTtyd(url, encrypted);
+    },
+    clearSandboxTtyd: () => sandboxRepository.clearSandboxTtyd(),
+  };
+
+  // Broadcaster adapter
+  const broadcaster: SandboxBroadcaster = {
+    broadcast: (message) => messenger.broadcast(message as ServerMessage),
+  };
+
+  // WebSocket manager adapter — thin delegation to wsManager
+  const lifecycleWsManager: WebSocketManager = {
+    getSandboxWebSocket: () => wsManager.getSandboxSocket(),
+    detachSandboxWebSocket: (code, reason) => wsManager.detachSandboxSocket(code, reason),
+    sendToSandbox: (message) => {
+      const ws = wsManager.getSandboxSocket();
+      return ws ? wsManager.send(ws, message) : false;
+    },
+    getConnectedClientCount: () => wsManager.getConnectedClientCount(),
+  };
+
+  // ID generator adapter
+  const idGenerator: IdGenerator = {
+    generateId: () => generateId(),
+  };
+
+  // Build configuration
+  const controlPlaneUrl =
+    env.WORKER_URL ||
+    `https://open-inspect-control-plane.${env.CF_ACCOUNT_ID || "workers"}.workers.dev`;
+
+  // Create D1-backed lookups if database is available
+  let mcpServerLookup: McpServerLookup | undefined;
+  if (db) {
+    const mcpStore = new McpServerStore(db, env.REPO_SECRETS_ENCRYPTION_KEY);
+    mcpServerLookup = {
+      getDecryptedForSession: (repositories) => mcpStore.getDecryptedForSession(repositories),
+    };
+  }
+
+  // Session-scoped gate: resolved from the primary member (the scalar mirror
+  // this lookup is called with) — see resolveSessionScopedSettings for the
+  // per-feature scope rules. Token absence short-circuits to false so a
+  // misconfigured deployment never installs a tool that would 503 on every call.
+  let slackAgentNotifyLookup: SlackAgentNotifyLookup | undefined;
+  if (db) {
+    const tokenPresent = !!env.SLACK_BOT_TOKEN;
+    const settingsStore = new IntegrationSettingsStore(db);
+    slackAgentNotifyLookup = {
+      isEnabledForRepo: async (repoOwner, repoName) => {
+        if (!tokenPresent) return false;
+        const settings =
+          repoOwner && repoName
+            ? (await settingsStore.getResolvedConfig("slack", `${repoOwner}/${repoName}`)).settings
+            : ((await settingsStore.getGlobal("slack"))?.defaults ?? {});
+        return resolveSlackSettings(settings).agentNotificationsEnabled;
+      },
+    };
+  }
+
+  const sandboxDashboardUrlBuilder =
+    sandboxBackend === "modal"
+      ? (providerObjectId: string) =>
+          resolveSandboxDashboardUrl(sandboxDashboardSettings, providerObjectId)
+      : undefined;
+
+  const config = {
+    ...DEFAULT_LIFECYCLE_CONFIG,
+    controlPlaneUrl,
+    model: DEFAULT_MODEL,
+    // Re-derived per use: on the first-ever activation the manager is built
+    // during the init request, before the session row exists.
+    getSessionId: () => resolvePublicSessionId(sessionCoreRepository.getSession(), durableObjectId),
+    inactivity: {
+      ...DEFAULT_LIFECYCLE_CONFIG.inactivity,
+      timeoutMs: parseInt(env.SANDBOX_INACTIVITY_TIMEOUT_MS || "600000", 10),
+    },
+    mcpServerLookup,
+    slackAgentNotifyLookup,
+    sandboxDashboardUrlBuilder,
+  };
+
+  // Create the image lookup if D1 is available and the provider supports
+  // prebuilt images.
+  let imageBuildLookup: ImageBuildLookup | undefined;
+  const imageBuildProvider = sandboxBackend ? resolveImageBuildProvider(sandboxBackend) : null;
+  if (db && imageBuildProvider) {
+    imageBuildLookup = createImageBuildLookup(db, imageBuildProvider);
+  }
+
+  return new SandboxLifecycleManager(
+    provider,
+    storage,
+    broadcaster,
+    lifecycleWsManager,
+    alarmScheduler,
+    idGenerator,
+    config,
+    imageBuildLookup
+  );
+}

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -1,11 +1,15 @@
 /**
  * Composition root for one session runtime.
  *
- * `createSessionComponents` builds the entire collaborator graph eagerly, in
+ * `createSessionRuntime` builds the entire collaborator graph eagerly, in
  * topological order, with exactly one session-scoped logger created before
- * anything can capture it. `SessionDO.ensureInitialized()` is the single call
- * site; the schema must already be applied when this runs, because the factory
- * reads the session row to derive the logger's `session_id`.
+ * anything can capture it — and returns only the narrow surface the platform
+ * adapter needs: the server entry points, the log, and alarm rehydration.
+ * Repositories, services, and handlers stay local to this factory;
+ * `SessionRuntime.internals` exposes them for integration-test introspection
+ * only. `SessionDO.ensureInitialized()` is the single call site; the schema
+ * must already be applied when this runs, because the factory reads the
+ * session row to derive the logger's `session_id`.
  *
  * The only deferred constructions left are the two provider factories, both of
  * which throw on reachable configurations (`createSandboxProviderFromEnv` on
@@ -49,7 +53,7 @@ import {
   resolveScmProviderFromEnv,
   type SourceControlProvider,
 } from "../source-control";
-import type { Env } from "../types";
+import type { Env, ClientInfo } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import { SessionCoreRepository } from "./session-core-repository";
 import { SandboxRepository } from "./sandbox-repository";
@@ -112,9 +116,20 @@ import { MessageService } from "./services/message.service";
 import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
 import {
   createEarliestAlarmScheduler,
+  handleAlarmDelivery,
   PersistedAlarmDeadlineStore,
   type RehydratableAlarmScheduler,
 } from "./alarm/scheduler";
+import { createSessionInternalRoutes } from "./http/routes";
+import { SessionServer } from "./server";
+import { SessionHttpDispatcher } from "./http/dispatcher";
+import { SessionMessageRouter, type SessionClientCommands } from "./message-router";
+import { SessionDisconnectHandler } from "./disconnect-handler";
+import type { Clock, SandboxDisconnectMonitor, SessionBroadcaster, SocketRegistry } from "./ports";
+import { SessionConnectionAuthenticator } from "./connection-authenticator";
+import { SessionSnapshotReader } from "./snapshot-reader";
+import { SessionAccessReader } from "./sandbox-access-reader";
+import { createSessionScopedLogger } from "./session-logger";
 import { SessionDiffStore } from "./diffs/store";
 import { SessionDiffService } from "./diffs/service";
 import { SessionDiffsHandler } from "./http/handlers/session-diffs.handler";
@@ -136,6 +151,29 @@ export interface SessionPlatform {
   ctx: DurableObjectState;
   sql: SqlStorage;
   db: SqlDatabase | null;
+  /**
+   * The adapter's idempotent initializer, threaded into the server stack so
+   * hibernation-restored callbacks self-heal exactly as before. Within this
+   * factory's own activation it is always a no-op (the adapter initializes
+   * before touching the runtime).
+   */
+  ensureInitialized: (rehydrateAlarm?: boolean) => void;
+}
+
+/**
+ * What the platform adapter (SessionDO) is allowed to touch. Everything else
+ * stays inside the factory; `internals` exists for integration tests that
+ * spy on or substitute live collaborators, and production code must not
+ * reach through it.
+ */
+export interface SessionRuntime {
+  readonly log: Logger;
+  readonly server: SessionServer<WebSocket, ClientInfo>;
+  readonly alarms: {
+    /** Re-arm any persisted alarm deadline after a cold start. */
+    rehydrate(): void;
+  };
+  readonly internals: SessionComponents;
 }
 
 export interface SessionComponents {
@@ -277,8 +315,8 @@ function resolveExecutionTimeoutMs(
   return parseInt(env.EXECUTION_TIMEOUT_MS || String(DEFAULT_SANDBOX_TIMEOUT_SECONDS * 1000), 10);
 }
 
-export function createSessionComponents(platform: SessionPlatform, env: Env): SessionComponents {
-  const { ctx, sql, db } = platform;
+export function createSessionRuntime(platform: SessionPlatform, env: Env): SessionRuntime {
+  const { ctx, sql, db, ensureInitialized } = platform;
   const durableObjectId = ctx.id.toString();
   const transaction = <T>(closure: () => T): T => ctx.storage.transactionSync(closure);
 
@@ -297,15 +335,18 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
   const sessionCoreRepository = new SessionCoreRepository(sql, transaction);
   const alarmDeadlines = new PersistedAlarmDeadlineStore(sql);
 
-  // The session-scoped logger, created before anything can capture a logger at
-  // all. Before `init` writes the session row this resolves to the Durable
-  // Object id; the lifecycle manager re-derives its log context per use, so it
-  // picks up the public session id once the row exists.
-  const session = sessionCoreRepository.getSession();
-  const log = createLogger(
-    "session-do",
-    { session_id: resolvePublicSessionId(session, durableObjectId) },
-    parseLogLevel(env.LOG_LEVEL)
+  // The session-scoped logger, created before anything can capture a logger
+  // at all. Its `session_id` is injected per emit through the latched
+  // resolver: before `init` writes the session row it is the Durable Object
+  // id, and it upgrades to the public id the moment the row exists — for
+  // every component in the graph, however early it captured the logger.
+  const getPublicSessionId = createLatchedPublicSessionIdResolver(
+    () => sessionCoreRepository.getSession(),
+    durableObjectId
+  );
+  const log = createSessionScopedLogger(
+    createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL)),
+    getPublicSessionId
   );
   const backgroundTasks = createCloudflareBackgroundTasks(ctx, () => log);
   // The sandbox repository validates the status it reads and warns on anything
@@ -326,12 +367,16 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
   const connections = new DurableObjectSessionConnections(ctx, wsManager);
   const messenger: SessionMessenger = new SessionMessengerImpl(connections);
 
-  // Deferred: `createSourceControlProviderFromEnv` throws on reachable configs.
-  // Consumers read it through the returned record rather than capturing the
-  // memo directly, so the collaborator-wiring suite can substitute a stub by
-  // replacing `components.sourceControlProvider`.
-  const scmProviderOnce = once(() => createSourceControlProviderFromEnv(env));
-  const sourceControlProvider = () => components.sourceControlProvider();
+  // Deferred: `createSourceControlProviderFromEnv` throws on reachable
+  // configs. The cell is a local `let`, so consumer closures read a binding
+  // that exists before any of them (no temporal dead zone and no read through
+  // the returned record); `internals.sourceControlProvider` exposes it as an
+  // accessor pair because live-DO integration tests can only substitute a
+  // stub after the init request has already built this graph.
+  let scmProvider: () => SourceControlProvider = once(() =>
+    createSourceControlProviderFromEnv(env)
+  );
+  const sourceControlProvider = () => scmProvider();
 
   const sandboxDashboardSettings: SandboxDashboardSettings = {
     sandboxProvider: env.SANDBOX_PROVIDER,
@@ -417,7 +462,7 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
   const lifecycleManager = createLifecycleManager({
     env,
     db,
-    durableObjectId,
+    getSessionId: getPublicSessionId,
     sessionCoreRepository,
     sandboxRepository,
     userEnvResolver,
@@ -675,6 +720,161 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
     repository: participantRepository,
   });
 
+  // Tier 9 — the read models, connection admission, and the server stack.
+  const snapshotReader = new SessionSnapshotReader({
+    sessionCoreRepository,
+    sandboxRepository,
+    messageRepository,
+    artifactRepository,
+    messageService,
+    eventStream,
+    sandboxDashboardSettings,
+    db,
+    durableObjectId,
+    transaction,
+    log,
+  });
+
+  const accessReader = new SessionAccessReader({
+    sessionCoreRepository,
+    sandboxRepository,
+    repoSecretsEncryptionKey: env.REPO_SECRETS_ENCRYPTION_KEY,
+    log,
+  });
+
+  const connectionAuthenticator = new SessionConnectionAuthenticator({
+    connections,
+    wsManager,
+    sessionCoreRepository,
+    sandboxRepository,
+    lifecycleManager,
+    messenger,
+    backgroundTasks,
+    messageQueue,
+    participantService,
+    presenceService,
+    snapshotReader,
+    schedulePullRequestRefresh,
+    getScmProviderName: () => resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    log,
+  });
+
+  // Internal HTTP route table (transport wiring only).
+  const routes = createSessionInternalRoutes({
+    init: (request, _url, requestLog) => sessionLifecycleHandler.init(request, requestLog),
+    state: () => sessionLifecycleHandler.getState(),
+    snapshot: () => snapshotReader.handleSnapshot(),
+    sandboxAccess: () => accessReader.handleSandboxAccess(),
+    prompt: (request, _url, requestLog) => messagesHandler.enqueuePrompt(request, requestLog),
+    stop: () => messagesHandler.stop(),
+    sandboxEvent: (request) => sandboxHandler.sandboxEvent(request),
+    createMediaArtifact: (request) => sandboxHandler.createMediaArtifact(request),
+    recordAttachment: (request) => {
+      const session = sessionCoreRepository.getSession();
+      return attachmentsHandler.recordAttachment(
+        request,
+        session ? resolvePublicSessionId(session, durableObjectId) : null
+      );
+    },
+    listParticipants: () => participantsHandler.listParticipants(),
+    addParticipant: (request) => sandboxHandler.addParticipant(request),
+    listEvents: (_request, url) => messagesHandler.listEvents(url),
+    listArtifacts: (_request, url) => messagesHandler.listArtifacts(url),
+    listMessages: (_request, url) => messagesHandler.listMessages(url),
+    createPr: (request, _url, requestLog) => pullRequestHandler.createPr(request, requestLog),
+    pullRequestArtifactSnapshot: (request, url) =>
+      pullRequestHandler.pullRequestArtifactSnapshot(request, url),
+    pullRequestsRefresh: () => pullRequestHandler.refreshPullRequests(),
+    wsToken: (request, _url, requestLog) => wsTokenHandler.generateWsToken(request, requestLog),
+    updateTitle: (request) => sessionLifecycleHandler.updateTitle(request),
+    archive: (request) => sessionLifecycleHandler.archive(request),
+    unarchive: (request) => sessionLifecycleHandler.unarchive(request),
+    expireDraft: () => sessionLifecycleHandler.expireDraft(),
+    verifySandboxToken: (request, _url, requestLog) =>
+      sandboxHandler.verifySandboxToken(request, requestLog),
+    openaiTokenRefresh: (_request, _url, requestLog) =>
+      sandboxHandler.openaiTokenRefresh(requestLog),
+    xaiTokenRefresh: (_request, _url, requestLog) => sandboxHandler.xaiTokenRefresh(requestLog),
+    scmCredentials: (_request, _url, requestLog) => sandboxHandler.scmCredentials(requestLog),
+    tunnelUrls: (_request, _url, requestLog) => sandboxHandler.tunnelUrls(requestLog),
+    spawnContext: () => childSessionsHandler.getSpawnContext(),
+    activePromptAuthor: () => childSessionsHandler.getActivePromptAuthor(),
+    childSummary: (_request, url) => childSessionsHandler.getChildSummary(url),
+    parentPrompt: (request) => childSessionsHandler.parentPrompt(request),
+    cancel: () => sessionLifecycleHandler.cancel(),
+    childSessionUpdate: (request) => childSessionsHandler.childSessionUpdate(request),
+    diffState: () => diffsHandler.state(),
+    diffStore: (request) => diffsHandler.storeBundle(request),
+    diffFailure: (request) => diffsHandler.recordFailure(request),
+    diffResolveFile: (_request, url) => diffsHandler.resolveFile(url),
+    diffRetry: () => diffsHandler.retry(),
+  });
+
+  const clock: Clock = {
+    nowMs: () => Date.now(),
+    monotonicNowMs: () => performance.now(),
+  };
+  const sockets: SocketRegistry<WebSocket, ClientInfo> = {
+    classify: (ws) => wsManager.classify(ws),
+    send: (ws, message) => wsManager.send(ws, message),
+    getClient: (ws) => connectionAuthenticator.getClientInfo(ws),
+    close: (ws, code, reason) => wsManager.close(ws, code, reason),
+    clearSandboxIfMatch: (ws) => wsManager.clearSandboxSocketIfMatch(ws),
+    removeClient: (ws) => wsManager.removeClient(ws),
+    hasParticipant: (participantId) =>
+      Array.from(wsManager.getAuthenticatedClients()).some(
+        (client) => client.participantId === participantId
+      ),
+  };
+  const clientCommands: SessionClientCommands<WebSocket, ClientInfo> = {
+    subscribe: (ws, message) => connectionAuthenticator.handleSubscribe(ws, message),
+    submitPrompt: (ws, client, message) => messageQueue.handlePromptMessage(ws, client, message),
+    cancelPrompt: (ws, message) => messageQueue.cancelQueuedPrompt(ws, message),
+    stopExecution: () => messageQueue.stopExecution(),
+    notifyTyping: () => presenceService.handleTyping(),
+    updatePresence: (client, message) => presenceService.updatePresence(client, message),
+    getHistoryPage: (message) => eventStream.getHistoryPage(message),
+  };
+  const sandboxDisconnects: SandboxDisconnectMonitor = {
+    getStatus: () => sandboxRepository.getSandbox()?.status,
+    scheduleCheck: () => lifecycleManager.scheduleDisconnectCheck(),
+  };
+  const disconnectBroadcaster: SessionBroadcaster = {
+    broadcastPresence: () => presenceService.broadcastPresence(),
+    broadcast: (message) => messenger.broadcast(message),
+  };
+
+  const server = new SessionServer<WebSocket, ClientInfo>({
+    ensureInitialized,
+    http: new SessionHttpDispatcher({
+      ensureInitialized,
+      getLogger: () => log,
+      routes,
+      handleWebSocketUpgrade: (request, url, requestLog) =>
+        connectionAuthenticator.handleWebSocketUpgrade(request, url, requestLog),
+      clock,
+    }),
+    messages: new SessionMessageRouter({
+      getLogger: () => log,
+      sockets,
+      clientCommands,
+      processSandboxEvent: (event) => sandboxEventProcessor.processSandboxEvent(event),
+      clock,
+    }),
+    disconnects: new SessionDisconnectHandler({
+      getLogger: () => log,
+      sockets,
+      sandbox: sandboxDisconnects,
+      broadcaster: disconnectBroadcaster,
+    }),
+    handleScheduledDeadline: () =>
+      handleAlarmDelivery(
+        alarmDeadlines,
+        () => alarmHandler.handle(),
+        () => alarmScheduler.rearmPending()
+      ),
+  });
+
   const components: SessionComponents = {
     log,
     backgroundTasks,
@@ -693,7 +893,14 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
     connections,
     messenger,
     sandboxDashboardSettings,
-    sourceControlProvider: scmProviderOnce,
+    // Accessor pair over the local cell: production reads never go through
+    // this property; the setter is the live-DO integration seam.
+    get sourceControlProvider() {
+      return scmProvider;
+    },
+    set sourceControlProvider(next: () => SourceControlProvider) {
+      scmProvider = next;
+    },
     userEnvResolver,
     participantService,
     callbackService,
@@ -718,13 +925,25 @@ export function createSessionComponents(platform: SessionPlatform, env: Env): Se
     participantsHandler,
     diffsHandler,
   };
-  return components;
+
+  return {
+    log,
+    server,
+    alarms: {
+      rehydrate: () =>
+        backgroundTasks.submit(() => alarmScheduler.rehydrate(), {
+          name: "alarm.rehydrate",
+        }),
+    },
+    internals: components,
+  };
 }
 
 interface LifecycleManagerDeps {
   env: Env;
   db: SqlDatabase | null;
-  durableObjectId: string;
+  /** The latched public-session-id resolver shared with the session logger. */
+  getSessionId: () => string;
   sessionCoreRepository: SessionCoreRepository;
   sandboxRepository: SandboxRepository;
   userEnvResolver: UserEnvResolver;
@@ -739,7 +958,7 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
   const {
     env,
     db,
-    durableObjectId,
+    getSessionId,
     sessionCoreRepository,
     sandboxRepository,
     userEnvResolver,
@@ -881,10 +1100,7 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     // activation the manager is built during the init request, before the row
     // is written. Latched afterwards — the manager derives log context from
     // this on every log line, and the id is immutable once row-backed.
-    getSessionId: createLatchedPublicSessionIdResolver(
-      () => sessionCoreRepository.getSession(),
-      durableObjectId
-    ),
+    getSessionId,
     inactivity: {
       ...DEFAULT_LIFECYCLE_CONFIG.inactivity,
       timeoutMs: parseInt(env.SANDBOX_INACTIVITY_TIMEOUT_MS || "600000", 10),

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -86,34 +86,24 @@ import { UserEnvResolver } from "./user-env-resolver";
 import { resolveSessionRepoId } from "./repo-id-resolution";
 import { Scheduler } from "../scheduler/scheduler";
 import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
-import type { BackgroundTasks } from "../platform-ports";
 import { PresenceService } from "./presence-service";
 import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
 import { SessionEventStream } from "./event-stream";
-import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
-import {
-  createChildSessionsHandler,
-  type ChildSessionsHandler,
-} from "./http/handlers/child-sessions.handler";
-import { createSandboxHandler, type SandboxHandler } from "./http/handlers/sandbox.handler";
+import { createMessagesHandler } from "./http/handlers/messages.handler";
+import { createChildSessionsHandler } from "./http/handlers/child-sessions.handler";
+import { createSandboxHandler } from "./http/handlers/sandbox.handler";
 import { AttachmentsHandler } from "./http/handlers/attachments.handler";
-import { createWsTokenHandler, type WsTokenHandler } from "./http/handlers/ws-token.handler";
+import { createWsTokenHandler } from "./http/handlers/ws-token.handler";
 import {
   createSessionLifecycleHandler,
   type SessionLifecycleHandler,
 } from "./http/handlers/session-lifecycle.handler";
-import {
-  createPullRequestHandler,
-  type PullRequestHandler,
-} from "./http/handlers/pull-request.handler";
-import {
-  createParticipantsHandler,
-  type ParticipantsHandler,
-} from "./http/handlers/participants.handler";
+import { createPullRequestHandler } from "./http/handlers/pull-request.handler";
+import { createParticipantsHandler } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
-import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
+import { createAlarmHandler } from "./alarm/handler";
 import {
   createEarliestAlarmScheduler,
   handleAlarmDelivery,
@@ -176,56 +166,26 @@ export interface SessionRuntime {
   readonly internals: SessionComponents;
 }
 
+/**
+ * The live-DO integration seams. Every field here is reached by an
+ * integration test through `SessionRuntime.internals` (spying on a live
+ * collaborator or, for `sourceControlProvider`, substituting one); nothing in
+ * production reads this record. Add a field only together with the test that
+ * consumes it — everything else stays local to the factory.
+ */
 export interface SessionComponents {
-  log: Logger;
-  backgroundTasks: BackgroundTasks;
-  // Repositories over the DO-embedded SQLite.
-  sessionCoreRepository: SessionCoreRepository;
   sandboxRepository: SandboxRepository;
-  attachmentRepository: SessionAttachmentRepository;
-  artifactRepository: ArtifactRepository;
-  eventRepository: EventRepository;
-  messageRepository: MessageRepository;
-  participantRepository: ParticipantRepository;
-  wsClientMappingRepository: WsClientMappingRepository;
-  // Alarm persistence and scheduling.
-  alarmDeadlines: PersistedAlarmDeadlineStore;
-  alarmScheduler: RehydratableAlarmScheduler;
-  alarmHandler: AlarmHandler;
-  // Sockets and messaging.
-  wsManager: SessionWebSocketManager;
-  connections: DurableObjectSessionConnections;
-  messenger: SessionMessenger;
-  // Immutable env projection for the provider dashboard link.
-  sandboxDashboardSettings: SandboxDashboardSettings;
-  /** Deferred: `createSourceControlProviderFromEnv` throws on reachable configs. */
+  /**
+   * Deferred: `createSourceControlProviderFromEnv` throws on reachable
+   * configs. Assignable — the setter swaps the underlying cell for tests.
+   */
   sourceControlProvider: () => SourceControlProvider;
-  // Domain services.
   userEnvResolver: UserEnvResolver;
-  participantService: ParticipantService;
-  callbackService: CallbackNotificationService;
-  presenceService: PresenceService;
-  statusService: SessionStatusService;
-  titleService: SessionTitleService;
-  terminalMessageProjection: SessionTerminalMessageProjection;
-  diffService: SessionDiffService;
-  eventStream: SessionEventStream;
   lifecycleManager: SandboxLifecycleManager;
   messageQueue: SessionMessageQueue;
-  messageService: MessageService;
+  presenceService: PresenceService;
   sandboxEventProcessor: SessionSandboxEventProcessor;
-  /** Fire a background read-through refresh of the session's PR artifacts. */
-  schedulePullRequestRefresh: (trigger: "open" | "manual") => void;
-  // Internal HTTP handlers.
-  messagesHandler: MessagesHandler;
-  childSessionsHandler: ChildSessionsHandler;
-  sandboxHandler: SandboxHandler;
-  attachmentsHandler: AttachmentsHandler;
-  wsTokenHandler: WsTokenHandler;
   sessionLifecycleHandler: SessionLifecycleHandler;
-  pullRequestHandler: PullRequestHandler;
-  participantsHandler: ParticipantsHandler;
-  diffsHandler: SessionDiffsHandler;
 }
 
 /** `resolveSandboxBackendName` throws on unsupported values; graph-time uses need null instead. */
@@ -876,23 +836,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   });
 
   const components: SessionComponents = {
-    log,
-    backgroundTasks,
-    sessionCoreRepository,
     sandboxRepository,
-    attachmentRepository,
-    artifactRepository,
-    eventRepository,
-    messageRepository,
-    participantRepository,
-    wsClientMappingRepository,
-    alarmDeadlines,
-    alarmScheduler,
-    alarmHandler,
-    wsManager,
-    connections,
-    messenger,
-    sandboxDashboardSettings,
     // Accessor pair over the local cell: production reads never go through
     // this property; the setter is the live-DO integration seam.
     get sourceControlProvider() {
@@ -902,28 +846,11 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
       scmProvider = next;
     },
     userEnvResolver,
-    participantService,
-    callbackService,
-    presenceService,
-    statusService,
-    titleService,
-    terminalMessageProjection,
-    diffService,
-    eventStream,
     lifecycleManager,
     messageQueue,
-    messageService,
+    presenceService,
     sandboxEventProcessor,
-    schedulePullRequestRefresh,
-    messagesHandler,
-    childSessionsHandler,
-    sandboxHandler,
-    attachmentsHandler,
-    wsTokenHandler,
     sessionLifecycleHandler,
-    pullRequestHandler,
-    participantsHandler,
-    diffsHandler,
   };
 
   return {

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -59,7 +59,7 @@ import { EventRepository } from "./event-repository";
 import { MessageRepository } from "./message-repository";
 import { ParticipantRepository } from "./participant-repository";
 import { WsClientMappingRepository } from "./ws-client-mapping-repository";
-import { resolvePublicSessionId } from "./public-session-id";
+import { createLatchedPublicSessionIdResolver, resolvePublicSessionId } from "./public-session-id";
 import { resolveScmSettings } from "./scm-settings-resolution";
 import { validateReasoningEffort } from "./reasoning-effort";
 import {
@@ -877,9 +877,14 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     ...DEFAULT_LIFECYCLE_CONFIG,
     controlPlaneUrl,
     model: DEFAULT_MODEL,
-    // Re-derived per use: on the first-ever activation the manager is built
-    // during the init request, before the session row exists.
-    getSessionId: () => resolvePublicSessionId(sessionCoreRepository.getSession(), durableObjectId),
+    // Re-derived per use until the session row exists: on the first-ever
+    // activation the manager is built during the init request, before the row
+    // is written. Latched afterwards — the manager derives log context from
+    // this on every log line, and the id is immutable once row-backed.
+    getSessionId: createLatchedPublicSessionIdResolver(
+      () => sessionCoreRepository.getSession(),
+      durableObjectId
+    ),
     inactivity: {
       ...DEFAULT_LIFECYCLE_CONFIG.inactivity,
       timeoutMs: parseInt(env.SANDBOX_INACTIVITY_TIMEOUT_MS || "600000", 10),

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -1,0 +1,390 @@
+import { isSessionPromptable } from "@open-inspect/shared/types/session-activity";
+import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+import { hashToken } from "../auth/crypto";
+import type { Logger } from "../logger";
+import { isSandboxReconnectBlockedStatus } from "../sandbox/lifecycle/decisions";
+import type { SandboxLifecycleManager } from "../sandbox/lifecycle/manager";
+import type { SourceControlProviderName } from "../source-control";
+import type { BackgroundTasks } from "../platform-ports";
+import type { ClientInfo } from "../types";
+import { isValidSandboxToken } from "./sandbox-access";
+import { resolveParticipantName } from "./participant-name";
+import { getAvatarUrl, type ParticipantService } from "./participant-service";
+import type { PresenceService } from "./presence-service";
+import type { SessionMessageQueue } from "./message-queue";
+import type { SessionMessenger } from "./messenger";
+import type { SandboxRepository } from "./sandbox-repository";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionSnapshotReader } from "./snapshot-reader";
+import type { SessionWebSocketManager } from "./websocket-manager";
+import type { DurableObjectSessionConnections } from "./durable-object-session-connections";
+
+/**
+ * Maximum age of a WebSocket authentication token (in milliseconds).
+ * Tokens older than this are rejected with close code 4001, forcing
+ * the client to fetch a fresh token on reconnect.
+ */
+const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface SessionConnectionAuthenticatorDeps {
+  connections: DurableObjectSessionConnections;
+  wsManager: SessionWebSocketManager;
+  sessionCoreRepository: SessionCoreRepository;
+  sandboxRepository: SandboxRepository;
+  lifecycleManager: SandboxLifecycleManager;
+  messenger: SessionMessenger;
+  backgroundTasks: BackgroundTasks;
+  messageQueue: Pick<SessionMessageQueue, "processMessageQueue">;
+  participantService: ParticipantService;
+  presenceService: PresenceService;
+  snapshotReader: SessionSnapshotReader;
+  schedulePullRequestRefresh: (trigger: "open" | "manual") => void;
+  /** Resolved per call — throws on an invalid `SCM_PROVIDER`, like today's sites. */
+  getScmProviderName: () => SourceControlProviderName;
+  /** The session-scoped logger; upgrade/subscribe paths also receive request-scoped children. */
+  log: Logger;
+}
+
+/**
+ * Admits connections to the session: sandbox WebSocket upgrades (token +
+ * lifecycle-state guards, re-checked after the non-storage token-hash await),
+ * client subscriptions (token TTL, snapshot handoff), and post-hibernation
+ * client identity recovery.
+ */
+export class SessionConnectionAuthenticator {
+  constructor(private readonly deps: SessionConnectionAuthenticatorDeps) {}
+
+  /**
+   * Handle WebSocket upgrade request. `log` is the request-scoped logger.
+   */
+  async handleWebSocketUpgrade(request: Request, url: URL, log: Logger): Promise<Response> {
+    const {
+      connections,
+      wsManager,
+      sessionCoreRepository,
+      sandboxRepository,
+      lifecycleManager,
+      messenger,
+      backgroundTasks,
+      messageQueue,
+    } = this.deps;
+    log.debug("WebSocket upgrade requested");
+    const isSandbox = url.searchParams.get("type") === "sandbox";
+
+    // Validate sandbox authentication
+    if (isSandbox) {
+      const wsStartTime = Date.now();
+      const authHeader = request.headers.get("Authorization");
+      const sandboxId = request.headers.get("X-Sandbox-ID");
+      const providedToken = authHeader?.startsWith("Bearer ")
+        ? authHeader.slice("Bearer ".length)
+        : null;
+
+      // Get expected values from DB
+      const sandbox = sandboxRepository.getSandbox();
+      const expectedSandboxId = sandbox?.modal_sandbox_id;
+
+      // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
+      if (expectedSandboxId && sandboxId !== expectedSandboxId) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "auth_failed",
+          reject_reason: "sandbox_id_mismatch",
+          expected_sandbox_id: expectedSandboxId,
+          sandbox_id: sandboxId,
+          duration_ms: Date.now() - wsStartTime,
+        });
+        return new Response("Forbidden: Wrong sandbox ID", { status: 403 });
+      }
+
+      // Validate auth token
+      const tokenMatches = await isValidSandboxToken(providedToken, sandbox);
+      if (!tokenMatches) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "auth_failed",
+          reject_reason: "token_mismatch",
+          duration_ms: Date.now() - wsStartTime,
+        });
+        return new Response("Unauthorized: Invalid auth token", { status: 401 });
+      }
+
+      // Reject connection if the session itself is closed for good. Narrower
+      // than "not active": `completed` and `failed` sessions are idle, not
+      // over — warm-on-typing spawns a sandbox for one before the follow-up
+      // prompt arrives, and rejecting its bridge stranded that prompt.
+      //
+      // Read after authentication, not before: token hashing is a non-storage
+      // await, so the input gate lets a cancel or archive land while this
+      // request is suspended. Admission needs a fresh, synchronous read.
+      const currentSession = sessionCoreRepository.getSession();
+      if (currentSession && !isSessionPromptable(currentSession.status)) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "rejected",
+          reject_reason: "session_terminal",
+          session_status: currentSession.status,
+          duration_ms: Date.now() - wsStartTime,
+        });
+        return new Response("Session is terminal", { status: 410 });
+      }
+
+      const currentSandbox = sandboxRepository.getSandbox();
+      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
+      // still connect after a slow boot and self-heal by becoming ready.
+      if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "rejected",
+          reject_reason: "sandbox_stopped",
+          sandbox_status: currentSandbox.status,
+          duration_ms: Date.now() - wsStartTime,
+        });
+        return new Response("Sandbox is stopped", { status: 410 });
+      }
+      if (
+        currentSandbox?.modal_sandbox_id !== expectedSandboxId ||
+        currentSandbox?.auth_token_hash !== sandbox?.auth_token_hash ||
+        currentSandbox?.auth_token !== sandbox?.auth_token
+      ) {
+        return new Response("Forbidden: Sandbox credentials changed", { status: 403 });
+      }
+
+      // Auth passed — continue to WebSocket accept below
+      // The success ws.connect event is emitted after the WebSocket is accepted
+    }
+
+    try {
+      const { client, server } = connections.createUpgradeSockets();
+
+      const sandboxId = request.headers.get("X-Sandbox-ID");
+
+      if (isSandbox) {
+        // The lifecycle manager publishes access after any pending provider
+        // startup has persisted its URLs and credentials.
+        const accessIsPersisted = !lifecycleManager.isProviderStartupPending();
+        const { replaced } = wsManager.acceptAndSetSandboxSocket(server, sandboxId ?? undefined);
+        // Notify manager that sandbox connected so it can reset the spawning flag
+        lifecycleManager.onSandboxConnected();
+        sandboxRepository.updateSandboxStatus("ready");
+        messenger.broadcast({ type: "sandbox_status", status: "ready" });
+        if (accessIsPersisted) {
+          messenger.broadcast({ type: "sandbox_access_changed" });
+        }
+
+        // Set initial activity timestamp and schedule inactivity check
+        // IMPORTANT: Must await to ensure alarm is scheduled before returning
+        const now = Date.now();
+        lifecycleManager.updateLastActivity(now);
+        sandboxRepository.updateSandboxHeartbeat(now);
+        await lifecycleManager.scheduleInactivityCheck();
+
+        log.info("ws.connect", {
+          event: "ws.connect",
+          ws_type: "sandbox",
+          outcome: "success",
+          sandbox_id: sandboxId,
+          replaced_existing: replaced,
+          duration_ms: Date.now() - now,
+        });
+
+        // Process any pending messages now that sandbox is connected
+        backgroundTasks.submit(() => messageQueue.processMessageQueue(), {
+          name: "message_queue.process",
+        });
+      } else {
+        const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        wsManager.acceptClientSocket(server, wsId);
+        backgroundTasks.submit(() => wsManager.enforceAuthTimeout(server, wsId), {
+          name: "websocket.enforce_auth_timeout",
+          context: { ws_id: wsId },
+        });
+      }
+
+      return new Response(null, { status: 101, webSocket: client });
+    } catch (error) {
+      log.error("WebSocket upgrade failed", {
+        error: error instanceof Error ? error : String(error),
+      });
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+  }
+
+  /**
+   * Handle client subscription with token validation.
+   */
+  async handleSubscribe(
+    ws: WebSocket,
+    data: {
+      token: string;
+      clientId: string;
+    }
+  ): Promise<void> {
+    const { wsManager, participantService, presenceService, log } = this.deps;
+    // Validate the WebSocket auth token
+    if (!data.token) {
+      log.warn("ws.connect", {
+        event: "ws.connect",
+        ws_type: "client",
+        outcome: "auth_failed",
+        reject_reason: "no_token",
+      });
+      wsManager.close(ws, 4001, "Authentication required");
+      return;
+    }
+
+    if (wsManager.isClientAuthenticated(ws) || wsManager.isClientSynchronizing(ws)) {
+      wsManager.close(ws, 4003, "Already subscribed");
+      return;
+    }
+    wsManager.setClientSynchronizing(ws, true);
+
+    try {
+      // Hash the incoming token and look up participant
+      const tokenHash = await hashToken(data.token);
+      const participant = participantService.getByWsTokenHash(tokenHash);
+
+      if (!participant) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "client",
+          outcome: "auth_failed",
+          reject_reason: "invalid_token",
+        });
+        wsManager.close(ws, 4001, "Invalid authentication token");
+        return;
+      }
+
+      // Reject tokens older than the TTL
+      if (
+        participant.ws_token_created_at === null ||
+        Date.now() - participant.ws_token_created_at > WS_TOKEN_TTL_MS
+      ) {
+        log.warn("ws.connect", {
+          event: "ws.connect",
+          ws_type: "client",
+          outcome: "auth_failed",
+          reject_reason: "token_expired",
+          participant_id: participant.id,
+          user_id: participant.user_id,
+        });
+        wsManager.close(ws, 4001, "Token expired");
+        return;
+      }
+
+      log.info("ws.connect", {
+        event: "ws.connect",
+        ws_type: "client",
+        outcome: "success",
+        participant_id: participant.id,
+        user_id: participant.user_id,
+        client_id: data.clientId,
+      });
+
+      // Build client info from participant data
+      const clientInfo: ClientInfo = {
+        participantId: participant.id,
+        userId: participant.canonical_user_id ?? participant.user_id,
+        name: resolveParticipantName(participant),
+        avatar: getAvatarUrl(participant.scm_login, this.deps.getScmProviderName()),
+        status: "active",
+        lastSeen: Date.now(),
+        clientId: data.clientId,
+        ws,
+      };
+
+      const enrichment = await this.deps.snapshotReader.resolveSessionSnapshotEnrichment();
+      if (!this.completeClientSubscription(ws, clientInfo, enrichment)) {
+        wsManager.close(ws, 4009, "Session synchronization failed");
+        return;
+      }
+
+      presenceService.sendPresence(ws);
+      presenceService.broadcastPresence();
+      this.deps.schedulePullRequestRefresh("open");
+    } finally {
+      wsManager.setClientSynchronizing(ws, false);
+    }
+  }
+
+  /**
+   * Finish the snapshot-to-stream handoff synchronously. Keeping the final read,
+   * send, and registration in a non-async method makes the no-await invariant
+   * structural rather than a convention inside the async authentication flow.
+   */
+  private completeClientSubscription(
+    ws: WebSocket,
+    client: ClientInfo,
+    enrichment: Parameters<SessionSnapshotReader["readSessionSnapshot"]>[0]
+  ): boolean {
+    const { wsManager, snapshotReader, log } = this.deps;
+    const snapshot = snapshotReader.readSessionSnapshot(enrichment);
+    if (!snapshot) return false;
+
+    if (
+      !wsManager.send(ws, {
+        type: "subscribed",
+        ...snapshot,
+        participantId: client.participantId,
+        participant: {
+          participantId: client.participantId,
+          userId: client.userId,
+          name: client.name,
+          avatar: client.avatar,
+        },
+      } satisfies ServerMessage)
+    ) {
+      return false;
+    }
+
+    wsManager.setClient(ws, client);
+    const parsed = wsManager.classify(ws);
+    if (parsed.kind === "client" && parsed.wsId) {
+      wsManager.persistClientMapping(parsed.wsId, client.participantId, client.clientId);
+      log.debug("Stored ws_client_mapping", {
+        ws_id: parsed.wsId,
+        participant_id: client.participantId,
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Get client info for a WebSocket, reconstructing from storage if needed after hibernation.
+   */
+  getClientInfo(ws: WebSocket): ClientInfo | null {
+    const { wsManager, log } = this.deps;
+    // 1. In-memory cache (manager)
+    const cached = wsManager.getClient(ws);
+    if (cached) return cached;
+
+    // 2. DB recovery (manager handles tag parsing + DB lookup)
+    const mapping = wsManager.recoverClientMapping(ws);
+    if (!mapping) {
+      log.warn("No client mapping found after hibernation, closing WebSocket");
+      wsManager.close(ws, 4002, "Session expired, please reconnect");
+      return null;
+    }
+
+    // 3. Build ClientInfo
+    log.info("Recovered client info from DB", { user_id: mapping.user_id });
+    const clientInfo: ClientInfo = {
+      participantId: mapping.participant_id,
+      userId: mapping.canonical_user_id ?? mapping.user_id,
+      name: resolveParticipantName(mapping),
+      avatar: getAvatarUrl(mapping.scm_login, this.deps.getScmProviderName()),
+      status: "active",
+      lastSeen: Date.now(),
+      clientId: mapping.client_id || `client-${Date.now()}`,
+      ws,
+    };
+
+    // 4. Re-cache
+    wsManager.setClient(ws, clientInfo);
+    return clientInfo;
+  }
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -5,6 +5,11 @@
  * - SQLite database for persistent state
  * - WebSocket connections with hibernation support
  * - Prompt queue and event streaming
+ *
+ * The collaborator graph is built eagerly by `createSessionComponents` in
+ * `ensureInitialized()`. This class owns only the Cloudflare adapters (fetch,
+ * WebSocket callbacks, alarm) and the domain logic Phase 3 has not yet
+ * extracted: connection auth, the snapshot read model, and sandbox access.
  */
 
 import { DurableObject } from "cloudflare:workers";
@@ -15,137 +20,40 @@ import {
   type SessionSnapshotState,
 } from "@open-inspect/shared/types/server-messages";
 import { isSessionPromptable } from "@open-inspect/shared/types/session-activity";
-import { resolveAppName } from "@open-inspect/shared/app-name";
 import { DEFAULT_MODEL } from "@open-inspect/shared/models";
-import { generateId, hashToken, encryptToken } from "../auth/crypto";
-import { resolveSandboxBackendName } from "../sandbox/provider-name";
-import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
-import { createImageBuildLookup } from "../image-builds/lookup";
-import { resolveImageBuildProvider } from "../image-builds/provider-policy";
+import { hashToken } from "../auth/crypto";
 import { createLogger, parseLogLevel } from "../logger";
 import type { Logger } from "../logger";
-import {
-  SandboxLifecycleManager,
-  DEFAULT_LIFECYCLE_CONFIG,
-  type SandboxStorage,
-  type SandboxBroadcaster,
-  type WebSocketManager,
-  type IdGenerator,
-  type ImageBuildLookup,
-  type McpServerLookup,
-  type SlackAgentNotifyLookup,
-} from "../sandbox/lifecycle/manager";
-import { McpServerStore } from "../db/mcp-servers";
-import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
-import { SessionIndexStore } from "../db/session-index";
 import { isSandboxReconnectBlockedStatus } from "../sandbox/lifecycle/decisions";
-import { DEFAULT_SANDBOX_TIMEOUT_SECONDS } from "../sandbox/provider";
-import { parsePersistedSandboxSettings } from "../sandbox/settings";
-import {
-  createSourceControlProviderFromEnv,
-  resolveScmProviderFromEnv,
-  type SourceControlProvider,
-} from "../source-control";
+import { resolveScmProviderFromEnv } from "../source-control";
 import type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
 import type { Env, ClientInfo } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, SandboxRow } from "./types";
-import { SessionCoreRepository } from "./session-core-repository";
-import { SandboxRepository } from "./sandbox-repository";
 import { DEFAULT_SANDBOX_STATUS } from "../sandbox/sandbox-status";
-import { SessionAttachmentRepository } from "./session-attachment-repository";
-import { ArtifactRepository } from "./artifact-repository";
-import { EventRepository } from "./event-repository";
-import { MessageRepository } from "./message-repository";
-import { ParticipantRepository } from "./participant-repository";
-import { WsClientMappingRepository } from "./ws-client-mapping-repository";
 import { resolveParticipantName } from "./participant-name";
-import { validateReasoningEffort } from "./reasoning-effort";
 import { safeParseTunnelUrls } from "./tunnel-urls";
 import { resolvePublicSessionId } from "./public-session-id";
-import { resolveScmSettings } from "./scm-settings-resolution";
 import {
   decryptStoredAccessValue,
   isValidSandboxToken,
   resolveSandboxDashboardUrl,
-  type SandboxDashboardSettings,
 } from "./sandbox-access";
-import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
-import { DurableObjectSessionConnections } from "./durable-object-session-connections";
-import { SessionPullRequestStore } from "../db/session-pull-request-store";
-import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
-import { refreshSessionPullRequests } from "./pull-request-refresh";
 import { findPrArtifactForRepo } from "./pr-artifacts";
 import { EnvironmentStore } from "../db/environments";
-import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
-import { XaiTokenRefreshService } from "./xai-token-refresh-service";
-import { ScmCredentialsService } from "./scm-credentials-service";
-import { ParticipantService, getAvatarUrl } from "./participant-service";
-import { UserScmTokenStore } from "../db/user-scm-tokens";
-import { CallbackNotificationService } from "./callback-notification-service";
-import { UserEnvResolver } from "./user-env-resolver";
-import { resolveSessionRepoId } from "./repo-id-resolution";
-import { Scheduler } from "../scheduler/scheduler";
-import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
-import type { BackgroundTasks } from "../platform-ports";
-import { PresenceService } from "./presence-service";
-import { SessionMessageQueue } from "./message-queue";
-import { SessionSandboxEventProcessor } from "./sandbox-events";
-import { SessionTerminalMessageProjection } from "./terminal-message-projection";
-import { SessionEventStream } from "./event-stream";
+import { getAvatarUrl } from "./participant-service";
 import { createSessionInternalRoutes } from "./http/routes";
-import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
-import {
-  createChildSessionsHandler,
-  type ChildSessionsHandler,
-} from "./http/handlers/child-sessions.handler";
-import { createSandboxHandler, type SandboxHandler } from "./http/handlers/sandbox.handler";
-import { AttachmentsHandler } from "./http/handlers/attachments.handler";
-import { createWsTokenHandler, type WsTokenHandler } from "./http/handlers/ws-token.handler";
-import {
-  createSessionLifecycleHandler,
-  type SessionLifecycleHandler,
-} from "./http/handlers/session-lifecycle.handler";
-import {
-  normalizeSessionTitle,
-  type SessionTitleUpdateOptions,
-  type SessionTitleUpdateResult,
-} from "./title";
-import {
-  createPullRequestHandler,
-  type PullRequestHandler,
-} from "./http/handlers/pull-request.handler";
-import {
-  createParticipantsHandler,
-  type ParticipantsHandler,
-} from "./http/handlers/participants.handler";
-import { MessageService } from "./services/message.service";
-import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
-import {
-  createEarliestAlarmScheduler,
-  handleAlarmDelivery,
-  PersistedAlarmDeadlineStore,
-  type RehydratableAlarmScheduler,
-} from "./alarm/scheduler";
-import { SessionDiffStore } from "./diffs/store";
-import { SessionDiffService } from "./diffs/service";
-import { SessionDiffsHandler } from "./http/handlers/session-diffs.handler";
-import { SessionMessengerImpl, type SessionMessenger } from "./messenger";
-import { SessionStatusService } from "./session-status-service";
-import { parseArtifactMetadata } from "./artifact-metadata";
+import { handleAlarmDelivery } from "./alarm/scheduler";
 import { SessionServer } from "./server";
 import { SessionHttpDispatcher } from "./http/dispatcher";
 import { SessionMessageRouter, type SessionClientCommands } from "./message-router";
 import { SessionDisconnectHandler } from "./disconnect-handler";
 import type { Clock, SandboxDisconnectMonitor, SessionBroadcaster, SocketRegistry } from "./ports";
-
-/**
- * Timeout for WebSocket authentication (in milliseconds).
- * Client WebSockets must send a valid 'subscribe' message within this time
- * or the connection will be closed. This prevents resource abuse from
- * unauthenticated connections that never complete the handshake.
- */
-const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
+import {
+  createSessionComponents,
+  type SessionComponents,
+  type SessionPlatform,
+} from "./components";
 
 /**
  * Maximum age of a WebSocket authentication token (in milliseconds).
@@ -167,191 +75,112 @@ export class SessionDO extends DurableObject<Env> {
    * binding at runtime. Distinct from `this.sql`, the DO-embedded SQLite.
    */
   private readonly db: SqlDatabase | null;
-  private readonly backgroundTasks: BackgroundTasks;
-  private readonly alarmDeadlines: PersistedAlarmDeadlineStore;
-  /** Immutable env projection for the provider dashboard link. */
-  private readonly sandboxDashboardSettings: SandboxDashboardSettings;
-  private sessionCoreRepository: SessionCoreRepository;
-  private sandboxRepository: SandboxRepository;
-  private attachmentRepository: SessionAttachmentRepository;
-  private artifactRepository: ArtifactRepository;
-  private eventRepository: EventRepository;
-  private messageRepository: MessageRepository;
-  private participantRepository: ParticipantRepository;
-  private wsClientMappingRepository: WsClientMappingRepository;
   private initialized = false;
-  // Session-scoped logger. Assigned during initialization only — never
-  // per-request. Request-serving code receives a request-scoped child
-  // (with trace_id / request_id) threaded explicitly from fetch().
+  // Boot logger until ensureInitialized() replaces it with the session-scoped
+  // logger the composition root creates. Request-serving code receives a
+  // request-scoped child (with trace_id / request_id) threaded explicitly
+  // from fetch().
   private log: Logger;
-  // WebSocket manager (lazily initialized like lifecycleManager)
-  private _wsManager: SessionWebSocketManager | null = null;
-  private _connections: DurableObjectSessionConnections | null = null;
-  // Session messenger (constructed in ensureInitialized once the session logger exists)
-  private messenger!: SessionMessenger;
-  // Session diff service (constructed in ensureInitialized once the session logger exists)
-  private diffService!: SessionDiffService;
-  // Session diffs HTTP handler (constructed in ensureInitialized alongside the service)
-  private diffsHandler!: SessionDiffsHandler;
-  // Lifecycle manager (lazily initialized)
-  private _lifecycleManager: SandboxLifecycleManager | null = null;
-  // Source control provider (lazily initialized)
-  private _sourceControlProvider: SourceControlProvider | null = null;
-  // Participant service (lazily initialized)
-  private _participantService: ParticipantService | null = null;
-  // Callback notification service (lazily initialized)
-  private _callbackService: CallbackNotificationService | null = null;
-  // Presence service (lazily initialized)
-  private _presenceService: PresenceService | null = null;
-  // Message queue service (lazily initialized)
-  private _messageQueue: SessionMessageQueue | null = null;
-  // Message service (lazily initialized)
-  private _messageService: MessageService | null = null;
-  private _eventStream: SessionEventStream | null = null;
-  // Messages handler (lazily initialized)
-  private _messagesHandler: MessagesHandler | null = null;
-  // Child sessions handler (lazily initialized)
-  private _childSessionsHandler: ChildSessionsHandler | null = null;
-  // Sandbox handler (lazily initialized)
-  private _sandboxHandler: SandboxHandler | null = null;
-  // Session attachments handler (lazily initialized)
-  private _attachmentsHandler: AttachmentsHandler | null = null;
-  // WebSocket token handler (lazily initialized)
-  private _wsTokenHandler: WsTokenHandler | null = null;
-  // Session lifecycle handler (lazily initialized)
-  private _sessionLifecycleHandler: SessionLifecycleHandler | null = null;
-  // Pull request handler (lazily initialized)
-  private _pullRequestHandler: PullRequestHandler | null = null;
-  private readonly prCreationClaims = new PullRequestCreationClaims();
-  // Participants handler (lazily initialized)
-  private _participantsHandler: ParticipantsHandler | null = null;
-  // Alarm handler (lazily initialized)
-  private _alarmHandler: AlarmHandler | null = null;
-  private _alarmScheduler: RehydratableAlarmScheduler | null = null;
-  // Sandbox event processor (lazily initialized)
-  private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
-  // Session status service (lazily initialized)
-  private _statusService: SessionStatusService | null = null;
-  private _terminalMessageProjection: SessionTerminalMessageProjection | null = null;
-  private _userEnvResolver: UserEnvResolver | null = null;
+  // The eagerly constructed collaborator graph. Every runtime entry point
+  // (fetch, WebSocket callbacks, alarm) calls ensureInitialized() before any
+  // of these closures dereference it.
+  private components!: SessionComponents;
   private readonly server: SessionServer<WebSocket, ClientInfo>;
 
-  // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
+  // Internal HTTP route table (transport wiring only; handlers live in the
+  // component graph).
   private readonly routes = createSessionInternalRoutes({
-    init: (request, _url, log) => this.sessionLifecycleHandler.init(request, log),
-    state: () => this.sessionLifecycleHandler.getState(),
+    init: (request, _url, log) => this.components.sessionLifecycleHandler.init(request, log),
+    state: () => this.components.sessionLifecycleHandler.getState(),
     snapshot: () => this.handleSnapshot(),
     sandboxAccess: () => this.handleSandboxAccess(),
-    prompt: (request, _url, log) => this.messagesHandler.enqueuePrompt(request, log),
-    stop: () => this.messagesHandler.stop(),
-    sandboxEvent: (request) => this.sandboxHandler.sandboxEvent(request),
-    createMediaArtifact: (request) => this.sandboxHandler.createMediaArtifact(request),
+    prompt: (request, _url, log) => this.components.messagesHandler.enqueuePrompt(request, log),
+    stop: () => this.components.messagesHandler.stop(),
+    sandboxEvent: (request) => this.components.sandboxHandler.sandboxEvent(request),
+    createMediaArtifact: (request) => this.components.sandboxHandler.createMediaArtifact(request),
     recordAttachment: (request) => {
-      const session = this.sessionCoreRepository.getSession();
-      return this.attachmentsHandler.recordAttachment(
+      const session = this.components.sessionCoreRepository.getSession();
+      return this.components.attachmentsHandler.recordAttachment(
         request,
         session ? resolvePublicSessionId(session, this.ctx.id.toString()) : null
       );
     },
-    listParticipants: () => this.participantsHandler.listParticipants(),
-    addParticipant: (request) => this.sandboxHandler.addParticipant(request),
-    listEvents: (_request, url) => this.messagesHandler.listEvents(url),
-    listArtifacts: (_request, url) => this.messagesHandler.listArtifacts(url),
-    listMessages: (_request, url) => this.messagesHandler.listMessages(url),
-    createPr: (request, _url, log) => this.pullRequestHandler.createPr(request, log),
+    listParticipants: () => this.components.participantsHandler.listParticipants(),
+    addParticipant: (request) => this.components.sandboxHandler.addParticipant(request),
+    listEvents: (_request, url) => this.components.messagesHandler.listEvents(url),
+    listArtifacts: (_request, url) => this.components.messagesHandler.listArtifacts(url),
+    listMessages: (_request, url) => this.components.messagesHandler.listMessages(url),
+    createPr: (request, _url, log) => this.components.pullRequestHandler.createPr(request, log),
     pullRequestArtifactSnapshot: (request, url) =>
-      this.pullRequestHandler.pullRequestArtifactSnapshot(request, url),
-    pullRequestsRefresh: () => this.pullRequestHandler.refreshPullRequests(),
-    wsToken: (request, _url, log) => this.wsTokenHandler.generateWsToken(request, log),
-    updateTitle: (request) => this.sessionLifecycleHandler.updateTitle(request),
-    archive: (request) => this.sessionLifecycleHandler.archive(request),
-    unarchive: (request) => this.sessionLifecycleHandler.unarchive(request),
-    expireDraft: () => this.sessionLifecycleHandler.expireDraft(),
+      this.components.pullRequestHandler.pullRequestArtifactSnapshot(request, url),
+    pullRequestsRefresh: () => this.components.pullRequestHandler.refreshPullRequests(),
+    wsToken: (request, _url, log) => this.components.wsTokenHandler.generateWsToken(request, log),
+    updateTitle: (request) => this.components.sessionLifecycleHandler.updateTitle(request),
+    archive: (request) => this.components.sessionLifecycleHandler.archive(request),
+    unarchive: (request) => this.components.sessionLifecycleHandler.unarchive(request),
+    expireDraft: () => this.components.sessionLifecycleHandler.expireDraft(),
     verifySandboxToken: (request, _url, log) =>
-      this.sandboxHandler.verifySandboxToken(request, log),
-    openaiTokenRefresh: (_request, _url, log) => this.sandboxHandler.openaiTokenRefresh(log),
-    xaiTokenRefresh: (_request, _url, log) => this.sandboxHandler.xaiTokenRefresh(log),
-    scmCredentials: (_request, _url, log) => this.sandboxHandler.scmCredentials(log),
-    tunnelUrls: (_request, _url, log) => this.sandboxHandler.tunnelUrls(log),
-    spawnContext: () => this.childSessionsHandler.getSpawnContext(),
-    activePromptAuthor: () => this.childSessionsHandler.getActivePromptAuthor(),
-    childSummary: (_request, url) => this.childSessionsHandler.getChildSummary(url),
-    parentPrompt: (request) => this.childSessionsHandler.parentPrompt(request),
-    cancel: () => this.sessionLifecycleHandler.cancel(),
-    childSessionUpdate: (request) => this.childSessionsHandler.childSessionUpdate(request),
-    diffState: () => this.diffsHandler.state(),
-    diffStore: (request) => this.diffsHandler.storeBundle(request),
-    diffFailure: (request) => this.diffsHandler.recordFailure(request),
-    diffResolveFile: (_request, url) => this.diffsHandler.resolveFile(url),
-    diffRetry: () => this.diffsHandler.retry(),
+      this.components.sandboxHandler.verifySandboxToken(request, log),
+    openaiTokenRefresh: (_request, _url, log) =>
+      this.components.sandboxHandler.openaiTokenRefresh(log),
+    xaiTokenRefresh: (_request, _url, log) => this.components.sandboxHandler.xaiTokenRefresh(log),
+    scmCredentials: (_request, _url, log) => this.components.sandboxHandler.scmCredentials(log),
+    tunnelUrls: (_request, _url, log) => this.components.sandboxHandler.tunnelUrls(log),
+    spawnContext: () => this.components.childSessionsHandler.getSpawnContext(),
+    activePromptAuthor: () => this.components.childSessionsHandler.getActivePromptAuthor(),
+    childSummary: (_request, url) => this.components.childSessionsHandler.getChildSummary(url),
+    parentPrompt: (request) => this.components.childSessionsHandler.parentPrompt(request),
+    cancel: () => this.components.sessionLifecycleHandler.cancel(),
+    childSessionUpdate: (request) =>
+      this.components.childSessionsHandler.childSessionUpdate(request),
+    diffState: () => this.components.diffsHandler.state(),
+    diffStore: (request) => this.components.diffsHandler.storeBundle(request),
+    diffFailure: (request) => this.components.diffsHandler.recordFailure(request),
+    diffResolveFile: (_request, url) => this.components.diffsHandler.resolveFile(url),
+    diffRetry: () => this.components.diffsHandler.retry(),
   });
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     // eslint-disable-next-line no-restricted-syntax -- composition root: the DO's one env.DB read
     this.db = env.DB ?? null;
-    this.backgroundTasks = createCloudflareBackgroundTasks(ctx, () => this.log);
     this.sql = ctx.storage.sql;
-    this.sandboxDashboardSettings = {
-      sandboxProvider: env.SANDBOX_PROVIDER,
-      modalWorkspace: env.MODAL_WORKSPACE,
-      modalEnvironment: env.MODAL_ENVIRONMENT,
-    };
-    this.alarmDeadlines = new PersistedAlarmDeadlineStore(this.sql);
-    this.attachmentRepository = new SessionAttachmentRepository(this.sql);
-    this.artifactRepository = new ArtifactRepository(this.sql);
-    this.eventRepository = new EventRepository(this.sql, (closure) =>
-      ctx.storage.transactionSync(closure)
-    );
-    this.messageRepository = new MessageRepository(
-      this.sql,
-      (closure) => ctx.storage.transactionSync(closure),
-      this.attachmentRepository,
-      this.eventRepository
-    );
-    this.participantRepository = new ParticipantRepository(this.sql);
-    this.wsClientMappingRepository = new WsClientMappingRepository(this.sql);
-    this.sessionCoreRepository = new SessionCoreRepository(this.sql, (closure) =>
-      ctx.storage.transactionSync(closure)
-    );
     this.log = createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL));
-    // After this.log: the sandbox repository validates the status it reads and
-    // warns on anything unmodelled, so it needs a logger.
-    this.sandboxRepository = new SandboxRepository(this.sql, this.log);
     const ensureInitialized = (rehydrateAlarm?: boolean) => this.ensureInitialized(rehydrateAlarm);
     const clock: Clock = {
       nowMs: () => Date.now(),
       monotonicNowMs: () => performance.now(),
     };
     const sockets: SocketRegistry<WebSocket, ClientInfo> = {
-      classify: (ws) => this.wsManager.classify(ws),
-      send: (ws, message) => this.wsManager.send(ws, message),
+      classify: (ws) => this.components.wsManager.classify(ws),
+      send: (ws, message) => this.components.wsManager.send(ws, message),
       getClient: (ws) => this.getClientInfo(ws),
-      close: (ws, code, reason) => this.wsManager.close(ws, code, reason),
-      clearSandboxIfMatch: (ws) => this.wsManager.clearSandboxSocketIfMatch(ws),
-      removeClient: (ws) => this.wsManager.removeClient(ws),
+      close: (ws, code, reason) => this.components.wsManager.close(ws, code, reason),
+      clearSandboxIfMatch: (ws) => this.components.wsManager.clearSandboxSocketIfMatch(ws),
+      removeClient: (ws) => this.components.wsManager.removeClient(ws),
       hasParticipant: (participantId) =>
-        Array.from(this.wsManager.getAuthenticatedClients()).some(
+        Array.from(this.components.wsManager.getAuthenticatedClients()).some(
           (client) => client.participantId === participantId
         ),
     };
     const clientCommands: SessionClientCommands<WebSocket, ClientInfo> = {
       subscribe: (ws, message) => this.handleSubscribe(ws, message),
       submitPrompt: (ws, client, message) =>
-        this.messageQueue.handlePromptMessage(ws, client, message),
-      cancelPrompt: (ws, message) => this.messageQueue.cancelQueuedPrompt(ws, message),
-      stopExecution: () => this.messageQueue.stopExecution(),
-      notifyTyping: () => this.presenceService.handleTyping(),
-      updatePresence: (client, message) => this.presenceService.updatePresence(client, message),
-      getHistoryPage: (message) => this.eventStream.getHistoryPage(message),
+        this.components.messageQueue.handlePromptMessage(ws, client, message),
+      cancelPrompt: (ws, message) => this.components.messageQueue.cancelQueuedPrompt(ws, message),
+      stopExecution: () => this.components.messageQueue.stopExecution(),
+      notifyTyping: () => this.components.presenceService.handleTyping(),
+      updatePresence: (client, message) =>
+        this.components.presenceService.updatePresence(client, message),
+      getHistoryPage: (message) => this.components.eventStream.getHistoryPage(message),
     };
     const sandboxDisconnects: SandboxDisconnectMonitor = {
-      getStatus: () => this.sandboxRepository.getSandbox()?.status,
-      scheduleCheck: () => this.lifecycleManager.scheduleDisconnectCheck(),
+      getStatus: () => this.components.sandboxRepository.getSandbox()?.status,
+      scheduleCheck: () => this.components.lifecycleManager.scheduleDisconnectCheck(),
     };
     const broadcaster: SessionBroadcaster = {
-      broadcastPresence: () => this.presenceService.broadcastPresence(),
-      broadcast: (message) => this.messenger.broadcast(message),
+      broadcastPresence: () => this.components.presenceService.broadcastPresence(),
+      broadcast: (message) => this.components.messenger.broadcast(message),
     };
     // Cloudflare composition root: adapt DO callbacks and hibernating sockets to the server.
     this.server = new SessionServer({
@@ -368,7 +197,8 @@ export class SessionDO extends DurableObject<Env> {
         getLogger: () => this.log,
         sockets,
         clientCommands,
-        processSandboxEvent: (event) => this.sandboxEventProcessor.processSandboxEvent(event),
+        processSandboxEvent: (event) =>
+          this.components.sandboxEventProcessor.processSandboxEvent(event),
         clock,
       }),
       disconnects: new SessionDisconnectHandler({
@@ -379,726 +209,26 @@ export class SessionDO extends DurableObject<Env> {
       }),
       handleScheduledDeadline: () =>
         handleAlarmDelivery(
-          this.alarmDeadlines,
-          () => this.alarmHandler.handle(),
-          () => this.alarmScheduler.rearmPending()
+          this.components.alarmDeadlines,
+          () => this.components.alarmHandler.handle(),
+          () => this.components.alarmScheduler.rearmPending()
         ),
     });
-    // Note: session_id context is set in ensureInitialized() once DB is ready
   }
 
   /**
-   * Get the lifecycle manager, creating it lazily if needed.
-   * The manager is created with adapters that delegate to the DO's methods.
-   */
-  private get lifecycleManager(): SandboxLifecycleManager {
-    if (!this._lifecycleManager) {
-      this._lifecycleManager = this.createLifecycleManager();
-    }
-    return this._lifecycleManager;
-  }
-
-  /**
-   * Get the source control provider, creating it lazily if needed.
-   */
-  private get sourceControlProvider(): SourceControlProvider {
-    if (!this._sourceControlProvider) {
-      this._sourceControlProvider = this.createSourceControlProvider();
-    }
-    return this._sourceControlProvider;
-  }
-
-  private get userEnvResolver(): UserEnvResolver {
-    if (!this._userEnvResolver) {
-      this._userEnvResolver = new UserEnvResolver({
-        db: this.db,
-        sessionCoreRepository: this.sessionCoreRepository,
-        resolveRepoId: (session) =>
-          resolveSessionRepoId(
-            session,
-            this.sessionCoreRepository,
-            () => this.sourceControlProvider
-          ),
-        durableObjectId: this.ctx.id.toString(),
-        repoSecretsEncryptionKey: this.env.REPO_SECRETS_ENCRYPTION_KEY,
-        secretsCapEnforcement: this.env.SECRETS_CAP_ENFORCEMENT,
-        log: () => this.log,
-      });
-    }
-    return this._userEnvResolver;
-  }
-
-  /**
-   * Get the participant service, creating it lazily if needed.
-   */
-  private get participantService(): ParticipantService {
-    if (!this._participantService) {
-      const userScmTokenStore =
-        this.db && this.env.TOKEN_ENCRYPTION_KEY
-          ? new UserScmTokenStore(this.db, this.env.TOKEN_ENCRYPTION_KEY)
-          : null;
-      this._participantService = new ParticipantService({
-        repository: this.participantRepository,
-        getProcessingMessageAuthor: () => this.messageRepository.getProcessingMessageAuthor(),
-        env: this.env,
-        log: this.log,
-        generateId: () => generateId(),
-        userScmTokenStore,
-      });
-    }
-    return this._participantService;
-  }
-
-  /**
-   * Get the callback notification service, creating it lazily if needed.
-   */
-  private get callbackService(): CallbackNotificationService {
-    if (!this._callbackService) {
-      const scheduler = this.db
-        ? new Scheduler(this.db, this.env, this.backgroundTasks)
-        : undefined;
-
-      this._callbackService = new CallbackNotificationService({
-        repository: this.sessionCoreRepository,
-        messageRepository: this.messageRepository,
-        env: this.env,
-        completeAutomationRun: scheduler
-          ? (completion) => scheduler.runComplete(completion)
-          : undefined,
-        log: this.log,
-        getSessionId: () =>
-          resolvePublicSessionId(this.sessionCoreRepository.getSession(), this.ctx.id.toString()),
-      });
-    }
-    return this._callbackService;
-  }
-
-  /**
-   * Get the presence service, creating it lazily if needed.
-   */
-  private get presenceService(): PresenceService {
-    if (!this._presenceService) {
-      this._presenceService = new PresenceService({
-        getAuthenticatedClients: () => this.wsManager.getAuthenticatedClients(),
-        messenger: this.messenger,
-        send: (ws, msg) => this.wsManager.send(ws, msg),
-        getSandboxSocket: () => this.wsManager.getSandboxSocket(),
-        isSpawning: () => this.lifecycleManager.isSpawning(),
-        spawnSandbox: () => this.lifecycleManager.spawnSandbox(),
-        log: this.log,
-      });
-    }
-    return this._presenceService;
-  }
-
-  /**
-   * Get the WebSocket manager, creating it lazily if needed.
-   * Lazy initialization ensures the logger has session_id context
-   * (set by ensureInitialized()) by the time the manager is created.
-   */
-  private get wsManager(): SessionWebSocketManager {
-    if (!this._wsManager) {
-      this._wsManager = new SessionWebSocketManagerImpl(
-        this.ctx,
-        this.sandboxRepository,
-        this.wsClientMappingRepository,
-        this.log,
-        { authTimeoutMs: WS_AUTH_TIMEOUT_MS }
-      );
-    }
-    return this._wsManager;
-  }
-
-  private get connections(): DurableObjectSessionConnections {
-    if (!this._connections) {
-      this._connections = new DurableObjectSessionConnections(this.ctx, this.wsManager);
-    }
-    return this._connections;
-  }
-
-  private get executionTimeoutMs(): number {
-    try {
-      const sandboxTimeoutMs = parsePersistedSandboxSettings(
-        this.sessionCoreRepository.getSession()?.sandbox_settings ?? null
-      ).sandboxTimeoutMs;
-      // This watchdog starts before bridge setup, so it must not race the
-      // bridge's earlier snapshot-reserved prompt deadline.
-      if (sandboxTimeoutMs !== undefined) return sandboxTimeoutMs;
-    } catch {
-      this.log.warn("Failed to parse sandbox_settings for execution timeout, using fallback");
-    }
-    return parseInt(
-      this.env.EXECUTION_TIMEOUT_MS || String(DEFAULT_SANDBOX_TIMEOUT_SECONDS * 1000),
-      10
-    );
-  }
-
-  private get alarmScheduler(): RehydratableAlarmScheduler {
-    if (!this._alarmScheduler) {
-      this._alarmScheduler = createEarliestAlarmScheduler(this.ctx.storage, this.alarmDeadlines);
-    }
-    return this._alarmScheduler;
-  }
-
-  private get messageQueue(): SessionMessageQueue {
-    if (!this._messageQueue) {
-      this._messageQueue = new SessionMessageQueue(
-        this.backgroundTasks,
-        this.log,
-        this.sessionCoreRepository,
-        this.messageRepository,
-        this.participantRepository,
-        this.attachmentRepository,
-        this.wsManager,
-        this.messenger,
-        this.participantService,
-        this.callbackService,
-        this.statusService,
-        (model) => this.userEnvResolver.getProviderAuthenticationError(model),
-        (messageId, messageCreatedAt, completedAt) =>
-          this.terminalMessageProjection.recordTerminalMessage({
-            messageId,
-            messageCreatedAt,
-            terminalMessageCompletedAt: completedAt,
-          }),
-        this.lifecycleManager,
-        this.db ? new SessionIndexStore(this.db) : null,
-        resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
-        this.alarmScheduler,
-        this.executionTimeoutMs
-      );
-    }
-
-    return this._messageQueue;
-  }
-
-  private get terminalMessageProjection(): SessionTerminalMessageProjection {
-    if (!this._terminalMessageProjection) {
-      this._terminalMessageProjection = new SessionTerminalMessageProjection(
-        this.db ? new SessionIndexStore(this.db) : null,
-        () => {
-          const session = this.sessionCoreRepository.getSession();
-          return session ? resolvePublicSessionId(session, this.ctx.id.toString()) : null;
-        },
-        this.log
-      );
-    }
-    return this._terminalMessageProjection;
-  }
-
-  private get messageService(): MessageService {
-    if (!this._messageService) {
-      this._messageService = new MessageService({
-        repository: this.messageRepository,
-        eventRepository: this.eventRepository,
-        artifactRepository: this.artifactRepository,
-        messageQueue: this.messageQueue,
-        stopExecution: () => this.messageQueue.stopExecution(),
-        parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, this.log),
-      });
-    }
-
-    return this._messageService;
-  }
-
-  private get eventStream(): SessionEventStream {
-    if (!this._eventStream) {
-      this._eventStream = new SessionEventStream(this.eventRepository);
-    }
-
-    return this._eventStream;
-  }
-
-  private get messagesHandler(): MessagesHandler {
-    if (!this._messagesHandler) {
-      this._messagesHandler = createMessagesHandler({
-        messageService: this.messageService,
-      });
-    }
-
-    return this._messagesHandler;
-  }
-
-  private get childSessionsHandler(): ChildSessionsHandler {
-    if (!this._childSessionsHandler) {
-      this._childSessionsHandler = createChildSessionsHandler({
-        messageRepository: this.messageRepository,
-        eventRepository: this.eventRepository,
-        participantRepository: this.participantRepository,
-        artifactRepository: this.artifactRepository,
-        getSession: () => this.sessionCoreRepository.getSession(),
-        getSandbox: () => this.sandboxRepository.getSandbox(),
-        getPublicSessionId: (session) => resolvePublicSessionId(session, this.ctx.id.toString()),
-        parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, this.log),
-        messenger: this.messenger,
-        messageService: this.messageService,
-      });
-    }
-
-    return this._childSessionsHandler;
-  }
-
-  private get sandboxHandler(): SandboxHandler {
-    if (!this._sandboxHandler) {
-      this._sandboxHandler = createSandboxHandler({
-        messageRepository: this.messageRepository,
-        eventRepository: this.eventRepository,
-        participantRepository: this.participantRepository,
-        artifactRepository: this.artifactRepository,
-        processSandboxEvent: (event) => this.sandboxEventProcessor.processSandboxEvent(event),
-        getSandbox: () => this.sandboxRepository.getSandbox(),
-        isValidSandboxToken: (token, sandbox) => isValidSandboxToken(token, sandbox),
-        getSession: () => this.sessionCoreRepository.getSession(),
-        refreshOpenAIToken: async (session, log) => {
-          const service = new OpenAITokenRefreshService(
-            this.db!,
-            this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) =>
-              resolveSessionRepoId(
-                sessionRow,
-                this.sessionCoreRepository,
-                () => this.sourceControlProvider
-              ),
-            log
-          );
-          return service.refresh(session);
-        },
-        refreshXaiToken: async (session, log) => {
-          const service = new XaiTokenRefreshService(
-            this.db!,
-            this.env.REPO_SECRETS_ENCRYPTION_KEY!,
-            (sessionRow) =>
-              resolveSessionRepoId(
-                sessionRow,
-                this.sessionCoreRepository,
-                () => this.sourceControlProvider
-              ),
-            log
-          );
-          return service.refresh(session);
-        },
-        isManagedSecretsConfigured: () => Boolean(this.db && this.env.REPO_SECRETS_ENCRYPTION_KEY),
-        getScmCredentials: (log) =>
-          new ScmCredentialsService(this.sourceControlProvider, log).getCredentials(),
-        messenger: this.messenger,
-        generateId: () => generateId(),
-        now: () => Date.now(),
-      });
-    }
-
-    return this._sandboxHandler;
-  }
-
-  private get attachmentsHandler(): AttachmentsHandler {
-    if (!this._attachmentsHandler) {
-      this._attachmentsHandler = new AttachmentsHandler(this.attachmentRepository, this.log);
-    }
-
-    return this._attachmentsHandler;
-  }
-
-  private get wsTokenHandler(): WsTokenHandler {
-    if (!this._wsTokenHandler) {
-      this._wsTokenHandler = createWsTokenHandler({
-        repository: this.participantRepository,
-        getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
-        generateId: (bytes) => generateId(bytes),
-        hashToken: (token) => hashToken(token),
-        now: () => Date.now(),
-      });
-    }
-
-    return this._wsTokenHandler;
-  }
-
-  private get sessionLifecycleHandler(): SessionLifecycleHandler {
-    if (!this._sessionLifecycleHandler) {
-      this._sessionLifecycleHandler = createSessionLifecycleHandler({
-        sessionCoreRepository: this.sessionCoreRepository,
-        sandboxRepository: this.sandboxRepository,
-        messageRepository: this.messageRepository,
-        participantRepository: this.participantRepository,
-        getDurableObjectId: () => this.ctx.id.toString(),
-        tokenEncryptionKey: this.env.TOKEN_ENCRYPTION_KEY,
-        encryptToken: (token, encryptionKey) => encryptToken(token, encryptionKey),
-        validateReasoningEffort: (model, effort) =>
-          validateReasoningEffort(model, effort, this.log),
-        generateId: (bytes) => generateId(bytes),
-        now: () => Date.now(),
-        scheduleWarmSandbox: () =>
-          this.backgroundTasks.submit(() => this.lifecycleManager.warmSandbox(), {
-            name: "sandbox.warm",
-          }),
-        getSession: () => this.sessionCoreRepository.getSession(),
-        getSandbox: () => this.sandboxRepository.getSandbox(),
-        getPublicSessionId: (session) => resolvePublicSessionId(session, this.ctx.id.toString()),
-        getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
-        statusService: this.statusService,
-        applySessionTitleUpdate: (title, options) => this.applySessionTitleUpdate(title, options),
-        cancelSession: async () => {
-          await this.statusService.cancel(() => this.messageQueue.cancelExecution());
-        },
-        getSandboxSocket: () => this.wsManager.getSandboxSocket(),
-        sendToSandbox: (ws, message) => this.wsManager.send(ws, message),
-        updateSandboxStatus: (status) => this.sandboxRepository.updateSandboxStatus(status),
-      });
-    }
-
-    return this._sessionLifecycleHandler;
-  }
-
-  private get pullRequestHandler(): PullRequestHandler {
-    if (!this._pullRequestHandler) {
-      this._pullRequestHandler = createPullRequestHandler({
-        getSession: () => this.sessionCoreRepository.getSession(),
-        getSessionRepositories: () => this.sessionCoreRepository.getSessionRepositories(),
-        getPromptingParticipantForPR: () => this.participantService.getPromptingParticipantForPR(),
-        resolveAuthForPR: (participant) => this.participantService.resolveAuthForPR(participant),
-        getSessionUrl: (session) => {
-          const sessionId = session.session_name || session.id;
-          const webAppUrl = this.env.WEB_APP_URL || this.env.WORKER_URL || "";
-          return webAppUrl + "/session/" + sessionId;
-        },
-        createPullRequest: async (input, log) => {
-          const pullRequestService = new SessionPullRequestService({
-            repository: this.sessionCoreRepository,
-            artifactRepository: this.artifactRepository,
-            claims: this.prCreationClaims,
-            sourceControlProvider: this.sourceControlProvider,
-            log,
-            generateId: () => generateId(),
-            pushBranchToRemote: (pushSpec) =>
-              this.sandboxEventProcessor.pushBranchToRemote(pushSpec),
-            messenger: this.messenger,
-            appName: resolveAppName(this.env),
-            sessionPullRequests: this.db ? new SessionPullRequestStore(this.db) : undefined,
-            resolveScmSettings: (repo) => resolveScmSettings(this.db, repo),
-          });
-
-          return pullRequestService.createPullRequest(input);
-        },
-        getArtifactById: (artifactId) => this.artifactRepository.getArtifactById(artifactId),
-        updateArtifact: (artifactId, data) =>
-          this.artifactRepository.updateArtifact(artifactId, data),
-        messenger: this.messenger,
-        now: () => Date.now(),
-        triggerPullRequestRefresh: () => this.schedulePullRequestRefresh("manual"),
-      });
-    }
-
-    return this._pullRequestHandler;
-  }
-
-  /** Fire a background read-through refresh. */
-  private schedulePullRequestRefresh(trigger: "open" | "manual"): void {
-    this.backgroundTasks.submit(
-      () =>
-        refreshSessionPullRequests(
-          this.sessionCoreRepository,
-          this.artifactRepository,
-          this.sourceControlProvider,
-          this.db ? new SessionPullRequestStore(this.db) : null
-        ).then(({ updated, failures }) => {
-          for (const artifact of updated) {
-            this.messenger.broadcast({ type: "artifact_updated", artifact });
-          }
-          for (const failure of failures) {
-            this.log.error("Pull request refresh failed for artifact", {
-              trigger,
-              reason: failure.reason,
-              artifact_id: failure.artifactId,
-              pr_number: failure.prNumber,
-              repo_owner: failure.repoOwner,
-              repo_name: failure.repoName,
-              error: failure.error instanceof Error ? failure.error : String(failure.error),
-            });
-          }
-        }),
-      {
-        name: "pull_request.refresh",
-        context: { trigger },
-      }
-    );
-  }
-
-  private get participantsHandler(): ParticipantsHandler {
-    if (!this._participantsHandler) {
-      this._participantsHandler = createParticipantsHandler({
-        repository: this.participantRepository,
-      });
-    }
-
-    return this._participantsHandler;
-  }
-
-  private get alarmHandler(): AlarmHandler {
-    if (!this._alarmHandler) {
-      this._alarmHandler = createAlarmHandler({
-        repository: this.messageRepository,
-        messageQueue: this.messageQueue,
-        lifecycleManager: this.lifecycleManager,
-        alarmScheduler: this.alarmScheduler,
-        executionTimeoutMs: this.executionTimeoutMs,
-        now: () => Date.now(),
-        log: this.log,
-      });
-    }
-
-    return this._alarmHandler;
-  }
-
-  private get sandboxEventProcessor(): SessionSandboxEventProcessor {
-    if (!this._sandboxEventProcessor) {
-      this._sandboxEventProcessor = new SessionSandboxEventProcessor(
-        this.backgroundTasks,
-        () => this.log,
-        this.sessionCoreRepository,
-        this.sandboxRepository,
-        this.messageRepository,
-        this.eventRepository,
-        this.artifactRepository,
-        this.callbackService,
-        this.wsManager,
-        this.messenger,
-        this.diffService,
-        (title, options) => this.applySessionTitleUpdate(title, options),
-        (reason) => this.lifecycleManager.triggerSnapshot(reason),
-        (messageId, messageCreatedAt, completedAt) =>
-          this.terminalMessageProjection.recordTerminalMessage({
-            messageId,
-            messageCreatedAt,
-            terminalMessageCompletedAt: completedAt,
-          }),
-        this.statusService,
-        (timestamp) => this.lifecycleManager.updateLastActivity(timestamp),
-        () => this.lifecycleManager.scheduleInactivityCheck(),
-        () => this.messageQueue.processMessageQueue(),
-        () => this.messageQueue.broadcastPromptQueue()
-      );
-    }
-
-    return this._sandboxEventProcessor;
-  }
-
-  /**
-   * Get the session status service, creating it lazily if needed.
-   * Lazy initialization ensures the session-scoped logger and messenger
-   * (set by ensureInitialized()) exist by the time the service is created.
-   */
-  private get statusService(): SessionStatusService {
-    if (!this._statusService) {
-      this._statusService = new SessionStatusService(
-        this.backgroundTasks,
-        this.log,
-        this.sessionCoreRepository,
-        this.messageRepository,
-        this.artifactRepository,
-        this.messenger,
-        this.db ? new SessionIndexStore(this.db) : null,
-        this.env.SESSION ?? null
-      );
-    }
-
-    return this._statusService;
-  }
-
-  /**
-   * Create the source control provider.
-   */
-  private createSourceControlProvider(): SourceControlProvider {
-    return createSourceControlProviderFromEnv(this.env);
-  }
-
-  /**
-   * Create the lifecycle manager with all required adapters.
-   */
-  private createLifecycleManager(): SandboxLifecycleManager {
-    const sandboxBackend = resolveSandboxBackendName(this.env.SANDBOX_PROVIDER);
-
-    const provider = createSandboxProviderFromEnv(this.env, sandboxBackend);
-
-    // Storage adapter
-    const storage: SandboxStorage = {
-      getSandbox: () => this.sandboxRepository.getSandbox(),
-      getSandboxWithCircuitBreaker: () => this.sandboxRepository.getSandboxWithCircuitBreaker(),
-      getSession: () => this.sessionCoreRepository.getSession(),
-      getSessionRepositories: () =>
-        this.sessionCoreRepository.getSessionRepositories().map((entry) => ({
-          repoOwner: entry.repoOwner,
-          repoName: entry.repoName,
-          baseBranch: entry.baseBranch ?? "main",
-          baseSha: entry.row?.base_sha ?? null,
-        })),
-      getUserEnvVars: () => this.userEnvResolver.getUserEnvVars(),
-      updateSandboxStatus: (status) => this.sandboxRepository.updateSandboxStatus(status),
-      updateSandboxForSpawn: (data) => this.sandboxRepository.updateSandboxForSpawn(data),
-      updateSandboxForResume: (data) => this.sandboxRepository.updateSandboxForResume(data),
-      updateSandboxModalObjectId: (id) => this.sandboxRepository.updateSandboxModalObjectId(id),
-      updateSandboxRuntimeVersion: (runtimeVersion) =>
-        this.sandboxRepository.updateSandboxRuntimeVersion(runtimeVersion),
-      updateSandboxSnapshotImageId: (sandboxId, imageId, runtimeVersion) =>
-        this.sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion),
-      updateSandboxLastActivity: (timestamp) =>
-        this.sandboxRepository.updateSandboxLastActivity(timestamp),
-      incrementCircuitBreakerFailure: (timestamp) =>
-        this.sandboxRepository.incrementCircuitBreakerFailure(timestamp),
-      resetCircuitBreaker: () => this.sandboxRepository.resetCircuitBreaker(),
-      setLastSpawnError: (error, timestamp) =>
-        this.sandboxRepository.updateSandboxSpawnError(error, timestamp),
-      updateSandboxCodeServer: async (url, password) => {
-        const encrypted = this.env.REPO_SECRETS_ENCRYPTION_KEY
-          ? await encryptToken(password, this.env.REPO_SECRETS_ENCRYPTION_KEY)
-          : password;
-        this.sandboxRepository.updateSandboxCodeServer(url, encrypted);
-      },
-      clearSandboxCodeServer: () => this.sandboxRepository.clearSandboxCodeServer(),
-      clearSandboxCodeServerUrl: () => this.sandboxRepository.clearSandboxCodeServerUrl(),
-      updateSandboxVnc: async (url, password) => {
-        const encrypted = this.env.REPO_SECRETS_ENCRYPTION_KEY
-          ? await encryptToken(password, this.env.REPO_SECRETS_ENCRYPTION_KEY)
-          : password;
-        this.sandboxRepository.updateSandboxVnc(url, encrypted);
-      },
-      clearSandboxVnc: () => this.sandboxRepository.clearSandboxVnc(),
-      clearSandboxVncUrl: () => this.sandboxRepository.clearSandboxVncUrl(),
-      updateSandboxTunnelUrls: (urls) => this.sandboxRepository.updateSandboxTunnelUrls(urls),
-      clearSandboxTunnelUrls: () => this.sandboxRepository.clearSandboxTunnelUrls(),
-      updateSandboxTtyd: async (url, token) => {
-        const encrypted = this.env.REPO_SECRETS_ENCRYPTION_KEY
-          ? await encryptToken(token, this.env.REPO_SECRETS_ENCRYPTION_KEY)
-          : token;
-        this.sandboxRepository.updateSandboxTtyd(url, encrypted);
-      },
-      clearSandboxTtyd: () => this.sandboxRepository.clearSandboxTtyd(),
-    };
-
-    // Broadcaster adapter
-    const broadcaster: SandboxBroadcaster = {
-      broadcast: (message) => this.messenger.broadcast(message as ServerMessage),
-    };
-
-    // WebSocket manager adapter — thin delegation to wsManager
-    const wsManager: WebSocketManager = {
-      getSandboxWebSocket: () => this.wsManager.getSandboxSocket(),
-      detachSandboxWebSocket: (code, reason) => this.wsManager.detachSandboxSocket(code, reason),
-      sendToSandbox: (message) => {
-        const ws = this.wsManager.getSandboxSocket();
-        return ws ? this.wsManager.send(ws, message) : false;
-      },
-      getConnectedClientCount: () => this.wsManager.getConnectedClientCount(),
-    };
-
-    // ID generator adapter
-    const idGenerator: IdGenerator = {
-      generateId: () => generateId(),
-    };
-
-    // Build configuration
-    const controlPlaneUrl =
-      this.env.WORKER_URL ||
-      `https://open-inspect-control-plane.${this.env.CF_ACCOUNT_ID || "workers"}.workers.dev`;
-
-    // Resolve sessionId for lifecycle manager logging context
-    const session = this.sessionCoreRepository.getSession();
-    const sessionId = resolvePublicSessionId(session, this.ctx.id.toString());
-
-    // Create D1-backed lookups if database is available
-    let mcpServerLookup: McpServerLookup | undefined;
-    if (this.db) {
-      const mcpStore = new McpServerStore(this.db, this.env.REPO_SECRETS_ENCRYPTION_KEY);
-      mcpServerLookup = {
-        getDecryptedForSession: (repositories) => mcpStore.getDecryptedForSession(repositories),
-      };
-    }
-
-    // Session-scoped gate: resolved from the primary member (the scalar mirror
-    // this lookup is called with) — see resolveSessionScopedSettings for the
-    // per-feature scope rules. Token absence short-circuits to false so a
-    // misconfigured deployment never installs a tool that would 503 on every call.
-    let slackAgentNotifyLookup: SlackAgentNotifyLookup | undefined;
-    if (this.db) {
-      const tokenPresent = !!this.env.SLACK_BOT_TOKEN;
-      const settingsStore = new IntegrationSettingsStore(this.db);
-      slackAgentNotifyLookup = {
-        isEnabledForRepo: async (repoOwner, repoName) => {
-          if (!tokenPresent) return false;
-          const settings =
-            repoOwner && repoName
-              ? (await settingsStore.getResolvedConfig("slack", `${repoOwner}/${repoName}`))
-                  .settings
-              : ((await settingsStore.getGlobal("slack"))?.defaults ?? {});
-          return resolveSlackSettings(settings).agentNotificationsEnabled;
-        },
-      };
-    }
-
-    const sandboxDashboardUrlBuilder =
-      sandboxBackend === "modal"
-        ? (providerObjectId: string) =>
-            resolveSandboxDashboardUrl(this.sandboxDashboardSettings, providerObjectId)
-        : undefined;
-
-    const config = {
-      ...DEFAULT_LIFECYCLE_CONFIG,
-      controlPlaneUrl,
-      model: DEFAULT_MODEL,
-      sessionId,
-      inactivity: {
-        ...DEFAULT_LIFECYCLE_CONFIG.inactivity,
-        timeoutMs: parseInt(this.env.SANDBOX_INACTIVITY_TIMEOUT_MS || "600000", 10),
-      },
-      mcpServerLookup,
-      slackAgentNotifyLookup,
-      sandboxDashboardUrlBuilder,
-    };
-
-    // Create the image lookup if D1 is available and the provider supports
-    // prebuilt images.
-    let imageBuildLookup: ImageBuildLookup | undefined;
-    const imageBuildProvider = resolveImageBuildProvider(sandboxBackend);
-    if (this.db && imageBuildProvider) {
-      imageBuildLookup = createImageBuildLookup(this.db, imageBuildProvider);
-    }
-
-    return new SandboxLifecycleManager(
-      provider,
-      storage,
-      broadcaster,
-      wsManager,
-      this.alarmScheduler,
-      idGenerator,
-      config,
-      imageBuildLookup
-    );
-  }
-
-  /**
-   * Initialize the session with required data.
+   * Initialize the session runtime: apply the schema, then build the whole
+   * collaborator graph eagerly. Every runtime entry point calls this first.
    */
   private ensureInitialized(rehydrateAlarm = true): void {
     if (this.initialized) return;
     initSchema(this.sql);
     this.initialized = true;
-    const session = this.sessionCoreRepository.getSession();
-    const sessionId = resolvePublicSessionId(session, this.ctx.id.toString());
-    this.log = createLogger(
-      "session-do",
-      { session_id: sessionId },
-      parseLogLevel(this.env.LOG_LEVEL)
-    );
-    // Constructed here rather than in the constructor so they (and the
-    // WebSocket manager they force) capture the session-scoped logger,
-    // never the request-scoped child installed by fetch().
-    this.messenger = new SessionMessengerImpl(this.connections);
-    this.diffService = new SessionDiffService(
-      new SessionDiffStore(this.sql),
-      this.sessionCoreRepository,
-      this.messenger,
-      this.log
-    );
-    this.diffsHandler = new SessionDiffsHandler(this.diffService);
+    const platform: SessionPlatform = { ctx: this.ctx, sql: this.sql, db: this.db };
+    this.components = createSessionComponents(platform, this.env);
+    this.log = this.components.log;
     if (rehydrateAlarm) {
-      this.backgroundTasks.submit(() => this.alarmScheduler.rehydrate(), {
+      this.components.backgroundTasks.submit(() => this.components.alarmScheduler.rehydrate(), {
         name: "alarm.rehydrate",
       });
     }
@@ -1128,7 +258,7 @@ export class SessionDO extends DurableObject<Env> {
         : null;
 
       // Get expected values from DB
-      const sandbox = this.sandboxRepository.getSandbox();
+      const sandbox = this.components.sandboxRepository.getSandbox();
       const expectedSandboxId = sandbox?.modal_sandbox_id;
 
       // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
@@ -1166,7 +296,7 @@ export class SessionDO extends DurableObject<Env> {
       // Read after authentication, not before: token hashing is a non-storage
       // await, so the input gate lets a cancel or archive land while this
       // request is suspended. Admission needs a fresh, synchronous read.
-      const currentSession = this.sessionCoreRepository.getSession();
+      const currentSession = this.components.sessionCoreRepository.getSession();
       if (currentSession && !isSessionPromptable(currentSession.status)) {
         log.warn("ws.connect", {
           event: "ws.connect",
@@ -1179,7 +309,7 @@ export class SessionDO extends DurableObject<Env> {
         return new Response("Session is terminal", { status: 410 });
       }
 
-      const currentSandbox = this.sandboxRepository.getSandbox();
+      const currentSandbox = this.components.sandboxRepository.getSandbox();
       // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
       // still connect after a slow boot and self-heal by becoming ready.
       if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
@@ -1206,32 +336,32 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     try {
-      const { client, server } = this.connections.createUpgradeSockets();
+      const { client, server } = this.components.connections.createUpgradeSockets();
 
       const sandboxId = request.headers.get("X-Sandbox-ID");
 
       if (isSandbox) {
         // The lifecycle manager publishes access after any pending provider
         // startup has persisted its URLs and credentials.
-        const accessIsPersisted = !this.lifecycleManager.isProviderStartupPending();
-        const { replaced } = this.wsManager.acceptAndSetSandboxSocket(
+        const accessIsPersisted = !this.components.lifecycleManager.isProviderStartupPending();
+        const { replaced } = this.components.wsManager.acceptAndSetSandboxSocket(
           server,
           sandboxId ?? undefined
         );
         // Notify manager that sandbox connected so it can reset the spawning flag
-        this.lifecycleManager.onSandboxConnected();
-        this.sandboxRepository.updateSandboxStatus("ready");
-        this.messenger.broadcast({ type: "sandbox_status", status: "ready" });
+        this.components.lifecycleManager.onSandboxConnected();
+        this.components.sandboxRepository.updateSandboxStatus("ready");
+        this.components.messenger.broadcast({ type: "sandbox_status", status: "ready" });
         if (accessIsPersisted) {
-          this.messenger.broadcast({ type: "sandbox_access_changed" });
+          this.components.messenger.broadcast({ type: "sandbox_access_changed" });
         }
 
         // Set initial activity timestamp and schedule inactivity check
         // IMPORTANT: Must await to ensure alarm is scheduled before returning
         const now = Date.now();
-        this.lifecycleManager.updateLastActivity(now);
-        this.sandboxRepository.updateSandboxHeartbeat(now);
-        await this.lifecycleManager.scheduleInactivityCheck();
+        this.components.lifecycleManager.updateLastActivity(now);
+        this.components.sandboxRepository.updateSandboxHeartbeat(now);
+        await this.components.lifecycleManager.scheduleInactivityCheck();
 
         log.info("ws.connect", {
           event: "ws.connect",
@@ -1243,16 +373,22 @@ export class SessionDO extends DurableObject<Env> {
         });
 
         // Process any pending messages now that sandbox is connected
-        this.backgroundTasks.submit(() => this.messageQueue.processMessageQueue(), {
-          name: "message_queue.process",
-        });
+        this.components.backgroundTasks.submit(
+          () => this.components.messageQueue.processMessageQueue(),
+          {
+            name: "message_queue.process",
+          }
+        );
       } else {
         const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-        this.wsManager.acceptClientSocket(server, wsId);
-        this.backgroundTasks.submit(() => this.wsManager.enforceAuthTimeout(server, wsId), {
-          name: "websocket.enforce_auth_timeout",
-          context: { ws_id: wsId },
-        });
+        this.components.wsManager.acceptClientSocket(server, wsId);
+        this.components.backgroundTasks.submit(
+          () => this.components.wsManager.enforceAuthTimeout(server, wsId),
+          {
+            name: "websocket.enforce_auth_timeout",
+            context: { ws_id: wsId },
+          }
+        );
       }
 
       return new Response(null, { status: 101, webSocket: client });
@@ -1312,6 +448,7 @@ export class SessionDO extends DurableObject<Env> {
       clientId: string;
     }
   ): Promise<void> {
+    const { wsManager, participantService, presenceService } = this.components;
     // Validate the WebSocket auth token
     if (!data.token) {
       this.log.warn("ws.connect", {
@@ -1320,20 +457,20 @@ export class SessionDO extends DurableObject<Env> {
         outcome: "auth_failed",
         reject_reason: "no_token",
       });
-      this.wsManager.close(ws, 4001, "Authentication required");
+      wsManager.close(ws, 4001, "Authentication required");
       return;
     }
 
-    if (this.wsManager.isClientAuthenticated(ws) || this.wsManager.isClientSynchronizing(ws)) {
-      this.wsManager.close(ws, 4003, "Already subscribed");
+    if (wsManager.isClientAuthenticated(ws) || wsManager.isClientSynchronizing(ws)) {
+      wsManager.close(ws, 4003, "Already subscribed");
       return;
     }
-    this.wsManager.setClientSynchronizing(ws, true);
+    wsManager.setClientSynchronizing(ws, true);
 
     try {
       // Hash the incoming token and look up participant
       const tokenHash = await hashToken(data.token);
-      const participant = this.participantService.getByWsTokenHash(tokenHash);
+      const participant = participantService.getByWsTokenHash(tokenHash);
 
       if (!participant) {
         this.log.warn("ws.connect", {
@@ -1342,7 +479,7 @@ export class SessionDO extends DurableObject<Env> {
           outcome: "auth_failed",
           reject_reason: "invalid_token",
         });
-        this.wsManager.close(ws, 4001, "Invalid authentication token");
+        wsManager.close(ws, 4001, "Invalid authentication token");
         return;
       }
 
@@ -1359,7 +496,7 @@ export class SessionDO extends DurableObject<Env> {
           participant_id: participant.id,
           user_id: participant.user_id,
         });
-        this.wsManager.close(ws, 4001, "Token expired");
+        wsManager.close(ws, 4001, "Token expired");
         return;
       }
 
@@ -1389,15 +526,15 @@ export class SessionDO extends DurableObject<Env> {
 
       const enrichment = await this.resolveSessionSnapshotEnrichment();
       if (!this.completeClientSubscription(ws, clientInfo, enrichment)) {
-        this.wsManager.close(ws, 4009, "Session synchronization failed");
+        wsManager.close(ws, 4009, "Session synchronization failed");
         return;
       }
 
-      this.presenceService.sendPresence(ws);
-      this.presenceService.broadcastPresence();
-      this.schedulePullRequestRefresh("open");
+      presenceService.sendPresence(ws);
+      presenceService.broadcastPresence();
+      this.components.schedulePullRequestRefresh("open");
     } finally {
-      this.wsManager.setClientSynchronizing(ws, false);
+      wsManager.setClientSynchronizing(ws, false);
     }
   }
 
@@ -1411,11 +548,12 @@ export class SessionDO extends DurableObject<Env> {
     client: ClientInfo,
     enrichment: SessionSnapshotEnrichment
   ): boolean {
+    const { wsManager } = this.components;
     const snapshot = this.readSessionSnapshot(enrichment);
     if (!snapshot) return false;
 
     if (
-      !this.wsManager.send(ws, {
+      !wsManager.send(ws, {
         type: "subscribed",
         ...snapshot,
         participantId: client.participantId,
@@ -1430,10 +568,10 @@ export class SessionDO extends DurableObject<Env> {
       return false;
     }
 
-    this.wsManager.setClient(ws, client);
-    const parsed = this.wsManager.classify(ws);
+    wsManager.setClient(ws, client);
+    const parsed = wsManager.classify(ws);
     if (parsed.kind === "client" && parsed.wsId) {
-      this.wsManager.persistClientMapping(parsed.wsId, client.participantId, client.clientId);
+      wsManager.persistClientMapping(parsed.wsId, client.participantId, client.clientId);
       this.log.debug("Stored ws_client_mapping", {
         ws_id: parsed.wsId,
         participant_id: client.participantId,
@@ -1446,15 +584,16 @@ export class SessionDO extends DurableObject<Env> {
    * Get client info for a WebSocket, reconstructing from storage if needed after hibernation.
    */
   private getClientInfo(ws: WebSocket): ClientInfo | null {
+    const { wsManager } = this.components;
     // 1. In-memory cache (manager)
-    const cached = this.wsManager.getClient(ws);
+    const cached = wsManager.getClient(ws);
     if (cached) return cached;
 
     // 2. DB recovery (manager handles tag parsing + DB lookup)
-    const mapping = this.wsManager.recoverClientMapping(ws);
+    const mapping = wsManager.recoverClientMapping(ws);
     if (!mapping) {
       this.log.warn("No client mapping found after hibernation, closing WebSocket");
-      this.wsManager.close(ws, 4002, "Session expired, please reconnect");
+      wsManager.close(ws, 4002, "Session expired, please reconnect");
       return null;
     }
 
@@ -1472,71 +611,12 @@ export class SessionDO extends DurableObject<Env> {
     };
 
     // 4. Re-cache
-    this.wsManager.setClient(ws, clientInfo);
+    wsManager.setClient(ws, clientInfo);
     return clientInfo;
   }
 
-  private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
-    if (!this.db) return;
-    const sessionStore = new SessionIndexStore(this.db);
-    this.backgroundTasks.submit(
-      () => sessionStore.updateTitleIfNewer(sessionId, title, updatedAt),
-      {
-        name: "session_index.update_title",
-        context: { session_id: sessionId, updated_at: updatedAt },
-      }
-    );
-  }
-
-  private applySessionTitleUpdate(
-    title: string,
-    options: SessionTitleUpdateOptions = {}
-  ): SessionTitleUpdateResult {
-    const normalized = normalizeSessionTitle(title);
-    if (!normalized.ok) {
-      return { ok: false, reason: "invalid", error: normalized.error };
-    }
-    const titleText = normalized.title;
-
-    const session = this.sessionCoreRepository.getSession();
-    if (!session) {
-      return { ok: false, reason: "not_found", error: "Session not found" };
-    }
-
-    const updatedAt = Math.max(Date.now(), session.updated_at + 1);
-    if (options.onlyIfUnset) {
-      const didUpdate = this.sessionCoreRepository.updateSessionTitleIfUnset(
-        session.id,
-        titleText,
-        updatedAt
-      );
-      if (!didUpdate) {
-        return { ok: false, reason: "already_set", error: "Session title is already set" };
-      }
-    } else {
-      this.sessionCoreRepository.updateSessionTitle(session.id, titleText, updatedAt);
-    }
-
-    const publicSessionId = resolvePublicSessionId(session, this.ctx.id.toString());
-    this.syncSessionIndexTitle(publicSessionId, titleText, updatedAt);
-    this.messenger.broadcast({ type: "session_title", title: titleText });
-
-    if (session.parent_session_id) {
-      this.statusService.notifyParentOfChildUpdate(
-        { ...session, title: titleText },
-        publicSessionId,
-        {
-          status: session.status,
-          title: titleText,
-        }
-      );
-    }
-
-    return { ok: true, title: titleText };
-  }
-
   private async resolveSessionSnapshotEnrichment(): Promise<SessionSnapshotEnrichment> {
-    const session = this.sessionCoreRepository.getSession();
+    const session = this.components.sessionCoreRepository.getSession();
     const environmentId = session?.environment_id ?? null;
     const environmentName = await this.resolveEnvironmentName(environmentId);
     return { environmentId, environmentName };
@@ -1545,9 +625,9 @@ export class SessionDO extends DurableObject<Env> {
   private readSessionState(
     enrichment: SessionSnapshotEnrichment
   ): { session: SessionSnapshotState; sandbox: SandboxRow | null } | null {
-    const session = this.sessionCoreRepository.getSession();
+    const session = this.components.sessionCoreRepository.getSession();
     if (!session) return null;
-    const sandbox = this.sandboxRepository.getSandbox();
+    const sandbox = this.components.sandboxRepository.getSandbox();
     const publicSession: SessionSnapshotState = {
       id: resolvePublicSessionId(session, this.ctx.id.toString()),
       title: session.title,
@@ -1557,7 +637,7 @@ export class SessionDO extends DurableObject<Env> {
       branchName: session.branch_name,
       status: session.status,
       sandboxStatus: sandbox?.status ?? DEFAULT_SANDBOX_STATUS,
-      messageCount: this.messageRepository.getMessageCount(),
+      messageCount: this.components.messageRepository.getMessageCount(),
       createdAt: session.created_at,
       model: session.model ?? DEFAULT_MODEL,
       reasoningEffort: session.reasoning_effort ?? undefined,
@@ -1569,7 +649,7 @@ export class SessionDO extends DurableObject<Env> {
       tunnelUrls: sandbox?.tunnel_urls ? safeParseTunnelUrls(sandbox.tunnel_urls, this.log) : null,
       ttydUrl: sandbox?.ttyd_url ?? null,
       sandboxDashboardUrl: resolveSandboxDashboardUrl(
-        this.sandboxDashboardSettings,
+        this.components.sandboxDashboardSettings,
         sandbox?.modal_object_id
       ),
       repositories: this.getSessionRepositoryStates(session),
@@ -1586,9 +666,9 @@ export class SessionDO extends DurableObject<Env> {
       if (!local) return null;
       return {
         session: local.session,
-        artifacts: this.messageService.listArtifacts().artifacts,
-        timeline: this.eventStream.getReplay(),
-        promptQueue: this.messageRepository.listPromptQueue(),
+        artifacts: this.components.messageService.listArtifacts().artifacts,
+        timeline: this.components.eventStream.getReplay(),
+        promptQueue: this.components.messageRepository.listPromptQueue(),
         spawnError: local.sandbox?.last_spawn_error ?? null,
       };
     });
@@ -1606,10 +686,10 @@ export class SessionDO extends DurableObject<Env> {
 
   private async handleSandboxAccess(): Promise<Response> {
     const headers = { "Cache-Control": "private, no-store" };
-    if (!this.sessionCoreRepository.getSession()) {
+    if (!this.components.sessionCoreRepository.getSession()) {
       return Response.json({ error: "Session not found" }, { status: 404, headers });
     }
-    const sandbox = this.sandboxRepository.getSandbox();
+    const sandbox = this.components.sandboxRepository.getSandbox();
     if (!sandbox || sandbox.status !== "ready") {
       return Response.json({ error: "Sandbox access is unavailable" }, { status: 409, headers });
     }
@@ -1620,7 +700,7 @@ export class SessionDO extends DurableObject<Env> {
       decryptStoredAccessValue(sandbox.vnc_password, encryptionKey, this.log),
       decryptStoredAccessValue(sandbox.ttyd_token, encryptionKey, this.log),
     ]);
-    const current = this.sandboxRepository.getSandbox();
+    const current = this.components.sandboxRepository.getSandbox();
     if (
       !current ||
       current.id !== sandbox.id ||
@@ -1679,7 +759,7 @@ export class SessionDO extends DurableObject<Env> {
    */
   private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
     const prUrlForRepo = this.getPrUrlLookup();
-    return this.sessionCoreRepository.getSessionRepositories().map((member) => ({
+    return this.components.sessionCoreRepository.getSessionRepositories().map((member) => ({
       position: member.position,
       repoOwner: member.repoOwner,
       repoName: member.repoName,
@@ -1700,7 +780,7 @@ export class SessionDO extends DurableObject<Env> {
     repoName: string,
     isPrimary: boolean
   ) => string | null {
-    const artifacts = this.artifactRepository
+    const artifacts = this.components.artifactRepository
       .listArtifacts()
       .filter((artifact) => artifact.url !== null);
     return (repoOwner, repoName, isPrimary) =>
@@ -1711,6 +791,6 @@ export class SessionDO extends DurableObject<Env> {
    * Check if any message is currently being processed.
    */
   private getIsProcessing(): boolean {
-    return this.messageRepository.getProcessingMessage() !== null;
+    return this.components.messageRepository.getProcessingMessage() !== null;
   }
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1,71 +1,17 @@
 /**
- * Session Durable Object implementation.
+ * Session Durable Object: the Cloudflare adapter for one session runtime.
  *
- * Each session gets its own Durable Object instance with:
- * - SQLite database for persistent state
- * - WebSocket connections with hibernation support
- * - Prompt queue and event streaming
- *
- * The collaborator graph is built eagerly by `createSessionComponents` in
- * `ensureInitialized()`. This class owns only the Cloudflare adapters (fetch,
- * WebSocket callbacks, alarm) and the domain logic Phase 3 has not yet
- * extracted: connection auth, the snapshot read model, and sandbox access.
+ * All application wiring lives in `createSessionRuntime` (session/components.ts),
+ * which returns the narrow surface this class needs — the server entry points,
+ * the session logger, and alarm rehydration. This class only initializes the
+ * runtime per activation and forwards the platform callbacks.
  */
 
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
-import {
-  sessionSnapshotSchema,
-  type ServerMessage,
-  type SessionSnapshotState,
-} from "@open-inspect/shared/types/server-messages";
-import { isSessionPromptable } from "@open-inspect/shared/types/session-activity";
-import { DEFAULT_MODEL } from "@open-inspect/shared/models";
-import { hashToken } from "../auth/crypto";
-import { createLogger, parseLogLevel } from "../logger";
-import type { Logger } from "../logger";
-import { isSandboxReconnectBlockedStatus } from "../sandbox/lifecycle/decisions";
-import { resolveScmProviderFromEnv } from "../source-control";
-import type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
-import type { Env, ClientInfo } from "../types";
+import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
-import type { SessionRow, SandboxRow } from "./types";
-import { DEFAULT_SANDBOX_STATUS } from "../sandbox/sandbox-status";
-import { resolveParticipantName } from "./participant-name";
-import { safeParseTunnelUrls } from "./tunnel-urls";
-import { resolvePublicSessionId } from "./public-session-id";
-import {
-  decryptStoredAccessValue,
-  isValidSandboxToken,
-  resolveSandboxDashboardUrl,
-} from "./sandbox-access";
-import { findPrArtifactForRepo } from "./pr-artifacts";
-import { EnvironmentStore } from "../db/environments";
-import { getAvatarUrl } from "./participant-service";
-import { createSessionInternalRoutes } from "./http/routes";
-import { handleAlarmDelivery } from "./alarm/scheduler";
-import { SessionServer } from "./server";
-import { SessionHttpDispatcher } from "./http/dispatcher";
-import { SessionMessageRouter, type SessionClientCommands } from "./message-router";
-import { SessionDisconnectHandler } from "./disconnect-handler";
-import type { Clock, SandboxDisconnectMonitor, SessionBroadcaster, SocketRegistry } from "./ports";
-import {
-  createSessionComponents,
-  type SessionComponents,
-  type SessionPlatform,
-} from "./components";
-
-/**
- * Maximum age of a WebSocket authentication token (in milliseconds).
- * Tokens older than this are rejected with close code 4001, forcing
- * the client to fetch a fresh token on reconnect.
- */
-const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-interface SessionSnapshotEnrichment {
-  environmentId: string | null;
-  environmentName: string | null;
-}
+import { createSessionRuntime, type SessionRuntime } from "./components";
 
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
@@ -75,162 +21,49 @@ export class SessionDO extends DurableObject<Env> {
    * binding at runtime. Distinct from `this.sql`, the DO-embedded SQLite.
    */
   private readonly db: SqlDatabase | null;
-  private initialized = false;
-  // Boot logger until ensureInitialized() replaces it with the session-scoped
-  // logger the composition root creates. Request-serving code receives a
-  // request-scoped child (with trace_id / request_id) threaded explicitly
-  // from fetch().
-  private log: Logger;
-  // The eagerly constructed collaborator graph. Every runtime entry point
-  // (fetch, WebSocket callbacks, alarm) calls ensureInitialized() before any
-  // of these closures dereference it.
-  private components!: SessionComponents;
-  private readonly server: SessionServer<WebSocket, ClientInfo>;
-
-  // Internal HTTP route table (transport wiring only; handlers live in the
-  // component graph).
-  private readonly routes = createSessionInternalRoutes({
-    init: (request, _url, log) => this.components.sessionLifecycleHandler.init(request, log),
-    state: () => this.components.sessionLifecycleHandler.getState(),
-    snapshot: () => this.handleSnapshot(),
-    sandboxAccess: () => this.handleSandboxAccess(),
-    prompt: (request, _url, log) => this.components.messagesHandler.enqueuePrompt(request, log),
-    stop: () => this.components.messagesHandler.stop(),
-    sandboxEvent: (request) => this.components.sandboxHandler.sandboxEvent(request),
-    createMediaArtifact: (request) => this.components.sandboxHandler.createMediaArtifact(request),
-    recordAttachment: (request) => {
-      const session = this.components.sessionCoreRepository.getSession();
-      return this.components.attachmentsHandler.recordAttachment(
-        request,
-        session ? resolvePublicSessionId(session, this.ctx.id.toString()) : null
-      );
-    },
-    listParticipants: () => this.components.participantsHandler.listParticipants(),
-    addParticipant: (request) => this.components.sandboxHandler.addParticipant(request),
-    listEvents: (_request, url) => this.components.messagesHandler.listEvents(url),
-    listArtifacts: (_request, url) => this.components.messagesHandler.listArtifacts(url),
-    listMessages: (_request, url) => this.components.messagesHandler.listMessages(url),
-    createPr: (request, _url, log) => this.components.pullRequestHandler.createPr(request, log),
-    pullRequestArtifactSnapshot: (request, url) =>
-      this.components.pullRequestHandler.pullRequestArtifactSnapshot(request, url),
-    pullRequestsRefresh: () => this.components.pullRequestHandler.refreshPullRequests(),
-    wsToken: (request, _url, log) => this.components.wsTokenHandler.generateWsToken(request, log),
-    updateTitle: (request) => this.components.sessionLifecycleHandler.updateTitle(request),
-    archive: (request) => this.components.sessionLifecycleHandler.archive(request),
-    unarchive: (request) => this.components.sessionLifecycleHandler.unarchive(request),
-    expireDraft: () => this.components.sessionLifecycleHandler.expireDraft(),
-    verifySandboxToken: (request, _url, log) =>
-      this.components.sandboxHandler.verifySandboxToken(request, log),
-    openaiTokenRefresh: (_request, _url, log) =>
-      this.components.sandboxHandler.openaiTokenRefresh(log),
-    xaiTokenRefresh: (_request, _url, log) => this.components.sandboxHandler.xaiTokenRefresh(log),
-    scmCredentials: (_request, _url, log) => this.components.sandboxHandler.scmCredentials(log),
-    tunnelUrls: (_request, _url, log) => this.components.sandboxHandler.tunnelUrls(log),
-    spawnContext: () => this.components.childSessionsHandler.getSpawnContext(),
-    activePromptAuthor: () => this.components.childSessionsHandler.getActivePromptAuthor(),
-    childSummary: (_request, url) => this.components.childSessionsHandler.getChildSummary(url),
-    parentPrompt: (request) => this.components.childSessionsHandler.parentPrompt(request),
-    cancel: () => this.components.sessionLifecycleHandler.cancel(),
-    childSessionUpdate: (request) =>
-      this.components.childSessionsHandler.childSessionUpdate(request),
-    diffState: () => this.components.diffsHandler.state(),
-    diffStore: (request) => this.components.diffsHandler.storeBundle(request),
-    diffFailure: (request) => this.components.diffsHandler.recordFailure(request),
-    diffResolveFile: (_request, url) => this.components.diffsHandler.resolveFile(url),
-    diffRetry: () => this.components.diffsHandler.retry(),
-  });
+  // The per-activation runtime; null until ensureInitialized() builds it.
+  private _runtime: SessionRuntime | null = null;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
-    // eslint-disable-next-line no-restricted-syntax -- composition root: the DO's one env.DB read
+    // eslint-disable-next-line no-restricted-syntax -- composition root input: the DO's one env.DB read
     this.db = env.DB ?? null;
     this.sql = ctx.storage.sql;
-    this.log = createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL));
-    const ensureInitialized = (rehydrateAlarm?: boolean) => this.ensureInitialized(rehydrateAlarm);
-    const clock: Clock = {
-      nowMs: () => Date.now(),
-      monotonicNowMs: () => performance.now(),
-    };
-    const sockets: SocketRegistry<WebSocket, ClientInfo> = {
-      classify: (ws) => this.components.wsManager.classify(ws),
-      send: (ws, message) => this.components.wsManager.send(ws, message),
-      getClient: (ws) => this.getClientInfo(ws),
-      close: (ws, code, reason) => this.components.wsManager.close(ws, code, reason),
-      clearSandboxIfMatch: (ws) => this.components.wsManager.clearSandboxSocketIfMatch(ws),
-      removeClient: (ws) => this.components.wsManager.removeClient(ws),
-      hasParticipant: (participantId) =>
-        Array.from(this.components.wsManager.getAuthenticatedClients()).some(
-          (client) => client.participantId === participantId
-        ),
-    };
-    const clientCommands: SessionClientCommands<WebSocket, ClientInfo> = {
-      subscribe: (ws, message) => this.handleSubscribe(ws, message),
-      submitPrompt: (ws, client, message) =>
-        this.components.messageQueue.handlePromptMessage(ws, client, message),
-      cancelPrompt: (ws, message) => this.components.messageQueue.cancelQueuedPrompt(ws, message),
-      stopExecution: () => this.components.messageQueue.stopExecution(),
-      notifyTyping: () => this.components.presenceService.handleTyping(),
-      updatePresence: (client, message) =>
-        this.components.presenceService.updatePresence(client, message),
-      getHistoryPage: (message) => this.components.eventStream.getHistoryPage(message),
-    };
-    const sandboxDisconnects: SandboxDisconnectMonitor = {
-      getStatus: () => this.components.sandboxRepository.getSandbox()?.status,
-      scheduleCheck: () => this.components.lifecycleManager.scheduleDisconnectCheck(),
-    };
-    const broadcaster: SessionBroadcaster = {
-      broadcastPresence: () => this.components.presenceService.broadcastPresence(),
-      broadcast: (message) => this.components.messenger.broadcast(message),
-    };
-    // Cloudflare composition root: adapt DO callbacks and hibernating sockets to the server.
-    this.server = new SessionServer({
-      ensureInitialized,
-      http: new SessionHttpDispatcher({
-        ensureInitialized,
-        getLogger: () => this.log,
-        routes: this.routes,
-        handleWebSocketUpgrade: (request, url, log) =>
-          this.handleWebSocketUpgrade(request, url, log),
-        clock,
-      }),
-      messages: new SessionMessageRouter({
-        getLogger: () => this.log,
-        sockets,
-        clientCommands,
-        processSandboxEvent: (event) =>
-          this.components.sandboxEventProcessor.processSandboxEvent(event),
-        clock,
-      }),
-      disconnects: new SessionDisconnectHandler({
-        getLogger: () => this.log,
-        sockets,
-        sandbox: sandboxDisconnects,
-        broadcaster,
-      }),
-      handleScheduledDeadline: () =>
-        handleAlarmDelivery(
-          this.components.alarmDeadlines,
-          () => this.components.alarmHandler.handle(),
-          () => this.components.alarmScheduler.rearmPending()
-        ),
-    });
+  }
+
+  /** The runtime, (re)built on first touch after construction or eviction. */
+  private get runtime(): SessionRuntime {
+    this.ensureInitialized();
+    return this._runtime!;
   }
 
   /**
    * Initialize the session runtime: apply the schema, then build the whole
-   * collaborator graph eagerly. Every runtime entry point calls this first.
+   * collaborator graph eagerly. Every platform entry point calls this first.
    */
   private ensureInitialized(rehydrateAlarm = true): void {
-    if (this.initialized) return;
+    if (this._runtime) return;
+    const initStart = performance.now();
     initSchema(this.sql);
-    this.initialized = true;
-    const platform: SessionPlatform = { ctx: this.ctx, sql: this.sql, db: this.db };
-    this.components = createSessionComponents(platform, this.env);
-    this.log = this.components.log;
+    const runtime = createSessionRuntime(
+      {
+        ctx: this.ctx,
+        sql: this.sql,
+        db: this.db,
+        ensureInitialized: (rehydrate) => this.ensureInitialized(rehydrate),
+      },
+      this.env
+    );
+    // Publish only after the graph is fully built: a throw above leaves the
+    // activation uninitialized, so the next event retries initialization
+    // instead of dereferencing an undefined runtime.
+    this._runtime = runtime;
+    runtime.log.info("do.init", {
+      event: "do.init",
+      duration_ms: Math.round((performance.now() - initStart) * 100) / 100,
+    });
     if (rehydrateAlarm) {
-      this.components.backgroundTasks.submit(() => this.components.alarmScheduler.rehydrate(), {
-        name: "alarm.rehydrate",
-      });
+      runtime.alarms.rehydrate();
     }
   }
 
@@ -238,173 +71,14 @@ export class SessionDO extends DurableObject<Env> {
    * Handle incoming HTTP requests.
    */
   async fetch(request: Request): Promise<Response> {
-    return this.server.onRequest(request);
-  }
-
-  /**
-   * Handle WebSocket upgrade request. `log` is the request-scoped logger.
-   */
-  private async handleWebSocketUpgrade(request: Request, url: URL, log: Logger): Promise<Response> {
-    log.debug("WebSocket upgrade requested");
-    const isSandbox = url.searchParams.get("type") === "sandbox";
-
-    // Validate sandbox authentication
-    if (isSandbox) {
-      const wsStartTime = Date.now();
-      const authHeader = request.headers.get("Authorization");
-      const sandboxId = request.headers.get("X-Sandbox-ID");
-      const providedToken = authHeader?.startsWith("Bearer ")
-        ? authHeader.slice("Bearer ".length)
-        : null;
-
-      // Get expected values from DB
-      const sandbox = this.components.sandboxRepository.getSandbox();
-      const expectedSandboxId = sandbox?.modal_sandbox_id;
-
-      // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
-      if (expectedSandboxId && sandboxId !== expectedSandboxId) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "auth_failed",
-          reject_reason: "sandbox_id_mismatch",
-          expected_sandbox_id: expectedSandboxId,
-          sandbox_id: sandboxId,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Forbidden: Wrong sandbox ID", { status: 403 });
-      }
-
-      // Validate auth token
-      const tokenMatches = await isValidSandboxToken(providedToken, sandbox);
-      if (!tokenMatches) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "auth_failed",
-          reject_reason: "token_mismatch",
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Unauthorized: Invalid auth token", { status: 401 });
-      }
-
-      // Reject connection if the session itself is closed for good. Narrower
-      // than "not active": `completed` and `failed` sessions are idle, not
-      // over — warm-on-typing spawns a sandbox for one before the follow-up
-      // prompt arrives, and rejecting its bridge stranded that prompt.
-      //
-      // Read after authentication, not before: token hashing is a non-storage
-      // await, so the input gate lets a cancel or archive land while this
-      // request is suspended. Admission needs a fresh, synchronous read.
-      const currentSession = this.components.sessionCoreRepository.getSession();
-      if (currentSession && !isSessionPromptable(currentSession.status)) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "rejected",
-          reject_reason: "session_terminal",
-          session_status: currentSession.status,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Session is terminal", { status: 410 });
-      }
-
-      const currentSandbox = this.components.sandboxRepository.getSandbox();
-      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
-      // still connect after a slow boot and self-heal by becoming ready.
-      if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "rejected",
-          reject_reason: "sandbox_stopped",
-          sandbox_status: currentSandbox.status,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Sandbox is stopped", { status: 410 });
-      }
-      if (
-        currentSandbox?.modal_sandbox_id !== expectedSandboxId ||
-        currentSandbox?.auth_token_hash !== sandbox?.auth_token_hash ||
-        currentSandbox?.auth_token !== sandbox?.auth_token
-      ) {
-        return new Response("Forbidden: Sandbox credentials changed", { status: 403 });
-      }
-
-      // Auth passed — continue to WebSocket accept below
-      // The success ws.connect event is emitted after the WebSocket is accepted
-    }
-
-    try {
-      const { client, server } = this.components.connections.createUpgradeSockets();
-
-      const sandboxId = request.headers.get("X-Sandbox-ID");
-
-      if (isSandbox) {
-        // The lifecycle manager publishes access after any pending provider
-        // startup has persisted its URLs and credentials.
-        const accessIsPersisted = !this.components.lifecycleManager.isProviderStartupPending();
-        const { replaced } = this.components.wsManager.acceptAndSetSandboxSocket(
-          server,
-          sandboxId ?? undefined
-        );
-        // Notify manager that sandbox connected so it can reset the spawning flag
-        this.components.lifecycleManager.onSandboxConnected();
-        this.components.sandboxRepository.updateSandboxStatus("ready");
-        this.components.messenger.broadcast({ type: "sandbox_status", status: "ready" });
-        if (accessIsPersisted) {
-          this.components.messenger.broadcast({ type: "sandbox_access_changed" });
-        }
-
-        // Set initial activity timestamp and schedule inactivity check
-        // IMPORTANT: Must await to ensure alarm is scheduled before returning
-        const now = Date.now();
-        this.components.lifecycleManager.updateLastActivity(now);
-        this.components.sandboxRepository.updateSandboxHeartbeat(now);
-        await this.components.lifecycleManager.scheduleInactivityCheck();
-
-        log.info("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "success",
-          sandbox_id: sandboxId,
-          replaced_existing: replaced,
-          duration_ms: Date.now() - now,
-        });
-
-        // Process any pending messages now that sandbox is connected
-        this.components.backgroundTasks.submit(
-          () => this.components.messageQueue.processMessageQueue(),
-          {
-            name: "message_queue.process",
-          }
-        );
-      } else {
-        const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-        this.components.wsManager.acceptClientSocket(server, wsId);
-        this.components.backgroundTasks.submit(
-          () => this.components.wsManager.enforceAuthTimeout(server, wsId),
-          {
-            name: "websocket.enforce_auth_timeout",
-            context: { ws_id: wsId },
-          }
-        );
-      }
-
-      return new Response(null, { status: 101, webSocket: client });
-    } catch (error) {
-      log.error("WebSocket upgrade failed", {
-        error: error instanceof Error ? error : String(error),
-      });
-      return new Response("WebSocket upgrade failed", { status: 500 });
-    }
+    return this.runtime.server.onRequest(request);
   }
 
   /**
    * Handle WebSocket message (with hibernation support).
    */
   async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    await this.server.onMessage(ws, message);
+    await this.runtime.server.onMessage(ws, message);
   }
 
   /**
@@ -416,381 +90,22 @@ export class SessionDO extends DurableObject<Env> {
     reason: string,
     wasClean: boolean
   ): Promise<void> {
-    await this.server.onClose(ws, code, reason, wasClean);
+    await this.runtime.server.onClose(ws, code, reason, wasClean);
   }
 
   /**
    * Handle WebSocket error.
    */
   async webSocketError(ws: WebSocket, error: Error): Promise<void> {
-    this.server.onError(ws, error);
+    this.runtime.server.onError(ws, error);
   }
 
   /**
-   * Durable Object alarm handler.
-   *
-   * Checks for stuck processing messages (defense-in-depth execution timeout)
-   * BEFORE delegating to the lifecycle manager for inactivity and heartbeat
-   * monitoring. This ensures stuck messages are failed even when the sandbox
-   * is already dead and handleAlarm() returns early.
+   * Durable Object alarm handler. Initializes without re-arming the alarm —
+   * this delivery is the alarm — then delegates deadline handling.
    */
   async alarm(): Promise<void> {
-    await this.server.onScheduledDeadline();
-  }
-
-  /**
-   * Handle client subscription with token validation.
-   */
-  private async handleSubscribe(
-    ws: WebSocket,
-    data: {
-      token: string;
-      clientId: string;
-    }
-  ): Promise<void> {
-    const { wsManager, participantService, presenceService } = this.components;
-    // Validate the WebSocket auth token
-    if (!data.token) {
-      this.log.warn("ws.connect", {
-        event: "ws.connect",
-        ws_type: "client",
-        outcome: "auth_failed",
-        reject_reason: "no_token",
-      });
-      wsManager.close(ws, 4001, "Authentication required");
-      return;
-    }
-
-    if (wsManager.isClientAuthenticated(ws) || wsManager.isClientSynchronizing(ws)) {
-      wsManager.close(ws, 4003, "Already subscribed");
-      return;
-    }
-    wsManager.setClientSynchronizing(ws, true);
-
-    try {
-      // Hash the incoming token and look up participant
-      const tokenHash = await hashToken(data.token);
-      const participant = participantService.getByWsTokenHash(tokenHash);
-
-      if (!participant) {
-        this.log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "client",
-          outcome: "auth_failed",
-          reject_reason: "invalid_token",
-        });
-        wsManager.close(ws, 4001, "Invalid authentication token");
-        return;
-      }
-
-      // Reject tokens older than the TTL
-      if (
-        participant.ws_token_created_at === null ||
-        Date.now() - participant.ws_token_created_at > WS_TOKEN_TTL_MS
-      ) {
-        this.log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "client",
-          outcome: "auth_failed",
-          reject_reason: "token_expired",
-          participant_id: participant.id,
-          user_id: participant.user_id,
-        });
-        wsManager.close(ws, 4001, "Token expired");
-        return;
-      }
-
-      this.log.info("ws.connect", {
-        event: "ws.connect",
-        ws_type: "client",
-        outcome: "success",
-        participant_id: participant.id,
-        user_id: participant.user_id,
-        client_id: data.clientId,
-      });
-
-      // Build client info from participant data
-      const clientInfo: ClientInfo = {
-        participantId: participant.id,
-        userId: participant.canonical_user_id ?? participant.user_id,
-        name: resolveParticipantName(participant),
-        avatar: getAvatarUrl(
-          participant.scm_login,
-          resolveScmProviderFromEnv(this.env.SCM_PROVIDER)
-        ),
-        status: "active",
-        lastSeen: Date.now(),
-        clientId: data.clientId,
-        ws,
-      };
-
-      const enrichment = await this.resolveSessionSnapshotEnrichment();
-      if (!this.completeClientSubscription(ws, clientInfo, enrichment)) {
-        wsManager.close(ws, 4009, "Session synchronization failed");
-        return;
-      }
-
-      presenceService.sendPresence(ws);
-      presenceService.broadcastPresence();
-      this.components.schedulePullRequestRefresh("open");
-    } finally {
-      wsManager.setClientSynchronizing(ws, false);
-    }
-  }
-
-  /**
-   * Finish the snapshot-to-stream handoff synchronously. Keeping the final read,
-   * send, and registration in a non-async method makes the no-await invariant
-   * structural rather than a convention inside the async authentication flow.
-   */
-  private completeClientSubscription(
-    ws: WebSocket,
-    client: ClientInfo,
-    enrichment: SessionSnapshotEnrichment
-  ): boolean {
-    const { wsManager } = this.components;
-    const snapshot = this.readSessionSnapshot(enrichment);
-    if (!snapshot) return false;
-
-    if (
-      !wsManager.send(ws, {
-        type: "subscribed",
-        ...snapshot,
-        participantId: client.participantId,
-        participant: {
-          participantId: client.participantId,
-          userId: client.userId,
-          name: client.name,
-          avatar: client.avatar,
-        },
-      } satisfies ServerMessage)
-    ) {
-      return false;
-    }
-
-    wsManager.setClient(ws, client);
-    const parsed = wsManager.classify(ws);
-    if (parsed.kind === "client" && parsed.wsId) {
-      wsManager.persistClientMapping(parsed.wsId, client.participantId, client.clientId);
-      this.log.debug("Stored ws_client_mapping", {
-        ws_id: parsed.wsId,
-        participant_id: client.participantId,
-      });
-    }
-    return true;
-  }
-
-  /**
-   * Get client info for a WebSocket, reconstructing from storage if needed after hibernation.
-   */
-  private getClientInfo(ws: WebSocket): ClientInfo | null {
-    const { wsManager } = this.components;
-    // 1. In-memory cache (manager)
-    const cached = wsManager.getClient(ws);
-    if (cached) return cached;
-
-    // 2. DB recovery (manager handles tag parsing + DB lookup)
-    const mapping = wsManager.recoverClientMapping(ws);
-    if (!mapping) {
-      this.log.warn("No client mapping found after hibernation, closing WebSocket");
-      wsManager.close(ws, 4002, "Session expired, please reconnect");
-      return null;
-    }
-
-    // 3. Build ClientInfo (DO owns domain logic)
-    this.log.info("Recovered client info from DB", { user_id: mapping.user_id });
-    const clientInfo: ClientInfo = {
-      participantId: mapping.participant_id,
-      userId: mapping.canonical_user_id ?? mapping.user_id,
-      name: resolveParticipantName(mapping),
-      avatar: getAvatarUrl(mapping.scm_login, resolveScmProviderFromEnv(this.env.SCM_PROVIDER)),
-      status: "active",
-      lastSeen: Date.now(),
-      clientId: mapping.client_id || `client-${Date.now()}`,
-      ws,
-    };
-
-    // 4. Re-cache
-    wsManager.setClient(ws, clientInfo);
-    return clientInfo;
-  }
-
-  private async resolveSessionSnapshotEnrichment(): Promise<SessionSnapshotEnrichment> {
-    const session = this.components.sessionCoreRepository.getSession();
-    const environmentId = session?.environment_id ?? null;
-    const environmentName = await this.resolveEnvironmentName(environmentId);
-    return { environmentId, environmentName };
-  }
-
-  private readSessionState(
-    enrichment: SessionSnapshotEnrichment
-  ): { session: SessionSnapshotState; sandbox: SandboxRow | null } | null {
-    const session = this.components.sessionCoreRepository.getSession();
-    if (!session) return null;
-    const sandbox = this.components.sandboxRepository.getSandbox();
-    const publicSession: SessionSnapshotState = {
-      id: resolvePublicSessionId(session, this.ctx.id.toString()),
-      title: session.title,
-      repoOwner: session.repo_owner,
-      repoName: session.repo_name,
-      baseBranch: session.base_branch,
-      branchName: session.branch_name,
-      status: session.status,
-      sandboxStatus: sandbox?.status ?? DEFAULT_SANDBOX_STATUS,
-      messageCount: this.components.messageRepository.getMessageCount(),
-      createdAt: session.created_at,
-      model: session.model ?? DEFAULT_MODEL,
-      reasoningEffort: session.reasoning_effort ?? undefined,
-      isProcessing: this.getIsProcessing(),
-      parentSessionId: session.parent_session_id,
-      totalCost: session.total_cost ?? 0,
-      codeServerUrl: sandbox?.code_server_url ?? null,
-      vncUrl: sandbox?.vnc_url ?? null,
-      tunnelUrls: sandbox?.tunnel_urls ? safeParseTunnelUrls(sandbox.tunnel_urls, this.log) : null,
-      ttydUrl: sandbox?.ttyd_url ?? null,
-      sandboxDashboardUrl: resolveSandboxDashboardUrl(
-        this.components.sandboxDashboardSettings,
-        sandbox?.modal_object_id
-      ),
-      repositories: this.getSessionRepositoryStates(session),
-      environmentId: session.environment_id ?? null,
-      environmentName:
-        session.environment_id === enrichment.environmentId ? enrichment.environmentName : null,
-    };
-    return { session: publicSession, sandbox };
-  }
-
-  private readSessionSnapshot(enrichment: SessionSnapshotEnrichment) {
-    return this.ctx.storage.transactionSync(() => {
-      const local = this.readSessionState(enrichment);
-      if (!local) return null;
-      return {
-        session: local.session,
-        artifacts: this.components.messageService.listArtifacts().artifacts,
-        timeline: this.components.eventStream.getReplay(),
-        promptQueue: this.components.messageRepository.listPromptQueue(),
-        spawnError: local.sandbox?.last_spawn_error ?? null,
-      };
-    });
-  }
-
-  private async handleSnapshot(): Promise<Response> {
-    const headers = { "Cache-Control": "private, no-store" };
-    const enrichment = await this.resolveSessionSnapshotEnrichment();
-    const snapshot = this.readSessionSnapshot(enrichment);
-    if (!snapshot) {
-      return Response.json({ error: "Session not found" }, { status: 404, headers });
-    }
-    return Response.json(sessionSnapshotSchema.parse(snapshot), { headers });
-  }
-
-  private async handleSandboxAccess(): Promise<Response> {
-    const headers = { "Cache-Control": "private, no-store" };
-    if (!this.components.sessionCoreRepository.getSession()) {
-      return Response.json({ error: "Session not found" }, { status: 404, headers });
-    }
-    const sandbox = this.components.sandboxRepository.getSandbox();
-    if (!sandbox || sandbox.status !== "ready") {
-      return Response.json({ error: "Sandbox access is unavailable" }, { status: 409, headers });
-    }
-
-    const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
-    const [codeServerPassword, vncPassword, ttydToken] = await Promise.all([
-      decryptStoredAccessValue(sandbox.code_server_password, encryptionKey, this.log),
-      decryptStoredAccessValue(sandbox.vnc_password, encryptionKey, this.log),
-      decryptStoredAccessValue(sandbox.ttyd_token, encryptionKey, this.log),
-    ]);
-    const current = this.components.sandboxRepository.getSandbox();
-    if (
-      !current ||
-      current.id !== sandbox.id ||
-      current.status !== "ready" ||
-      current.code_server_url !== sandbox.code_server_url ||
-      current.code_server_password !== sandbox.code_server_password ||
-      current.vnc_url !== sandbox.vnc_url ||
-      current.vnc_password !== sandbox.vnc_password ||
-      current.ttyd_url !== sandbox.ttyd_url ||
-      current.ttyd_token !== sandbox.ttyd_token
-    ) {
-      return Response.json({ error: "Sandbox access changed; retry" }, { status: 409, headers });
-    }
-    return Response.json(
-      {
-        codeServer:
-          current.code_server_url && codeServerPassword
-            ? { url: current.code_server_url, password: codeServerPassword }
-            : null,
-        vnc:
-          current.vnc_url && vncPassword ? { url: current.vnc_url, password: vncPassword } : null,
-        ttyd: current.ttyd_url && ttydToken ? { url: current.ttyd_url, token: ttydToken } : null,
-      },
-      { headers }
-    );
-  }
-
-  /**
-   * The launch environment's current display name, or null when the session has
-   * no environment or the environment was deleted after launch (§7.6). Resolved
-   * live rather than snapshotted so deletion is reflected; best-effort, so a
-   * lookup failure resolves null rather than failing the whole state read.
-   */
-  private async resolveEnvironmentName(environmentId: string | null): Promise<string | null> {
-    if (!environmentId || !this.db) {
-      return null;
-    }
-    try {
-      const environment = await new EnvironmentStore(this.db).getById(environmentId);
-      return environment?.name ?? null;
-    } catch (e) {
-      this.log.warn("Failed to resolve environment name for session state", {
-        environment_id: environmentId,
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return null;
-    }
-  }
-
-  /**
-   * Member repositories for SessionState, in position order (see
-   * buildSessionRepositories for the scalar-mirror fallback). Members synthesized
-   * from the scalars — and member rows written before per-repo git state
-   * existed, whose git columns are null while the scalars are set — have the
-   * primary entry overlaid with the session scalars.
-   */
-  private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
-    const prUrlForRepo = this.getPrUrlLookup();
-    return this.components.sessionCoreRepository.getSessionRepositories().map((member) => ({
-      position: member.position,
-      repoOwner: member.repoOwner,
-      repoName: member.repoName,
-      repoId: member.row ? member.row.repo_id : (session?.repo_id ?? null),
-      baseBranch: member.baseBranch ?? "main",
-      branchName:
-        member.row?.branch_name ?? (member.isPrimary ? (session?.branch_name ?? null) : null),
-      baseSha: member.row?.base_sha ?? (member.isPrimary ? (session?.base_sha ?? null) : null),
-      currentSha:
-        member.row?.current_sha ?? (member.isPrimary ? (session?.current_sha ?? null) : null),
-      prUrl: prUrlForRepo(member.repoOwner, member.repoName, member.isPrimary),
-    }));
-  }
-
-  /** Per-repo PR URL lookup over the session's PR artifacts. */
-  private getPrUrlLookup(): (
-    repoOwner: string,
-    repoName: string,
-    isPrimary: boolean
-  ) => string | null {
-    const artifacts = this.components.artifactRepository
-      .listArtifacts()
-      .filter((artifact) => artifact.url !== null);
-    return (repoOwner, repoName, isPrimary) =>
-      findPrArtifactForRepo(artifacts, { repoOwner, repoName }, isPrimary)?.url ?? null;
-  }
-
-  /**
-   * Check if any message is currently being processed.
-   */
-  private getIsProcessing(): boolean {
-    return this.components.messageRepository.getProcessingMessage() !== null;
+    this.ensureInitialized(false);
+    await this._runtime!.server.onScheduledDeadline();
   }
 }

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -217,7 +217,7 @@ function buildQueue() {
     projectTerminalMessage,
     sandboxLifecycle,
     null,
-    "github",
+    () => "github",
     createEarliestAlarmScheduler(
       { getAlarm, setAlarm, deleteAlarm: vi.fn(async () => {}) },
       {
@@ -231,7 +231,7 @@ function buildQueue() {
         completeDelivery: vi.fn(),
       }
     ),
-    EXECUTION_TIMEOUT_MS
+    () => EXECUTION_TIMEOUT_MS
   );
 
   return {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -121,6 +121,10 @@ it("creates a canonical SHA-256 web prompt fingerprint", async () => {
 });
 
 function buildQueue() {
+  // Mutable so tests can pin that the deadline honors the value current at
+  // dispatch time — the thunk exists because settings can be persisted after
+  // the queue is constructed.
+  let executionTimeoutMs = EXECUTION_TIMEOUT_MS;
   const log = {
     debug: vi.fn(),
     info: vi.fn(),
@@ -231,7 +235,7 @@ function buildQueue() {
         completeDelivery: vi.fn(),
       }
     ),
-    () => EXECUTION_TIMEOUT_MS
+    () => executionTimeoutMs
   );
 
   return {
@@ -250,6 +254,9 @@ function buildQueue() {
     getProviderAuthenticationError,
     projectTerminalMessage,
     log,
+    setExecutionTimeoutMs(value: number) {
+      executionTimeoutMs = value;
+    },
   };
 }
 
@@ -962,6 +969,32 @@ describe("SessionMessageQueue", () => {
       const deadline = h.setAlarm.mock.calls[0][0];
       expect(deadline).toBeGreaterThanOrEqual(before + EXECUTION_TIMEOUT_MS);
       expect(deadline).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS);
+    });
+
+    it("arms each deadline with the timeout current at that dispatch", async () => {
+      const h = buildQueue();
+      // Model /internal/init persisting a sandbox_settings override after the
+      // graph (and this queue) was already built eagerly.
+      h.setExecutionTimeoutMs(EXECUTION_TIMEOUT_MS * 3);
+      const before = Date.now();
+
+      await dispatchPrompt(h);
+
+      expect(h.setAlarm).toHaveBeenCalledTimes(1);
+      const first = h.setAlarm.mock.calls[0][0];
+      expect(first).toBeGreaterThanOrEqual(before + EXECUTION_TIMEOUT_MS * 3);
+      expect(first).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS * 3);
+
+      // A later dispatch must re-resolve — the value is never captured, not
+      // even at first use.
+      h.setExecutionTimeoutMs(EXECUTION_TIMEOUT_MS * 5);
+      const beforeSecond = Date.now();
+      await dispatchPrompt(h);
+
+      expect(h.setAlarm).toHaveBeenCalledTimes(2);
+      const second = h.setAlarm.mock.calls[1][0];
+      expect(second).toBeGreaterThanOrEqual(beforeSecond + EXECUTION_TIMEOUT_MS * 5);
+      expect(second).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS * 5);
     });
 
     it("keeps an earlier existing alarm", async () => {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -148,9 +148,11 @@ export class SessionMessageQueue {
     ) => Promise<void>,
     private readonly sandboxLifecycle: SandboxLifecycle,
     private readonly sessionIndex: SessionIndexStore | null,
-    private readonly scmProvider: SourceControlProviderName,
+    /** Deferred: resolving the name throws on an invalid `SCM_PROVIDER`. */
+    private readonly getScmProvider: () => SourceControlProviderName,
     private readonly alarmScheduler: AlarmScheduler,
-    private readonly executionTimeoutMs: number
+    /** Resolved per use so it honors settings persisted after construction. */
+    private readonly getExecutionTimeoutMs: () => number
   ) {}
 
   async handlePromptMessage(
@@ -354,7 +356,7 @@ export class SessionMessageQueue {
         this.log.error("prompt.invalid_stored_attachments")
       )
     );
-    const gitIdentity = resolveParticipantGitIdentity(author, this.scmProvider);
+    const gitIdentity = resolveParticipantGitIdentity(author, this.getScmProvider());
     const requestedEffort =
       message.reasoning_effort ??
       session?.reasoning_effort ??
@@ -400,7 +402,7 @@ export class SessionMessageQueue {
       this.sandboxLifecycle.updateLastActivity(now);
 
       // Execution timeout shares the DO's single alarm slot with lifecycle checks.
-      const deadline = now + this.executionTimeoutMs;
+      const deadline = now + this.getExecutionTimeoutMs();
       await this.alarmScheduler.schedule(deadline);
 
       this.backgroundTasks.submit(() => this.callbackService.notifyStarted(message.id), {
@@ -597,7 +599,7 @@ export class SessionMessageQueue {
         participantId: participant.id,
         userId: participant.canonical_user_id ?? participant.user_id,
         name: resolveParticipantName(participant),
-        avatar: getAvatarUrl(participant.scm_login, this.scmProvider),
+        avatar: getAvatarUrl(participant.scm_login, this.getScmProvider()),
       },
       ...(attachments && attachments.length > 0 ? { attachments } : {}),
     };

--- a/packages/control-plane/src/session/public-session-id.test.ts
+++ b/packages/control-plane/src/session/public-session-id.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { resolvePublicSessionId } from "./public-session-id";
+import { describe, expect, it, vi } from "vitest";
+import { createLatchedPublicSessionIdResolver, resolvePublicSessionId } from "./public-session-id";
 import type { SessionRow } from "./types";
 
 function sessionRow(overrides: Partial<SessionRow>): SessionRow {
@@ -32,5 +32,40 @@ describe("resolvePublicSessionId", () => {
 
   it("falls back to the durable object id when the row carries neither identifier", () => {
     expect(resolvePublicSessionId(sessionRow({ session_name: "", id: "" }), "do-id")).toBe("do-id");
+  });
+});
+
+describe("createLatchedPublicSessionIdResolver", () => {
+  it("re-reads on every call while no session row exists", () => {
+    const getSession = vi.fn((): SessionRow | null => null);
+    const resolve = createLatchedPublicSessionIdResolver(getSession, "do-id");
+
+    expect(resolve()).toBe("do-id");
+    expect(resolve()).toBe("do-id");
+    expect(getSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("upgrades to the public id once the row appears, then stops reading", () => {
+    let row: SessionRow | null = null;
+    const getSession = vi.fn(() => row);
+    const resolve = createLatchedPublicSessionIdResolver(getSession, "do-id");
+
+    expect(resolve()).toBe("do-id");
+    row = sessionRow({ session_name: "public-name" });
+    expect(resolve()).toBe("public-name");
+
+    // Latched: the id is immutable once row-backed, so no further reads.
+    row = sessionRow({ session_name: "some-other-name" });
+    expect(resolve()).toBe("public-name");
+    expect(getSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("never latches the durable-object-id fallback", () => {
+    const getSession = vi.fn((): SessionRow | null => null);
+    const resolve = createLatchedPublicSessionIdResolver(getSession, "do-id");
+    resolve();
+    resolve();
+    resolve();
+    expect(getSession).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/control-plane/src/session/public-session-id.ts
+++ b/packages/control-plane/src/session/public-session-id.ts
@@ -14,3 +14,27 @@ export function resolvePublicSessionId(
 ): string {
   return session?.session_name || session?.id || durableObjectId;
 }
+
+/**
+ * A per-use resolver over the live session row that latches once a row exists.
+ *
+ * Components built during the init request — before the row is written — must
+ * re-read until the public id resolves. Afterwards the id is immutable
+ * (`session_name` is only ever written by the init-time insert and the row id
+ * never changes), so further reads are pure waste on hot paths like per-log-
+ * line context derivation. The latch never captures the Durable Object id
+ * fallback, only a row-backed id.
+ */
+export function createLatchedPublicSessionIdResolver(
+  getSession: () => SessionRow | null,
+  durableObjectId: string
+): () => string {
+  let latched: string | undefined;
+  return () => {
+    if (latched !== undefined) return latched;
+    const session = getSession();
+    const resolved = resolvePublicSessionId(session, durableObjectId);
+    if (session) latched = resolved;
+    return resolved;
+  };
+}

--- a/packages/control-plane/src/session/sandbox-access-reader.ts
+++ b/packages/control-plane/src/session/sandbox-access-reader.ts
@@ -1,0 +1,64 @@
+import type { Logger } from "../logger";
+import { decryptStoredAccessValue } from "./sandbox-access";
+import type { SandboxRepository } from "./sandbox-repository";
+import type { SessionCoreRepository } from "./session-core-repository";
+
+export interface SessionAccessReaderDeps {
+  sessionCoreRepository: SessionCoreRepository;
+  sandboxRepository: SandboxRepository;
+  repoSecretsEncryptionKey: string | undefined;
+  log: Logger;
+}
+
+/**
+ * Serves the sandbox access credentials (code-server, VNC, ttyd) for a ready
+ * sandbox, decrypting stored secrets and re-checking the row after the async
+ * decrypts so a mid-flight replacement cannot leak mismatched credentials.
+ */
+export class SessionAccessReader {
+  constructor(private readonly deps: SessionAccessReaderDeps) {}
+
+  async handleSandboxAccess(): Promise<Response> {
+    const headers = { "Cache-Control": "private, no-store" };
+    if (!this.deps.sessionCoreRepository.getSession()) {
+      return Response.json({ error: "Session not found" }, { status: 404, headers });
+    }
+    const sandbox = this.deps.sandboxRepository.getSandbox();
+    if (!sandbox || sandbox.status !== "ready") {
+      return Response.json({ error: "Sandbox access is unavailable" }, { status: 409, headers });
+    }
+
+    const encryptionKey = this.deps.repoSecretsEncryptionKey;
+    const [codeServerPassword, vncPassword, ttydToken] = await Promise.all([
+      decryptStoredAccessValue(sandbox.code_server_password, encryptionKey, this.deps.log),
+      decryptStoredAccessValue(sandbox.vnc_password, encryptionKey, this.deps.log),
+      decryptStoredAccessValue(sandbox.ttyd_token, encryptionKey, this.deps.log),
+    ]);
+    const current = this.deps.sandboxRepository.getSandbox();
+    if (
+      !current ||
+      current.id !== sandbox.id ||
+      current.status !== "ready" ||
+      current.code_server_url !== sandbox.code_server_url ||
+      current.code_server_password !== sandbox.code_server_password ||
+      current.vnc_url !== sandbox.vnc_url ||
+      current.vnc_password !== sandbox.vnc_password ||
+      current.ttyd_url !== sandbox.ttyd_url ||
+      current.ttyd_token !== sandbox.ttyd_token
+    ) {
+      return Response.json({ error: "Sandbox access changed; retry" }, { status: 409, headers });
+    }
+    return Response.json(
+      {
+        codeServer:
+          current.code_server_url && codeServerPassword
+            ? { url: current.code_server_url, password: codeServerPassword }
+            : null,
+        vnc:
+          current.vnc_url && vncPassword ? { url: current.vnc_url, password: vncPassword } : null,
+        ttyd: current.ttyd_url && ttydToken ? { url: current.ttyd_url, token: ttydToken } : null,
+      },
+      { headers }
+    );
+  }
+}

--- a/packages/control-plane/src/session/session-logger.test.ts
+++ b/packages/control-plane/src/session/session-logger.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import type { Logger } from "../logger";
+import { createSessionScopedLogger } from "./session-logger";
+
+interface Line {
+  level: string;
+  msg: string;
+  data?: Record<string, unknown>;
+}
+
+function recordingLogger(lines: Line[], childContexts: Record<string, unknown>[] = []): Logger {
+  const push = (level: string) => (msg: string, data?: Record<string, unknown>) => {
+    lines.push({ level, msg, data });
+  };
+  return {
+    debug: push("debug"),
+    info: push("info"),
+    warn: push("warn"),
+    error: push("error"),
+    child: (context) => {
+      childContexts.push(context);
+      return recordingLogger(lines, childContexts);
+    },
+  };
+}
+
+describe("createSessionScopedLogger", () => {
+  it("injects the session id current at emit time, not creation time", () => {
+    const lines: Line[] = [];
+    let currentId = "do-fallback-id";
+    const log = createSessionScopedLogger(recordingLogger(lines), () => currentId);
+
+    log.info("first");
+    currentId = "public-session-name";
+    log.warn("second");
+
+    expect(lines).toEqual([
+      { level: "info", msg: "first", data: { session_id: "do-fallback-id" } },
+      { level: "warn", msg: "second", data: { session_id: "public-session-name" } },
+    ]);
+  });
+
+  it("keeps the injection on children and lets explicit data override", () => {
+    const lines: Line[] = [];
+    const childContexts: Record<string, unknown>[] = [];
+    const log = createSessionScopedLogger(recordingLogger(lines, childContexts), () => "sess-1");
+
+    const child = log.child({ trace_id: "trace-9" });
+    child.error("from child", { detail: 1 });
+    child.info("override", { session_id: "explicit" });
+
+    expect(childContexts).toEqual([{ trace_id: "trace-9" }]);
+    expect(lines).toEqual([
+      { level: "error", msg: "from child", data: { session_id: "sess-1", detail: 1 } },
+      { level: "info", msg: "override", data: { session_id: "explicit" } },
+    ]);
+  });
+});

--- a/packages/control-plane/src/session/session-logger.ts
+++ b/packages/control-plane/src/session/session-logger.ts
@@ -1,0 +1,23 @@
+import type { Logger } from "../logger";
+
+/**
+ * Wrap a logger so every line carries the session id current at emit time.
+ *
+ * The underlying logger snapshots its context at creation, but the session's
+ * public id does not exist until `/internal/init` writes the row — a static
+ * context would pin whichever id existed when the graph was built (the
+ * Durable Object id, on a first-ever activation). Injecting per call through
+ * a latched resolver keeps one logger for the whole graph while its
+ * `session_id` upgrades the moment the row exists. Explicit per-call data can
+ * still override the field, and children keep the injection.
+ */
+export function createSessionScopedLogger(base: Logger, getSessionId: () => string): Logger {
+  const wrap = (inner: Logger): Logger => ({
+    debug: (msg, data) => inner.debug(msg, { session_id: getSessionId(), ...data }),
+    info: (msg, data) => inner.info(msg, { session_id: getSessionId(), ...data }),
+    warn: (msg, data) => inner.warn(msg, { session_id: getSessionId(), ...data }),
+    error: (msg, data) => inner.error(msg, { session_id: getSessionId(), ...data }),
+    child: (context) => wrap(inner.child(context)),
+  });
+  return wrap(base);
+}

--- a/packages/control-plane/src/session/snapshot-reader.ts
+++ b/packages/control-plane/src/session/snapshot-reader.ts
@@ -1,0 +1,185 @@
+import {
+  sessionSnapshotSchema,
+  type SessionSnapshotState,
+} from "@open-inspect/shared/types/server-messages";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
+import type { SessionRepositoryState } from "@open-inspect/shared/types/repositories";
+import type { Logger } from "../logger";
+import type { SqlDatabase } from "../db/sql-database";
+import { EnvironmentStore } from "../db/environments";
+import { DEFAULT_SANDBOX_STATUS } from "../sandbox/sandbox-status";
+import type { SandboxDashboardSettings } from "./sandbox-access";
+import { resolveSandboxDashboardUrl } from "./sandbox-access";
+import { findPrArtifactForRepo } from "./pr-artifacts";
+import { resolvePublicSessionId } from "./public-session-id";
+import { safeParseTunnelUrls } from "./tunnel-urls";
+import type { ArtifactRepository } from "./artifact-repository";
+import type { MessageRepository } from "./message-repository";
+import type { SandboxRepository } from "./sandbox-repository";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionEventStream } from "./event-stream";
+import type { MessageService } from "./services/message.service";
+import type { SessionRow, SandboxRow } from "./types";
+
+export interface SessionSnapshotEnrichment {
+  environmentId: string | null;
+  environmentName: string | null;
+}
+
+export interface SessionSnapshotReaderDeps {
+  sessionCoreRepository: SessionCoreRepository;
+  sandboxRepository: SandboxRepository;
+  messageRepository: MessageRepository;
+  artifactRepository: ArtifactRepository;
+  messageService: MessageService;
+  eventStream: SessionEventStream;
+  sandboxDashboardSettings: SandboxDashboardSettings;
+  /** Null when the deployment has no D1 binding — environment names resolve null. */
+  db: SqlDatabase | null;
+  durableObjectId: string;
+  /** DO storage transaction so the snapshot reads are a consistent cut. */
+  transaction: <T>(closure: () => T) => T;
+  log: Logger;
+}
+
+/**
+ * Read model for the session: the snapshot served over HTTP and pushed on
+ * subscribe, and the per-repository git state it embeds.
+ */
+export class SessionSnapshotReader {
+  constructor(private readonly deps: SessionSnapshotReaderDeps) {}
+
+  async handleSnapshot(): Promise<Response> {
+    const headers = { "Cache-Control": "private, no-store" };
+    const enrichment = await this.resolveSessionSnapshotEnrichment();
+    const snapshot = this.readSessionSnapshot(enrichment);
+    if (!snapshot) {
+      return Response.json({ error: "Session not found" }, { status: 404, headers });
+    }
+    return Response.json(sessionSnapshotSchema.parse(snapshot), { headers });
+  }
+
+  async resolveSessionSnapshotEnrichment(): Promise<SessionSnapshotEnrichment> {
+    const session = this.deps.sessionCoreRepository.getSession();
+    const environmentId = session?.environment_id ?? null;
+    const environmentName = await this.resolveEnvironmentName(environmentId);
+    return { environmentId, environmentName };
+  }
+
+  readSessionSnapshot(enrichment: SessionSnapshotEnrichment) {
+    return this.deps.transaction(() => {
+      const local = this.readSessionState(enrichment);
+      if (!local) return null;
+      return {
+        session: local.session,
+        artifacts: this.deps.messageService.listArtifacts().artifacts,
+        timeline: this.deps.eventStream.getReplay(),
+        promptQueue: this.deps.messageRepository.listPromptQueue(),
+        spawnError: local.sandbox?.last_spawn_error ?? null,
+      };
+    });
+  }
+
+  private readSessionState(
+    enrichment: SessionSnapshotEnrichment
+  ): { session: SessionSnapshotState; sandbox: SandboxRow | null } | null {
+    const session = this.deps.sessionCoreRepository.getSession();
+    if (!session) return null;
+    const sandbox = this.deps.sandboxRepository.getSandbox();
+    const publicSession: SessionSnapshotState = {
+      id: resolvePublicSessionId(session, this.deps.durableObjectId),
+      title: session.title,
+      repoOwner: session.repo_owner,
+      repoName: session.repo_name,
+      baseBranch: session.base_branch,
+      branchName: session.branch_name,
+      status: session.status,
+      sandboxStatus: sandbox?.status ?? DEFAULT_SANDBOX_STATUS,
+      messageCount: this.deps.messageRepository.getMessageCount(),
+      createdAt: session.created_at,
+      model: session.model ?? DEFAULT_MODEL,
+      reasoningEffort: session.reasoning_effort ?? undefined,
+      isProcessing: this.getIsProcessing(),
+      parentSessionId: session.parent_session_id,
+      totalCost: session.total_cost ?? 0,
+      codeServerUrl: sandbox?.code_server_url ?? null,
+      vncUrl: sandbox?.vnc_url ?? null,
+      tunnelUrls: sandbox?.tunnel_urls
+        ? safeParseTunnelUrls(sandbox.tunnel_urls, this.deps.log)
+        : null,
+      ttydUrl: sandbox?.ttyd_url ?? null,
+      sandboxDashboardUrl: resolveSandboxDashboardUrl(
+        this.deps.sandboxDashboardSettings,
+        sandbox?.modal_object_id
+      ),
+      repositories: this.getSessionRepositoryStates(session),
+      environmentId: session.environment_id ?? null,
+      environmentName:
+        session.environment_id === enrichment.environmentId ? enrichment.environmentName : null,
+    };
+    return { session: publicSession, sandbox };
+  }
+
+  /**
+   * The launch environment's current display name, or null when the session has
+   * no environment or the environment was deleted after launch (§7.6). Resolved
+   * live rather than snapshotted so deletion is reflected; best-effort, so a
+   * lookup failure resolves null rather than failing the whole state read.
+   */
+  private async resolveEnvironmentName(environmentId: string | null): Promise<string | null> {
+    if (!environmentId || !this.deps.db) {
+      return null;
+    }
+    try {
+      const environment = await new EnvironmentStore(this.deps.db).getById(environmentId);
+      return environment?.name ?? null;
+    } catch (e) {
+      this.deps.log.warn("Failed to resolve environment name for session state", {
+        environment_id: environmentId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Member repositories for SessionState, in position order (see
+   * buildSessionRepositories for the scalar-mirror fallback). Members synthesized
+   * from the scalars — and member rows written before per-repo git state
+   * existed, whose git columns are null while the scalars are set — have the
+   * primary entry overlaid with the session scalars.
+   */
+  private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
+    const prUrlForRepo = this.getPrUrlLookup();
+    return this.deps.sessionCoreRepository.getSessionRepositories().map((member) => ({
+      position: member.position,
+      repoOwner: member.repoOwner,
+      repoName: member.repoName,
+      repoId: member.row ? member.row.repo_id : (session?.repo_id ?? null),
+      baseBranch: member.baseBranch ?? "main",
+      branchName:
+        member.row?.branch_name ?? (member.isPrimary ? (session?.branch_name ?? null) : null),
+      baseSha: member.row?.base_sha ?? (member.isPrimary ? (session?.base_sha ?? null) : null),
+      currentSha:
+        member.row?.current_sha ?? (member.isPrimary ? (session?.current_sha ?? null) : null),
+      prUrl: prUrlForRepo(member.repoOwner, member.repoName, member.isPrimary),
+    }));
+  }
+
+  /** Per-repo PR URL lookup over the session's PR artifacts. */
+  private getPrUrlLookup(): (
+    repoOwner: string,
+    repoName: string,
+    isPrimary: boolean
+  ) => string | null {
+    const artifacts = this.deps.artifactRepository
+      .listArtifacts()
+      .filter((artifact) => artifact.url !== null);
+    return (repoOwner, repoName, isPrimary) =>
+      findPrArtifactForRepo(artifacts, { repoOwner, repoName }, isPrimary)?.url ?? null;
+  }
+
+  private getIsProcessing(): boolean {
+    return this.deps.messageRepository.getProcessingMessage() !== null;
+  }
+}

--- a/packages/control-plane/src/session/title-service.test.ts
+++ b/packages/control-plane/src/session/title-service.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
+import type { SessionIndexStore } from "../db/session-index";
+import { SessionTitleService } from "./title-service";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionRow } from "./types";
+
+const NOW = 1_700_000_000_000;
+
+function sessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "public-name",
+    parent_session_id: null,
+    status: "active",
+    updated_at: NOW - 5_000,
+    ...overrides,
+  } as SessionRow;
+}
+
+function makeHarness(options: { session?: SessionRow | null; withoutIndexStore?: boolean } = {}) {
+  const session = options.session === undefined ? sessionRow() : options.session;
+  const repository = {
+    getSession: vi.fn(() => session),
+    updateSessionTitle: vi.fn(),
+    updateSessionTitleIfUnset: vi.fn(() => true),
+  };
+  const messenger = { broadcast: vi.fn(), sendToSandbox: vi.fn(async () => {}) };
+  const statusService = { notifyParentOfChildUpdate: vi.fn() };
+  const backgroundTasks = createTestBackgroundTasks();
+  const updateTitleIfNewer = vi.fn(async () => {});
+  const service = new SessionTitleService({
+    sessionCoreRepository: repository as unknown as SessionCoreRepository,
+    messenger,
+    statusService,
+    backgroundTasks,
+    sessionIndexStore: options.withoutIndexStore
+      ? null
+      : ({ updateTitleIfNewer } as unknown as SessionIndexStore),
+    durableObjectId: "do-hex-id",
+    now: () => NOW,
+  });
+  return { service, repository, messenger, statusService, backgroundTasks, updateTitleIfNewer };
+}
+
+describe("SessionTitleService", () => {
+  it("rejects an invalid title before touching persistence", () => {
+    const h = makeHarness();
+
+    const result = h.service.applySessionTitleUpdate("   ");
+
+    expect(result).toEqual({ ok: false, reason: "invalid", error: expect.any(String) });
+    expect(h.repository.updateSessionTitle).not.toHaveBeenCalled();
+    expect(h.messenger.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when the session row does not exist", () => {
+    const h = makeHarness({ session: null });
+
+    const result = h.service.applySessionTitleUpdate("A title");
+
+    expect(result).toEqual({ ok: false, reason: "not_found", error: "Session not found" });
+    expect(h.repository.updateSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it("returns already_set when onlyIfUnset loses to an existing title", () => {
+    const h = makeHarness();
+    h.repository.updateSessionTitleIfUnset.mockReturnValue(false);
+
+    const result = h.service.applySessionTitleUpdate("A title", { onlyIfUnset: true });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "already_set",
+      error: "Session title is already set",
+    });
+    expect(h.repository.updateSessionTitle).not.toHaveBeenCalled();
+    expect(h.messenger.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("persists, broadcasts, and schedules the index sync on success", async () => {
+    const h = makeHarness();
+
+    const result = h.service.applySessionTitleUpdate("  New title  ");
+
+    expect(result).toEqual({ ok: true, title: "New title" });
+    expect(h.repository.updateSessionTitle).toHaveBeenCalledWith("session-1", "New title", NOW);
+    expect(h.messenger.broadcast).toHaveBeenCalledWith({
+      type: "session_title",
+      title: "New title",
+    });
+    expect(h.backgroundTasks.submissions).toEqual([
+      expect.objectContaining({ name: "session_index.update_title" }),
+    ]);
+    await h.backgroundTasks.settle();
+    expect(h.backgroundTasks.failures).toEqual([]);
+    expect(h.updateTitleIfNewer).toHaveBeenCalledWith("public-name", "New title", NOW);
+    expect(h.statusService.notifyParentOfChildUpdate).not.toHaveBeenCalled();
+  });
+
+  it("advances updated_at monotonically when the clock is behind the row", () => {
+    const h = makeHarness({ session: sessionRow({ updated_at: NOW + 10_000 }) });
+
+    h.service.applySessionTitleUpdate("A title");
+
+    expect(h.repository.updateSessionTitle).toHaveBeenCalledWith(
+      "session-1",
+      "A title",
+      NOW + 10_001
+    );
+  });
+
+  it("notifies the parent session for child sessions", () => {
+    const h = makeHarness({ session: sessionRow({ parent_session_id: "parent-1" }) });
+
+    h.service.applySessionTitleUpdate("Child title");
+
+    expect(h.statusService.notifyParentOfChildUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1", title: "Child title" }),
+      "public-name",
+      { status: "active", title: "Child title" }
+    );
+  });
+
+  it("skips the index sync when no D1 store is bound", () => {
+    const h = makeHarness({ withoutIndexStore: true });
+
+    const result = h.service.applySessionTitleUpdate("A title");
+
+    expect(result).toEqual({ ok: true, title: "A title" });
+    expect(h.backgroundTasks.submissions).toEqual([]);
+  });
+});

--- a/packages/control-plane/src/session/title-service.ts
+++ b/packages/control-plane/src/session/title-service.ts
@@ -1,0 +1,87 @@
+import type { BackgroundTasks } from "../platform-ports";
+import type { SessionIndexStore } from "../db/session-index";
+import type { SessionMessenger } from "./messenger";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionStatusService } from "./session-status-service";
+import { resolvePublicSessionId } from "./public-session-id";
+import {
+  normalizeSessionTitle,
+  type SessionTitleUpdateOptions,
+  type SessionTitleUpdateResult,
+} from "./title";
+
+export interface SessionTitleServiceDeps {
+  sessionCoreRepository: SessionCoreRepository;
+  messenger: SessionMessenger;
+  statusService: Pick<SessionStatusService, "notifyParentOfChildUpdate">;
+  backgroundTasks: BackgroundTasks;
+  /** Null when the deployment has no D1 binding — the index sync is skipped. */
+  sessionIndexStore: SessionIndexStore | null;
+  durableObjectId: string;
+  now: () => number;
+}
+
+/**
+ * Applies session title updates: normalization, persistence, the D1 session
+ * index sync, the `session_title` broadcast, and parent notification for child
+ * sessions.
+ */
+export class SessionTitleService {
+  constructor(private readonly deps: SessionTitleServiceDeps) {}
+
+  applySessionTitleUpdate(
+    title: string,
+    options: SessionTitleUpdateOptions = {}
+  ): SessionTitleUpdateResult {
+    const { sessionCoreRepository, messenger, statusService, durableObjectId, now } = this.deps;
+    const normalized = normalizeSessionTitle(title);
+    if (!normalized.ok) {
+      return { ok: false, reason: "invalid", error: normalized.error };
+    }
+    const titleText = normalized.title;
+
+    const session = sessionCoreRepository.getSession();
+    if (!session) {
+      return { ok: false, reason: "not_found", error: "Session not found" };
+    }
+
+    const updatedAt = Math.max(now(), session.updated_at + 1);
+    if (options.onlyIfUnset) {
+      const didUpdate = sessionCoreRepository.updateSessionTitleIfUnset(
+        session.id,
+        titleText,
+        updatedAt
+      );
+      if (!didUpdate) {
+        return { ok: false, reason: "already_set", error: "Session title is already set" };
+      }
+    } else {
+      sessionCoreRepository.updateSessionTitle(session.id, titleText, updatedAt);
+    }
+
+    const publicSessionId = resolvePublicSessionId(session, durableObjectId);
+    this.syncSessionIndexTitle(publicSessionId, titleText, updatedAt);
+    messenger.broadcast({ type: "session_title", title: titleText });
+
+    if (session.parent_session_id) {
+      statusService.notifyParentOfChildUpdate({ ...session, title: titleText }, publicSessionId, {
+        status: session.status,
+        title: titleText,
+      });
+    }
+
+    return { ok: true, title: titleText };
+  }
+
+  private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
+    const { sessionIndexStore, backgroundTasks } = this.deps;
+    if (!sessionIndexStore) return;
+    backgroundTasks.submit(
+      () => sessionIndexStore.updateTitleIfNewer(sessionId, title, updatedAt),
+      {
+        name: "session_index.update_title",
+        context: { session_id: sessionId, updated_at: updatedAt },
+      }
+    );
+  }
+}

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -226,7 +226,7 @@ function makeHarness(
   const storage = fakeSqlStorage({ session, memberRows: options.memberRows ?? [] });
   const db = new FakeSqlDatabase();
   const logs: LogEntry[] = [];
-  let currentLogger = recordingLogger(logs);
+  const log = recordingLogger(logs);
   const sessionCoreRepository = new SessionCoreRepository(storage.sql, (closure) => closure());
   let resolveRepoIdCalls = 0;
   // Default mirrors production wiring: the real resolution function over a
@@ -249,7 +249,7 @@ function makeHarness(
     durableObjectId: "do-id-fallback",
     repoSecretsEncryptionKey: options.encryptionKey,
     secretsCapEnforcement: options.capEnforcement,
-    log: () => currentLogger,
+    log,
   });
 
   return {
@@ -258,9 +258,6 @@ function makeHarness(
     logs,
     sqlCalls: storage.calls,
     resolveRepoIdCalls: () => resolveRepoIdCalls,
-    setLogger(logger: Logger) {
-      currentLogger = logger;
-    },
   };
 }
 
@@ -529,27 +526,6 @@ describe("UserEnvResolver", () => {
       await expect(
         h.resolver.getProviderAuthenticationError("anthropic/claude-sonnet-4-5")
       ).resolves.toBeNull();
-    });
-  });
-
-  describe("thunk contracts", () => {
-    it("logs through the logger current at call time, not construction time", async () => {
-      const h = makeHarness({ session: null });
-      const swappedEntries: LogEntry[] = [];
-
-      await h.resolver.getUserEnvVars();
-      expect(h.logs).toHaveLength(1);
-
-      h.setLogger(recordingLogger(swappedEntries));
-      await h.resolver.getUserEnvVars();
-
-      // The swapped-in logger received the second warn; the original saw only the first.
-      expect(swappedEntries).toContainEqual({
-        level: "warn",
-        msg: "Cannot load secrets: no session",
-        data: undefined,
-      });
-      expect(h.logs).toHaveLength(1);
     });
   });
 });

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -48,12 +48,8 @@ export interface UserEnvResolverDeps {
   durableObjectId: string;
   repoSecretsEncryptionKey: string | undefined;
   secretsCapEnforcement: string | undefined;
-  /**
-   * Thunk, deliberately: the owner replaces its logger with a session-scoped
-   * one during initialization, so a by-value capture would pin whichever
-   * logger existed at construction.
-   */
-  log: () => Logger;
+  /** The session-scoped logger; the composition root creates it before this class. */
+  log: Logger;
 }
 
 interface UserEnvContext {
@@ -68,7 +64,7 @@ export class UserEnvResolver {
   private readonly durableObjectId: string;
   private readonly repoSecretsEncryptionKey: string | undefined;
   private readonly secretsCapEnforcement: string | undefined;
-  private readonly log: () => Logger;
+  private readonly log: Logger;
 
   constructor(deps: UserEnvResolverDeps) {
     this.db = deps.db;
@@ -103,7 +99,7 @@ export class UserEnvResolver {
       context.providerAuthModes
     );
     if (!issue) return null;
-    this.log().error("provider_auth.unavailable", {
+    this.log.error("provider_auth.unavailable", {
       event: "provider_auth.unavailable",
       provider: issue.provider,
       auth_mode: context.providerAuthModes[issue.provider],
@@ -114,7 +110,7 @@ export class UserEnvResolver {
   private async loadUserEnvContext(): Promise<UserEnvContext | null> {
     const session = this.sessionCoreRepository.getSession();
     if (!session) {
-      this.log().warn("Cannot load secrets: no session");
+      this.log.warn("Cannot load secrets: no session");
       return null;
     }
 
@@ -128,7 +124,7 @@ export class UserEnvResolver {
     ) as Record<SubscriptionProviderId, SessionProviderAuthMode>;
 
     if (!this.repoSecretsEncryptionKey) {
-      this.log().debug("Ordinary secrets not configured, skipping secret loading", {
+      this.log.debug("Ordinary secrets not configured, skipping secret loading", {
         has_encryption_key: !!this.repoSecretsEncryptionKey,
       });
       const sandboxEnv = prepareManagedProviderEnv({
@@ -160,13 +156,13 @@ export class UserEnvResolver {
     auditSecretsMerge({
       merge,
       mode: parseSecretsCapMode(this.secretsCapEnforcement),
-      log: this.log(),
+      log: this.log,
       context: { session_id: session.id },
     });
 
     const mergedCount = Object.keys(merge.merged).length;
     if (mergedCount > 0) {
-      this.log().info("Secrets merged for sandbox", {
+      this.log.info("Secrets merged for sandbox", {
         source_count: sources.length,
         merged_count: mergedCount,
         payload_bytes: merge.totalBytes,

--- a/packages/control-plane/test/integration/create-pr.test.ts
+++ b/packages/control-plane/test/integration/create-pr.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
 import type { SourceControlProvider } from "../../src/source-control";
 import type { SessionDO } from "../../src/session/durable-object";
+import { componentsOf } from "./session-do-access";
 import { initNamedSession, initSession, queryDO, seedMessage, serviceFetch } from "./helpers";
 
 describe("POST /internal/create-pr", () => {
@@ -157,9 +158,7 @@ describe("POST /internal/create-pr", () => {
         }),
       } as unknown as SourceControlProvider;
 
-      (
-        instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
-      )._sourceControlProvider = mockProvider;
+      componentsOf(instance).sourceControlProvider = () => mockProvider;
     });
 
     const res = await stub.fetch("http://internal/internal/create-pr", {
@@ -238,9 +237,7 @@ describe("POST /internal/create-pr", () => {
         }),
       } as unknown as SourceControlProvider;
 
-      (
-        instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
-      )._sourceControlProvider = mockProvider;
+      componentsOf(instance).sourceControlProvider = () => mockProvider;
     });
 
     const res = await stub.fetch("http://internal/internal/create-pr", {
@@ -332,9 +329,7 @@ describe("POST /internal/create-pr", () => {
         }),
       } as unknown as SourceControlProvider;
 
-      (
-        instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
-      )._sourceControlProvider = mockProvider;
+      componentsOf(instance).sourceControlProvider = () => mockProvider;
     });
   }
 
@@ -500,9 +495,7 @@ describe("POST /internal/create-pr", () => {
           }),
         } as unknown as SourceControlProvider;
 
-        (
-          instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
-        )._sourceControlProvider = mockProvider;
+        componentsOf(instance).sourceControlProvider = () => mockProvider;
       });
     }
 

--- a/packages/control-plane/test/integration/session-components.test.ts
+++ b/packages/control-plane/test/integration/session-components.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
 import type { Env } from "../../src/types";
-import { createSessionComponents } from "../../src/session/components";
+import { createSessionRuntime } from "../../src/session/components";
 import { componentsOf } from "./session-do-access";
 
-describe("createSessionComponents", () => {
+describe("createSessionRuntime", () => {
   it("builds the whole graph eagerly without constructing either provider", async () => {
     const stub = env.SESSION.get(env.SESSION.idFromName(`components-eager-${crypto.randomUUID()}`));
 
@@ -25,10 +25,16 @@ describe("createSessionComponents", () => {
 
       // Eager construction of either provider would throw right here and fail
       // every request on such a deployment; the graph must still assemble.
-      const components = createSessionComponents(
-        { ctx: instance.ctx, sql: instance.ctx.storage.sql, db: null },
+      const runtime = createSessionRuntime(
+        {
+          ctx: instance.ctx,
+          sql: instance.ctx.storage.sql,
+          db: null,
+          ensureInitialized: () => {},
+        },
         misconfigured
       );
+      const components = runtime.internals;
 
       let scmError: string | null = null;
       try {
@@ -39,6 +45,7 @@ describe("createSessionComponents", () => {
 
       return {
         built: Boolean(
+          runtime.server &&
           components.lifecycleManager &&
           components.messageQueue &&
           components.sessionLifecycleHandler &&

--- a/packages/control-plane/test/integration/session-components.test.ts
+++ b/packages/control-plane/test/integration/session-components.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import type { SessionDO } from "../../src/session/durable-object";
+import type { Env } from "../../src/types";
+import { createSessionComponents } from "../../src/session/components";
+import { componentsOf } from "./session-do-access";
+
+describe("createSessionComponents", () => {
+  it("builds the whole graph eagerly without constructing either provider", async () => {
+    const stub = env.SESSION.get(env.SESSION.idFromName(`components-eager-${crypto.randomUUID()}`));
+
+    const result = await runInDurableObject(stub, (instance: SessionDO) => {
+      // Apply the schema (idempotent init) — the factory reads the session row.
+      componentsOf(instance);
+
+      // A deployment shape that works today only because both provider
+      // factories are deferred: no sandbox credentials, no valid SCM provider.
+      const misconfigured = {
+        ...(instance as unknown as { env: Env }).env,
+        SANDBOX_PROVIDER: "not-a-real-sandbox-provider",
+        MODAL_API_SECRET: undefined,
+        MODAL_WORKSPACE: undefined,
+        SCM_PROVIDER: "not-a-real-provider",
+      } as Env;
+
+      // Eager construction of either provider would throw right here and fail
+      // every request on such a deployment; the graph must still assemble.
+      const components = createSessionComponents(
+        { ctx: instance.ctx, sql: instance.ctx.storage.sql, db: null },
+        misconfigured
+      );
+
+      let scmError: string | null = null;
+      try {
+        components.sourceControlProvider();
+      } catch (error) {
+        scmError = error instanceof Error ? error.message : String(error);
+      }
+
+      return {
+        built: Boolean(
+          components.lifecycleManager &&
+          components.messageQueue &&
+          components.sessionLifecycleHandler &&
+          components.sandboxEventProcessor
+        ),
+        scmError,
+      };
+    });
+
+    expect(result.built).toBe(true);
+    // The deferred SCM factory still surfaces its configuration error at the
+    // first operation that needs it.
+    expect(result.scmError).toMatch(/SCM_PROVIDER/i);
+  });
+});

--- a/packages/control-plane/test/integration/session-do-access.ts
+++ b/packages/control-plane/test/integration/session-do-access.ts
@@ -4,9 +4,15 @@ import type { SessionComponents } from "../../src/session/components";
 
 /**
  * The DO internals integration tests are allowed to reach: the (private)
- * idempotent initializer and the component graph it builds. `Pick`-typed
- * casts tie each helper to the real types so a rename breaks the helper
- * instead of silently passing.
+ * idempotent initializer and the component graph it builds.
+ *
+ * NOTE: `test/integration/**` is never typechecked (eslint + grep are the only
+ * static gates here), and the `as unknown` cast below has no structural tie to
+ * SessionDO — its members are private, so they cannot be `Pick`ed. Renaming
+ * `ensureInitialized` or `components` on the DO surfaces only as runtime
+ * TypeErrors across the integration suite; keep this interface in sync with
+ * SessionDO by hand. The `SessionComponents` import does keep component-graph
+ * renames visible, but in-editor only.
  */
 export interface SessionDOInternals {
   ensureInitialized(rehydrateAlarm?: boolean): void;

--- a/packages/control-plane/test/integration/session-do-access.ts
+++ b/packages/control-plane/test/integration/session-do-access.ts
@@ -1,20 +1,33 @@
 import { runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
-import type { UserEnvResolver } from "../../src/session/user-env-resolver";
+import type { SessionComponents } from "../../src/session/components";
 
 /**
- * Invoke the DO's real (private) user-env resolver. The single place secrets
- * tests reach past SessionDO's encapsulation; `Pick` ties the cast to the real
- * class so a rename breaks this helper instead of silently passing.
+ * The DO internals integration tests are allowed to reach: the (private)
+ * idempotent initializer and the component graph it builds. `Pick`-typed
+ * casts tie each helper to the real types so a rename breaks the helper
+ * instead of silently passing.
+ */
+export interface SessionDOInternals {
+  ensureInitialized(rehydrateAlarm?: boolean): void;
+  components: SessionComponents;
+}
+
+/** Initialize (idempotent) and expose the DO's component graph. */
+export function componentsOf(instance: SessionDO): SessionComponents {
+  const internals = instance as unknown as SessionDOInternals;
+  internals.ensureInitialized();
+  return internals.components;
+}
+
+/**
+ * Invoke the DO's real user-env resolver. The single place secrets tests
+ * reach past SessionDO's encapsulation.
  */
 export function getUserEnvVars(
   stub: DurableObjectStub
 ): Promise<Record<string, string> | undefined> {
   return runInDurableObject(stub, (instance: SessionDO) =>
-    (
-      instance as unknown as {
-        userEnvResolver: Pick<UserEnvResolver, "getUserEnvVars">;
-      }
-    ).userEnvResolver.getUserEnvVars()
+    componentsOf(instance).userEnvResolver.getUserEnvVars()
   );
 }

--- a/packages/control-plane/test/integration/session-do-access.ts
+++ b/packages/control-plane/test/integration/session-do-access.ts
@@ -1,29 +1,26 @@
 import { runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
-import type { SessionComponents } from "../../src/session/components";
+import type { SessionRuntime } from "../../src/session/components";
 
 /**
- * The DO internals integration tests are allowed to reach: the (private)
- * idempotent initializer and the component graph it builds.
+ * The DO internals integration tests are allowed to reach: the private
+ * `runtime` accessor (which initializes on first touch) and the component
+ * graph behind `SessionRuntime.internals`.
  *
  * NOTE: `test/integration/**` is never typechecked (eslint + grep are the only
  * static gates here), and the `as unknown` cast below has no structural tie to
  * SessionDO — its members are private, so they cannot be `Pick`ed. Renaming
- * `ensureInitialized` or `components` on the DO surfaces only as runtime
- * TypeErrors across the integration suite; keep this interface in sync with
- * SessionDO by hand. The `SessionComponents` import does keep component-graph
- * renames visible, but in-editor only.
+ * the DO's `runtime` accessor surfaces only as runtime TypeErrors across the
+ * integration suite; keep this interface in sync with SessionDO by hand. The
+ * `SessionRuntime` import does keep graph renames visible, but in-editor only.
  */
 export interface SessionDOInternals {
-  ensureInitialized(rehydrateAlarm?: boolean): void;
-  components: SessionComponents;
+  runtime: SessionRuntime;
 }
 
 /** Initialize (idempotent) and expose the DO's component graph. */
-export function componentsOf(instance: SessionDO): SessionComponents {
-  const internals = instance as unknown as SessionDOInternals;
-  internals.ensureInitialized();
-  return internals.components;
+export function componentsOf(instance: SessionDO): SessionRuntime["internals"] {
+  return (instance as unknown as SessionDOInternals).runtime.internals;
 }
 
 /**

--- a/packages/control-plane/test/integration/session-do-collaborator-wiring.test.ts
+++ b/packages/control-plane/test/integration/session-do-collaborator-wiring.test.ts
@@ -1,13 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
 import type { Mock } from "vitest";
-import type { SandboxLifecycleManager } from "../../src/sandbox/lifecycle/manager";
-import type { PresenceService } from "../../src/session/presence-service";
-import type { SessionSandboxEventProcessor } from "../../src/session/sandbox-events";
+import type { SessionComponents } from "../../src/session/components";
 import type { SessionDO } from "../../src/session/durable-object";
 import type { SourceControlProvider } from "../../src/source-control";
 import type { GitPushSpec } from "../../src/source-control";
 import { cleanD1Tables } from "./cleanup";
+import { componentsOf } from "./session-do-access";
 import { initSession, queryDO, seedMessage, waitForSandboxStatus } from "./helpers";
 
 /**
@@ -34,23 +33,14 @@ import { initSession, queryDO, seedMessage, waitForSandboxStatus } from "./helpe
  * lazy getters with an explicit `SessionComponents` seam, repoint THIS function
  * at it and every test below should keep passing unchanged.
  */
-function collaboratorsOf(instance: SessionDO): {
-  lifecycleManager: SandboxLifecycleManager;
-  presenceService: PresenceService;
-  sandboxEventProcessor: SessionSandboxEventProcessor;
-} {
-  return instance as unknown as {
-    lifecycleManager: SandboxLifecycleManager;
-    presenceService: PresenceService;
-    sandboxEventProcessor: SessionSandboxEventProcessor;
-  };
+function collaboratorsOf(
+  instance: SessionDO
+): Pick<SessionComponents, "lifecycleManager" | "presenceService" | "sandboxEventProcessor"> {
+  return componentsOf(instance);
 }
 
 /** The repository this suite's stubbed provider pushes to. */
 const PUSH_REPO = { repoOwner: "acme", repoName: "web-app" } as const;
-
-/** Own-property key used to count reads of a shadowed lazy getter. */
-const GETTER_READS = "__wiringLifecycleManagerReads";
 
 function notUsedHere(member: string): never {
   throw new Error(`${member} is not exercised by the collaborator-wiring suite`);
@@ -186,9 +176,10 @@ describe("SessionDO collaborator wiring", () => {
     });
 
     await runInDurableObject(stub, (instance: SessionDO) => {
-      (
-        instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
-      )._sourceControlProvider = stubSourceControlProvider();
+      // SCM access reads through the components record, so replacing this
+      // property substitutes the stub for every consumer.
+      const provider = stubSourceControlProvider();
+      componentsOf(instance).sourceControlProvider = () => provider;
       // Without a connected sandbox the real implementation short-circuits to
       // `{ success: true }`, which is exactly what a dropped edge would return.
       // Spying is the only way to tell the two apart from out here.
@@ -228,61 +219,50 @@ describe("SessionDO collaborator wiring", () => {
     ]);
   });
 
-  it("keeps session init succeeding when the sandbox provider cannot be built", async () => {
+  it("keeps session init succeeding when the warm spawn cannot build its sandbox provider", async () => {
     const sessionName = `wiring-provider-throws-${crypto.randomUUID()}`;
     const stub = env.SESSION.get(env.SESSION.idFromName(sessionName));
 
-    // `lifecycleManager` is a lazy getter that constructs the sandbox provider,
-    // and that construction throws on a deployment missing provider
-    // credentials. Shadow it before init so the warm-spawn thunk hits the same
-    // failure; init must still succeed, because its session rows are already
-    // committed by the time the warm spawn is scheduled.
+    // The sandbox provider is deferred: constructing it throws on a deployment
+    // missing provider credentials, and that construction now happens on first
+    // provider touch inside `warmSandbox` rather than at graph construction.
+    // Model that failure mode before init; init must still succeed, because
+    // its session rows are already committed by the time the warm spawn runs.
+    // (Init's own ensureInitialized() is idempotent, so pre-initializing here
+    // matches production order within the same activation.)
     await runInDurableObject(stub, (instance: SessionDO) => {
-      const probe = instance as unknown as Record<string, unknown>;
-      probe[GETTER_READS] = 0;
-      Object.defineProperty(instance, "lifecycleManager", {
-        configurable: true,
-        get() {
-          probe[GETTER_READS] = (probe[GETTER_READS] as number) + 1;
-          throw new Error("MODAL_API_SECRET and MODAL_WORKSPACE are required");
-        },
-      });
+      componentsOf(instance).lifecycleManager.warmSandbox = vi.fn(() =>
+        Promise.reject(new Error("MODAL_API_SECRET and MODAL_WORKSPACE are required"))
+      );
     });
 
-    try {
-      const response = await stub.fetch("http://internal/internal/init", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionName,
-          repoOwner: "acme",
-          repoName: "web-app",
-          repoId: 12345,
-          userId: "user-1",
-        }),
-      });
+    const response = await stub.fetch("http://internal/internal/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionName,
+        repoOwner: "acme",
+        repoName: "web-app",
+        repoId: 12345,
+        userId: "user-1",
+      }),
+    });
 
-      expect(response.status).toBe(200);
+    expect(response.status).toBe(200);
 
-      // Asserting only the 200 would be a false positive: removing warm-spawn
-      // scheduling from init altogether also returns 200. The read count is
-      // what pins that init still reaches the warm-spawn edge, so the 200 is
-      // evidence the throw was absorbed rather than evidence it never happened.
-      // `submit` invokes the warm-spawn task factory synchronously inside its
-      // own try/catch, so the getter read still lands before init responds and
-      // the throw is logged as background_task.failed instead of escaping.
-      const getterReads = await runInDurableObject(
-        stub,
-        (instance: SessionDO) => (instance as unknown as Record<string, number>)[GETTER_READS] ?? 0
-      );
-      expect(getterReads).toBeGreaterThan(0);
-    } finally {
-      await runInDurableObject(stub, (instance: SessionDO) => {
-        const probe = instance as unknown as Record<string, unknown>;
-        delete probe.lifecycleManager;
-        delete probe[GETTER_READS];
-      });
-    }
+    // Asserting only the 200 would be a false positive: removing warm-spawn
+    // scheduling from init altogether also returns 200. The call count is
+    // what pins that init still reaches the warm-spawn edge, so the 200 is
+    // evidence the rejection was absorbed rather than evidence it never
+    // happened. `submit` runs the task factory synchronously and routes the
+    // rejection to background_task.failed instead of letting it escape.
+    const warmSpawnCalls = await runInDurableObject(stub, (instance: SessionDO) => {
+      const spy = componentsOf(instance).lifecycleManager.warmSandbox as unknown as Mock<
+        () => Promise<void>
+      >;
+      return spy.mock.calls.length;
+    });
+    expect(warmSpawnCalls).toBeGreaterThan(0);
   });
 
   it("surfaces stored tunnel URLs in the session snapshot", async () => {

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
+import { componentsOf } from "./session-do-access";
 import { encryptToken } from "../../src/auth/crypto";
 import {
   collectMessages,
@@ -142,9 +143,7 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     ...statements: string[]
   ): Promise<void> {
     await runInDurableObject(stub, (instance: SessionDO) => {
-      const repository = (
-        instance as unknown as { sandboxRepository: { getSandbox: () => unknown } }
-      ).sandboxRepository;
+      const repository = componentsOf(instance).sandboxRepository;
       const readSandbox = repository.getSandbox.bind(repository);
       vi.spyOn(repository, "getSandbox").mockImplementation(() => {
         const sandbox = readSandbox();
@@ -359,11 +358,9 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
       status: "spawning",
     });
     await runInDurableObject(stub, (instance: SessionDO) => {
-      const lifecycleManager = (
-        instance as unknown as {
-          lifecycleManager: { providerStartupPending: boolean };
-        }
-      ).lifecycleManager;
+      const lifecycleManager = componentsOf(instance).lifecycleManager as unknown as {
+        providerStartupPending: boolean;
+      };
       lifecycleManager.providerStartupPending = true;
     });
     const { ws: clientWs } = await openClientWs(name, { subscribe: true });


### PR DESCRIPTION
## What

Phase 2b+3 of the SessionDO decomposition. All construction and wiring moves out of `SessionDO` into `createSessionRuntime(platform, env)` (`session/components.ts`) — an eager, topologically-ordered composition root that returns a **narrow runtime surface**, not the graph:

```ts
interface SessionRuntime {
  readonly log: Logger;
  readonly server: SessionServer<WebSocket, ClientInfo>;  // onRequest / onMessage / onClose / onError / onScheduledDeadline
  readonly alarms: { rehydrate(): void };
  readonly internals: SessionComponents;                  // integration-test introspection only
}
```

- **`durable-object.ts`: 1716 → 111 lines.** The DO is now a pure Cloudflare adapter: it initializes the runtime once per activation and forwards the five platform callbacks. All 24 lazy getters, 23 memo fields, the routes table, the socket adapters, and every domain method are gone from it.
- The domain logic that previously stayed behind is extracted along real ownership lines:
  - `SessionConnectionAuthenticator` (`connection-authenticator.ts`) — sandbox WS upgrade guards (the post-auth re-check block), client subscribe + token TTL, snapshot handoff, post-hibernation identity recovery;
  - `SessionSnapshotReader` (`snapshot-reader.ts`) — the session read model (snapshot route + subscribe payload, per-repo git state, environment-name enrichment);
  - `SessionAccessReader` (`sandbox-access-reader.ts`) — sandbox access credential decryption/authorization;
  - `SessionTitleService` (`title-service.ts`) — title normalization/persistence/broadcast/index-sync.
- Repositories, services, and handlers are **local to the factory**. Production code cannot reach them: the DO touches only `log`, `server`, and `alarms`. `internals` is not the graph — it is the **enumerated set of integration-test seams** (8 fields: 7 live collaborators to spy on, plus the substitutable SCM provider cell), each with a test that reaches it inside a `runInDurableObject` callback (the pre-existing idiom — those tests run against a live DO whose graph the init request already built, so their seams are necessarily late-bound). Adding a seam means adding both the field and its consuming test.
- The boundary is **governed, not conventional**: a scoped `no-restricted-imports` rule allows only `session/durable-object.ts` (and tests) to import the composition root — red-verified by tripping it from a sibling module. Together with the DO exposing nothing to reference, the planned Phase 5 back-edge rule becomes trivial.
- **One session-scoped logger with live context**: the factory creates a single logger whose `session_id` is injected per emit through a latched resolver (`session-logger.ts` + `createLatchedPublicSessionIdResolver`). On a first-ever activation the id upgrades from the DO id to the public session name the moment `/internal/init` writes the row — for every component, however early it captured the logger. (Previously the id was frozen at logger creation; on genesis activations that meant the DO id for the whole activation.)

## The two provider factories stay deferred — deliberately

`createSandboxProviderFromEnv` and `createSourceControlProviderFromEnv` **throw on reachable configurations** (missing provider credentials; invalid `SCM_PROVIDER`; GitLab without a token; Bitbucket). Constructing them eagerly would turn `/internal/init` — which works on such deployments today and is pinned by the wiring suite — into a 500 on every request. The deferral is confined to documented cells at the root:

- the sandbox provider, behind `createDeferredSandboxProvider` (getter-shape adapter over `once()`, so the lifecycle manager's signature and its 84 test construction sites don't change, and optional-method presence probes stay truthful);
- the SCM provider, behind `once()` in a **local cell**; consumer closures capture a stable local binding (no temporal dead zone, no read through the returned record). `internals.sourceControlProvider` is an accessor pair over that cell — the getter for introspection, the setter as the live-DO integration seam;
- `resolveScmProviderFromEnv` / `resolveSandboxBackendName` name resolution (also throwing) resolved per use.

`test/integration/session-components.test.ts` pins the invariant: the full graph assembles under a deployment where both factories and both name resolutions throw.

## Initialization

`ensureInitialized()` builds into a local and **publishes last** — a throw during schema init or graph construction leaves the activation uninitialized, so the next event retries instead of dereferencing an undefined runtime. It also emits a one-line `do.init` event with the initialization duration; the dispatcher's per-request `init_ms` now reads ~0 because initialization happens before dispatch (the cold-start cost moved to `do.init` — deliberate observability change).

`SessionServerDeps.ensureInitialized` is kept and threaded through as a declared factory input, so hibernation-restored callbacks self-heal with exactly the same contract (and `server.test.ts` stays untouched).

## Frozen-at-construction values became per-use thunks

Two values used to be read at first getter touch — after `/internal/init` commits the row — and would have been frozen too early by eager construction:

- `executionTimeoutMs` (honors `sandbox_settings`): `SessionMessageQueue` and the alarm handler take `getExecutionTimeoutMs: () => number`, resolved when a deadline is armed. Pinned by a two-dispatch freshness test.
- the lifecycle manager's log-correlation id: `config.sessionId` → `config.getSessionId` thunk with a memoized derivation, sharing the same latched resolver as the session logger. Pinned by a log-context transition test.

All three pins are **mutation-verified**: the intended regression mutants (first-use freeze, latch-the-fallback, constructor-time capture) each fail their test.

## Behavior notes (deliberate, small)

- Unsupported `SANDBOX_PROVIDER`: the lifecycle manager now constructs; the same `Unsupported SANDBOX_PROVIDER` error surfaces at the spawn that needs the provider (absorbed at the background-task boundary). Strictly more requests work on such a deployment.
- Log lines from all session components now carry a live `session_id` (upgrade mid-activation on genesis) — an observability improvement, not a wire-format change.
- `do.request`'s `init_ms` reads ~0; `do.init` supersedes it (see Initialization).
- `UserEnvResolver`'s `log` dep is a plain `Logger`; the call-time-logger contract test is deleted with the contract it pinned.

## Tests

- **Integration: 81 files / 999 tests green**, including the eviction/hibernation suite and the WS auth-race suite, against the runtime shape.
- Unit: 206 files / 3184 tests, including new suites for the session logger wrapper, the latched resolver, the deferred-provider adapter, and the title service.
- Integration tests that pierced DO privates are consolidated behind one accessor (`componentsOf` in `session-do-access.ts`, honestly documented: this directory is never typechecked, so the casts are hand-synced).

## What this unblocks

Phase 4 (collapse the five socket-port abstractions) and Phase 5 (the lint rule pinning that nothing the factory builds references the DO — now trivially true, since the DO exposes nothing to reference). The #1589 spawn-generation fence design now has its home in `SessionConnectionAuthenticator`.

Part of the SessionDO decomposition plan (Wave A #1577/#1578/#1579, Phase 1.5 #1583, Wave B #1585/#1586/#1587).

---

## Review history

**Round 1 (pre-open, 6-lens adversarial pass):** 4 findings confirmed and fixed — per-log-line SQL read in the manager's log derivation (→ latched resolver), missing pins for the per-use thunk contracts (→ mutation-verified tests), stale seam doc comment.

**Round 2 (teammate review, Request Changes at `d1d6c385`):** all findings accepted and addressed at `9c6c01a4`:
1. *Init can poison an activation* → build-into-local, publish-last (above).
2. *Mutable back-edge / TDZ in the SCM thunk* → local cell + accessor pair; consumer closures never read through the returned record; `SessionRuntime` itself is immutable. One qualification kept from the discussion: pre-construction injection through factory inputs cannot serve the live-DO integration idiom (tests inject **after** the init request they triggered has built the graph), so one explicit, documented late-bound seam remains — on `internals`, not on the runtime.
3. *Service-locator surface / no ownership boundaries* → the narrow `SessionRuntime` above, one step further than the sketch: since the routes table and socket wiring also moved into the factory, the adapter needs only `log`/`server`/`alarms` rather than per-capability members. Connection auth, snapshot assembly, and sandbox access are extracted as owning classes. At `d5e791b7`, `SessionComponents` was additionally shrunk from the full graph (~41 entries) to the 8 test-reached seams, and the only-the-adapter-imports-the-root lint rule landed.
4. *(Non-blocking) genesis logger pins the DO id* → fixed for all components via the per-emit `session_id` injection, not just the lifecycle manager.
