### PR TITLE
fix: report fatal sandbox errors to the session and its caller

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -869,6 +869,7 @@ export class SessionDO extends DurableObject<Env> {
             messageCreatedAt,
             terminalMessageCompletedAt: completedAt,
           }),
+        (error, completedAt) => this.messageQueue.failUnfinishedMessages(error, completedAt),
         this.statusService,
         (timestamp) => this.lifecycleManager.updateLastActivity(timestamp),
         () => this.lifecycleManager.scheduleInactivityCheck(),

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -1346,4 +1346,56 @@ describe("SessionMessageQueue", () => {
       expect(h.repository.updateParticipantCoalesce).not.toHaveBeenCalled();
     });
   });
+
+  describe("failUnfinishedMessages", () => {
+    it("settles a prompt that never left pending and tells its caller why", () => {
+      const h = buildQueue();
+      // A boot failure fails the prompt before it is ever dispatched, so it is
+      // still "pending" — failStuckProcessingMessage only ever sees "processing".
+      h.repository.listUnfinishedMessages.mockReturnValue([
+        createMessage({ id: "msg-boot", status: "pending" }),
+      ]);
+
+      const failed = h.queue.failUnfinishedMessages("git sync failed for owner/repo", 5000);
+
+      expect(failed).toBe(1);
+      expect(h.repository.recordMessageCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: "msg-boot",
+          success: false,
+          error: "git sync failed for owner/repo",
+        }),
+        5000,
+        "pending"
+      );
+      expect(h.callbackService.notifyComplete).toHaveBeenCalledWith(
+        "msg-boot",
+        false,
+        "git sync failed for owner/repo"
+      );
+    });
+
+    it("settles a processing prompt against its own status", () => {
+      const h = buildQueue();
+      h.repository.listUnfinishedMessages.mockReturnValue([
+        createMessage({ id: "msg-running", status: "processing" }),
+      ]);
+
+      h.queue.failUnfinishedMessages("sandbox died", 5000);
+
+      expect(h.repository.recordMessageCompletion).toHaveBeenCalledWith(
+        expect.anything(),
+        5000,
+        "processing"
+      );
+    });
+
+    it("stays quiet when there is nothing in flight to settle", () => {
+      const h = buildQueue();
+      h.repository.listUnfinishedMessages.mockReturnValue([]);
+
+      expect(h.queue.failUnfinishedMessages("sandbox died", 5000)).toBe(0);
+      expect(h.callbackService.notifyComplete).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -531,6 +531,27 @@ export class SessionMessageQueue {
     await this.sessionStatus.reconcileAfterExecution(false);
   }
 
+  /**
+   * Settle every in-flight prompt because the sandbox reported it cannot continue.
+   *
+   * A boot failure fails the prompt before it is ever dispatched, so it is still
+   * `pending` — `failStuckProcessingMessage` only ever sees `processing` — and
+   * only `execution_complete` otherwise notifies the originating client. Without
+   * this the caller that asked for the work is told nothing at all.
+   */
+  failUnfinishedMessages(error: string, completedAt: number): number {
+    let failed = 0;
+    for (const message of this.messageRepository.listUnfinishedMessages()) {
+      const expectedStatus = message.status === "processing" ? "processing" : "pending";
+      if (this.failMessage(message, error, completedAt, expectedStatus)) failed++;
+    }
+    if (failed > 0) {
+      this.messenger.broadcast({ type: "processing_status", isProcessing: false });
+      this.broadcastPromptQueue();
+    }
+    return failed;
+  }
+
   private failMessage(
     message: { id: string; created_at: number },
     error: string,

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -70,7 +70,11 @@ function createProcessor() {
   const diffService = { pinBaselines: vi.fn() };
   const triggerSnapshot = vi.fn(async (_reason: string) => {});
   const projectTerminalMessage = vi.fn(async () => {});
-  const statusService = { reconcileAfterExecution: vi.fn(async (_success: boolean) => {}) };
+  const failUnfinishedMessages = vi.fn((_error: string, _completedAt: number) => 0);
+  const statusService = {
+    reconcileAfterExecution: vi.fn(async (_success: boolean) => {}),
+    transition: vi.fn(async (_status: string) => true),
+  };
   const scheduleInactivityCheck = vi.fn(async () => {});
   const processMessageQueue = vi.fn(async () => {});
   const broadcastPromptQueue = vi.fn();
@@ -100,6 +104,7 @@ function createProcessor() {
     applySessionTitleUpdate,
     triggerSnapshot,
     projectTerminalMessage,
+    failUnfinishedMessages,
     statusService as unknown as SessionStatusService,
     updateLastActivity,
     scheduleInactivityCheck,
@@ -118,6 +123,7 @@ function createProcessor() {
     diffService,
     triggerSnapshot,
     projectTerminalMessage,
+    failUnfinishedMessages,
     statusService,
     scheduleInactivityCheck,
     processMessageQueue,
@@ -938,5 +944,40 @@ describe("SessionSandboxEventProcessor", () => {
       // Token events return early before ACK logic
       expect(h.wsManager.send).not.toHaveBeenCalled();
     });
+  });
+
+  it("settles in-flight prompts and drives the session to failed on a fatal error", async () => {
+    const h = createProcessor();
+
+    await h.processor.processSandboxEvent({
+      type: "error",
+      error: "git sync failed for owner/repo",
+      sandboxId: "sandbox-1",
+      timestamp: 4000,
+      fatal: true,
+    } as never);
+
+    // Settling is what notifies whoever asked for the work; before this a boot
+    // failure reached them as silence and the session sat "active" forever.
+    expect(h.failUnfinishedMessages).toHaveBeenCalledWith(
+      "git sync failed for owner/repo",
+      expect.any(Number)
+    );
+    expect(h.statusService.transition).toHaveBeenCalledWith("failed");
+  });
+
+  it("leaves in-flight prompts and status alone for a non-fatal error event", async () => {
+    const h = createProcessor();
+
+    await h.processor.processSandboxEvent({
+      type: "error",
+      error: "tool blew up",
+      sandboxId: "sandbox-1",
+      timestamp: 4000,
+      messageId: "msg-1",
+    } as never);
+
+    expect(h.failUnfinishedMessages).not.toHaveBeenCalled();
+    expect(h.statusService.transition).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -61,6 +61,8 @@ export class SessionSandboxEventProcessor {
       messageCreatedAt: number,
       completedAt: number
     ) => Promise<void>,
+    /** Settles in-flight prompts and notifies their caller; owned by the message queue. */
+    private readonly failUnfinishedMessages: (error: string, completedAt: number) => number,
     private readonly statusService: SessionStatusService,
     private readonly updateLastActivity: (timestamp: number) => void,
     private readonly scheduleInactivityCheck: () => Promise<void>,
@@ -292,6 +294,18 @@ export class SessionSandboxEventProcessor {
     }
 
     this.messenger.broadcast({ type: "sandbox_event", event });
+
+    // A fatal error is the sandbox saying it cannot continue. Only
+    // execution_complete otherwise moves status or notifies the caller, so
+    // without this a boot failure — a repository that will not clone, an image
+    // that will not start — left the session sitting "active" with no messages
+    // forever, and whoever asked for the work hearing nothing at all. Settle
+    // in-flight prompts so the reason reaches them, and transition after persist
+    // and broadcast so it is on record first.
+    if (event.type === "error" && event.fatal) {
+      this.failUnfinishedMessages(event.error, now);
+      await this.statusService.transition("failed");
+    }
 
     if (CRITICAL_EVENT_TYPES.has(event.type)) {
       this.sendAck(ackId);

--- a/packages/shared/src/types/sandbox-events.ts
+++ b/packages/shared/src/types/sandbox-events.ts
@@ -101,9 +101,18 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
     status: gitSyncStatusSchema,
     sha: z.string().optional(),
   }),
-  messageSandboxEventBaseSchema.extend({
+  sandboxEventBaseSchema.extend({
     type: z.literal("error"),
     error: z.string(),
+    // Message-scoped when the bridge reports a failure mid-execution, absent
+    // for a fatal boot error — that happens before any message exists, which
+    // is why requiring messageId here hard-rejected exactly the case the
+    // event most needs to carry. processSandboxEvent already falls back to the
+    // processing message when it is absent.
+    messageId: z.string().optional(),
+    // The sandbox cannot continue. Drives the session to "failed" and settles
+    // in-flight prompts; a plain error stays advisory and leaves status alone.
+    fatal: z.boolean().optional(),
     isSubtask: z.boolean().optional(),
     childSessionId: z.string().optional(),
     taskCallId: z.string().optional(),

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -119,6 +119,10 @@ export function buildTimelineItems(events: SandboxEvent[]): TimelineItem[] {
   for (const event of deduped) {
     if (!("isSubtask" in event) || !event.isSubtask || !("taskCallId" in event)) continue;
     if (!event.taskCallId) continue;
+    // An `error` event carries an optional messageId — a fatal boot error
+    // happens before any message exists — so it cannot be keyed to a parent
+    // Task call. Leave it at the top level rather than mis-nesting it.
+    if (!event.messageId) continue;
 
     const key = taskKey(event.messageId, event.taskCallId);
     if (!tasks.has(key)) continue;


### PR DESCRIPTION
## Summary

A sandbox that dies before it can run leaves its session sitting `active` with no messages, and never tells whoever asked for the work. Three things line up to produce that:

- **The event is rejected at the parse layer.** `supervisor.py` already posts `{"error": message, "fatal": true}` via `_report_fatal_error`, but the `error` variant of `sandboxEventSchema` extended `messageSandboxEventBaseSchema`, so `messageId` was required. A fatal boot error happens before any message exists, so the one event that most needs to get through is exactly the one that cannot. `fatal` was not in the schema at all.
- **Nothing moved session status.** Only `execution_complete` transitions, so the session stays `active` indefinitely. At any scale this is unpleasant to operate: a total sandbox outage is indistinguishable from a pile of merely-slow sessions.
- **Nothing notified the caller.** `notifyComplete` is only reached from `execution_complete`, so the prompt stays `pending` forever and the Slack/Linear/GitHub bot that requested the session hears nothing back. On a PR that means the bot's acknowledgement reaction reads as "still thinking" rather than "died before it began".

## Changes

- `shared`: on the `error` event, make `messageId` optional and add `fatal`. `processSandboxEvent` already falls back to the processing message when `messageId` is absent.
- `message-queue`: add `failUnfinishedMessages`, next to the existing `failMessage` that already synthesizes the terminal event, records it, projects it and notifies the caller for stop, cancel and the stuck-processing timeout. That path only ever inspects the `processing` message; a prompt that fails during boot is still `pending`, which is why it was never covered.
- `sandbox-events`: on a fatal error, settle in-flight prompts and transition the session to `failed`, after persist and broadcast so the reason is on record first.
- `web`: an `error` event can now arrive without a `messageId`, so it cannot be keyed to a parent Task call — leave it at the top level rather than mis-nesting it.

## Notes

- Settling before a possible late `execution_complete` is safe: `recordMessageCompletion` only writes while the row still holds the expected status, so whichever event arrives second finds nothing to settle and delivers no second callback.
- A non-fatal `error` stays advisory — status and in-flight prompts are untouched — which the tests pin.

## Test plan

- [x] `npm run typecheck` and `npm run lint` clean
- [x] `control-plane` 3171 tests pass, including new coverage for settling a `pending` prompt, settling a `processing` prompt against its own status, the no-op case, and the non-fatal case leaving everything alone
- [x] `shared` 686, `slack-bot` 420, `github-bot` 135, `linear-bot` 224 pass
- [x] `web` 1213 pass; the single failure in `use-session-rename.test.tsx` reproduces on an unmodified `main` and is unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fatal sandbox errors now correctly fail in-progress prompts and mark the session as failed.
  * Advisory errors no longer alter active prompts or session status.
  * Fatal startup errors appear correctly as top-level timeline events.
* **Reliability**
  * In-flight messages now receive completion notifications when a sandbox cannot continue.
  * Error events can be reported without being associated with a specific message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->