### PR TITLE
fix(control-plane): don't stop a sandbox for inactivity mid-execution

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -624,6 +624,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 60000, // Well past timeout
       status: "stopped",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -640,6 +641,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 60000,
       status: "failed",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -653,6 +655,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 60000,
       status: "stale",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -666,6 +669,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: null,
       status: "ready",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -682,6 +686,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 1000, // Just past timeout
       status: "ready",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -698,6 +703,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 1000,
       status: "ready",
       connectedClientCount: 2,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -716,6 +722,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - inactiveTime,
       status: "ready",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -734,6 +741,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - inactiveTime,
       status: "ready",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -751,6 +759,7 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 60000,
       status: "spawning", // Not ready
       connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);
@@ -764,6 +773,56 @@ describe("evaluateInactivityTimeout", () => {
       lastActivity: now - config.timeoutMs - 1000,
       status: "ready",
       connectedClientCount: 0,
+      hasInFlightExecution: false,
+    };
+
+    const decision = evaluateInactivityTimeout(state, config, now);
+
+    expect(decision.action).toBe("timeout");
+  });
+
+  it('returns "schedule" while an execution is in flight, however long it has been quiet', () => {
+    const now = Date.now();
+    // A single long tool call emits no events, so activity is arbitrarily stale
+    // while the sandbox is still working.
+    const state: InactivityState = {
+      lastActivity: now - config.timeoutMs * 3,
+      status: "ready",
+      connectedClientCount: 0,
+      hasInFlightExecution: true,
+    };
+
+    const decision = evaluateInactivityTimeout(state, config, now);
+
+    expect(decision.action).toBe("schedule");
+    if (decision.action === "schedule") {
+      expect(decision.nextCheckMs).toBe(config.minCheckIntervalMs);
+    }
+  });
+
+  it("prefers the in-flight check over the connected-client extension", () => {
+    const now = Date.now();
+    const state: InactivityState = {
+      lastActivity: now - config.timeoutMs - 1000,
+      status: "ready",
+      connectedClientCount: 2,
+      hasInFlightExecution: true,
+    };
+
+    const decision = evaluateInactivityTimeout(state, config, now);
+
+    // "extend" warns the user the sandbox is about to stop, which is wrong
+    // while it is mid-execution.
+    expect(decision.action).toBe("schedule");
+  });
+
+  it('returns "timeout" once the execution finishes and the sandbox goes idle', () => {
+    const now = Date.now();
+    const state: InactivityState = {
+      lastActivity: now - config.timeoutMs - 1000,
+      status: "ready",
+      connectedClientCount: 0,
+      hasInFlightExecution: false,
     };
 
     const decision = evaluateInactivityTimeout(state, config, now);

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -362,6 +362,15 @@ export interface InactivityState {
   status: SandboxStatus;
   /** Number of connected client WebSockets */
   connectedClientCount: number;
+  /**
+   * Whether a message is still being executed.
+   *
+   * Activity is derived from sandbox events, and a single long tool call (a
+   * build, a test suite, a poll loop) emits none while it runs — so an
+   * executing sandbox can look idle. Required rather than optional so a new
+   * caller has to answer the question instead of silently inheriting `false`.
+   */
+  hasInFlightExecution: boolean;
 }
 
 /**
@@ -409,7 +418,12 @@ export type InactivityAction =
  * @example
  * ```typescript
  * const decision = evaluateInactivityTimeout(
- *   { lastActivity: now - 600001, status: "ready", connectedClientCount: 1 },
+ *   {
+ *     lastActivity: now - 600001,
+ *     status: "ready",
+ *     connectedClientCount: 1,
+ *     hasInFlightExecution: false,
+ *   },
  *   DEFAULT_INACTIVITY_CONFIG,
  *   now
  * );
@@ -443,6 +457,15 @@ export function evaluateInactivityTimeout(
 
   // Check if inactivity threshold exceeded
   if (inactiveTime >= config.timeoutMs) {
+    // A sandbox that is still executing a message is busy, not abandoned.
+    // Stopping it here kills the running tool call and fails the message, so
+    // keep checking back until the execution finishes and the ordinary idle
+    // countdown can start. The execution timeout alarm remains the backstop
+    // for a run that never finishes.
+    if (state.hasInFlightExecution) {
+      return { action: "schedule", nextCheckMs: config.minCheckIntervalMs };
+    }
+
     // If clients are still connected, they may be actively reviewing
     // Grant an extension and warn them
     if (state.connectedClientCount > 0) {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1919,6 +1919,36 @@ describe("SandboxLifecycleManager", () => {
       expect(wsManager.sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
     });
 
+    it("does not stop the sandbox while an execution is in flight", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "ready",
+        last_heartbeat: now - 10000, // Still heartbeating
+        last_activity: now - 30 * 60 * 1000, // A long, event-free tool call
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager(false, 0); // No clients
+      const provider = createMockProvider();
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        wsManager,
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const result = await manager.handleAlarm({ hasInFlightExecution: true });
+
+      expect(result).toBe("no_action");
+      expect(storage.calls).not.toContain("updateSandboxStatus:stopped");
+      expect(wsManager.sendToSandbox).not.toHaveBeenCalled();
+      expect(provider.takeSnapshot).not.toHaveBeenCalled();
+    });
+
     it("extends timeout when clients connected", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1879,7 +1879,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      const result = await manager.handleAlarm();
+      const result = await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(result).toBe("sandbox_terminated");
       expect(storage.calls).toContain("updateSandboxStatus:stale");
@@ -1912,7 +1912,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      const result = await manager.handleAlarm();
+      const result = await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(result).toBe("sandbox_terminated");
       expect(storage.calls).toContain("updateSandboxStatus:stopped");
@@ -1972,7 +1972,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       // Should extend, not timeout
       expect(storage.calls).not.toContain("updateSandboxStatus:stopped");
@@ -2005,7 +2005,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(storage.calls).not.toContain("updateSandboxStatus:stopped");
       expect(alarmScheduler.alarms.length).toBe(1);
@@ -2033,7 +2033,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(provider.takeSnapshot).toHaveBeenCalled();
     });
@@ -2063,7 +2063,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(provider.takeSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -2107,7 +2107,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(provider.takeSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -2147,7 +2147,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(provider.takeSnapshot).not.toHaveBeenCalled();
       expect(stopSandbox).toHaveBeenCalledWith(
@@ -2189,7 +2189,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(storage.calls).toContain("clearSandboxVnc");
       expect(sandbox.vnc_url).toBeNull();
@@ -2217,7 +2217,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      const result = await manager.handleAlarm();
+      const result = await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(result).toBe("sandbox_failed");
       expect(storage.calls).toContain("updateSandboxStatus:failed");
@@ -2255,7 +2255,7 @@ describe("SandboxLifecycleManager", () => {
         createTestConfig()
       );
 
-      await manager.handleAlarm();
+      await manager.handleAlarm({ hasInFlightExecution: false });
 
       expect(storage.calls).not.toContain("updateSandboxStatus:failed");
       // Should schedule a follow-up alarm

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -294,10 +294,10 @@ export interface SandboxAlarmOptions {
   /**
    * Whether a message is still being executed. The caller owns message state
    * (the lifecycle manager deliberately does not depend on the message queue),
-   * so it has to be passed in. Defaults to `false` for callers with no message
-   * queue at all.
+   * so it has to be passed in. Required, with no default: a caller that could
+   * omit it would silently reintroduce stopping a sandbox mid-execution.
    */
-  hasInFlightExecution?: boolean;
+  hasInFlightExecution: boolean;
 }
 
 /**
@@ -1212,7 +1212,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * Handle alarm for inactivity and heartbeat monitoring.
    */
-  async handleAlarm(options: SandboxAlarmOptions = {}): Promise<SandboxAlarmResult> {
+  async handleAlarm(options: SandboxAlarmOptions): Promise<SandboxAlarmResult> {
     const sandbox = this.storage.getSandbox();
     if (!sandbox) {
       this.log.debug("Alarm fired: no sandbox found");
@@ -1323,7 +1323,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       lastActivity: sandbox.last_activity,
       status: sandbox.status,
       connectedClientCount: connectedClients,
-      hasInFlightExecution: options.hasInFlightExecution ?? false,
+      hasInFlightExecution: options.hasInFlightExecution,
     };
 
     const inactivityDecision = evaluateInactivityTimeout(

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -289,6 +289,17 @@ export type UnresponsiveSandboxTrigger =
 
 export type SandboxAlarmResult = "no_action" | "sandbox_failed" | "sandbox_terminated";
 
+/** Session state the alarm needs that the lifecycle manager cannot read itself. */
+export interface SandboxAlarmOptions {
+  /**
+   * Whether a message is still being executed. The caller owns message state
+   * (the lifecycle manager deliberately does not depend on the message queue),
+   * so it has to be passed in. Defaults to `false` for callers with no message
+   * queue at all.
+   */
+  hasInFlightExecution?: boolean;
+}
+
 /**
  * Manages sandbox lifecycle operations.
  *
@@ -1201,7 +1212,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * Handle alarm for inactivity and heartbeat monitoring.
    */
-  async handleAlarm(): Promise<SandboxAlarmResult> {
+  async handleAlarm(options: SandboxAlarmOptions = {}): Promise<SandboxAlarmResult> {
     const sandbox = this.storage.getSandbox();
     if (!sandbox) {
       this.log.debug("Alarm fired: no sandbox found");
@@ -1312,6 +1323,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       lastActivity: sandbox.last_activity,
       status: sandbox.status,
       connectedClientCount: connectedClients,
+      hasInFlightExecution: options.hasInFlightExecution ?? false,
     };
 
     const inactivityDecision = evaluateInactivityTimeout(

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -16,7 +16,7 @@ function createHandler() {
   };
   const lifecycleManager = {
     handleAlarm: vi
-      .fn<(options?: SandboxAlarmOptions) => Promise<SandboxAlarmResult>>()
+      .fn<(options: SandboxAlarmOptions) => Promise<SandboxAlarmResult>>()
       .mockResolvedValue("no_action"),
   };
   const alarmScheduler = {
@@ -177,6 +177,43 @@ describe("createAlarmHandler", () => {
     expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledTimes(1);
     expect(alarmScheduler.schedule).not.toHaveBeenCalled();
     expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports no in-flight execution after failing a timed-out message", async () => {
+    const { handler, repository, messageQueue, lifecycleManager } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 500,
+    });
+    // Mirror the production write: failing the message clears it from
+    // `processing`, so nothing is executing by the time the lifecycle runs and
+    // inactivity cleanup is due now rather than a check interval later.
+    messageQueue.failStuckProcessingMessage.mockImplementation(async () => {
+      repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+    });
+
+    await handler.handle();
+
+    expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledTimes(1);
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledWith({ hasInFlightExecution: false });
+  });
+
+  it("reports an execution that started while the timed-out one was failed", async () => {
+    const { handler, repository, messageQueue, lifecycleManager } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 500,
+    });
+    messageQueue.failStuckProcessingMessage.mockImplementation(async () => {
+      repository.getProcessingMessageWithStartedAt.mockReturnValue({
+        id: "message-2",
+        started_at: 1999,
+      });
+    });
+
+    await handler.handle();
+
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledWith({ hasInFlightExecution: true });
   });
 
   it("fails stuck work without resuming after a connecting timeout", async () => {

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../../logger";
 import { createAlarmHandler } from "./handler";
 import type { MessageRepository } from "../message-repository";
 import { createEarliestAlarmScheduler } from "./scheduler";
-import type { SandboxAlarmResult } from "../../sandbox/lifecycle/manager";
+import type { SandboxAlarmOptions, SandboxAlarmResult } from "../../sandbox/lifecycle/manager";
 
 function createHandler() {
   const repository = {
@@ -15,7 +15,9 @@ function createHandler() {
     resumeAfterSandboxTermination: vi.fn<() => Promise<void>>().mockResolvedValue(),
   };
   const lifecycleManager = {
-    handleAlarm: vi.fn<() => Promise<SandboxAlarmResult>>().mockResolvedValue("no_action"),
+    handleAlarm: vi
+      .fn<(options?: SandboxAlarmOptions) => Promise<SandboxAlarmResult>>()
+      .mockResolvedValue("no_action"),
   };
   const alarmScheduler = {
     schedule: vi.fn<(timestamp: number) => Promise<void>>().mockResolvedValue(),
@@ -65,6 +67,23 @@ describe("createAlarmHandler", () => {
     expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
     expect(messageQueue.recoverStopConfirmationTimeout).toHaveBeenCalledOnce();
     expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledWith({ hasInFlightExecution: false });
+  });
+
+  it("tells the lifecycle manager an execution is in flight", async () => {
+    const { handler, repository, messageQueue, lifecycleManager, now } = createHandler();
+    // Processing, but nowhere near the execution timeout: the sandbox is busy,
+    // and the inactivity check must not stop it out from under the run.
+    now.mockReturnValue(1000);
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 900,
+    });
+
+    await handler.handle();
+
+    expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledWith({ hasInFlightExecution: true });
   });
 
   it("does not fail processing message when execution timeout is not reached", async () => {

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -63,10 +63,12 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
         }
       }
 
-      // `processing` is this session's in-flight execution: while it is set the
-      // sandbox is working, however long it has gone without emitting an event.
+      // Re-read rather than reusing `processing`: the branch above may have just
+      // failed that message, in which case nothing is executing and inactivity
+      // cleanup is due now rather than a check interval later. A re-read also
+      // sees a replacement message that started processing in the meantime.
       const lifecycleResult = await deps.lifecycleManager.handleAlarm({
-        hasInFlightExecution: processing !== null,
+        hasInFlightExecution: deps.repository.getProcessingMessageWithStartedAt() !== null,
       });
       if (lifecycleResult !== "no_action") {
         await deps.messageQueue.failStuckProcessingMessage();

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -63,7 +63,11 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
         }
       }
 
-      const lifecycleResult = await deps.lifecycleManager.handleAlarm();
+      // `processing` is this session's in-flight execution: while it is set the
+      // sandbox is working, however long it has gone without emitting an event.
+      const lifecycleResult = await deps.lifecycleManager.handleAlarm({
+        hasInFlightExecution: processing !== null,
+      });
       if (lifecycleResult !== "no_action") {
         await deps.messageQueue.failStuckProcessingMessage();
       }


### PR DESCRIPTION
## Summary

The inactivity watchdog stops a sandbox while it is still executing a message, which kills the running tool call and fails the message with `Execution timed out (stuck processing)`.

`last_activity` is only refreshed by sandbox events — `tool_call`, `step_start`, `step_finish`, `artifact` (`session/sandbox-events.ts`). Heartbeats do not count. A single long tool call emits one event when it starts and one when it finishes, so anything quiet for longer than `SANDBOX_INACTIVITY_TIMEOUT_MS` (default 10 min) looks abandoned while it is actually working: a slow build, a long test suite, a poll loop waiting on CI.

With no client WebSocket attached — every automation and bot-driven session — `evaluateInactivityTimeout` returns `timeout`, the manager snapshots and stops the sandbox, and `createAlarmHandler` sees a non-`no_action` lifecycle result and calls `failStuckProcessingMessage()`. The user sees an execution-timeout error roughly 10 minutes into a turn, with `EXECUTION_TIMEOUT_MS` (default 7200s) nowhere near elapsed.

The `extend`-with-warning branch for connected clients shows the intent is to reap *abandoned* sessions. Reaping a live execution looks unintended.

### The change

- `InactivityState` gains a required `hasInFlightExecution` field. Required, not optional, so a future caller has to answer the question rather than silently inherit the old behaviour.
- When the threshold is crossed and an execution is in flight, return `schedule` at `minCheckIntervalMs` instead of `timeout`. The ordinary idle countdown resumes once the execution finishes. It takes precedence over the `extend` branch, whose "sandbox will stop in 5 minutes due to inactivity" warning is wrong mid-run.
- `handleAlarm` takes a `SandboxAlarmOptions` argument to receive it. `createAlarmHandler` already reads the processing message to evaluate the execution timeout, so the fact costs nothing extra to pass down, and the lifecycle manager stays independent of the message queue.

The execution timeout alarm remains the backstop for a run that never completes. The trade-off is that a session wedged in `processing` with a live heartbeat now holds its sandbox until that timeout rather than 10 minutes — deliberate, since the alternative is killing legitimate long-running work.

## Test plan

- [x] `evaluateInactivityTimeout` returns `schedule` when activity is stale by 3x the timeout and an execution is in flight
- [x] the in-flight check takes precedence over the connected-client extension
- [x] `handleAlarm({ hasInFlightExecution: true })` returns `no_action` and neither snapshots, stops, nor shuts down the sandbox
- [x] the alarm handler passes `hasInFlightExecution: true` when a message is processing and `false` when none is
- [x] all three new assertions fail with the guard removed (verified by reverting it)
- [x] `npx vitest run` in `packages/control-plane` — 203 files, 3171 tests pass
- [x] `npm run typecheck -w @open-inspect/control-plane`
- [x] eslint and prettier clean on the changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandboxes with executions in progress are no longer incorrectly considered idle.
  * In-flight executions are protected from inactivity-based shutdowns, even when no clients are connected.
  * Alarm handling now preserves active processing and avoids incorrectly marking it as stuck.
* **Tests**
  * Added coverage for timeout scheduling, execution completion, and connected-client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->