### PR TITLE
refactor(control-plane): govern session boundaries, dedupe root wiring

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,12 +165,15 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: ["**/session/components", "./components"],
+              // Last-segment match: covers any relative depth (./, ../, ../../)
+              // and extension-bearing specifiers. The basename is unique in
+              // this package, so anchoring on it is precise.
+              regex: "(?:^|/)components(?:\\.[cm]?[jt]sx?)?$",
               message:
                 "Only the platform adapter (session/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
             },
             {
-              group: ["**/session/durable-object", "./durable-object"],
+              regex: "(?:^|/)durable-object(?:\\.[cm]?[jt]sx?)?$",
               message:
                 "Only the worker entrypoint (src/index.ts) may import the platform adapter. Depend on the session collaborators, not the Durable Object.",
             },
@@ -189,7 +192,10 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: ["**/session/components", "./components"],
+              // Last-segment match: covers any relative depth (./, ../, ../../)
+              // and extension-bearing specifiers. The basename is unique in
+              // this package, so anchoring on it is precise.
+              regex: "(?:^|/)components(?:\\.[cm]?[jt]sx?)?$",
               message:
                 "Only the platform adapter (session/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
             },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,18 +139,50 @@ export default tseslint.config(
     },
   },
 
-  // The session composition root is the platform adapter's private wiring:
-  // only durable-object.ts may import it. This is what keeps "composition
-  // root" a governed invariant rather than a convention — services take their
-  // dependencies as constructor inputs, never by reaching into the root.
-  // (Uses the base rule so it stacks with the repo-wide
-  // @typescript-eslint/no-restricted-imports paths above.)
+  // Session boundary rules, in the same family as the env.DB ban above. Two
+  // bans, both via the base no-restricted-imports rule so they stack with the
+  // repo-wide @typescript-eslint/no-restricted-imports paths config:
+  //  - the composition root (session/components.ts) is the platform adapter's
+  //    private wiring: only durable-object.ts may import it — services take
+  //    their dependencies as constructor inputs, never by reaching into the
+  //    root;
+  //  - the platform adapter (session/durable-object.ts) is the Cloudflare
+  //    edge of the session: only the worker entrypoint may import it, so
+  //    nothing the factory builds can hold a reference back to the DO.
+  // Flat-config gotcha: a later object's config for the same rule REPLACES
+  // the earlier one for files both match, so this general block carries both
+  // bans and each exempted file re-declares the ban that still applies to it.
   {
     files: ["packages/control-plane/src/**/*.ts"],
     ignores: [
       "packages/control-plane/src/session/durable-object.ts",
+      "packages/control-plane/src/index.ts",
       "packages/control-plane/src/**/*.test.ts",
     ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/session/components", "./components"],
+              message:
+                "Only the platform adapter (session/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
+            },
+            {
+              group: ["**/session/durable-object", "./durable-object"],
+              message:
+                "Only the worker entrypoint (src/index.ts) may import the platform adapter. Depend on the session collaborators, not the Durable Object.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // The worker entrypoint may import the adapter (it exports the DO class to
+  // the runtime) but not the composition root.
+  {
+    files: ["packages/control-plane/src/index.ts"],
     rules: {
       "no-restricted-imports": [
         "error",

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -49,6 +49,7 @@ import { SessionIndexStore } from "../db/session-index";
 import { parsePersistedSandboxSettings } from "../sandbox/settings";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
 import type { Env, ClientInfo } from "../types";
+import type { SessionRow } from "./types";
 import type { SqlDatabase } from "../db/sql-database";
 import { SessionCoreRepository } from "./session-core-repository";
 import { SandboxRepository } from "./sandbox-repository";
@@ -269,6 +270,13 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   const sourceControlProvider = () => scmProvider;
   const scmProviderName = scmProvider.name;
 
+  // Shared single instances/closures — every consumer below takes these
+  // rather than re-deriving its own copy.
+  const sessionIndexStore = db ? new SessionIndexStore(db) : null;
+  const sessionPullRequestStore = db ? new SessionPullRequestStore(db) : null;
+  const resolveRepoId = (sessionRow: SessionRow) =>
+    resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider);
+
   const sandboxDashboardSettings: SandboxDashboardSettings = {
     sandboxProvider: env.SANDBOX_PROVIDER,
     modalWorkspace: env.MODAL_WORKSPACE,
@@ -279,8 +287,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   const userEnvResolver = new UserEnvResolver({
     db,
     sessionCoreRepository,
-    resolveRepoId: (sessionRow) =>
-      resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider),
+    resolveRepoId,
     durableObjectId,
     repoSecretsEncryptionKey: env.REPO_SECRETS_ENCRYPTION_KEY,
     secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
@@ -288,13 +295,23 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   });
 
   const terminalMessageProjection = new SessionTerminalMessageProjection(
-    db ? new SessionIndexStore(db) : null,
+    sessionIndexStore,
     () => {
       const current = sessionCoreRepository.getSession();
       return current ? resolvePublicSessionId(current, durableObjectId) : null;
     },
     log
   );
+  const recordTerminalMessage = (
+    messageId: string,
+    messageCreatedAt: number,
+    completedAt: number
+  ): Promise<void> =>
+    terminalMessageProjection.recordTerminalMessage({
+      messageId,
+      messageCreatedAt,
+      terminalMessageCompletedAt: completedAt,
+    });
 
   const userScmTokenStore =
     db && env.TOKEN_ENCRYPTION_KEY ? new UserScmTokenStore(db, env.TOKEN_ENCRYPTION_KEY) : null;
@@ -326,7 +343,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     messageRepository,
     artifactRepository,
     messenger,
-    db ? new SessionIndexStore(db) : null,
+    sessionIndexStore,
     env.SESSION ?? null
   );
 
@@ -335,7 +352,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     messenger,
     statusService,
     backgroundTasks,
-    sessionIndexStore: db ? new SessionIndexStore(db) : null,
+    sessionIndexStore,
     durableObjectId,
     now: () => Date.now(),
   });
@@ -378,14 +395,9 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     callbackService,
     statusService,
     (model) => userEnvResolver.getProviderAuthenticationError(model),
-    (messageId, messageCreatedAt, completedAt) =>
-      terminalMessageProjection.recordTerminalMessage({
-        messageId,
-        messageCreatedAt,
-        terminalMessageCompletedAt: completedAt,
-      }),
+    recordTerminalMessage,
     lifecycleManager,
-    db ? new SessionIndexStore(db) : null,
+    sessionIndexStore,
     scmProviderName,
     alarmScheduler,
     getExecutionTimeoutMs
@@ -425,12 +437,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     diffService,
     (title, options) => titleService.applySessionTitleUpdate(title, options),
     (reason) => lifecycleManager.triggerSnapshot(reason),
-    (messageId, messageCreatedAt, completedAt) =>
-      terminalMessageProjection.recordTerminalMessage({
-        messageId,
-        messageCreatedAt,
-        terminalMessageCompletedAt: completedAt,
-      }),
+    recordTerminalMessage,
     statusService,
     (timestamp) => lifecycleManager.updateLastActivity(timestamp),
     () => lifecycleManager.scheduleInactivityCheck(),
@@ -455,7 +462,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
           sessionCoreRepository,
           artifactRepository,
           sourceControlProvider(),
-          db ? new SessionPullRequestStore(db) : null
+          sessionPullRequestStore
         ).then(({ updated, failures }) => {
           for (const artifact of updated) {
             messenger.broadcast({ type: "artifact_updated", artifact });
@@ -510,7 +517,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
       const service = new OpenAITokenRefreshService(
         db!,
         env.REPO_SECRETS_ENCRYPTION_KEY!,
-        (row) => resolveSessionRepoId(row, sessionCoreRepository, sourceControlProvider),
+        resolveRepoId,
         requestLog
       );
       return service.refresh(sessionRow);
@@ -519,7 +526,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
       const service = new XaiTokenRefreshService(
         db!,
         env.REPO_SECRETS_ENCRYPTION_KEY!,
-        (row) => resolveSessionRepoId(row, sessionCoreRepository, sourceControlProvider),
+        resolveRepoId,
         requestLog
       );
       return service.refresh(sessionRow);
@@ -594,7 +601,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
         pushBranchToRemote: (pushSpec) => sandboxEventProcessor.pushBranchToRemote(pushSpec),
         messenger,
         appName: resolveAppName(env),
-        sessionPullRequests: db ? new SessionPullRequestStore(db) : undefined,
+        sessionPullRequests: sessionPullRequestStore ?? undefined,
         resolveScmSettings: (repo) => resolveScmSettings(db, repo),
       });
 

--- a/packages/control-plane/src/session/http/dispatcher.ts
+++ b/packages/control-plane/src/session/http/dispatcher.ts
@@ -17,7 +17,6 @@ export class SessionHttpDispatcher {
   async dispatch(request: Request): Promise<Response> {
     const fetchStart = this.deps.clock.monotonicNowMs();
     this.deps.ensureInitialized();
-    const initMs = this.deps.clock.monotonicNowMs() - fetchStart;
     const log = this.requestLogger(request);
     const url = new URL(request.url);
     const path = url.pathname;
@@ -53,7 +52,6 @@ export class SessionHttpDispatcher {
         http_path: path,
         http_status: status,
         duration_ms: Math.round(totalMs * 100) / 100,
-        init_ms: Math.round(initMs * 100) / 100,
         handler_ms: Math.round(handlerMs * 100) / 100,
         outcome,
       });

--- a/packages/control-plane/src/session/server.test.ts
+++ b/packages/control-plane/src/session/server.test.ts
@@ -25,7 +25,7 @@ function createHarness() {
   let currentClient: TestClient | null = client;
   let connectionKind: "client" | "sandbox" = "client";
   let now = 1000;
-  const monotonicTimes = [0, 2, 5, 8, 10];
+  const monotonicTimes = [0, 5, 8, 10];
   const ensureInitialized = vi.fn();
   const clock: Clock = {
     nowMs: () => now,
@@ -170,7 +170,6 @@ describe("SessionServer", () => {
       http_path: SessionInternalPaths.state,
       http_status: 200,
       duration_ms: 10,
-      init_ms: 2,
       handler_ms: 3,
       outcome: "success",
     });


### PR DESCRIPTION
## What

Phase 5 of the SessionDO decomposition plan, plus the small root deduplications that #1594/#1602 exposed. Zero behavior change (one log field dropped, see below).

### The back-edge boundary rule (Phase 5)

The plan's original Phase 5 rule — "no `this.` inside arguments passed to a constructor in `durable-object.ts`" — became vacuous after #1594: the adapter passes no collaborators anywhere. What remains meaningful is the module-level back edge, and it's now governed:

- **Only `src/index.ts` may import `session/durable-object`** (it exports the DO class to the runtime). Nothing the factory builds can hold a reference back to the DO, because nothing else can even name its module.
- This completes the pair with #1594's rule that only the adapter may import the composition root.

Both bans live in one `no-restricted-imports` block (base rule, so the repo-wide `@typescript-eslint/no-restricted-imports` shared-auth config still stacks). Flat-config replaces per-rule configs for overlapping file sets rather than merging them, so the general block carries both bans and `src/index.ts` re-declares the composition-root ban it is still subject to — the structure is commented in `eslint.config.js`.

Red-verified in all three directions: a session module importing the adapter trips; `title-service.ts` importing the root still trips after the restructure; `index.ts` importing the root trips.

### Root deduplication

`createSessionRuntime` constructed several identical things repeatedly; each is now one shared local:

- `SessionIndexStore` — was constructed 4× (`db ? new SessionIndexStore(db) : null` at the terminal-message projection, status service, title service, message queue)
- `SessionPullRequestStore` — was constructed 2× (PR refresh, PR creation)
- the `resolveSessionRepoId` closure — was declared 3× (user-env resolver, OpenAI + xAI token refresh)
- the terminal-message projection closure — was declared 2× (message queue, sandbox event processor)

### `init_ms` removed from `do.request`

Since #1594, initialization happens before dispatch (the adapter builds the runtime on first event), so the dispatcher's per-request `init_ms` always reads ~0 — the one-line `do.init` event carries the real cold-start duration. The dead field and its clock read are removed; `duration_ms`/`handler_ms` are unchanged. (The dispatcher still calls `ensureInitialized()` — removing that dep is Phase 4's churn, where the server stack is already being touched.)

## Tests

3180 unit / 1002 integration green; typecheck, eslint, prettier green. `server.test.ts` touched only to drop the `init_ms` assertion and its fake-clock sample.

Part of the SessionDO decomposition plan (#1577/#1578/#1579, #1583, #1585/#1586/#1587, #1594, #1602). Phase 4 (socket-port collapse) follows on top of this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session runtime efficiency by reusing shared session and pull-request services.
  * Centralized terminal-message recording for more consistent session behavior.

* **Bug Fixes**
  * Simplified request timing information by removing initialization-time metrics from request logs.

* **Tests**
  * Updated session server tests to reflect the revised request timing data.
  * Added validation for session import boundaries to help prevent configuration-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->