### PR TITLE
fix(control-plane): close sandbox admission race with two-phase spawn write

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -269,10 +269,10 @@ export function evaluateSpawnDecision(
 ): SpawnAction {
   const timeSinceLastSpawn = now - state.createdAt;
 
-  // In-memory flag first: it is set synchronously when a spawn/restore starts,
-  // but the persisted "spawning" status lands only after the first await. A
-  // second evaluation in that window must not pick resume/restore again, or
-  // concurrent prompts launch duplicate sandboxes.
+  // In-memory flag first: it is set synchronously when a spawn/restore starts
+  // and stays up until the provider call resolves. A second evaluation in
+  // that window must not pick resume/restore again, or concurrent prompts
+  // launch duplicate sandboxes.
   if (isSpawningInMemory) {
     return { action: "skip", reason: "spawn already in progress (in-memory flag)" };
   }

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -38,6 +38,29 @@ import {
 } from "../provider";
 import type { SandboxRow, SessionRow } from "../../session/types";
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
+import { hashToken } from "../../auth/crypto";
+import type * as AuthCrypto from "../../auth/crypto";
+
+// Gate for the #1589 admission-race suite: hashToken passes through to the
+// real implementation, but a test can hold the next call open to keep the
+// spawn paused inside its one non-storage await.
+let hashTokenGate: Promise<void> = Promise.resolve();
+let releaseHashTokenGate: () => void = () => {};
+function blockNextHashToken(): void {
+  hashTokenGate = new Promise((resolve) => {
+    releaseHashTokenGate = resolve;
+  });
+}
+vi.mock("../../auth/crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof AuthCrypto>();
+  return {
+    ...actual,
+    hashToken: vi.fn(async (token: string) => {
+      await hashTokenGate;
+      return actual.hashToken(token);
+    }),
+  };
+});
 
 // ==================== Mock Factories ====================
 
@@ -151,6 +174,10 @@ function createMockStorage(
         sandbox.runtime_version = null;
         if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
       }
+    }),
+    updateSandboxAuthTokenHash: vi.fn((authTokenHash: string) => {
+      calls.push("updateSandboxAuthTokenHash");
+      if (sandbox) sandbox.auth_token_hash = authTokenHash;
     }),
     updateSandboxForResume: vi.fn((data) => {
       calls.push(`updateSandboxForResume:${data.status}`);
@@ -3726,5 +3753,80 @@ describe("SandboxLifecycleManager log context", () => {
     const line = errorLogs.find((entry) => entry.msg === "Cannot spawn sandbox: no session");
     expect(line).toBeDefined();
     expect(line).not.toHaveProperty("session_id");
+  });
+});
+
+describe("spawn admission race (#1589)", () => {
+  // `await hashToken` is a non-storage await, so the DO input gate admits
+  // other events while it runs. Whatever the sandbox row says at that moment
+  // is what a stale bridge's admission read sees — so the replacement
+  // identity, with credentials invalidated, must already be persisted.
+  function raceHarness(sandbox: ReturnType<typeof createMockSandbox>) {
+    const storage = createMockStorage(createMockSession(), sandbox);
+    const manager = new SandboxLifecycleManager(
+      createMockProvider(),
+      storage,
+      createMockBroadcaster(),
+      createMockWebSocketManager(false),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+    return { storage, manager };
+  }
+
+  it("fresh spawn: reserves the new identity before hashing opens the input gate", async () => {
+    const sandbox = createMockSandbox({
+      status: "failed",
+      modal_sandbox_id: "sb-old",
+      auth_token_hash: "old-hash",
+    });
+    const { storage, manager } = raceHarness(sandbox);
+
+    blockNextHashToken();
+    const spawn = manager.spawnSandbox();
+    await vi.waitFor(() => expect(vi.mocked(hashToken)).toHaveBeenCalled());
+
+    // Mid-window view — what a stale bridge authenticating right now reads.
+    expect(sandbox.modal_sandbox_id).not.toBe("sb-old");
+    expect(sandbox.auth_token_hash).toBe("");
+    expect(sandbox.status).toBe("spawning");
+
+    releaseHashTokenGate();
+    await spawn;
+
+    // Phase 2 published the real hash after the identity reservation.
+    expect(sandbox.auth_token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(storage.calls.indexOf("updateSandboxForSpawn")).toBeLessThan(
+      storage.calls.indexOf("updateSandboxAuthTokenHash")
+    );
+  });
+
+  it("snapshot restore: reserves the new identity before hashing opens the input gate", async () => {
+    const sandbox = createMockSandbox({
+      status: "stopped",
+      modal_sandbox_id: "sb-old",
+      auth_token_hash: "old-hash",
+      snapshot_image_id: "img-abc123",
+      snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
+      created_at: Date.now() - 60000,
+    });
+    const { storage, manager } = raceHarness(sandbox);
+
+    blockNextHashToken();
+    const spawn = manager.spawnSandbox();
+    await vi.waitFor(() => expect(vi.mocked(hashToken)).toHaveBeenCalled());
+
+    expect(sandbox.modal_sandbox_id).not.toBe("sb-old");
+    expect(sandbox.auth_token_hash).toBe("");
+    expect(sandbox.status).toBe("spawning");
+
+    releaseHashTokenGate();
+    await spawn;
+
+    expect(sandbox.auth_token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(storage.calls.indexOf("updateSandboxForSpawn")).toBeLessThan(
+      storage.calls.indexOf("updateSandboxAuthTokenHash")
+    );
   });
 });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -3852,17 +3852,21 @@ describe("spawn admission race (#1589)", () => {
     );
   });
 
-  it("fails the spawn when the reservation is superseded before hash publication", async () => {
+  it("abandons the attempt without failure writes when the reservation is superseded", async () => {
     const sandbox = createMockSandbox({ status: "failed" });
     const { storage, manager } = raceHarness(sandbox);
     vi.mocked(storage.updateSandboxAuthTokenHash).mockReturnValue(false);
 
     await manager.spawnSandbox();
 
-    expect(sandbox.status).toBe("failed");
-    expect(storage.setLastSpawnError).toHaveBeenCalledWith(
+    // The row and circuit breaker describe the newer reservation now — the
+    // superseded attempt must not mark them failed on its way out.
+    expect(sandbox.status).toBe("spawning");
+    expect(storage.calls).not.toContain("updateSandboxStatus:failed");
+    expect(storage.incrementCircuitBreakerFailure).not.toHaveBeenCalled();
+    expect(storage.setLastSpawnError).not.toHaveBeenCalledWith(
       expect.stringContaining("superseded"),
-      expect.any(Number)
+      expect.anything()
     );
   });
 });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -4,7 +4,7 @@
  * Uses mocked dependencies to test lifecycle orchestration logic.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
@@ -168,16 +168,18 @@ function createMockStorage(
       if (sandbox) {
         sandbox.status = data.status;
         sandbox.created_at = data.createdAt;
-        sandbox.auth_token_hash = data.authTokenHash;
+        sandbox.auth_token_hash = "";
         sandbox.auth_token = null;
         sandbox.modal_sandbox_id = data.modalSandboxId;
         sandbox.runtime_version = null;
         if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
       }
     }),
-    updateSandboxAuthTokenHash: vi.fn((authTokenHash: string) => {
+    updateSandboxAuthTokenHash: vi.fn((modalSandboxId: string, authTokenHash: string) => {
       calls.push("updateSandboxAuthTokenHash");
-      if (sandbox) sandbox.auth_token_hash = authTokenHash;
+      if (!sandbox || sandbox.modal_sandbox_id !== modalSandboxId) return false;
+      sandbox.auth_token_hash = authTokenHash;
+      return true;
     }),
     updateSandboxForResume: vi.fn((data) => {
       calls.push(`updateSandboxForResume:${data.status}`);
@@ -565,7 +567,7 @@ describe("SandboxLifecycleManager", () => {
         vi.mocked(storage.updateSandboxForSpawn).mockImplementation((data) => {
           calls.push("fence");
           sandbox.status = data.status;
-          sandbox.auth_token_hash = data.authTokenHash;
+          sandbox.auth_token_hash = "";
           sandbox.modal_sandbox_id = data.modalSandboxId;
         });
         vi.mocked(storage.updateSandboxModalObjectId).mockImplementation((id) => {
@@ -3775,6 +3777,14 @@ describe("spawn admission race (#1589)", () => {
     return { storage, manager };
   }
 
+  afterEach(() => {
+    // Never leave the gate blocked: hashToken awaits the module-level gate on
+    // every call, so a failed mid-window assertion would otherwise hang every
+    // later test that spawns.
+    releaseHashTokenGate();
+    hashTokenGate = Promise.resolve();
+  });
+
   it("fresh spawn: reserves the new identity before hashing opens the input gate", async () => {
     const sandbox = createMockSandbox({
       status: "failed",
@@ -3784,8 +3794,14 @@ describe("spawn admission race (#1589)", () => {
     const { storage, manager } = raceHarness(sandbox);
 
     blockNextHashToken();
+    const hashCallsBefore = vi.mocked(hashToken).mock.calls.length;
     const spawn = manager.spawnSandbox();
-    await vi.waitFor(() => expect(vi.mocked(hashToken)).toHaveBeenCalled());
+    // Call history spans the whole file, so wait for the count to rise: THIS
+    // spawn has then provably reached the gated hash — with the phase-1
+    // reservation, which precedes it, already persisted.
+    await vi.waitFor(() =>
+      expect(vi.mocked(hashToken).mock.calls.length).toBeGreaterThan(hashCallsBefore)
+    );
 
     // Mid-window view — what a stale bridge authenticating right now reads.
     expect(sandbox.modal_sandbox_id).not.toBe("sb-old");
@@ -3814,8 +3830,14 @@ describe("spawn admission race (#1589)", () => {
     const { storage, manager } = raceHarness(sandbox);
 
     blockNextHashToken();
+    const hashCallsBefore = vi.mocked(hashToken).mock.calls.length;
     const spawn = manager.spawnSandbox();
-    await vi.waitFor(() => expect(vi.mocked(hashToken)).toHaveBeenCalled());
+    // Call history spans the whole file, so wait for the count to rise: THIS
+    // spawn has then provably reached the gated hash — with the phase-1
+    // reservation, which precedes it, already persisted.
+    await vi.waitFor(() =>
+      expect(vi.mocked(hashToken).mock.calls.length).toBeGreaterThan(hashCallsBefore)
+    );
 
     expect(sandbox.modal_sandbox_id).not.toBe("sb-old");
     expect(sandbox.auth_token_hash).toBe("");
@@ -3827,6 +3849,20 @@ describe("spawn admission race (#1589)", () => {
     expect(sandbox.auth_token_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(storage.calls.indexOf("updateSandboxForSpawn")).toBeLessThan(
       storage.calls.indexOf("updateSandboxAuthTokenHash")
+    );
+  });
+
+  it("fails the spawn when the reservation is superseded before hash publication", async () => {
+    const sandbox = createMockSandbox({ status: "failed" });
+    const { storage, manager } = raceHarness(sandbox);
+    vi.mocked(storage.updateSandboxAuthTokenHash).mockReturnValue(false);
+
+    await manager.spawnSandbox();
+
+    expect(sandbox.status).toBe("failed");
+    expect(storage.setLastSpawnError).toHaveBeenCalledWith(
+      expect.stringContaining("superseded"),
+      expect.any(Number)
     );
   });
 });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -111,6 +111,13 @@ export interface SandboxStorage {
     modalSandboxId: string;
     preserveProviderObjectId?: boolean;
   }): void;
+  /**
+   * Publish the auth-token hash for the identity reserved by
+   * `updateSandboxForSpawn` (phase 2 of the two-phase spawn write — the
+   * reservation persists with credentials invalidated before the hash await
+   * opens the input gate, #1589).
+   */
+  updateSandboxAuthTokenHash(authTokenHash: string): void;
   /** Update sandbox state for in-place resume without rotating auth/token identity */
   updateSandboxForResume(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
@@ -468,18 +475,24 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       let sandboxAuthToken = this.idGenerator.generateId();
       const hasRepository = sessionHasRepository(session);
       let expectedSandboxId = buildSandboxIdForSession(session, now);
-      const authTokenHash = await hashToken(sandboxAuthToken);
 
-      // Store expected sandbox ID and auth token BEFORE calling provider
+      // Two-phase write (#1589). Phase 1, before the first non-storage await:
+      // persist the replacement identity with credentials invalidated, so a
+      // stale bridge that authenticates while the token hashes below fails
+      // the sandbox-id and token checks instead of matching the old row.
       await this.enterProviderStartup("spawning", now, () =>
         this.storage.updateSandboxForSpawn({
           status: "spawning",
           createdAt: now,
-          authTokenHash,
+          authTokenHash: "",
           modalSandboxId: expectedSandboxId,
           preserveProviderObjectId: true,
         })
       );
+      // Phase 2: publish the credentials the new bridge will present. The
+      // hash-less gap is unobservable — the provider has not been invoked.
+      const authTokenHash = await hashToken(sandboxAuthToken);
+      this.storage.updateSandboxAuthTokenHash(authTokenHash);
 
       await this.stopPriorProviderSandbox();
 
@@ -564,17 +577,19 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         // locks such an orphan out of this DO exactly like the next
         // user-initiated respawn would.
         sandboxAuthToken = this.idGenerator.generateId();
-        const retryAuthTokenHash = await hashToken(sandboxAuthToken);
         const retryNow = Math.max(Date.now(), now + 1);
         expectedSandboxId = buildSandboxIdForSession(session, retryNow);
+        // Same two-phase ordering as the initial write (#1589).
         await this.enterProviderStartup("spawning", retryNow, () =>
           this.storage.updateSandboxForSpawn({
             status: "spawning",
             createdAt: retryNow,
-            authTokenHash: retryAuthTokenHash,
+            authTokenHash: "",
             modalSandboxId: expectedSandboxId,
           })
         );
+        const retryAuthTokenHash = await hashToken(sandboxAuthToken);
+        this.storage.updateSandboxAuthTokenHash(retryAuthTokenHash);
         result = await this.provider.createSandbox({
           ...createConfig,
           sandboxId: expectedSandboxId,
@@ -819,19 +834,22 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
       const now = Date.now();
       const sandboxAuthToken = this.idGenerator.generateId();
-      const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
       const expectedSandboxId = buildSandboxIdForSession(session, now);
 
-      // Store expected sandbox ID and auth token
+      // Two-phase write (#1589): reserve the replacement identity with
+      // credentials invalidated before the hash await opens the input gate,
+      // then publish the hash. See doSpawn for the full rationale.
       await this.enterProviderStartup("spawning", now, () =>
         this.storage.updateSandboxForSpawn({
           status: "spawning",
           createdAt: now,
-          authTokenHash: sandboxAuthTokenHash,
+          authTokenHash: "",
           modalSandboxId: expectedSandboxId,
           preserveProviderObjectId: true,
         })
       );
+      const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
+      this.storage.updateSandboxAuthTokenHash(sandboxAuthTokenHash);
 
       // A restored sandbox runs the snapshot's binaries whatever the provider
       // exports at launch, so the snapshot's version is the authoritative one.

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -311,6 +311,19 @@ export type SandboxAlarmResult = "no_action" | "sandbox_failed" | "sandbox_termi
  * Uses dependency injection for all external interactions, enabling unit testing
  * with mocked dependencies.
  */
+/**
+ * A spawn attempt discovered at hash publication that a newer reservation
+ * had replaced its identity. The attempt must abandon without failure
+ * writes: the sandbox row and circuit breaker now describe the newer
+ * attempt, and marking them failed would clobber it.
+ */
+class SpawnSupersededError extends Error {
+  constructor() {
+    super("Spawn reservation superseded before its auth hash was published");
+    this.name = "SpawnSupersededError";
+  }
+}
+
 export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * In-memory flag to prevent concurrent spawn attempts within the same request.
@@ -480,7 +493,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     );
     const authTokenHash = await hashToken(sandboxAuthToken);
     if (!this.storage.updateSandboxAuthTokenHash(expectedSandboxId, authTokenHash)) {
-      throw new Error("Spawn reservation superseded before its auth hash was published");
+      throw new SpawnSupersededError();
     }
     return { sandboxAuthToken, expectedSandboxId };
   }
@@ -637,6 +650,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         repo_name: session.repo_name,
       });
     } catch (error) {
+      if (error instanceof SpawnSupersededError) {
+        this.log.warn("Spawn attempt superseded; abandoning", {
+          event: "sandbox.spawn_superseded",
+        });
+        return;
+      }
       const errorMessage = error instanceof Error ? error.message : "Failed to spawn sandbox";
       this.log.error("Sandbox spawn completed", {
         event: "sandbox.spawn",
@@ -937,6 +956,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         this.reportSandboxError(result.error || "Failed to restore from snapshot");
       }
     } catch (error) {
+      if (error instanceof SpawnSupersededError) {
+        this.log.warn("Restore attempt superseded; abandoning", {
+          event: "sandbox.spawn_superseded",
+        });
+        return;
+      }
       const errorMessage = error instanceof Error ? error.message : "Failed to restore sandbox";
       this.log.error("Sandbox restore completed", {
         event: "sandbox.restore",

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -100,24 +100,26 @@ export interface SandboxStorage {
   /** Update sandbox status */
   updateSandboxStatus(status: SandboxStatus): void;
   /**
-   * Update sandbox for spawn (status, auth token, sandbox ID, created_at).
+   * Reserve a replacement sandbox identity (status, sandbox ID, created_at).
    * Clears every field describing the previous sandbox instance, runtime
-   * version included.
+   * version included, and invalidates the stored credentials — phase 1 of
+   * the two-phase spawn write (#1589). No token can match the row until
+   * `updateSandboxAuthTokenHash` publishes the new hash.
    */
   updateSandboxForSpawn(data: {
     status: SandboxStatus;
     createdAt: number;
-    authTokenHash: string;
     modalSandboxId: string;
     preserveProviderObjectId?: boolean;
   }): void;
   /**
    * Publish the auth-token hash for the identity reserved by
-   * `updateSandboxForSpawn` (phase 2 of the two-phase spawn write — the
-   * reservation persists with credentials invalidated before the hash await
-   * opens the input gate, #1589).
+   * `updateSandboxForSpawn` (phase 2 of the two-phase spawn write, #1589).
+   * Applies only while that identity is still the persisted sandbox, and
+   * reports whether it was — a delayed publisher must not attach its hash
+   * to a newer reservation.
    */
-  updateSandboxAuthTokenHash(authTokenHash: string): void;
+  updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean;
   /** Update sandbox state for in-place resume without rotating auth/token identity */
   updateSandboxForResume(data: { status: SandboxStatus; createdAt: number }): void;
   /** Update sandbox Modal object ID (for snapshot API) */
@@ -453,6 +455,37 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   }
 
   /**
+   * Allocate and persist a replacement spawn identity with the two-phase
+   * write from #1589. Phase 1, before the first non-storage await: persist
+   * the new sandbox ID with credentials invalidated, so a stale bridge that
+   * authenticates while the token hashes below fails the sandbox-id and
+   * token checks instead of matching the old row. Phase 2: publish the hash,
+   * scoped to the reserved identity — the hash-less gap is unobservable
+   * because the provider has not been invoked yet.
+   */
+  private async reserveSpawnIdentity(
+    session: SessionRow,
+    createdAt: number,
+    opts: { preserveProviderObjectId: boolean }
+  ): Promise<{ sandboxAuthToken: string; expectedSandboxId: string }> {
+    const sandboxAuthToken = this.idGenerator.generateId();
+    const expectedSandboxId = buildSandboxIdForSession(session, createdAt);
+    await this.enterProviderStartup("spawning", createdAt, () =>
+      this.storage.updateSandboxForSpawn({
+        status: "spawning",
+        createdAt,
+        modalSandboxId: expectedSandboxId,
+        preserveProviderObjectId: opts.preserveProviderObjectId,
+      })
+    );
+    const authTokenHash = await hashToken(sandboxAuthToken);
+    if (!this.storage.updateSandboxAuthTokenHash(expectedSandboxId, authTokenHash)) {
+      throw new Error("Spawn reservation superseded before its auth hash was published");
+    }
+    return { sandboxAuthToken, expectedSandboxId };
+  }
+
+  /**
    * Execute a fresh sandbox spawn.
    */
   private async doSpawn(): Promise<void> {
@@ -472,27 +505,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
       const now = Date.now();
       const sessionId = session.session_name || session.id;
-      let sandboxAuthToken = this.idGenerator.generateId();
       const hasRepository = sessionHasRepository(session);
-      let expectedSandboxId = buildSandboxIdForSession(session, now);
-
-      // Two-phase write (#1589). Phase 1, before the first non-storage await:
-      // persist the replacement identity with credentials invalidated, so a
-      // stale bridge that authenticates while the token hashes below fails
-      // the sandbox-id and token checks instead of matching the old row.
-      await this.enterProviderStartup("spawning", now, () =>
-        this.storage.updateSandboxForSpawn({
-          status: "spawning",
-          createdAt: now,
-          authTokenHash: "",
-          modalSandboxId: expectedSandboxId,
-          preserveProviderObjectId: true,
-        })
-      );
-      // Phase 2: publish the credentials the new bridge will present. The
-      // hash-less gap is unobservable — the provider has not been invoked.
-      const authTokenHash = await hashToken(sandboxAuthToken);
-      this.storage.updateSandboxAuthTokenHash(authTokenHash);
+      let { sandboxAuthToken, expectedSandboxId } = await this.reserveSpawnIdentity(session, now, {
+        preserveProviderObjectId: true,
+      });
 
       await this.stopPriorProviderSandbox();
 
@@ -576,20 +592,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         // indistinguishable here), and rotating the token hash and sandbox id
         // locks such an orphan out of this DO exactly like the next
         // user-initiated respawn would.
-        sandboxAuthToken = this.idGenerator.generateId();
         const retryNow = Math.max(Date.now(), now + 1);
-        expectedSandboxId = buildSandboxIdForSession(session, retryNow);
-        // Same two-phase ordering as the initial write (#1589).
-        await this.enterProviderStartup("spawning", retryNow, () =>
-          this.storage.updateSandboxForSpawn({
-            status: "spawning",
-            createdAt: retryNow,
-            authTokenHash: "",
-            modalSandboxId: expectedSandboxId,
-          })
-        );
-        const retryAuthTokenHash = await hashToken(sandboxAuthToken);
-        this.storage.updateSandboxAuthTokenHash(retryAuthTokenHash);
+        ({ sandboxAuthToken, expectedSandboxId } = await this.reserveSpawnIdentity(
+          session,
+          retryNow,
+          { preserveProviderObjectId: false }
+        ));
         result = await this.provider.createSandbox({
           ...createConfig,
           sandboxId: expectedSandboxId,
@@ -833,23 +841,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.storage.setLastSpawnError(null, null);
 
       const now = Date.now();
-      const sandboxAuthToken = this.idGenerator.generateId();
-      const expectedSandboxId = buildSandboxIdForSession(session, now);
-
-      // Two-phase write (#1589): reserve the replacement identity with
-      // credentials invalidated before the hash await opens the input gate,
-      // then publish the hash. See doSpawn for the full rationale.
-      await this.enterProviderStartup("spawning", now, () =>
-        this.storage.updateSandboxForSpawn({
-          status: "spawning",
-          createdAt: now,
-          authTokenHash: "",
-          modalSandboxId: expectedSandboxId,
-          preserveProviderObjectId: true,
-        })
+      const { sandboxAuthToken, expectedSandboxId } = await this.reserveSpawnIdentity(
+        session,
+        now,
+        { preserveProviderObjectId: true }
       );
-      const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
-      this.storage.updateSandboxAuthTokenHash(sandboxAuthTokenHash);
 
       // A restored sandbox runs the snapshot's binaries whatever the provider
       // exports at launch, so the snapshot's version is the authoritative one.

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -847,8 +847,8 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     getUserEnvVars: () => userEnvResolver.getUserEnvVars(),
     updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
     updateSandboxForSpawn: (data) => sandboxRepository.updateSandboxForSpawn(data),
-    updateSandboxAuthTokenHash: (authTokenHash) =>
-      sandboxRepository.updateSandboxAuthTokenHash(authTokenHash),
+    updateSandboxAuthTokenHash: (modalSandboxId, authTokenHash) =>
+      sandboxRepository.updateSandboxAuthTokenHash(modalSandboxId, authTokenHash),
     updateSandboxForResume: (data) => sandboxRepository.updateSandboxForResume(data),
     updateSandboxModalObjectId: (id) => sandboxRepository.updateSandboxModalObjectId(id),
     updateSandboxRuntimeVersion: (runtimeVersion) =>

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -847,6 +847,8 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     getUserEnvVars: () => userEnvResolver.getUserEnvVars(),
     updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
     updateSandboxForSpawn: (data) => sandboxRepository.updateSandboxForSpawn(data),
+    updateSandboxAuthTokenHash: (authTokenHash) =>
+      sandboxRepository.updateSandboxAuthTokenHash(authTokenHash),
     updateSandboxForResume: (data) => sandboxRepository.updateSandboxForResume(data),
     updateSandboxModalObjectId: (id) => sandboxRepository.updateSandboxModalObjectId(id),
     updateSandboxRuntimeVersion: (runtimeVersion) =>

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -16,12 +16,14 @@ function createLog() {
 function createMockSql() {
   const calls: Array<{ query: string; params: unknown[] }> = [];
   const data = new Map<string, unknown[]>();
+  const written = new Map<string, number>();
   const sql: SqlStorage = {
     exec(query: string, ...params: unknown[]): SqlResult {
       calls.push({ query, params });
       return {
         toArray: () => data.get(query) ?? [],
         one: () => null,
+        rowsWritten: written.get(query) ?? 0,
       };
     },
   };
@@ -29,6 +31,7 @@ function createMockSql() {
     sql,
     calls,
     setData: (query: string, rows: unknown[]) => data.set(query, rows),
+    setRowsWritten: (query: string, rows: number) => written.set(query, rows),
   };
 }
 
@@ -105,38 +108,55 @@ describe("SandboxRepository", () => {
   });
 
   describe("updateSandboxForSpawn", () => {
-    it("sets all spawn fields atomically", () => {
+    it("sets all spawn fields atomically and invalidates credentials", () => {
       repository.updateSandboxForSpawn({
         status: "spawning",
         createdAt: 1000,
-        authTokenHash: "token-hash-123",
         modalSandboxId: "modal-sb-1",
       });
 
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toContain("UPDATE sandbox SET");
       expect(mock.calls[0].query).toContain("status");
-      expect(mock.calls[0].query).toContain("auth_token_hash");
       expect(mock.calls[0].query).toContain("modal_sandbox_id");
+      // The reservation itself empties the hash (#1589 phase 1) — no caller
+      // can accidentally reserve with live credentials.
+      expect(mock.calls[0].query).toContain("auth_token_hash = ''");
       expect(mock.calls[0].query).toContain("auth_token = NULL");
       expect(mock.calls[0].query).toContain("modal_object_id = NULL");
       expect(mock.calls[0].query).toContain("vnc_url = NULL");
       expect(mock.calls[0].query).toContain("vnc_password = NULL");
       // A replacement sandbox must not inherit the predecessor's runtime.
       expect(mock.calls[0].query).toContain("runtime_version = NULL");
-      expect(mock.calls[0].params).toEqual(["spawning", 1000, "token-hash-123", "modal-sb-1"]);
+      expect(mock.calls[0].params).toEqual(["spawning", 1000, "modal-sb-1"]);
     });
 
     it("can preserve the provider object ID while fencing a replacement", () => {
       repository.updateSandboxForSpawn({
         status: "spawning",
         createdAt: 123,
-        authTokenHash: "hash",
         modalSandboxId: "sandbox-new",
         preserveProviderObjectId: true,
       });
 
       expect(mock.calls[0].query).toContain("modal_object_id = modal_object_id");
+    });
+  });
+
+  describe("updateSandboxAuthTokenHash", () => {
+    const query = `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ?`;
+
+    it("publishes the hash scoped to the reserved identity", () => {
+      mock.setRowsWritten(query, 1);
+
+      expect(repository.updateSandboxAuthTokenHash("modal-sb-1", "hash-1")).toBe(true);
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toBe(query);
+      expect(mock.calls[0].params).toEqual(["hash-1", "modal-sb-1"]);
+    });
+
+    it("reports a superseded reservation instead of touching the current row", () => {
+      expect(repository.updateSandboxAuthTokenHash("modal-sb-stale", "hash-1")).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -122,6 +122,14 @@ export class SandboxRepository {
     );
   }
 
+  /** Phase 2 of the two-phase spawn write: publish the reserved identity's hash. */
+  updateSandboxAuthTokenHash(authTokenHash: string): void {
+    this.sql.exec(
+      `UPDATE sandbox SET auth_token_hash = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      authTokenHash
+    );
+  }
+
   updateSandboxForResume(data: ResumeSandboxData): void {
     this.sql.exec(
       `UPDATE sandbox SET

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -31,7 +31,6 @@ export interface CreateSandboxData {
 export interface SpawnSandboxData {
   status: SandboxStatus;
   createdAt: number;
-  authTokenHash: string;
   modalSandboxId: string;
   preserveProviderObjectId?: boolean;
 }
@@ -97,12 +96,17 @@ export class SandboxRepository {
     );
   }
 
+  /**
+   * Phase 1 of the two-phase spawn write (#1589): the reservation itself
+   * invalidates credentials — no token can match the emptied hash — until
+   * `updateSandboxAuthTokenHash` publishes the new one.
+   */
   updateSandboxForSpawn(data: SpawnSandboxData): void {
     this.sql.exec(
       `UPDATE sandbox SET
          status = ?,
          created_at = ?,
-         auth_token_hash = ?,
+         auth_token_hash = '',
          auth_token = NULL,
          modal_sandbox_id = ?,
          modal_object_id = ${data.preserveProviderObjectId ? "modal_object_id" : "NULL"},
@@ -117,17 +121,24 @@ export class SandboxRepository {
        WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       data.status,
       data.createdAt,
-      data.authTokenHash,
       data.modalSandboxId
     );
   }
 
-  /** Phase 2 of the two-phase spawn write: publish the reserved identity's hash. */
-  updateSandboxAuthTokenHash(authTokenHash: string): void {
-    this.sql.exec(
-      `UPDATE sandbox SET auth_token_hash = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
-      authTokenHash
+  /**
+   * Phase 2 of the two-phase spawn write (#1589): publish the reserved
+   * identity's hash. Scoped to that identity so a delayed publisher cannot
+   * attach its hash to a newer reservation; reports whether it applied.
+   */
+  updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean {
+    const result = this.sql.exec(
+      `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ?`,
+      authTokenHash,
+      modalSandboxId
     );
+    // Consume the result before reading rowsWritten so the count is final.
+    result.toArray();
+    return (result.rowsWritten ?? 0) > 0;
   }
 
   updateSandboxForResume(data: ResumeSandboxData): void {


### PR DESCRIPTION
## What

Closes #1589 with the issue's recommended fix: the **persist-first, two-phase spawn write**.

`doSpawn()`, its prebuilt-image retry, and `restoreFromSnapshot()` all followed the same ordering: set in-memory flags, `await hashToken(...)` — a non-storage await, so the DO input gate admits other events — and only then persist the new identity. During that await the OLD sandbox row was still the persisted truth, so a slow bridge from a reconnect-allowed sandbox (e.g. `failed`, deliberately reconnect-allowed so slow boots self-heal) could authenticate against the old row and pass every #1586 guard: both the pre-auth read and the post-auth re-read saw the same stale row. Comparing two persisted snapshots cannot detect a transition that has started but not persisted.

## The fix

All three sites now write in two phases:

1. **Phase 1 — synchronous, before the first non-storage await**: `updateSandboxForSpawn` persists the replacement identity (`status: "spawning"`, new `modal_sandbox_id`) with `auth_token_hash: ""` — no token can match it. DO SQLite writes are synchronous, so this is visible before the input gate can open. A stale bridge arriving in what used to be the window now fails the sandbox-ID check (403) or the token check (401), or the #1586 credentials-consistency re-check (403).
2. **Phase 2 — after hashing**: a new narrow `SandboxStorage.updateSandboxAuthTokenHash()` publishes the real hash. The hash-less gap is unobservable: the provider has not been invoked yet, so no bridge holding the new identity can exist.

Accepted caveat, per the issue: a spawn failure after phase 1 leaves the old credentials invalidated — replacement only starts when the old sandbox is being discarded, and failure paths already mark `failed` and re-spawn.

## Red-first race test

Per the issue's requirement, the interleaving is reproduced before being fixed: `manager.test.ts` mocks `hashToken` with a pass-through gate (default open — the other 118 tests run unchanged against the real implementation), holds the next call open, starts a spawn, and asserts the **mid-window persisted row** — exactly what a stale bridge's admission read sees. On the previous code both cases fail with the old identity still visible (`expected 'sb-old' not to be 'sb-old'`); with the fix, the row already carries the new `modal_sandbox_id`, an emptied hash, and `spawning`. After release, the tests pin that phase 2 published a real hash and that the reservation write strictly precedes it. Both the fresh-spawn and snapshot-restore paths are covered; the image-retry path uses the same two-phase ordering (its existing `updateSandboxForSpawn`-call-count assertions are unchanged).

## Notes

- Fix option 2 from the issue (the spawn-generation fence in the admission path) is superseded — revisit only if two-phase persistence proves insufficient.
- `SandboxStorage` gains one method; implementers are the composition-root adapter and the shared test mock.

Battery: 3172 unit (203 files) / 1002 integration (81 files), typecheck, eslint, prettier — green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Improved sandbox startup and snapshot restore authentication handling.
  * Sandbox credentials are invalidated before replacement credentials are generated, preventing stale authentication attempts during transitions.
  * New authentication hashes are persisted only after generation completes and are tied to the active sandbox identity.

* **Bug Fixes**
  * Improved protection against authentication race conditions during sandbox creation and snapshot restoration.
  * Prevented superseded sandbox launches from publishing outdated credentials or incorrectly marking the newer launch as failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->