### PR TITLE
refactor(control-plane): composition classes for the root's three biggest closure bags

### DIFF
--- a/packages/control-plane/src/session/client-command-facade.ts
+++ b/packages/control-plane/src/session/client-command-facade.ts
@@ -1,0 +1,62 @@
+/**
+ * Concrete client-command surface handed to the session message router.
+ *
+ * The router's `SessionClientCommands` port stays generic so the server stack
+ * unit-tests over string connections; this class is its production
+ * implementation, holding the four collaborators as constructor deps instead
+ * of a closure bag in the composition root.
+ */
+
+import type { ClientInfo } from "../types";
+import type {
+  SessionClientCommands,
+  ClientCancelPrompt,
+  ClientPresence,
+  ClientPrompt,
+  ClientSubscribe,
+  FetchHistory,
+} from "./message-router";
+import type { SessionEventStream, SessionHistoryPage } from "./event-stream";
+import type { SessionConnectionAuthenticator } from "./connection-authenticator";
+import type { SessionMessageQueue } from "./message-queue";
+import type { PresenceService } from "./presence-service";
+
+export class SessionClientCommandFacade implements SessionClientCommands<WebSocket, ClientInfo> {
+  constructor(
+    private readonly authenticator: SessionConnectionAuthenticator,
+    private readonly prompts: SessionMessageQueue,
+    private readonly presence: PresenceService,
+    private readonly events: SessionEventStream
+  ) {}
+
+  subscribe(connection: WebSocket, message: ClientSubscribe): Promise<void> {
+    return this.authenticator.handleSubscribe(connection, message);
+  }
+
+  submitPrompt(connection: WebSocket, client: ClientInfo, message: ClientPrompt): Promise<void> {
+    return this.prompts.handlePromptMessage(connection, client, message);
+  }
+
+  cancelPrompt(connection: WebSocket, message: ClientCancelPrompt): Promise<void> {
+    return this.prompts.cancelQueuedPrompt(connection, message);
+  }
+
+  stopExecution(): Promise<void> {
+    return this.prompts.stopExecution();
+  }
+
+  notifyTyping(): Promise<void> {
+    return this.presence.handleTyping();
+  }
+
+  updatePresence(client: ClientInfo, message: ClientPresence): void {
+    this.presence.updatePresence(client, message);
+  }
+
+  getHistoryPage(message: {
+    cursor: NonNullable<FetchHistory["cursor"]>;
+    limit?: number;
+  }): SessionHistoryPage {
+    return this.events.getHistoryPage(message);
+  }
+}

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -34,8 +34,6 @@ import type { Logger } from "../logger";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
-  type SandboxStorage,
-  type WebSocketManager,
   type IdGenerator,
   type ImageBuildLookup,
   type McpServerLookup,
@@ -66,6 +64,8 @@ import {
   type SandboxDashboardSettings,
 } from "./sandbox-access";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
+import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
+import { SessionClientCommandFacade } from "./client-command-facade";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
 import { refreshSessionPullRequests } from "./pull-request-refresh";
@@ -106,7 +106,7 @@ import {
 import { createSessionInternalRoutes } from "./http/routes";
 import { SessionServer } from "./server";
 import { SessionHttpDispatcher } from "./http/dispatcher";
-import { SessionMessageRouter, type SessionClientCommands } from "./message-router";
+import { SessionMessageRouter } from "./message-router";
 import { SessionDisconnectHandler } from "./disconnect-handler";
 import type { Clock, SandboxDisconnectMonitor, SessionBroadcaster, SocketRegistry } from "./ports";
 import { SessionConnectionAuthenticator } from "./connection-authenticator";
@@ -720,15 +720,12 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
         (client) => client.participantId === participantId
       ),
   };
-  const clientCommands: SessionClientCommands<WebSocket, ClientInfo> = {
-    subscribe: (ws, message) => connectionAuthenticator.handleSubscribe(ws, message),
-    submitPrompt: (ws, client, message) => messageQueue.handlePromptMessage(ws, client, message),
-    cancelPrompt: (ws, message) => messageQueue.cancelQueuedPrompt(ws, message),
-    stopExecution: () => messageQueue.stopExecution(),
-    notifyTyping: () => presenceService.handleTyping(),
-    updatePresence: (client, message) => presenceService.updatePresence(client, message),
-    getHistoryPage: (message) => eventStream.getHistoryPage(message),
-  };
+  const clientCommands = new SessionClientCommandFacade(
+    connectionAuthenticator,
+    messageQueue,
+    presenceService,
+    eventStream
+  );
   const sandboxDisconnects: SandboxDisconnectMonitor = {
     getStatus: () => sandboxRepository.getSandbox()?.status,
     scheduleCheck: () => lifecycleManager.scheduleDisconnectCheck(),
@@ -832,73 +829,13 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
   const sandboxBackend = resolveSandboxBackendName(env.SANDBOX_PROVIDER);
   const provider = createSandboxProviderFromEnv(env, sandboxBackend);
 
-  // Storage adapter
-  const storage: SandboxStorage = {
-    getSandbox: () => sandboxRepository.getSandbox(),
-    getSandboxWithCircuitBreaker: () => sandboxRepository.getSandboxWithCircuitBreaker(),
-    getSession: () => sessionCoreRepository.getSession(),
-    getSessionRepositories: () =>
-      sessionCoreRepository.getSessionRepositories().map((entry) => ({
-        repoOwner: entry.repoOwner,
-        repoName: entry.repoName,
-        baseBranch: entry.baseBranch ?? "main",
-        baseSha: entry.row?.base_sha ?? null,
-      })),
-    getUserEnvVars: () => userEnvResolver.getUserEnvVars(),
-    updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
-    updateSandboxForSpawn: (data) => sandboxRepository.updateSandboxForSpawn(data),
-    updateSandboxAuthTokenHash: (modalSandboxId, authTokenHash) =>
-      sandboxRepository.updateSandboxAuthTokenHash(modalSandboxId, authTokenHash),
-    updateSandboxForResume: (data) => sandboxRepository.updateSandboxForResume(data),
-    updateSandboxModalObjectId: (id) => sandboxRepository.updateSandboxModalObjectId(id),
-    updateSandboxRuntimeVersion: (runtimeVersion) =>
-      sandboxRepository.updateSandboxRuntimeVersion(runtimeVersion),
-    updateSandboxSnapshotImageId: (sandboxId, imageId, runtimeVersion) =>
-      sandboxRepository.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion),
-    updateSandboxLastActivity: (timestamp) =>
-      sandboxRepository.updateSandboxLastActivity(timestamp),
-    incrementCircuitBreakerFailure: (timestamp) =>
-      sandboxRepository.incrementCircuitBreakerFailure(timestamp),
-    resetCircuitBreaker: () => sandboxRepository.resetCircuitBreaker(),
-    setLastSpawnError: (error, timestamp) =>
-      sandboxRepository.updateSandboxSpawnError(error, timestamp),
-    updateSandboxCodeServer: async (url, password) => {
-      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
-        ? await encryptToken(password, env.REPO_SECRETS_ENCRYPTION_KEY)
-        : password;
-      sandboxRepository.updateSandboxCodeServer(url, encrypted);
-    },
-    clearSandboxCodeServer: () => sandboxRepository.clearSandboxCodeServer(),
-    clearSandboxCodeServerUrl: () => sandboxRepository.clearSandboxCodeServerUrl(),
-    updateSandboxVnc: async (url, password) => {
-      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
-        ? await encryptToken(password, env.REPO_SECRETS_ENCRYPTION_KEY)
-        : password;
-      sandboxRepository.updateSandboxVnc(url, encrypted);
-    },
-    clearSandboxVnc: () => sandboxRepository.clearSandboxVnc(),
-    clearSandboxVncUrl: () => sandboxRepository.clearSandboxVncUrl(),
-    updateSandboxTunnelUrls: (urls) => sandboxRepository.updateSandboxTunnelUrls(urls),
-    clearSandboxTunnelUrls: () => sandboxRepository.clearSandboxTunnelUrls(),
-    updateSandboxTtyd: async (url, token) => {
-      const encrypted = env.REPO_SECRETS_ENCRYPTION_KEY
-        ? await encryptToken(token, env.REPO_SECRETS_ENCRYPTION_KEY)
-        : token;
-      sandboxRepository.updateSandboxTtyd(url, encrypted);
-    },
-    clearSandboxTtyd: () => sandboxRepository.clearSandboxTtyd(),
-  };
-
-  // WebSocket manager adapter — thin delegation to wsManager
-  const lifecycleWsManager: WebSocketManager = {
-    getSandboxWebSocket: () => wsManager.getSandboxSocket(),
-    detachSandboxWebSocket: (code, reason) => wsManager.detachSandboxSocket(code, reason),
-    sendToSandbox: (message) => {
-      const ws = wsManager.getSandboxSocket();
-      return ws ? wsManager.send(ws, message) : false;
-    },
-    getConnectedClientCount: () => wsManager.getConnectedClientCount(),
-  };
+  const storage = new DurableObjectSandboxStorage(
+    sandboxRepository,
+    sessionCoreRepository,
+    userEnvResolver,
+    env.REPO_SECRETS_ENCRYPTION_KEY
+  );
+  const lifecycleWsManager = new LifecycleSocketAdapter(wsManager);
 
   // ID generator adapter
   const idGenerator: IdGenerator = {

--- a/packages/control-plane/src/session/message-router.ts
+++ b/packages/control-plane/src/session/message-router.ts
@@ -7,11 +7,11 @@ import type { Clock, ConnectedClient, SocketRegistry } from "./ports";
 
 const FETCH_HISTORY_MIN_INTERVAL_MS = 200;
 
-type ClientCancelPrompt = Extract<ClientMessage, { type: "cancel_prompt" }>;
-type ClientPresence = Extract<ClientMessage, { type: "presence" }>;
-type ClientPrompt = Extract<ClientMessage, { type: "prompt" }>;
-type ClientSubscribe = Extract<ClientMessage, { type: "subscribe" }>;
-type FetchHistory = Extract<ClientMessage, { type: "fetch_history" }>;
+export type ClientCancelPrompt = Extract<ClientMessage, { type: "cancel_prompt" }>;
+export type ClientPresence = Extract<ClientMessage, { type: "presence" }>;
+export type ClientPrompt = Extract<ClientMessage, { type: "prompt" }>;
+export type ClientSubscribe = Extract<ClientMessage, { type: "subscribe" }>;
+export type FetchHistory = Extract<ClientMessage, { type: "fetch_history" }>;
 
 type BoundarySchema<T> = {
   safeParse(

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
@@ -63,11 +63,15 @@ describe("DurableObjectSandboxStorage", () => {
     }
   });
 
-  it("stores secrets as-is when no key is configured", async () => {
+  it("stores secrets as-is and synchronously when no key is configured", () => {
     const { storage, sandboxes } = createStorage();
 
-    await storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
+    // No await before asserting: the keyless branch must persist before the
+    // call returns, so a same-turn caller that does not await still observes
+    // the write (and a later clear cannot be overwritten by a deferred store).
+    const result = storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
 
+    expect(result).toBeUndefined();
     expect(sandboxes.updateSandboxCodeServer).toHaveBeenCalledWith(
       "https://cs.example",
       "cs-secret"

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the lifecycle-manager port adapters — the pieces with real
+ * logic: the encrypt-before-store branch, the repository-shape defaults, the
+ * setLastSpawnError rename, and the no-socket send branch. Pure forwards are
+ * covered through the manager and server suites.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { decryptToken } from "../auth/crypto";
+import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
+import type { SandboxRepository } from "./sandbox-repository";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { UserEnvResolver } from "./user-env-resolver";
+import type { SessionWebSocketManager } from "./websocket-manager";
+
+const ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef";
+
+function createStorage(overrides: { encryptionKey?: string } = {}) {
+  const sandboxes = {
+    updateSandboxCodeServer: vi.fn(),
+    updateSandboxVnc: vi.fn(),
+    updateSandboxTtyd: vi.fn(),
+    updateSandboxSpawnError: vi.fn(),
+  } as unknown as SandboxRepository;
+  const sessions = {
+    getSessionRepositories: vi.fn(() => [
+      { repoOwner: "acme", repoName: "web-app", baseBranch: null, row: undefined },
+      {
+        repoOwner: "acme",
+        repoName: "api",
+        baseBranch: "develop",
+        row: { base_sha: "abc123" },
+      },
+    ]),
+  } as unknown as SessionCoreRepository;
+  const userEnv = {} as UserEnvResolver;
+  const storage = new DurableObjectSandboxStorage(
+    sandboxes,
+    sessions,
+    userEnv,
+    overrides.encryptionKey
+  );
+  return { storage, sandboxes, sessions };
+}
+
+describe("DurableObjectSandboxStorage", () => {
+  it("encrypts secrets before storing when a key is configured", async () => {
+    const { storage, sandboxes } = createStorage({ encryptionKey: ENCRYPTION_KEY });
+
+    await storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
+    await storage.updateSandboxVnc("https://vnc.example", "vnc-secret");
+    await storage.updateSandboxTtyd("https://ttyd.example", "ttyd-token");
+
+    for (const [mock, url, plaintext] of [
+      [vi.mocked(sandboxes.updateSandboxCodeServer), "https://cs.example", "cs-secret"],
+      [vi.mocked(sandboxes.updateSandboxVnc), "https://vnc.example", "vnc-secret"],
+      [vi.mocked(sandboxes.updateSandboxTtyd), "https://ttyd.example", "ttyd-token"],
+    ] as const) {
+      const [storedUrl, storedSecret] = mock.mock.calls[0];
+      expect(storedUrl).toBe(url);
+      expect(storedSecret).not.toBe(plaintext);
+      await expect(decryptToken(storedSecret, ENCRYPTION_KEY)).resolves.toBe(plaintext);
+    }
+  });
+
+  it("stores secrets as-is when no key is configured", async () => {
+    const { storage, sandboxes } = createStorage();
+
+    await storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
+
+    expect(sandboxes.updateSandboxCodeServer).toHaveBeenCalledWith(
+      "https://cs.example",
+      "cs-secret"
+    );
+  });
+
+  it("maps repository entries with baseBranch and baseSha defaults", () => {
+    const { storage } = createStorage();
+
+    expect(storage.getSessionRepositories()).toEqual([
+      { repoOwner: "acme", repoName: "web-app", baseBranch: "main", baseSha: null },
+      { repoOwner: "acme", repoName: "api", baseBranch: "develop", baseSha: "abc123" },
+    ]);
+  });
+
+  it("forwards setLastSpawnError to the spawn-error column update", () => {
+    const { storage, sandboxes } = createStorage();
+
+    storage.setLastSpawnError("boom", 1234);
+
+    expect(sandboxes.updateSandboxSpawnError).toHaveBeenCalledWith("boom", 1234);
+  });
+});
+
+describe("LifecycleSocketAdapter", () => {
+  function createSockets(sandboxSocket: WebSocket | null) {
+    return {
+      getSandboxSocket: vi.fn(() => sandboxSocket),
+      send: vi.fn(() => true),
+      detachSandboxSocket: vi.fn(),
+      getConnectedClientCount: vi.fn(() => 2),
+    } as unknown as SessionWebSocketManager;
+  }
+
+  it("reports an unsent message when no sandbox socket is connected", () => {
+    const sockets = createSockets(null);
+    const adapter = new LifecycleSocketAdapter(sockets);
+
+    expect(adapter.sendToSandbox({ type: "ping" })).toBe(false);
+    expect(sockets.send).not.toHaveBeenCalled();
+  });
+
+  it("sends through the registered sandbox socket", () => {
+    const sandboxSocket = { readyState: 1 } as unknown as WebSocket;
+    const sockets = createSockets(sandboxSocket);
+    const adapter = new LifecycleSocketAdapter(sockets);
+
+    expect(adapter.sendToSandbox({ type: "ping" })).toBe(true);
+    expect(sockets.send).toHaveBeenCalledWith(sandboxSocket, { type: "ping" });
+  });
+});

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -1,0 +1,173 @@
+/**
+ * Composition-root adapters for the sandbox lifecycle manager's ports.
+ *
+ * The manager owns `SandboxStorage` and `WebSocketManager`; these classes
+ * implement them over the session's collaborators so the root wires objects
+ * instead of building closure-bag literals inline (deps standard: pass
+ * collaborators directly, give shared-collaborator groups a composition
+ * class).
+ */
+
+import { encryptToken } from "../auth/crypto";
+import type { SandboxStorage, WebSocketManager } from "../sandbox/lifecycle/manager";
+import type { SessionRepositoryInfo } from "../sandbox/provider";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
+import type {
+  SandboxRepository,
+  SandboxCircuitBreakerState,
+  SpawnSandboxData,
+  ResumeSandboxData,
+} from "./sandbox-repository";
+import type { SessionCoreRepository } from "./session-core-repository";
+import type { UserEnvResolver } from "./user-env-resolver";
+import type { SessionWebSocketManager } from "./websocket-manager";
+import type { SandboxRow, SessionRow } from "./types";
+
+export class DurableObjectSandboxStorage implements SandboxStorage {
+  constructor(
+    private readonly sandboxes: SandboxRepository,
+    private readonly sessions: SessionCoreRepository,
+    private readonly userEnv: UserEnvResolver,
+    /** Absent on deployments without a secrets key — values persist unencrypted. */
+    private readonly encryptionKey: string | undefined
+  ) {}
+
+  getSandbox(): SandboxRow | null {
+    return this.sandboxes.getSandbox();
+  }
+
+  getSandboxWithCircuitBreaker(): SandboxCircuitBreakerState | null {
+    return this.sandboxes.getSandboxWithCircuitBreaker();
+  }
+
+  getSession(): SessionRow | null {
+    return this.sessions.getSession();
+  }
+
+  getSessionRepositories(): SessionRepositoryInfo[] {
+    return this.sessions.getSessionRepositories().map((entry) => ({
+      repoOwner: entry.repoOwner,
+      repoName: entry.repoName,
+      baseBranch: entry.baseBranch ?? "main",
+      baseSha: entry.row?.base_sha ?? null,
+    }));
+  }
+
+  getUserEnvVars(): Promise<Record<string, string> | undefined> {
+    return this.userEnv.getUserEnvVars();
+  }
+
+  updateSandboxStatus(status: SandboxStatus): void {
+    this.sandboxes.updateSandboxStatus(status);
+  }
+
+  updateSandboxForSpawn(data: SpawnSandboxData): void {
+    this.sandboxes.updateSandboxForSpawn(data);
+  }
+
+  updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean {
+    return this.sandboxes.updateSandboxAuthTokenHash(modalSandboxId, authTokenHash);
+  }
+
+  updateSandboxForResume(data: ResumeSandboxData): void {
+    this.sandboxes.updateSandboxForResume(data);
+  }
+
+  updateSandboxModalObjectId(modalObjectId: string | null): void {
+    this.sandboxes.updateSandboxModalObjectId(modalObjectId);
+  }
+
+  updateSandboxRuntimeVersion(runtimeVersion: string | null): void {
+    this.sandboxes.updateSandboxRuntimeVersion(runtimeVersion);
+  }
+
+  updateSandboxSnapshotImageId(
+    sandboxId: string,
+    imageId: string,
+    runtimeVersion: string | null
+  ): void {
+    this.sandboxes.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion);
+  }
+
+  updateSandboxLastActivity(timestamp: number): void {
+    this.sandboxes.updateSandboxLastActivity(timestamp);
+  }
+
+  incrementCircuitBreakerFailure(timestamp: number): void {
+    this.sandboxes.incrementCircuitBreakerFailure(timestamp);
+  }
+
+  resetCircuitBreaker(): void {
+    this.sandboxes.resetCircuitBreaker();
+  }
+
+  setLastSpawnError(error: string | null, timestamp: number | null): void {
+    this.sandboxes.updateSandboxSpawnError(error, timestamp);
+  }
+
+  async updateSandboxCodeServer(url: string, password: string): Promise<void> {
+    this.sandboxes.updateSandboxCodeServer(url, await this.encryptIfConfigured(password));
+  }
+
+  clearSandboxCodeServer(): void {
+    this.sandboxes.clearSandboxCodeServer();
+  }
+
+  clearSandboxCodeServerUrl(): void {
+    this.sandboxes.clearSandboxCodeServerUrl();
+  }
+
+  async updateSandboxVnc(url: string, password: string): Promise<void> {
+    this.sandboxes.updateSandboxVnc(url, await this.encryptIfConfigured(password));
+  }
+
+  clearSandboxVnc(): void {
+    this.sandboxes.clearSandboxVnc();
+  }
+
+  clearSandboxVncUrl(): void {
+    this.sandboxes.clearSandboxVncUrl();
+  }
+
+  updateSandboxTunnelUrls(urls: Record<string, string>): void {
+    this.sandboxes.updateSandboxTunnelUrls(urls);
+  }
+
+  clearSandboxTunnelUrls(): void {
+    this.sandboxes.clearSandboxTunnelUrls();
+  }
+
+  async updateSandboxTtyd(url: string, token: string): Promise<void> {
+    this.sandboxes.updateSandboxTtyd(url, await this.encryptIfConfigured(token));
+  }
+
+  clearSandboxTtyd(): void {
+    this.sandboxes.clearSandboxTtyd();
+  }
+
+  private async encryptIfConfigured(value: string): Promise<string> {
+    return this.encryptionKey ? encryptToken(value, this.encryptionKey) : value;
+  }
+}
+
+/** The lifecycle manager's view of the session socket registry. */
+export class LifecycleSocketAdapter implements WebSocketManager {
+  constructor(private readonly sockets: SessionWebSocketManager) {}
+
+  getSandboxWebSocket(): WebSocket | null {
+    return this.sockets.getSandboxSocket();
+  }
+
+  detachSandboxWebSocket(code: number, reason: string): void {
+    this.sockets.detachSandboxSocket(code, reason);
+  }
+
+  sendToSandbox(message: object): boolean {
+    const ws = this.sockets.getSandboxSocket();
+    return ws ? this.sockets.send(ws, message) : false;
+  }
+
+  getConnectedClientCount(): number {
+    return this.sockets.getConnectedClientCount();
+  }
+}

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -105,8 +105,10 @@ export class DurableObjectSandboxStorage implements SandboxStorage {
     this.sandboxes.updateSandboxSpawnError(error, timestamp);
   }
 
-  async updateSandboxCodeServer(url: string, password: string): Promise<void> {
-    this.sandboxes.updateSandboxCodeServer(url, await this.encryptIfConfigured(password));
+  updateSandboxCodeServer(url: string, password: string): void | Promise<void> {
+    return this.persistEncrypted(password, (stored) =>
+      this.sandboxes.updateSandboxCodeServer(url, stored)
+    );
   }
 
   clearSandboxCodeServer(): void {
@@ -117,8 +119,10 @@ export class DurableObjectSandboxStorage implements SandboxStorage {
     this.sandboxes.clearSandboxCodeServerUrl();
   }
 
-  async updateSandboxVnc(url: string, password: string): Promise<void> {
-    this.sandboxes.updateSandboxVnc(url, await this.encryptIfConfigured(password));
+  updateSandboxVnc(url: string, password: string): void | Promise<void> {
+    return this.persistEncrypted(password, (stored) =>
+      this.sandboxes.updateSandboxVnc(url, stored)
+    );
   }
 
   clearSandboxVnc(): void {
@@ -137,22 +141,41 @@ export class DurableObjectSandboxStorage implements SandboxStorage {
     this.sandboxes.clearSandboxTunnelUrls();
   }
 
-  async updateSandboxTtyd(url: string, token: string): Promise<void> {
-    this.sandboxes.updateSandboxTtyd(url, await this.encryptIfConfigured(token));
+  updateSandboxTtyd(url: string, token: string): void | Promise<void> {
+    return this.persistEncrypted(token, (stored) => this.sandboxes.updateSandboxTtyd(url, stored));
   }
 
   clearSandboxTtyd(): void {
     this.sandboxes.clearSandboxTtyd();
   }
 
-  private async encryptIfConfigured(value: string): Promise<string> {
-    return this.encryptionKey ? encryptToken(value, this.encryptionKey) : value;
+  /**
+   * Encrypt-at-rest for access secrets. The keyless branch persists
+   * synchronously so callers that do not await still observe the write in the
+   * same turn, matching the pre-extraction literal's ordering.
+   */
+  private persistEncrypted(value: string, persist: (stored: string) => void): void | Promise<void> {
+    if (!this.encryptionKey) {
+      persist(value);
+      return;
+    }
+    return encryptToken(value, this.encryptionKey).then(persist);
   }
 }
 
+/**
+ * The slice of the socket registry the lifecycle manager's port needs —
+ * narrowed like the messenger's `DeliverySockets` so lifecycle wiring cannot
+ * grow dependencies on admission, identity, or teardown operations.
+ */
+type LifecycleSockets = Pick<
+  SessionWebSocketManager,
+  "getSandboxSocket" | "detachSandboxSocket" | "send" | "getConnectedClientCount"
+>;
+
 /** The lifecycle manager's view of the session socket registry. */
 export class LifecycleSocketAdapter implements WebSocketManager {
-  constructor(private readonly sockets: SessionWebSocketManager) {}
+  constructor(private readonly sockets: LifecycleSockets) {}
 
   getSandboxWebSocket(): WebSocket | null {
     return this.sockets.getSandboxSocket();


### PR DESCRIPTION
## What

First PR of the deps-style normalization campaign (follow-through on the #1594–#1604 decomposition): replace the composition root's three biggest closure-bag literals with composition classes, per the house deps standard from the #1045-series (pass collaborators directly with full types; give a closure group that shares collaborators a named class).

Behavior-preserving — no port changes, no call-flow changes.

## Changes

- **`DurableObjectSandboxStorage`** (new `session/sandbox-lifecycle-adapters.ts`) implements the lifecycle manager's `SandboxStorage` port over its four real collaborators: `SandboxRepository`, `SessionCoreRepository`, `UserEnvResolver`, and the secrets encryption key. Replaces the 28-property literal in the root. The encrypt-before-store rule (code-server/VNC/ttyd secrets), previously copy-pasted three times inline, is one private `encryptIfConfigured` method.
- **`LifecycleSocketAdapter`** (same file) implements the manager's `WebSocketManager` port over `SessionWebSocketManager` — the name translation and the no-socket send branch get a typed home instead of a literal.
- **`SessionClientCommandFacade`** (new `session/client-command-facade.ts`) implements the message router's `SessionClientCommands<WebSocket, ClientInfo>` port with the four services as constructor deps. The port itself stays generic — that genericity is what lets the server stack unit-test over string connections, so the facade is the production binding, not a port rewrite. The router's client-message type aliases are now exported (they are referenced by the exported port, so naming them outside the module was already implied).

Net: 39 function-valued props removed from `components.ts`; the root now constructs objects in these three spots instead of authoring behavior inline.

## Tests

New `sandbox-lifecycle-adapters.test.ts` covers the pieces with real logic, which previously lived untested inside the root literal: the encrypt-when-configured branch (round-trips via `decryptToken`), the plaintext-passthrough branch, the repository-shape defaults (`baseBranch` → `"main"`, missing row → `baseSha: null`), the `setLastSpawnError` → `updateSandboxSpawnError` rename, and both `sendToSandbox` branches. Pure forwards stay covered through the manager and server suites.

## Queue context

Next in the campaign (separate PRs): handler deps-bags → classes (normalizing the 7-factory/5-class split), vestigial thunk removal (`getLogger: () => log` first), and the `test/integration` typecheck spike.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved session command handling for prompts, execution controls, typing indicators, presence, subscriptions, and history.
  - Improved sandbox lifecycle and WebSocket handling for more consistent session connectivity.
- **Security**
  - Sandbox access credentials can now be encrypted when configured, while retaining compatibility with existing setups.
- **Tests**
  - Added coverage for credential storage, sandbox startup errors, repository behavior, and WebSocket communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->