### PR TITLE
refactor(control-plane): require the secrets encryption key and dissolve the storage middle-man

### DIFF
--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -98,11 +98,13 @@ const remoteRowWithHeaders = {
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
+const TEST_ENCRYPTION_KEY = "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==";
+
 describe("McpServerStore", () => {
   describe("list()", () => {
     it("returns all servers when no repoScope filter", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.list();
       expect(results).toHaveLength(2);
       expect(results[0].name).toBe("playwright");
@@ -110,7 +112,7 @@ describe("McpServerStore", () => {
 
     it("filters by repoScope (global servers always included)", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       // sampleRow has no repo_scope (global) → should be included
       // remoteRow is scoped to carboncopyinc/habakkuk → should be included
       const results = await store.list("carboncopyinc/habakkuk");
@@ -119,7 +121,7 @@ describe("McpServerStore", () => {
 
     it("excludes repo-scoped servers when repo does not match", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       // remoteRow is scoped to carboncopyinc/habakkuk, not bencered/dom
       const results = await store.list("bencered/dom");
       expect(results).toHaveLength(1);
@@ -130,7 +132,7 @@ describe("McpServerStore", () => {
   describe("get()", () => {
     it("returns metadata (no credentials) when row found", async () => {
       const { db } = createFakeD1({ firstResult: sampleRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.get("abc123");
       expect(result).not.toBeNull();
       expect(result!.name).toBe("playwright");
@@ -144,7 +146,7 @@ describe("McpServerStore", () => {
 
     it("returns null when not found", async () => {
       const { db } = createFakeD1({ firstResult: null });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.get("nonexistent");
       expect(result).toBeNull();
     });
@@ -152,7 +154,7 @@ describe("McpServerStore", () => {
     it("handles corrupted JSON in command gracefully", async () => {
       const corruptRow = { ...sampleRow, command: "not-json" };
       const { db } = createFakeD1({ firstResult: corruptRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.get("abc123");
       // Should fall back to wrapping the string in an array
       expect(result!.command).toEqual(["not-json"]);
@@ -161,7 +163,7 @@ describe("McpServerStore", () => {
     it("reports hasEnv=false when env is empty", async () => {
       const emptyEnvRow = { ...sampleRow, env: "{}" };
       const { db } = createFakeD1({ firstResult: emptyEnvRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.get("abc123");
       expect(result!.hasEnv).toBe(false);
     });
@@ -172,7 +174,7 @@ describe("McpServerStore", () => {
         env: JSON.stringify({ Authorization: "Bearer tok" }),
       };
       const { db } = createFakeD1({ firstResult: remoteWithHeaders });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.get("def456");
       expect(result!.hasHeaders).toBe(true);
       expect(result!.hasEnv).toBe(false);
@@ -182,7 +184,7 @@ describe("McpServerStore", () => {
   describe("create()", () => {
     it("throws McpServerValidationError for local server without command", async () => {
       const { db } = createFakeD1();
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const invalid = {
         name: "test",
         type: "local",
@@ -193,7 +195,7 @@ describe("McpServerStore", () => {
 
     it("throws McpServerValidationError for remote server without url", async () => {
       const { db } = createFakeD1({ firstResult: remoteRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const invalid = {
         name: "test",
         type: "remote",
@@ -204,7 +206,7 @@ describe("McpServerStore", () => {
 
     it("throws McpServerValidationError (not generic Error) so routes can return 400", async () => {
       const { db } = createFakeD1();
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const invalid = {
         name: "x",
         type: "local",
@@ -219,7 +221,7 @@ describe("McpServerStore", () => {
   describe("update()", () => {
     it("returns null when server not found", async () => {
       const { db } = createFakeD1({ firstResult: null });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.update("nonexistent", { name: "new-name" });
       expect(result).toBeNull();
     });
@@ -253,7 +255,7 @@ describe("McpServerStore", () => {
       };
       const db = { prepare: () => fakeStmt, dump: vi.fn(), exec: vi.fn() } as unknown as D1Database;
 
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       // Attempt to patch id (not in the allowed type, but simulate via cast)
       const result = await store.update("abc123", {
         id: "malicious-id",
@@ -266,7 +268,7 @@ describe("McpServerStore", () => {
     it("throws McpServerValidationError when changing type to remote without url", async () => {
       // sampleRow is a local server with no url
       const { db } = createFakeD1({ firstResult: sampleRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const err = await store.update("abc123", { type: "remote" }).catch((e) => e);
       expect(err).toBeInstanceOf(McpServerValidationError);
       expect(err.message).toMatch(/require a URL/i);
@@ -275,7 +277,7 @@ describe("McpServerStore", () => {
     it("throws McpServerValidationError when changing type to local without command", async () => {
       // remoteRow is a remote server with no command
       const { db } = createFakeD1({ firstResult: remoteRow });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const err = await store.update("def456", { type: "local" }).catch((e) => e);
       expect(err).toBeInstanceOf(McpServerValidationError);
       expect(err.message).toMatch(/require a command/i);
@@ -285,14 +287,14 @@ describe("McpServerStore", () => {
   describe("delete()", () => {
     it("returns true when row deleted", async () => {
       const { db } = createFakeD1({ changes: 1 });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.delete("abc123");
       expect(result).toBe(true);
     });
 
     it("returns false when row not found", async () => {
       const { db } = createFakeD1({ changes: 0 });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const result = await store.delete("nonexistent");
       expect(result).toBe(false);
     });
@@ -301,7 +303,7 @@ describe("McpServerStore", () => {
   describe("getDecryptedForSession()", () => {
     it("returns global and matching repo-scoped servers", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([
         { repoOwner: "carboncopyinc", repoName: "habakkuk" },
       ]);
@@ -310,7 +312,7 @@ describe("McpServerStore", () => {
 
     it("excludes servers scoped to different repos", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([
         { repoOwner: "bencered", repoName: "dom" },
       ]);
@@ -320,7 +322,7 @@ describe("McpServerStore", () => {
 
     it("matches scoped servers through any member of a multi-repo session", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([
         { repoOwner: "bencered", repoName: "dom" },
         { repoOwner: "carboncopyinc", repoName: "habakkuk" },
@@ -330,7 +332,7 @@ describe("McpServerStore", () => {
 
     it("returns only unscoped servers for repo-less sessions", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([]);
       expect(results).toHaveLength(1);
       expect(results[0].name).toBe("playwright");
@@ -338,7 +340,7 @@ describe("McpServerStore", () => {
 
     it("returns headers (not env) for remote servers", async () => {
       const { db } = createFakeD1({ allResults: [remoteRowWithHeaders] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([
         { repoOwner: "carboncopyinc", repoName: "habakkuk" },
       ]);
@@ -354,7 +356,7 @@ describe("McpServerStore", () => {
 
     it("returns env (not headers) for local servers", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results).toHaveLength(1);
       const local = results[0];
@@ -390,7 +392,7 @@ describe("McpServerStore", () => {
 
     it("create() throws McpServerValidationError on duplicate name (not 503)", async () => {
       const db = createConstraintErrorD1();
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const err = await store
         .create({ name: "playwright", type: "local", command: ["npx", "x"], enabled: true })
         .catch((e) => e);
@@ -421,7 +423,7 @@ describe("McpServerStore", () => {
         },
       };
       const db = { prepare: () => fakeStmt, dump: vi.fn(), exec: vi.fn() } as unknown as D1Database;
-      const store = new McpServerStore(db);
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const err = await store.update("abc123", { name: "other-server" }).catch((e) => e);
       expect(err).toBeInstanceOf(McpServerValidationError);
     });
@@ -430,14 +432,14 @@ describe("McpServerStore", () => {
   describe("encryption / decryption (via getDecryptedForSession)", () => {
     it("no-key path returns plaintext env as-is", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
-      const store = new McpServerStore(db); // no encryption key
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY); // no encryption key
       const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({ DEBUG: "1" });
     });
 
     it("falls back to plaintext when decryption fails (pre-encryption row)", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
-      const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({ DEBUG: "1" });
     });
@@ -446,7 +448,7 @@ describe("McpServerStore", () => {
       const { db } = createFakeD1({
         allResults: [{ ...sampleRow, env: "notjson_notcipher" }],
       });
-      const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
       const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({});
     });

--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -364,6 +364,22 @@ describe("McpServerStore", () => {
       expect(local.env).toEqual({ DEBUG: "1" });
       expect(local.headers).toBeUndefined();
     });
+
+    it("reads an empty credential map without a doomed decrypt attempt", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const emptyEnvRow = { ...sampleRow, env: "{}" };
+      const { db } = createFakeD1({ allResults: [emptyEnvRow] });
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
+
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].env ?? {}).toEqual({});
+      // The "{}" sentinel is written plaintext by encryptEnv; reading it must
+      // not attempt a decrypt that fails into the env_decrypt_error path.
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
   });
 
   describe("UNIQUE constraint handling", () => {

--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -381,6 +381,20 @@ describe("McpServerStore", () => {
       expect(errorSpy).not.toHaveBeenCalled();
       errorSpy.mockRestore();
     });
+
+    it('reads the legacy "null" credential sentinel as an empty map', async () => {
+      // rowToMetadata's credential-free set is "", "{}", and "null" — the
+      // decrypt path must accept all three. JSON.parse("null") is null, so
+      // without the guard this row throws in the catch and rejects the call.
+      const nullEnvRow = { ...sampleRow, env: "null" };
+      const { db } = createFakeD1({ allResults: [nullEnvRow] });
+      const store = new McpServerStore(db, TEST_ENCRYPTION_KEY);
+
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].env ?? {}).toEqual({});
+    });
   });
 
   describe("UNIQUE constraint handling", () => {

--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ValidatedCreateMcpServerInput } from "@open-inspect/shared/types/integrations";
 import { McpServerStore, McpServerValidationError } from "./mcp-servers";
+import { generateEncryptionKey } from "../auth/crypto";
 
 // ─── Fake D1 helpers ────────────────────────────────────────────────────────
 
@@ -98,7 +99,7 @@ const remoteRowWithHeaders = {
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-const TEST_ENCRYPTION_KEY = "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==";
+const TEST_ENCRYPTION_KEY = generateEncryptionKey();
 
 describe("McpServerStore", () => {
   describe("list()", () => {

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -59,7 +59,12 @@ function safeJsonParseCommand(raw: string | null): string[] | undefined {
 
 function safeJsonParseEnv(raw: string): Record<string, string> {
   try {
-    return JSON.parse(raw);
+    const parsed: unknown = JSON.parse(raw);
+    // JSON.parse accepts non-object documents ("null", numbers, strings);
+    // callers iterate keys, so anything but a plain object is "no env".
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, string>)
+      : {};
   } catch {
     return {};
   }
@@ -111,9 +116,10 @@ export class McpServerStore {
 
   private async decryptEnv(raw: string): Promise<Record<string, string>> {
     // The write side stores an empty credential map as plaintext "{}" (see
-    // encryptEnv) — recognize the sentinel, and legacy empty columns, before
-    // attempting a decrypt that is guaranteed to fail into the error path.
-    if (!raw || raw === "{}") return {};
+    // encryptEnv) — recognize the full credential-free sentinel set that
+    // rowToMetadata classifies ("", "{}", "null") before attempting a decrypt
+    // that is guaranteed to fail into the error path.
+    if (!raw || raw === "{}" || raw === "null") return {};
     try {
       const plain = await decryptToken(raw, this.encryptionKey);
       return safeJsonParseEnv(plain);

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -99,18 +99,17 @@ function rowToMetadata(row: McpServerRow): McpServerMetadata {
 export class McpServerStore {
   constructor(
     private readonly db: SqlDatabase,
-    private readonly encryptionKey?: string
+    private readonly encryptionKey: string
   ) {}
 
   /** Empty dicts are stored as plaintext "{}" so rowToMetadata() can detect "no credentials". */
   private async encryptEnv(env: Record<string, string>): Promise<string> {
     const plain = JSON.stringify(env);
-    if (!this.encryptionKey || Object.keys(env).length === 0) return plain;
+    if (Object.keys(env).length === 0) return plain;
     return encryptToken(plain, this.encryptionKey);
   }
 
   private async decryptEnv(raw: string): Promise<Record<string, string>> {
-    if (!this.encryptionKey) return safeJsonParseEnv(raw);
     try {
       const plain = await decryptToken(raw, this.encryptionKey);
       return safeJsonParseEnv(plain);

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -110,6 +110,10 @@ export class McpServerStore {
   }
 
   private async decryptEnv(raw: string): Promise<Record<string, string>> {
+    // The write side stores an empty credential map as plaintext "{}" (see
+    // encryptEnv) — recognize the sentinel, and legacy empty columns, before
+    // attempting a decrypt that is guaranteed to fail into the error path.
+    if (!raw || raw === "{}") return {};
     try {
       const plain = await decryptToken(raw, this.encryptionKey);
       return safeJsonParseEnv(plain);

--- a/packages/control-plane/src/env-validation.test.ts
+++ b/packages/control-plane/src/env-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { generateEncryptionKey } from "./auth/crypto";
+import { requireRepoSecretsEncryptionKey } from "./env-validation";
+import type { Env } from "./types";
+
+function envWith(key: string | undefined): Env {
+  return { REPO_SECRETS_ENCRYPTION_KEY: key } as Env;
+}
+
+describe("requireRepoSecretsEncryptionKey", () => {
+  it("returns a canonical base64-encoded 32-byte key", () => {
+    const key = generateEncryptionKey();
+
+    expect(requireRepoSecretsEncryptionKey(envWith(key))).toBe(key);
+  });
+
+  it("throws when the key is absent", () => {
+    expect(() => requireRepoSecretsEncryptionKey(envWith(undefined))).toThrow(/not configured/);
+  });
+
+  it("throws on malformed base64, including embedded whitespace", () => {
+    expect(() => requireRepoSecretsEncryptionKey(envWith("not base64!!"))).toThrow(
+      /not valid base64/
+    );
+    expect(() => requireRepoSecretsEncryptionKey(envWith(`${generateEncryptionKey()}\n`))).toThrow(
+      /not valid base64/
+    );
+  });
+
+  it("throws on keys that decode to the wrong length", () => {
+    // Both strings shipped as test fixtures before this validator existed:
+    // one decodes to 24 bytes (a silent AES-192 downgrade), one to 34 (a
+    // DataError at the first secret write).
+    expect(() =>
+      requireRepoSecretsEncryptionKey(envWith("0123456789abcdef0123456789abcdef"))
+    ).toThrow(/32 bytes.*got 24/);
+    expect(() =>
+      requireRepoSecretsEncryptionKey(envWith("bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA=="))
+    ).toThrow(/32 bytes.*got 34/);
+  });
+});

--- a/packages/control-plane/src/env-validation.ts
+++ b/packages/control-plane/src/env-validation.ts
@@ -9,11 +9,38 @@
 
 import type { Env } from "./types";
 
+/** Strict base64 — rejects whitespace and stray characters `atob` may accept. */
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+const AES_256_KEY_BYTES = 32;
+const KEY_GENERATION_HINT = "generate with: openssl rand -base64 32";
+
+/**
+ * Validates the full key contract, not just presence: `encryptToken` imports
+ * the base64-decoded bytes as raw AES material, so a malformed key would
+ * otherwise survive graph construction and throw at the first secret write —
+ * mid-spawn — while a short key would silently downgrade to AES-128/192.
+ */
 export function requireRepoSecretsEncryptionKey(env: Env): string {
   const key = env.REPO_SECRETS_ENCRYPTION_KEY;
   if (!key) {
     throw new Error(
       "REPO_SECRETS_ENCRYPTION_KEY is not configured; refusing to operate on secrets without encryption at rest"
+    );
+  }
+  let decodedBytes: number | null = null;
+  if (BASE64_PATTERN.test(key)) {
+    try {
+      decodedBytes = atob(key).length;
+    } catch {
+      decodedBytes = null;
+    }
+  }
+  if (decodedBytes === null) {
+    throw new Error(`REPO_SECRETS_ENCRYPTION_KEY is not valid base64 (${KEY_GENERATION_HINT})`);
+  }
+  if (decodedBytes !== AES_256_KEY_BYTES) {
+    throw new Error(
+      `REPO_SECRETS_ENCRYPTION_KEY must decode to ${AES_256_KEY_BYTES} bytes for AES-256, got ${decodedBytes} (${KEY_GENERATION_HINT})`
     );
   }
   return key;

--- a/packages/control-plane/src/env-validation.ts
+++ b/packages/control-plane/src/env-validation.ts
@@ -1,0 +1,20 @@
+/**
+ * Eager environment validation shared by worker routes and the session graph.
+ *
+ * Misconfigured deployments fail loudly at the first touch instead of running
+ * degraded (the #1602 posture). Secrets-at-rest encryption in particular must
+ * never silently fall back to plaintext: Terraform requires the key, so its
+ * absence always means a broken deployment.
+ */
+
+import type { Env } from "./types";
+
+export function requireRepoSecretsEncryptionKey(env: Env): string {
+  const key = env.REPO_SECRETS_ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error(
+      "REPO_SECRETS_ENCRYPTION_KEY is not configured; refusing to operate on secrets without encryption at rest"
+    );
+  }
+  return key;
+}

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -9,6 +9,7 @@ import {
 } from "../db/mcp-servers";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
+import { requireRepoSecretsEncryptionKey } from "../env-validation";
 import {
   type Route,
   GITHUB_USER_OR_SERVICE_ROUTE,
@@ -33,7 +34,7 @@ async function handleListMcpServers(
   const url = new URL(request.url);
   const repo = url.searchParams.get("repo") ?? undefined;
 
-  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
   const servers = await store.list(repo);
   logger.info("MCP servers listed", {
     event: "mcp_server.list",
@@ -54,7 +55,7 @@ async function handleGetMcpServer(
   if (!id) return error("Missing server ID", 400);
   if (!ctx.db) return error("Database not configured", 503);
 
-  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
   const server = await store.get(id);
   if (!server) return error("MCP server not found", 404);
   logger.info("MCP server retrieved", {
@@ -80,7 +81,7 @@ async function handleCreateMcpServer(
   if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
   try {
-    const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
     const server = await store.create(parsed.data);
     logger.info("MCP server created", {
       event: "mcp_server.created",
@@ -114,7 +115,7 @@ async function handleUpdateMcpServer(
   if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
   try {
-    const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
     const { revision, ...patch } = parsed.data;
     const updated = await store.update(id, patch, revision);
     if (!updated) return error("MCP server not found", 404);
@@ -147,7 +148,7 @@ async function handleDeleteMcpServer(
   if (!id) return error("Missing server ID", 400);
   if (!ctx.db) return error("Database not configured", 503);
 
-  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
   const deleted = await store.delete(id);
   if (!deleted) return error("MCP server not found", 404);
 

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -80,8 +80,9 @@ async function handleCreateMcpServer(
   const parsed = createMcpServerInputSchema.safeParse(body);
   if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
+  const encryptionKey = requireRepoSecretsEncryptionKey(env);
   try {
-    const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
+    const store = new McpServerStore(ctx.db, encryptionKey);
     const server = await store.create(parsed.data);
     logger.info("MCP server created", {
       event: "mcp_server.created",
@@ -114,8 +115,9 @@ async function handleUpdateMcpServer(
   const parsed = updateMcpServerInputSchema.safeParse(body);
   if (!parsed.success) return error("Invalid MCP server configuration", 400);
 
+  const encryptionKey = requireRepoSecretsEncryptionKey(env);
   try {
-    const store = new McpServerStore(ctx.db, requireRepoSecretsEncryptionKey(env));
+    const store = new McpServerStore(ctx.db, encryptionKey);
     const { revision, ...patch } = parsed.data;
     const updated = await store.update(id, patch, revision);
     if (!updated) return error("MCP server not found", 404);

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -9,6 +9,7 @@ import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
   type SandboxStorage,
+  type SessionContextReader,
   type SandboxBroadcaster,
   type WebSocketManager,
   type AlarmScheduler,
@@ -134,7 +135,7 @@ function createMockStorage(
     | null = createMockSandbox(),
   userEnvVars: Record<string, string> | undefined = undefined,
   sessionRepositories: SessionRepositoryInfo[] = []
-): SandboxStorage & { calls: string[] } {
+): SandboxStorage & SessionContextReader & { calls: string[] } {
   const calls: string[] = [];
 
   return {
@@ -474,6 +475,7 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
   const manager = new SandboxLifecycleManager(
     provider,
     storage,
+    storage,
     broadcaster,
     wsManager,
     alarmScheduler,
@@ -531,6 +533,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         alarmScheduler,
@@ -586,6 +589,7 @@ describe("SandboxLifecycleManager", () => {
         const manager = new SandboxLifecycleManager(
           provider,
           storage,
+          storage,
           createMockBroadcaster(),
           createMockWebSocketManager(false),
           alarmScheduler,
@@ -631,6 +635,7 @@ describe("SandboxLifecycleManager", () => {
         const manager = new SandboxLifecycleManager(
           provider,
           storage,
+          storage,
           createMockBroadcaster(),
           createMockWebSocketManager(false),
           createMockAlarmScheduler(),
@@ -673,6 +678,7 @@ describe("SandboxLifecycleManager", () => {
         });
         const manager = new SandboxLifecycleManager(
           provider,
+          storage,
           storage,
           createMockBroadcaster(),
           createMockWebSocketManager(false),
@@ -717,6 +723,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -744,6 +751,7 @@ describe("SandboxLifecycleManager", () => {
       const storage = createMockStorage(createMockSession(), sandbox);
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -783,6 +791,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -815,6 +824,7 @@ describe("SandboxLifecycleManager", () => {
       });
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -850,6 +860,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -878,6 +889,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -901,6 +913,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -928,6 +941,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -967,6 +981,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -1013,6 +1028,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1037,6 +1053,7 @@ describe("SandboxLifecycleManager", () => {
       const storage = createMockStorage(createMockSession(), sandbox);
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -1073,6 +1090,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1104,6 +1122,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1130,6 +1149,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -1159,6 +1179,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1180,9 +1201,11 @@ describe("SandboxLifecycleManager", () => {
         snapshot_image_id: "img-abc123",
         snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
+      const mockStorage = createMockStorage(createMockSession(), sandbox);
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
-        createMockStorage(createMockSession(), sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1222,9 +1245,11 @@ describe("SandboxLifecycleManager", () => {
           })
         ),
       });
+      const mockStorage = createMockStorage(createMockSession(), sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(createMockSession(), sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1271,6 +1296,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1313,6 +1339,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1348,6 +1375,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         createMockWebSocketManager(false),
@@ -1391,6 +1419,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         createMockWebSocketManager(false),
@@ -1436,6 +1465,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1468,6 +1498,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1498,6 +1529,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1523,6 +1555,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -1546,6 +1579,7 @@ describe("SandboxLifecycleManager", () => {
       const provider = createMockProvider();
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -1577,6 +1611,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -1616,6 +1651,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1648,6 +1684,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1677,6 +1714,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1704,6 +1742,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1730,6 +1769,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1754,6 +1794,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1776,6 +1817,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         createMockWebSocketManager(),
@@ -1817,6 +1859,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
@@ -1843,6 +1886,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         createMockWebSocketManager(),
@@ -1872,6 +1916,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
@@ -1900,6 +1945,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -1934,6 +1980,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -1963,6 +2010,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -1997,6 +2045,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         alarmScheduler,
@@ -2024,6 +2073,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -2054,6 +2104,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         wsManager,
@@ -2099,6 +2150,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         wsManager,
         createMockAlarmScheduler(),
@@ -2138,6 +2190,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false, 0),
@@ -2181,6 +2234,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false, 0),
         createMockAlarmScheduler(),
@@ -2208,6 +2262,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         createMockWebSocketManager(),
@@ -2247,6 +2302,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(),
         alarmScheduler,
@@ -2280,6 +2336,7 @@ describe("SandboxLifecycleManager", () => {
         const manager = new SandboxLifecycleManager(
           provider,
           storage,
+          storage,
           createMockBroadcaster(),
           wsManager,
           createMockAlarmScheduler(),
@@ -2300,12 +2357,14 @@ describe("SandboxLifecycleManager", () => {
         resolveStop = resolve;
       });
       const wsManager = createMockWebSocketManager(true);
+      const mockStorage = createMockStorage();
       const manager = new SandboxLifecycleManager(
         createMockProvider({
           capabilities: { supportsExplicitStop: true },
           stopSandbox: vi.fn(() => providerStop),
         }),
-        createMockStorage(),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         wsManager,
         createMockAlarmScheduler(),
@@ -2338,6 +2397,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(),
         alarmScheduler,
@@ -2368,6 +2428,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -2390,6 +2451,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         wsManager,
         createMockAlarmScheduler(),
@@ -2411,6 +2473,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         broadcaster,
         wsManager,
@@ -2436,6 +2499,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(),
         createMockAlarmScheduler(),
@@ -2459,6 +2523,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         createMockProvider(),
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(),
@@ -2514,6 +2579,7 @@ describe("SandboxLifecycleManager", () => {
       const provider = overrides?.provider ?? createMockProvider();
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -2728,6 +2794,7 @@ describe("SandboxLifecycleManager", () => {
       const provider = overrides?.provider ?? createMockProvider();
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -2963,6 +3030,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3078,9 +3146,11 @@ describe("SandboxLifecycleManager", () => {
       });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const provider = createMockProvider();
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3105,9 +3175,11 @@ describe("SandboxLifecycleManager", () => {
         snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
       });
       const provider = createMockProvider();
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3135,9 +3207,11 @@ describe("SandboxLifecycleManager", () => {
         capabilities: { supportsPersistentResume: true },
         resumeSandbox: vi.fn(async () => ({ success: true })),
       });
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3159,9 +3233,11 @@ describe("SandboxLifecycleManager", () => {
       });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const provider = createMockProvider();
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3180,9 +3256,11 @@ describe("SandboxLifecycleManager", () => {
       const session = createMockSession({ spawn_source: "agent", sandbox_settings: null });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const provider = createMockProvider();
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3207,9 +3285,11 @@ describe("SandboxLifecycleManager", () => {
         capabilities: { supportsSandboxTimeout: false },
       });
       const broadcaster = createMockBroadcaster();
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3232,9 +3312,11 @@ describe("SandboxLifecycleManager", () => {
       const provider = createMockProvider({
         capabilities: { supportsSandboxTimeout: false },
       });
+      const mockStorage = createMockStorage(session, sandbox);
       const manager = new SandboxLifecycleManager(
         provider,
-        createMockStorage(session, sandbox),
+        mockStorage,
+        mockStorage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3260,6 +3342,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3284,6 +3367,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -3312,6 +3396,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3339,6 +3424,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3365,6 +3451,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -3402,6 +3489,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3436,6 +3524,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3464,6 +3553,7 @@ describe("SandboxLifecycleManager", () => {
 
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -3503,6 +3593,7 @@ describe("SandboxLifecycleManager", () => {
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
+        storage,
         broadcaster,
         createMockWebSocketManager(false),
         createMockAlarmScheduler(),
@@ -3537,6 +3628,7 @@ describe("SandboxLifecycleManager", () => {
       const config = { ...createTestConfig(), slackAgentNotifyLookup: opts.lookup };
       const manager = new SandboxLifecycleManager(
         provider,
+        storage,
         storage,
         createMockBroadcaster(),
         createMockWebSocketManager(false),
@@ -3707,9 +3799,11 @@ describe("SandboxLifecycleManager", () => {
 describe("SandboxLifecycleManager log context", () => {
   it("derives session_id from getSessionId per use, upgrading once the id changes", async () => {
     let currentId = "do-fallback-id";
+    const mockStorage = createMockStorage(null);
     const manager = new SandboxLifecycleManager(
       createMockProvider(),
-      createMockStorage(null),
+      mockStorage,
+      mockStorage,
       createMockBroadcaster(),
       createMockWebSocketManager(false),
       createMockAlarmScheduler(),
@@ -3736,9 +3830,11 @@ describe("SandboxLifecycleManager log context", () => {
   });
 
   it("omits session_id entirely when no getSessionId is configured", async () => {
+    const mockStorage = createMockStorage(null);
     const manager = new SandboxLifecycleManager(
       createMockProvider(),
-      createMockStorage(null),
+      mockStorage,
+      mockStorage,
       createMockBroadcaster(),
       createMockWebSocketManager(false),
       createMockAlarmScheduler(),
@@ -3767,6 +3863,7 @@ describe("spawn admission race (#1589)", () => {
     const storage = createMockStorage(createMockSession(), sandbox);
     const manager = new SandboxLifecycleManager(
       createMockProvider(),
+      storage,
       storage,
       createMockBroadcaster(),
       createMockWebSocketManager(false),

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1064,7 +1064,7 @@ describe("SandboxLifecycleManager", () => {
         last_spawn_failure: now - 60000,
       });
       const storage = createMockStorage(createMockSession(), sandbox);
-      // updateSandboxSpawnError is a bare synchronous sql.exec in the DO, so
+      // setLastSpawnError is a bare synchronous sql.exec in the DO, so
       // this is a real failure mode, not a hypothetical one.
       vi.mocked(storage.setLastSpawnError).mockImplementation(() => {
         throw new Error("storage unavailable");

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -815,7 +815,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * changing state, and that distinction is theirs to make.
    */
   reportSandboxError(reason: string): void {
-    // Persisting is best effort. `updateSandboxSpawnError` is a bare synchronous
+    // Persisting is best effort. `setLastSpawnError` is a bare synchronous
     // sql.exec, so a storage failure would otherwise also cost the broadcast —
     // the one signal an already-open tab gets — and, from the message queue's
     // spawn catch, would replace the spawn error being reported with the

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -79,13 +79,12 @@ interface SandboxCircuitBreakerInfo {
 }
 
 /**
- * Storage adapter for sandbox data operations.
+ * The session context a spawn needs alongside sandbox storage. A separate
+ * port from `SandboxStorage`: sandbox-row persistence is one collaborator's
+ * contract, these reads belong to others, and conflating them forced every
+ * implementer to bridge unrelated objects.
  */
-export interface SandboxStorage {
-  /** Get current sandbox state */
-  getSandbox(): SandboxRow | null;
-  /** Get sandbox with circuit breaker state (subset of fields) */
-  getSandboxWithCircuitBreaker(): SandboxCircuitBreakerInfo | null;
+export interface SessionContextReader {
   /** Get current session */
   getSession(): SessionRow | null;
   /**
@@ -97,6 +96,17 @@ export interface SandboxStorage {
   getSessionRepositories(): SessionRepositoryInfo[];
   /** Get user env vars for sandbox injection */
   getUserEnvVars(): Promise<Record<string, string> | undefined>;
+}
+
+/**
+ * Storage adapter for sandbox data operations — the sandbox repository's
+ * contract, satisfied by it structurally.
+ */
+export interface SandboxStorage {
+  /** Get current sandbox state */
+  getSandbox(): SandboxRow | null;
+  /** Get sandbox with circuit breaker state (subset of fields) */
+  getSandboxWithCircuitBreaker(): SandboxCircuitBreakerInfo | null;
   /** Update sandbox status */
   updateSandboxStatus(status: SandboxStatus): void;
   /**
@@ -357,6 +367,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   constructor(
     private readonly provider: SandboxProvider,
     private readonly storage: SandboxStorage,
+    private readonly sessionContext: SessionContextReader,
     private readonly broadcaster: SandboxBroadcaster,
     private readonly wsManager: WebSocketManager,
     private readonly alarmScheduler: AlarmScheduler,
@@ -508,7 +519,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     let session: SessionRow | null = null;
 
     try {
-      session = this.storage.getSession();
+      session = this.sessionContext.getSession();
       if (!session) {
         this.log.error("Cannot spawn sandbox: no session");
         return;
@@ -525,9 +536,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
       await this.stopPriorProviderSandbox();
 
-      const userEnvVars = await this.storage.getUserEnvVars();
+      const userEnvVars = await this.sessionContext.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
-      const repositories = this.storage.getSessionRepositories();
+      const repositories = this.sessionContext.getSessionRepositories();
       const multiRepoFields = multiRepoSpawnFields(repositories);
 
       // Prebuilt-image selection: an environment session matches its
@@ -851,7 +862,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     let session: SessionRow | null = null;
 
     try {
-      session = this.storage.getSession();
+      session = this.sessionContext.getSession();
       if (!session) {
         this.log.error("Cannot restore: no session");
         return;
@@ -874,10 +885,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
       await this.stopPriorProviderSandbox();
 
-      const userEnvVars = await this.storage.getUserEnvVars();
+      const userEnvVars = await this.sessionContext.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
 
-      const repositories = this.storage.getSessionRepositories();
+      const repositories = this.sessionContext.getSessionRepositories();
       const codeServerEnabled = session.code_server_enabled === 1;
       const vncEnabled = session.vnc_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
@@ -993,7 +1004,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     this.providerStartupPending = true;
 
     try {
-      const session = this.storage.getSession();
+      const session = this.sessionContext.getSession();
       const sandbox = this.storage.getSandbox();
       if (!session || !sandbox?.modal_sandbox_id) {
         this.log.error("Cannot resume sandbox: missing session or logical sandbox ID");
@@ -1074,7 +1085,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
 
     const sandbox = this.storage.getSandbox();
-    const session = this.storage.getSession();
+    const session = this.sessionContext.getSession();
 
     if (!sandbox?.modal_object_id || !session) {
       this.log.debug("Cannot snapshot: no modal_object_id or session");
@@ -1242,7 +1253,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
 
     const sandbox = providerObjectId ? null : this.storage.getSandbox();
-    const session = this.storage.getSession();
+    const session = this.sessionContext.getSession();
     const objectId = providerObjectId ?? sandbox?.modal_object_id;
     if (!objectId || !session) {
       return;

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -44,11 +44,12 @@ import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integratio
 import { SessionIndexStore } from "../db/session-index";
 import { parsePersistedSandboxSettings } from "../sandbox/settings";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
+import { requireRepoSecretsEncryptionKey } from "../env-validation";
 import type { Env, ClientInfo } from "../types";
 import type { SessionRow } from "./types";
 import type { SqlDatabase } from "../db/sql-database";
 import { SessionCoreRepository } from "./session-core-repository";
-import { SandboxRepository } from "./sandbox-repository";
+import type { SandboxRepository } from "./sandbox-repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
 import { ArtifactRepository } from "./artifact-repository";
 import { EventRepository } from "./event-repository";
@@ -219,6 +220,10 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   const sessionCoreRepository = new SessionCoreRepository(sql, transaction);
   const alarmDeadlines = new PersistedAlarmDeadlineStore(sql);
 
+  // Secrets-at-rest encryption is not optional. Every consumer below takes
+  // the validated key, so no fallback path can persist a secret in plaintext.
+  const repoSecretsEncryptionKey = requireRepoSecretsEncryptionKey(env);
+
   // The session-scoped logger, created before anything can capture a logger
   // at all. Its `session_id` is injected per emit through the latched
   // resolver: before `init` writes the session row it is the Durable Object
@@ -233,9 +238,40 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     getPublicSessionId
   );
   const backgroundTasks = createCloudflareBackgroundTasks(ctx, () => log);
-  // The sandbox repository validates the status it reads and warns on anything
-  // unmodelled, so it needs the session logger.
-  const sandboxRepository = new SandboxRepository(sql, log);
+
+  // Constructed eagerly — an invalid SCM configuration fails right here. The
+  // cell is a local `let` so live-DO integration tests can substitute a stub
+  // after the init request has already built this graph; consumer closures
+  // read the cell per call (never through the returned record), and
+  // `internals.sourceControlProvider` exposes it as an accessor pair.
+  let scmProvider: SourceControlProvider = createSourceControlProviderFromEnv(env);
+  const sourceControlProvider = () => scmProvider;
+  const scmProviderName = scmProvider.name;
+
+  const resolveRepoId = (sessionRow: SessionRow) =>
+    resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider);
+
+  const userEnvResolver = new UserEnvResolver({
+    db,
+    sessionCoreRepository,
+    resolveRepoId,
+    durableObjectId,
+    repoSecretsEncryptionKey,
+    secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
+    log,
+  });
+
+  // The single sandbox-storage instance: the repository (which validates the
+  // status it reads and owns encrypt-at-rest, so it needs the session logger
+  // and the key) plus the session-context reads the lifecycle manager's
+  // storage port bundles with it.
+  const sandboxRepository = new DurableObjectSandboxStorage(
+    sql,
+    log,
+    repoSecretsEncryptionKey,
+    sessionCoreRepository,
+    userEnvResolver
+  );
 
   // Tier 2 — sockets and alarm scheduling.
   const wsManager: SessionWebSocketManager = new SessionWebSocketManagerImpl(
@@ -258,21 +294,10 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   // Tier 3 — outbound delivery over the socket registry.
   const messenger: SessionMessenger = new SessionMessengerImpl(wsManager);
 
-  // Constructed eagerly — an invalid SCM configuration fails right here. The
-  // cell is a local `let` so live-DO integration tests can substitute a stub
-  // after the init request has already built this graph; consumer closures
-  // read the cell per call (never through the returned record), and
-  // `internals.sourceControlProvider` exposes it as an accessor pair.
-  let scmProvider: SourceControlProvider = createSourceControlProviderFromEnv(env);
-  const sourceControlProvider = () => scmProvider;
-  const scmProviderName = scmProvider.name;
-
   // Shared single instances/closures — every consumer below takes these
   // rather than re-deriving its own copy.
   const sessionIndexStore = db ? new SessionIndexStore(db) : null;
   const sessionPullRequestStore = db ? new SessionPullRequestStore(db) : null;
-  const resolveRepoId = (sessionRow: SessionRow) =>
-    resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider);
 
   const sandboxDashboardSettings: SandboxDashboardSettings = {
     sandboxProvider: env.SANDBOX_PROVIDER,
@@ -281,16 +306,6 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   };
 
   // Tier 4 — session-scoped domain services.
-  const userEnvResolver = new UserEnvResolver({
-    db,
-    sessionCoreRepository,
-    resolveRepoId,
-    durableObjectId,
-    repoSecretsEncryptionKey: env.REPO_SECRETS_ENCRYPTION_KEY,
-    secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
-    log,
-  });
-
   const terminalMessageProjection = new SessionTerminalMessageProjection(
     sessionIndexStore,
     () => {
@@ -368,9 +383,8 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     env,
     db,
     getSessionId: getPublicSessionId,
-    sessionCoreRepository,
-    sandboxRepository,
-    userEnvResolver,
+    storage: sandboxRepository,
+    repoSecretsEncryptionKey,
     messenger,
     wsManager,
     alarmScheduler,
@@ -513,7 +527,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     refreshOpenAIToken: async (sessionRow, requestLog) => {
       const service = new OpenAITokenRefreshService(
         db!,
-        env.REPO_SECRETS_ENCRYPTION_KEY!,
+        repoSecretsEncryptionKey,
         resolveRepoId,
         requestLog
       );
@@ -522,13 +536,13 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     refreshXaiToken: async (sessionRow, requestLog) => {
       const service = new XaiTokenRefreshService(
         db!,
-        env.REPO_SECRETS_ENCRYPTION_KEY!,
+        repoSecretsEncryptionKey,
         resolveRepoId,
         requestLog
       );
       return service.refresh(sessionRow);
     },
-    isManagedSecretsConfigured: () => Boolean(db && env.REPO_SECRETS_ENCRYPTION_KEY),
+    isManagedSecretsConfigured: () => Boolean(db),
     getScmCredentials: (requestLog) =>
       new ScmCredentialsService(sourceControlProvider(), requestLog).getCredentials(),
     messenger,
@@ -633,7 +647,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   const accessReader = new SessionAccessReader({
     sessionCoreRepository,
     sandboxRepository,
-    repoSecretsEncryptionKey: env.REPO_SECRETS_ENCRYPTION_KEY,
+    repoSecretsEncryptionKey,
     log,
   });
 
@@ -800,9 +814,9 @@ interface LifecycleManagerDeps {
   db: SqlDatabase | null;
   /** The latched public-session-id resolver shared with the session logger. */
   getSessionId: () => string;
-  sessionCoreRepository: SessionCoreRepository;
-  sandboxRepository: SandboxRepository;
-  userEnvResolver: UserEnvResolver;
+  /** The one storage instance — the repository with its session-context reads. */
+  storage: DurableObjectSandboxStorage;
+  repoSecretsEncryptionKey: string;
   messenger: SessionMessenger;
   wsManager: SessionWebSocketManager;
   alarmScheduler: RehydratableAlarmScheduler;
@@ -815,9 +829,8 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     env,
     db,
     getSessionId,
-    sessionCoreRepository,
-    sandboxRepository,
-    userEnvResolver,
+    storage,
+    repoSecretsEncryptionKey,
     messenger,
     wsManager,
     alarmScheduler,
@@ -829,12 +842,6 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
   const sandboxBackend = resolveSandboxBackendName(env.SANDBOX_PROVIDER);
   const provider = createSandboxProviderFromEnv(env, sandboxBackend);
 
-  const storage = new DurableObjectSandboxStorage(
-    sandboxRepository,
-    sessionCoreRepository,
-    userEnvResolver,
-    env.REPO_SECRETS_ENCRYPTION_KEY
-  );
   const lifecycleWsManager = new LifecycleSocketAdapter(wsManager);
 
   // ID generator adapter
@@ -850,7 +857,7 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
   // Create D1-backed lookups if database is available
   let mcpServerLookup: McpServerLookup | undefined;
   if (db) {
-    const mcpStore = new McpServerStore(db, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const mcpStore = new McpServerStore(db, repoSecretsEncryptionKey);
     mcpServerLookup = {
       getDecryptedForSession: (repositories) => mcpStore.getDecryptedForSession(repositories),
     };

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -34,6 +34,8 @@ import type { Logger } from "../logger";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
+  type SandboxStorage,
+  type SessionContextReader,
   type IdGenerator,
   type ImageBuildLookup,
   type McpServerLookup,
@@ -49,7 +51,7 @@ import type { Env, ClientInfo } from "../types";
 import type { SessionRow } from "./types";
 import type { SqlDatabase } from "../db/sql-database";
 import { SessionCoreRepository } from "./session-core-repository";
-import type { SandboxRepository } from "./sandbox-repository";
+import { SandboxRepository } from "./sandbox-repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
 import { ArtifactRepository } from "./artifact-repository";
 import { EventRepository } from "./event-repository";
@@ -65,7 +67,7 @@ import {
   type SandboxDashboardSettings,
 } from "./sandbox-access";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
-import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
+import { LifecycleSessionContext, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
 import { SessionClientCommandFacade } from "./client-command-facade";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
 import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
@@ -238,40 +240,10 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     getPublicSessionId
   );
   const backgroundTasks = createCloudflareBackgroundTasks(ctx, () => log);
-
-  // Constructed eagerly — an invalid SCM configuration fails right here. The
-  // cell is a local `let` so live-DO integration tests can substitute a stub
-  // after the init request has already built this graph; consumer closures
-  // read the cell per call (never through the returned record), and
-  // `internals.sourceControlProvider` exposes it as an accessor pair.
-  let scmProvider: SourceControlProvider = createSourceControlProviderFromEnv(env);
-  const sourceControlProvider = () => scmProvider;
-  const scmProviderName = scmProvider.name;
-
-  const resolveRepoId = (sessionRow: SessionRow) =>
-    resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider);
-
-  const userEnvResolver = new UserEnvResolver({
-    db,
-    sessionCoreRepository,
-    resolveRepoId,
-    durableObjectId,
-    repoSecretsEncryptionKey,
-    secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
-    log,
-  });
-
-  // The single sandbox-storage instance: the repository (which validates the
-  // status it reads and owns encrypt-at-rest, so it needs the session logger
-  // and the key) plus the session-context reads the lifecycle manager's
-  // storage port bundles with it.
-  const sandboxRepository = new DurableObjectSandboxStorage(
-    sql,
-    log,
-    repoSecretsEncryptionKey,
-    sessionCoreRepository,
-    userEnvResolver
-  );
+  // The sandbox repository validates the status it reads and warns on anything
+  // unmodelled, so it needs the session logger — and it owns encrypt-at-rest
+  // for access secrets, so it takes the key.
+  const sandboxRepository = new SandboxRepository(sql, log, repoSecretsEncryptionKey);
 
   // Tier 2 — sockets and alarm scheduling.
   const wsManager: SessionWebSocketManager = new SessionWebSocketManagerImpl(
@@ -294,10 +266,21 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   // Tier 3 — outbound delivery over the socket registry.
   const messenger: SessionMessenger = new SessionMessengerImpl(wsManager);
 
+  // Constructed eagerly — an invalid SCM configuration fails right here. The
+  // cell is a local `let` so live-DO integration tests can substitute a stub
+  // after the init request has already built this graph; consumer closures
+  // read the cell per call (never through the returned record), and
+  // `internals.sourceControlProvider` exposes it as an accessor pair.
+  let scmProvider: SourceControlProvider = createSourceControlProviderFromEnv(env);
+  const sourceControlProvider = () => scmProvider;
+  const scmProviderName = scmProvider.name;
+
   // Shared single instances/closures — every consumer below takes these
   // rather than re-deriving its own copy.
   const sessionIndexStore = db ? new SessionIndexStore(db) : null;
   const sessionPullRequestStore = db ? new SessionPullRequestStore(db) : null;
+  const resolveRepoId = (sessionRow: SessionRow) =>
+    resolveSessionRepoId(sessionRow, sessionCoreRepository, sourceControlProvider);
 
   const sandboxDashboardSettings: SandboxDashboardSettings = {
     sandboxProvider: env.SANDBOX_PROVIDER,
@@ -306,6 +289,16 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   };
 
   // Tier 4 — session-scoped domain services.
+  const userEnvResolver = new UserEnvResolver({
+    db,
+    sessionCoreRepository,
+    resolveRepoId,
+    durableObjectId,
+    repoSecretsEncryptionKey,
+    secretsCapEnforcement: env.SECRETS_CAP_ENFORCEMENT,
+    log,
+  });
+
   const terminalMessageProjection = new SessionTerminalMessageProjection(
     sessionIndexStore,
     () => {
@@ -384,6 +377,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     db,
     getSessionId: getPublicSessionId,
     storage: sandboxRepository,
+    sessionContext: new LifecycleSessionContext(sessionCoreRepository, userEnvResolver),
     repoSecretsEncryptionKey,
     messenger,
     wsManager,
@@ -814,8 +808,9 @@ interface LifecycleManagerDeps {
   db: SqlDatabase | null;
   /** The latched public-session-id resolver shared with the session logger. */
   getSessionId: () => string;
-  /** The one storage instance — the repository with its session-context reads. */
-  storage: DurableObjectSandboxStorage;
+  /** The repository, satisfying the manager's storage port structurally. */
+  storage: SandboxStorage;
+  sessionContext: SessionContextReader;
   repoSecretsEncryptionKey: string;
   messenger: SessionMessenger;
   wsManager: SessionWebSocketManager;
@@ -830,6 +825,7 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
     db,
     getSessionId,
     storage,
+    sessionContext,
     repoSecretsEncryptionKey,
     messenger,
     wsManager,
@@ -918,6 +914,7 @@ function createLifecycleManager(deps: LifecycleManagerDeps): SandboxLifecycleMan
   return new SandboxLifecycleManager(
     provider,
     storage,
+    sessionContext,
     messenger,
     lifecycleWsManager,
     alarmScheduler,

--- a/packages/control-plane/src/session/sandbox-access-reader.ts
+++ b/packages/control-plane/src/session/sandbox-access-reader.ts
@@ -6,7 +6,7 @@ import type { SessionCoreRepository } from "./session-core-repository";
 export interface SessionAccessReaderDeps {
   sessionCoreRepository: SessionCoreRepository;
   sandboxRepository: SandboxRepository;
-  repoSecretsEncryptionKey: string | undefined;
+  repoSecretsEncryptionKey: string;
   log: Logger;
 }
 

--- a/packages/control-plane/src/session/sandbox-access.test.ts
+++ b/packages/control-plane/src/session/sandbox-access.test.ts
@@ -54,13 +54,6 @@ describe("decryptStoredAccessValue", () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
-  it("returns the value verbatim when no encryption key is configured", async () => {
-    const log = warnLog();
-
-    await expect(decryptStoredAccessValue("plaintext", undefined, log)).resolves.toBe("plaintext");
-    expect(log.warn).not.toHaveBeenCalled();
-  });
-
   it("round-trips a value encrypted with the configured key", async () => {
     const encrypted = await encryptToken("s3cret", ENCRYPTION_KEY);
 

--- a/packages/control-plane/src/session/sandbox-access.ts
+++ b/packages/control-plane/src/session/sandbox-access.ts
@@ -51,11 +51,10 @@ export async function isValidSandboxToken(
  */
 export async function decryptStoredAccessValue(
   value: string | null,
-  encryptionKey: string | undefined,
+  encryptionKey: string,
   log: Pick<Logger, "warn">
 ): Promise<string | null> {
   if (!value) return null;
-  if (!encryptionKey) return value;
   try {
     return await decryptToken(value, encryptionKey);
   } catch (error) {

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
@@ -1,27 +1,27 @@
 /**
- * Unit tests for the lifecycle-manager port adapters — the pieces with real
- * logic: the encrypt-before-store branch, the repository-shape defaults, the
- * setLastSpawnError rename, and the no-socket send branch. Pure forwards are
- * covered through the manager and server suites.
+ * Unit tests for the lifecycle-manager port adapters. The storage class is
+ * the repository itself plus three session-context reads, so the tests cover
+ * the context logic (repository-shape defaults) and pin the inheritance
+ * wiring; encryption behavior lives with the repository and is tested there.
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { decryptToken } from "../auth/crypto";
 import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
-import type { SandboxRepository } from "./sandbox-repository";
+import type { SqlStorage } from "./sql-storage";
+import type { Logger } from "../logger";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
-const ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef";
-
-function createStorage(overrides: { encryptionKey?: string } = {}) {
-  const sandboxes = {
-    updateSandboxCodeServer: vi.fn(),
-    updateSandboxVnc: vi.fn(),
-    updateSandboxTtyd: vi.fn(),
-    updateSandboxSpawnError: vi.fn(),
-  } as unknown as SandboxRepository;
+function createStorage() {
+  const execCalls: string[] = [];
+  const sql = {
+    exec: vi.fn((query: string) => {
+      execCalls.push(query);
+      return { toArray: () => [], one: () => null };
+    }),
+  } as unknown as SqlStorage;
+  const log = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as Logger;
   const sessions = {
     getSessionRepositories: vi.fn(() => [
       { repoOwner: "acme", repoName: "web-app", baseBranch: null, row: undefined },
@@ -33,51 +33,20 @@ function createStorage(overrides: { encryptionKey?: string } = {}) {
       },
     ]),
   } as unknown as SessionCoreRepository;
-  const userEnv = {} as UserEnvResolver;
+  const userEnv = {
+    getUserEnvVars: vi.fn(async () => ({ FOO: "bar" })),
+  } as unknown as UserEnvResolver;
   const storage = new DurableObjectSandboxStorage(
-    sandboxes,
+    sql,
+    log,
+    "0123456789abcdef0123456789abcdef",
     sessions,
-    userEnv,
-    overrides.encryptionKey
+    userEnv
   );
-  return { storage, sandboxes, sessions };
+  return { storage, execCalls, userEnv };
 }
 
 describe("DurableObjectSandboxStorage", () => {
-  it("encrypts secrets before storing when a key is configured", async () => {
-    const { storage, sandboxes } = createStorage({ encryptionKey: ENCRYPTION_KEY });
-
-    await storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
-    await storage.updateSandboxVnc("https://vnc.example", "vnc-secret");
-    await storage.updateSandboxTtyd("https://ttyd.example", "ttyd-token");
-
-    for (const [mock, url, plaintext] of [
-      [vi.mocked(sandboxes.updateSandboxCodeServer), "https://cs.example", "cs-secret"],
-      [vi.mocked(sandboxes.updateSandboxVnc), "https://vnc.example", "vnc-secret"],
-      [vi.mocked(sandboxes.updateSandboxTtyd), "https://ttyd.example", "ttyd-token"],
-    ] as const) {
-      const [storedUrl, storedSecret] = mock.mock.calls[0];
-      expect(storedUrl).toBe(url);
-      expect(storedSecret).not.toBe(plaintext);
-      await expect(decryptToken(storedSecret, ENCRYPTION_KEY)).resolves.toBe(plaintext);
-    }
-  });
-
-  it("stores secrets as-is and synchronously when no key is configured", () => {
-    const { storage, sandboxes } = createStorage();
-
-    // No await before asserting: the keyless branch must persist before the
-    // call returns, so a same-turn caller that does not await still observes
-    // the write (and a later clear cannot be overwritten by a deferred store).
-    const result = storage.updateSandboxCodeServer("https://cs.example", "cs-secret");
-
-    expect(result).toBeUndefined();
-    expect(sandboxes.updateSandboxCodeServer).toHaveBeenCalledWith(
-      "https://cs.example",
-      "cs-secret"
-    );
-  });
-
   it("maps repository entries with baseBranch and baseSha defaults", () => {
     const { storage } = createStorage();
 
@@ -87,12 +56,19 @@ describe("DurableObjectSandboxStorage", () => {
     ]);
   });
 
-  it("forwards setLastSpawnError to the spawn-error column update", () => {
-    const { storage, sandboxes } = createStorage();
+  it("forwards user env resolution to the resolver", async () => {
+    const { storage, userEnv } = createStorage();
 
-    storage.setLastSpawnError("boom", 1234);
+    await expect(storage.getUserEnvVars()).resolves.toEqual({ FOO: "bar" });
+    expect(userEnv.getUserEnvVars).toHaveBeenCalledOnce();
+  });
 
-    expect(sandboxes.updateSandboxSpawnError).toHaveBeenCalledWith("boom", 1234);
+  it("is the repository — sandbox writes hit SQL with no forwarding layer", () => {
+    const { storage, execCalls } = createStorage();
+
+    storage.updateSandboxStatus("ready");
+
+    expect(execCalls[0]).toContain("UPDATE sandbox SET status");
   });
 });
 

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
@@ -1,75 +1,49 @@
 /**
- * Unit tests for the lifecycle-manager port adapters. The storage class is
- * the repository itself plus three session-context reads, so the tests cover
- * the context logic (repository-shape defaults) and pin the inheritance
- * wiring; encryption behavior lives with the repository and is tested there.
+ * Unit tests for the lifecycle-manager port adapters: the session-context
+ * facade's repository-shape defaults and the socket slice's send branches.
+ * Sandbox storage needs no adapter — the repository satisfies that port
+ * directly and is tested as itself.
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { generateEncryptionKey } from "../auth/crypto";
-import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
-import type { SqlStorage } from "./sql-storage";
-import type { Logger } from "../logger";
+import { LifecycleSessionContext, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
-function createStorage() {
-  const execCalls: string[] = [];
-  const sql = {
-    exec: vi.fn((query: string) => {
-      execCalls.push(query);
-      return { toArray: () => [], one: () => null };
-    }),
-  } as unknown as SqlStorage;
-  const log = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as Logger;
-  const sessions = {
-    getSessionRepositories: vi.fn(() => [
-      { repoOwner: "acme", repoName: "web-app", baseBranch: null, row: undefined },
-      {
-        repoOwner: "acme",
-        repoName: "api",
-        baseBranch: "develop",
-        row: { base_sha: "abc123" },
-      },
-    ]),
-  } as unknown as SessionCoreRepository;
-  const userEnv = {
-    getUserEnvVars: vi.fn(async () => ({ FOO: "bar" })),
-  } as unknown as UserEnvResolver;
-  const storage = new DurableObjectSandboxStorage(
-    sql,
-    log,
-    generateEncryptionKey(),
-    sessions,
-    userEnv
-  );
-  return { storage, execCalls, userEnv };
-}
+describe("LifecycleSessionContext", () => {
+  function createContext() {
+    const sessions = {
+      getSessionRepositories: vi.fn(() => [
+        { repoOwner: "acme", repoName: "web-app", baseBranch: null, row: undefined },
+        {
+          repoOwner: "acme",
+          repoName: "api",
+          baseBranch: "develop",
+          row: { base_sha: "abc123" },
+        },
+      ]),
+    } as unknown as SessionCoreRepository;
+    const userEnv = {
+      getUserEnvVars: vi.fn(async () => ({ FOO: "bar" })),
+    } as unknown as UserEnvResolver;
+    return { context: new LifecycleSessionContext(sessions, userEnv), userEnv };
+  }
 
-describe("DurableObjectSandboxStorage", () => {
   it("maps repository entries with baseBranch and baseSha defaults", () => {
-    const { storage } = createStorage();
+    const { context } = createContext();
 
-    expect(storage.getSessionRepositories()).toEqual([
+    expect(context.getSessionRepositories()).toEqual([
       { repoOwner: "acme", repoName: "web-app", baseBranch: "main", baseSha: null },
       { repoOwner: "acme", repoName: "api", baseBranch: "develop", baseSha: "abc123" },
     ]);
   });
 
   it("forwards user env resolution to the resolver", async () => {
-    const { storage, userEnv } = createStorage();
+    const { context, userEnv } = createContext();
 
-    await expect(storage.getUserEnvVars()).resolves.toEqual({ FOO: "bar" });
+    await expect(context.getUserEnvVars()).resolves.toEqual({ FOO: "bar" });
     expect(userEnv.getUserEnvVars).toHaveBeenCalledOnce();
-  });
-
-  it("is the repository — sandbox writes hit SQL with no forwarding layer", () => {
-    const { storage, execCalls } = createStorage();
-
-    storage.updateSandboxStatus("ready");
-
-    expect(execCalls[0]).toContain("UPDATE sandbox SET status");
   });
 });
 

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { generateEncryptionKey } from "../auth/crypto";
 import { DurableObjectSandboxStorage, LifecycleSocketAdapter } from "./sandbox-lifecycle-adapters";
 import type { SqlStorage } from "./sql-storage";
 import type { Logger } from "../logger";
@@ -39,7 +40,7 @@ function createStorage() {
   const storage = new DurableObjectSandboxStorage(
     sql,
     log,
-    "0123456789abcdef0123456789abcdef",
+    generateEncryptionKey(),
     sessions,
     userEnv
   );

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -1,33 +1,26 @@
 /**
  * Composition-root adapters for the sandbox lifecycle manager's ports.
  *
- * `DurableObjectSandboxStorage` satisfies the manager's `SandboxStorage` port
- * without a forwarding layer: the sandbox-row surface (encryption included) is
- * the repository itself, inherited; this class adds only the session-context
- * reads the port bundles with it. Keeping the `implements` here — not on the
- * repository — keeps the manager-port dependency at the composition edge.
+ * `SandboxStorage` needs no adapter at all — it is the repository's contract
+ * and `SandboxRepository` satisfies it structurally. What lives here are the
+ * two ports that genuinely span or narrow other collaborators: the session
+ * context the manager reads alongside storage, and the slice of the socket
+ * registry it may touch.
  */
 
-import type { SandboxStorage, WebSocketManager } from "../sandbox/lifecycle/manager";
+import type { SessionContextReader, WebSocketManager } from "../sandbox/lifecycle/manager";
 import type { SessionRepositoryInfo } from "../sandbox/provider";
-import type { Logger } from "../logger";
-import { SandboxRepository } from "./sandbox-repository";
-import type { SqlStorage } from "./sql-storage";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionRow } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
-export class DurableObjectSandboxStorage extends SandboxRepository implements SandboxStorage {
+/** The session-context reads owned by the session repositories and resolver. */
+export class LifecycleSessionContext implements SessionContextReader {
   constructor(
-    sql: SqlStorage,
-    log: Logger,
-    encryptionKey: string,
     private readonly sessions: SessionCoreRepository,
     private readonly userEnv: UserEnvResolver
-  ) {
-    super(sql, log, encryptionKey);
-  }
+  ) {}
 
   getSession(): SessionRow | null {
     return this.sessions.getSession();

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -1,43 +1,32 @@
 /**
  * Composition-root adapters for the sandbox lifecycle manager's ports.
  *
- * The manager owns `SandboxStorage` and `WebSocketManager`; these classes
- * implement them over the session's collaborators so the root wires objects
- * instead of building closure-bag literals inline (deps standard: pass
- * collaborators directly, give shared-collaborator groups a composition
- * class).
+ * `DurableObjectSandboxStorage` satisfies the manager's `SandboxStorage` port
+ * without a forwarding layer: the sandbox-row surface (encryption included) is
+ * the repository itself, inherited; this class adds only the session-context
+ * reads the port bundles with it. Keeping the `implements` here — not on the
+ * repository — keeps the manager-port dependency at the composition edge.
  */
 
-import { encryptToken } from "../auth/crypto";
 import type { SandboxStorage, WebSocketManager } from "../sandbox/lifecycle/manager";
 import type { SessionRepositoryInfo } from "../sandbox/provider";
-import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
-import type {
-  SandboxRepository,
-  SandboxCircuitBreakerState,
-  SpawnSandboxData,
-  ResumeSandboxData,
-} from "./sandbox-repository";
+import type { Logger } from "../logger";
+import { SandboxRepository } from "./sandbox-repository";
+import type { SqlStorage } from "./sql-storage";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { UserEnvResolver } from "./user-env-resolver";
+import type { SessionRow } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
-import type { SandboxRow, SessionRow } from "./types";
 
-export class DurableObjectSandboxStorage implements SandboxStorage {
+export class DurableObjectSandboxStorage extends SandboxRepository implements SandboxStorage {
   constructor(
-    private readonly sandboxes: SandboxRepository,
+    sql: SqlStorage,
+    log: Logger,
+    encryptionKey: string,
     private readonly sessions: SessionCoreRepository,
-    private readonly userEnv: UserEnvResolver,
-    /** Absent on deployments without a secrets key — values persist unencrypted. */
-    private readonly encryptionKey: string | undefined
-  ) {}
-
-  getSandbox(): SandboxRow | null {
-    return this.sandboxes.getSandbox();
-  }
-
-  getSandboxWithCircuitBreaker(): SandboxCircuitBreakerState | null {
-    return this.sandboxes.getSandboxWithCircuitBreaker();
+    private readonly userEnv: UserEnvResolver
+  ) {
+    super(sql, log, encryptionKey);
   }
 
   getSession(): SessionRow | null {
@@ -55,111 +44,6 @@ export class DurableObjectSandboxStorage implements SandboxStorage {
 
   getUserEnvVars(): Promise<Record<string, string> | undefined> {
     return this.userEnv.getUserEnvVars();
-  }
-
-  updateSandboxStatus(status: SandboxStatus): void {
-    this.sandboxes.updateSandboxStatus(status);
-  }
-
-  updateSandboxForSpawn(data: SpawnSandboxData): void {
-    this.sandboxes.updateSandboxForSpawn(data);
-  }
-
-  updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean {
-    return this.sandboxes.updateSandboxAuthTokenHash(modalSandboxId, authTokenHash);
-  }
-
-  updateSandboxForResume(data: ResumeSandboxData): void {
-    this.sandboxes.updateSandboxForResume(data);
-  }
-
-  updateSandboxModalObjectId(modalObjectId: string | null): void {
-    this.sandboxes.updateSandboxModalObjectId(modalObjectId);
-  }
-
-  updateSandboxRuntimeVersion(runtimeVersion: string | null): void {
-    this.sandboxes.updateSandboxRuntimeVersion(runtimeVersion);
-  }
-
-  updateSandboxSnapshotImageId(
-    sandboxId: string,
-    imageId: string,
-    runtimeVersion: string | null
-  ): void {
-    this.sandboxes.updateSandboxSnapshotImageId(sandboxId, imageId, runtimeVersion);
-  }
-
-  updateSandboxLastActivity(timestamp: number): void {
-    this.sandboxes.updateSandboxLastActivity(timestamp);
-  }
-
-  incrementCircuitBreakerFailure(timestamp: number): void {
-    this.sandboxes.incrementCircuitBreakerFailure(timestamp);
-  }
-
-  resetCircuitBreaker(): void {
-    this.sandboxes.resetCircuitBreaker();
-  }
-
-  setLastSpawnError(error: string | null, timestamp: number | null): void {
-    this.sandboxes.updateSandboxSpawnError(error, timestamp);
-  }
-
-  updateSandboxCodeServer(url: string, password: string): void | Promise<void> {
-    return this.persistEncrypted(password, (stored) =>
-      this.sandboxes.updateSandboxCodeServer(url, stored)
-    );
-  }
-
-  clearSandboxCodeServer(): void {
-    this.sandboxes.clearSandboxCodeServer();
-  }
-
-  clearSandboxCodeServerUrl(): void {
-    this.sandboxes.clearSandboxCodeServerUrl();
-  }
-
-  updateSandboxVnc(url: string, password: string): void | Promise<void> {
-    return this.persistEncrypted(password, (stored) =>
-      this.sandboxes.updateSandboxVnc(url, stored)
-    );
-  }
-
-  clearSandboxVnc(): void {
-    this.sandboxes.clearSandboxVnc();
-  }
-
-  clearSandboxVncUrl(): void {
-    this.sandboxes.clearSandboxVncUrl();
-  }
-
-  updateSandboxTunnelUrls(urls: Record<string, string>): void {
-    this.sandboxes.updateSandboxTunnelUrls(urls);
-  }
-
-  clearSandboxTunnelUrls(): void {
-    this.sandboxes.clearSandboxTunnelUrls();
-  }
-
-  updateSandboxTtyd(url: string, token: string): void | Promise<void> {
-    return this.persistEncrypted(token, (stored) => this.sandboxes.updateSandboxTtyd(url, stored));
-  }
-
-  clearSandboxTtyd(): void {
-    this.sandboxes.clearSandboxTtyd();
-  }
-
-  /**
-   * Encrypt-at-rest for access secrets. The keyless branch persists
-   * synchronously so callers that do not await still observe the write in the
-   * same turn, matching the pre-extraction literal's ordering.
-   */
-  private persistEncrypted(value: string, persist: (stored: string) => void): void | Promise<void> {
-    if (!this.encryptionKey) {
-      persist(value);
-      return;
-    }
-    return encryptToken(value, this.encryptionKey).then(persist);
   }
 }
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SandboxRepository } from "./sandbox-repository";
-import { decryptToken } from "../auth/crypto";
+import { decryptToken, generateEncryptionKey } from "../auth/crypto";
 import type { SqlResult, SqlStorage } from "./sql-storage";
 import type { Logger } from "../logger";
 
@@ -36,7 +36,7 @@ function createMockSql() {
   };
 }
 
-const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef";
+const TEST_ENCRYPTION_KEY = generateEncryptionKey();
 
 describe("SandboxRepository", () => {
   let mock: ReturnType<typeof createMockSql>;

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SandboxRepository } from "./sandbox-repository";
+import { decryptToken } from "../auth/crypto";
 import type { SqlResult, SqlStorage } from "./sql-storage";
 import type { Logger } from "../logger";
 
@@ -35,6 +36,8 @@ function createMockSql() {
   };
 }
 
+const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef";
+
 describe("SandboxRepository", () => {
   let mock: ReturnType<typeof createMockSql>;
   let repository: SandboxRepository;
@@ -43,7 +46,7 @@ describe("SandboxRepository", () => {
   beforeEach(() => {
     mock = createMockSql();
     log = createLog();
-    repository = new SandboxRepository(mock.sql, log);
+    repository = new SandboxRepository(mock.sql, log, TEST_ENCRYPTION_KEY);
   });
 
   describe("getSandbox", () => {
@@ -246,9 +249,9 @@ describe("SandboxRepository", () => {
     });
   });
 
-  describe("updateSandboxSpawnError", () => {
+  describe("setLastSpawnError", () => {
     it("updates spawn error fields", () => {
-      repository.updateSandboxSpawnError("Failed to spawn sandbox", 123456);
+      repository.setLastSpawnError("Failed to spawn sandbox", 123456);
 
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toContain("UPDATE sandbox SET last_spawn_error");
@@ -257,13 +260,30 @@ describe("SandboxRepository", () => {
   });
 
   describe("VNC access", () => {
-    it("stores and clears VNC credentials", () => {
-      repository.updateSandboxVnc("https://vnc.test", "encrypted-password");
+    it("stores encrypted credentials and clears them", async () => {
+      await repository.updateSandboxVnc("https://vnc.test", "vnc-secret");
       repository.clearSandboxVnc();
 
       expect(mock.calls[0].query).toContain("SET vnc_url = ?, vnc_password = ?");
-      expect(mock.calls[0].params).toEqual(["https://vnc.test", "encrypted-password"]);
+      const [url, stored] = mock.calls[0].params as [string, string];
+      expect(url).toBe("https://vnc.test");
+      expect(stored).not.toBe("vnc-secret");
+      await expect(decryptToken(stored, TEST_ENCRYPTION_KEY)).resolves.toBe("vnc-secret");
       expect(mock.calls[1].query).toContain("SET vnc_url = NULL, vnc_password = NULL");
+    });
+
+    it("encrypts code-server and ttyd secrets the same way", async () => {
+      await repository.updateSandboxCodeServer("https://cs.test", "cs-secret");
+      await repository.updateSandboxTtyd("https://ttyd.test", "ttyd-token");
+
+      for (const [call, plaintext] of [
+        [mock.calls[0], "cs-secret"],
+        [mock.calls[1], "ttyd-token"],
+      ] as const) {
+        const stored = call.params[1] as string;
+        expect(stored).not.toBe(plaintext);
+        await expect(decryptToken(stored, TEST_ENCRYPTION_KEY)).resolves.toBe(plaintext);
+      }
     });
 
     it("can clear only the VNC URL", () => {

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -4,6 +4,7 @@ import type { SqlResult, SqlStorage } from "./sql-storage";
 import type { SandboxRow } from "./types";
 import type { Logger } from "../logger";
 import { coerceSandboxStatus } from "../sandbox/sandbox-status";
+import { encryptToken } from "../auth/crypto";
 
 /** A sandbox row exactly as SQLite returns it, before the status is validated. */
 type RawSandboxRow = Omit<SandboxRow, "status"> & { status: string };
@@ -41,11 +42,20 @@ export interface ResumeSandboxData {
   createdAt: number;
 }
 
-/** Persistence for the sandbox scoped to one session. */
+/**
+ * Persistence for the sandbox scoped to one session.
+ *
+ * Owns encrypt-at-rest for access secrets (code-server/VNC passwords, ttyd
+ * tokens): callers hand over plaintext and every write path encrypts before
+ * touching a column, so no caller can accidentally persist a secret in the
+ * clear. Matches the D1 stores (`McpServerStore`, scoped secrets), which own
+ * their keys the same way.
+ */
 export class SandboxRepository {
   constructor(
     private readonly sql: SqlStorage,
-    private readonly log: Logger
+    private readonly log: Logger,
+    private readonly encryptionKey: string
   ) {}
 
   private rows<T>(result: SqlResult): T[] {
@@ -226,7 +236,7 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxSpawnError(error: string | null, timestamp: number | null): void {
+  setLastSpawnError(error: string | null, timestamp: number | null): void {
     this.sql.exec(
       `UPDATE sandbox SET last_spawn_error = ?, last_spawn_error_at = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       error,
@@ -234,11 +244,11 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxCodeServer(url: string, password: string): void {
+  async updateSandboxCodeServer(url: string, password: string): Promise<void> {
     this.sql.exec(
       `UPDATE sandbox SET code_server_url = ?, code_server_password = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       url,
-      password
+      await this.encrypt(password)
     );
   }
 
@@ -254,11 +264,11 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxVnc(url: string, password: string): void {
+  async updateSandboxVnc(url: string, password: string): Promise<void> {
     this.sql.exec(
       `UPDATE sandbox SET vnc_url = ?, vnc_password = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       url,
-      password
+      await this.encrypt(password)
     );
   }
 
@@ -285,11 +295,11 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxTtyd(url: string, encryptedToken: string): void {
+  async updateSandboxTtyd(url: string, token: string): Promise<void> {
     this.sql.exec(
       `UPDATE sandbox SET ttyd_url = ?, ttyd_token = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       url,
-      encryptedToken
+      await this.encrypt(token)
     );
   }
 
@@ -303,6 +313,10 @@ export class SandboxRepository {
     this.sql.exec(
       `UPDATE sandbox SET spawn_failure_count = 0 WHERE id = (SELECT id FROM sandbox LIMIT 1)`
     );
+  }
+
+  private encrypt(value: string): Promise<string> {
+    return encryptToken(value, this.encryptionKey);
   }
 
   incrementCircuitBreakerFailure(timestamp: number): void {

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -215,7 +215,7 @@ function makeHarness(
     memberRows?: SessionRepositoryRow[];
     /** Model a deployment where the DB binding is missing. */
     withoutDb?: boolean;
-    /** Omit to model a deployment without REPO_SECRETS_ENCRYPTION_KEY. */
+    /** Defaults to ENCRYPTION_KEY — the key is required in production. */
     encryptionKey?: string;
     /** Omit to model an unset SECRETS_CAP_ENFORCEMENT (fail-closed enforce). */
     capEnforcement?: string;
@@ -247,7 +247,7 @@ function makeHarness(
       return resolveRepoId(sessionForRepoId);
     },
     durableObjectId: "do-id-fallback",
-    repoSecretsEncryptionKey: options.encryptionKey,
+    repoSecretsEncryptionKey: options.encryptionKey ?? ENCRYPTION_KEY,
     secretsCapEnforcement: options.capEnforcement,
     log,
   });
@@ -295,19 +295,7 @@ describe("UserEnvResolver", () => {
     );
   });
 
-  describe("without REPO_SECRETS_ENCRYPTION_KEY", () => {
-    it("skips secret loading and derives env from provider auth modes only", async () => {
-      const h = makeHarness();
-      h.db.providerAuthRows = providerAuthRows({ openai: "provider_account", xai: "api_key" });
-
-      await expect(h.resolver.getUserEnvVars()).resolves.toEqual({ OPENAI_OAUTH_MANAGED: "1" });
-
-      expect(h.logs.some((entry) => entry.level === "debug")).toBe(true);
-      // Provider auth is resolved by the session's public id; no secrets table is read.
-      expect(h.db.providerAuthBinds).toEqual(["sess-public-1"]);
-      expect(h.db.queries).toHaveLength(1);
-    });
-
+  describe("with no stored secrets", () => {
     it("returns undefined (not {}) when no provider is managed", async () => {
       const h = makeHarness();
       h.db.providerAuthRows = providerAuthRows(API_KEY_MODES);

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -46,7 +46,7 @@ export interface UserEnvResolverDeps {
   resolveRepoId: (session: SessionRow) => Promise<number>;
   /** The owning Durable Object's id; the resolvePublicSessionId fallback. */
   durableObjectId: string;
-  repoSecretsEncryptionKey: string | undefined;
+  repoSecretsEncryptionKey: string;
   secretsCapEnforcement: string | undefined;
   /** The session-scoped logger; the composition root creates it before this class. */
   log: Logger;
@@ -62,7 +62,7 @@ export class UserEnvResolver {
   private readonly sessionCoreRepository: SessionCoreRepository;
   private readonly resolveRepoId: (session: SessionRow) => Promise<number>;
   private readonly durableObjectId: string;
-  private readonly repoSecretsEncryptionKey: string | undefined;
+  private readonly repoSecretsEncryptionKey: string;
   private readonly secretsCapEnforcement: string | undefined;
   private readonly log: Logger;
 
@@ -122,18 +122,6 @@ export class UserEnvResolver {
     const providerAuthModes = Object.fromEntries(
       providerAuth.map(({ provider, authMode }) => [provider, authMode])
     ) as Record<SubscriptionProviderId, SessionProviderAuthMode>;
-
-    if (!this.repoSecretsEncryptionKey) {
-      this.log.debug("Ordinary secrets not configured, skipping secret loading", {
-        has_encryption_key: !!this.repoSecretsEncryptionKey,
-      });
-      const sandboxEnv = prepareManagedProviderEnv({
-        exposedSecrets: {},
-        brokerSecrets: {},
-        providerAuthModes,
-      });
-      return { sandboxEnv, providerAuthModes };
-    }
 
     // Fail hard on secret loading — sandboxes must not silently lose secrets
     const encryptionKey = this.repoSecretsEncryptionKey;


### PR DESCRIPTION
## What

Campaign item 2, combining two agreed decisions: **the secrets encryption key is required** (it always was operationally — Terraform declares it with no default — but the code treated it as optional and silently fell back to storing plaintext), and **the storage middle-man from #1608 is dissolved** (its ~25 one-line pass-throughs were the smell that prompted the design discussion).

## Encryption key is required

- New `requireRepoSecretsEncryptionKey(env)`: the session graph throws at construction when the key is absent (the #1602 eager posture — a misconfigured deployment fails every request at initialization instead of running degraded), and the five MCP-server routes validate the same way.
- Every plaintext-**write** fallback is deleted: the sandbox access-secret stores, `McpServerStore`'s keyless branch, and `UserEnvResolver`'s "skip secret loading" branch. `isManagedSecretsConfigured` reduces to `Boolean(db)`.
- Plaintext-**read** fallbacks stay: pre-encryption legacy rows still decrypt-or-degrade exactly as before (`McpServerStore`'s catch fallback, access values resolving to null on decrypt failure).
- The integration environment already provides a test key in its miniflare bindings, so no test-infra changes were needed.

## Encryption is owned by persistence; the middle-man is gone

- `SandboxRepository` takes the key at construction and encrypts code-server/VNC/ttyd secrets inside its write methods — the same pattern the D1 stores already use. No caller can persist an access secret in the clear, structurally.
- The manager's conflated port is **split into two roles** — the root cause behind both the #1608 forwarding layer and an interim inheritance design. `SandboxStorage` shrinks to the sandbox-row contract, which `SandboxRepository` now satisfies **structurally** (no adapter, no subclass, and no manager-port import in the repository — the structural check happens at the composition boundary). The three session-context reads become their own `SessionContextReader` port, implemented by a small `LifecycleSessionContext` facade over `SessionCoreRepository` + `UserEnvResolver` — an honest adapter: it spans two collaborators and owns the repository-shape defaults. `DurableObjectSandboxStorage` is deleted.
- The shared test mock already implements both ports, so the manager's test harness changes are mechanical: the same fake is passed for both parameters at every constructor site.
- `updateSandboxSpawnError` is renamed `setLastSpawnError` to match the port vocabulary, removing the last name translation.

## Tests

Encryption round-trips (via `decryptToken`) now live in `sandbox-repository.test.ts` with the logic; the adapter tests pin the context mapping and the inheritance wiring ("sandbox writes hit SQL with no forwarding layer"). Deleted-behavior tests are deleted with their behavior: the keyless verbatim-read test, the resolver's skip-secret-loading test, and #1608's synchronous-keyless-persist test (that branch no longer exists — with the key required, every secret write takes the same WebCrypto await it always took on real deployments). `McpServerStore` tests construct keyed; their plaintext-seeded rows now exercise the legacy-read fallback, which is exactly what such rows are.

## Behavior change (intended)

A deployment without `REPO_SECRETS_ENCRYPTION_KEY` now fails loudly at session initialization and on MCP routes, instead of silently persisting secrets unencrypted. Valid deployments are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Repository secrets encryption is now required for control-plane operations.
  * Sandbox passwords, tokens, credentials, and stored environment secrets are encrypted before persistence.
  * Encryption keys are strictly validated for required format and length.

* **Bug Fixes**
  * Improved handling of unavailable or empty stored secrets.
  * Reduced unnecessary decryption errors for empty credentials.
  * Improved sandbox error reporting.

* **Refactor**
  * Streamlined sandbox lifecycle and session-context handling for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->