### PR TITLE
fix(control-plane): keep quiet executions active

### DIFF
--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -779,7 +779,7 @@ describe("SessionSandboxEventProcessor", () => {
       expect(h.updateLastActivity).toHaveBeenCalledWith(expect.any(Number));
     });
 
-    it("does not reset activity timer on heartbeat", async () => {
+    it("does not reset activity timer on heartbeat while idle", async () => {
       const h = createProcessor();
       await h.processor.processSandboxEvent({
         type: "heartbeat",
@@ -789,6 +789,20 @@ describe("SessionSandboxEventProcessor", () => {
       });
 
       expect(h.updateLastActivity).not.toHaveBeenCalled();
+    });
+
+    it("resets activity timer on heartbeat while a message is processing", async () => {
+      const h = createProcessor();
+      h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
+
+      await h.processor.processSandboxEvent({
+        type: "heartbeat",
+        sandboxId: "sb-1",
+        status: "ready",
+        timestamp: 1000,
+      });
+
+      expect(h.updateLastActivity).toHaveBeenCalledWith(expect.any(Number));
     });
 
     it("does not reset activity timer on token", async () => {

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -78,6 +78,12 @@ export class SessionSandboxEventProcessor {
 
     if (event.type === "heartbeat") {
       this.sandboxRepository.updateSandboxHeartbeat(now);
+      // A quiet tool call may emit no events for longer than the inactivity
+      // timeout. While its message is processing, the bridge heartbeat proves
+      // the sandbox is still occupied and should renew its activity timestamp.
+      if (this.messageRepository.getProcessingMessage() !== null) {
+        this.updateLastActivity(now);
+      }
       return;
     }
 

--- a/packages/control-plane/test/integration/sandbox-events.test.ts
+++ b/packages/control-plane/test/integration/sandbox-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { initSession, queryDO, seedMessage } from "./helpers";
+import { runInSessionDO } from "./session-do-access";
 
 describe("POST /internal/sandbox-event", () => {
   it("stores token event", async () => {
@@ -166,10 +167,14 @@ describe("POST /internal/sandbox-event", () => {
     });
   });
 
-  it("heartbeat updates last_heartbeat without storing event", async () => {
+  it("heartbeat counts as activity only while a message is processing", async () => {
     const { stub } = await initSession();
+    const previousActivity = 123;
+    await runInSessionDO(stub, (_instance, state) => {
+      state.storage.sql.exec("UPDATE sandbox SET last_activity = ?", previousActivity);
+    });
 
-    const res = await stub.fetch("http://internal/internal/sandbox-event", {
+    const idleHeartbeat = await stub.fetch("http://internal/internal/sandbox-event", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -180,13 +185,47 @@ describe("POST /internal/sandbox-event", () => {
       }),
     });
 
-    expect(res.status).toBe(200);
+    expect(idleHeartbeat.status).toBe(200);
 
-    const sandbox = await queryDO<{ last_heartbeat: number }>(
+    const idleSandbox = await queryDO<{ last_heartbeat: number; last_activity: number }>(
       stub,
-      "SELECT last_heartbeat FROM sandbox"
+      "SELECT last_heartbeat, last_activity FROM sandbox"
     );
-    expect(sandbox[0].last_heartbeat).toEqual(expect.any(Number));
+    expect(idleSandbox[0].last_heartbeat).toEqual(expect.any(Number));
+    expect(idleSandbox[0].last_activity).toBe(previousActivity);
+
+    const participants = await queryDO<{ id: string }>(
+      stub,
+      "SELECT id FROM participants WHERE user_id = 'user-1'"
+    );
+    await seedMessage(stub, {
+      id: "msg-processing",
+      authorId: participants[0].id,
+      content: "Run a long build",
+      source: "web",
+      status: "processing",
+      createdAt: Date.now() - 1000,
+      startedAt: Date.now() - 500,
+    });
+
+    const processingHeartbeat = await stub.fetch("http://internal/internal/sandbox-event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "heartbeat",
+        sandboxId: "sb-1",
+        status: "running",
+        timestamp: Date.now() / 1000,
+      }),
+    });
+
+    expect(processingHeartbeat.status).toBe(200);
+    const processingSandbox = await queryDO<{ last_heartbeat: number; last_activity: number }>(
+      stub,
+      "SELECT last_heartbeat, last_activity FROM sandbox"
+    );
+    expect(processingSandbox[0].last_activity).toBe(processingSandbox[0].last_heartbeat);
+    expect(processingSandbox[0].last_activity).toBeGreaterThan(previousActivity);
 
     // Heartbeats should NOT be stored as events
     const events = await queryDO<{ type: string }>(


### PR DESCRIPTION
## Summary

- count bridge heartbeats as sandbox activity while a message is processing
- keep idle heartbeats liveness-only so abandoned sandboxes still reach inactivity cleanup
- add unit and Durable Object integration coverage for both states

## Motivation

A long-running tool call can emit no agent events for longer than the sandbox inactivity timeout even though the bridge remains healthy. Previously, bridge heartbeats refreshed only heartbeat liveness, so the lifecycle alarm could classify the sandbox as idle and stop it mid-execution.

The sandbox event processor already owns which incoming events count as activity. While a message is processing, a live bridge heartbeat now renews the existing activity timestamp. After processing finishes, heartbeats no longer renew activity and ordinary idle cleanup remains unchanged.

This is a deliberately narrow alternative to #1601. It does not change execution-timeout recovery, provider stop behavior, queue recovery, schema, or cleanup semantics.

## Validation

- npm test -w @open-inspect/control-plane — 205 files, 3,188 tests passed
- npm run test:integration -w @open-inspect/control-plane — 81 files, 1,002 tests passed
- npm run typecheck -w @open-inspect/control-plane
- npm run lint --workspace=@open-inspect/control-plane -- --no-fix
- Prettier check for all changed files
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heartbeat tracking so idle heartbeats maintain liveness without incorrectly extending activity timers.
  * Heartbeats received while processing a message now correctly refresh activity status.
  * Heartbeat events continue to be excluded from stored event history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->