### PR TITLE
refactor(control-plane): convert session HTTP handler factories to classes

### DIFF
--- a/packages/control-plane/src/env-validation.test.ts
+++ b/packages/control-plane/src/env-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { generateEncryptionKey } from "./auth/crypto";
-import { requireRepoSecretsEncryptionKey } from "./env-validation";
+import { requireRepoSecretsEncryptionKey, requireTokenEncryptionKey } from "./env-validation";
 import type { Env } from "./types";
 
 function envWith(key: string | undefined): Env {
@@ -37,5 +37,27 @@ describe("requireRepoSecretsEncryptionKey", () => {
     expect(() =>
       requireRepoSecretsEncryptionKey(envWith("bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA=="))
     ).toThrow(/32 bytes.*got 34/);
+  });
+});
+
+describe("requireTokenEncryptionKey", () => {
+  // Shares the material validator with the repo-secrets key; these tests pin
+  // the token-specific wiring (which env var is read, whose name errors carry).
+  it("returns a canonical base64-encoded 32-byte key", () => {
+    const key = generateEncryptionKey();
+
+    expect(requireTokenEncryptionKey({ TOKEN_ENCRYPTION_KEY: key } as Env)).toBe(key);
+  });
+
+  it("throws with the token key's name when absent or malformed", () => {
+    expect(() => requireTokenEncryptionKey({} as Env)).toThrow(
+      /TOKEN_ENCRYPTION_KEY is not configured/
+    );
+    expect(() =>
+      requireTokenEncryptionKey({ TOKEN_ENCRYPTION_KEY: "not base64!!" } as Env)
+    ).toThrow(/TOKEN_ENCRYPTION_KEY is not valid base64/);
+    expect(() =>
+      requireTokenEncryptionKey({ TOKEN_ENCRYPTION_KEY: "dG9vc2hvcnQ=" } as Env)
+    ).toThrow(/TOKEN_ENCRYPTION_KEY must decode to 32 bytes/);
   });
 });

--- a/packages/control-plane/src/env-validation.ts
+++ b/packages/control-plane/src/env-validation.ts
@@ -3,7 +3,7 @@
  *
  * Misconfigured deployments fail loudly at the first touch instead of running
  * degraded (the #1602 posture). Secrets-at-rest encryption in particular must
- * never silently fall back to plaintext: Terraform requires the key, so its
+ * never silently fall back to plaintext: Terraform requires the keys, so their
  * absence always means a broken deployment.
  */
 
@@ -20,11 +20,10 @@ const KEY_GENERATION_HINT = "generate with: openssl rand -base64 32";
  * otherwise survive graph construction and throw at the first secret write —
  * mid-spawn — while a short key would silently downgrade to AES-128/192.
  */
-export function requireRepoSecretsEncryptionKey(env: Env): string {
-  const key = env.REPO_SECRETS_ENCRYPTION_KEY;
+function requireEncryptionKey(key: string | undefined, name: string, protects: string): string {
   if (!key) {
     throw new Error(
-      "REPO_SECRETS_ENCRYPTION_KEY is not configured; refusing to operate on secrets without encryption at rest"
+      `${name} is not configured; refusing to operate on ${protects} without encryption at rest`
     );
   }
   let decodedBytes: number | null = null;
@@ -36,12 +35,24 @@ export function requireRepoSecretsEncryptionKey(env: Env): string {
     }
   }
   if (decodedBytes === null) {
-    throw new Error(`REPO_SECRETS_ENCRYPTION_KEY is not valid base64 (${KEY_GENERATION_HINT})`);
+    throw new Error(`${name} is not valid base64 (${KEY_GENERATION_HINT})`);
   }
   if (decodedBytes !== AES_256_KEY_BYTES) {
     throw new Error(
-      `REPO_SECRETS_ENCRYPTION_KEY must decode to ${AES_256_KEY_BYTES} bytes for AES-256, got ${decodedBytes} (${KEY_GENERATION_HINT})`
+      `${name} must decode to ${AES_256_KEY_BYTES} bytes for AES-256, got ${decodedBytes} (${KEY_GENERATION_HINT})`
     );
   }
   return key;
+}
+
+export function requireRepoSecretsEncryptionKey(env: Env): string {
+  return requireEncryptionKey(
+    env.REPO_SECRETS_ENCRYPTION_KEY,
+    "REPO_SECRETS_ENCRYPTION_KEY",
+    "secrets"
+  );
+}
+
+export function requireTokenEncryptionKey(env: Env): string {
+  return requireEncryptionKey(env.TOKEN_ENCRYPTION_KEY, "TOKEN_ENCRYPTION_KEY", "OAuth tokens");
 }

--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateEncryptionKey } from "./auth/crypto";
 import type { Principal } from "./auth/principal";
 import { SessionIndexStore } from "./db/session-index";
 import { UserStore } from "./db/user-store";
@@ -129,6 +130,9 @@ describe("handleCreateSession D1 ordering", () => {
     return {
       ...TEST_SERVICE_SECRETS,
       SCM_PROVIDER: "github",
+      // GitHub-identity enrichment reads the token store unconditionally, so
+      // the env must carry valid key material (the db stub answers "no rows").
+      TOKEN_ENCRYPTION_KEY: generateEncryptionKey(),
       DB: {
         prepare: vi.fn(() => statement),
         batch: vi.fn(),

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -60,7 +60,6 @@ import { ParticipantRepository } from "./participant-repository";
 import { WsClientMappingRepository } from "./ws-client-mapping-repository";
 import { createLatchedPublicSessionIdResolver, resolvePublicSessionId } from "./public-session-id";
 import { resolveScmSettings } from "./scm-settings-resolution";
-import { validateReasoningEffort } from "./reasoning-effort";
 import {
   isValidSandboxToken,
   resolveSandboxDashboardUrl,
@@ -92,10 +91,7 @@ import { ChildSessionsHandler } from "./http/handlers/child-sessions.handler";
 import { SandboxHandler } from "./http/handlers/sandbox.handler";
 import { AttachmentsHandler } from "./http/handlers/attachments.handler";
 import { WsTokenHandler } from "./http/handlers/ws-token.handler";
-import {
-  createSessionLifecycleHandler,
-  type SessionLifecycleHandler,
-} from "./http/handlers/session-lifecycle.handler";
+import { SessionLifecycleHandler } from "./http/handlers/session-lifecycle.handler";
 import { PullRequestHandler } from "./http/handlers/pull-request.handler";
 import { ParticipantsHandler } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
@@ -556,35 +552,29 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     hashToken
   );
 
-  const sessionLifecycleHandler = createSessionLifecycleHandler({
+  const lifecycleWsManager = new LifecycleSocketAdapter(wsManager);
+  const sessionLifecycleHandler = new SessionLifecycleHandler(
     sessionCoreRepository,
     sandboxRepository,
     messageRepository,
     participantRepository,
-    getDurableObjectId: () => durableObjectId,
+    participantService,
+    statusService,
+    titleService,
+    lifecycleWsManager,
+    durableObjectId,
+    log,
     tokenEncryptionKey,
-    encryptToken: (token, encryptionKey) => encryptToken(token, encryptionKey),
-    validateReasoningEffort: (model, effort) => validateReasoningEffort(model, effort, log),
-    generateId: (bytes) => generateId(bytes),
-    now: () => Date.now(),
-    scheduleWarmSandbox: () =>
+    () =>
       backgroundTasks.submit(() => lifecycleManager.warmSandbox(), {
         name: "sandbox.warm",
       }),
-    getSession: () => sessionCoreRepository.getSession(),
-    getSandbox: () => sandboxRepository.getSandbox(),
-    getPublicSessionId: (sessionRow) => resolvePublicSessionId(sessionRow, durableObjectId),
-    getParticipantByUserId: (userId) => participantService.getByUserId(userId),
-    statusService,
-    applySessionTitleUpdate: (title, options) =>
-      titleService.applySessionTitleUpdate(title, options),
-    cancelSession: async () => {
+    async () => {
       await statusService.cancel(() => messageQueue.cancelExecution());
     },
-    getSandboxSocket: () => wsManager.getSandboxSocket(),
-    sendToSandbox: (ws, message) => wsManager.send(ws, message),
-    updateSandboxStatus: (status) => sandboxRepository.updateSandboxStatus(status),
-  });
+    encryptToken,
+    generateId
+  );
 
   const prCreationClaims = new PullRequestCreationClaims();
   const pullRequestHandler = new PullRequestHandler(

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -88,7 +88,7 @@ import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
 import { SessionEventStream } from "./event-stream";
 import { MessagesHandler } from "./http/handlers/messages.handler";
-import { createChildSessionsHandler } from "./http/handlers/child-sessions.handler";
+import { ChildSessionsHandler } from "./http/handlers/child-sessions.handler";
 import { createSandboxHandler } from "./http/handlers/sandbox.handler";
 import { AttachmentsHandler } from "./http/handlers/attachments.handler";
 import { WsTokenHandler } from "./http/handlers/ws-token.handler";
@@ -494,18 +494,18 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   // Tier 8 — internal HTTP handlers.
   const messagesHandler = new MessagesHandler(messageService);
 
-  const childSessionsHandler = createChildSessionsHandler({
+  const childSessionsHandler = new ChildSessionsHandler(
     messageRepository,
     eventRepository,
     participantRepository,
     artifactRepository,
-    getSession: () => sessionCoreRepository.getSession(),
-    getSandbox: () => sandboxRepository.getSandbox(),
-    getPublicSessionId: (sessionRow) => resolvePublicSessionId(sessionRow, durableObjectId),
-    parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, log),
+    sessionCoreRepository,
+    sandboxRepository,
+    durableObjectId,
+    log,
     messenger,
-    messageService,
-  });
+    messageService
+  );
 
   const sandboxHandler = createSandboxHandler({
     messageRepository,

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -46,7 +46,7 @@ import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integratio
 import { SessionIndexStore } from "../db/session-index";
 import { parsePersistedSandboxSettings } from "../sandbox/settings";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
-import { requireRepoSecretsEncryptionKey } from "../env-validation";
+import { requireRepoSecretsEncryptionKey, requireTokenEncryptionKey } from "../env-validation";
 import type { Env, ClientInfo } from "../types";
 import type { SessionRow } from "./types";
 import type { SqlDatabase } from "../db/sql-database";
@@ -225,6 +225,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   // Secrets-at-rest encryption is not optional. Every consumer below takes
   // the validated key, so no fallback path can persist a secret in plaintext.
   const repoSecretsEncryptionKey = requireRepoSecretsEncryptionKey(env);
+  const tokenEncryptionKey = requireTokenEncryptionKey(env);
 
   // The session-scoped logger, created before anything can capture a logger
   // at all. Its `session_id` is injected per emit through the latched
@@ -318,8 +319,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
       terminalMessageCompletedAt: completedAt,
     });
 
-  const userScmTokenStore =
-    db && env.TOKEN_ENCRYPTION_KEY ? new UserScmTokenStore(db, env.TOKEN_ENCRYPTION_KEY) : null;
+  const userScmTokenStore = db ? new UserScmTokenStore(db, tokenEncryptionKey) : null;
   const participantService = new ParticipantService({
     repository: participantRepository,
     getProcessingMessageAuthor: () => messageRepository.getProcessingMessageAuthor(),
@@ -560,7 +560,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     messageRepository,
     participantRepository,
     getDurableObjectId: () => durableObjectId,
-    tokenEncryptionKey: env.TOKEN_ENCRYPTION_KEY,
+    tokenEncryptionKey,
     encryptToken: (token, encryptionKey) => encryptToken(token, encryptionKey),
     validateReasoningEffort: (model, effort) => validateReasoningEffort(model, effort, log),
     generateId: (bytes) => generateId(bytes),

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -545,12 +545,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
   const attachmentsHandler = new AttachmentsHandler(attachmentRepository, log);
 
-  const wsTokenHandler = new WsTokenHandler(
-    participantRepository,
-    participantService,
-    generateId,
-    hashToken
-  );
+  const wsTokenHandler = new WsTokenHandler(participantRepository, generateId, hashToken);
 
   const lifecycleWsManager = new LifecycleSocketAdapter(wsManager);
   const sessionLifecycleHandler = new SessionLifecycleHandler(
@@ -558,12 +553,10 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     sandboxRepository,
     messageRepository,
     participantRepository,
-    participantService,
     statusService,
     titleService,
     lifecycleWsManager,
     durableObjectId,
-    log,
     tokenEncryptionKey,
     () =>
       backgroundTasks.submit(() => lifecycleManager.warmSandbox(), {

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -87,17 +87,17 @@ import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
 import { SessionEventStream } from "./event-stream";
-import { createMessagesHandler } from "./http/handlers/messages.handler";
+import { MessagesHandler } from "./http/handlers/messages.handler";
 import { createChildSessionsHandler } from "./http/handlers/child-sessions.handler";
 import { createSandboxHandler } from "./http/handlers/sandbox.handler";
 import { AttachmentsHandler } from "./http/handlers/attachments.handler";
-import { createWsTokenHandler } from "./http/handlers/ws-token.handler";
+import { WsTokenHandler } from "./http/handlers/ws-token.handler";
 import {
   createSessionLifecycleHandler,
   type SessionLifecycleHandler,
 } from "./http/handlers/session-lifecycle.handler";
 import { createPullRequestHandler } from "./http/handlers/pull-request.handler";
-import { createParticipantsHandler } from "./http/handlers/participants.handler";
+import { ParticipantsHandler } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
 import { createAlarmHandler } from "./alarm/handler";
 import {
@@ -492,9 +492,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   };
 
   // Tier 8 — internal HTTP handlers.
-  const messagesHandler = createMessagesHandler({
-    messageService,
-  });
+  const messagesHandler = new MessagesHandler(messageService);
 
   const childSessionsHandler = createChildSessionsHandler({
     messageRepository,
@@ -546,13 +544,12 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
   const attachmentsHandler = new AttachmentsHandler(attachmentRepository, log);
 
-  const wsTokenHandler = createWsTokenHandler({
-    repository: participantRepository,
-    getParticipantByUserId: (userId) => participantService.getByUserId(userId),
-    generateId: (bytes) => generateId(bytes),
-    hashToken: (token) => hashToken(token),
-    now: () => Date.now(),
-  });
+  const wsTokenHandler = new WsTokenHandler(
+    participantRepository,
+    participantService,
+    generateId,
+    hashToken
+  );
 
   const sessionLifecycleHandler = createSessionLifecycleHandler({
     sessionCoreRepository,
@@ -619,9 +616,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     triggerPullRequestRefresh: () => schedulePullRequestRefresh("manual"),
   });
 
-  const participantsHandler = createParticipantsHandler({
-    repository: participantRepository,
-  });
+  const participantsHandler = new ParticipantsHandler(participantRepository);
 
   // Tier 9 — the read models, connection admission, and the server stack.
   const snapshotReader = new SessionSnapshotReader({

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -89,7 +89,7 @@ import { SessionTerminalMessageProjection } from "./terminal-message-projection"
 import { SessionEventStream } from "./event-stream";
 import { MessagesHandler } from "./http/handlers/messages.handler";
 import { ChildSessionsHandler } from "./http/handlers/child-sessions.handler";
-import { createSandboxHandler } from "./http/handlers/sandbox.handler";
+import { SandboxHandler } from "./http/handlers/sandbox.handler";
 import { AttachmentsHandler } from "./http/handlers/attachments.handler";
 import { WsTokenHandler } from "./http/handlers/ws-token.handler";
 import {
@@ -507,40 +507,45 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     messageService
   );
 
-  const sandboxHandler = createSandboxHandler({
+  // Per-request adapters: each token/credential refresh constructs its
+  // service around the request-scoped log, so these stay functions.
+  const refreshOpenAIToken = async (sessionRow: SessionRow, requestLog: Logger) => {
+    const service = new OpenAITokenRefreshService(
+      db!,
+      repoSecretsEncryptionKey,
+      resolveRepoId,
+      requestLog
+    );
+    return service.refresh(sessionRow);
+  };
+  const refreshXaiToken = async (sessionRow: SessionRow, requestLog: Logger) => {
+    const service = new XaiTokenRefreshService(
+      db!,
+      repoSecretsEncryptionKey,
+      resolveRepoId,
+      requestLog
+    );
+    return service.refresh(sessionRow);
+  };
+  const getScmCredentials = (requestLog: Logger) =>
+    new ScmCredentialsService(sourceControlProvider(), requestLog).getCredentials();
+
+  const sandboxHandler = new SandboxHandler(
     messageRepository,
     eventRepository,
     participantRepository,
     artifactRepository,
-    processSandboxEvent: (event) => sandboxEventProcessor.processSandboxEvent(event),
-    getSandbox: () => sandboxRepository.getSandbox(),
-    isValidSandboxToken: (token, sandbox) => isValidSandboxToken(token, sandbox),
-    getSession: () => sessionCoreRepository.getSession(),
-    refreshOpenAIToken: async (sessionRow, requestLog) => {
-      const service = new OpenAITokenRefreshService(
-        db!,
-        repoSecretsEncryptionKey,
-        resolveRepoId,
-        requestLog
-      );
-      return service.refresh(sessionRow);
-    },
-    refreshXaiToken: async (sessionRow, requestLog) => {
-      const service = new XaiTokenRefreshService(
-        db!,
-        repoSecretsEncryptionKey,
-        resolveRepoId,
-        requestLog
-      );
-      return service.refresh(sessionRow);
-    },
-    isManagedSecretsConfigured: () => Boolean(db),
-    getScmCredentials: (requestLog) =>
-      new ScmCredentialsService(sourceControlProvider(), requestLog).getCredentials(),
+    sessionCoreRepository,
+    sandboxRepository,
+    sandboxEventProcessor,
     messenger,
-    generateId: () => generateId(),
-    now: () => Date.now(),
-  });
+    Boolean(db),
+    refreshOpenAIToken,
+    refreshXaiToken,
+    getScmCredentials,
+    isValidSandboxToken,
+    generateId
+  );
 
   const attachmentsHandler = new AttachmentsHandler(attachmentRepository, log);
 

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -96,7 +96,7 @@ import {
   createSessionLifecycleHandler,
   type SessionLifecycleHandler,
 } from "./http/handlers/session-lifecycle.handler";
-import { createPullRequestHandler } from "./http/handlers/pull-request.handler";
+import { PullRequestHandler } from "./http/handlers/pull-request.handler";
 import { ParticipantsHandler } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
 import { createAlarmHandler } from "./alarm/handler";
@@ -587,17 +587,17 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   });
 
   const prCreationClaims = new PullRequestCreationClaims();
-  const pullRequestHandler = createPullRequestHandler({
-    getSession: () => sessionCoreRepository.getSession(),
-    getSessionRepositories: () => sessionCoreRepository.getSessionRepositories(),
-    getPromptingParticipantForPR: () => participantService.getPromptingParticipantForPR(),
-    resolveAuthForPR: (participant) => participantService.resolveAuthForPR(participant),
-    getSessionUrl: (sessionRow) => {
+  const pullRequestHandler = new PullRequestHandler(
+    sessionCoreRepository,
+    participantService,
+    artifactRepository,
+    messenger,
+    (sessionRow) => {
       const sessionId = sessionRow.session_name || sessionRow.id;
       const webAppUrl = env.WEB_APP_URL || env.WORKER_URL || "";
       return webAppUrl + "/session/" + sessionId;
     },
-    createPullRequest: async (input, requestLog) => {
+    async (input, requestLog) => {
       const pullRequestService = new SessionPullRequestService({
         repository: sessionCoreRepository,
         artifactRepository,
@@ -614,12 +614,8 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
       return pullRequestService.createPullRequest(input);
     },
-    getArtifactById: (artifactId) => artifactRepository.getArtifactById(artifactId),
-    updateArtifact: (artifactId, data) => artifactRepository.updateArtifact(artifactId, data),
-    messenger,
-    now: () => Date.now(),
-    triggerPullRequestRefresh: () => schedulePullRequestRefresh("manual"),
-  });
+    () => schedulePullRequestRefresh("manual")
+  );
 
   const participantsHandler = new ParticipantsHandler(participantRepository);
 

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { MAX_CHILD_FOLLOW_UP_PROMPT_CHARS } from "@open-inspect/shared/types/session-api";
-import { createChildSessionsHandler } from "./child-sessions.handler";
+import { ChildSessionsHandler } from "./child-sessions.handler";
 import { PromptQueueFullError, SessionNotPromptableError } from "../../message-queue";
 import {
   FINAL_RESPONSE_EVENT_PAGE_LIMIT,
@@ -19,11 +19,14 @@ import type { ArtifactRepository } from "../../artifact-repository";
 import type { ParticipantRepository } from "../../participant-repository";
 import type { EventRepository } from "../../event-repository";
 import type { MessageRepository } from "../../message-repository";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { SandboxRepository } from "../../sandbox-repository";
+import type { Logger } from "../../../logger";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
     id: "session-1",
-    session_name: null,
+    session_name: "public-session-1",
     title: "Session Title",
     repo_owner: "acme",
     repo_name: "repo",
@@ -159,10 +162,6 @@ function createHandler() {
   const artifactRepository = { listArtifacts: vi.fn() };
   const getSession = vi.fn<() => SessionRow | null>();
   const getSandbox = vi.fn<() => SandboxRow | null>();
-  const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
-  const parseArtifactMetadata = vi.fn((artifact: Pick<ArtifactRow, "metadata">) =>
-    artifact.metadata ? (JSON.parse(artifact.metadata) as Record<string, unknown>) : null
-  );
   const broadcast = vi.fn();
   const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
   const enqueuePrompt = vi.fn(async () => ({
@@ -170,19 +169,20 @@ function createHandler() {
     status: "queued" as const,
   }));
   const messageService = { enqueuePrompt };
+  const log = { warn: vi.fn() } as unknown as Logger;
 
-  const handler = createChildSessionsHandler({
-    messageRepository: repository as unknown as MessageRepository,
-    eventRepository: repository as unknown as EventRepository,
-    participantRepository: repository as unknown as ParticipantRepository,
-    artifactRepository: artifactRepository as unknown as ArtifactRepository,
-    getSession,
-    getSandbox,
-    getPublicSessionId,
-    parseArtifactMetadata,
+  const handler = new ChildSessionsHandler(
+    repository as unknown as MessageRepository,
+    repository as unknown as EventRepository,
+    repository as unknown as ParticipantRepository,
+    artifactRepository as unknown as ArtifactRepository,
+    { getSession } as unknown as SessionCoreRepository,
+    { getSandbox } as unknown as SandboxRepository,
+    "durable-object-id",
+    log,
     messenger,
-    messageService,
-  });
+    messageService
+  );
 
   return {
     handler,
@@ -190,14 +190,12 @@ function createHandler() {
     artifactRepository,
     getSession,
     getSandbox,
-    getPublicSessionId,
-    parseArtifactMetadata,
     broadcast,
     enqueuePrompt,
   };
 }
 
-describe("createChildSessionsHandler", () => {
+describe("ChildSessionsHandler", () => {
   describe("parentPrompt", () => {
     function request(body: unknown): Request {
       const withAuthor =
@@ -533,11 +531,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("maps child summary and filters noisy events", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession());
     getSandbox.mockReturnValue(createSandbox());
-    getPublicSessionId.mockReturnValue("public-session-1");
 
     artifactRepository.listArtifacts.mockReturnValue([
       createArtifact({ type: "pr", metadata: '{"number":42}' }),
@@ -606,11 +602,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("includes final response when requested", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession({ status: "completed" }));
     getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
-    getPublicSessionId.mockReturnValue("public-session-1");
     artifactRepository.listArtifacts.mockReturnValue([
       createArtifact({
         type: "branch",
@@ -681,11 +675,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("scopes final response artifacts to the terminal message window", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession({ status: "completed" }));
     getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
-    getPublicSessionId.mockReturnValue("public-session-1");
     artifactRepository.listArtifacts.mockReturnValue([
       createArtifact({
         id: "artifact-old",
@@ -746,11 +738,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("paginates final response events when requested", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession({ status: "completed" }));
     getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
-    getPublicSessionId.mockReturnValue("public-session-1");
     artifactRepository.listArtifacts.mockReturnValue([]);
     repository.getLatestTerminalMessage.mockReturnValue(createMessage({ id: "msg-final" }));
     repository.listEventPage
@@ -832,11 +822,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("includes chronological trajectory when requested", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession());
     getSandbox.mockReturnValue(createSandbox());
-    getPublicSessionId.mockReturnValue("public-session-1");
     artifactRepository.listArtifacts.mockReturnValue([]);
     repository.getLatestTerminalMessage.mockReturnValue(null);
     repository.listEventPage.mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null });
@@ -875,11 +863,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("returns 400 for malformed trajectory cursors", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession());
     getSandbox.mockReturnValue(createSandbox());
-    getPublicSessionId.mockReturnValue("public-session-1");
 
     const response = handler.getChildSummary(
       new URL("http://internal/internal/child-summary?include=trajectory&trajectoryCursor=bad")
@@ -898,13 +884,12 @@ describe("createChildSessionsHandler", () => {
         handler,
         getSession,
         getSandbox,
-        getPublicSessionId,
+
         repository,
         artifactRepository,
       } = createHandler();
       getSession.mockReturnValue(createSession());
       getSandbox.mockReturnValue(createSandbox());
-      getPublicSessionId.mockReturnValue("public-session-1");
 
       const response = handler.getChildSummary(
         new URL(
@@ -934,11 +919,9 @@ describe("createChildSessionsHandler", () => {
   });
 
   it("paginates trajectory with an explicit limit and cursor", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId, repository, artifactRepository } =
-      createHandler();
+    const { handler, getSession, getSandbox, repository, artifactRepository } = createHandler();
     getSession.mockReturnValue(createSession());
     getSandbox.mockReturnValue(createSandbox());
-    getPublicSessionId.mockReturnValue("public-session-1");
     artifactRepository.listArtifacts.mockReturnValue([]);
     repository.getLatestTerminalMessage.mockReturnValue(null);
     repository.listEventPage.mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null });

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -2,17 +2,22 @@ import { childFollowUpPromptRequestSchema } from "@open-inspect/shared/types/ses
 import { isSessionPromptable } from "@open-inspect/shared/types/session-activity";
 import { z } from "zod";
 import { sessionStatusSchema } from "@open-inspect/shared/types/sessions";
+import type { Logger } from "../../../logger";
 import { parsePersistedSandboxSettings } from "../../../sandbox/settings";
+import { parseArtifactMetadata } from "../../artifact-metadata";
 import type { SessionMessenger } from "../../messenger";
 import { PromptQueueFullError, SessionNotPromptableError } from "../../message-queue";
 import type { MessageRepository } from "../../message-repository";
 import type { ArtifactRepository } from "../../artifact-repository";
 import type { EventRepository } from "../../event-repository";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { SandboxRepository } from "../../sandbox-repository";
 import type { MessageService } from "../../services/message.service";
 import type { SpawnContext } from "../../spawn-context";
 import { activePromptAuthorSchema, type ActivePromptAuthor } from "../../active-prompt-author";
-import type { ArtifactRow, ParticipantRow, SandboxRow, SessionRow } from "../../types";
+import { resolvePublicSessionId } from "../../public-session-id";
+import type { ParticipantRow } from "../../types";
 import {
   RECENT_EVENT_FETCH_LIMIT,
   buildChildSessionDetail,
@@ -21,29 +26,6 @@ import {
   type ChildSummaryFinalResponseInput,
   type ChildSummaryTrajectoryInput,
 } from "./child-session-summary";
-
-export interface ChildSessionsHandlerDeps {
-  messageRepository: MessageRepository;
-  eventRepository: EventRepository;
-  participantRepository: ParticipantRepository;
-  artifactRepository: ArtifactRepository;
-  getSession: () => SessionRow | null;
-  getSandbox: () => SandboxRow | null;
-  getPublicSessionId: (session: SessionRow) => string;
-  parseArtifactMetadata: (
-    artifact: Pick<ArtifactRow, "id" | "metadata">
-  ) => Record<string, unknown> | null;
-  messenger: SessionMessenger;
-  messageService: Pick<MessageService, "enqueuePrompt">;
-}
-
-export interface ChildSessionsHandler {
-  getSpawnContext: () => Response;
-  getActivePromptAuthor: () => Response;
-  getChildSummary: (url?: URL) => Response;
-  parentPrompt: (request: Request) => Promise<Response>;
-  childSessionUpdate: (request: Request) => Promise<Response>;
-}
 
 const parentPromptRequestSchema = childFollowUpPromptRequestSchema.extend({
   parentSessionId: z.string().min(1),
@@ -82,194 +64,210 @@ function toActivePromptAuthor(participant: ParticipantRow): ActivePromptAuthor {
     scmEmail: participant.scm_email,
   };
 }
-export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): ChildSessionsHandler {
-  return {
-    getSpawnContext(): Response {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
 
-      const promptAuthor = resolvePromptAuthorParticipant(
-        deps.messageRepository,
-        deps.participantRepository
-      );
-      if (promptAuthor instanceof Response) return promptAuthor;
-      let sandboxTimeoutMs: number | undefined;
-      try {
-        sandboxTimeoutMs = parsePersistedSandboxSettings(session.sandbox_settings).sandboxTimeoutMs;
-      } catch {
-        sandboxTimeoutMs = undefined;
-      }
-      const context: SpawnContext = {
-        repoOwner: session.repo_owner,
-        repoName: session.repo_name,
-        repoId: session.repo_id,
-        model: session.model,
-        reasoningEffort: session.reasoning_effort ?? null,
-        baseBranch: session.base_branch,
-        sandboxTimeoutMs,
-        promptAuthor: {
-          userId: promptAuthor.user_id,
-          ...(promptAuthor.canonical_user_id
-            ? { canonicalUserId: promptAuthor.canonical_user_id }
-            : {}),
-          scmUserId: promptAuthor.scm_user_id,
-          scmLogin: promptAuthor.scm_login,
-          scmName: promptAuthor.scm_name,
-          scmEmail: promptAuthor.scm_email,
-          scmAccessTokenEncrypted: promptAuthor.scm_access_token_encrypted,
-          scmRefreshTokenEncrypted: promptAuthor.scm_refresh_token_encrypted,
-          scmTokenExpiresAt: promptAuthor.scm_token_expires_at,
-        },
+/**
+ * HTTP boundary for the parent/child session endpoints: spawn context and
+ * prompt-author reads for child spawning, the child summary read model, and
+ * the parent-prompt/status-update callbacks children invoke.
+ */
+export class ChildSessionsHandler {
+  constructor(
+    private readonly messageRepository: MessageRepository,
+    private readonly eventRepository: EventRepository,
+    private readonly participantRepository: ParticipantRepository,
+    private readonly artifactRepository: ArtifactRepository,
+    private readonly sessionCoreRepository: SessionCoreRepository,
+    private readonly sandboxRepository: SandboxRepository,
+    private readonly durableObjectId: string,
+    private readonly log: Logger,
+    private readonly messenger: SessionMessenger,
+    private readonly messageService: Pick<MessageService, "enqueuePrompt">
+  ) {}
+
+  getSpawnContext(): Response {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const promptAuthor = resolvePromptAuthorParticipant(
+      this.messageRepository,
+      this.participantRepository
+    );
+    if (promptAuthor instanceof Response) return promptAuthor;
+    let sandboxTimeoutMs: number | undefined;
+    try {
+      sandboxTimeoutMs = parsePersistedSandboxSettings(session.sandbox_settings).sandboxTimeoutMs;
+    } catch {
+      sandboxTimeoutMs = undefined;
+    }
+    const context: SpawnContext = {
+      repoOwner: session.repo_owner,
+      repoName: session.repo_name,
+      repoId: session.repo_id,
+      model: session.model,
+      reasoningEffort: session.reasoning_effort ?? null,
+      baseBranch: session.base_branch,
+      sandboxTimeoutMs,
+      promptAuthor: {
+        userId: promptAuthor.user_id,
+        ...(promptAuthor.canonical_user_id
+          ? { canonicalUserId: promptAuthor.canonical_user_id }
+          : {}),
+        scmUserId: promptAuthor.scm_user_id,
+        scmLogin: promptAuthor.scm_login,
+        scmName: promptAuthor.scm_name,
+        scmEmail: promptAuthor.scm_email,
+        scmAccessTokenEncrypted: promptAuthor.scm_access_token_encrypted,
+        scmRefreshTokenEncrypted: promptAuthor.scm_refresh_token_encrypted,
+        scmTokenExpiresAt: promptAuthor.scm_token_expires_at,
+      },
+    };
+
+    return Response.json(context);
+  }
+
+  getActivePromptAuthor(): Response {
+    if (!this.sessionCoreRepository.getSession()) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+    const author = resolvePromptAuthorParticipant(
+      this.messageRepository,
+      this.participantRepository
+    );
+    return author instanceof Response ? author : Response.json(toActivePromptAuthor(author));
+  }
+
+  getChildSummary(url?: URL): Response {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const parsedOptions = parseChildSummaryOptions(url);
+    if (!parsedOptions.ok) {
+      return Response.json({ error: parsedOptions.error }, { status: 400 });
+    }
+
+    const options = parsedOptions.options;
+    const sandbox = this.sandboxRepository.getSandbox();
+    const artifacts = this.artifactRepository.listArtifacts();
+    const recentEventRows = this.eventRepository.listEventPage({
+      limit: RECENT_EVENT_FETCH_LIMIT,
+    }).events;
+    let finalResponse: ChildSummaryFinalResponseInput | undefined;
+    let trajectory: ChildSummaryTrajectoryInput | undefined;
+
+    if (options.includeFinalResponse) {
+      const terminalMessage = this.messageRepository.getLatestTerminalMessage();
+      const collectedEvents = terminalMessage
+        ? collectFinalResponseEventRows(this.eventRepository, terminalMessage.id)
+        : { eventRows: [], eventLimitReached: false };
+      finalResponse = { message: terminalMessage, ...collectedEvents };
+    }
+
+    if (options.includeTrajectory) {
+      const page = this.eventRepository.getEventTimelinePage({
+        limit: options.trajectoryLimit,
+        cursor: options.trajectoryCursor ?? undefined,
+      });
+      trajectory = {
+        eventRows: page.events,
+        hasMore: page.hasMore,
+        nextCursor: page.nextCursor,
+        limit: options.trajectoryLimit,
       };
+    }
 
-      return Response.json(context);
-    },
+    return Response.json(
+      buildChildSessionDetail({
+        session,
+        sandbox,
+        publicSessionId: resolvePublicSessionId(session, this.durableObjectId),
+        artifacts,
+        recentEventRows,
+        hasUnfinishedPrompt: this.messageRepository.getPendingOrProcessingCount() > 0,
+        parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, this.log),
+        finalResponse,
+        trajectory,
+      })
+    );
+  }
 
-    getActivePromptAuthor(): Response {
-      if (!deps.getSession()) return Response.json({ error: "Session not found" }, { status: 404 });
-      const author = resolvePromptAuthorParticipant(
-        deps.messageRepository,
-        deps.participantRepository
-      );
-      return author instanceof Response ? author : Response.json(toActivePromptAuthor(author));
-    },
-
-    getChildSummary(url?: URL): Response {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-
-      const parsedOptions = parseChildSummaryOptions(url);
-      if (!parsedOptions.ok) {
-        return Response.json({ error: parsedOptions.error }, { status: 400 });
-      }
-
-      const options = parsedOptions.options;
-      const sandbox = deps.getSandbox();
-      const artifacts = deps.artifactRepository.listArtifacts();
-      const recentEventRows = deps.eventRepository.listEventPage({
-        limit: RECENT_EVENT_FETCH_LIMIT,
-      }).events;
-      let finalResponse: ChildSummaryFinalResponseInput | undefined;
-      let trajectory: ChildSummaryTrajectoryInput | undefined;
-
-      if (options.includeFinalResponse) {
-        const terminalMessage = deps.messageRepository.getLatestTerminalMessage();
-        const collectedEvents = terminalMessage
-          ? collectFinalResponseEventRows(deps.eventRepository, terminalMessage.id)
-          : { eventRows: [], eventLimitReached: false };
-        finalResponse = { message: terminalMessage, ...collectedEvents };
-      }
-
-      if (options.includeTrajectory) {
-        const page = deps.eventRepository.getEventTimelinePage({
-          limit: options.trajectoryLimit,
-          cursor: options.trajectoryCursor ?? undefined,
-        });
-        trajectory = {
-          eventRows: page.events,
-          hasMore: page.hasMore,
-          nextCursor: page.nextCursor,
-          limit: options.trajectoryLimit,
-        };
-      }
-
+  async parentPrompt(request: Request): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid prompt body" }, { status: 400 });
+    }
+    const parsed = parentPromptRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      const reason = parsed.error.issues[0]?.message;
       return Response.json(
-        buildChildSessionDetail({
-          session,
-          sandbox,
-          publicSessionId: deps.getPublicSessionId(session),
-          artifacts,
-          recentEventRows,
-          hasUnfinishedPrompt: deps.messageRepository.getPendingOrProcessingCount() > 0,
-          parseArtifactMetadata: deps.parseArtifactMetadata,
-          finalResponse,
-          trajectory,
+        { error: reason ? `Invalid prompt body: ${reason}` : "Invalid prompt body" },
+        { status: 400 }
+      );
+    }
+
+    const session = this.sessionCoreRepository.getSession();
+    if (!session || session.parent_session_id !== parsed.data.parentSessionId) {
+      return Response.json({ error: "Child session not found" }, { status: 404 });
+    }
+    if (!isSessionPromptable(session.status)) {
+      return Response.json({ error: `Cannot prompt a ${session.status} session` }, { status: 409 });
+    }
+    try {
+      return Response.json(
+        await this.messageService.enqueuePrompt({
+          content: parsed.data.content,
+          authorId: parsed.data.author.userId,
+          canonicalUserId: parsed.data.author.canonicalUserId ?? undefined,
+          source: "agent",
+          scmEnrichment: {
+            userId: parsed.data.author.scmUserId,
+            login: parsed.data.author.scmLogin,
+            name: parsed.data.author.scmName,
+            email: parsed.data.author.scmEmail,
+            accessTokenEncrypted: null,
+            refreshTokenEncrypted: null,
+            tokenExpiresAt: null,
+          },
         })
       );
-    },
-
-    async parentPrompt(request: Request): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid prompt body" }, { status: 400 });
+    } catch (error) {
+      if (error instanceof SessionNotPromptableError) {
+        return Response.json({ error: error.message }, { status: 409 });
       }
-      const parsed = parentPromptRequestSchema.safeParse(raw);
-      if (!parsed.success) {
-        const reason = parsed.error.issues[0]?.message;
-        return Response.json(
-          { error: reason ? `Invalid prompt body: ${reason}` : "Invalid prompt body" },
-          { status: 400 }
-        );
+      if (error instanceof PromptQueueFullError) {
+        return Response.json({ error: "Child prompt queue is full" }, { status: 429 });
       }
+      throw error;
+    }
+  }
 
-      const session = deps.getSession();
-      if (!session || session.parent_session_id !== parsed.data.parentSessionId) {
-        return Response.json({ error: "Child session not found" }, { status: 404 });
-      }
-      if (!isSessionPromptable(session.status)) {
-        return Response.json(
-          { error: `Cannot prompt a ${session.status} session` },
-          { status: 409 }
-        );
-      }
-      try {
-        return Response.json(
-          await deps.messageService.enqueuePrompt({
-            content: parsed.data.content,
-            authorId: parsed.data.author.userId,
-            canonicalUserId: parsed.data.author.canonicalUserId ?? undefined,
-            source: "agent",
-            scmEnrichment: {
-              userId: parsed.data.author.scmUserId,
-              login: parsed.data.author.scmLogin,
-              name: parsed.data.author.scmName,
-              email: parsed.data.author.scmEmail,
-              accessTokenEncrypted: null,
-              refreshTokenEncrypted: null,
-              tokenExpiresAt: null,
-            },
-          })
-        );
-      } catch (error) {
-        if (error instanceof SessionNotPromptableError) {
-          return Response.json({ error: error.message }, { status: 409 });
-        }
-        if (error instanceof PromptQueueFullError) {
-          return Response.json({ error: "Child prompt queue is full" }, { status: 429 });
-        }
-        throw error;
-      }
-    },
+  async childSessionUpdate(request: Request): Promise<Response> {
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
+    }
+    const result = childSessionUpdateBodySchema.safeParse(rawBody);
 
-    async childSessionUpdate(request: Request): Promise<Response> {
-      let rawBody: unknown;
-      try {
-        rawBody = await request.json();
-      } catch {
-        return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
-      }
-      const result = childSessionUpdateBodySchema.safeParse(rawBody);
+    if (!result.success) {
+      return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
+    }
 
-      if (!result.success) {
-        return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
-      }
+    const body = result.data;
 
-      const body = result.data;
+    this.messenger.broadcast({
+      type: "child_session_update",
+      childSessionId: body.childSessionId,
+      status: body.status,
+      title: body.title ?? null,
+    });
 
-      deps.messenger.broadcast({
-        type: "child_session_update",
-        childSessionId: body.childSessionId,
-        status: body.status,
-        title: body.title ?? null,
-      });
-
-      return Response.json({ ok: true });
-    },
-  };
+    return Response.json({ ok: true });
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
-import { createMessagesHandler } from "./messages.handler";
+import { MessagesHandler } from "./messages.handler";
 import type { MessageService } from "../../services/message.service";
 
 function createHandler() {
@@ -22,15 +22,13 @@ function createHandler() {
   } as unknown as Logger;
 
   return {
-    handler: createMessagesHandler({
-      messageService,
-    }),
+    handler: new MessagesHandler(messageService),
     messageService,
     log,
   };
 }
 
-describe("createMessagesHandler", () => {
+describe("MessagesHandler", () => {
   it("enqueues prompt and returns queued response", async () => {
     const { handler, messageService, log } = createHandler();
     vi.mocked(messageService.enqueuePrompt).mockResolvedValue({

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -18,108 +18,98 @@ import {
  */
 const VALID_MESSAGE_STATUSES = ["pending", "processing", "completed", "failed"] as const;
 
-export interface MessagesHandlerDeps {
-  messageService: MessageService;
-}
+/**
+ * HTTP boundary for the prompt/event/artifact/message endpoints: parses
+ * requests, delegates to the message service, and maps thrown domain errors
+ * to statuses.
+ */
+export class MessagesHandler {
+  constructor(private readonly messageService: MessageService) {}
 
-export interface MessagesHandler {
-  enqueuePrompt: (request: Request, log: Logger) => Promise<Response>;
-  stop: () => Promise<Response>;
-  listEvents: (url: URL) => Response;
-  listArtifacts: (url: URL) => Response;
-  listMessages: (url: URL) => Response;
-}
-
-export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandler {
-  return {
-    async enqueuePrompt(request: Request, log: Logger): Promise<Response> {
-      try {
-        const raw = await request.json();
-        const result = enqueuePromptRequestSchema.safeParse(raw);
-        if (!result.success) {
-          return Response.json({ error: "Invalid prompt body" }, { status: 400 });
-        }
-
-        const body: EnqueuePromptRequest = result.data;
-        return Response.json(await deps.messageService.enqueuePrompt(body));
-      } catch (error) {
-        if (error instanceof SessionAttachmentError) {
-          return Response.json({ error: error.message }, { status: 400 });
-        }
-        if (error instanceof SessionNotPromptableError) {
-          return Response.json({ error: error.message }, { status: 409 });
-        }
-        if (error instanceof PromptQueueFullError) {
-          return Response.json(
-            { error: error.message, code: "PROMPT_QUEUE_FULL" },
-            { status: 429 }
-          );
-        }
-        if (error instanceof PromptRequestConflictError) {
-          return Response.json(
-            { error: error.message, code: "PROMPT_REQUEST_CONFLICT" },
-            { status: 409 }
-          );
-        }
-        log.error("handleEnqueuePrompt error", {
-          error: error instanceof Error ? error : String(error),
-        });
-        throw error;
-      }
-    },
-
-    async stop(): Promise<Response> {
-      return Response.json(await deps.messageService.stop());
-    },
-
-    listEvents(url: URL): Response {
-      const cursorResult = parseEventListCursor(url.searchParams.get("cursor"));
-      const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 200);
-      const type = url.searchParams.get("type");
-      const messageId = url.searchParams.get("message_id");
-
-      if (type && !eventTypeSchema.safeParse(type).success) {
-        return Response.json({ error: `Invalid event type: ${type}` }, { status: 400 });
+  async enqueuePrompt(request: Request, log: Logger): Promise<Response> {
+    try {
+      const raw = await request.json();
+      const result = enqueuePromptRequestSchema.safeParse(raw);
+      if (!result.success) {
+        return Response.json({ error: "Invalid prompt body" }, { status: 400 });
       }
 
-      if (!cursorResult.ok) {
-        return Response.json({ error: cursorResult.error }, { status: 400 });
+      const body: EnqueuePromptRequest = result.data;
+      return Response.json(await this.messageService.enqueuePrompt(body));
+    } catch (error) {
+      if (error instanceof SessionAttachmentError) {
+        return Response.json({ error: error.message }, { status: 400 });
       }
-
-      const result = deps.messageService.listEvents({
-        cursor: cursorResult.cursor,
-        limit,
-        type,
-        messageId,
+      if (error instanceof SessionNotPromptableError) {
+        return Response.json({ error: error.message }, { status: 409 });
+      }
+      if (error instanceof PromptQueueFullError) {
+        return Response.json({ error: error.message, code: "PROMPT_QUEUE_FULL" }, { status: 429 });
+      }
+      if (error instanceof PromptRequestConflictError) {
+        return Response.json(
+          { error: error.message, code: "PROMPT_REQUEST_CONFLICT" },
+          { status: 409 }
+        );
+      }
+      log.error("handleEnqueuePrompt error", {
+        error: error instanceof Error ? error : String(error),
       });
+      throw error;
+    }
+  }
 
-      return Response.json(result);
-    },
+  async stop(): Promise<Response> {
+    return Response.json(await this.messageService.stop());
+  }
 
-    listArtifacts(url: URL): Response {
-      const artifactId = url.searchParams.get("artifactId");
-      if (artifactId) {
-        return Response.json(deps.messageService.getArtifact(artifactId));
-      }
+  listEvents(url: URL): Response {
+    const cursorResult = parseEventListCursor(url.searchParams.get("cursor"));
+    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 200);
+    const type = url.searchParams.get("type");
+    const messageId = url.searchParams.get("message_id");
 
-      return Response.json(deps.messageService.listArtifacts());
-    },
+    if (type && !eventTypeSchema.safeParse(type).success) {
+      return Response.json({ error: `Invalid event type: ${type}` }, { status: 400 });
+    }
 
-    listMessages(url: URL): Response {
-      const cursor = url.searchParams.get("cursor");
-      const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 100);
-      const status = url.searchParams.get("status");
+    if (!cursorResult.ok) {
+      return Response.json({ error: cursorResult.error }, { status: 400 });
+    }
 
-      if (
-        status &&
-        !VALID_MESSAGE_STATUSES.includes(status as (typeof VALID_MESSAGE_STATUSES)[number])
-      ) {
-        return Response.json({ error: `Invalid message status: ${status}` }, { status: 400 });
-      }
+    const result = this.messageService.listEvents({
+      cursor: cursorResult.cursor,
+      limit,
+      type,
+      messageId,
+    });
 
-      const result = deps.messageService.listMessages({ cursor, limit, status });
+    return Response.json(result);
+  }
 
-      return Response.json(result);
-    },
-  };
+  listArtifacts(url: URL): Response {
+    const artifactId = url.searchParams.get("artifactId");
+    if (artifactId) {
+      return Response.json(this.messageService.getArtifact(artifactId));
+    }
+
+    return Response.json(this.messageService.listArtifacts());
+  }
+
+  listMessages(url: URL): Response {
+    const cursor = url.searchParams.get("cursor");
+    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 100);
+    const status = url.searchParams.get("status");
+
+    if (
+      status &&
+      !VALID_MESSAGE_STATUSES.includes(status as (typeof VALID_MESSAGE_STATUSES)[number])
+    ) {
+      return Response.json({ error: `Invalid message status: ${status}` }, { status: 400 });
+    }
+
+    const result = this.messageService.listMessages({ cursor, limit, status });
+
+    return Response.json(result);
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/participants.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/participants.handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ParticipantRow } from "../../types";
-import { createParticipantsHandler } from "./participants.handler";
+import { ParticipantsHandler } from "./participants.handler";
 import type { ParticipantRepository } from "../../participant-repository";
 
 function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
@@ -28,9 +28,7 @@ function createHandler() {
     listParticipants: vi.fn(),
   };
 
-  const handler = createParticipantsHandler({
-    repository: repository as unknown as ParticipantRepository,
-  });
+  const handler = new ParticipantsHandler(repository as unknown as ParticipantRepository);
 
   return {
     handler,
@@ -38,7 +36,7 @@ function createHandler() {
   };
 }
 
-describe("createParticipantsHandler", () => {
+describe("ParticipantsHandler", () => {
   it("returns an empty list when there are no participants", async () => {
     const { handler, repository } = createHandler();
     repository.listParticipants.mockReturnValue([]);

--- a/packages/control-plane/src/session/http/handlers/participants.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/participants.handler.ts
@@ -1,31 +1,24 @@
 import type { ParticipantRepository } from "../../participant-repository";
 
-export interface ParticipantsHandlerDeps {
-  repository: ParticipantRepository;
-}
+/** HTTP boundary for the participant listing endpoint. */
+export class ParticipantsHandler {
+  constructor(private readonly repository: ParticipantRepository) {}
 
-export interface ParticipantsHandler {
-  listParticipants: () => Response;
-}
+  listParticipants(): Response {
+    const participants = this.repository.listParticipants();
 
-export function createParticipantsHandler(deps: ParticipantsHandlerDeps): ParticipantsHandler {
-  return {
-    listParticipants(): Response {
-      const participants = deps.repository.listParticipants();
-
-      return Response.json({
-        participants: participants.map((participant) => ({
-          id: participant.id,
-          userId: participant.user_id,
-          ...(participant.canonical_user_id
-            ? { canonicalUserId: participant.canonical_user_id }
-            : {}),
-          scmLogin: participant.scm_login,
-          scmName: participant.scm_name,
-          role: participant.role,
-          joinedAt: participant.joined_at,
-        })),
-      });
-    },
-  };
+    return Response.json({
+      participants: participants.map((participant) => ({
+        id: participant.id,
+        userId: participant.user_id,
+        ...(participant.canonical_user_id
+          ? { canonicalUserId: participant.canonical_user_id }
+          : {}),
+        scmLogin: participant.scm_login,
+        scmName: participant.scm_name,
+        role: participant.role,
+        joinedAt: participant.joined_at,
+      })),
+    });
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -3,7 +3,10 @@ import type { Logger } from "../../../logger";
 import type { SessionRepositoryRow } from "../../types";
 import { buildSessionRepositories, type SessionRepositoryEntry } from "../../repository-target";
 import type { ArtifactRow, ParticipantRow, SessionRow } from "../../types";
-import { createPullRequestHandler } from "./pull-request.handler";
+import { PullRequestHandler } from "./pull-request.handler";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { ArtifactRepository } from "../../artifact-repository";
+import type { ParticipantService } from "../../participant-service";
 
 function createRepositoryRow(
   position: number,
@@ -103,25 +106,24 @@ function createHandler() {
     child: vi.fn(),
   } as unknown as Logger;
 
-  const pullRequestHandler = createPullRequestHandler({
-    getSession,
-    getSessionRepositories,
-    getPromptingParticipantForPR,
-    resolveAuthForPR,
+  const pullRequestHandler = new PullRequestHandler(
+    { getSession, getSessionRepositories } as unknown as SessionCoreRepository,
+    { getPromptingParticipantForPR, resolveAuthForPR } as unknown as ParticipantService,
+    { getArtifactById, updateArtifact } as unknown as ArtifactRepository,
+    messenger,
     getSessionUrl,
     createPullRequest,
-    getArtifactById,
-    updateArtifact,
-    messenger,
-    now,
     triggerPullRequestRefresh,
-  });
+    now
+  );
 
   // Bind the request-scoped log so call sites exercise the threading without
   // repeating it at every invocation.
   const handler = {
-    ...pullRequestHandler,
     createPr: (request: Request) => pullRequestHandler.createPr(request, log),
+    pullRequestArtifactSnapshot: (request: Request, url: URL) =>
+      pullRequestHandler.pullRequestArtifactSnapshot(request, url),
+    refreshPullRequests: () => pullRequestHandler.refreshPullRequests(),
   };
 
   return {
@@ -144,7 +146,7 @@ function createHandler() {
   };
 }
 
-describe("createPullRequestHandler", () => {
+describe("PullRequestHandler", () => {
   it("returns 404 when session is missing", async () => {
     const { handler, getSession } = createHandler();
     getSession.mockReturnValue(null);

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,5 +1,4 @@
 import type { Logger } from "../../../logger";
-import type { SourceControlAuthContext } from "../../../source-control";
 import type { SessionMessenger } from "../../messenger";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
 import {
@@ -11,8 +10,10 @@ import {
   resolveSessionRepositoryTarget,
   type SessionRepositoryEntry,
 } from "../../repository-target";
-import type { UpdateArtifactData } from "../../artifact-repository";
-import type { ArtifactRow, ParticipantRow, SessionRow } from "../../types";
+import type { ArtifactRepository } from "../../artifact-repository";
+import type { ParticipantService } from "../../participant-service";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { SessionRow } from "../../types";
 import { z } from "zod";
 
 const createPrRequestSchema = z.object({
@@ -27,175 +28,160 @@ const createPrRequestSchema = z.object({
 
 type CreatePrRequest = z.infer<typeof createPrRequestSchema>;
 
-type PromptingParticipantResult =
-  | { participant: ParticipantRow; error?: never; status?: never }
-  | { participant?: never; error: string; status: number };
+/**
+ * HTTP boundary for the pull-request endpoints: PR creation, sandbox-reported
+ * snapshot application, and the manual refresh trigger.
+ */
+export class PullRequestHandler {
+  constructor(
+    private readonly sessionCoreRepository: SessionCoreRepository,
+    private readonly participants: ParticipantService,
+    private readonly artifactRepository: ArtifactRepository,
+    private readonly messenger: SessionMessenger,
+    private readonly getSessionUrl: (session: SessionRow) => string,
+    private readonly createPullRequest: (
+      input: CreatePullRequestInput,
+      log: Logger
+    ) => Promise<CreatePullRequestResult>,
+    /** Kicks off a background read-through refresh. */
+    private readonly triggerPullRequestRefresh: () => void,
+    private readonly now: () => number = Date.now
+  ) {}
 
-type ResolveAuthForPrResult =
-  | { auth: SourceControlAuthContext | null; error?: never; status?: never }
-  | { auth?: never; error: string; status: number };
+  async createPr(request: Request, log: Logger): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-export interface PullRequestHandlerDeps {
-  getSession: () => SessionRow | null;
-  getSessionRepositories: () => SessionRepositoryEntry[];
-  getPromptingParticipantForPR: () => Promise<PromptingParticipantResult>;
-  resolveAuthForPR: (participant: ParticipantRow) => Promise<ResolveAuthForPrResult>;
-  getSessionUrl: (session: SessionRow) => string;
-  createPullRequest: (
-    input: CreatePullRequestInput,
-    log: Logger
-  ) => Promise<CreatePullRequestResult>;
-  getArtifactById: (artifactId: string) => ArtifactRow | null;
-  updateArtifact: (artifactId: string, data: UpdateArtifactData) => void;
-  messenger: SessionMessenger;
-  now: () => number;
-  /** Kicks off a background read-through refresh. */
-  triggerPullRequestRefresh: () => void;
-}
+    const parsed = createPrRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const body: CreatePrRequest = parsed.data;
 
-export interface PullRequestHandler {
-  createPr: (request: Request, log: Logger) => Promise<Response>;
-  pullRequestArtifactSnapshot: (request: Request, url: URL) => Promise<Response>;
-  refreshPullRequests: () => Response;
-}
-
-export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequestHandler {
-  return {
-    async createPr(request: Request, log: Logger): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
-
-      const parsed = createPrRequestSchema.safeParse(raw);
-      if (!parsed.success) {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
-      const body: CreatePrRequest = parsed.data;
-
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-      if (!session.repo_owner || !session.repo_name) {
-        return Response.json(
-          { error: "Pull requests require a repository context" },
-          { status: 400 }
-        );
-      }
-
-      // Membership is a security boundary (this route is reachable with
-      // sandbox auth): naming a repo outside the session is 403, an
-      // ambiguous or half-specified target is 400.
-      let target: SessionRepositoryEntry;
-      try {
-        target = resolveSessionRepositoryTarget(
-          { repoOwner: body.repoOwner, repoName: body.repoName },
-          deps.getSessionRepositories()
-        );
-      } catch (error) {
-        const mapped = mapRepositoryTargetError(error);
-        if (!mapped) throw error;
-        return Response.json({ error: mapped.error }, { status: mapped.status });
-      }
-
-      const promptingParticipantResult = await deps.getPromptingParticipantForPR();
-      if (!promptingParticipantResult.participant) {
-        return Response.json(
-          { error: promptingParticipantResult.error },
-          { status: promptingParticipantResult.status }
-        );
-      }
-
-      const promptingParticipant = promptingParticipantResult.participant;
-      const authResolution = await deps.resolveAuthForPR(promptingParticipant);
-      if ("error" in authResolution) {
-        return Response.json({ error: authResolution.error }, { status: authResolution.status });
-      }
-
-      // Base-branch defaulting happens in the service (requested > target
-      // repo's base branch > repo default), so the raw request value passes
-      // through untouched.
-      const result = await deps.createPullRequest(
-        {
-          title: body.title,
-          body: body.body,
-          baseBranch: body.baseBranch,
-          headBranch: body.headBranch,
-          repoOwner: target.repoOwner,
-          repoName: target.repoName,
-          promptingUserId: promptingParticipant.user_id,
-          promptingAuth: authResolution.auth,
-          sessionUrl: deps.getSessionUrl(session),
-          draft: body.draft,
-        },
-        log
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+    if (!session.repo_owner || !session.repo_name) {
+      return Response.json(
+        { error: "Pull requests require a repository context" },
+        { status: 400 }
       );
+    }
 
-      if (result.kind === "error") {
-        return Response.json({ error: result.error }, { status: result.status });
-      }
+    // Membership is a security boundary (this route is reachable with
+    // sandbox auth): naming a repo outside the session is 403, an
+    // ambiguous or half-specified target is 400.
+    let target: SessionRepositoryEntry;
+    try {
+      target = resolveSessionRepositoryTarget(
+        { repoOwner: body.repoOwner, repoName: body.repoName },
+        this.sessionCoreRepository.getSessionRepositories()
+      );
+    } catch (error) {
+      const mapped = mapRepositoryTargetError(error);
+      if (!mapped) throw error;
+      return Response.json({ error: mapped.error }, { status: mapped.status });
+    }
 
-      return Response.json({
-        prNumber: result.prNumber,
-        prUrl: result.prUrl,
-        state: result.state,
-        headBranch: result.headBranch,
-        baseBranch: result.baseBranch,
-        updated: result.updated,
-      });
-    },
+    const promptingParticipantResult = await this.participants.getPromptingParticipantForPR();
+    if (!promptingParticipantResult.participant) {
+      return Response.json(
+        { error: promptingParticipantResult.error },
+        { status: promptingParticipantResult.status }
+      );
+    }
 
-    /**
-     * Transport shell for snapshot application (design §6): parse the
-     * request, resolve the artifact, compute the update via the canonical
-     * preparePullRequestArtifactUpdate, and perform the write + broadcast it
-     * prescribes. Stale and materially identical snapshots answer
-     * `{ applied: false }` — no write, no broadcast.
-     */
-    async pullRequestArtifactSnapshot(request: Request, url: URL): Promise<Response> {
-      const artifactId = url.searchParams.get("artifactId");
-      if (!artifactId) {
-        return Response.json({ error: "artifactId query parameter is required" }, { status: 400 });
-      }
+    const promptingParticipant = promptingParticipantResult.participant;
+    const authResolution = await this.participants.resolveAuthForPR(promptingParticipant);
+    if ("error" in authResolution) {
+      return Response.json({ error: authResolution.error }, { status: authResolution.status });
+    }
 
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+    // Base-branch defaulting happens in the service (requested > target
+    // repo's base branch > repo default), so the raw request value passes
+    // through untouched.
+    const result = await this.createPullRequest(
+      {
+        title: body.title,
+        body: body.body,
+        baseBranch: body.baseBranch,
+        headBranch: body.headBranch,
+        repoOwner: target.repoOwner,
+        repoName: target.repoName,
+        promptingUserId: promptingParticipant.user_id,
+        promptingAuth: authResolution.auth,
+        sessionUrl: this.getSessionUrl(session),
+        draft: body.draft,
+      },
+      log
+    );
 
-      const parsed = pullRequestSnapshotSchema.safeParse(raw);
-      if (!parsed.success) {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+    if (result.kind === "error") {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
 
-      const artifact = deps.getArtifactById(artifactId);
-      if (!artifact || artifact.type !== "pr") {
-        return Response.json({ error: "Pull request artifact not found" }, { status: 404 });
-      }
+    return Response.json({
+      prNumber: result.prNumber,
+      prUrl: result.prUrl,
+      state: result.state,
+      headBranch: result.headBranch,
+      baseBranch: result.baseBranch,
+      updated: result.updated,
+    });
+  }
 
-      const artifactUpdate = preparePullRequestArtifactUpdate(artifact, parsed.data, deps.now());
-      if (!artifactUpdate) {
-        return Response.json({ applied: false });
-      }
+  /**
+   * Transport shell for snapshot application (design §6): parse the
+   * request, resolve the artifact, compute the update via the canonical
+   * preparePullRequestArtifactUpdate, and perform the write + broadcast it
+   * prescribes. Stale and materially identical snapshots answer
+   * `{ applied: false }` — no write, no broadcast.
+   */
+  async pullRequestArtifactSnapshot(request: Request, url: URL): Promise<Response> {
+    const artifactId = url.searchParams.get("artifactId");
+    if (!artifactId) {
+      return Response.json({ error: "artifactId query parameter is required" }, { status: 400 });
+    }
 
-      deps.updateArtifact(artifact.id, artifactUpdate.update);
-      deps.messenger.broadcast({ type: "artifact_updated", artifact: artifactUpdate.artifact });
-      return Response.json({ applied: true });
-    },
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-    /**
-     * Manual sync (design §5.3): fire the read-through refresh in the
-     * background and return immediately — the endpoint never blocks on a
-     * provider read.
-     */
-    refreshPullRequests(): Response {
-      deps.triggerPullRequestRefresh();
-      return Response.json({ status: "refreshing" }, { status: 202 });
-    },
-  };
+    const parsed = pullRequestSnapshotSchema.safeParse(raw);
+    if (!parsed.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const artifact = this.artifactRepository.getArtifactById(artifactId);
+    if (!artifact || artifact.type !== "pr") {
+      return Response.json({ error: "Pull request artifact not found" }, { status: 404 });
+    }
+
+    const artifactUpdate = preparePullRequestArtifactUpdate(artifact, parsed.data, this.now());
+    if (!artifactUpdate) {
+      return Response.json({ applied: false });
+    }
+
+    this.artifactRepository.updateArtifact(artifact.id, artifactUpdate.update);
+    this.messenger.broadcast({ type: "artifact_updated", artifact: artifactUpdate.artifact });
+    return Response.json({ applied: true });
+  }
+
+  /**
+   * Manual sync (design §5.3): fire the read-through refresh in the
+   * background and return immediately — the endpoint never blocks on a
+   * provider read.
+   */
+  refreshPullRequests(): Response {
+    this.triggerPullRequestRefresh();
+    return Response.json({ status: "refreshing" }, { status: 202 });
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -7,13 +7,16 @@ import {
   OpenAITokenUpstreamError,
 } from "../../openai-token-refresh-service";
 import type { SandboxRow, SessionRow } from "../../types";
-import { createSandboxHandler } from "./sandbox.handler";
+import { SandboxHandler } from "./sandbox.handler";
 import type { ArtifactRepository } from "../../artifact-repository";
 import type { ParticipantRepository } from "../../participant-repository";
 import type { EventRepository } from "../../event-repository";
 import type { MessageRepository } from "../../message-repository";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { SandboxRepository } from "../../sandbox-repository";
+import type { SessionSandboxEventProcessor } from "../../sandbox-events";
 
-function createHandler() {
+function createHandler({ managedSecretsConfigured = true } = {}) {
   const repository = {
     createParticipant: vi.fn(),
     createEvent: vi.fn(),
@@ -26,7 +29,6 @@ function createHandler() {
   const getSession = vi.fn<() => SessionRow | null>();
   const refreshOpenAIToken = vi.fn();
   const refreshXaiToken = vi.fn();
-  const isManagedSecretsConfigured = vi.fn();
   const getScmCredentials = vi.fn();
   const broadcast = vi.fn();
   const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) };
@@ -41,28 +43,30 @@ function createHandler() {
     child: vi.fn(),
   } as unknown as Logger;
 
-  const sandboxHandler = createSandboxHandler({
-    messageRepository: repository as unknown as MessageRepository,
-    eventRepository: repository as unknown as EventRepository,
-    participantRepository: repository as unknown as ParticipantRepository,
+  const sandboxHandler = new SandboxHandler(
+    repository as unknown as MessageRepository,
+    repository as unknown as EventRepository,
+    repository as unknown as ParticipantRepository,
     artifactRepository,
-    processSandboxEvent,
-    getSandbox,
-    isValidSandboxToken,
-    getSession,
+    { getSession } as unknown as SessionCoreRepository,
+    { getSandbox } as unknown as SandboxRepository,
+    { processSandboxEvent } as unknown as SessionSandboxEventProcessor,
+    messenger,
+    managedSecretsConfigured,
     refreshOpenAIToken,
     refreshXaiToken,
-    isManagedSecretsConfigured,
     getScmCredentials,
-    messenger,
+    isValidSandboxToken,
     generateId,
-    now,
-  });
+    now
+  );
 
   // Bind the request-scoped log so call sites exercise the threading without
   // repeating it at every invocation.
   const handler = {
-    ...sandboxHandler,
+    sandboxEvent: (request: Request) => sandboxHandler.sandboxEvent(request),
+    createMediaArtifact: (request: Request) => sandboxHandler.createMediaArtifact(request),
+    addParticipant: (request: Request) => sandboxHandler.addParticipant(request),
     verifySandboxToken: (request: Request) => sandboxHandler.verifySandboxToken(request, log),
     openaiTokenRefresh: () => sandboxHandler.openaiTokenRefresh(log),
     xaiTokenRefresh: () => sandboxHandler.xaiTokenRefresh(log),
@@ -80,7 +84,6 @@ function createHandler() {
     getSession,
     refreshOpenAIToken,
     refreshXaiToken,
-    isManagedSecretsConfigured,
     getScmCredentials,
     broadcast,
     generateId,
@@ -89,7 +92,7 @@ function createHandler() {
   };
 }
 
-describe("createSandboxHandler", () => {
+describe("SandboxHandler", () => {
   it("processes sandbox event and returns ok response", async () => {
     const { handler, processSandboxEvent } = createHandler();
     const event = {
@@ -486,9 +489,8 @@ describe("createSandboxHandler", () => {
   });
 
   it("returns 500 when openai secrets are not configured", async () => {
-    const { handler, getSession, isManagedSecretsConfigured } = createHandler();
+    const { handler, getSession } = createHandler({ managedSecretsConfigured: false });
     getSession.mockReturnValue({} as SessionRow);
-    isManagedSecretsConfigured.mockReturnValue(false);
 
     const response = await handler.openaiTokenRefresh();
 
@@ -507,9 +509,8 @@ describe("createSandboxHandler", () => {
     ],
     [OpenAITokenUpstreamError, 502, "OpenAI token refresh failed"],
   ])("maps %s to status %i", async (ErrorType, status, message) => {
-    const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
+    const { handler, getSession, refreshOpenAIToken } = createHandler();
     getSession.mockReturnValue({ id: "session-1" } as SessionRow);
-    isManagedSecretsConfigured.mockReturnValue(true);
     refreshOpenAIToken.mockRejectedValue(new ErrorType(message));
 
     const response = await handler.openaiTokenRefresh();
@@ -519,9 +520,8 @@ describe("createSandboxHandler", () => {
   });
 
   it("does not mask unexpected OpenAI token refresh failures", async () => {
-    const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken } = createHandler();
+    const { handler, getSession, refreshOpenAIToken } = createHandler();
     getSession.mockReturnValue({ id: "session-1" } as SessionRow);
-    isManagedSecretsConfigured.mockReturnValue(true);
     const unexpected = new Error("unexpected refresh failure");
     refreshOpenAIToken.mockRejectedValue(unexpected);
 
@@ -529,11 +529,9 @@ describe("createSandboxHandler", () => {
   });
 
   it("returns openai access token payload on success", async () => {
-    const { handler, getSession, isManagedSecretsConfigured, refreshOpenAIToken, log } =
-      createHandler();
+    const { handler, getSession, refreshOpenAIToken, log } = createHandler();
     const session = { id: "session-1" } as SessionRow;
     getSession.mockReturnValue(session);
-    isManagedSecretsConfigured.mockReturnValue(true);
     refreshOpenAIToken.mockResolvedValue({
       accessToken: "access-token",
       expiresIn: 3600,
@@ -553,11 +551,9 @@ describe("createSandboxHandler", () => {
   });
 
   it("returns xAI access token payload on success", async () => {
-    const { handler, getSession, isManagedSecretsConfigured, refreshXaiToken, log } =
-      createHandler();
+    const { handler, getSession, refreshXaiToken, log } = createHandler();
     const session = { id: "session-1" } as SessionRow;
     getSession.mockReturnValue(session);
-    isManagedSecretsConfigured.mockReturnValue(true);
     refreshXaiToken.mockResolvedValue({ ok: true, accessToken: "xai-access", expiresIn: 3600 });
 
     const response = await handler.xaiTokenRefresh();
@@ -579,9 +575,8 @@ describe("createSandboxHandler", () => {
   });
 
   it("returns 500 when managed secrets are not configured for xAI", async () => {
-    const { handler, getSession, isManagedSecretsConfigured } = createHandler();
+    const { handler, getSession } = createHandler({ managedSecretsConfigured: false });
     getSession.mockReturnValue({} as SessionRow);
-    isManagedSecretsConfigured.mockReturnValue(false);
 
     const response = await handler.xaiTokenRefresh();
 
@@ -590,9 +585,8 @@ describe("createSandboxHandler", () => {
   });
 
   it("returns mapped service error from xAI token refresh", async () => {
-    const { handler, getSession, isManagedSecretsConfigured, refreshXaiToken } = createHandler();
+    const { handler, getSession, refreshXaiToken } = createHandler();
     getSession.mockReturnValue({ id: "session-1" } as SessionRow);
-    isManagedSecretsConfigured.mockReturnValue(true);
     refreshXaiToken.mockResolvedValue({ ok: false, status: 401, error: "xAI unauthorized" });
 
     const response = await handler.xaiTokenRefresh();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -21,6 +21,9 @@ import type { MessageRepository } from "../../message-repository";
 import type { ArtifactRepository } from "../../artifact-repository";
 import type { EventRepository } from "../../event-repository";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { SessionCoreRepository } from "../../session-core-repository";
+import type { SandboxRepository } from "../../sandbox-repository";
+import type { SessionSandboxEventProcessor } from "../../sandbox-events";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
 import { parseTunnelUrls } from "../../tunnel-urls";
@@ -36,328 +39,326 @@ const addParticipantRequestSchema = z.object({
 
 type AddParticipantRequest = z.infer<typeof addParticipantRequestSchema>;
 
-export interface SandboxHandlerDeps {
-  messageRepository: MessageRepository;
-  eventRepository: EventRepository;
-  participantRepository: ParticipantRepository;
-  artifactRepository: ArtifactRepository;
-  processSandboxEvent: (event: SandboxEvent) => Promise<void>;
-  getSandbox: () => SandboxRow | null;
-  isValidSandboxToken: (token: string | null, sandbox: SandboxRow | null) => Promise<boolean>;
-  getSession: () => SessionRow | null;
-  refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAIToken>;
-  refreshXaiToken: (session: SessionRow, log: Logger) => Promise<XaiTokenRefreshResult>;
-  isManagedSecretsConfigured: () => boolean;
-  getScmCredentials: (log: Logger) => Promise<ScmCredentialsResult>;
-  messenger: SessionMessenger;
-  generateId: () => string;
-  now: () => number;
-}
+/**
+ * HTTP boundary for the sandbox-facing endpoints: event ingestion, media
+ * artifacts, participant registration, token verification, and the
+ * credential/token refresh routes the in-sandbox tooling calls.
+ */
+export class SandboxHandler {
+  constructor(
+    private readonly messageRepository: MessageRepository,
+    private readonly eventRepository: EventRepository,
+    private readonly participantRepository: ParticipantRepository,
+    private readonly artifactRepository: ArtifactRepository,
+    private readonly sessionCoreRepository: SessionCoreRepository,
+    private readonly sandboxRepository: SandboxRepository,
+    private readonly sandboxEventProcessor: SessionSandboxEventProcessor,
+    private readonly messenger: SessionMessenger,
+    /** Fixed at composition time: managed secrets exist only when D1 is bound. */
+    private readonly managedSecretsConfigured: boolean,
+    private readonly refreshOpenAIToken: (session: SessionRow, log: Logger) => Promise<OpenAIToken>,
+    private readonly refreshXaiToken: (
+      session: SessionRow,
+      log: Logger
+    ) => Promise<XaiTokenRefreshResult>,
+    private readonly getScmCredentials: (log: Logger) => Promise<ScmCredentialsResult>,
+    private readonly isValidSandboxToken: (
+      token: string | null,
+      sandbox: SandboxRow | null
+    ) => Promise<boolean>,
+    private readonly generateId: () => string,
+    private readonly now: () => number = Date.now
+  ) {}
 
-export interface SandboxHandler {
-  sandboxEvent: (request: Request) => Promise<Response>;
-  createMediaArtifact: (request: Request) => Promise<Response>;
-  addParticipant: (request: Request) => Promise<Response>;
-  verifySandboxToken: (request: Request, log: Logger) => Promise<Response>;
-  openaiTokenRefresh: (log: Logger) => Promise<Response>;
-  xaiTokenRefresh: (log: Logger) => Promise<Response>;
-  scmCredentials: (log: Logger) => Promise<Response>;
-  /** Return the sandbox's resolved tunnel URLs as a `{ [port]: url }` map. */
-  tunnelUrls: (log: Logger) => Promise<Response>;
-}
+  async sandboxEvent(request: Request): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
-  return {
-    async sandboxEvent(request: Request): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+    const result = sandboxEventSchema.safeParse(raw);
+    if (!result.success) {
+      return Response.json({ error: "Invalid sandbox event" }, { status: 400 });
+    }
 
-      const result = sandboxEventSchema.safeParse(raw);
-      if (!result.success) {
-        return Response.json({ error: "Invalid sandbox event" }, { status: 400 });
-      }
+    const event: SandboxEvent = result.data;
+    await this.sandboxEventProcessor.processSandboxEvent(event);
+    return Response.json({ status: "ok" });
+  }
 
-      const event: SandboxEvent = result.data;
-      await deps.processSandboxEvent(event);
-      return Response.json({ status: "ok" });
-    },
+  async createMediaArtifact(request: Request): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-    async createMediaArtifact(request: Request): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+    const result = createMediaArtifactRequestSchema.safeParse(raw);
+    if (!result.success) {
+      return Response.json({ error: "Invalid media artifact body" }, { status: 400 });
+    }
 
-      const result = createMediaArtifactRequestSchema.safeParse(raw);
-      if (!result.success) {
-        return Response.json({ error: "Invalid media artifact body" }, { status: 400 });
-      }
+    const body: CreateMediaArtifactRequest = result.data;
+    const sandbox = this.sandboxRepository.getSandbox();
+    if (!sandbox) {
+      return Response.json({ error: "No sandbox" }, { status: 404 });
+    }
 
-      const body: CreateMediaArtifactRequest = result.data;
-      const sandbox = deps.getSandbox();
-      if (!sandbox) {
-        return Response.json({ error: "No sandbox" }, { status: 404 });
-      }
+    if (!body.artifactId || !body.objectKey) {
+      return Response.json({ error: "artifactId and objectKey are required" }, { status: 400 });
+    }
 
-      if (!body.artifactId || !body.objectKey) {
-        return Response.json({ error: "artifactId and objectKey are required" }, { status: 400 });
-      }
+    const processingMessage = this.messageRepository.getProcessingMessage();
+    if (!processingMessage) {
+      return Response.json({ error: "No active prompt" }, { status: 409 });
+    }
 
-      const processingMessage = deps.messageRepository.getProcessingMessage();
-      if (!processingMessage) {
-        return Response.json({ error: "No active prompt" }, { status: 409 });
-      }
+    const artifactType = assertArtifactType(body.artifactType);
+    const now = this.now();
+    const timestampSeconds = now / 1000;
+    const artifact: SessionArtifact = {
+      id: body.artifactId,
+      type: artifactType,
+      url: body.objectKey,
+      metadata: body.metadata ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
 
-      const artifactType = assertArtifactType(body.artifactType);
-      const now = deps.now();
-      const timestampSeconds = now / 1000;
-      const artifact: SessionArtifact = {
-        id: body.artifactId,
-        type: artifactType,
-        url: body.objectKey,
-        metadata: body.metadata ?? null,
-        createdAt: now,
-        updatedAt: now,
-      };
+    this.artifactRepository.createArtifact({
+      id: artifact.id,
+      type: artifact.type,
+      url: artifact.url,
+      metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
+      createdAt: now,
+    });
 
-      deps.artifactRepository.createArtifact({
-        id: artifact.id,
-        type: artifact.type,
-        url: artifact.url,
-        metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
-        createdAt: now,
+    const event: Extract<SandboxEvent, { type: "artifact" }> = {
+      type: "artifact",
+      artifactType: artifact.type,
+      artifactId: artifact.id,
+      url: body.objectKey,
+      metadata: artifact.metadata ?? undefined,
+      messageId: processingMessage.id,
+      sandboxId: sandbox.modal_sandbox_id ?? sandbox.id,
+      timestamp: timestampSeconds,
+    };
+
+    this.eventRepository.createEvent({
+      id: this.generateId(),
+      type: event.type,
+      data: JSON.stringify(event),
+      messageId: processingMessage.id,
+      createdAt: now,
+    });
+
+    this.messenger.broadcast({ type: "artifact_created", artifact });
+    this.messenger.broadcast({ type: "sandbox_event", event });
+
+    return Response.json({ status: "ok", artifactId: artifact.id });
+  }
+
+  async addParticipant(request: Request): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const result = addParticipantRequestSchema.safeParse(raw);
+    if (!result.success) {
+      return Response.json({ error: "Invalid participant body" }, { status: 400 });
+    }
+
+    const body: AddParticipantRequest = result.data;
+
+    const id = this.generateId();
+    const now = this.now();
+
+    this.participantRepository.createParticipant({
+      id,
+      userId: body.userId,
+      scmLogin: body.scmLogin ?? null,
+      scmName: body.scmName ?? null,
+      scmEmail: body.scmEmail ?? null,
+      role: body.role ?? "member",
+      joinedAt: now,
+    });
+
+    return Response.json({ id, status: "added" });
+  }
+
+  async verifySandboxToken(request: Request, log: Logger): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ valid: false, error: "Missing token" }, { status: 400 });
+    }
+
+    const body = raw && typeof raw === "object" ? raw : null;
+    const token = body && "token" in body ? body.token : undefined;
+
+    if (typeof token !== "string" || !token) {
+      return Response.json({ valid: false, error: "Missing token" }, { status: 400 });
+    }
+
+    const sandbox = this.sandboxRepository.getSandbox();
+    if (!sandbox) {
+      log.warn("Sandbox token verification failed: no sandbox");
+      return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
+    }
+
+    // Boot-time states (spawning/connecting) must authenticate — the git
+    // credential broker is already called during the initial clone, before
+    // the WebSocket connect flips the status to ready.
+    if (isDeadSandboxStatus(sandbox.status)) {
+      log.warn("Sandbox token verification failed: sandbox is dead", {
+        status: sandbox.status,
       });
+      return Response.json({ valid: false, error: "Sandbox not active" }, { status: 410 });
+    }
 
-      const event: Extract<SandboxEvent, { type: "artifact" }> = {
-        type: "artifact",
-        artifactType: artifact.type,
-        artifactId: artifact.id,
-        url: body.objectKey,
-        metadata: artifact.metadata ?? undefined,
-        messageId: processingMessage.id,
-        sandboxId: sandbox.modal_sandbox_id ?? sandbox.id,
-        timestamp: timestampSeconds,
-      };
+    const isTokenValid = await this.isValidSandboxToken(token, sandbox);
+    if (!isTokenValid) {
+      log.warn("Sandbox token verification failed: token mismatch");
+      return Response.json({ valid: false, error: "Invalid token" }, { status: 401 });
+    }
 
-      deps.eventRepository.createEvent({
-        id: deps.generateId(),
-        type: event.type,
-        data: JSON.stringify(event),
-        messageId: processingMessage.id,
-        createdAt: now,
-      });
+    log.info("Sandbox token verified successfully");
+    return Response.json({ valid: true }, { status: 200 });
+  }
 
-      deps.messenger.broadcast({ type: "artifact_created", artifact });
-      deps.messenger.broadcast({ type: "sandbox_event", event });
+  async openaiTokenRefresh(log: Logger): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "No session" }, { status: 404 });
+    }
 
-      return Response.json({ status: "ok", artifactId: artifact.id });
-    },
+    if (!this.managedSecretsConfigured) {
+      return Response.json({ error: "Secrets not configured" }, { status: 500 });
+    }
 
-    async addParticipant(request: Request): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
+    let token: OpenAIToken;
+    try {
+      token = await this.refreshOpenAIToken(session, log);
+    } catch (error) {
+      if (error instanceof OpenAITokenNotConfiguredError) {
+        return Response.json({ error: error.message }, { status: 404 });
       }
-
-      const result = addParticipantRequestSchema.safeParse(raw);
-      if (!result.success) {
-        return Response.json({ error: "Invalid participant body" }, { status: 400 });
+      if (error instanceof OpenAITokenUnauthorizedError) {
+        return Response.json({ error: error.message }, { status: 401 });
       }
-
-      const body: AddParticipantRequest = result.data;
-
-      const id = deps.generateId();
-      const now = deps.now();
-
-      deps.participantRepository.createParticipant({
-        id,
-        userId: body.userId,
-        scmLogin: body.scmLogin ?? null,
-        scmName: body.scmName ?? null,
-        scmEmail: body.scmEmail ?? null,
-        role: body.role ?? "member",
-        joinedAt: now,
-      });
-
-      return Response.json({ id, status: "added" });
-    },
-
-    async verifySandboxToken(request: Request, log: Logger): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ valid: false, error: "Missing token" }, { status: 400 });
+      if (error instanceof OpenAITokenStorageError) {
+        return Response.json({ error: error.message }, { status: 500 });
       }
-
-      const body = raw && typeof raw === "object" ? raw : null;
-      const token = body && "token" in body ? body.token : undefined;
-
-      if (typeof token !== "string" || !token) {
-        return Response.json({ valid: false, error: "Missing token" }, { status: 400 });
+      if (error instanceof OpenAITokenUpstreamError) {
+        return Response.json({ error: error.message }, { status: 502 });
       }
+      throw error;
+    }
 
-      const sandbox = deps.getSandbox();
-      if (!sandbox) {
-        log.warn("Sandbox token verification failed: no sandbox");
-        return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
+    return Response.json(
+      {
+        access_token: token.accessToken,
+        expires_in: token.expiresIn,
+        account_id: token.accountId,
+      },
+      { status: 200, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  async xaiTokenRefresh(log: Logger): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "No session" }, { status: 404 });
+    }
+    if (!this.managedSecretsConfigured) {
+      return Response.json({ error: "Secrets not configured" }, { status: 500 });
+    }
+    const result = await this.refreshXaiToken(session, log);
+    if (!result.ok) {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
+    return Response.json(
+      { access_token: result.accessToken, expires_in: result.expiresIn },
+      { status: 200, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  /**
+   * Return the sandbox's resolved tunnel URLs as a `{ [port]: url }` map.
+   *
+   * `sandbox.tunnel_urls` is a JSON-encoded `{ [port: string]: string }`
+   * stored by `SandboxLifecycleManager#storeAndBroadcastTunnelUrls`. When the
+   * control plane has resolved Modal tunnel URLs but the in-sandbox file write
+   * (`sandbox.open` from outside) hasn't propagated to the sandbox's own
+   * filesystem view — a real failure mode on the Modal provider — this
+   * endpoint is the in-sandbox fallback for retrieving them via
+   * `SANDBOX_AUTH_TOKEN`.
+   *
+   * Responses:
+   * - `404` when no sandbox exists for the session.
+   * - `500` when the stored value is malformed — invalid JSON, not a plain
+   *   object, or holding a non-string value — so the in-sandbox setup hard-
+   *   fails on corrupt data instead of writing a garbage `.tunnels.env`. Note
+   *   a not-yet-resolved sandbox still returns `200` with an empty map, so the
+   *   client must tolerate an empty result and retry until ports appear.
+   * - `200` with `{ tunnelUrls }` otherwise (empty map when none are stored).
+   */
+  async tunnelUrls(log: Logger): Promise<Response> {
+    const sandbox = this.sandboxRepository.getSandbox();
+    if (!sandbox) {
+      return Response.json({ error: "No sandbox" }, { status: 404 });
+    }
+
+    let urls: Record<string, string> = {};
+    if (sandbox.tunnel_urls) {
+      const parsed = parseTunnelUrls(sandbox.tunnel_urls);
+      if (!parsed) {
+        log.warn("Invalid stored tunnel_urls");
+        return Response.json({ error: "Invalid stored tunnel URLs" }, { status: 500 });
       }
+      urls = parsed;
+    }
 
-      // Boot-time states (spawning/connecting) must authenticate — the git
-      // credential broker is already called during the initial clone, before
-      // the WebSocket connect flips the status to ready.
-      if (isDeadSandboxStatus(sandbox.status)) {
-        log.warn("Sandbox token verification failed: sandbox is dead", {
-          status: sandbox.status,
-        });
-        return Response.json({ valid: false, error: "Sandbox not active" }, { status: 410 });
-      }
+    return Response.json(
+      { tunnelUrls: urls },
+      { status: 200, headers: { "Cache-Control": "no-store" } }
+    );
+  }
 
-      const isTokenValid = await deps.isValidSandboxToken(token, sandbox);
-      if (!isTokenValid) {
-        log.warn("Sandbox token verification failed: token mismatch");
-        return Response.json({ valid: false, error: "Invalid token" }, { status: 401 });
-      }
-
-      log.info("Sandbox token verified successfully");
-      return Response.json({ valid: true }, { status: 200 });
-    },
-
-    async openaiTokenRefresh(log: Logger): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "No session" }, { status: 404 });
-      }
-
-      if (!deps.isManagedSecretsConfigured()) {
-        return Response.json({ error: "Secrets not configured" }, { status: 500 });
-      }
-
-      let token: OpenAIToken;
-      try {
-        token = await deps.refreshOpenAIToken(session, log);
-      } catch (error) {
-        if (error instanceof OpenAITokenNotConfiguredError) {
-          return Response.json({ error: error.message }, { status: 404 });
-        }
-        if (error instanceof OpenAITokenUnauthorizedError) {
-          return Response.json({ error: error.message }, { status: 401 });
-        }
-        if (error instanceof OpenAITokenStorageError) {
-          return Response.json({ error: error.message }, { status: 500 });
-        }
-        if (error instanceof OpenAITokenUpstreamError) {
-          return Response.json({ error: error.message }, { status: 502 });
-        }
-        throw error;
-      }
-
+  async scmCredentials(log: Logger): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "No session" }, { status: 404 });
+    }
+    if (!session.repo_owner || !session.repo_name) {
       return Response.json(
-        {
-          access_token: token.accessToken,
-          expires_in: token.expiresIn,
-          account_id: token.accountId,
-        },
-        { status: 200, headers: { "Cache-Control": "no-store" } }
+        { error: "SCM credentials require a repository context" },
+        { status: 400 }
       );
-    },
+    }
 
-    async xaiTokenRefresh(log: Logger): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "No session" }, { status: 404 });
-      }
-      if (!deps.isManagedSecretsConfigured()) {
-        return Response.json({ error: "Secrets not configured" }, { status: 500 });
-      }
-      const result = await deps.refreshXaiToken(session, log);
-      if (!result.ok) {
-        return Response.json({ error: result.error }, { status: result.status });
-      }
-      return Response.json(
-        { access_token: result.accessToken, expires_in: result.expiresIn },
-        { status: 200, headers: { "Cache-Control": "no-store" } }
-      );
-    },
+    const result = await this.getScmCredentials(log);
+    if (!result.ok) {
+      return Response.json({ error: result.error }, { status: result.status });
+    }
 
-    /**
-     * Return the sandbox's resolved tunnel URLs as a `{ [port]: url }` map.
-     *
-     * `sandbox.tunnel_urls` is a JSON-encoded `{ [port: string]: string }`
-     * stored by `SandboxLifecycleManager#storeAndBroadcastTunnelUrls`. When the
-     * control plane has resolved Modal tunnel URLs but the in-sandbox file write
-     * (`sandbox.open` from outside) hasn't propagated to the sandbox's own
-     * filesystem view — a real failure mode on the Modal provider — this
-     * endpoint is the in-sandbox fallback for retrieving them via
-     * `SANDBOX_AUTH_TOKEN`.
-     *
-     * Responses:
-     * - `404` when no sandbox exists for the session.
-     * - `500` when the stored value is malformed — invalid JSON, not a plain
-     *   object, or holding a non-string value — so the in-sandbox setup hard-
-     *   fails on corrupt data instead of writing a garbage `.tunnels.env`. Note
-     *   a not-yet-resolved sandbox still returns `200` with an empty map, so the
-     *   client must tolerate an empty result and retry until ports appear.
-     * - `200` with `{ tunnelUrls }` otherwise (empty map when none are stored).
-     */
-    async tunnelUrls(log: Logger): Promise<Response> {
-      const sandbox = deps.getSandbox();
-      if (!sandbox) {
-        return Response.json({ error: "No sandbox" }, { status: 404 });
+    return Response.json(
+      {
+        username: result.username,
+        password: result.password,
+        expires_at_epoch_ms: result.expiresAtEpochMs,
+      },
+      {
+        status: 200,
+        headers: { "Cache-Control": "no-store" },
       }
-
-      let urls: Record<string, string> = {};
-      if (sandbox.tunnel_urls) {
-        const parsed = parseTunnelUrls(sandbox.tunnel_urls);
-        if (!parsed) {
-          log.warn("Invalid stored tunnel_urls");
-          return Response.json({ error: "Invalid stored tunnel URLs" }, { status: 500 });
-        }
-        urls = parsed;
-      }
-
-      return Response.json(
-        { tunnelUrls: urls },
-        { status: 200, headers: { "Cache-Control": "no-store" } }
-      );
-    },
-
-    async scmCredentials(log: Logger): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "No session" }, { status: 404 });
-      }
-      if (!session.repo_owner || !session.repo_name) {
-        return Response.json(
-          { error: "SCM credentials require a repository context" },
-          { status: 400 }
-        );
-      }
-
-      const result = await deps.getScmCredentials(log);
-      if (!result.ok) {
-        return Response.json({ error: result.error }, { status: result.status });
-      }
-
-      return Response.json(
-        {
-          username: result.username,
-          password: result.password,
-          expires_at_epoch_ms: result.expiresAtEpochMs,
-        },
-        {
-          status: 200,
-          headers: { "Cache-Control": "no-store" },
-        }
-      );
-    },
-  };
+    );
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
-import { createSessionLifecycleHandler } from "./session-lifecycle.handler";
+import { SessionLifecycleHandler } from "./session-lifecycle.handler";
+import type { ParticipantService } from "../../participant-service";
+import type { SessionTitleService } from "../../title-service";
+import type { WebSocketManager } from "../../../sandbox/lifecycle/manager";
 import type { SessionStatusService } from "../../session-status-service";
 import type { ParticipantRepository } from "../../participant-repository";
 import type { MessageRepository } from "../../message-repository";
@@ -89,6 +92,7 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 }
 
 function createHandler() {
+  const getSession = vi.fn<() => SessionRow | null>();
   const repository = {
     upsertSession: vi.fn(),
     replaceSessionRepositories: vi.fn(),
@@ -96,11 +100,16 @@ function createHandler() {
     createParticipant: vi.fn(),
     getPendingOrProcessingCount: vi.fn(() => 0),
     getMessageCount: vi.fn(() => 0),
+    getSession,
   };
-  const sandboxRepository = { createSandbox: vi.fn() } as unknown as SandboxRepository;
-  const getDurableObjectId = vi.fn(() => "session-do-id");
+  const getSandbox = vi.fn<() => SandboxRow | null>();
+  const updateSandboxStatus = vi.fn();
+  const sandboxRepository = {
+    createSandbox: vi.fn(),
+    getSandbox,
+    updateSandboxStatus,
+  } as unknown as SandboxRepository;
   const encryptToken = vi.fn();
-  const validateReasoningEffort = vi.fn();
   const generateId = vi.fn();
   const now = vi.fn(() => 1234);
   const scheduleWarmSandbox = vi.fn();
@@ -111,9 +120,6 @@ function createHandler() {
     error: vi.fn(),
     child: vi.fn(),
   } as unknown as Logger;
-  const getSession = vi.fn<() => SessionRow | null>();
-  const getSandbox = vi.fn<() => SandboxRow | null>();
-  const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
   const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const transition = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
   const repairIndexStatus = vi.fn<() => Promise<void>>();
@@ -127,53 +133,54 @@ function createHandler() {
   const cancelSession = vi.fn();
   const getSandboxSocket = vi.fn<() => WebSocket | null>();
   const sendToSandbox = vi.fn();
-  const updateSandboxStatus = vi.fn();
 
-  const lifecycleHandler = createSessionLifecycleHandler({
-    sessionCoreRepository: repository as unknown as SessionCoreRepository,
+  const lifecycleHandler = new SessionLifecycleHandler(
+    repository as unknown as SessionCoreRepository,
     sandboxRepository,
-    messageRepository: repository as unknown as MessageRepository,
-    participantRepository: repository as unknown as ParticipantRepository,
-    getDurableObjectId,
-    tokenEncryptionKey: "encryption-key",
-    encryptToken,
-    validateReasoningEffort,
-    generateId,
-    now,
-    scheduleWarmSandbox,
-    getSession,
-    getSandbox,
-    getPublicSessionId,
-    getParticipantByUserId,
+    repository as unknown as MessageRepository,
+    repository as unknown as ParticipantRepository,
+    { getByUserId: getParticipantByUserId } as unknown as ParticipantService,
     statusService,
-    applySessionTitleUpdate,
+    { applySessionTitleUpdate } as unknown as SessionTitleService,
+    {
+      getSandboxWebSocket: getSandboxSocket,
+      detachSandboxWebSocket: vi.fn(),
+      sendToSandbox,
+      getConnectedClientCount: vi.fn(() => 0),
+    } as unknown as WebSocketManager,
+    "session-do-id",
+    log,
+    "encryption-key",
+    scheduleWarmSandbox,
     cancelSession,
-    getSandboxSocket,
-    sendToSandbox,
-    updateSandboxStatus,
-  });
+    encryptToken,
+    generateId,
+    now
+  );
 
   // Bind the request-scoped log so call sites exercise the threading without
   // repeating it at every invocation.
   const handler = {
-    ...lifecycleHandler,
     init: (request: Request) => lifecycleHandler.init(request, log),
+    getState: () => lifecycleHandler.getState(),
+    updateTitle: (request: Request) => lifecycleHandler.updateTitle(request),
+    archive: (request: Request) => lifecycleHandler.archive(request),
+    unarchive: (request: Request) => lifecycleHandler.unarchive(request),
+    expireDraft: () => lifecycleHandler.expireDraft(),
+    cancel: () => lifecycleHandler.cancel(),
   };
 
   return {
     handler,
     repository,
     sandboxRepository,
-    getDurableObjectId,
     encryptToken,
-    validateReasoningEffort,
     generateId,
     now,
     scheduleWarmSandbox,
     log,
     getSession,
     getSandbox,
-    getPublicSessionId,
     getParticipantByUserId,
     transition,
     repairIndexStatus,
@@ -186,7 +193,7 @@ function createHandler() {
   };
 }
 
-describe("createSessionLifecycleHandler", () => {
+describe("SessionLifecycleHandler", () => {
   it.each([
     ["repoOwner without repoName", { repoOwner: "acme", repoName: null }],
     ["repoId without repository context", { repoOwner: null, repoName: null, repoId: 123 }],
@@ -221,16 +228,12 @@ describe("createSessionLifecycleHandler", () => {
       handler,
       repository,
       sandboxRepository,
-      getDurableObjectId,
       encryptToken,
-      validateReasoningEffort,
       generateId,
       scheduleWarmSandbox,
       log,
     } = createHandler();
-    getDurableObjectId.mockReturnValue("session-do-id");
     encryptToken.mockResolvedValue("encrypted-scm-token");
-    validateReasoningEffort.mockReturnValue("high");
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -323,8 +326,7 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("persists the repositories list in position order", async () => {
-    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
-    validateReasoningEffort.mockReturnValue(null);
+    const { handler, repository, generateId } = createHandler();
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -354,8 +356,7 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("persists an empty member set for repo-less sessions", async () => {
-    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
-    validateReasoningEffort.mockReturnValue(null);
+    const { handler, repository, generateId } = createHandler();
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -376,8 +377,7 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("accepts nullable init fields and sandbox settings", async () => {
-    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
-    validateReasoningEffort.mockReturnValue(null);
+    const { handler, repository, generateId } = createHandler();
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -437,8 +437,7 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("preserves optional init fields the schema must not silently drop", async () => {
-    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
-    validateReasoningEffort.mockReturnValue("high");
+    const { handler, repository, generateId } = createHandler();
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -575,10 +574,8 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("falls back to pre-encrypted token when plain-token encryption fails", async () => {
-    const { handler, repository, encryptToken, validateReasoningEffort, generateId, log } =
-      createHandler();
+    const { handler, repository, encryptToken, generateId, log } = createHandler();
     encryptToken.mockRejectedValue(new Error("encrypt failed"));
-    validateReasoningEffort.mockReturnValue(null);
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -610,8 +607,7 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("logs invalid model warning and stores normalized model", async () => {
-    const { handler, repository, validateReasoningEffort, generateId, log } = createHandler();
-    validateReasoningEffort.mockReturnValue(null);
+    const { handler, repository, generateId, log } = createHandler();
     generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
 
     const response = await handler.init(
@@ -652,10 +648,9 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("maps state response with sandbox details", async () => {
-    const { handler, getSession, getSandbox, getPublicSessionId } = createHandler();
+    const { handler, getSession, getSandbox } = createHandler();
     getSession.mockReturnValue(createSession());
     getSandbox.mockReturnValue(createSandbox());
-    getPublicSessionId.mockReturnValue("public-session-1");
 
     const response = handler.getState();
 
@@ -1081,7 +1076,7 @@ describe("createSessionLifecycleHandler", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "cancelled" });
     expect(cancelSession).toHaveBeenCalledOnce();
-    expect(sendToSandbox).toHaveBeenCalledWith(ws, { type: "shutdown" });
+    expect(sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
     expect(updateSandboxStatus).toHaveBeenCalledWith("stopped");
   });
 });

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import { SessionLifecycleHandler } from "./session-lifecycle.handler";
-import type { ParticipantService } from "../../participant-service";
 import type { SessionTitleService } from "../../title-service";
 import type { WebSocketManager } from "../../../sandbox/lifecycle/manager";
 import type { SessionStatusService } from "../../session-status-service";
@@ -93,6 +92,7 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 
 function createHandler() {
   const getSession = vi.fn<() => SessionRow | null>();
+  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const repository = {
     upsertSession: vi.fn(),
     replaceSessionRepositories: vi.fn(),
@@ -101,6 +101,7 @@ function createHandler() {
     getPendingOrProcessingCount: vi.fn(() => 0),
     getMessageCount: vi.fn(() => 0),
     getSession,
+    getParticipantByUserId,
   };
   const getSandbox = vi.fn<() => SandboxRow | null>();
   const updateSandboxStatus = vi.fn();
@@ -120,7 +121,6 @@ function createHandler() {
     error: vi.fn(),
     child: vi.fn(),
   } as unknown as Logger;
-  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const transition = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
   const repairIndexStatus = vi.fn<() => Promise<void>>();
   const settleFromMessageState = vi.fn<() => Promise<SessionRow["status"]>>();
@@ -139,7 +139,6 @@ function createHandler() {
     sandboxRepository,
     repository as unknown as MessageRepository,
     repository as unknown as ParticipantRepository,
-    { getByUserId: getParticipantByUserId } as unknown as ParticipantService,
     statusService,
     { applySessionTitleUpdate } as unknown as SessionTitleService,
     {
@@ -149,7 +148,6 @@ function createHandler() {
       getConnectedClientCount: vi.fn(() => 0),
     } as unknown as WebSocketManager,
     "session-do-id",
-    log,
     "encryption-key",
     scheduleWarmSandbox,
     cancelSession,

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -40,7 +40,7 @@ export interface SessionLifecycleHandlerDeps {
   messageRepository: MessageRepository;
   participantRepository: ParticipantRepository;
   getDurableObjectId: () => string;
-  tokenEncryptionKey?: string;
+  tokenEncryptionKey: string;
   encryptToken: (token: string, encryptionKey: string) => Promise<string>;
   validateReasoningEffort: (model: string, effort: string | undefined) => string | null;
   generateId: (bytes?: number) => string;
@@ -202,7 +202,7 @@ export function createSessionLifecycleHandler(
       }
 
       let encryptedToken = body.scmTokenEncrypted ?? null;
-      if (body.scmToken && deps.tokenEncryptionKey) {
+      if (body.scmToken) {
         try {
           encryptedToken = await deps.encryptToken(body.scmToken, deps.tokenEncryptionKey);
           log.debug("Encrypted SCM token for storage");

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -8,7 +8,6 @@ import type { SessionCoreRepository } from "../../session-core-repository";
 import type { SandboxRepository } from "../../sandbox-repository";
 import type { MessageRepository } from "../../message-repository";
 import type { ParticipantRepository } from "../../participant-repository";
-import type { ParticipantService } from "../../participant-service";
 import type { SessionStatusService } from "../../session-status-service";
 import type { SessionTitleService } from "../../title-service";
 import { resolvePublicSessionId } from "../../public-session-id";
@@ -132,12 +131,10 @@ export class SessionLifecycleHandler {
     private readonly sandboxRepository: SandboxRepository,
     private readonly messageRepository: MessageRepository,
     private readonly participantRepository: ParticipantRepository,
-    private readonly participants: ParticipantService,
     private readonly statusService: SessionStatusService,
     private readonly titleService: SessionTitleService,
     private readonly sockets: WebSocketManager,
     private readonly durableObjectId: string,
-    private readonly log: Logger,
     private readonly tokenEncryptionKey: string,
     private readonly scheduleWarmSandbox: () => void,
     private readonly cancelSession: () => Promise<void>,
@@ -200,11 +197,7 @@ export class SessionLifecycleHandler {
       });
     }
 
-    const reasoningEffort = validateReasoningEffort(
-      model,
-      body.reasoningEffort ?? undefined,
-      this.log
-    );
+    const reasoningEffort = validateReasoningEffort(model, body.reasoningEffort ?? undefined, log);
     const baseBranch = hasRepoOwner ? body.branch || body.defaultBranch || "main" : null;
 
     const repositories = body.repositories ?? [];
@@ -368,7 +361,7 @@ export class SessionLifecycleHandler {
       return Response.json({ error: normalizedTitle.error }, { status: 400 });
     }
 
-    const participant = this.participants.getByUserId(body.userId);
+    const participant = this.participantRepository.getParticipantByUserId(body.userId);
     if (!participant) {
       return Response.json(
         { error: "Not authorized to update the session title" },
@@ -407,7 +400,7 @@ export class SessionLifecycleHandler {
       return Response.json({ error: "userId is required" }, { status: 400 });
     }
 
-    const participant = this.participants.getByUserId(body.userId);
+    const participant = this.participantRepository.getParticipantByUserId(body.userId);
     if (!participant) {
       return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
     }
@@ -498,7 +491,7 @@ export class SessionLifecycleHandler {
       return Response.json({ error: "userId is required" }, { status: 400 });
     }
 
-    const participant = this.participants.getByUserId(body.userId);
+    const participant = this.participantRepository.getParticipantByUserId(body.userId);
     if (!participant) {
       return Response.json({ error: "Not authorized to unarchive this session" }, { status: 403 });
     }

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -1,23 +1,19 @@
 import type { Logger } from "../../../logger";
-import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import type { RepositoryRef } from "@open-inspect/shared/types/repositories";
 import { getValidModelOrDefault, isValidModel } from "@open-inspect/shared/models";
 import { normalizeSandboxSettings } from "../../../sandbox/settings";
-import type {
-  SandboxStatus,
-  SessionStatus,
-  SpawnSource,
-} from "@open-inspect/shared/types/sessions";
+import type { WebSocketManager } from "../../../sandbox/lifecycle/manager";
+import type { SessionStatus, SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { SessionCoreRepository } from "../../session-core-repository";
 import type { SandboxRepository } from "../../sandbox-repository";
 import type { MessageRepository } from "../../message-repository";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { ParticipantService } from "../../participant-service";
 import type { SessionStatusService } from "../../session-status-service";
-import {
-  normalizeSessionTitle,
-  type SessionTitleUpdateOptions,
-  type SessionTitleUpdateResult,
-} from "../../title";
+import type { SessionTitleService } from "../../title-service";
+import { resolvePublicSessionId } from "../../public-session-id";
+import { validateReasoningEffort } from "../../reasoning-effort";
+import { normalizeSessionTitle, type SessionTitleUpdateResult } from "../../title";
 import { z } from "zod";
 import { isSessionInactive } from "@open-inspect/shared/types/session-activity";
 
@@ -34,33 +30,6 @@ function isCancellable(status: SessionStatus): boolean {
   return !isSessionInactive(status);
 }
 
-export interface SessionLifecycleHandlerDeps {
-  sessionCoreRepository: SessionCoreRepository;
-  sandboxRepository: SandboxRepository;
-  messageRepository: MessageRepository;
-  participantRepository: ParticipantRepository;
-  getDurableObjectId: () => string;
-  tokenEncryptionKey: string;
-  encryptToken: (token: string, encryptionKey: string) => Promise<string>;
-  validateReasoningEffort: (model: string, effort: string | undefined) => string | null;
-  generateId: (bytes?: number) => string;
-  now: () => number;
-  scheduleWarmSandbox: () => void;
-  getSession: () => SessionRow | null;
-  getSandbox: () => SandboxRow | null;
-  getPublicSessionId: (session: SessionRow) => string;
-  getParticipantByUserId: (userId: string) => ParticipantRow | null;
-  statusService: SessionStatusService;
-  applySessionTitleUpdate: (
-    title: string,
-    options?: SessionTitleUpdateOptions
-  ) => SessionTitleUpdateResult;
-  cancelSession: () => Promise<void>;
-  getSandboxSocket: () => WebSocket | null;
-  sendToSandbox: (ws: WebSocket, message: string | object) => boolean;
-  updateSandboxStatus: (status: SandboxStatus) => void;
-}
-
 function sessionTitleUpdateStatus(
   result: Extract<SessionTitleUpdateResult, { ok: false }>
 ): 400 | 404 | 409 {
@@ -72,16 +41,6 @@ function sessionTitleUpdateStatus(
     case "already_set":
       return 409;
   }
-}
-
-export interface SessionLifecycleHandler {
-  init: (request: Request, log: Logger) => Promise<Response>;
-  getState: () => Response;
-  updateTitle: (request: Request) => Promise<Response>;
-  archive: (request: Request) => Promise<Response>;
-  unarchive: (request: Request) => Promise<Response>;
-  expireDraft: () => Promise<Response>;
-  cancel: () => Promise<Response>;
 }
 
 const repositoryRefSchema = z.object({
@@ -163,406 +122,421 @@ const titleUpdateBodySchema = z.object({
 
 type TitleUpdateBody = z.infer<typeof titleUpdateBodySchema>;
 
-export function createSessionLifecycleHandler(
-  deps: SessionLifecycleHandlerDeps
-): SessionLifecycleHandler {
-  return {
-    async init(request: Request, log: Logger): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+/**
+ * HTTP boundary for the session lifecycle endpoints: init, state reads, title
+ * updates, archive/unarchive, draft expiry, and cancellation.
+ */
+export class SessionLifecycleHandler {
+  constructor(
+    private readonly sessionCoreRepository: SessionCoreRepository,
+    private readonly sandboxRepository: SandboxRepository,
+    private readonly messageRepository: MessageRepository,
+    private readonly participantRepository: ParticipantRepository,
+    private readonly participants: ParticipantService,
+    private readonly statusService: SessionStatusService,
+    private readonly titleService: SessionTitleService,
+    private readonly sockets: WebSocketManager,
+    private readonly durableObjectId: string,
+    private readonly log: Logger,
+    private readonly tokenEncryptionKey: string,
+    private readonly scheduleWarmSandbox: () => void,
+    private readonly cancelSession: () => Promise<void>,
+    private readonly encryptToken: (token: string, encryptionKey: string) => Promise<string>,
+    private readonly generateId: (bytes?: number) => string,
+    private readonly now: () => number = Date.now
+  ) {}
 
-      const parseResult = initRequestSchema.safeParse(raw);
-      if (!parseResult.success) {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+  async init(request: Request, log: Logger): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-      const body: InitRequest = parseResult.data;
+    const parseResult = initRequestSchema.safeParse(raw);
+    if (!parseResult.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-      const sessionId = deps.getDurableObjectId();
-      const sessionName = body.sessionName;
-      const now = deps.now();
-      const repoOwner = body.repoOwner?.trim() || null;
-      const repoName = body.repoName?.trim() || null;
-      const hasRepoOwner = repoOwner !== null;
-      const hasRepoName = repoName !== null;
-      const hasRepoId = body.repoId != null;
-      if (
-        hasRepoOwner !== hasRepoName ||
-        (!hasRepoOwner && hasRepoId) ||
-        (hasRepoOwner && !hasRepoId)
-      ) {
-        return Response.json(
-          { error: "Repository context must include repoOwner, repoName, and repoId together" },
-          { status: 400 }
-        );
-      }
+    const body: InitRequest = parseResult.data;
 
-      let encryptedToken = body.scmTokenEncrypted ?? null;
-      if (body.scmToken) {
-        try {
-          encryptedToken = await deps.encryptToken(body.scmToken, deps.tokenEncryptionKey);
-          log.debug("Encrypted SCM token for storage");
-        } catch (error) {
-          log.error("Failed to encrypt SCM token", {
-            error: error instanceof Error ? error : String(error),
-          });
-        }
-      }
-
-      const model = getValidModelOrDefault(body.model);
-      if (body.model && !isValidModel(body.model)) {
-        log.warn("Invalid model name, using default", {
-          requested_model: body.model,
-          default_model: model,
-        });
-      }
-
-      const reasoningEffort = deps.validateReasoningEffort(
-        model,
-        body.reasoningEffort ?? undefined
+    const sessionId = this.durableObjectId;
+    const sessionName = body.sessionName;
+    const now = this.now();
+    const repoOwner = body.repoOwner?.trim() || null;
+    const repoName = body.repoName?.trim() || null;
+    const hasRepoOwner = repoOwner !== null;
+    const hasRepoName = repoName !== null;
+    const hasRepoId = body.repoId != null;
+    if (
+      hasRepoOwner !== hasRepoName ||
+      (!hasRepoOwner && hasRepoId) ||
+      (hasRepoOwner && !hasRepoId)
+    ) {
+      return Response.json(
+        { error: "Repository context must include repoOwner, repoName, and repoId together" },
+        { status: 400 }
       );
-      const baseBranch = hasRepoOwner ? body.branch || body.defaultBranch || "main" : null;
+    }
 
-      const repositories = body.repositories ?? [];
-      if (repositories.length > 0) {
-        const primary = repositories[0];
-        if (
-          !hasRepoOwner ||
-          primary.repoOwner !== repoOwner ||
-          primary.repoName !== repoName ||
-          primary.repoId !== body.repoId ||
-          primary.baseBranch !== baseBranch
-        ) {
-          return Response.json(
-            { error: "repositories[0] must match the scalar repository mirror" },
-            { status: 400 }
-          );
-        }
-      } else if (hasRepoOwner && body.repositories !== undefined) {
-        // An explicit empty list alongside scalar context is a producer bug —
-        // initialize.ts synthesizes a one-entry list for scalar callers.
+    let encryptedToken = body.scmTokenEncrypted ?? null;
+    if (body.scmToken) {
+      try {
+        encryptedToken = await this.encryptToken(body.scmToken, this.tokenEncryptionKey);
+        log.debug("Encrypted SCM token for storage");
+      } catch (error) {
+        log.error("Failed to encrypt SCM token", {
+          error: error instanceof Error ? error : String(error),
+        });
+      }
+    }
+
+    const model = getValidModelOrDefault(body.model);
+    if (body.model && !isValidModel(body.model)) {
+      log.warn("Invalid model name, using default", {
+        requested_model: body.model,
+        default_model: model,
+      });
+    }
+
+    const reasoningEffort = validateReasoningEffort(
+      model,
+      body.reasoningEffort ?? undefined,
+      this.log
+    );
+    const baseBranch = hasRepoOwner ? body.branch || body.defaultBranch || "main" : null;
+
+    const repositories = body.repositories ?? [];
+    if (repositories.length > 0) {
+      const primary = repositories[0];
+      if (
+        !hasRepoOwner ||
+        primary.repoOwner !== repoOwner ||
+        primary.repoName !== repoName ||
+        primary.repoId !== body.repoId ||
+        primary.baseBranch !== baseBranch
+      ) {
         return Response.json(
-          { error: "repositories must include the scalar repository" },
+          { error: "repositories[0] must match the scalar repository mirror" },
           { status: 400 }
         );
       }
+    } else if (hasRepoOwner && body.repositories !== undefined) {
+      // An explicit empty list alongside scalar context is a producer bug —
+      // initialize.ts synthesizes a one-entry list for scalar callers.
+      return Response.json(
+        { error: "repositories must include the scalar repository" },
+        { status: 400 }
+      );
+    }
 
-      deps.sessionCoreRepository.transaction(() => {
-        deps.sessionCoreRepository.upsertSession({
-          id: sessionId,
-          sessionName,
-          title: body.title ?? null,
-          repoOwner,
-          repoName,
-          repoId: hasRepoOwner ? body.repoId : null,
-          baseBranch,
-          model,
-          reasoningEffort,
-          status: "created",
-          parentSessionId: body.parentSessionId ?? null,
-          spawnSource: body.spawnSource ?? "user",
-          spawnDepth: body.spawnDepth ?? 0,
-          codeServerEnabled: body.codeServerEnabled ?? false,
-          vncEnabled: body.vncEnabled ?? false,
-          sandboxSettings: body.sandboxSettings
-            ? JSON.stringify(normalizeSandboxSettings(body.sandboxSettings, { invalid: "omit" }))
-            : null,
-          environmentId: body.environmentId ?? null,
-          createdAt: now,
-          updatedAt: now,
-        });
-
-        // Legacy scalar producers (spawn paths not yet list-aware) still get a
-        // member row so spawn/read paths have one source of truth.
-        const memberRepositories: RepositoryRef[] =
-          repositories.length > 0
-            ? repositories
-            : repoOwner !== null && repoName !== null && body.repoId != null && baseBranch !== null
-              ? [{ repoOwner, repoName, repoId: body.repoId, baseBranch }]
-              : [];
-        deps.sessionCoreRepository.replaceSessionRepositories(
-          memberRepositories.map((repo, position) => ({
-            position,
-            repoOwner: repo.repoOwner,
-            repoName: repo.repoName,
-            repoId: repo.repoId,
-            baseBranch: repo.baseBranch,
-          }))
-        );
-        const sandboxId = deps.generateId();
-        deps.sandboxRepository.createSandbox({
-          id: sandboxId,
-          status: "pending",
-          gitSyncStatus: "pending",
-          createdAt: 0,
-        });
-
-        const participantId = deps.generateId();
-        deps.participantRepository.createParticipant({
-          id: participantId,
-          userId: body.userId,
-          ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
-          scmUserId: body.scmUserId ?? null,
-          scmLogin: body.scmLogin ?? null,
-          scmName: body.scmName ?? null,
-          scmEmail: body.scmEmail ?? null,
-          scmAccessTokenEncrypted: encryptedToken,
-          scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
-          scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
-          role: "owner",
-          joinedAt: now,
-        });
-      });
-
-      log.info("Triggering sandbox spawn for new session");
-      deps.scheduleWarmSandbox();
-
-      return Response.json({ sessionId, status: "created" });
-    },
-
-    getState(): Response {
-      const session = deps.getSession();
-      if (!session) {
-        return new Response("Session not found", { status: 404 });
-      }
-
-      const sandbox = deps.getSandbox();
-
-      return Response.json({
-        id: deps.getPublicSessionId(session),
-        title: session.title,
-        repoOwner: session.repo_owner,
-        repoName: session.repo_name,
-        baseBranch: session.base_branch,
-        branchName: session.branch_name,
-        baseSha: session.base_sha,
-        currentSha: session.current_sha,
-        opencodeSessionId: session.opencode_session_id,
-        status: session.status,
-        model: session.model,
-        reasoningEffort: session.reasoning_effort ?? undefined,
-        createdAt: session.created_at,
-        updatedAt: session.updated_at,
-        sandbox: sandbox
-          ? {
-              id: sandbox.id,
-              modalSandboxId: sandbox.modal_sandbox_id,
-              status: sandbox.status,
-              gitSyncStatus: sandbox.git_sync_status,
-              lastHeartbeat: sandbox.last_heartbeat,
-            }
+    this.sessionCoreRepository.transaction(() => {
+      this.sessionCoreRepository.upsertSession({
+        id: sessionId,
+        sessionName,
+        title: body.title ?? null,
+        repoOwner,
+        repoName,
+        repoId: hasRepoOwner ? body.repoId : null,
+        baseBranch,
+        model,
+        reasoningEffort,
+        status: "created",
+        parentSessionId: body.parentSessionId ?? null,
+        spawnSource: body.spawnSource ?? "user",
+        spawnDepth: body.spawnDepth ?? 0,
+        codeServerEnabled: body.codeServerEnabled ?? false,
+        vncEnabled: body.vncEnabled ?? false,
+        sandboxSettings: body.sandboxSettings
+          ? JSON.stringify(normalizeSandboxSettings(body.sandboxSettings, { invalid: "omit" }))
           : null,
+        environmentId: body.environmentId ?? null,
+        createdAt: now,
+        updatedAt: now,
       });
-    },
 
-    async updateTitle(request: Request): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
+      // Legacy scalar producers (spawn paths not yet list-aware) still get a
+      // member row so spawn/read paths have one source of truth.
+      const memberRepositories: RepositoryRef[] =
+        repositories.length > 0
+          ? repositories
+          : repoOwner !== null && repoName !== null && body.repoId != null && baseBranch !== null
+            ? [{ repoOwner, repoName, repoId: body.repoId, baseBranch }]
+            : [];
+      this.sessionCoreRepository.replaceSessionRepositories(
+        memberRepositories.map((repo, position) => ({
+          position,
+          repoOwner: repo.repoOwner,
+          repoName: repo.repoName,
+          repoId: repo.repoId,
+          baseBranch: repo.baseBranch,
+        }))
+      );
+      const sandboxId = this.generateId();
+      this.sandboxRepository.createSandbox({
+        id: sandboxId,
+        status: "pending",
+        gitSyncStatus: "pending",
+        createdAt: 0,
+      });
 
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
+      const participantId = this.generateId();
+      this.participantRepository.createParticipant({
+        id: participantId,
+        userId: body.userId,
+        ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
+        scmUserId: body.scmUserId ?? null,
+        scmLogin: body.scmLogin ?? null,
+        scmName: body.scmName ?? null,
+        scmEmail: body.scmEmail ?? null,
+        scmAccessTokenEncrypted: encryptedToken,
+        scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
+        scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
+        role: "owner",
+        joinedAt: now,
+      });
+    });
+
+    log.info("Triggering sandbox spawn for new session");
+    this.scheduleWarmSandbox();
+
+    return Response.json({ sessionId, status: "created" });
+  }
+
+  getState(): Response {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return new Response("Session not found", { status: 404 });
+    }
+
+    const sandbox = this.sandboxRepository.getSandbox();
+
+    return Response.json({
+      id: resolvePublicSessionId(session, this.durableObjectId),
+      title: session.title,
+      repoOwner: session.repo_owner,
+      repoName: session.repo_name,
+      baseBranch: session.base_branch,
+      branchName: session.branch_name,
+      baseSha: session.base_sha,
+      currentSha: session.current_sha,
+      opencodeSessionId: session.opencode_session_id,
+      status: session.status,
+      model: session.model,
+      reasoningEffort: session.reasoning_effort ?? undefined,
+      createdAt: session.created_at,
+      updatedAt: session.updated_at,
+      sandbox: sandbox
+        ? {
+            id: sandbox.id,
+            modalSandboxId: sandbox.modal_sandbox_id,
+            status: sandbox.status,
+            gitSyncStatus: sandbox.git_sync_status,
+            lastHeartbeat: sandbox.last_heartbeat,
+          }
+        : null,
+    });
+  }
+
+  async updateTitle(request: Request): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const parseResult = titleUpdateBodySchema.safeParse(raw);
+    if (!parseResult.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const body: TitleUpdateBody = parseResult.data;
+
+    if (!body.userId) {
+      return Response.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    const normalizedTitle = normalizeSessionTitle(body.title);
+    if (!normalizedTitle.ok) {
+      return Response.json({ error: normalizedTitle.error }, { status: 400 });
+    }
+
+    const participant = this.participants.getByUserId(body.userId);
+    if (!participant) {
+      return Response.json(
+        { error: "Not authorized to update the session title" },
+        { status: 403 }
+      );
+    }
+
+    const result = this.titleService.applySessionTitleUpdate(normalizedTitle.title, {
+      onlyIfUnset: false,
+    });
+    if (!result.ok) {
+      return Response.json({ error: result.error }, { status: sessionTitleUpdateStatus(result) });
+    }
+
+    return Response.json({ title: result.title });
+  }
+
+  async archive(request: Request): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    let body: UserIdBody;
+    try {
+      const result = userIdBodySchema.safeParse(await request.json());
+      if (!result.success) {
         return Response.json({ error: "Invalid request body" }, { status: 400 });
       }
+      body = result.data;
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-      const parseResult = titleUpdateBodySchema.safeParse(raw);
-      if (!parseResult.success) {
+    if (!body.userId) {
+      return Response.json({ error: "userId is required" }, { status: 400 });
+    }
+
+    const participant = this.participants.getByUserId(body.userId);
+    if (!participant) {
+      return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
+    }
+
+    if (session.status === "cancelled") {
+      return Response.json({ error: "Cancelled sessions cannot be archived" }, { status: 409 });
+    }
+
+    if (this.messageRepository.getPendingOrProcessingCount() > 0) {
+      return Response.json({ error: "Cannot archive a session with queued work" }, { status: 409 });
+    }
+
+    await this.statusService.transition("archived");
+
+    return Response.json({ status: "archived" });
+  }
+
+  /**
+   * Retire a warm session that never received a prompt.
+   *
+   * The web client warms a session on the first keystroke, so navigating away
+   * without submitting leaves a `created` row whose sandbox idles out — and no
+   * other transition reaches it, because `active` needs an enqueued prompt and
+   * the terminal statuses need a finished execution.
+   *
+   * The sweep selects candidates from the D1 index, which it may have read
+   * before a prompt arrived. Re-checking here is what makes that safe: the
+   * Durable Object is the authority on the session's own state and runs
+   * single-threaded, so a session that started work in the meantime is left
+   * alone rather than archived out from under its author.
+   */
+  async expireDraft(): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    if (session.status !== "created") {
+      // Reaching here means the index still reads `created` while this session
+      // has moved on — which is exactly what happens when an earlier
+      // transition's D1 projection failed (they are logged and swallowed).
+      // Repairing the mirror is what stops the row being selected instead of
+      // being retried every sweep forever.
+      await this.statusService.repairIndexStatus();
+      return Response.json({ outcome: "not_draft", status: session.status });
+    }
+
+    if (
+      this.messageRepository.getPendingOrProcessingCount() > 0 ||
+      this.messageRepository.getMessageCount() > 0
+    ) {
+      // A session holding messages while still `created` is a broken aggregate:
+      // enqueueing a prompt inserts the message and transitions to `active` in
+      // the same Durable Object turn, so current code cannot produce this. It
+      // survives only on rows predating that guarantee, and answering without
+      // changing anything is what let them pin the head of the sweep's
+      // oldest-first batch forever. Settle the status to what the messages say
+      // instead. A queued prompt is left for the dispatch timeout rather than
+      // archived: archiving discards a real request, and `archived` is not
+      // promptable, so the author could not resume it either.
+      const settled = await this.statusService.settleFromMessageState();
+      return Response.json({ outcome: "has_work", status: settled });
+    }
+
+    await this.statusService.transition("archived");
+
+    return Response.json({ outcome: "archived", status: "archived" });
+  }
+
+  async unarchive(request: Request): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    let body: UserIdBody;
+    try {
+      const result = userIdBodySchema.safeParse(await request.json());
+      if (!result.success) {
         return Response.json({ error: "Invalid request body" }, { status: 400 });
       }
+      body = result.data;
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-      const body: TitleUpdateBody = parseResult.data;
+    if (!body.userId) {
+      return Response.json({ error: "userId is required" }, { status: 400 });
+    }
 
-      if (!body.userId) {
-        return Response.json({ error: "userId is required" }, { status: 400 });
+    const participant = this.participants.getByUserId(body.userId);
+    if (!participant) {
+      return Response.json({ error: "Not authorized to unarchive this session" }, { status: 403 });
+    }
+
+    if (session.status !== "archived") {
+      return Response.json({ error: "Session is not archived" }, { status: 409 });
+    }
+
+    // Restoring, not starting: unarchive returns the session to whatever its
+    // messages already imply. Asserting "active" here claimed work that does
+    // not exist, and no settle path would ever correct it — they all run off
+    // execution events, so an idle session sat in the in-progress group until
+    // someone prompted it again.
+    const settled = await this.statusService.settleFromMessageState();
+
+    return Response.json({ status: settled });
+  }
+
+  async cancel(): Promise<Response> {
+    const session = this.sessionCoreRepository.getSession();
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    if (!isCancellable(session.status)) {
+      return Response.json({ error: `Session already ${session.status}` }, { status: 409 });
+    }
+
+    await this.cancelSession();
+
+    const sandbox = this.sandboxRepository.getSandbox();
+    if (sandbox && sandbox.status !== "stopped" && sandbox.status !== "failed") {
+      if (this.sockets.getSandboxWebSocket()) {
+        this.sockets.sendToSandbox({ type: "shutdown" });
       }
+      this.sandboxRepository.updateSandboxStatus("stopped");
+    }
 
-      const normalizedTitle = normalizeSessionTitle(body.title);
-      if (!normalizedTitle.ok) {
-        return Response.json({ error: normalizedTitle.error }, { status: 400 });
-      }
-
-      const participant = deps.getParticipantByUserId(body.userId);
-      if (!participant) {
-        return Response.json(
-          { error: "Not authorized to update the session title" },
-          { status: 403 }
-        );
-      }
-
-      const result = deps.applySessionTitleUpdate(normalizedTitle.title, { onlyIfUnset: false });
-      if (!result.ok) {
-        return Response.json({ error: result.error }, { status: sessionTitleUpdateStatus(result) });
-      }
-
-      return Response.json({ title: result.title });
-    },
-
-    async archive(request: Request): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-
-      let body: UserIdBody;
-      try {
-        const result = userIdBodySchema.safeParse(await request.json());
-        if (!result.success) {
-          return Response.json({ error: "Invalid request body" }, { status: 400 });
-        }
-        body = result.data;
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
-
-      if (!body.userId) {
-        return Response.json({ error: "userId is required" }, { status: 400 });
-      }
-
-      const participant = deps.getParticipantByUserId(body.userId);
-      if (!participant) {
-        return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
-      }
-
-      if (session.status === "cancelled") {
-        return Response.json({ error: "Cancelled sessions cannot be archived" }, { status: 409 });
-      }
-
-      if (deps.messageRepository.getPendingOrProcessingCount() > 0) {
-        return Response.json(
-          { error: "Cannot archive a session with queued work" },
-          { status: 409 }
-        );
-      }
-
-      await deps.statusService.transition("archived");
-
-      return Response.json({ status: "archived" });
-    },
-
-    /**
-     * Retire a warm session that never received a prompt.
-     *
-     * The web client warms a session on the first keystroke, so navigating away
-     * without submitting leaves a `created` row whose sandbox idles out — and no
-     * other transition reaches it, because `active` needs an enqueued prompt and
-     * the terminal statuses need a finished execution.
-     *
-     * The sweep selects candidates from the D1 index, which it may have read
-     * before a prompt arrived. Re-checking here is what makes that safe: the
-     * Durable Object is the authority on the session's own state and runs
-     * single-threaded, so a session that started work in the meantime is left
-     * alone rather than archived out from under its author.
-     */
-    async expireDraft(): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-
-      if (session.status !== "created") {
-        // Reaching here means the index still reads `created` while this session
-        // has moved on — which is exactly what happens when an earlier
-        // transition's D1 projection failed (they are logged and swallowed).
-        // Repairing the mirror is what stops the row being selected instead of
-        // being retried every sweep forever.
-        await deps.statusService.repairIndexStatus();
-        return Response.json({ outcome: "not_draft", status: session.status });
-      }
-
-      if (
-        deps.messageRepository.getPendingOrProcessingCount() > 0 ||
-        deps.messageRepository.getMessageCount() > 0
-      ) {
-        // A session holding messages while still `created` is a broken aggregate:
-        // enqueueing a prompt inserts the message and transitions to `active` in
-        // the same Durable Object turn, so current code cannot produce this. It
-        // survives only on rows predating that guarantee, and answering without
-        // changing anything is what let them pin the head of the sweep's
-        // oldest-first batch forever. Settle the status to what the messages say
-        // instead. A queued prompt is left for the dispatch timeout rather than
-        // archived: archiving discards a real request, and `archived` is not
-        // promptable, so the author could not resume it either.
-        const settled = await deps.statusService.settleFromMessageState();
-        return Response.json({ outcome: "has_work", status: settled });
-      }
-
-      await deps.statusService.transition("archived");
-
-      return Response.json({ outcome: "archived", status: "archived" });
-    },
-
-    async unarchive(request: Request): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-
-      let body: UserIdBody;
-      try {
-        const result = userIdBodySchema.safeParse(await request.json());
-        if (!result.success) {
-          return Response.json({ error: "Invalid request body" }, { status: 400 });
-        }
-        body = result.data;
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
-
-      if (!body.userId) {
-        return Response.json({ error: "userId is required" }, { status: 400 });
-      }
-
-      const participant = deps.getParticipantByUserId(body.userId);
-      if (!participant) {
-        return Response.json(
-          { error: "Not authorized to unarchive this session" },
-          { status: 403 }
-        );
-      }
-
-      if (session.status !== "archived") {
-        return Response.json({ error: "Session is not archived" }, { status: 409 });
-      }
-
-      // Restoring, not starting: unarchive returns the session to whatever its
-      // messages already imply. Asserting "active" here claimed work that does
-      // not exist, and no settle path would ever correct it — they all run off
-      // execution events, so an idle session sat in the in-progress group until
-      // someone prompted it again.
-      const settled = await deps.statusService.settleFromMessageState();
-
-      return Response.json({ status: settled });
-    },
-
-    async cancel(): Promise<Response> {
-      const session = deps.getSession();
-      if (!session) {
-        return Response.json({ error: "Session not found" }, { status: 404 });
-      }
-
-      if (!isCancellable(session.status)) {
-        return Response.json({ error: `Session already ${session.status}` }, { status: 409 });
-      }
-
-      await deps.cancelSession();
-
-      const sandbox = deps.getSandbox();
-      if (sandbox && sandbox.status !== "stopped" && sandbox.status !== "failed") {
-        const sandboxWs = deps.getSandboxSocket();
-        if (sandboxWs) {
-          deps.sendToSandbox(sandboxWs, { type: "shutdown" });
-        }
-        deps.updateSandboxStatus("stopped");
-      }
-
-      return Response.json({ status: "cancelled" });
-    },
-  };
+    return Response.json({ status: "cancelled" });
+  }
 }

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
 import type { ParticipantRow } from "../../types";
-import { createWsTokenHandler } from "./ws-token.handler";
+import { WsTokenHandler } from "./ws-token.handler";
 import type { ParticipantRepository } from "../../participant-repository";
+import type { ParticipantService } from "../../participant-service";
 
 function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
   return {
@@ -45,13 +46,13 @@ function createHandler() {
     child: vi.fn(),
   } as unknown as Logger;
 
-  const wsTokenHandler = createWsTokenHandler({
-    repository: repository as unknown as ParticipantRepository,
-    getParticipantByUserId,
+  const wsTokenHandler = new WsTokenHandler(
+    repository as unknown as ParticipantRepository,
+    { getByUserId: getParticipantByUserId } as unknown as ParticipantService,
     generateId,
     hashToken,
-    now,
-  });
+    now
+  );
 
   // Bind the request-scoped log so call sites exercise the threading without
   // repeating it at every invocation.
@@ -70,7 +71,7 @@ function createHandler() {
   };
 }
 
-describe("createWsTokenHandler", () => {
+describe("WsTokenHandler", () => {
   it("returns 400 when userId is missing", async () => {
     const { handler } = createHandler();
 

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
@@ -3,7 +3,6 @@ import type { Logger } from "../../../logger";
 import type { ParticipantRow } from "../../types";
 import { WsTokenHandler } from "./ws-token.handler";
 import type { ParticipantRepository } from "../../participant-repository";
-import type { ParticipantService } from "../../participant-service";
 
 function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
   return {
@@ -26,13 +25,14 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 }
 
 function createHandler() {
+  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const repository = {
     createParticipant: vi.fn(),
     updateParticipantCoalesce: vi.fn(),
     updateParticipantWsToken: vi.fn(),
+    getParticipantByUserId,
   };
 
-  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const generateId = vi
     .fn<(bytes?: number) => string>()
     .mockImplementation((bytes?: number) => (bytes === 32 ? "plain-token" : "participant-1"));
@@ -48,7 +48,6 @@ function createHandler() {
 
   const wsTokenHandler = new WsTokenHandler(
     repository as unknown as ParticipantRepository,
-    { getByUserId: getParticipantByUserId } as unknown as ParticipantService,
     generateId,
     hashToken,
     now

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
@@ -1,6 +1,5 @@
 import type { Logger } from "../../../logger";
 import type { ParticipantRepository } from "../../participant-repository";
-import type { ParticipantService } from "../../participant-service";
 import { z } from "zod";
 
 const nullableOptionalString = z.string().nullable().optional();
@@ -27,7 +26,6 @@ type GenerateWsTokenRequest = z.infer<typeof generateWsTokenRequestSchema>;
 export class WsTokenHandler {
   constructor(
     private readonly repository: ParticipantRepository,
-    private readonly participants: ParticipantService,
     private readonly generateId: (bytes?: number) => string,
     private readonly hashToken: (token: string) => Promise<string>,
     private readonly now: () => number = Date.now
@@ -52,7 +50,7 @@ export class WsTokenHandler {
     }
 
     const now = this.now();
-    let participant = this.participants.getByUserId(body.userId);
+    let participant = this.repository.getParticipantByUserId(body.userId);
 
     if (participant) {
       // Only accept client tokens if they're newer than what we have in the DB.
@@ -102,7 +100,7 @@ export class WsTokenHandler {
         role: "member",
         joinedAt: now,
       });
-      participant = this.participants.getByUserId(body.userId)!;
+      participant = this.repository.getParticipantByUserId(body.userId)!;
     }
 
     const plainToken = this.generateId(32);

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "../../../logger";
 import type { ParticipantRepository } from "../../participant-repository";
-import type { ParticipantRow } from "../../types";
+import type { ParticipantService } from "../../participant-service";
 import { z } from "zod";
 
 const nullableOptionalString = z.string().nullable().optional();
@@ -19,102 +19,101 @@ const generateWsTokenRequestSchema = z.object({
 
 type GenerateWsTokenRequest = z.infer<typeof generateWsTokenRequestSchema>;
 
-export interface WsTokenHandlerDeps {
-  repository: ParticipantRepository;
-  getParticipantByUserId: (userId: string) => ParticipantRow | null;
-  generateId: (bytes?: number) => string;
-  hashToken: (token: string) => Promise<string>;
-  now: () => number;
-}
+/**
+ * HTTP boundary for WS-token minting: upserts the requesting participant
+ * (coalescing SCM tokens against server-side refreshes) and rotates their
+ * WebSocket token.
+ */
+export class WsTokenHandler {
+  constructor(
+    private readonly repository: ParticipantRepository,
+    private readonly participants: ParticipantService,
+    private readonly generateId: (bytes?: number) => string,
+    private readonly hashToken: (token: string) => Promise<string>,
+    private readonly now: () => number = Date.now
+  ) {}
 
-export interface WsTokenHandler {
-  generateWsToken: (request: Request, log: Logger) => Promise<Response>;
-}
+  async generateWsToken(request: Request, log: Logger): Promise<Response> {
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
 
-export function createWsTokenHandler(deps: WsTokenHandlerDeps): WsTokenHandler {
-  return {
-    async generateWsToken(request: Request, log: Logger): Promise<Response> {
-      let raw: unknown;
-      try {
-        raw = await request.json();
-      } catch {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
+    const parsed = generateWsTokenRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
+    const body: GenerateWsTokenRequest = parsed.data;
 
-      const parsed = generateWsTokenRequestSchema.safeParse(raw);
-      if (!parsed.success) {
-        return Response.json({ error: "Invalid request body" }, { status: 400 });
-      }
-      const body: GenerateWsTokenRequest = parsed.data;
+    if (!body.userId) {
+      return Response.json({ error: "userId is required" }, { status: 400 });
+    }
 
-      if (!body.userId) {
-        return Response.json({ error: "userId is required" }, { status: 400 });
-      }
+    const now = this.now();
+    let participant = this.participants.getByUserId(body.userId);
 
-      const now = deps.now();
-      let participant = deps.getParticipantByUserId(body.userId);
+    if (participant) {
+      // Only accept client tokens if they're newer than what we have in the DB.
+      // The server-side refresh may have rotated tokens, and the client could
+      // be sending stale values from an old session cookie.
+      const clientExpiresAt = body.scmTokenExpiresAt ?? null;
+      const dbExpiresAt = participant.scm_token_expires_at;
+      const clientSentAnyToken =
+        body.scmTokenEncrypted != null || body.scmRefreshTokenEncrypted != null;
 
-      if (participant) {
-        // Only accept client tokens if they're newer than what we have in the DB.
-        // The server-side refresh may have rotated tokens, and the client could
-        // be sending stale values from an old session cookie.
-        const clientExpiresAt = body.scmTokenExpiresAt ?? null;
-        const dbExpiresAt = participant.scm_token_expires_at;
-        const clientSentAnyToken =
-          body.scmTokenEncrypted != null || body.scmRefreshTokenEncrypted != null;
+      const shouldUpdateTokens =
+        clientSentAnyToken &&
+        (dbExpiresAt == null || (clientExpiresAt != null && clientExpiresAt > dbExpiresAt));
 
-        const shouldUpdateTokens =
-          clientSentAnyToken &&
-          (dbExpiresAt == null || (clientExpiresAt != null && clientExpiresAt > dbExpiresAt));
+      // If we already have a refresh token (server-side refresh may rotate it),
+      // only accept an incoming refresh token when we're also accepting the
+      // access token update, or when we don't have one yet.
+      const shouldUpdateRefreshToken =
+        body.scmRefreshTokenEncrypted != null &&
+        (participant.scm_refresh_token_encrypted == null || shouldUpdateTokens);
 
-        // If we already have a refresh token (server-side refresh may rotate it),
-        // only accept an incoming refresh token when we're also accepting the
-        // access token update, or when we don't have one yet.
-        const shouldUpdateRefreshToken =
-          body.scmRefreshTokenEncrypted != null &&
-          (participant.scm_refresh_token_encrypted == null || shouldUpdateTokens);
-
-        deps.repository.updateParticipantCoalesce(participant.id, {
-          ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
-          scmUserId: body.scmUserId ?? null,
-          scmLogin: body.scmLogin ?? null,
-          scmName: body.scmName ?? null,
-          scmEmail: body.scmEmail ?? null,
-          scmAccessTokenEncrypted: shouldUpdateTokens ? (body.scmTokenEncrypted ?? null) : null,
-          scmRefreshTokenEncrypted: shouldUpdateRefreshToken
-            ? (body.scmRefreshTokenEncrypted ?? null)
-            : null,
-          scmTokenExpiresAt: shouldUpdateTokens ? clientExpiresAt : null,
-        });
-      } else {
-        const id = deps.generateId();
-        deps.repository.createParticipant({
-          id,
-          userId: body.userId,
-          ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
-          scmUserId: body.scmUserId ?? null,
-          scmLogin: body.scmLogin ?? null,
-          scmName: body.scmName ?? null,
-          scmEmail: body.scmEmail ?? null,
-          scmAccessTokenEncrypted: body.scmTokenEncrypted ?? null,
-          scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
-          scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
-          role: "member",
-          joinedAt: now,
-        });
-        participant = deps.getParticipantByUserId(body.userId)!;
-      }
-
-      const plainToken = deps.generateId(32);
-      const tokenHash = await deps.hashToken(plainToken);
-
-      deps.repository.updateParticipantWsToken(participant.id, tokenHash, now);
-      log.info("Generated WS token", { participant_id: participant.id, user_id: body.userId });
-
-      return Response.json({
-        token: plainToken,
-        participantId: participant.id,
+      this.repository.updateParticipantCoalesce(participant.id, {
+        ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
+        scmUserId: body.scmUserId ?? null,
+        scmLogin: body.scmLogin ?? null,
+        scmName: body.scmName ?? null,
+        scmEmail: body.scmEmail ?? null,
+        scmAccessTokenEncrypted: shouldUpdateTokens ? (body.scmTokenEncrypted ?? null) : null,
+        scmRefreshTokenEncrypted: shouldUpdateRefreshToken
+          ? (body.scmRefreshTokenEncrypted ?? null)
+          : null,
+        scmTokenExpiresAt: shouldUpdateTokens ? clientExpiresAt : null,
       });
-    },
-  };
+    } else {
+      const id = this.generateId();
+      this.repository.createParticipant({
+        id,
+        userId: body.userId,
+        ...(body.canonicalUserId ? { canonicalUserId: body.canonicalUserId } : {}),
+        scmUserId: body.scmUserId ?? null,
+        scmLogin: body.scmLogin ?? null,
+        scmName: body.scmName ?? null,
+        scmEmail: body.scmEmail ?? null,
+        scmAccessTokenEncrypted: body.scmTokenEncrypted ?? null,
+        scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
+        scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
+        role: "member",
+        joinedAt: now,
+      });
+      participant = this.participants.getByUserId(body.userId)!;
+    }
+
+    const plainToken = this.generateId(32);
+    const tokenHash = await this.hashToken(plainToken);
+
+    this.repository.updateParticipantWsToken(participant.id, tokenHash, now);
+    log.info("Generated WS token", { participant_id: participant.id, user_id: body.userId });
+
+    return Response.json({
+      token: plainToken,
+      participantId: participant.id,
+    });
+  }
 }

--- a/packages/control-plane/src/session/identity.test.ts
+++ b/packages/control-plane/src/session/identity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { generateEncryptionKey } from "../auth/crypto";
 import type { UserStore } from "../db/user-store";
 import type { Env } from "../types";
 import {
@@ -120,9 +121,15 @@ describe("parseAuthorId", () => {
 describe("resolveGitHubEnrichment", () => {
   // This is the fire-time F1/F2 gate: a resolved user with no linked GitHub
   // identity must yield null so no SCM token is attached (bot-attributed
-  // fallback). With no TOKEN_ENCRYPTION_KEY the token-store branch is skipped,
-  // so these unit tests need no D1 — they pin the identity-selection boundary.
-  const env = { DB: {}, TOKEN_ENCRYPTION_KEY: "" } as unknown as Env;
+  // fallback). The db stub answers the token-store lookup with "no stored
+  // tokens", so these tests pin the identity-selection boundary without D1.
+  const emptyTokenDb = {
+    prepare: () => ({ bind: () => ({ first: async () => null }) }),
+  } as unknown as Env["DB"];
+  const env = {
+    DB: emptyTokenDb,
+    TOKEN_ENCRYPTION_KEY: generateEncryptionKey(),
+  } as unknown as Env;
 
   function fakeStore(
     identities: Array<{
@@ -167,7 +174,7 @@ describe("resolveGitHubEnrichment", () => {
     // The SCM identifier is the GitHub provider id — never the Google sub.
     expect(enrichment!.scmUserId).toBe("gh-42");
     expect(enrichment!.scmLogin).toBe("pm-dev");
-    // No token-encryption key configured → no token material leaks in.
+    // No stored tokens for this identity → no token material leaks in.
     expect(enrichment!.accessTokenEncrypted).toBeUndefined();
   });
 

--- a/packages/control-plane/src/session/identity.test.ts
+++ b/packages/control-plane/src/session/identity.test.ts
@@ -7,6 +7,7 @@ import {
   resolveBrowserGitHubEnrichment,
   resolveGitAuthorIdentity,
   resolveGitHubEnrichment,
+  resolveGitHubEnrichmentForRequest,
 } from "./identity";
 
 describe("resolveGitAuthorIdentity", () => {
@@ -194,6 +195,24 @@ describe("resolveGitHubEnrichment", () => {
     const enrichment = await resolveGitHubEnrichment(env, env.DB, store, "user-1");
 
     expect(enrichment?.email).toBe("42+pm-dev@users.noreply.github.com");
+  });
+});
+
+describe("resolveGitHubEnrichmentForRequest", () => {
+  it("rejects invalid token-encryption key material before any authority branch runs", async () => {
+    const env = { DB: {}, TOKEN_ENCRYPTION_KEY: "dG9vc2hvcnQ=" } as unknown as Env;
+    const store = { getIdentitiesForUser: vi.fn(), getUserById: vi.fn() } as unknown as UserStore;
+    const authority = {
+      kind: "browser_session",
+      accountClient: {},
+      githubAccount: null,
+    } as unknown as Parameters<typeof resolveGitHubEnrichmentForRequest>[4];
+
+    await expect(
+      resolveGitHubEnrichmentForRequest(env, env.DB, store, "user-1", authority)
+    ).rejects.toThrow(/TOKEN_ENCRYPTION_KEY must decode to 32 bytes/);
+    // The guard fires before either branch touches identity or account state.
+    expect(store.getIdentitiesForUser).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -206,6 +206,9 @@ export async function resolveGitHubEnrichmentForRequest(
   userId: string,
   authority: GitHubCredentialAuthority
 ): Promise<GitHubEnrichment | null> {
+  // One invariant for the whole boundary: both authorities encrypt with
+  // validated AES-256 material, regardless of which branch runs.
+  const tokenEncryptionKey = requireTokenEncryptionKey(env);
   if (authority.kind === "legacy") {
     return resolveGitHubEnrichment(env, db, userStore, userId);
   }
@@ -216,6 +219,6 @@ export async function resolveGitHubEnrichmentForRequest(
   return resolveBrowserGitHubEnrichment(userId, githubAccount, {
     getAccessToken: (selection) => accountClient.getAccessToken({ body: selection }),
     getAccountInfo: (selection) => accountClient.accountInfo({ query: selection }),
-    encryptAccessToken: (accessToken) => encryptToken(accessToken, env.TOKEN_ENCRYPTION_KEY),
+    encryptAccessToken: (accessToken) => encryptToken(accessToken, tokenEncryptionKey),
   });
 }

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -4,6 +4,7 @@ import {
 } from "@open-inspect/shared/types/github-identity";
 import { z } from "zod";
 import { encryptToken } from "../auth/crypto";
+import { requireTokenEncryptionKey } from "../env-validation";
 import type {
   GitHubAccountSelection,
   GitHubCredentialAuthority,
@@ -168,11 +169,9 @@ export async function resolveGitHubEnrichment(
 
   const [user, tokens] = await Promise.all([
     userStore.getUserById(userId),
-    env.TOKEN_ENCRYPTION_KEY
-      ? new UserScmTokenStore(db, env.TOKEN_ENCRYPTION_KEY).getEncryptedTokens(
-          githubIdentity.providerUserId
-        )
-      : null,
+    new UserScmTokenStore(db, requireTokenEncryptionKey(env)).getEncryptedTokens(
+      githubIdentity.providerUserId
+    ),
   ]);
 
   const authorIdentity = resolveGitAuthorIdentity({


### PR DESCRIPTION
## Summary

Item 3 of the deps-style normalization campaign (follow-up to #1608/#1609): the seven session HTTP handlers still built as `createXHandler(deps)` factories over deps-bags become classes with direct constructor collaborators, matching the `SessionDiffsHandler` (#1047) and `AttachmentsHandler` precedents. One prerequisite commit makes `TOKEN_ENCRYPTION_KEY` required, mirroring #1609's treatment of the repo-secrets key.

The deps-bags were where most of the composition root's pure same-name forwards lived — closures like `getSession: () => sessionCoreRepository.getSession()` that exist only because a bag can't hold the repository itself. Net effect in `components.ts`: 43 function-valued closure lines removed, 8 added back as named per-request adapters (−35), and all seven `XHandlerDeps` interfaces deleted.

## `TOKEN_ENCRYPTION_KEY` is now required (first commit)

Terraform already requires the key (no default, `sensitive`) and the `Env` type declares it non-optional — the three falsy-guards were silent-degradation branches:

- `identity.ts` silently dropped stored SCM tokens from GitHub enrichment,
- the session graph silently skipped constructing the user token store,
- session init silently discarded a plaintext SCM token instead of encrypting it.

`requireTokenEncryptionKey(env)` shares the AES-256 material validator with `requireRepoSecretsEncryptionKey` (strict base64, exactly 32 decoded bytes) and is thrown at session-graph construction, so a misconfigured deployment fails every request at init rather than degrading. Plaintext-read paths are untouched.

## Conversion rules (uniform across all seven)

- **Collaborators become constructor params with their real types** — repositories, services, messenger. `deps.getSession()` → `this.sessionCoreRepository.getSession()`.
- **Constant thunks become data** — `getDurableObjectId: () => durableObjectId` → `durableObjectId: string`; `isManagedSecretsConfigured: () => Boolean(db)` → `managedSecretsConfigured: boolean` (fixed at composition).
- **Module functions re-wrapped only to bind composition-time values are called directly** — `resolvePublicSessionId(session, this.durableObjectId)`, `parseArtifactMetadata(artifact, this.log)`, `validateReasoningEffort(model, effort, this.log)`; same instances, same arguments as the deleted closures.
- **Genuine adapters stay function-typed params** (8 total): the three per-request token/credential service factories on `SandboxHandler`, the request-log-scoped `createPullRequest` factory + `getSessionUrl` + background `triggerPullRequestRefresh` on `PullRequestHandler`, and `scheduleWarmSandbox` + `cancelSession` on `SessionLifecycleHandler`.
- **Seams stay functions without eta-expansion** — the root passes `generateId`/`hashToken`/`encryptToken`/`isValidSandboxToken` as bare module references; `now` defaults to `Date.now` per the `AttachmentsHandler` precedent.
- **The class replaces the same-named interface**, so the internal route table (`components.ts` tier 9) is untouched — those wrappers adapt the uniform route signature to method arities and are not forwards.
- `SessionLifecycleHandler`'s cancel path reuses the lifecycle `WebSocketManager` port via a `LifecycleSocketAdapter` instance (#1608) instead of two raw socket forwards; the adapter's `sendToSandbox` performs the identical resolve-then-send.
- `PullRequestHandler`'s local result-union aliases were byte-identical to `ParticipantService`'s declared return types and are deleted.

## Behavior notes

- Behavior-preserving except the deliberate key-requirement change above.
- Tests now exercise the real `resolvePublicSessionId` (via `session_name` fixtures) and the real `validateReasoningEffort` (whose catalog answers match what the old stubs returned) instead of stubs.
- One commit per handler group; every commit is independently green.

## Testing

- `tsc --noEmit` (prod + test configs), ESLint, Prettier
- Unit: 205 files / 3186 tests green
- Integration (workerd + real D1): green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for the token encryption key used to protect OAuth tokens.
  * Token-based identity enrichment now requires valid encryption-key configuration.

* **Bug Fixes**
  * Improved configuration errors for missing, malformed, or incorrectly sized encryption keys.

* **Refactor**
  * Updated session and HTTP request handling for more consistent dependency management without changing endpoint behavior.

* **Tests**
  * Expanded coverage for encryption-key validation and token-related session flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->