### PR TITLE
fix(e2b): install Bun in runtime PATH

### DIFF
--- a/packages/e2b-infra/build-template.py
+++ b/packages/e2b-infra/build-template.py
@@ -53,7 +53,7 @@ if MEM < 2 or MEM % 2 != 0:
 # `sleep` on each create from the base template — one harmless idle process.
 START_CMD = "sleep infinity"
 READY_CMD = (
-    "command -v python && command -v node && command -v opencode "
+    "command -v python && command -v node && command -v bun && command -v opencode "
     "&& command -v code-server "
     '&& test "$(command -v gh)" = /usr/local/bin/gh && test -x /usr/bin/gh '
     "&& PYTHONPATH=/app python -c 'import sandbox_runtime'"

--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update \
   && apt-get install -y nodejs \
   && npm install -g pnpm@latest \
   # Install bun system-wide (not /root/.bun, which the runtime `user` can't read).
-  && BUN_INSTALL=/usr/local curl -fsSL https://bun.sh/install | bash \
+  && curl -fsSL https://bun.sh/install \
+     | BUN_INSTALL=/usr/local bash \
   && python -m pip install --upgrade pip
 
 # Python runtime deps for the supervisor + bridge.


### PR DESCRIPTION
while working on #1037 i noticed that the e2b sandboxes started by the current template were failing to run bun despite being installed by the dockerfile.

The Dockerfile previously ran the installer like this:

`BUN_INSTALL=/usr/local curl ... | bash`

That environment variable applied to `curl`, not the `bash` process running the installer. Bun therefore used its default install location, which was outside the runtime user's PATH.

This change passes `BUN_INSTALL=/usr/local` to `bash` and also adds `command -v bun` to the template readiness check.


### Before

<img width="1228" height="755" alt="e2b-bun-issue-before" src="https://github.com/user-attachments/assets/781533c4-5983-4262-bcf8-acb0cdddcf26" />

### After

<img width="1231" height="782" alt="e2b-bun-issue-after" src="https://github.com/user-attachments/assets/7258ce2b-8f53-42f3-9a98-2a8603181fa5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template readiness checks now verify that Bun is available before finalization.
* **Chores**
  * Improved the Bun installation setup during environment creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->