### PR TITLE
refactor(control-plane): drop vestigial logger thunks

### DIFF
--- a/packages/control-plane/src/cloudflare/background-tasks.test.ts
+++ b/packages/control-plane/src/cloudflare/background-tasks.test.ts
@@ -33,7 +33,7 @@ describe("createCloudflareBackgroundTasks", () => {
   it("catches and logs rejected tasks", async () => {
     const waitUntil = vi.fn();
     const logger = { error: vi.fn() };
-    const background = createCloudflareBackgroundTasks({ waitUntil }, () => logger as never);
+    const background = createCloudflareBackgroundTasks({ waitUntil }, logger as never);
 
     background.submit(() => Promise.reject(new Error("task failed")), {
       name: "test.task",
@@ -51,7 +51,7 @@ describe("createCloudflareBackgroundTasks", () => {
   it("absorbs and logs a factory that throws synchronously", () => {
     const waitUntil = vi.fn();
     const logger = { error: vi.fn() };
-    const background = createCloudflareBackgroundTasks({ waitUntil }, () => logger as never);
+    const background = createCloudflareBackgroundTasks({ waitUntil }, logger as never);
 
     expect(() =>
       background.submit(

--- a/packages/control-plane/src/cloudflare/background-tasks.ts
+++ b/packages/control-plane/src/cloudflare/background-tasks.ts
@@ -7,12 +7,12 @@ const log = createLogger("background-tasks");
 /** Keep Cloudflare event-lifetime extension at Worker and Durable Object boundaries. */
 export function createCloudflareBackgroundTasks(
   context: WaitUntilContext,
-  getLogger: () => Logger = () => log
+  logger: Logger = log
 ): BackgroundTasks {
   return {
     submit(task, metadata): void {
       const logFailure = (error: unknown): void => {
-        getLogger().error("background_task.failed", {
+        logger.error("background_task.failed", {
           task_name: metadata.name,
           ...metadata.context,
           error: error instanceof Error ? error : String(error),

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -236,7 +236,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL)),
     getPublicSessionId
   );
-  const backgroundTasks = createCloudflareBackgroundTasks(ctx, () => log);
+  const backgroundTasks = createCloudflareBackgroundTasks(ctx, log);
   // The sandbox repository validates the status it reads and warns on anything
   // unmodelled, so it needs the session logger — and it owns encrypt-at-rest
   // for access secrets, so it takes the key.
@@ -426,7 +426,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
   const sandboxEventProcessor = new SessionSandboxEventProcessor(
     backgroundTasks,
-    () => log,
+    log,
     sessionCoreRepository,
     sandboxRepository,
     messageRepository,
@@ -724,21 +724,21 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
   const server = new SessionServer<WebSocket, ClientInfo>({
     http: new SessionHttpDispatcher({
-      getLogger: () => log,
+      log,
       routes,
       handleWebSocketUpgrade: (request, url, requestLog) =>
         connectionAuthenticator.handleWebSocketUpgrade(request, url, requestLog),
       clock,
     }),
     messages: new SessionMessageRouter({
-      getLogger: () => log,
+      log,
       sockets,
       clientCommands,
       processSandboxEvent: (event) => sandboxEventProcessor.processSandboxEvent(event),
       clock,
     }),
     disconnects: new SessionDisconnectHandler({
-      getLogger: () => log,
+      log,
       sockets,
       sandbox: sandboxDisconnects,
       broadcaster: disconnectBroadcaster,

--- a/packages/control-plane/src/session/disconnect-handler.ts
+++ b/packages/control-plane/src/session/disconnect-handler.ts
@@ -8,7 +8,7 @@ import type {
 } from "./ports";
 
 export interface SessionDisconnectHandlerDeps<Connection, Client extends ConnectedClient> {
-  getLogger: () => Logger;
+  log: Logger;
   sockets: SocketRegistry<Connection, Client>;
   sandbox: SandboxDisconnectMonitor;
   broadcaster: SessionBroadcaster;
@@ -30,7 +30,7 @@ export class SessionDisconnectHandler<Connection, Client extends ConnectedClient
       if (classified.kind === "sandbox") {
         if (!this.deps.sockets.clearSandboxIfMatch(connection)) {
           // A newer sandbox socket is active; this close must not schedule its termination.
-          this.deps.getLogger().debug("Ignoring close for replaced sandbox socket", { code });
+          this.deps.log.debug("Ignoring close for replaced sandbox socket", { code });
           return;
         }
 
@@ -38,7 +38,7 @@ export class SessionDisconnectHandler<Connection, Client extends ConnectedClient
         const reconnectBlocked =
           sandboxStatus !== undefined && isSandboxReconnectBlockedStatus(sandboxStatus);
         if (!reconnectBlocked) {
-          this.deps.getLogger().warn("Sandbox WebSocket disconnected; awaiting reconnect", {
+          this.deps.log.warn("Sandbox WebSocket disconnected; awaiting reconnect", {
             event: "sandbox.disconnected",
             code,
             reason,
@@ -66,7 +66,7 @@ export class SessionDisconnectHandler<Connection, Client extends ConnectedClient
   }
 
   handleError(connection: Connection, error: Error): void {
-    this.deps.getLogger().error("WebSocket error", { error });
+    this.deps.log.error("WebSocket error", { error });
     this.deps.sockets.close(connection, 1011, "Internal error");
   }
 }

--- a/packages/control-plane/src/session/http/dispatcher.ts
+++ b/packages/control-plane/src/session/http/dispatcher.ts
@@ -3,7 +3,7 @@ import type { Clock } from "../ports";
 import type { SessionInternalRoute } from "./routes";
 
 export interface SessionHttpDispatcherDeps {
-  getLogger: () => Logger;
+  log: Logger;
   routes: readonly SessionInternalRoute[];
   handleWebSocketUpgrade: (request: Request, url: URL, log: Logger) => Promise<Response>;
   clock: Clock;
@@ -58,7 +58,7 @@ export class SessionHttpDispatcher {
 
   private requestLogger(request: Request): Logger {
     // Never mutate the session logger with request correlation shared by later callbacks.
-    const sessionLog = this.deps.getLogger();
+    const sessionLog = this.deps.log;
     const traceId = request.headers.get("x-trace-id");
     const requestId = request.headers.get("x-request-id");
     if (!traceId && !requestId) return sessionLog;

--- a/packages/control-plane/src/session/message-router.ts
+++ b/packages/control-plane/src/session/message-router.ts
@@ -36,7 +36,7 @@ export interface SessionClientCommands<Connection, Client extends ConnectedClien
 }
 
 export interface SessionMessageRouterDeps<Connection, Client extends ConnectedClient> {
-  getLogger: () => Logger;
+  log: Logger;
   sockets: SocketRegistry<Connection, Client>;
   clientCommands: SessionClientCommands<Connection, Client>;
   processSandboxEvent: (event: SandboxEvent) => Promise<void>;
@@ -65,7 +65,7 @@ export class SessionMessageRouter<Connection, Client extends ConnectedClient> {
     try {
       await this.deps.processSandboxEvent(parsed.data);
     } catch (error) {
-      this.deps.getLogger().error("Error processing sandbox message", {
+      this.deps.log.error("Error processing sandbox message", {
         error: error instanceof Error ? error : String(error),
       });
     }
@@ -126,7 +126,7 @@ export class SessionMessageRouter<Connection, Client extends ConnectedClient> {
           data satisfies never;
       }
     } catch (error) {
-      this.deps.getLogger().error("Error processing client message", {
+      this.deps.log.error("Error processing client message", {
         error: error instanceof Error ? error : String(error),
       });
       this.deps.sockets.send(connection, {
@@ -183,7 +183,7 @@ export class SessionMessageRouter<Connection, Client extends ConnectedClient> {
     try {
       raw = JSON.parse(message);
     } catch (error) {
-      this.deps.getLogger().error("Invalid WebSocket JSON", {
+      this.deps.log.error("Invalid WebSocket JSON", {
         boundary,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -192,7 +192,7 @@ export class SessionMessageRouter<Connection, Client extends ConnectedClient> {
 
     const result = schema.safeParse(raw);
     if (!result.success) {
-      this.deps.getLogger().warn("Invalid WebSocket message", {
+      this.deps.log.warn("Invalid WebSocket message", {
         boundary,
         issues: result.error.issues,
       });

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -87,7 +87,7 @@ function createProcessor() {
 
   const processor = new SessionSandboxEventProcessor(
     backgroundTasks,
-    () => log,
+    log,
     repository as unknown as SessionCoreRepository,
     repository as unknown as SandboxRepository,
     repository as unknown as MessageRepository,

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -38,10 +38,7 @@ export class SessionSandboxEventProcessor {
 
   constructor(
     private readonly backgroundTasks: BackgroundTasks,
-    // The DO swaps its logger for a request-scoped child during fetch();
-    // a getter keeps this singleton reading the current logger instead of
-    // capturing one by value at construction time.
-    private readonly getLog: () => Logger,
+    private readonly log: Logger,
     private readonly repository: SessionCoreRepository,
     private readonly sandboxRepository: SandboxRepository,
     private readonly messageRepository: MessageRepository,
@@ -67,10 +64,6 @@ export class SessionSandboxEventProcessor {
     private readonly processMessageQueue: () => Promise<void>,
     private readonly broadcastPromptQueue: () => void
   ) {}
-
-  private get log(): Logger {
-    return this.getLog();
-  }
 
   async processSandboxEvent(event: SandboxEventWithAck): Promise<void> {
     if (event.type === "heartbeat" || event.type === "token") {

--- a/packages/control-plane/src/session/server.test.ts
+++ b/packages/control-plane/src/session/server.test.ts
@@ -67,7 +67,7 @@ function createHarness() {
   };
 
   const httpDeps: SessionHttpDispatcherDeps = {
-    getLogger: () => log,
+    log,
     routes: [
       {
         method: "GET",
@@ -79,14 +79,14 @@ function createHarness() {
     clock,
   };
   const messageDeps: SessionMessageRouterDeps<string, TestClient> = {
-    getLogger: () => log,
+    log,
     sockets,
     clientCommands,
     processSandboxEvent: vi.fn(async () => undefined),
     clock,
   };
   const disconnectDeps = {
-    getLogger: () => log,
+    log,
     sockets,
     sandbox,
     broadcaster,


### PR DESCRIPTION
## Summary

Behavior-preserving follow-up to #1608/#1609/#1612 (deps-style normalization, per the #1045–#1049 standard): drop the vestigial logger thunks. Five sites took the session logger as a zero-arg function (`getLogger: () => Logger` / `getLog: () => Logger`) and called it on every use; all five are fed a value that is constant after composition, so they now take `log: Logger` directly.

The thunks existed for the DO-era log swap: `SessionDO` used to reassign its logger once the public session id resolved, so anything that captured a logger by value at construction time kept logging the stale id. That mechanism is gone — the composition root builds one session-scoped logger whose `session_id` is injected **per emit** through the latched resolver (`components.ts`: "for every component in the graph, however early it captured the logger"). The comment in `sandbox-events.ts` justifying its getter ("The DO swaps its logger for a request-scoped child during fetch()") described behavior that no longer exists.

## Changes

| Site | Before | After |
| --- | --- | --- |
| `SessionHttpDispatcher` deps | `getLogger: () => Logger` | `log: Logger` |
| `SessionMessageRouter` deps | `getLogger: () => Logger` | `log: Logger` |
| `SessionDisconnectHandler` deps | `getLogger: () => Logger` | `log: Logger` |
| `SessionSandboxEventProcessor` ctor | `getLog: () => Logger` + `private get log()` accessor | `private readonly log: Logger` (accessor deleted; internal `this.log` uses unchanged) |
| `createCloudflareBackgroundTasks` | `getLogger: () => Logger = () => log` | `logger: Logger = log` (worker/scheduler callers use the default, unchanged) |

Composition root: the three `getLogger: () => log` props and two `() => log` arguments become `log`.

## What deliberately stays a function

Everything that is genuinely dynamic, per the campaign's classification:

- **Latched resolvers** — `getSessionId` (DO id until the session row exists, public id after).
- **Live queries** — `getStatus`, `getAuthenticatedClients`, `getSandboxSocket`, `getProcessingMessageAuthor`, `isSpawning`.
- **Post-init freshness reads** — `getExecutionTimeoutMs`.
- **The SCM provider cell** — `() => scmProvider` reads a mutable `let` that live-DO integration tests substitute after graph construction.
- **Clock/id seams and adapters** — `now`, `generateId`, action-shaped deps.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` (both tsconfigs) clean
- `npm run lint -w @open-inspect/control-plane` clean
- Unit: 3187 passed; integration: 1002 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated session and background task components to receive logging instances directly.
  * Streamlined error, request, message, disconnect, and sandbox-event logging.
  * Preserved existing session handling, cleanup, reconnection, and close behavior.

* **Tests**
  * Updated automated tests and test setup to match the simplified logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->