### PR TITLE
chore(control-plane): define DEFAULT_BASE_BRANCH once

### DIFF
--- a/packages/control-plane/src/automation/repository.ts
+++ b/packages/control-plane/src/automation/repository.ts
@@ -1,6 +1,7 @@
 import type { AutomationRepositoryInsert } from "../db/automation-store";
 import type { Env } from "../types";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 /** A repository resolved for one firing: access checked, branch defaulted. */
 interface ResolvedAutomationRepository {
@@ -58,7 +59,8 @@ export async function resolveAutomationRepositories(
             repoOwner: access.repoOwner,
             repoName: access.repoName,
             repoId: access.repoId,
-            baseBranch: requested.base_branch?.trim() || access.defaultBranch || "main",
+            baseBranch:
+              requested.base_branch?.trim() || access.defaultBranch || DEFAULT_BASE_BRANCH,
           },
           error: null,
         };

--- a/packages/control-plane/src/repos/default-branch.ts
+++ b/packages/control-plane/src/repos/default-branch.ts
@@ -1,0 +1,6 @@
+/**
+ * Last-resort base branch, assumed only when neither the caller nor the SCM
+ * provider's repository metadata supplies one (e.g. repository rows persisted
+ * before base_branch was stored). Configured per-repo defaults always win.
+ */
+export const DEFAULT_BASE_BRANCH = "main";

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -5,6 +5,7 @@ import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
 import type { EnvironmentStore } from "../db/environments";
 import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
+import { DEFAULT_BASE_BRANCH } from "./default-branch";
 
 /**
  * One requested member of a session's repository list, exactly as normalized
@@ -92,7 +93,7 @@ export async function resolveSessionRepositories(
             repoOwner: access.repoOwner,
             repoName: access.repoName,
             repoId: access.repoId,
-            baseBranch: input.baseBranch?.trim() || access.defaultBranch || "main",
+            baseBranch: input.baseBranch?.trim() || access.defaultBranch || DEFAULT_BASE_BRANCH,
           },
           reason: null,
           errored: false,

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -36,6 +36,7 @@ import {
   type Route,
 } from "./shared";
 import { sessionRoute, type SessionRouteContext } from "./session-route";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 const logger = createLogger("router:session-child-spawn");
 const MAX_SPAWN_DEPTH = 2;
@@ -220,7 +221,9 @@ async function handleSpawnChild(
     repoId: spawnContext.repoId,
     environmentId: parentEnvironmentId,
     branch:
-      spawnContext.repoOwner && spawnContext.repoName ? (spawnContext.baseBranch ?? "main") : null,
+      spawnContext.repoOwner && spawnContext.repoName
+        ? (spawnContext.baseBranch ?? DEFAULT_BASE_BRANCH)
+        : null,
     title: body.title,
     model,
     reasoningEffort,

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -15,6 +15,7 @@ import { validateReasoningEffort } from "../../reasoning-effort";
 import { normalizeSessionTitle, type SessionTitleUpdateResult } from "../../title";
 import { z } from "zod";
 import { isSessionInactive } from "@open-inspect/shared/types/session-activity";
+import { DEFAULT_BASE_BRANCH } from "../../../repos/default-branch";
 
 /**
  * There is nothing to cancel once a session is no longer live work.
@@ -198,7 +199,9 @@ export class SessionLifecycleHandler {
     }
 
     const reasoningEffort = validateReasoningEffort(model, body.reasoningEffort ?? undefined, log);
-    const baseBranch = hasRepoOwner ? body.branch || body.defaultBranch || "main" : null;
+    const baseBranch = hasRepoOwner
+      ? body.branch || body.defaultBranch || DEFAULT_BASE_BRANCH
+      : null;
 
     const repositories = body.repositories ?? [];
     if (repositories.length > 0) {

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -8,6 +8,7 @@ import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { createLogger } from "../logger";
 import type { SessionSkillManifestInput } from "./skill-resolution";
 import type { SessionModelProviderAuthInput } from "../model-provider-accounts/provider-auth-contracts";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 const logger = createLogger("session-init");
 
@@ -106,7 +107,7 @@ export async function initializeSession(
   const defaultBranch = hasRepoOwner ? input.defaultBranch : null;
 
   const now = Date.now();
-  const baseBranch = hasRepoOwner ? branch || defaultBranch || "main" : null;
+  const baseBranch = hasRepoOwner ? branch || defaultBranch || DEFAULT_BASE_BRANCH : null;
 
   if (input.repositories?.length) {
     const primary = input.repositories[0];

--- a/packages/control-plane/src/session/repository-target.ts
+++ b/packages/control-plane/src/session/repository-target.ts
@@ -25,8 +25,8 @@ export interface SessionRepositoryEntry {
   /**
    * The entry's base branch: the row's, or the scalar mirror's for
    * synthesized entries. Null only for legacy sessions without a stored
-   * base branch — consumers apply their own default ("main" for state and
-   * spawn, the repo's default branch for PR creation).
+   * base branch — consumers apply their own default (DEFAULT_BASE_BRANCH
+   * for state and spawn, the repo's default branch for PR creation).
    */
   baseBranch: string | null;
   /** Whether this member is the session's primary (scalar-mirror) repo. */

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -14,6 +14,7 @@ import type { SessionCoreRepository } from "./session-core-repository";
 import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionRow } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 /** The session-context reads owned by the session repositories and resolver. */
 export class LifecycleSessionContext implements SessionContextReader {
@@ -30,7 +31,7 @@ export class LifecycleSessionContext implements SessionContextReader {
     return this.sessions.getSessionRepositories().map((entry) => ({
       repoOwner: entry.repoOwner,
       repoName: entry.repoName,
-      baseBranch: entry.baseBranch ?? "main",
+      baseBranch: entry.baseBranch ?? DEFAULT_BASE_BRANCH,
       baseSha: entry.row?.base_sha ?? null,
     }));
   }

--- a/packages/control-plane/src/session/session-core-repository.ts
+++ b/packages/control-plane/src/session/session-core-repository.ts
@@ -2,6 +2,7 @@ import type { SessionStatus, SpawnSource } from "@open-inspect/shared/types/sess
 import { buildSessionRepositories, type SessionRepositoryEntry } from "./repository-target";
 import type { SqlResult, SqlStorage, TransactionSync } from "./sql-storage";
 import type { SessionRepositoryRow, SessionRow } from "./types";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 /** Data for upserting a session. */
 export interface UpsertSessionData {
@@ -79,7 +80,7 @@ export class SessionCoreRepository {
       data.repoOwner,
       data.repoName,
       data.repoId ?? null,
-      data.baseBranch ?? (hasRepoOwner ? "main" : null),
+      data.baseBranch ?? (hasRepoOwner ? DEFAULT_BASE_BRANCH : null),
       data.model,
       data.reasoningEffort ?? null,
       data.status,

--- a/packages/control-plane/src/session/snapshot-reader.ts
+++ b/packages/control-plane/src/session/snapshot-reader.ts
@@ -20,6 +20,7 @@ import type { SessionCoreRepository } from "./session-core-repository";
 import type { SessionEventStream } from "./event-stream";
 import type { MessageService } from "./services/message.service";
 import type { SessionRow, SandboxRow } from "./types";
+import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
 
 export interface SessionSnapshotEnrichment {
   environmentId: string | null;
@@ -156,7 +157,7 @@ export class SessionSnapshotReader {
       repoOwner: member.repoOwner,
       repoName: member.repoName,
       repoId: member.row ? member.row.repo_id : (session?.repo_id ?? null),
-      baseBranch: member.baseBranch ?? "main",
+      baseBranch: member.baseBranch ?? DEFAULT_BASE_BRANCH,
       branchName:
         member.row?.branch_name ?? (member.isPrimary ? (session?.branch_name ?? null) : null),
       baseSha: member.row?.base_sha ?? (member.isPrimary ? (session?.base_sha ?? null) : null),


### PR DESCRIPTION
## Summary

Closes out the deps-style normalization campaign (#1608/#1609/#1612/#1615/#1616): the last-resort `"main"` base-branch fallback was written as a literal at seven independent sites. Per the repo convention ("define each default value exactly once — extract to a named constant and import everywhere"), it is now `DEFAULT_BASE_BRANCH` in `src/repos/default-branch.ts`, imported at all seven.

Deferred from the #1608 review round.

## The seven sites

All express the same concept — the branch assumed only when neither the caller nor the SCM provider's repository metadata supplies one; configured per-repo defaults (#757) always win:

- `repos/resolve.ts` — `input.baseBranch?.trim() || access.defaultBranch || …`
- `automation/repository.ts` — same shape for automation repo selections
- `routes/session-child-spawn.ts` — spawn-context fallback
- `session/initialize.ts` and `session/http/handlers/session-lifecycle.handler.ts` — init-payload fallback
- `session/snapshot-reader.ts` and `session/sandbox-lifecycle-adapters.ts` — legacy repository rows persisted before `base_branch` was stored

Test fixtures keep their literals (they are inputs, not the default's definition). No behavior change: the constant's value is `"main"`.

## Testing

- `npm run typecheck` (all three programs) clean; ESLint clean
- Unit + integration batteries green
- `rg '\?\? "main"|\|\| "main"' src` (non-test) → no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized repository branch fallback behavior across session initialization, automation, repository resolution, and child sessions.
  * Repositories without a configured or provider-supplied base branch now consistently use the default `main` branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->