### PR TITLE
Render rich pull request tool events in the timeline

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
@@ -96,6 +96,7 @@ export function resolveRepositoryTarget(repo, repositories) {
 // This sandbox-shipped file cannot import the workspace package at runtime.
 // Keep these envelopes symmetric with @open-inspect/shared/pull-request-tool.
 export function formatPullRequestSuccess(result) {
+  const state = result?.state === "draft" ? "draft" : "open";
   const branches =
     result?.headBranch && result?.baseBranch
       ? ` (${result.headBranch} -> ${result.baseBranch})`
@@ -105,7 +106,7 @@ export function formatPullRequestSuccess(result) {
     agentMessage = `Pull request updated with your latest commits.\n\nPR #${result.prNumber}${branches}: ${result.prUrl}`;
   } else {
     const status =
-      result?.state === "draft"
+      state === "draft"
         ? "The pull request is in draft mode."
         : "The pull request is now ready for review.";
     agentMessage = `Pull request created successfully!\n\nPR #${result.prNumber}${branches}: ${result.prUrl}\n\n${status}`;
@@ -115,7 +116,7 @@ export function formatPullRequestSuccess(result) {
     kind: result.updated ? "updated" : "created",
     prNumber: result.prNumber,
     prUrl: result.prUrl,
-    state: result.state,
+    state,
     headBranch: result.headBranch,
     baseBranch: result.baseBranch,
     agentMessage,

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
@@ -93,19 +93,42 @@ export function resolveRepositoryTarget(repo, repositories) {
   return owner.split("/").some((segment) => !segment) ? null : { owner, name };
 }
 
+// This sandbox-shipped file cannot import the workspace package at runtime.
+// Keep these envelopes symmetric with @open-inspect/shared/pull-request-tool.
 export function formatPullRequestSuccess(result) {
   const branches =
     result?.headBranch && result?.baseBranch
       ? ` (${result.headBranch} -> ${result.baseBranch})`
       : "";
+  let agentMessage;
   if (result?.updated) {
-    return `Pull request updated with your latest commits.\n\nPR #${result.prNumber}${branches}: ${result.prUrl}`;
+    agentMessage = `Pull request updated with your latest commits.\n\nPR #${result.prNumber}${branches}: ${result.prUrl}`;
+  } else {
+    const status =
+      result?.state === "draft"
+        ? "The pull request is in draft mode."
+        : "The pull request is now ready for review.";
+    agentMessage = `Pull request created successfully!\n\nPR #${result.prNumber}${branches}: ${result.prUrl}\n\n${status}`;
   }
-  const status =
-    result?.state === "draft"
-      ? "The pull request is in draft mode."
-      : "The pull request is now ready for review.";
-  return `Pull request created successfully!\n\nPR #${result.prNumber}${branches}: ${result.prUrl}\n\n${status}`;
+
+  return JSON.stringify({
+    kind: result.updated ? "updated" : "created",
+    prNumber: result.prNumber,
+    prUrl: result.prUrl,
+    state: result.state,
+    headBranch: result.headBranch,
+    baseBranch: result.baseBranch,
+    agentMessage,
+  });
+}
+
+export function formatPullRequestFailure(message) {
+  return JSON.stringify({ kind: "failure", message, agentMessage: message });
+}
+
+export function formatManualPullRequest(createPrUrl) {
+  const agentMessage = `Branch pushed successfully.\n\nCreate the pull request in GitHub:\n${createPrUrl}\n\nUse your logged-in GitHub account to finish creating the PR.`;
+  return JSON.stringify({ kind: "manual", createPrUrl, agentMessage });
 }
 
 async function getCurrentBranch(repoPath) {
@@ -181,10 +204,14 @@ export default tool({
     if (args.repo) {
       const target = resolveRepositoryTarget(args.repo, repositories);
       if (!target && repositories.length > 0) {
-        return `Failed to create pull request: ${args.repo} is not part of this session. Valid values: ${validValues}.`;
+        return formatPullRequestFailure(
+          `Failed to create pull request: ${args.repo} is not part of this session. Valid values: ${validValues}.`
+        );
       }
       if (!target) {
-        return 'Failed to create pull request: repo must be "owner/name".';
+        return formatPullRequestFailure(
+          'Failed to create pull request: repo must be "owner/name".'
+        );
       }
       // Use the manifest's canonical casing and path — checkout directories
       // and the control plane's member records are case-sensitive.
@@ -192,7 +219,9 @@ export default tool({
       repoName = target.name;
       repoPath = target.path;
     } else if (repositories.length > 1) {
-      return `Failed to create pull request: this session spans multiple repositories — pass repo with one of: ${validValues}.`;
+      return formatPullRequestFailure(
+        `Failed to create pull request: this session spans multiple repositories — pass repo with one of: ${validValues}.`
+      );
     }
 
     const headBranch = await getCurrentBranch(repoPath);
@@ -205,7 +234,9 @@ export default tool({
 
       if (!sessionId) {
         console.log("[create-pull-request] ERROR: Session ID not found");
-        return "Failed to create pull request: Session ID not found in environment. Please check that SESSION_CONFIG is set correctly.";
+        return formatPullRequestFailure(
+          "Failed to create pull request: Session ID not found in environment. Please check that SESSION_CONFIG is set correctly."
+        );
       }
 
       // Use the session-specific endpoint
@@ -252,14 +283,14 @@ export default tool({
         }
 
         console.log(`[create-pull-request] ERROR: HTTP ${response.status} - ${errorMessage}`);
-        return userMessage;
+        return formatPullRequestFailure(userMessage);
       }
 
       const result = await response.json();
 
       if (result?.status === "manual" && result?.createPrUrl) {
         console.log("[create-pull-request] SUCCESS: branch pushed, manual PR URL generated");
-        return `Branch pushed successfully.\n\nCreate the pull request in GitHub:\n${result.createPrUrl}\n\nUse your logged-in GitHub account to finish creating the PR.`;
+        return formatManualPullRequest(result.createPrUrl);
       }
 
       console.log(`[create-pull-request] SUCCESS: PR #${result.prNumber} created`);
@@ -267,7 +298,7 @@ export default tool({
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.log(`[create-pull-request] ERROR: ${message}`);
-      return `Failed to create pull request: ${message}`;
+      return formatPullRequestFailure(`Failed to create pull request: ${message}`);
     }
   },
 });

--- a/packages/sandbox-runtime/tests/test_repository_target.py
+++ b/packages/sandbox-runtime/tests/test_repository_target.py
@@ -149,10 +149,23 @@ def _format_success(tmp_path: Path, result_json: str) -> str:
 def test_formats_pull_request_state(tmp_path: Path, state: str, message: str) -> None:
     output = _format_success(
         tmp_path,
-        json.dumps({"prNumber": 42, "prUrl": "https://example.test/pull/42", "state": state}),
+        json.dumps(
+            {
+                "prNumber": 42,
+                "prUrl": "https://example.test/pull/42",
+                "state": state,
+                "headBranch": "feature-x",
+                "baseBranch": "main",
+                "updated": False,
+            }
+        ),
     )
 
     assert message in output
+    envelope = json.loads(output)
+    assert envelope["kind"] == "created"
+    assert envelope["prNumber"] == 42
+    assert envelope["headBranch"] == "feature-x"
 
 
 def test_formats_updated_pull_request(tmp_path: Path) -> None:

--- a/packages/sandbox-runtime/tests/test_repository_target.py
+++ b/packages/sandbox-runtime/tests/test_repository_target.py
@@ -208,3 +208,22 @@ def test_formats_branches_on_creation(tmp_path: Path) -> None:
     assert "created successfully" in output
     assert "feature-x" in output
     assert "release-1.0" in output
+
+
+def test_formats_schema_valid_success_without_optional_metadata(tmp_path: Path) -> None:
+    output = _format_success(
+        tmp_path,
+        json.dumps(
+            {
+                "prNumber": 42,
+                "prUrl": "https://example.test/pull/42",
+                "updated": False,
+            }
+        ),
+    )
+
+    envelope = json.loads(output)
+    assert envelope["kind"] == "created"
+    assert envelope["state"] == "open"
+    assert "headBranch" not in envelope
+    assert "baseBranch" not in envelope

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -94,6 +94,10 @@
       "import": "./dist/slack/index.js",
       "types": "./dist/slack/index.d.ts"
     },
+    "./pull-request-tool": {
+      "import": "./dist/pull-request-tool.js",
+      "types": "./dist/pull-request-tool.d.ts"
+    },
     "./completion/extractor": {
       "import": "./dist/completion/extractor.js",
       "types": "./dist/completion/extractor.d.ts"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,3 +19,4 @@ export * from "./user-id";
 export * from "./browser-auth-routes";
 export * from "./sign-in-provider";
 export * from "./slack";
+export * from "./pull-request-tool";

--- a/packages/shared/src/pull-request-tool.test.ts
+++ b/packages/shared/src/pull-request-tool.test.ts
@@ -44,4 +44,18 @@ describe("createPullRequestToolEnvelopeSchema", () => {
       }).success
     ).toBe(false);
   });
+
+  it("defaults state and accepts omitted branch metadata", () => {
+    const result = createPullRequestToolEnvelopeSchema.safeParse({
+      kind: "created",
+      prNumber: 42,
+      prUrl: "https://github.com/acme/web/pull/42",
+      agentMessage: "Pull request ready.",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ kind: "created", state: "open" });
+    }
+  });
 });

--- a/packages/shared/src/pull-request-tool.test.ts
+++ b/packages/shared/src/pull-request-tool.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createPullRequestToolEnvelopeSchema } from "./pull-request-tool";
+
+describe("createPullRequestToolEnvelopeSchema", () => {
+  it("accepts created and updated pull request results", () => {
+    for (const kind of ["created", "updated"] as const) {
+      expect(
+        createPullRequestToolEnvelopeSchema.safeParse({
+          kind,
+          prNumber: 42,
+          prUrl: "https://github.com/acme/web/pull/42",
+          state: "open",
+          headBranch: "feature/timeline",
+          baseBranch: "main",
+          agentMessage: "Pull request ready.",
+        }).success
+      ).toBe(true);
+    }
+  });
+
+  it("accepts manual and failure results", () => {
+    expect(
+      createPullRequestToolEnvelopeSchema.safeParse({
+        kind: "manual",
+        createPrUrl: "https://github.com/acme/web/compare/main...feature",
+        agentMessage: "Create the pull request in GitHub.",
+      }).success
+    ).toBe(true);
+    expect(
+      createPullRequestToolEnvelopeSchema.safeParse({
+        kind: "failure",
+        message: "Authentication failed.",
+        agentMessage: "Authentication failed.",
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects incomplete results", () => {
+    expect(
+      createPullRequestToolEnvelopeSchema.safeParse({
+        kind: "created",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/web/pull/42",
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/pull-request-tool.ts
+++ b/packages/shared/src/pull-request-tool.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const pullRequestCreatedOrUpdatedSchema = z.object({
+  kind: z.enum(["created", "updated"]),
+  prNumber: z.number().int().positive(),
+  prUrl: z.string().min(1),
+  state: z.enum(["open", "draft"]),
+  headBranch: z.string().min(1),
+  baseBranch: z.string().min(1),
+  agentMessage: z.string(),
+});
+
+export const createPullRequestToolEnvelopeSchema = z.discriminatedUnion("kind", [
+  pullRequestCreatedOrUpdatedSchema,
+  z.object({
+    kind: z.literal("manual"),
+    createPrUrl: z.string().min(1),
+    agentMessage: z.string(),
+  }),
+  z.object({
+    kind: z.literal("failure"),
+    message: z.string().min(1),
+    agentMessage: z.string(),
+  }),
+]);
+
+export type CreatePullRequestToolEnvelope = z.infer<typeof createPullRequestToolEnvelopeSchema>;

--- a/packages/shared/src/pull-request-tool.ts
+++ b/packages/shared/src/pull-request-tool.ts
@@ -4,9 +4,9 @@ const pullRequestCreatedOrUpdatedSchema = z.object({
   kind: z.enum(["created", "updated"]),
   prNumber: z.number().int().positive(),
   prUrl: z.string().min(1),
-  state: z.enum(["open", "draft"]),
-  headBranch: z.string().min(1),
-  baseBranch: z.string().min(1),
+  state: z.enum(["open", "draft"]).default("open"),
+  headBranch: z.string().min(1).optional(),
+  baseBranch: z.string().min(1).optional(),
   agentMessage: z.string(),
 });
 

--- a/packages/web/src/components/create-pull-request-event.test.tsx
+++ b/packages/web/src/components/create-pull-request-event.test.tsx
@@ -29,9 +29,15 @@ function createdOutput({
   draft?: boolean;
   url?: string;
 } = {}) {
-  return `Pull request created successfully!\n\nPR #42 (feature/creator -> main): ${url}\n\n${
-    draft ? "The pull request is in draft mode." : "The pull request is now ready for review."
-  }`;
+  return JSON.stringify({
+    kind: "created",
+    prNumber: 42,
+    prUrl: url,
+    state: draft ? "draft" : "open",
+    headBranch: "feature/creator",
+    baseBranch: "main",
+    agentMessage: "Pull request created successfully.",
+  });
 }
 
 function renderExpanded(overrides: Partial<ToolCallEvent> = {}) {
@@ -96,8 +102,15 @@ describe("CreatePullRequestEvent", () => {
 
   it("renders an updated pull request distinctly", () => {
     renderExpanded({
-      output:
-        "Pull request updated with your latest commits.\n\nPR #42 (feature/creator -> main): https://github.com/acme/web/pull/42",
+      output: JSON.stringify({
+        kind: "updated",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/web/pull/42",
+        state: "open",
+        headBranch: "feature/creator",
+        baseBranch: "main",
+        agentMessage: "Pull request updated with your latest commits.",
+      }),
     });
 
     expect(screen.getByText("Updated pull request #42")).toBeInTheDocument();
@@ -106,7 +119,11 @@ describe("CreatePullRequestEvent", () => {
 
   it("renders completed textual failures as failures", () => {
     renderExpanded({
-      output: "Authentication failed: token expired. Please re-authenticate.",
+      output: JSON.stringify({
+        kind: "failure",
+        message: "Authentication failed: token expired. Please re-authenticate.",
+        agentMessage: "Authentication failed: token expired. Please re-authenticate.",
+      }),
     });
 
     expect(screen.getByText("Create pull request failed")).toBeInTheDocument();
@@ -117,8 +134,11 @@ describe("CreatePullRequestEvent", () => {
 
   it("renders the manual creation fallback", () => {
     renderExpanded({
-      output:
-        "Branch pushed successfully.\n\nCreate the pull request in GitHub:\nhttps://github.com/acme/web/compare/main...feature\n\nUse your logged-in GitHub account to finish creating the PR.",
+      output: JSON.stringify({
+        kind: "manual",
+        createPrUrl: "https://github.com/acme/web/compare/main...feature",
+        agentMessage: "Create the pull request in GitHub.",
+      }),
     });
 
     expect(screen.getByText("Branch pushed for pull request")).toBeInTheDocument();
@@ -137,11 +157,33 @@ describe("CreatePullRequestEvent", () => {
   });
 
   it("preserves unrecognized output instead of dropping result details", () => {
-    renderExpanded({ output: "Provider accepted the request with an unfamiliar response." });
+    const output = "  Provider accepted the request with an unfamiliar response.\n";
+    renderExpanded({ output });
 
     expect(screen.getByText("Create pull request completed")).toBeInTheDocument();
     expect(screen.getByText("Result details below")).toBeInTheDocument();
-    expect(screen.getByText(/unfamiliar response/i)).toBeInTheDocument();
+    expect(screen.getByText(/unfamiliar response/i).textContent).toBe(output);
+  });
+
+  it("keeps unrecognized running output pending", () => {
+    renderExpanded({ status: "running", output: "Pushing branch to the remote..." });
+
+    expect(screen.getByText("Creating pull request")).toBeInTheDocument();
+    expect(screen.getByText("Pushing branch to the remote...")).toBeInTheDocument();
+    expect(screen.queryByText("Create pull request completed")).not.toBeInTheDocument();
+  });
+
+  it("renders persisted prose output through the legacy fallback", () => {
+    renderExpanded({
+      output:
+        "Pull request created successfully!\n\nPR #42 (feature/creator -> main): https://github.com/acme/web/pull/42\n\nThe pull request is now ready for review.",
+    });
+
+    expect(screen.getByText("Opened pull request #42")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open pr/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/web/pull/42"
+    );
   });
 
   it("shows pending state before output arrives", () => {

--- a/packages/web/src/components/create-pull-request-event.test.tsx
+++ b/packages/web/src/components/create-pull-request-event.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SandboxEvent } from "@/types/session";
+import { CreatePullRequestEvent } from "./create-pull-request-event";
+
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+
+const BASE_EVENT: ToolCallEvent = {
+  type: "tool_call",
+  tool: "create-pull-request",
+  callId: "call-1",
+  messageId: "message-1",
+  sandboxId: "sandbox-1",
+  timestamp: 1_700_000_000,
+  status: "completed",
+  args: {
+    title: "Show creator attribution",
+    body: "## Why\n\nShared skills now show their creator.",
+    repo: "group/platform/web",
+  },
+};
+
+function createdOutput({
+  draft = false,
+  url = "https://github.com/acme/web/pull/42",
+}: {
+  draft?: boolean;
+  url?: string;
+} = {}) {
+  return `Pull request created successfully!\n\nPR #42 (feature/creator -> main): ${url}\n\n${
+    draft ? "The pull request is in draft mode." : "The pull request is now ready for review."
+  }`;
+}
+
+function renderExpanded(overrides: Partial<ToolCallEvent> = {}) {
+  const event = { ...BASE_EVENT, ...overrides };
+  return render(<CreatePullRequestEvent event={event} isExpanded onToggle={() => {}} />);
+}
+
+afterEach(cleanup);
+
+describe("CreatePullRequestEvent", () => {
+  it("leaves expansion state with the parent", () => {
+    const onToggle = vi.fn();
+    render(
+      <CreatePullRequestEvent
+        event={{ ...BASE_EVENT, output: createdOutput() }}
+        isExpanded={false}
+        onToggle={onToggle}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: /open pr/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("renders a created pull request with opaque markdown body content", () => {
+    renderExpanded({ output: createdOutput() });
+
+    expect(screen.getByText("Opened pull request #42")).toBeInTheDocument();
+    expect(screen.getByText("group/platform/web")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Why" })).toBeInTheDocument();
+    expect(screen.getByText("Shared skills now show their creator.")).toBeInTheDocument();
+    expect(screen.getByText("feature/creator")).toBeInTheDocument();
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByText("Ready for review")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open pr/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/web/pull/42"
+    );
+  });
+
+  it("does not invent sections for a freeform body", () => {
+    renderExpanded({
+      args: {
+        title: "Plain description",
+        body: "This change keeps attribution visible without requiring structured headings.",
+      },
+      output: createdOutput(),
+    });
+
+    expect(screen.getByText(/without requiring structured headings/i)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /summary/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /verification/i })).not.toBeInTheDocument();
+  });
+
+  it("renders draft state", () => {
+    renderExpanded({ output: createdOutput({ draft: true }) });
+
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+    expect(screen.getByText("Draft pull request")).toBeInTheDocument();
+  });
+
+  it("renders an updated pull request distinctly", () => {
+    renderExpanded({
+      output:
+        "Pull request updated with your latest commits.\n\nPR #42 (feature/creator -> main): https://github.com/acme/web/pull/42",
+    });
+
+    expect(screen.getByText("Updated pull request #42")).toBeInTheDocument();
+    expect(screen.getByText("Latest commits pushed")).toBeInTheDocument();
+  });
+
+  it("renders completed textual failures as failures", () => {
+    renderExpanded({
+      output: "Authentication failed: token expired. Please re-authenticate.",
+    });
+
+    expect(screen.getByText("Create pull request failed")).toBeInTheDocument();
+    expect(screen.getByText("Couldn't create pull request")).toBeInTheDocument();
+    expect(screen.getByText(/token expired/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders the manual creation fallback", () => {
+    renderExpanded({
+      output:
+        "Branch pushed successfully.\n\nCreate the pull request in GitHub:\nhttps://github.com/acme/web/compare/main...feature\n\nUse your logged-in GitHub account to finish creating the PR.",
+    });
+
+    expect(screen.getByText("Branch pushed for pull request")).toBeInTheDocument();
+    expect(screen.getByText("Branch ready")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /create pr/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/web/compare/main...feature"
+    );
+  });
+
+  it("omits unsafe result links", () => {
+    renderExpanded({ output: createdOutput({ url: "javascript:alert(1)" }) });
+
+    expect(screen.getByText("Opened pull request #42")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /open pr/i })).not.toBeInTheDocument();
+  });
+
+  it("preserves unrecognized output instead of dropping result details", () => {
+    renderExpanded({ output: "Provider accepted the request with an unfamiliar response." });
+
+    expect(screen.getByText("Create pull request completed")).toBeInTheDocument();
+    expect(screen.getByText("Result details below")).toBeInTheDocument();
+    expect(screen.getByText(/unfamiliar response/i)).toBeInTheDocument();
+  });
+
+  it("shows pending state before output arrives", () => {
+    renderExpanded({ status: "running", output: undefined });
+
+    expect(screen.getByText("Creating pull request")).toBeInTheDocument();
+    expect(screen.getByText("Creating pull request...")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("allows long descriptions to be expanded", () => {
+    renderExpanded({
+      args: { title: "Long description", body: "Long body paragraph. ".repeat(30) },
+      output: createdOutput(),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Show full description" }));
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/create-pull-request-event.test.tsx
+++ b/packages/web/src/components/create-pull-request-event.test.tsx
@@ -79,6 +79,25 @@ describe("CreatePullRequestEvent", () => {
     );
   });
 
+  it("keeps the PR action when optional success metadata is absent", () => {
+    renderExpanded({
+      output: JSON.stringify({
+        kind: "created",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/web/pull/42",
+        agentMessage: "Pull request created successfully.",
+      }),
+    });
+
+    expect(screen.getByText("Opened pull request #42")).toBeInTheDocument();
+    expect(screen.getByText("Open")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open pr/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/web/pull/42"
+    );
+    expect(screen.queryByText("unknown")).not.toBeInTheDocument();
+  });
+
   it("does not invent sections for a freeform body", () => {
     renderExpanded({
       args: {

--- a/packages/web/src/components/create-pull-request-event.tsx
+++ b/packages/web/src/components/create-pull-request-event.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import {
+  createPullRequestToolEnvelopeSchema,
+  type CreatePullRequestToolEnvelope,
+} from "@open-inspect/shared/pull-request-tool";
 import type { SandboxEvent } from "@/types/session";
 import { formatSessionEventTime } from "@/lib/time";
 import { getSafeExternalUrl } from "@/lib/urls";
@@ -18,18 +22,20 @@ import { TimelineRowContent } from "./timeline-row-content";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 
+type LegacyCompletedResult = {
+  kind: "created" | "updated";
+  prNumber: number;
+  prUrl: string;
+  state: "open" | "draft";
+  headBranch?: string;
+  baseBranch?: string;
+  agentMessage: string;
+};
+
 type PullRequestResult =
-  | {
-      kind: "created" | "updated";
-      number: number;
-      url: string;
-      head?: string;
-      base?: string;
-      state: "open" | "draft";
-    }
-  | { kind: "manual"; url: string }
-  | { kind: "failure"; message: string }
-  | { kind: "pending" }
+  | CreatePullRequestToolEnvelope
+  | LegacyCompletedResult
+  | { kind: "pending"; output?: string }
   | { kind: "unknown"; output: string };
 
 const FAILURE_PREFIX =
@@ -38,33 +44,70 @@ const PR_LINE = /PR #(\d+)(?: \((.+?) -> (.+?)\))?: (\S+)/;
 const MANUAL_URL = /Create the pull request in GitHub:\s*\n(\S+)/;
 
 function parseResult(event: ToolCallEvent): PullRequestResult {
-  const output = event.output?.trim();
+  const rawOutput = event.output;
+  const output = rawOutput?.trim();
   if (!output) {
     return event.status === "error"
-      ? { kind: "failure", message: "Pull request creation failed." }
+      ? {
+          kind: "failure",
+          message: "Pull request creation failed.",
+          agentMessage: "Pull request creation failed.",
+        }
       : { kind: "pending" };
   }
 
-  if (FAILURE_PREFIX.test(output)) return { kind: "failure", message: output };
+  try {
+    const envelope = createPullRequestToolEnvelopeSchema.safeParse(JSON.parse(output));
+    if (envelope.success) return envelope.data;
+    return unrecognizedResult(event, rawOutput ?? output, output);
+  } catch {
+    // Persisted events predating the structured envelope contain prose output.
+  }
+
+  return parseLegacyResult(event, rawOutput ?? output, output);
+}
+
+function parseLegacyResult(
+  event: ToolCallEvent,
+  rawOutput: string,
+  output: string
+): PullRequestResult {
+  if (FAILURE_PREFIX.test(output)) {
+    return { kind: "failure", message: output, agentMessage: output };
+  }
 
   const manualMatch = output.match(MANUAL_URL);
-  if (manualMatch) return { kind: "manual", url: manualMatch[1] };
+  if (manualMatch) {
+    return { kind: "manual", createPrUrl: manualMatch[1], agentMessage: output };
+  }
 
   const prMatch = output.match(PR_LINE);
   if (prMatch) {
     return {
       kind: output.startsWith("Pull request updated") ? "updated" : "created",
-      number: Number(prMatch[1]),
-      url: prMatch[4],
-      head: prMatch[2],
-      base: prMatch[3],
+      prNumber: Number(prMatch[1]),
+      prUrl: prMatch[4],
+      headBranch: prMatch[2],
+      baseBranch: prMatch[3],
       state: output.includes("in draft mode") ? "draft" : "open",
+      agentMessage: output,
     };
   }
 
+  return unrecognizedResult(event, rawOutput, output);
+}
+
+function unrecognizedResult(
+  event: ToolCallEvent,
+  rawOutput: string,
+  output: string
+): PullRequestResult {
+  if (["pending", "running", "in_progress"].includes(event.status ?? "")) {
+    return { kind: "pending", output: rawOutput };
+  }
   return event.status === "error"
-    ? { kind: "failure", message: output }
-    : { kind: "unknown", output };
+    ? { kind: "failure", message: output, agentMessage: output }
+    : { kind: "unknown", output: rawOutput };
 }
 
 function getStringArg(event: ToolCallEvent, key: string): string | undefined {
@@ -127,7 +170,7 @@ function BranchRoute({ head, base }: { head: string; base: string }) {
   );
 }
 
-function PullRequestLink({ href, manual = false }: { href: string; manual?: boolean }) {
+function PullRequestLink({ href, label }: { href: string; label: string }) {
   return (
     <a
       href={href}
@@ -135,65 +178,107 @@ function PullRequestLink({ href, manual = false }: { href: string; manual?: bool
       rel="noopener noreferrer"
       className="inline-flex shrink-0 items-center gap-1.5 bg-foreground px-2.5 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-80"
     >
-      {manual ? "Create PR" : "Open PR"}
+      {label}
       <LinkIcon className="h-3 w-3" />
     </a>
   );
 }
 
-function summaryForResult(result: PullRequestResult): string {
+type PresentationTone = "success" | "muted" | "danger";
+type PresentationIcon = "pull-request" | "draft" | "error";
+
+interface PullRequestPresentation {
+  summary: string;
+  status?: string;
+  footer?: string;
+  tone: PresentationTone;
+  icon: PresentationIcon;
+  action?: { label: string; url: string };
+  prNumber?: number;
+  headBranch?: string;
+  baseBranch?: string;
+  detail?: string;
+  rawOutput?: string;
+}
+
+function presentationForResult(result: PullRequestResult): PullRequestPresentation {
   switch (result.kind) {
-    case "created":
-      return `Opened pull request #${result.number}`;
-    case "updated":
-      return `Updated pull request #${result.number}`;
+    case "created": {
+      const draft = result.state === "draft";
+      return {
+        summary: `Opened pull request #${result.prNumber}`,
+        status: draft ? "Draft" : "Open",
+        footer: draft ? "Draft pull request" : "Ready for review",
+        tone: draft ? "muted" : "success",
+        icon: draft ? "draft" : "pull-request",
+        action: { label: "Open PR", url: result.prUrl },
+        prNumber: result.prNumber,
+        headBranch: result.headBranch,
+        baseBranch: result.baseBranch,
+      };
+    }
+    case "updated": {
+      const draft = result.state === "draft";
+      return {
+        summary: `Updated pull request #${result.prNumber}`,
+        status: draft ? "Draft" : "Updated",
+        footer: "Latest commits pushed",
+        tone: draft ? "muted" : "success",
+        icon: draft ? "draft" : "pull-request",
+        action: { label: "Open PR", url: result.prUrl },
+        prNumber: result.prNumber,
+        headBranch: result.headBranch,
+        baseBranch: result.baseBranch,
+      };
+    }
     case "manual":
-      return "Branch pushed for pull request";
+      return {
+        summary: "Branch pushed for pull request",
+        status: "Branch pushed",
+        footer: "Branch ready",
+        tone: "success",
+        icon: "pull-request",
+        action: { label: "Create PR", url: result.createPrUrl },
+      };
     case "failure":
-      return "Create pull request failed";
+      return {
+        summary: "Create pull request failed",
+        tone: "danger",
+        icon: "error",
+        detail: result.message,
+      };
     case "unknown":
-      return "Create pull request completed";
+      return {
+        summary: "Create pull request completed",
+        status: "Completed",
+        footer: "Result details below",
+        tone: "muted",
+        icon: "pull-request",
+        rawOutput: result.output,
+      };
     case "pending":
-      return "Creating pull request";
+      return {
+        summary: "Creating pull request",
+        status: "Creating",
+        footer: result.output ?? "Creating pull request...",
+        tone: "muted",
+        icon: "pull-request",
+      };
   }
 }
 
-function statusForResult(result: Exclude<PullRequestResult, { kind: "failure" }>): string {
-  switch (result.kind) {
-    case "created":
-      return result.state === "draft" ? "Draft" : "Open";
-    case "updated":
-      return "Updated";
-    case "manual":
-      return "Branch pushed";
-    case "unknown":
-      return "Completed";
-    case "pending":
-      return "Creating";
-  }
-}
-
-function footerForResult(result: Exclude<PullRequestResult, { kind: "failure" }>): string {
-  switch (result.kind) {
-    case "created":
-      return result.state === "draft" ? "Draft pull request" : "Ready for review";
-    case "updated":
-      return "Latest commits pushed";
-    case "manual":
-      return "Branch ready";
-    case "unknown":
-      return "Result details below";
-    case "pending":
-      return "Creating pull request...";
-  }
-}
-
-function PullRequestCard({ event, result }: { event: ToolCallEvent; result: PullRequestResult }) {
+function PullRequestCard({
+  event,
+  presentation,
+}: {
+  event: ToolCallEvent;
+  presentation: PullRequestPresentation;
+}) {
   const title = getStringArg(event, "title") ?? "Pull request";
   const rawBody = event.args?.body;
   const body = typeof rawBody === "string" && rawBody.trim() ? rawBody : undefined;
 
-  if (result.kind === "failure") {
+  if (presentation.detail) {
     return (
       <div className="border border-destructive-border bg-destructive-muted p-4 text-xs">
         <div className="flex items-start gap-2 text-destructive">
@@ -201,7 +286,7 @@ function PullRequestCard({ event, result }: { event: ToolCallEvent; result: Pull
           <div>
             <div className="font-medium">Couldn&apos;t create pull request</div>
             <div className="mt-1 text-muted-foreground [overflow-wrap:anywhere]">
-              {result.message}
+              {presentation.detail}
             </div>
           </div>
         </div>
@@ -209,12 +294,8 @@ function PullRequestCard({ event, result }: { event: ToolCallEvent; result: Pull
     );
   }
 
-  const pullRequest = result.kind === "created" || result.kind === "updated" ? result : null;
-  const resultUrl = pullRequest?.url ?? (result.kind === "manual" ? result.url : null);
-  const safeUrl = getSafeExternalUrl(resultUrl);
+  const safeUrl = getSafeExternalUrl(presentation.action?.url);
   const repository = getStringArg(event, "repo") ?? repositoryFromUrl(safeUrl);
-  const status = statusForResult(result);
-  const mutedStatus = result.kind === "pending" || result.kind === "unknown" || status === "Draft";
 
   return (
     <div className="overflow-hidden border border-border bg-card">
@@ -224,26 +305,28 @@ function PullRequestCard({ event, result }: { event: ToolCallEvent; result: Pull
             <GitPrIcon className="h-4 w-4 shrink-0 text-foreground" />
             <span className="truncate">{repository ?? "Pull request"}</span>
           </span>
-          <span
-            className={cn(
-              "shrink-0 border px-2 py-0.5 font-medium",
-              mutedStatus
-                ? "border-border bg-muted text-muted-foreground"
-                : "border-success/30 bg-success-muted text-success"
-            )}
-          >
-            {status}
-          </span>
+          {presentation.status && (
+            <span
+              className={cn(
+                "shrink-0 border px-2 py-0.5 font-medium",
+                presentation.tone === "success"
+                  ? "border-success/30 bg-success-muted text-success"
+                  : "border-border bg-muted text-muted-foreground"
+              )}
+            >
+              {presentation.status}
+            </span>
+          )}
         </div>
         <div className="font-semibold leading-snug text-foreground">
           {title}
-          {pullRequest && (
-            <span className="font-normal text-muted-foreground"> #{pullRequest.number}</span>
+          {presentation.prNumber && (
+            <span className="font-normal text-muted-foreground"> #{presentation.prNumber}</span>
           )}
         </div>
-        {pullRequest?.head && pullRequest.base && (
+        {presentation.headBranch && presentation.baseBranch && (
           <div className="mt-3">
-            <BranchRoute head={pullRequest.head} base={pullRequest.base} />
+            <BranchRoute head={presentation.headBranch} base={presentation.baseBranch} />
           </div>
         )}
       </div>
@@ -251,13 +334,17 @@ function PullRequestCard({ event, result }: { event: ToolCallEvent; result: Pull
       {body && <PullRequestBody body={body} />}
 
       <div className="flex items-center justify-between gap-3 border-t border-border-muted p-3">
-        <span className="text-[11px] text-muted-foreground">{footerForResult(result)}</span>
-        {safeUrl && <PullRequestLink href={safeUrl} manual={result.kind === "manual"} />}
+        <span className="min-w-0 text-[11px] text-muted-foreground [overflow-wrap:anywhere]">
+          {presentation.footer}
+        </span>
+        {safeUrl && presentation.action && (
+          <PullRequestLink href={safeUrl} label={presentation.action.label} />
+        )}
       </div>
 
-      {result.kind === "unknown" && (
+      {presentation.rawOutput !== undefined && (
         <pre className="max-h-48 overflow-auto border-t border-border-muted p-3 text-xs text-foreground whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {result.output}
+          {presentation.rawOutput}
         </pre>
       )}
     </div>
@@ -278,9 +365,8 @@ export function CreatePullRequestEvent({
   showTime = true,
 }: CreatePullRequestEventProps) {
   const result = parseResult(event);
+  const presentation = presentationForResult(result);
   const time = formatSessionEventTime(event.timestamp);
-  const failed = result.kind === "failure";
-  const draft = result.kind === "created" && result.state === "draft";
 
   return (
     <div className="min-w-0 max-w-full py-0.5">
@@ -295,27 +381,23 @@ export function CreatePullRequestEvent({
             isExpanded && "rotate-90"
           )}
         />
-        {failed ? (
+        {presentation.icon === "error" ? (
           <ErrorIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-destructive" />
-        ) : draft ? (
+        ) : presentation.icon === "draft" ? (
           <GitPrDraftIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         ) : (
           <GitPrIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground" />
         )}
         <TimelineRowContent time={showTime ? time : undefined}>
-          <span
-            className={cn(
-              (result.kind === "created" || result.kind === "updated") && "text-foreground"
-            )}
-          >
-            {summaryForResult(result)}
+          <span className={cn(presentation.tone === "success" && "text-foreground")}>
+            {presentation.summary}
           </span>
         </TimelineRowContent>
       </button>
 
       {isExpanded && (
         <div className="mt-2 min-w-0 w-full max-w-full sm:ml-5 sm:w-[calc(100%_-_1.25rem)]">
-          <PullRequestCard event={event} result={result} />
+          <PullRequestCard event={event} presentation={presentation} />
         </div>
       )}
     </div>

--- a/packages/web/src/components/create-pull-request-event.tsx
+++ b/packages/web/src/components/create-pull-request-event.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState } from "react";
+import type { SandboxEvent } from "@/types/session";
+import { formatSessionEventTime } from "@/lib/time";
+import { getSafeExternalUrl } from "@/lib/urls";
+import {
+  BranchIcon,
+  ChevronRightIcon,
+  ErrorIcon,
+  GitPrDraftIcon,
+  GitPrIcon,
+  LinkIcon,
+} from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+import { SafeMarkdown } from "./safe-markdown";
+import { TimelineRowContent } from "./timeline-row-content";
+
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+
+type PullRequestResult =
+  | {
+      kind: "created" | "updated";
+      number: number;
+      url: string;
+      head?: string;
+      base?: string;
+      state: "open" | "draft";
+    }
+  | { kind: "manual"; url: string }
+  | { kind: "failure"; message: string }
+  | { kind: "pending" }
+  | { kind: "unknown"; output: string };
+
+const FAILURE_PREFIX =
+  /^(Failed to create pull request|Authentication failed|Session not found|Conflict):/;
+const PR_LINE = /PR #(\d+)(?: \((.+?) -> (.+?)\))?: (\S+)/;
+const MANUAL_URL = /Create the pull request in GitHub:\s*\n(\S+)/;
+
+function parseResult(event: ToolCallEvent): PullRequestResult {
+  const output = event.output?.trim();
+  if (!output) {
+    return event.status === "error"
+      ? { kind: "failure", message: "Pull request creation failed." }
+      : { kind: "pending" };
+  }
+
+  if (FAILURE_PREFIX.test(output)) return { kind: "failure", message: output };
+
+  const manualMatch = output.match(MANUAL_URL);
+  if (manualMatch) return { kind: "manual", url: manualMatch[1] };
+
+  const prMatch = output.match(PR_LINE);
+  if (prMatch) {
+    return {
+      kind: output.startsWith("Pull request updated") ? "updated" : "created",
+      number: Number(prMatch[1]),
+      url: prMatch[4],
+      head: prMatch[2],
+      base: prMatch[3],
+      state: output.includes("in draft mode") ? "draft" : "open",
+    };
+  }
+
+  return event.status === "error"
+    ? { kind: "failure", message: output }
+    : { kind: "unknown", output };
+}
+
+function getStringArg(event: ToolCallEvent, key: string): string | undefined {
+  const value = event.args?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function repositoryFromUrl(url: string | null): string | null {
+  if (!url) return null;
+  const parsed = new URL(url);
+  const match = parsed.pathname.match(
+    /^\/(.+?)\/(?:pull\/\d+|-\/merge_requests\/\d+|compare\/.+)\/?$/
+  );
+  if (!match) return parsed.hostname;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+function PullRequestBody({ body }: { body: string }) {
+  const [showFullBody, setShowFullBody] = useState(false);
+  const bodyNeedsClamp = body.length > 240 || body.split("\n").length > 8;
+
+  return (
+    <div className="border-t border-border-muted p-4">
+      <div className="relative">
+        <div className={cn("overflow-hidden", bodyNeedsClamp && !showFullBody && "max-h-40")}>
+          <SafeMarkdown
+            content={body}
+            className="text-xs prose-headings:mb-2 prose-headings:mt-4 prose-headings:text-xs prose-p:text-xs prose-li:text-xs"
+          />
+        </div>
+        {bodyNeedsClamp && !showFullBody && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-card to-transparent" />
+        )}
+      </div>
+      {bodyNeedsClamp && (
+        <button
+          type="button"
+          onClick={() => setShowFullBody((value) => !value)}
+          className="mt-2 text-[11px] font-medium text-accent hover:underline"
+        >
+          {showFullBody ? "Show less" : "Show full description"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function BranchRoute({ head, base }: { head: string; base: string }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 font-mono text-[11px] text-muted-foreground">
+      <BranchIcon className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 truncate">{head}</span>
+      <span className="shrink-0 font-sans text-secondary-foreground">into</span>
+      <span className="shrink-0">{base}</span>
+    </div>
+  );
+}
+
+function PullRequestLink({ href, manual = false }: { href: string; manual?: boolean }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex shrink-0 items-center gap-1.5 bg-foreground px-2.5 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-80"
+    >
+      {manual ? "Create PR" : "Open PR"}
+      <LinkIcon className="h-3 w-3" />
+    </a>
+  );
+}
+
+function summaryForResult(result: PullRequestResult): string {
+  switch (result.kind) {
+    case "created":
+      return `Opened pull request #${result.number}`;
+    case "updated":
+      return `Updated pull request #${result.number}`;
+    case "manual":
+      return "Branch pushed for pull request";
+    case "failure":
+      return "Create pull request failed";
+    case "unknown":
+      return "Create pull request completed";
+    case "pending":
+      return "Creating pull request";
+  }
+}
+
+function statusForResult(result: Exclude<PullRequestResult, { kind: "failure" }>): string {
+  switch (result.kind) {
+    case "created":
+      return result.state === "draft" ? "Draft" : "Open";
+    case "updated":
+      return "Updated";
+    case "manual":
+      return "Branch pushed";
+    case "unknown":
+      return "Completed";
+    case "pending":
+      return "Creating";
+  }
+}
+
+function footerForResult(result: Exclude<PullRequestResult, { kind: "failure" }>): string {
+  switch (result.kind) {
+    case "created":
+      return result.state === "draft" ? "Draft pull request" : "Ready for review";
+    case "updated":
+      return "Latest commits pushed";
+    case "manual":
+      return "Branch ready";
+    case "unknown":
+      return "Result details below";
+    case "pending":
+      return "Creating pull request...";
+  }
+}
+
+function PullRequestCard({ event, result }: { event: ToolCallEvent; result: PullRequestResult }) {
+  const title = getStringArg(event, "title") ?? "Pull request";
+  const rawBody = event.args?.body;
+  const body = typeof rawBody === "string" && rawBody.trim() ? rawBody : undefined;
+
+  if (result.kind === "failure") {
+    return (
+      <div className="border border-destructive-border bg-destructive-muted p-4 text-xs">
+        <div className="flex items-start gap-2 text-destructive">
+          <ErrorIcon className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <div className="font-medium">Couldn&apos;t create pull request</div>
+            <div className="mt-1 text-muted-foreground [overflow-wrap:anywhere]">
+              {result.message}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const pullRequest = result.kind === "created" || result.kind === "updated" ? result : null;
+  const resultUrl = pullRequest?.url ?? (result.kind === "manual" ? result.url : null);
+  const safeUrl = getSafeExternalUrl(resultUrl);
+  const repository = getStringArg(event, "repo") ?? repositoryFromUrl(safeUrl);
+  const status = statusForResult(result);
+  const mutedStatus = result.kind === "pending" || result.kind === "unknown" || status === "Draft";
+
+  return (
+    <div className="overflow-hidden border border-border bg-card">
+      <div className="bg-muted/40 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span className="flex min-w-0 items-center gap-1.5 truncate">
+            <GitPrIcon className="h-4 w-4 shrink-0 text-foreground" />
+            <span className="truncate">{repository ?? "Pull request"}</span>
+          </span>
+          <span
+            className={cn(
+              "shrink-0 border px-2 py-0.5 font-medium",
+              mutedStatus
+                ? "border-border bg-muted text-muted-foreground"
+                : "border-success/30 bg-success-muted text-success"
+            )}
+          >
+            {status}
+          </span>
+        </div>
+        <div className="font-semibold leading-snug text-foreground">
+          {title}
+          {pullRequest && (
+            <span className="font-normal text-muted-foreground"> #{pullRequest.number}</span>
+          )}
+        </div>
+        {pullRequest?.head && pullRequest.base && (
+          <div className="mt-3">
+            <BranchRoute head={pullRequest.head} base={pullRequest.base} />
+          </div>
+        )}
+      </div>
+
+      {body && <PullRequestBody body={body} />}
+
+      <div className="flex items-center justify-between gap-3 border-t border-border-muted p-3">
+        <span className="text-[11px] text-muted-foreground">{footerForResult(result)}</span>
+        {safeUrl && <PullRequestLink href={safeUrl} manual={result.kind === "manual"} />}
+      </div>
+
+      {result.kind === "unknown" && (
+        <pre className="max-h-48 overflow-auto border-t border-border-muted p-3 text-xs text-foreground whitespace-pre-wrap [overflow-wrap:anywhere]">
+          {result.output}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+interface CreatePullRequestEventProps {
+  event: ToolCallEvent;
+  isExpanded: boolean;
+  onToggle: () => void;
+  showTime?: boolean;
+}
+
+export function CreatePullRequestEvent({
+  event,
+  isExpanded,
+  onToggle,
+  showTime = true,
+}: CreatePullRequestEventProps) {
+  const result = parseResult(event);
+  const time = formatSessionEventTime(event.timestamp);
+  const failed = result.kind === "failure";
+  const draft = result.kind === "created" && result.state === "draft";
+
+  return (
+    <div className="min-w-0 max-w-full py-0.5">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronRightIcon
+          className={cn(
+            "mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground transition-transform duration-200",
+            isExpanded && "rotate-90"
+          )}
+        />
+        {failed ? (
+          <ErrorIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-destructive" />
+        ) : draft ? (
+          <GitPrDraftIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <GitPrIcon className="mt-[3px] h-3.5 w-3.5 shrink-0 text-secondary-foreground" />
+        )}
+        <TimelineRowContent time={showTime ? time : undefined}>
+          <span
+            className={cn(
+              (result.kind === "created" || result.kind === "updated") && "text-foreground"
+            )}
+          >
+            {summaryForResult(result)}
+          </span>
+        </TimelineRowContent>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-2 min-w-0 w-full max-w-full sm:ml-5 sm:w-[calc(100%_-_1.25rem)]">
+          <PullRequestCard event={event} result={result} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/tool-call-item.test.tsx
+++ b/packages/web/src/components/tool-call-item.test.tsx
@@ -92,4 +92,27 @@ describe("ToolCallItem", () => {
     expect(outputPre).toHaveClass("overflow-x-auto", "whitespace-pre");
     expect(outputPre).not.toHaveClass("whitespace-pre-wrap", "[overflow-wrap:anywhere]");
   });
+
+  it("uses the rich renderer for create-pull-request regardless of tool name casing", () => {
+    const event: Extract<SandboxEvent, { type: "tool_call" }> = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "message-call-5",
+      callId: "call-5",
+      tool: "Create-Pull-Request",
+      args: { title: "Improve the timeline", body: "A clearer pull request preview." },
+      output:
+        "Pull request created successfully!\n\nPR #42 (feature/timeline -> main): https://github.com/acme/web/pull/42\n\nThe pull request is now ready for review.",
+      status: "completed",
+      timestamp: 1,
+    };
+
+    render(<ToolCallItem event={event} isExpanded onToggle={() => {}} />);
+
+    expect(screen.getByText("Opened pull request #42")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open pr/i })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/web/pull/42"
+    );
+  });
 });

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -4,6 +4,7 @@ import type { SandboxEvent } from "@/types/session";
 import { formatSessionEventTime } from "@/lib/time";
 import { formatToolCall } from "@/lib/tool-formatters";
 import { SlackNotifyEvent } from "./slack-notify-event";
+import { CreatePullRequestEvent } from "./create-pull-request-event";
 import { TimelineRowContent } from "./timeline-row-content";
 import {
   ChevronRightIcon,
@@ -96,6 +97,17 @@ function ToolCallDetails({ event }: { event: ToolCallItemProps["event"] }) {
 }
 
 export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: ToolCallItemProps) {
+  if (event.tool?.toLowerCase() === "create-pull-request") {
+    return (
+      <CreatePullRequestEvent
+        event={event}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        showTime={showTime}
+      />
+    );
+  }
+
   if (event.tool === "slack-notify") {
     return (
       <SlackNotifyEvent


### PR DESCRIPTION
## Summary
- replace the generic `create-pull-request` argument/output disclosure with the selected pull request preview treatment
- render agent-authored PR bodies as sanitized Markdown without assuming Summary or Verification sections
- parse current created, updated, draft, manual, pending, and failure output variants while preserving unknown output verbatim
- validate external PR links and keep long descriptions progressively disclosed
- add focused coverage for rendering, lifecycle states, unsafe URLs, arbitrary body formats, and case-insensitive tool dispatch

## Verification
- `npm test -w @open-inspect/web -- src/components/create-pull-request-event.test.tsx src/components/tool-call-item.test.tsx`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `git diff --check`

## Testing note
- the full web suite completed all 1,226 assertions successfully, but Vitest exited nonzero because the pre-existing `sandbox-settings.test.tsx` timeout callback fired after jsdom teardown (`window is not defined`)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6e4947f5c6a40da91e6ca16c2823cbb7)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich pull-request timeline events for creation, updates, drafts, pending states, failures, and manual creation.
  * Added expandable descriptions with Markdown support, branch details, links, and status indicators.
  * Added safe handling for external links and unrecognized pull-request output.

* **Bug Fixes**
  * Pull-request tool calls now consistently use the specialized display, including mixed-case names.

* **Tests**
  * Added comprehensive coverage for pull-request states, expansion behavior, link safety, and fallback rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->