### PR TITLE
fix(control-plane): show automation children in Mine

### DIFF
--- a/packages/control-plane/src/db/session-inbox-store.ts
+++ b/packages/control-plane/src/db/session-inbox-store.ts
@@ -12,7 +12,7 @@ import type { SqlDatabase, SqlStatement } from "./sql-database";
 export interface ListSessionInboxOptions {
   category: SessionInboxCategory;
   createdByUserIds?: readonly string[];
-  excludeAutomationLineage?: boolean;
+  excludeAutomatedSessions?: boolean;
   viewerUserId: string;
   limit: number;
   cursor: SessionInboxCursor | null;
@@ -186,7 +186,7 @@ export class SessionInboxStore {
   private inboxCtes(
     options: Pick<
       ListSessionInboxOptions,
-      "createdByUserIds" | "excludeAutomationLineage" | "viewerUserId"
+      "createdByUserIds" | "excludeAutomatedSessions" | "viewerUserId"
     >
   ): { sql: string; params: unknown[] } {
     const { conditions, params } = this.eligibility(options);
@@ -243,14 +243,12 @@ export class SessionInboxStore {
   }
 
   private eligibility(
-    options: Pick<ListSessionInboxOptions, "createdByUserIds" | "excludeAutomationLineage">
+    options: Pick<ListSessionInboxOptions, "createdByUserIds" | "excludeAutomatedSessions">
   ): { conditions: string[]; params: unknown[] } {
     const conditions = ["sessions.status != 'archived'", "sessions.root_session_id IS NOT NULL"];
     const params: unknown[] = [];
-    if (options.excludeAutomationLineage) {
-      conditions.push(
-        "sessions.automation_id IS NULL AND sessions.spawn_source NOT IN ('automation', 'github-bot')"
-      );
+    if (options.excludeAutomatedSessions) {
+      conditions.push("sessions.spawn_source NOT IN ('automation', 'github-bot')");
     }
     if (options.createdByUserIds?.length) {
       conditions.push(

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -132,7 +132,7 @@ async function handleListSessionInbox(
   const commonOptions = {
     limit: SESSION_INBOX_LIMIT,
     createdByUserIds: mine === "true" ? [ctx.principal.userId] : [],
-    excludeAutomationLineage: mine === "true",
+    excludeAutomatedSessions: mine === "true",
     viewerUserId: ctx.principal.userId,
   };
 

--- a/packages/control-plane/test/integration/session-inbox.test.ts
+++ b/packages/control-plane/test/integration/session-inbox.test.ts
@@ -289,7 +289,7 @@ describe("session inbox", () => {
     expect(finishedBody.items[0].descendantSessions.map(({ id }) => id)).toEqual(["draft-child"]);
   });
 
-  it("limits the Mine view to user-created non-automation sessions", async () => {
+  it("shows user-attributed children of automation sessions in Mine", async () => {
     await serviceFetch("https://example.com/sessions/inbox?category=finished");
     const store = new SessionIndexStore(env.DB);
     await store.create(session("mine"));
@@ -300,6 +300,15 @@ describe("session inbox", () => {
         spawnSource: "automation",
       })
     );
+    await store.create(
+      session("automation-child", {
+        parentSessionId: "automation",
+        spawnSource: "agent",
+        spawnDepth: 1,
+        automationId: "automation-1",
+        updatedAt: 3000,
+      })
+    );
 
     const response = await serviceFetch(
       "https://example.com/sessions/inbox?category=finished&mine=true"
@@ -307,7 +316,7 @@ describe("session inbox", () => {
     const body = (await response.json()) as {
       items: Array<{ rootSession: { id: string } }>;
     };
-    expect(body.items.map((item) => item.rootSession.id)).toEqual(["mine"]);
+    expect(body.items.map((item) => item.rootSession.id)).toEqual(["automation-child", "mine"]);
   });
 
   it("reroots every visible subtree when Mine filters out the persisted root", async () => {

--- a/packages/control-plane/test/integration/session-inbox.test.ts
+++ b/packages/control-plane/test/integration/session-inbox.test.ts
@@ -289,11 +289,12 @@ describe("session inbox", () => {
     expect(finishedBody.items[0].descendantSessions.map(({ id }) => id)).toEqual(["draft-child"]);
   });
 
-  it("shows user-attributed children of automation sessions in Mine", async () => {
+  it("shows automation children but excludes directly automated sessions from Mine", async () => {
     await serviceFetch("https://example.com/sessions/inbox?category=finished");
     const store = new SessionIndexStore(env.DB);
     await store.create(session("mine"));
     await store.create(session("another-user", { userId: "22222222222222222222222222222222" }));
+    await store.create(session("github-bot", { spawnSource: "github-bot" }));
     await store.create(
       session("automation", {
         automationId: "automation-1",


### PR DESCRIPTION
## Summary
- keep directly automated and GitHub bot sessions hidden from the Mine inbox
- allow user-attributed agent children with automation lineage to appear as re-rooted Mine entries
- add integration coverage for an automation root with a user-attributed child

## Root cause
The Mine inbox rejected every session with a non-null `automation_id`. Child sessions inherit that ID from an automation parent, so even children created after a user follow-up were filtered out.

## Verification
- `npm run test:integration -w @open-inspect/control-plane -- session-inbox.test.ts`
- `npm test -w @open-inspect/control-plane -- src/routes/session-index.test.ts src/db/session-index.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- focused Prettier check
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/115a7540a10e9695039d22afac46028d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the “Mine” inbox view to include agent sessions spawned from automated sessions.
  * Clarified the option used to exclude automated sessions.

* **Bug Fixes**
  * Improved inbox filtering so directly automated and GitHub Bot sessions are excluded while eligible child sessions remain visible.

* **Tests**
  * Expanded integration coverage for automated sessions, their child sessions, and user-owned sessions in the “Mine” view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->