### PR TITLE
fix(slack): keep activity status alive during long tool calls

### DIFF
--- a/packages/control-plane/src/session/activity-heartbeat.ts
+++ b/packages/control-plane/src/session/activity-heartbeat.ts
@@ -1,0 +1,3 @@
+// Slack expires assistant thread status after two minutes without an update.
+// Keep the refresh interval below that boundary while avoiding per-event polling.
+export const SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS = 90_000;

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -158,6 +158,30 @@ describe("createAlarmHandler", () => {
     expect(alarmScheduler.schedule).toHaveBeenCalledWith(92_000);
   });
 
+  it("does not re-arm after the message completes during heartbeat delivery", async () => {
+    const { handler, repository, callbackService, alarmScheduler } = createHandler();
+    let resolveDelivery!: (value: boolean) => void;
+    const delivery = new Promise<boolean>((resolve) => {
+      resolveDelivery = resolve;
+    });
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 1500,
+    });
+    callbackService.notifyActivityHeartbeat.mockReturnValue(delivery);
+
+    const handled = handler.handle();
+    await vi.waitFor(() => {
+      expect(callbackService.notifyActivityHeartbeat).toHaveBeenCalledWith("message-1");
+    });
+    repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+    resolveDelivery(true);
+    await handled;
+
+    expect(alarmScheduler.schedule).toHaveBeenCalledTimes(1);
+    expect(alarmScheduler.schedule).toHaveBeenCalledWith(2500);
+  });
+
   it("does not refresh activity when the same alarm terminates the sandbox", async () => {
     const { handler, repository, messageQueue, lifecycleManager, callbackService, alarmScheduler } =
       createHandler();

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -158,6 +158,22 @@ describe("createAlarmHandler", () => {
     expect(alarmScheduler.schedule).toHaveBeenCalledWith(92_000);
   });
 
+  it("does not refresh activity when the same alarm terminates the sandbox", async () => {
+    const { handler, repository, messageQueue, lifecycleManager, callbackService, alarmScheduler } =
+      createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 1500,
+    });
+    lifecycleManager.handleAlarm.mockResolvedValue("sandbox_failed");
+
+    await handler.handle();
+
+    expect(alarmScheduler.schedule).toHaveBeenCalledWith(2500);
+    expect(callbackService.notifyActivityHeartbeat).not.toHaveBeenCalled();
+    expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledOnce();
+  });
+
   it("does not re-arm activity when the processing message is not from Slack", async () => {
     const { handler, repository, callbackService, alarmScheduler } = createHandler();
     repository.getProcessingMessageWithStartedAt.mockReturnValue({

--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -22,6 +22,11 @@ function createHandler() {
   const terminalMessageProjection = {
     flushPending: vi.fn<() => Promise<void>>().mockResolvedValue(),
   };
+  const callbackService = {
+    notifyActivityHeartbeat: vi
+      .fn<(messageId: string) => Promise<boolean>>()
+      .mockResolvedValue(true),
+  };
   const alarmScheduler = {
     schedule: vi.fn<(timestamp: number) => Promise<void>>().mockResolvedValue(),
     cancel: vi.fn<() => Promise<void>>().mockResolvedValue(),
@@ -42,6 +47,7 @@ function createHandler() {
     executionStop,
     lifecycleManager,
     terminalMessageProjection,
+    callbackService,
     alarmScheduler,
     getExecutionTimeoutMs: () => 1000,
     now,
@@ -55,6 +61,7 @@ function createHandler() {
     executionStop,
     lifecycleManager,
     terminalMessageProjection,
+    callbackService,
     alarmScheduler,
     now,
     log,
@@ -69,6 +76,7 @@ describe("createAlarmHandler", () => {
       messageQueue,
       executionStop,
       lifecycleManager,
+      callbackService,
       alarmScheduler,
       now,
     } = createHandler();
@@ -78,6 +86,7 @@ describe("createAlarmHandler", () => {
 
     expect(now).not.toHaveBeenCalled();
     expect(alarmScheduler.schedule).not.toHaveBeenCalled();
+    expect(callbackService.notifyActivityHeartbeat).not.toHaveBeenCalled();
     expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
     expect(executionStop.recoverStopConfirmationTimeout).toHaveBeenCalledOnce();
     expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
@@ -136,6 +145,33 @@ describe("createAlarmHandler", () => {
     expect(executionStop.resumeAfterSandboxTermination).toHaveBeenCalledOnce();
   });
 
+  it("schedules another activity refresh while a Slack message is still processing", async () => {
+    const { handler, repository, callbackService, alarmScheduler } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 1500,
+    });
+
+    await handler.handle();
+
+    expect(callbackService.notifyActivityHeartbeat).toHaveBeenCalledWith("message-1");
+    expect(alarmScheduler.schedule).toHaveBeenCalledWith(92_000);
+  });
+
+  it("does not re-arm activity when the processing message is not from Slack", async () => {
+    const { handler, repository, callbackService, alarmScheduler } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 1500,
+    });
+    callbackService.notifyActivityHeartbeat.mockResolvedValue(false);
+
+    await handler.handle();
+
+    expect(alarmScheduler.schedule).toHaveBeenCalledTimes(1);
+    expect(alarmScheduler.schedule).toHaveBeenCalledWith(2500);
+  });
+
   it("keeps the execution deadline ahead of a later lifecycle check", async () => {
     let currentAlarm: number | null = null;
     const storage = {
@@ -178,12 +214,17 @@ describe("createAlarmHandler", () => {
       resumeAfterSandboxTermination: vi.fn<() => Promise<void>>().mockResolvedValue(),
     };
 
+    const callbackService = {
+      notifyActivityHeartbeat: vi.fn(async () => true),
+    };
+
     const handler = createAlarmHandler({
       repository: repository as unknown as MessageRepository,
       messageQueue,
       executionStop,
       lifecycleManager,
       terminalMessageProjection: { flushPending: vi.fn(async () => {}) },
+      callbackService,
       alarmScheduler,
       getExecutionTimeoutMs: () => 1000,
       now: () => 2000,

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -55,6 +55,7 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
       // already failed (by lifecycle recovery or a prior alarm),
       // getProcessingMessageWithStartedAt() returns null.
       const processing = deps.repository.getProcessingMessageWithStartedAt();
+      let activityMessageId: string | null = null;
       if (processing?.started_at) {
         const now = deps.now();
         const executionTimeoutMs = deps.getExecutionTimeoutMs();
@@ -73,16 +74,11 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
           await deps.messageQueue.failStuckProcessingMessage();
         } else {
           // An earlier lifecycle or activity alarm has consumed the Durable
-          // Object's single alarm slot. Reassert the execution deadline first,
-          // then schedule another Slack refresh only when this message owns a
-          // valid Slack callback.
+          // Object's single alarm slot. Reassert the execution deadline first;
+          // a non-terminal lifecycle result below may then schedule another
+          // Slack refresh when this message owns a valid callback.
           await deps.alarmScheduler.schedule(processing.started_at + executionTimeoutMs);
-          const continueActivityHeartbeat = await deps.callbackService.notifyActivityHeartbeat(
-            processing.id
-          );
-          if (continueActivityHeartbeat) {
-            await deps.alarmScheduler.schedule(now + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS);
-          }
+          activityMessageId = processing.id;
         }
       }
 
@@ -92,6 +88,13 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
       }
       if (lifecycleResult === "sandbox_terminated") {
         await deps.executionStop.resumeAfterSandboxTermination();
+      }
+      if (lifecycleResult === "no_action" && activityMessageId) {
+        const continueActivityHeartbeat =
+          await deps.callbackService.notifyActivityHeartbeat(activityMessageId);
+        if (continueActivityHeartbeat) {
+          await deps.alarmScheduler.schedule(deps.now() + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS);
+        }
       }
       if (projectionFailure) throw projectionFailure.error;
     },

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -92,7 +92,8 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
       if (lifecycleResult === "no_action" && activityMessageId) {
         const continueActivityHeartbeat =
           await deps.callbackService.notifyActivityHeartbeat(activityMessageId);
-        if (continueActivityHeartbeat) {
+        const stillProcessing = deps.repository.getProcessingMessageWithStartedAt();
+        if (continueActivityHeartbeat && stillProcessing?.id === activityMessageId) {
           await deps.alarmScheduler.schedule(deps.now() + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS);
         }
       }

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -6,6 +6,8 @@ import type { SessionMessageQueue } from "../message-queue";
 import type { ExecutionStopCoordinator } from "../execution-stop-coordinator";
 import type { MessageRepository } from "../message-repository";
 import type { SessionTerminalMessageProjection } from "../terminal-message-projection";
+import type { CallbackNotificationService } from "../callback-notification-service";
+import { SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS } from "../activity-heartbeat";
 
 export interface AlarmHandlerDeps {
   repository: MessageRepository;
@@ -16,6 +18,7 @@ export interface AlarmHandlerDeps {
   >;
   lifecycleManager: Pick<SandboxLifecycleManager, "handleAlarm">;
   terminalMessageProjection: Pick<SessionTerminalMessageProjection, "flushPending">;
+  callbackService: Pick<CallbackNotificationService, "notifyActivityHeartbeat">;
   alarmScheduler: AlarmScheduler;
   /** Resolved per use so it honors settings persisted after construction. */
   getExecutionTimeoutMs: () => number;
@@ -69,10 +72,17 @@ export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
           });
           await deps.messageQueue.failStuckProcessingMessage();
         } else {
-          // An earlier lifecycle alarm has consumed the Durable Object's single
-          // alarm slot. Reassert this message's deadline before lifecycle handling
-          // schedules its next check so stuck-message recovery cannot be delayed.
+          // An earlier lifecycle or activity alarm has consumed the Durable
+          // Object's single alarm slot. Reassert the execution deadline first,
+          // then schedule another Slack refresh only when this message owns a
+          // valid Slack callback.
           await deps.alarmScheduler.schedule(processing.started_at + executionTimeoutMs);
+          const continueActivityHeartbeat = await deps.callbackService.notifyActivityHeartbeat(
+            processing.id
+          );
+          if (continueActivityHeartbeat) {
+            await deps.alarmScheduler.schedule(now + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS);
+          }
         }
       }
 

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -37,6 +37,9 @@ function createMockLogger(): Logger {
 function createMockRepository() {
   return {
     getMessageCallbackContext: vi.fn<MessageRepository["getMessageCallbackContext"]>(() => null),
+    getProcessingMessageWithStartedAt: vi.fn<
+      MessageRepository["getProcessingMessageWithStartedAt"]
+    >(() => ({ id: "msg-1", started_at: 1 })),
     getSession: vi.fn(() => null),
   };
 }
@@ -544,6 +547,54 @@ describe("CallbackNotificationService", () => {
       await expect(harness.service.notifyActivityHeartbeat("msg-1")).resolves.toBe(false);
       expect(harness.slackBot.fetch).not.toHaveBeenCalled();
       expect(harness.linearBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not deliver after the message completes while the heartbeat is prepared", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ source: "slack", channel: "C123" }),
+        source: "slack",
+      });
+      harness.repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+
+      await expect(harness.service.notifyActivityHeartbeat("msg-1")).resolves.toBe(false);
+
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("bounds a heartbeat fetch that never resolves", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ source: "slack", channel: "C123" }),
+          source: "slack",
+        });
+        harness.slackBot.fetch.mockImplementation(
+          (_input, init) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+                once: true,
+              });
+            })
+        );
+        let settled = false;
+        const heartbeat = harness.service.notifyActivityHeartbeat("msg-1").then(() => {
+          settled = true;
+        });
+        await vi.waitFor(() => {
+          expect(harness.slackBot.fetch).toHaveBeenCalledTimes(1);
+        });
+
+        await vi.advanceTimersByTimeAsync(10_001);
+        await vi.waitFor(() => {
+          expect(harness.slackBot.fetch).toHaveBeenCalledTimes(2);
+        });
+        await vi.advanceTimersByTimeAsync(10_001);
+        await heartbeat;
+
+        expect(settled).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("keeps the heartbeat active after a transient delivery failure", async () => {

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -503,6 +503,64 @@ describe("CallbackNotificationService", () => {
     );
   });
 
+  describe("notifyActivityHeartbeat", () => {
+    it("sends a signed refresh for a Slack processing message", async () => {
+      const context = {
+        source: "slack",
+        channel: "C123",
+        threadTs: "111.222",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+      };
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(context),
+        source: "slack",
+      });
+      harness.slackBot.fetch.mockResolvedValue(new Response("ok", { status: 200 }));
+
+      await expect(harness.service.notifyActivityHeartbeat("msg-1")).resolves.toBe(true);
+
+      expect(harness.slackBot.fetch).toHaveBeenCalledWith(
+        "https://internal/callbacks/activity",
+        expect.objectContaining({ method: "POST" })
+      );
+      const body = JSON.parse(String(harness.slackBot.fetch.mock.calls[0][1]?.body));
+      expect(body).toMatchObject({
+        sessionId: "session-123",
+        messageId: "msg-1",
+        timestamp: expect.any(Number),
+        context,
+        signature: expect.any(String),
+      });
+      expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
+    });
+
+    it("does not refresh or re-arm non-Slack messages", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(LINEAR_CALLBACK_CONTEXT),
+        source: "linear",
+      });
+
+      await expect(harness.service.notifyActivityHeartbeat("msg-1")).resolves.toBe(false);
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
+      expect(harness.linearBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("keeps the heartbeat active after a transient delivery failure", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ source: "slack", channel: "C123" }),
+        source: "slack",
+      });
+      harness.slackBot.fetch.mockRejectedValue(new Error("network unavailable"));
+
+      await expect(harness.service.notifyActivityHeartbeat("msg-1")).resolves.toBe(true);
+      expect(harness.log.warn).toHaveBeenCalledWith(
+        "callback.activity_heartbeat",
+        expect.objectContaining({ outcome: "error", error: expect.any(Error) })
+      );
+    });
+  });
+
   describe("notifyToolCall", () => {
     it("skips when throttled (< 3s since last call)", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -351,6 +351,90 @@ export class CallbackNotificationService {
   }
 
   /**
+   * Refresh Slack's expiring assistant-thread activity while a message remains
+   * in processing. Returns true only when the caller should schedule another
+   * refresh for this message.
+   */
+  async notifyActivityHeartbeat(messageId: string): Promise<boolean> {
+    const startedAt = Date.now();
+    const message = this.messageRepository.getMessageCallbackContext(messageId);
+    if (!message?.callback_context || message.source !== "slack") {
+      this.log.debug("callback.activity_heartbeat", {
+        message_id: messageId,
+        source: message?.source ?? null,
+        outcome: "skipped",
+        skip_reason: message?.callback_context ? "non_slack_source" : "no_callback_context",
+      });
+      return false;
+    }
+
+    const { binding, secret } = this.resolveCallbackRoute("slack");
+    if (!secret || !binding) {
+      this.log.debug("callback.activity_heartbeat", {
+        message_id: messageId,
+        source: "slack",
+        outcome: "skipped",
+        skip_reason: secret ? "no_binding" : "no_secret",
+      });
+      return false;
+    }
+
+    let context: unknown;
+    try {
+      context = JSON.parse(message.callback_context);
+    } catch (error) {
+      this.log.warn("callback.activity_heartbeat", {
+        message_id: messageId,
+        source: "slack",
+        outcome: "error",
+        error: error instanceof Error ? error : new Error(String(error)),
+        duration_ms: Date.now() - startedAt,
+      });
+      return false;
+    }
+
+    let sessionId: string | null = null;
+    try {
+      sessionId = this.getSessionId();
+      const callbackData = {
+        sessionId,
+        messageId,
+        timestamp: Date.now(),
+        context,
+      };
+      const signature = await this.signPayload(callbackData, secret);
+      const response = await binding.fetch("https://internal/callbacks/activity", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...callbackData, signature }),
+      });
+      const fields = {
+        message_id: messageId,
+        session_id: sessionId,
+        source: "slack",
+        outcome: response.ok ? "success" : "error",
+        http_status: response.status,
+        duration_ms: Date.now() - startedAt,
+      };
+      if (response.ok) this.log.info("callback.activity_heartbeat", fields);
+      else this.log.warn("callback.activity_heartbeat", fields);
+    } catch (error) {
+      this.log.warn("callback.activity_heartbeat", {
+        message_id: messageId,
+        session_id: sessionId,
+        source: "slack",
+        outcome: "error",
+        error: error instanceof Error ? error : new Error(String(error)),
+        duration_ms: Date.now() - startedAt,
+      });
+    }
+
+    // Delivery is best-effort. Keep refreshing while the message remains active
+    // so a transient Slack or service-binding failure can recover on the next alarm.
+    return true;
+  }
+
+  /**
    * Notify the originating client of a tool_call event (best-effort, throttled).
    * Max 1 callback per 3 seconds per session.
    */

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -403,20 +403,44 @@ export class CallbackNotificationService {
         context,
       };
       const signature = await this.signPayload(callbackData, secret);
-      const response = await binding.fetch("https://internal/callbacks/activity", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...callbackData, signature }),
-      });
+      const processing = this.messageRepository.getProcessingMessageWithStartedAt();
+      if (processing?.id !== messageId) {
+        this.log.debug("callback.activity_heartbeat", {
+          message_id: messageId,
+          session_id: sessionId,
+          source: "slack",
+          outcome: "skipped",
+          skip_reason: "no_longer_processing",
+        });
+        return false;
+      }
+
+      let lastError: unknown;
+      const delivery = await deliverWithRetry(
+        (signal) =>
+          binding.fetch("https://internal/callbacks/activity", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ...callbackData, signature }),
+            signal,
+          }),
+        this.sleep,
+        ({ error }) => {
+          lastError = error;
+        }
+      );
       const fields = {
         message_id: messageId,
         session_id: sessionId,
         source: "slack",
-        outcome: response.ok ? "success" : "error",
-        http_status: response.status,
+        outcome: delivery.delivered ? "success" : "error",
+        ...(delivery.httpStatus !== undefined ? { http_status: delivery.httpStatus } : {}),
+        ...(lastError !== undefined
+          ? { error: lastError instanceof Error ? lastError : new Error(String(lastError)) }
+          : {}),
         duration_ms: Date.now() - startedAt,
       };
-      if (response.ok) this.log.info("callback.activity_heartbeat", fields);
+      if (delivery.delivered) this.log.info("callback.activity_heartbeat", fields);
       else this.log.warn("callback.activity_heartbeat", fields);
     } catch (error) {
       this.log.warn("callback.activity_heartbeat", {

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -542,6 +542,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     executionStop,
     lifecycleManager,
     terminalMessageProjection,
+    callbackService,
     alarmScheduler,
     getExecutionTimeoutMs,
     now: () => Date.now(),

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -17,6 +17,7 @@ import type { MessageRepository } from "./message-repository";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
+import { SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS } from "./activity-heartbeat";
 import { createEarliestAlarmScheduler } from "./alarm/scheduler";
 import { ExecutionStopCoordinator } from "./execution-stop-coordinator";
 import { MessageFailureService } from "./message-failure-service";
@@ -1447,6 +1448,24 @@ describe("SessionMessageQueue", () => {
       const deadline = h.setAlarm.mock.calls[0][0];
       expect(deadline).toBeGreaterThanOrEqual(before + EXECUTION_TIMEOUT_MS);
       expect(deadline).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS);
+    });
+
+    it("schedules Slack activity before its two-minute expiry", async () => {
+      const h = buildQueue();
+      h.repository.getNextPendingMessage.mockReturnValue(createMessage({ source: "slack" }));
+      h.wsManager.getSandboxSocket.mockReturnValue({ readyState: 1 } as WebSocket);
+      const before = Date.now();
+
+      await h.queue.processMessageQueue();
+
+      expect(h.setAlarm).toHaveBeenCalledTimes(2);
+      const activityDeadline = h.setAlarm.mock.calls[1][0];
+      expect(activityDeadline).toBeGreaterThanOrEqual(
+        before + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS
+      );
+      expect(activityDeadline).toBeLessThanOrEqual(
+        Date.now() + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS
+      );
     });
 
     it("arms each deadline with the timeout current at that dispatch", async () => {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -32,6 +32,7 @@ import type { SessionMessenger } from "./messenger";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
+import { SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS } from "./activity-heartbeat";
 import type { SessionStatusService } from "./session-status-service";
 import type { EnqueuePromptRequest } from "./enqueue-prompt-contract";
 import { getAvatarUrl } from "./participant-service";
@@ -496,9 +497,14 @@ export class SessionMessageQueue {
       this.broadcastPromptQueue();
       this.sandboxLifecycle.updateLastActivity(now);
 
-      // Execution timeout shares the DO's single alarm slot with lifecycle checks.
+      // Execution timeout and Slack activity share the DO's single alarm slot.
+      // The scheduler persists the earliest deadline and re-arms the other one
+      // after each delivery.
       const deadline = now + this.getExecutionTimeoutMs();
       await this.alarmScheduler.schedule(deadline);
+      if (message.source === "slack") {
+        await this.alarmScheduler.schedule(now + SLACK_ACTIVITY_HEARTBEAT_INTERVAL_MS);
+      }
 
       this.backgroundTasks.submit(() => this.callbackService.notifyStarted(message.id), {
         name: "callback.notify_started",

--- a/packages/slack-bot/src/activity-status.ts
+++ b/packages/slack-bot/src/activity-status.ts
@@ -7,7 +7,7 @@ const DEFAULT_STATUS_PART_MAX_LENGTH = 80;
 const DEFAULT_STATUS_TEXT_MAX_LENGTH = 80;
 const LOADING_MESSAGE_MAX_LENGTH = 50;
 const FILE_ARG_KEYS = ["filePath", "file_path", "filepath", "path", "file"];
-const TOOL_STATUS_INDICATOR = "Working...";
+export const ASSISTANT_WORKING_STATUS = "Working...";
 
 const log = createLogger("activity-status");
 
@@ -39,7 +39,7 @@ type AssistantThreadStatusResult =
     };
 
 type AssistantStatusMeta = {
-  event: "start" | "tool_call";
+  event: "start" | "tool_call" | "heartbeat";
   traceId?: string;
   sessionId?: string;
   tool?: string;
@@ -235,7 +235,9 @@ export async function setAssistantThreadStatusBestEffort(
   const eventName =
     meta.event === "tool_call"
       ? "slack.assistant_status.tool_call"
-      : "slack.assistant_status.start";
+      : meta.event === "heartbeat"
+        ? "slack.assistant_status.heartbeat"
+        : "slack.assistant_status.start";
   const base = {
     trace_id: meta.traceId,
     session_id: meta.sessionId,
@@ -246,7 +248,7 @@ export async function setAssistantThreadStatusBestEffort(
   };
 
   try {
-    const statusText = meta.event === "tool_call" ? TOOL_STATUS_INDICATOR : status;
+    const statusText = meta.event === "tool_call" ? ASSISTANT_WORKING_STATUS : status;
     const requestStatusLength = prepareStatusText(statusText).length;
     const requestLoadingMessageLengths = [status].map(
       (message) => prepareLoadingMessageText(message).length

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -89,7 +89,7 @@ async function makeActivityPayload(
   const data = {
     sessionId: "session-1",
     messageId: "message-1",
-    timestamp: 1778900000000,
+    timestamp: Date.now(),
     context: {
       source: "slack",
       channel: "C123",
@@ -169,6 +169,24 @@ describe("POST /callbacks/activity", () => {
 
     expect(response.status).toBe(401);
     expect(ctx.waitUntil).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stale", -60 * 60 * 1000],
+    ["future", 60 * 60 * 1000],
+  ])("rejects a signed %s heartbeat timestamp", async (_label, offsetMs) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const payload = await makeActivityPayload({ timestamp: Date.now() + offsetMs });
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(401);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -77,6 +77,32 @@ async function makeToolCallPayload(
   return signPayload(data, secret);
 }
 
+async function makeActivityPayload(
+  overrides: Partial<{
+    sessionId: string;
+    messageId: string;
+    timestamp: number;
+    context: Record<string, unknown>;
+  }> = {},
+  secret = "callback-secret"
+) {
+  const data = {
+    sessionId: "session-1",
+    messageId: "message-1",
+    timestamp: 1778900000000,
+    context: {
+      source: "slack",
+      channel: "C123",
+      threadTs: "111.222",
+      repoFullName: "acme/app",
+      model: "anthropic/claude-haiku-4-5",
+    },
+    ...overrides,
+  };
+
+  return signPayload(data, secret);
+}
+
 async function postToolCall(payload: unknown, env = makeEnv(), ctx = makeCtx()) {
   const response = await makeApp().fetch(
     new Request("http://localhost/callbacks/tool_call", {
@@ -101,6 +127,50 @@ function createDeferred<T>() {
   });
   return { promise, resolve };
 }
+
+describe("POST /callbacks/activity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a signed heartbeat and refreshes the Slack working status", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const payload = await makeActivityPayload();
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+    await flushWaitUntil(ctx);
+
+    expect(fetchMock).toHaveBeenCalledWith("https://slack.com/api/assistant.threads.setStatus", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer xoxb-test",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        channel_id: "C123",
+        thread_ts: "111.222",
+        status: "Working...",
+        loading_messages: ["Working..."],
+      }),
+    });
+  });
+
+  it("rejects a heartbeat with an invalid signature", async () => {
+    const payload = await makeActivityPayload({}, "wrong-secret");
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(401);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+  });
+});
 
 describe("POST /callbacks/tool_call", () => {
   afterEach(() => {

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -9,7 +9,11 @@ import { z } from "zod";
 import type { Env } from "./types";
 import { createSlackCompletionJob, type SlackCompletionJob } from "./completion/job";
 import { createLogger } from "./logger";
-import { formatToolStatus, setAssistantThreadStatusBestEffort } from "./activity-status";
+import {
+  ASSISTANT_WORKING_STATUS,
+  formatToolStatus,
+  setAssistantThreadStatusBestEffort,
+} from "./activity-status";
 
 const log = createLogger("callback");
 
@@ -34,6 +38,14 @@ const completionCallbackSchema = z.looseObject({
   messageId: z.string(),
   success: z.boolean(),
   error: z.string().optional(),
+  timestamp: z.number(),
+  signature: z.string(),
+  context: slackCallbackContextSchema,
+});
+
+const activityCallbackSchema = z.looseObject({
+  sessionId: z.string(),
+  messageId: z.string(),
   timestamp: z.number(),
   signature: z.string(),
   context: slackCallbackContextSchema,
@@ -228,6 +240,58 @@ callbacksRouter.post("/complete", async (c) => {
     "/callbacks/complete",
     startTime
   );
+});
+
+/** Refresh Slack's expiring assistant-thread activity for an active message. */
+callbacksRouter.post("/activity", async (c) => {
+  const startTime = Date.now();
+  const traceId = c.req.header("x-trace-id") || crypto.randomUUID();
+  let payload: unknown;
+
+  try {
+    payload = await c.req.json();
+  } catch {
+    return rejectInvalidPayload(c, "/callbacks/activity", traceId, startTime);
+  }
+
+  const parsed = activityCallbackSchema.safeParse(payload);
+  if (!parsed.success || !isSignedCallbackPayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/activity", traceId, startTime);
+  }
+  const valid = parsed.data;
+
+  const rejection = await rejectInvalidCallback(c, payload, {
+    path: "/callbacks/activity",
+    traceId,
+    startTime,
+  });
+  if (rejection) return rejection;
+
+  c.executionCtx.waitUntil(
+    setAssistantThreadStatusBestEffort(
+      c.env,
+      valid.context.channel,
+      valid.context.threadTs,
+      ASSISTANT_WORKING_STATUS,
+      {
+        event: "heartbeat",
+        traceId,
+        sessionId: valid.sessionId,
+      }
+    )
+  );
+
+  log.info("http.request", {
+    trace_id: traceId,
+    http_method: "POST",
+    http_path: "/callbacks/activity",
+    http_status: 200,
+    session_id: valid.sessionId,
+    message_id: valid.messageId,
+    duration_ms: Date.now() - startTime,
+  });
+
+  return c.json({ ok: true });
 });
 
 /**

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -16,6 +16,7 @@ import {
 } from "./activity-status";
 
 const log = createLogger("callback");
+const ACTIVITY_CALLBACK_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -266,6 +267,20 @@ callbacksRouter.post("/activity", async (c) => {
     startTime,
   });
   if (rejection) return rejection;
+
+  if (Math.abs(startTime - valid.timestamp) > ACTIVITY_CALLBACK_MAX_CLOCK_SKEW_MS) {
+    log.warn("http.request", {
+      trace_id: traceId,
+      http_method: "POST",
+      http_path: "/callbacks/activity",
+      http_status: 401,
+      outcome: "rejected",
+      reject_reason: "invalid_timestamp",
+      session_id: valid.sessionId,
+      duration_ms: Date.now() - startTime,
+    });
+    return c.json({ error: "unauthorized" }, 401);
+  }
 
   c.executionCtx.waitUntil(
     setAssistantThreadStatusBestEffort(


### PR DESCRIPTION
## Summary
- refresh Slack assistant-thread activity every 90 seconds while a Slack message is still processing
- use the persisted Durable Object alarm and a signed callback so refreshes survive runtime eviction without affecting other message sources
- stop re-arming automatically once the processing message completes, fails, or is cancelled

## Problem
Slack expires `assistant.threads.setStatus` after two minutes without an update. A quiet tool call longer than that leaves the agent running while its visible working status disappears.

## Testing
- `npm test -w @open-inspect/control-plane` — 3,194 passed
- `npm test -w @open-inspect/slack-bot` — 422 passed
- `npm run typecheck -w @open-inspect/control-plane` — passed
- `npm run typecheck -w @open-inspect/slack-bot` — passed
- `npm run lint -w @open-inspect/control-plane` — passed
- `npm run lint -w @open-inspect/slack-bot` — passed
- `npm run build -w @open-inspect/control-plane` — passed
- `npm run build -w @open-inspect/slack-bot` — passed

Fixes #1262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack assistant threads now remain marked as “Working…” while responses are processing.
  * Added automatic activity heartbeats approximately every 90 seconds.
  * Added signed callback handling to securely refresh Slack activity status.

* **Bug Fixes**
  * Activity refreshes continue through transient delivery failures.
  * Non-Slack and completed activities are excluded from unnecessary refreshes.
  * Invalid, expired, or future-dated callback requests are rejected.

* **Telemetry**
  * Added dedicated tracking for assistant activity heartbeat updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->