### PR TITLE
refactor(control-plane): make Autofix handler a class

### DIFF
--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -86,7 +86,7 @@ import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
 import { SessionEventStream } from "./event-stream";
-import { createAutofixHandler } from "./http/handlers/autofix.handler";
+import { AutofixHandler } from "./http/handlers/autofix.handler";
 import { MessagesHandler } from "./http/handlers/messages.handler";
 import { ChildSessionsHandler } from "./http/handlers/child-sessions.handler";
 import { SandboxHandler } from "./http/handlers/sandbox.handler";
@@ -425,7 +425,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     stopExecution: () => messageQueue.stopExecution(),
     parseArtifactMetadata: (artifact) => parseArtifactMetadata(artifact, log),
   });
-  const autofixHandler = createAutofixHandler(new SessionAutofixService(messageQueue));
+  const autofixHandler = new AutofixHandler(new SessionAutofixService(messageQueue));
 
   const sandboxEventProcessor = new SessionSandboxEventProcessor(
     backgroundTasks,

--- a/packages/control-plane/src/session/http/handlers/autofix.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/autofix.handler.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
 import type { SessionAutofixService } from "../../services/autofix.service";
-import { createAutofixHandler } from "./autofix.handler";
+import { AutofixHandler } from "./autofix.handler";
 
 function createHandler() {
   const service = { handle: vi.fn() } as unknown as SessionAutofixService;
   const log = { error: vi.fn() } as unknown as Logger;
-  return { handler: createAutofixHandler(service), service, log };
+  return { handler: new AutofixHandler(service), service, log };
 }
 
-describe("createAutofixHandler", () => {
+describe("AutofixHandler", () => {
   it("validates and dispatches Autofix admission commands", async () => {
     const { handler, service, log } = createHandler();
     vi.mocked(service.handle).mockResolvedValue({ kind: "enqueued", messageId: "msg-autofix" });

--- a/packages/control-plane/src/session/http/handlers/autofix.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/autofix.handler.ts
@@ -2,25 +2,22 @@ import { githubAutofixSessionCommandSchema } from "@open-inspect/shared";
 import type { Logger } from "../../../logger";
 import type { SessionAutofixService } from "../../services/autofix.service";
 
-export interface AutofixHandler {
-  handle(request: Request, log: Logger): Promise<Response>;
-}
+/** HTTP boundary for internal Autofix commands. */
+export class AutofixHandler {
+  constructor(private readonly service: SessionAutofixService) {}
 
-export function createAutofixHandler(service: SessionAutofixService): AutofixHandler {
-  return {
-    async handle(request: Request, log: Logger): Promise<Response> {
-      try {
-        const result = githubAutofixSessionCommandSchema.safeParse(await request.json());
-        if (!result.success) {
-          return Response.json({ error: "Invalid Autofix command" }, { status: 400 });
-        }
-        return Response.json(await service.handle(result.data));
-      } catch (error) {
-        log.error("handleAutofix error", {
-          error: error instanceof Error ? error : String(error),
-        });
-        throw error;
+  async handle(request: Request, log: Logger): Promise<Response> {
+    try {
+      const result = githubAutofixSessionCommandSchema.safeParse(await request.json());
+      if (!result.success) {
+        return Response.json({ error: "Invalid Autofix command" }, { status: 400 });
       }
-    },
-  };
+      return Response.json(await this.service.handle(result.data));
+    } catch (error) {
+      log.error("handleAutofix error", {
+        error: error instanceof Error ? error : String(error),
+      });
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- replace the Autofix session HTTP handler factory with a class
- inject `SessionAutofixService` directly through the constructor
- update session composition and handler tests to use the class API
- preserve the existing route adapter, validation, logging, and response behavior

## Context

This aligns the Autofix endpoint with the class-based session HTTP handler pattern established in #1612.

## TDD

- changed the handler test to instantiate `AutofixHandler`, confirming the red state with `AutofixHandler is not a constructor`
- implemented the class and reran the focused test to green

## Validation

- `npm run build -w @open-inspect/shared`
- focused Autofix handler tests: 2 passed
- `npm test -w @open-inspect/control-plane`: 3,253 passed
- `npm run test:integration -w @open-inspect/control-plane`: 1,006 passed
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- targeted Prettier check
- `npm run build -w @open-inspect/control-plane`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a531a7ca7d9557ead0ead1e406f70652)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintained autofix request handling, validation, error responses, and service dispatch behavior.
  * Updated internal handler wiring without changing the user-visible autofix experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->