### PR TITLE
refactor(control-plane): kind-parameterize sandbox access artifacts

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -37,7 +37,7 @@ import {
   type StopConfig,
   type StopResult,
 } from "../provider";
-import type { SandboxRow, SessionRow } from "../../session/types";
+import type { SandboxAccessKind, SandboxRow, SessionRow } from "../../session/types";
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { hashToken } from "../../auth/crypto";
 import type * as AuthCrypto from "../../auth/crypto";
@@ -127,6 +127,12 @@ function createMockSandbox(
     ...overrides,
   };
 }
+
+const ACCESS_FIELDS = {
+  codeServer: { url: "code_server_url", secret: "code_server_password" },
+  vnc: { url: "vnc_url", secret: "vnc_password" },
+  ttyd: { url: "ttyd_url", secret: "ttyd_token" },
+} as const;
 
 function createMockStorage(
   session: SessionRow | null = createMockSession(),
@@ -231,43 +237,23 @@ function createMockStorage(
         sandbox.last_spawn_error_at = timestamp;
       }
     }),
-    updateSandboxCodeServer: vi.fn(async (url: string, password: string) => {
-      calls.push(`updateSandboxCodeServer:${url}`);
+    updateSandboxAccess: vi.fn(async (kind: SandboxAccessKind, url: string, secret: string) => {
+      calls.push(`updateSandboxAccess:${kind}:${url}`);
       if (sandbox) {
-        sandbox.code_server_url = url;
-        sandbox.code_server_password = password;
+        sandbox[ACCESS_FIELDS[kind].url] = url;
+        sandbox[ACCESS_FIELDS[kind].secret] = secret;
       }
     }),
-    clearSandboxCodeServer: vi.fn(() => {
-      calls.push("clearSandboxCodeServer");
+    clearSandboxAccess: vi.fn((kind: SandboxAccessKind) => {
+      calls.push(`clearSandboxAccess:${kind}`);
       if (sandbox) {
-        sandbox.code_server_url = null;
-        sandbox.code_server_password = null;
+        sandbox[ACCESS_FIELDS[kind].url] = null;
+        sandbox[ACCESS_FIELDS[kind].secret] = null;
       }
     }),
-    clearSandboxCodeServerUrl: vi.fn(() => {
-      calls.push("clearSandboxCodeServerUrl");
-      if (sandbox) {
-        sandbox.code_server_url = null;
-      }
-    }),
-    updateSandboxVnc: vi.fn(async (url: string, password: string) => {
-      calls.push(`updateSandboxVnc:${url}`);
-      if (sandbox) {
-        sandbox.vnc_url = url;
-        sandbox.vnc_password = password;
-      }
-    }),
-    clearSandboxVnc: vi.fn(() => {
-      calls.push("clearSandboxVnc");
-      if (sandbox) {
-        sandbox.vnc_url = null;
-        sandbox.vnc_password = null;
-      }
-    }),
-    clearSandboxVncUrl: vi.fn(() => {
-      calls.push("clearSandboxVncUrl");
-      if (sandbox) sandbox.vnc_url = null;
+    clearSandboxAccessUrl: vi.fn((kind: SandboxAccessKind) => {
+      calls.push(`clearSandboxAccessUrl:${kind}`);
+      if (sandbox) sandbox[ACCESS_FIELDS[kind].url] = null;
     }),
     updateSandboxTunnelUrls: vi.fn(async (urls: Record<string, string>) => {
       calls.push(`updateSandboxTunnelUrls`);
@@ -279,20 +265,6 @@ function createMockStorage(
       calls.push("clearSandboxTunnelUrls");
       if (sandbox) {
         sandbox.tunnel_urls = null;
-      }
-    }),
-    updateSandboxTtyd: vi.fn(async (url: string, token: string) => {
-      calls.push("updateSandboxTtyd");
-      if (sandbox) {
-        sandbox.ttyd_url = url;
-        sandbox.ttyd_token = token;
-      }
-    }),
-    clearSandboxTtyd: vi.fn(() => {
-      calls.push("clearSandboxTtyd");
-      if (sandbox) {
-        sandbox.ttyd_url = null;
-        sandbox.ttyd_token = null;
       }
     }),
   };
@@ -736,7 +708,7 @@ describe("SandboxLifecycleManager", () => {
       expect(provider.createSandbox).toHaveBeenCalledWith(
         expect.objectContaining({ vncEnabled: true })
       );
-      expect(storage.updateSandboxVnc).toHaveBeenCalledWith("https://vnc.test", "secret");
+      expect(storage.updateSandboxAccess).toHaveBeenCalledWith("vnc", "https://vnc.test", "secret");
       expect(broadcaster.messages).not.toContainEqual({ type: "sandbox_access_changed" });
       expect(JSON.stringify(broadcaster.messages)).not.toContain("secret");
     });
@@ -2128,8 +2100,8 @@ describe("SandboxLifecycleManager", () => {
         })
       );
       expect(wsManager.sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
-      expect(storage.calls).toContain("clearSandboxCodeServer");
-      expect(storage.calls).toContain("clearSandboxVnc");
+      expect(storage.calls).toContain("clearSandboxAccess:codeServer");
+      expect(storage.calls).toContain("clearSandboxAccess:vnc");
     });
 
     it("does not explicitly stop providers when the capability is disabled", async () => {
@@ -2208,14 +2180,14 @@ describe("SandboxLifecycleManager", () => {
           reason: "inactivity_timeout",
         })
       );
-      expect(storage.calls).toContain("clearSandboxCodeServerUrl");
-      expect(storage.calls).not.toContain("clearSandboxCodeServer");
-      expect(storage.calls).toContain("clearSandboxVncUrl");
-      expect(storage.calls).not.toContain("clearSandboxVnc");
+      expect(storage.calls).toContain("clearSandboxAccessUrl:codeServer");
+      expect(storage.calls).not.toContain("clearSandboxAccess:codeServer");
+      expect(storage.calls).toContain("clearSandboxAccessUrl:vnc");
+      expect(storage.calls).not.toContain("clearSandboxAccess:vnc");
       expect(sandbox.vnc_password).toBe("encrypted-vnc-password");
     });
 
-    it("clears complete VNC access when URL-only clearing is unavailable", async () => {
+    it("clears complete access when URL-only clearing is unavailable", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({
         status: "ready",
@@ -2225,7 +2197,7 @@ describe("SandboxLifecycleManager", () => {
         vnc_password: "encrypted-vnc-password",
       });
       const storage = createMockStorage(createMockSession(), sandbox);
-      delete storage.clearSandboxVncUrl;
+      delete storage.clearSandboxAccessUrl;
       const provider = createMockProvider({
         capabilities: { supportsExplicitStop: true, supportsPersistentResume: true },
         stopSandbox: vi.fn(async () => ({ success: true })),
@@ -2244,7 +2216,7 @@ describe("SandboxLifecycleManager", () => {
 
       await manager.handleAlarm();
 
-      expect(storage.calls).toContain("clearSandboxVnc");
+      expect(storage.calls).toContain("clearSandboxAccess:vnc");
       expect(sandbox.vnc_url).toBeNull();
       expect(sandbox.vnc_password).toBeNull();
     });
@@ -2275,7 +2247,7 @@ describe("SandboxLifecycleManager", () => {
 
       expect(result).toBe("sandbox_failed");
       expect(storage.calls).toContain("updateSandboxStatus:failed");
-      expect(storage.calls).toContain("clearSandboxCodeServer");
+      expect(storage.calls).toContain("clearSandboxAccess:codeServer");
       expect(broadcaster.messages.some((m) => (m as { status?: string }).status === "failed")).toBe(
         true
       );

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -14,7 +14,12 @@ import type { McpServerConfig, SandboxSettings } from "@open-inspect/shared/type
 import { extractProviderAndModel } from "@open-inspect/shared/models";
 import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
-import { sessionHasRepository, type SandboxRow, type SessionRow } from "../../session/types";
+import {
+  sessionHasRepository,
+  type SandboxAccessKind,
+  type SandboxRow,
+  type SessionRow,
+} from "../../session/types";
 import {
   SandboxProviderError,
   type SandboxProvider,
@@ -153,26 +158,16 @@ export interface SandboxStorage {
   resetCircuitBreaker(): void;
   /** Persist last spawn error */
   setLastSpawnError(error: string | null, timestamp: number | null): void;
-  /** Update code-server URL and (encrypted) password on the sandbox row */
-  updateSandboxCodeServer(url: string, password: string): void | Promise<void>;
-  /** Clear stale code-server URL and password (e.g. on sandbox teardown) */
-  clearSandboxCodeServer(): void;
-  /** Clear the code-server URL while preserving the stored password */
-  clearSandboxCodeServerUrl?(): void;
-  /** Update VNC URL and (encrypted) password on the sandbox row */
-  updateSandboxVnc(url: string, password: string): void | Promise<void>;
-  /** Clear stale VNC URL and password */
-  clearSandboxVnc(): void;
-  /** Clear the VNC URL while preserving the stored password */
-  clearSandboxVncUrl?(): void;
+  /** Set one access artifact's URL and (encrypted) secret on the sandbox row */
+  updateSandboxAccess(kind: SandboxAccessKind, url: string, secret: string): void | Promise<void>;
+  /** Clear one access artifact's URL and secret (e.g. on sandbox teardown) */
+  clearSandboxAccess(kind: SandboxAccessKind): void;
+  /** Clear one access artifact's URL while preserving its stored secret */
+  clearSandboxAccessUrl?(kind: SandboxAccessKind): void;
   /** Update tunnel URLs for extra ports on the sandbox row */
   updateSandboxTunnelUrls(urls: Record<string, string>): void | Promise<void>;
   /** Clear stale tunnel URLs (e.g. on sandbox teardown) */
   clearSandboxTunnelUrls(): void;
-  /** Update ttyd proxy URL and (encrypted) JWT token on the sandbox row */
-  updateSandboxTtyd(url: string, token: string): void | Promise<void>;
-  /** Clear stale ttyd URL and token (e.g. on sandbox teardown) */
-  clearSandboxTtyd(): void;
 }
 
 /**
@@ -1220,23 +1215,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * removed.
    */
   private clearSandboxAccessState(): void {
-    if (this.usesProviderManagedStop() && this.storage.clearSandboxCodeServerUrl) {
-      this.storage.clearSandboxCodeServerUrl();
-      if (this.storage.clearSandboxVncUrl) {
-        this.storage.clearSandboxVncUrl();
-      } else {
-        this.storage.clearSandboxVnc();
-      }
-      this.storage.clearSandboxTunnelUrls();
-      this.storage.clearSandboxTtyd();
-      this.broadcaster.broadcast({ type: "sandbox_access_changed" });
-      return;
+    if (this.usesProviderManagedStop() && this.storage.clearSandboxAccessUrl) {
+      this.storage.clearSandboxAccessUrl("codeServer");
+      this.storage.clearSandboxAccessUrl("vnc");
+    } else {
+      this.storage.clearSandboxAccess("codeServer");
+      this.storage.clearSandboxAccess("vnc");
     }
-
-    this.storage.clearSandboxCodeServer();
-    this.storage.clearSandboxVnc();
     this.storage.clearSandboxTunnelUrls();
-    this.storage.clearSandboxTtyd();
+    this.storage.clearSandboxAccess("ttyd");
     this.broadcaster.broadcast({ type: "sandbox_access_changed" });
   }
 
@@ -1579,12 +1566,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
   private async storeCodeServer(url: string, password: string): Promise<void> {
     this.log.info("Storing code-server info", { url });
-    await this.storage.updateSandboxCodeServer(url, password);
+    await this.storage.updateSandboxAccess("codeServer", url, password);
   }
 
   private async storeVnc(url: string, password: string): Promise<void> {
     this.log.info("Storing VNC info", { url });
-    await this.storage.updateSandboxVnc(url, password);
+    await this.storage.updateSandboxAccess("vnc", url, password);
   }
 
   private parseSandboxSettings(session: SessionRow): SandboxSettings {
@@ -1637,7 +1624,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     );
 
     this.log.info("Storing ttyd info", { url });
-    await this.storage.updateSandboxTtyd(url, token);
+    await this.storage.updateSandboxAccess("ttyd", url, token);
   }
 
   private async finishProviderStartup(): Promise<void> {

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -259,10 +259,10 @@ describe("SandboxRepository", () => {
     });
   });
 
-  describe("VNC access", () => {
+  describe("access artifacts", () => {
     it("stores encrypted credentials and clears them", async () => {
-      await repository.updateSandboxVnc("https://vnc.test", "vnc-secret");
-      repository.clearSandboxVnc();
+      await repository.updateSandboxAccess("vnc", "https://vnc.test", "vnc-secret");
+      repository.clearSandboxAccess("vnc");
 
       expect(mock.calls[0].query).toContain("SET vnc_url = ?, vnc_password = ?");
       const [url, stored] = mock.calls[0].params as [string, string];
@@ -273,9 +273,11 @@ describe("SandboxRepository", () => {
     });
 
     it("encrypts code-server and ttyd secrets the same way", async () => {
-      await repository.updateSandboxCodeServer("https://cs.test", "cs-secret");
-      await repository.updateSandboxTtyd("https://ttyd.test", "ttyd-token");
+      await repository.updateSandboxAccess("codeServer", "https://cs.test", "cs-secret");
+      await repository.updateSandboxAccess("ttyd", "https://ttyd.test", "ttyd-token");
 
+      expect(mock.calls[0].query).toContain("SET code_server_url = ?, code_server_password = ?");
+      expect(mock.calls[1].query).toContain("SET ttyd_url = ?, ttyd_token = ?");
       for (const [call, plaintext] of [
         [mock.calls[0], "cs-secret"],
         [mock.calls[1], "ttyd-token"],
@@ -286,8 +288,8 @@ describe("SandboxRepository", () => {
       }
     });
 
-    it("can clear only the VNC URL", () => {
-      repository.clearSandboxVncUrl();
+    it("can clear only the URL", () => {
+      repository.clearSandboxAccessUrl("vnc");
 
       expect(mock.calls[0].query).toContain("SET vnc_url = NULL");
       expect(mock.calls[0].query).not.toContain("vnc_password");

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -1,13 +1,23 @@
 import type { GitSyncStatus } from "@open-inspect/shared/types/sandbox-events";
 import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import type { SqlResult, SqlStorage } from "./sql-storage";
-import type { SandboxRow } from "./types";
+import type { SandboxAccessKind, SandboxRow } from "./types";
 import type { Logger } from "../logger";
 import { coerceSandboxStatus } from "../sandbox/sandbox-status";
 import { encryptToken } from "../auth/crypto";
 
 /** A sandbox row exactly as SQLite returns it, before the status is validated. */
 type RawSandboxRow = Omit<SandboxRow, "status"> & { status: string };
+
+/** URL and secret columns backing each access artifact kind. */
+const ACCESS_ARTIFACT_COLUMNS: Record<
+  SandboxAccessKind,
+  { urlColumn: string; secretColumn: string }
+> = {
+  codeServer: { urlColumn: "code_server_url", secretColumn: "code_server_password" },
+  vnc: { urlColumn: "vnc_url", secretColumn: "vnc_password" },
+  ttyd: { urlColumn: "ttyd_url", secretColumn: "ttyd_token" },
+};
 
 /** Minimal sandbox state needed for circuit breaker spawn decisions. */
 export interface SandboxCircuitBreakerState {
@@ -244,42 +254,30 @@ export class SandboxRepository {
     );
   }
 
-  async updateSandboxCodeServer(url: string, password: string): Promise<void> {
+  /** Set one access artifact's URL and encrypted secret. */
+  async updateSandboxAccess(kind: SandboxAccessKind, url: string, secret: string): Promise<void> {
+    const { urlColumn, secretColumn } = ACCESS_ARTIFACT_COLUMNS[kind];
     this.sql.exec(
-      `UPDATE sandbox SET code_server_url = ?, code_server_password = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      `UPDATE sandbox SET ${urlColumn} = ?, ${secretColumn} = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       url,
-      await this.encrypt(password)
+      await this.encrypt(secret)
     );
   }
 
-  clearSandboxCodeServer(): void {
+  /** Clear one access artifact's URL and secret. */
+  clearSandboxAccess(kind: SandboxAccessKind): void {
+    const { urlColumn, secretColumn } = ACCESS_ARTIFACT_COLUMNS[kind];
     this.sql.exec(
-      `UPDATE sandbox SET code_server_url = NULL, code_server_password = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
+      `UPDATE sandbox SET ${urlColumn} = NULL, ${secretColumn} = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
     );
   }
 
-  clearSandboxCodeServerUrl(): void {
+  /** Clear one access artifact's URL while preserving its stored secret. */
+  clearSandboxAccessUrl(kind: SandboxAccessKind): void {
+    const { urlColumn } = ACCESS_ARTIFACT_COLUMNS[kind];
     this.sql.exec(
-      `UPDATE sandbox SET code_server_url = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
+      `UPDATE sandbox SET ${urlColumn} = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
     );
-  }
-
-  async updateSandboxVnc(url: string, password: string): Promise<void> {
-    this.sql.exec(
-      `UPDATE sandbox SET vnc_url = ?, vnc_password = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
-      url,
-      await this.encrypt(password)
-    );
-  }
-
-  clearSandboxVnc(): void {
-    this.sql.exec(
-      `UPDATE sandbox SET vnc_url = NULL, vnc_password = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
-    );
-  }
-
-  clearSandboxVncUrl(): void {
-    this.sql.exec(`UPDATE sandbox SET vnc_url = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`);
   }
 
   updateSandboxTunnelUrls(urls: Record<string, string>): void {
@@ -292,20 +290,6 @@ export class SandboxRepository {
   clearSandboxTunnelUrls(): void {
     this.sql.exec(
       `UPDATE sandbox SET tunnel_urls = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
-    );
-  }
-
-  async updateSandboxTtyd(url: string, token: string): Promise<void> {
-    this.sql.exec(
-      `UPDATE sandbox SET ttyd_url = ?, ttyd_token = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
-      url,
-      await this.encrypt(token)
-    );
-  }
-
-  clearSandboxTtyd(): void {
-    this.sql.exec(
-      `UPDATE sandbox SET ttyd_url = NULL, ttyd_token = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)`
     );
   }
 

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -173,6 +173,13 @@ export interface SandboxRow {
   created_at: number;
 }
 
+/**
+ * The sandbox access artifacts that pair a URL with an encrypted secret:
+ * code-server and VNC carry passwords, ttyd carries a minted JWT. Tunnel URLs
+ * are not a kind — they are a single JSON column with no secret.
+ */
+export type SandboxAccessKind = "codeServer" | "vnc" | "ttyd";
+
 // Command types for sandbox communication
 
 interface PromptCommand {


### PR DESCRIPTION
## Summary

Phase D item deferred from #1609's review round. The sandbox row's three URL+secret access artifacts — code-server, VNC, ttyd — each had their own update / clear / clear-URL-only methods: 8 near-identical methods on `SandboxRepository`, 8 matching entries on the `SandboxStorage` port, and 8 mock implementations. This PR replaces each set with one kind-parameterized trio:

- `updateSandboxAccess(kind, url, secret)` — encrypts the secret before writing, as before
- `clearSandboxAccess(kind)` — clears URL + secret
- `clearSandboxAccessUrl?(kind)` — clears the URL, preserving the stored secret

`SandboxAccessKind = "codeServer" | "vnc" | "ttyd"` lives next to `SandboxRow` (whose column families it names) and matches the keys the access endpoint already serves. The column names come from a repo-private record keyed by that closed union — the same interpolation pattern `updateSandboxForSpawn` already uses.

Tunnel URLs are deliberately **not** a fourth kind: they're a single JSON column with no secret — a different shape, and forcing them into the trio would trade real uniformity for fake uniformity.

## Behavior preservation

- The SQL emitted per (kind, operation) is byte-identical to the per-kind methods it replaces; the repo suite still pins encrypt-at-rest per kind and the exact `SET` clauses.
- `clearSandboxAccessState`'s sequence is unchanged in both branches (code-server, VNC, tunnels, ttyd, broadcast), including the provider-managed-stop distinction: URL-only clears for code-server/VNC (passwords survive persistent resume), full clear for ttyd (its JWT is minted per sandbox).
- One port narrowing worth calling out: the old port had two independent optional URL-clears with a nested fallback, so a storage could implement `clearSandboxCodeServerUrl` but not `clearSandboxVncUrl`. That partial state is no longer expressible — a storage either provides `clearSandboxAccessUrl` for all kinds or the manager falls back to full clears for both. The only real storage (`SandboxRepository`) implements everything, so composed behavior is identical; the fallback test now exercises the remaining meaningful case.
- The trio incidentally gives ttyd a URL-only clear. Nothing calls it — the manager keeps ttyd on the full clear for the reason above.

## Verification

- Typecheck: main + `tsconfig.test.json` + `test/integration` programs all clean
- ESLint + Prettier on all touched files
- Unit battery 3304/3304, integration battery 1006/1006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified sandbox access artifact management for code-server, VNC, and terminal access.
  * Standardized storing, clearing, and URL-only clearing of sandbox access details.
  * Preserved encrypted secret handling and existing tunnel behavior.
* **Tests**
  * Updated lifecycle and repository coverage for the unified access management flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->