### PR TITLE
Increase GitHub Autofix attempt default to 30

### DIFF
--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -44,7 +44,7 @@ export const GITHUB_AUTOFIX_DEFAULTS: ResolvedGitHubAutofixSettings = {
   prCommentsEnabled: true,
   openInspectReviewsEnabled: true,
   allowedReviewBots: [],
-  maxAttemptsPerPrPer24Hours: 10,
+  maxAttemptsPerPrPer24Hours: 30,
 };
 
 /** Overridable behavior settings for the GitHub bot. Used at both global and repo levels. */

--- a/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
+++ b/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import type { ResolvedGitHubAutofixSettings } from "@open-inspect/shared";
+import { GITHUB_AUTOFIX_DEFAULTS, type ResolvedGitHubAutofixSettings } from "@open-inspect/shared";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 
@@ -134,7 +134,7 @@ export function GitHubAutofixSettingsFields({
           }}
           className={compact ? "h-8 text-xs" : "max-w-32"}
         />
-        {value.maxAttemptsPerPrPer24Hours > 10 && (
+        {value.maxAttemptsPerPrPer24Hours > GITHUB_AUTOFIX_DEFAULTS.maxAttemptsPerPrPer24Hours && (
           <span className="block text-xs text-amber-600 dark:text-amber-400 mt-1">
             Higher attempt caps increase autonomous work and spend. Raise this only after reviewing
             dogfood volume and queue health.

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -176,7 +176,7 @@ describe("GitHubIntegrationSettings", () => {
                 prCommentsEnabled: true,
                 openInspectReviewsEnabled: true,
                 allowedReviewBots: [],
-                maxAttemptsPerPrPer24Hours: 10,
+                maxAttemptsPerPrPer24Hours: 30,
               },
             },
           },
@@ -198,7 +198,7 @@ describe("GitHubIntegrationSettings", () => {
     expect(screen.getByText(/bot-authored feedback is untrusted input/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole("spinbutton", { name: "Attempts per PR per 24 hours" }), {
-      target: { value: "20" },
+      target: { value: "40" },
     });
     expect(screen.getByText(/higher attempt caps increase autonomous work/i)).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- increase the GitHub Autofix default attempt cap from 10 to 30 per PR per 24 hours
- compare the elevated-cap warning against the shared default rather than a duplicated literal
- update the integration settings UI assertions for the new default

## Verification
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/web -- src/components/settings/integrations/github-integration-settings.test.tsx`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/39af83bae1a46f4f8a82c6966edcdd4d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the default GitHub Autofix limit to 30 attempts per pull request within 24 hours.
  * Updated settings warnings and validation to reflect the new limit.
* **Tests**
  * Updated GitHub integration coverage for the increased Autofix attempt limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->