### PR TITLE
perf: make timeline grouping linear

### DIFF
--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -172,12 +172,17 @@ export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimeli
     }
     const userMessage = item.event;
 
-    const completionIndex = items.findIndex(
-      (candidate, candidateIndex) =>
-        candidateIndex > index &&
+    let completionIndex = index + 1;
+    while (completionIndex < items.length) {
+      const candidate = items[completionIndex];
+      if (
         candidate.type === "single" &&
         (candidate.event.type === "user_message" || candidate.event.type === "execution_complete")
-    );
+      ) {
+        break;
+      }
+      completionIndex += 1;
+    }
     const completion = items[completionIndex];
     if (
       completion?.type !== "single" ||


### PR DESCRIPTION
## Summary

- replace the repeated array-wide completed-turn lookup with a forward scan from the current user message
- preserve existing completed, in-flight, and partial-history grouping behavior
- keep the change local to timeline derivation with no new state or abstractions

## Performance

Local consecutive-run microbenchmarks:

| Events | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1,000 | 0.364 ms | 0.309 ms | -15.1% |
| 5,000 | 2.859 ms | 1.527 ms | -46.6% |
| 100,000 | not previously measured | 69.633 ms | baseline established |

Scaling from 1,000 to 5,000 events improved from 7.85x to 4.95x, closely matching the 5x input increase.

## Verification

- `npm test -w @open-inspect/web` (1,254 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `NODE_ENV=production npm run build -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ba5b7c0d26d8e9234dd5cd821eb9ab18)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timeline processing without changing visible behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->