### PR TITLE
Clarify provider account row actions

### DIFF
--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -194,7 +194,7 @@ describe("Analytics API", () => {
 
   it("returns daily timeseries grouped by user", async () => {
     const store = new SessionIndexStore(env.DB);
-    const now = Date.now();
+    const now = new Date().setUTCHours(12, 0, 0, 0);
 
     const completedAt = now - 2 * 24 * 60 * 60 * 1000;
     const failedAt = completedAt + 60_000;
@@ -753,7 +753,7 @@ describe("Analytics API", () => {
 
   it("sums timeseries counts when distinct users share the same display name", async () => {
     const store = new SessionIndexStore(env.DB);
-    const now = Date.now();
+    const now = new Date().setUTCHours(12, 0, 0, 0);
     const dayAgo = now - 24 * 60 * 60 * 1000;
 
     // Two distinct users with the same display name

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -462,7 +462,7 @@ describe("ProviderAccountsSettings", () => {
     );
   });
 
-  it("surfaces reconnect as the primary action when an account needs attention", () => {
+  it("surfaces reconnect only as the primary action when an account needs attention", async () => {
     accountsResult = [{ ...account, status: "reconnect_required" }];
     render(<ProviderAccountsSettings />);
 
@@ -470,9 +470,15 @@ describe("ProviderAccountsSettings", () => {
     expect(
       screen.getByText("This account cannot start new sessions until it is reconnected.")
     ).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    expect(await screen.findByRole("menuitem", { name: "Rename" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Reconnect" })).not.toBeInTheDocument();
   });
 
-  it("surfaces enable as the primary action when an account is disabled", () => {
+  it("surfaces enable as the primary action when an account is disabled", async () => {
     accountsResult = [{ ...account, status: "disabled" }];
     render(<ProviderAccountsSettings />);
 
@@ -480,6 +486,11 @@ describe("ProviderAccountsSettings", () => {
     expect(
       screen.getByText("This account is disabled and is not available for new sessions.")
     ).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    expect(await screen.findByRole("menuitem", { name: "Reconnect" })).toBeInTheDocument();
   });
 
   it("confirms disable and runs the lifecycle action", async () => {

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -472,6 +472,16 @@ describe("ProviderAccountsSettings", () => {
     ).toBeInTheDocument();
   });
 
+  it("surfaces enable as the primary action when an account is disabled", () => {
+    accountsResult = [{ ...account, status: "disabled" }];
+    render(<ProviderAccountsSettings />);
+
+    expect(screen.getByRole("button", { name: "Enable" })).toBeInTheDocument();
+    expect(
+      screen.getByText("This account is disabled and is not available for new sessions.")
+    ).toBeInTheDocument();
+  });
+
   it("confirms disable and runs the lifecycle action", async () => {
     render(<ProviderAccountsSettings />);
     fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -358,6 +358,27 @@ describe("ProviderAccountsSettings", () => {
     expect(screen.getByLabelText("Automated authentication")).toHaveTextContent(
       "Use default: Team ChatGPT"
     );
+    expect(screen.getByText("Default for automation")).toBeInTheDocument();
+  });
+
+  it("does not label the stored account as the automation default in API key mode", () => {
+    defaultsResult = [
+      {
+        provider: "openai",
+        providerAccountId: account.id,
+        unattendedMode: "api_key",
+        createdBy: null,
+        updatedBy: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    render(<ProviderAccountsSettings />);
+
+    expect(screen.getByLabelText("Automated authentication")).toHaveTextContent(
+      "No account (API key)"
+    );
+    expect(screen.queryByText("Default for automation")).not.toBeInTheDocument();
   });
 
   it("sets the provider default from the account row", async () => {

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -100,7 +100,11 @@ describe("ProviderAccountsSettings", () => {
 
   it("reconnects OpenAI through device authorization with the selected account id", async () => {
     render(<ProviderAccountsSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Reconnect" }));
 
     expect(
       await screen.findByRole("heading", { name: "Reconnect Team ChatGPT" })
@@ -227,7 +231,11 @@ describe("ProviderAccountsSettings", () => {
     );
 
     render(<ProviderAccountsSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Reconnect" }));
 
     expect(await screen.findByText("Provider account is archived")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
@@ -283,7 +291,11 @@ describe("ProviderAccountsSettings", () => {
     accountsResult = [legacyAccount];
     render(<ProviderAccountsSettings />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "More actions for Legacy SuperGrok" }),
+      { button: 0, ctrlKey: false }
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Reconnect" }));
     expect(screen.getByRole("heading", { name: "Reconnect Legacy SuperGrok" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Refresh token"), { target: { value: "legacy-token" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -385,29 +397,30 @@ describe("ProviderAccountsSettings", () => {
     ];
     render(<ProviderAccountsSettings />);
 
-    const verifyButtons = screen.getAllByRole("button", { name: "Verify" });
-    fireEvent.click(verifyButtons[0]);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Verify" }));
 
     expect(screen.getByRole("button", { name: "Add account" })).toBeDisabled();
     expect(screen.getAllByLabelText("Automated authentication")[0]).toBeDisabled();
-    expect(verifyButtons[1]).toBeDisabled();
-    fireEvent.click(verifyButtons[1]);
+    expect(screen.getByRole("button", { name: "More actions for Backup ChatGPT" })).toBeDisabled();
     expect(runAction).toHaveBeenCalledTimes(1);
 
     await act(async () => finishAction());
     await waitFor(() => expect(screen.getByRole("button", { name: "Add account" })).toBeEnabled());
   });
 
-  it("keeps primary account actions on one line and moves secondary actions to overflow", async () => {
+  it("shows primary actions only for accounts needing intervention", async () => {
     render(<ProviderAccountsSettings />);
 
     expect(screen.queryByText(account.externalAccountId)).not.toBeInTheDocument();
     expect(screen.getByText("Verified Never")).toHaveClass("whitespace-nowrap");
     expect(screen.getByText("Used Never")).toHaveClass("whitespace-nowrap");
-    const reconnect = screen.getByRole("button", { name: "Reconnect" });
-    expect(screen.getByRole("button", { name: "Disable" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Verify" })).toBeInTheDocument();
-    expect(reconnect.parentElement).toHaveClass("flex", "shrink-0", "items-center");
+    expect(screen.queryByRole("button", { name: "Reconnect" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Disable" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Verify" })).not.toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
 
@@ -417,6 +430,9 @@ describe("ProviderAccountsSettings", () => {
     });
 
     expect(await screen.findByRole("menuitem", { name: "Make default" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Reconnect" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Verify" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Disable" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Rename" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Archive" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy account ID" }));
@@ -425,9 +441,23 @@ describe("ProviderAccountsSettings", () => {
     );
   });
 
+  it("surfaces reconnect as the primary action when an account needs attention", () => {
+    accountsResult = [{ ...account, status: "reconnect_required" }];
+    render(<ProviderAccountsSettings />);
+
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+    expect(
+      screen.getByText("This account cannot start new sessions until it is reconnected.")
+    ).toBeInTheDocument();
+  });
+
   it("confirms disable and runs the lifecycle action", async () => {
     render(<ProviderAccountsSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team ChatGPT" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Disable" }));
     fireEvent.click(screen.getByRole("button", { name: "Disable" }));
 
     await waitFor(() => {

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -294,6 +294,8 @@ export function ProviderAccountsSettings() {
                     (item) => item.provider === account.provider
                   );
                   const isDefault = providerDefault?.providerAccountId === account.id;
+                  const isDefaultForAutomation =
+                    isDefault && providerDefault.unattendedMode === "provider_account";
                   const externalAccountId = account.externalAccountId;
                   return (
                     <div key={account.id} className="p-4">
@@ -326,7 +328,7 @@ export function ProviderAccountsSettings() {
                               >
                                 {accountStatusLabel(account.status)}
                               </span>
-                              {isDefault && (
+                              {isDefaultForAutomation && (
                                 <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
                                   Default for automation
                                 </span>

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -105,6 +105,12 @@ function relativeDateLabel(timestamp: number | null) {
   return relative === "now" ? relative : `${relative} ago`;
 }
 
+function accountStatusLabel(status: ModelProviderAccount["status"]) {
+  if (status === "reconnect_required") return "Reconnect required";
+  if (status === "disabled") return "Disabled";
+  return "Ready";
+}
+
 function legacyKeyLocationLabel(location: LegacyProviderKeyLocation): string {
   if (location.scope === "global") return `Global: ${location.key}`;
   if (location.scope === "repository") {
@@ -290,174 +296,205 @@ export function ProviderAccountsSettings() {
                   const isDefault = providerDefault?.providerAccountId === account.id;
                   const externalAccountId = account.externalAccountId;
                   return (
-                    <div
-                      key={account.id}
-                      className="flex flex-col gap-4 p-4 lg:flex-row lg:items-center lg:justify-between"
-                    >
-                      <div className="flex min-w-0 items-start gap-3">
-                        <div className="flex size-10 shrink-0 items-center justify-center text-foreground">
-                          <SubscriptionProviderIcon
-                            provider={account.provider}
-                            className="size-6 text-primary"
-                          />
-                        </div>
-                        <div className="min-w-0">
-                          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                            <span className="font-medium text-foreground">
-                              {account.displayName}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              {provider?.subscriptionName ?? account.provider}
-                            </span>
-                            <span className="rounded bg-muted px-1.5 py-0.5 text-xs capitalize text-foreground">
-                              {account.status.replaceAll("_", " ")}
-                            </span>
-                            {isDefault && (
-                              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
-                                Default
-                              </span>
-                            )}
+                    <div key={account.id} className="p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 items-start gap-3">
+                          <div className="flex size-10 shrink-0 items-center justify-center text-foreground">
+                            <SubscriptionProviderIcon
+                              provider={account.provider}
+                              className="size-6 text-primary"
+                            />
                           </div>
-                          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                            <span
-                              className="whitespace-nowrap"
-                              title={
-                                account.lastVerifiedAt
-                                  ? dateLabel(account.lastVerifiedAt)
-                                  : undefined
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                              <span className="font-medium text-foreground">
+                                {account.displayName}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {provider?.subscriptionName ?? account.provider}
+                              </span>
+                            </div>
+                            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                              <span
+                                className={`rounded px-1.5 py-0.5 text-xs ${
+                                  account.status === "active"
+                                    ? "bg-success-muted text-success"
+                                    : account.status === "reconnect_required"
+                                      ? "bg-warning-muted text-warning"
+                                      : "bg-muted text-muted-foreground"
+                                }`}
+                              >
+                                {accountStatusLabel(account.status)}
+                              </span>
+                              {isDefault && (
+                                <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs text-primary">
+                                  Default for automation
+                                </span>
+                              )}
+                            </div>
+                            <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                              <span
+                                className="whitespace-nowrap"
+                                title={
+                                  account.lastVerifiedAt
+                                    ? dateLabel(account.lastVerifiedAt)
+                                    : undefined
+                                }
+                              >
+                                Verified {relativeDateLabel(account.lastVerifiedAt)}
+                              </span>
+                              <span
+                                className="whitespace-nowrap"
+                                title={
+                                  account.lastUsedAt ? dateLabel(account.lastUsedAt) : undefined
+                                }
+                              >
+                                Used {relativeDateLabel(account.lastUsedAt)}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          {account.status === "reconnect_required" && (
+                            <Button
+                              size="xs"
+                              disabled={saving}
+                              onClick={() =>
+                                beginConnection(
+                                  CONNECTION_STRATEGIES[account.provider].reconnect(account)
+                                )
                               }
                             >
-                              Verified {relativeDateLabel(account.lastVerifiedAt)}
-                            </span>
-                            <span
-                              className="whitespace-nowrap"
-                              title={account.lastUsedAt ? dateLabel(account.lastUsedAt) : undefined}
-                            >
-                              Used {relativeDateLabel(account.lastUsedAt)}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="flex max-w-full shrink-0 items-center gap-1.5 overflow-x-auto lg:justify-end">
-                        <Button
-                          size="xs"
-                          variant="subtle"
-                          disabled={saving}
-                          onClick={() =>
-                            beginConnection(
-                              CONNECTION_STRATEGIES[account.provider].reconnect(account)
-                            )
-                          }
-                        >
-                          Reconnect
-                        </Button>
-                        {account.status === "disabled" ? (
-                          <Button
-                            size="xs"
-                            variant="subtle"
-                            disabled={saving}
-                            onClick={() =>
-                              void run(
-                                () => runProviderAccountAction(account.id, "enable"),
-                                "Account enabled"
-                              )
-                            }
-                          >
-                            Enable
-                          </Button>
-                        ) : (
-                          <Button
-                            size="xs"
-                            variant="subtle"
-                            disabled={saving}
-                            onClick={() => beginConfirmation({ account, action: "disable" })}
-                          >
-                            Disable
-                          </Button>
-                        )}
-                        <Button
-                          size="xs"
-                          variant="subtle"
-                          disabled={saving}
-                          onClick={() =>
-                            void run(
-                              () => runProviderAccountAction(account.id, "verify"),
-                              "Account verified"
-                            )
-                          }
-                        >
-                          Verify
-                        </Button>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              size="icon"
-                              variant="subtle"
-                              className="size-7"
-                              aria-label={`More actions for ${account.displayName}`}
-                              disabled={saving}
-                            >
-                              <MoreIcon className="size-4" />
+                              Reconnect
                             </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {account.status === "active" && !isDefault && (
+                          )}
+                          {account.status === "disabled" && (
+                            <Button
+                              size="xs"
+                              disabled={saving}
+                              onClick={() =>
+                                void run(
+                                  () => runProviderAccountAction(account.id, "enable"),
+                                  "Account enabled"
+                                )
+                              }
+                            >
+                              Enable
+                            </Button>
+                          )}
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                size="icon"
+                                variant="subtle"
+                                className="size-7"
+                                aria-label={`More actions for ${account.displayName}`}
+                                disabled={saving}
+                              >
+                                <MoreIcon className="size-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
                               <DropdownMenuItem
                                 disabled={saving}
                                 onSelect={() =>
-                                  void run(
-                                    () =>
-                                      setProviderAccountDefault(
-                                        account.provider,
-                                        account.id,
-                                        providerDefault?.unattendedMode ?? "provider_account"
-                                      ),
-                                    "Default updated"
+                                  beginConnection(
+                                    CONNECTION_STRATEGIES[account.provider].reconnect(account)
                                   )
                                 }
                               >
-                                Make default
+                                Reconnect
                               </DropdownMenuItem>
-                            )}
-                            <DropdownMenuItem
-                              disabled={saving}
-                              onSelect={() => {
-                                if (operationInFlightRef.current) return;
-                                const displayName = window
-                                  .prompt("Account name", account.displayName)
-                                  ?.trim();
-                                if (displayName)
-                                  void run(
-                                    () => renameProviderAccount(account.id, displayName),
-                                    "Account renamed"
-                                  );
-                              }}
-                            >
-                              Rename
-                            </DropdownMenuItem>
-                            {externalAccountId && (
                               <DropdownMenuItem
+                                disabled={saving || account.status !== "active"}
                                 onSelect={() =>
-                                  void navigator.clipboard
-                                    .writeText(externalAccountId)
-                                    .then(() => toast.success("Account ID copied"))
-                                    .catch(() => toast.error("Failed to copy account ID"))
+                                  void run(
+                                    () => runProviderAccountAction(account.id, "verify"),
+                                    "Account verified"
+                                  )
                                 }
                               >
-                                Copy account ID
+                                Verify
                               </DropdownMenuItem>
-                            )}
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              className="text-destructive focus:text-destructive"
-                              disabled={saving}
-                              onSelect={() => beginConfirmation({ account, action: "archive" })}
-                            >
-                              Archive
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              {account.status === "active" && !isDefault && (
+                                <DropdownMenuItem
+                                  disabled={saving}
+                                  onSelect={() =>
+                                    void run(
+                                      () =>
+                                        setProviderAccountDefault(
+                                          account.provider,
+                                          account.id,
+                                          providerDefault?.unattendedMode ?? "provider_account"
+                                        ),
+                                      "Default updated"
+                                    )
+                                  }
+                                >
+                                  Make default
+                                </DropdownMenuItem>
+                              )}
+                              <DropdownMenuItem
+                                disabled={saving}
+                                onSelect={() => {
+                                  if (operationInFlightRef.current) return;
+                                  const displayName = window
+                                    .prompt("Account name", account.displayName)
+                                    ?.trim();
+                                  if (displayName)
+                                    void run(
+                                      () => renameProviderAccount(account.id, displayName),
+                                      "Account renamed"
+                                    );
+                                }}
+                              >
+                                Rename
+                              </DropdownMenuItem>
+                              {externalAccountId && (
+                                <DropdownMenuItem
+                                  onSelect={() =>
+                                    void navigator.clipboard
+                                      .writeText(externalAccountId)
+                                      .then(() => toast.success("Account ID copied"))
+                                      .catch(() => toast.error("Failed to copy account ID"))
+                                  }
+                                >
+                                  Copy account ID
+                                </DropdownMenuItem>
+                              )}
+                              <DropdownMenuSeparator />
+                              {account.status === "active" && (
+                                <DropdownMenuItem
+                                  disabled={saving}
+                                  onSelect={() => beginConfirmation({ account, action: "disable" })}
+                                >
+                                  Disable
+                                </DropdownMenuItem>
+                              )}
+                              <DropdownMenuItem
+                                className="text-destructive focus:text-destructive"
+                                disabled={saving}
+                                onSelect={() => beginConfirmation({ account, action: "archive" })}
+                              >
+                                Archive
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
                       </div>
+                      {account.status !== "active" && (
+                        <p
+                          className={`mt-3 rounded-md px-3 py-2 text-xs ${
+                            account.status === "reconnect_required"
+                              ? "bg-warning-muted text-warning"
+                              : "bg-muted text-muted-foreground"
+                          }`}
+                        >
+                          {account.status === "reconnect_required"
+                            ? "This account cannot start new sessions until it is reconnected."
+                            : "This account is disabled and is not available for new sessions."}
+                        </p>
+                      )}
                     </div>
                   );
                 })}

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -397,16 +397,18 @@ export function ProviderAccountsSettings() {
                               </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                disabled={saving}
-                                onSelect={() =>
-                                  beginConnection(
-                                    CONNECTION_STRATEGIES[account.provider].reconnect(account)
-                                  )
-                                }
-                              >
-                                Reconnect
-                              </DropdownMenuItem>
+                              {account.status !== "reconnect_required" && (
+                                <DropdownMenuItem
+                                  disabled={saving}
+                                  onSelect={() =>
+                                    beginConnection(
+                                      CONNECTION_STRATEGIES[account.provider].reconnect(account)
+                                    )
+                                  }
+                                >
+                                  Reconnect
+                                </DropdownMenuItem>
+                              )}
                               <DropdownMenuItem
                                 disabled={saving || account.status !== "active"}
                                 onSelect={() =>


### PR DESCRIPTION
## Summary
- simplify healthy provider-account rows by moving maintenance actions into the overflow menu
- surface only the relevant primary recovery action for disabled or reconnect-required accounts
- replace raw status labels with user-facing health labels and clarify automation defaults
- add contextual explanations for accounts that cannot start new sessions
- update account-settings tests for the revised action hierarchy and recovery states

## Verification
- `npm test -w @open-inspect/web -- --run "src/components/settings/provider-accounts-settings.test.tsx"`
- `npx prettier --check "packages/web/src/components/settings/provider-accounts-settings.tsx" "packages/web/src/components/settings/provider-accounts-settings.test.tsx"`
- `npx eslint "packages/web/src/components/settings/provider-accounts-settings.tsx" "packages/web/src/components/settings/provider-accounts-settings.test.tsx"`
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `git diff --check origin/main...HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3c43ceac7f30f69c8c4924a321088042)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned provider account rows with clearer status, default, verification, and usage information.
  * Consolidated account management actions into a “More actions” menu.
  * Added contextual Reconnect and Enable options for inactive or reconnect-required accounts.
  * Clarified when an account is the default for automation based on the selected mode.
* **Bug Fixes**
  * Improved action availability based on account status.
  * Added clearer messaging for disabled accounts and accounts requiring reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->