### PR TITLE
perf(web): virtualize long session timelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6252,6 +6252,33 @@
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -17859,6 +17886,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-virtual": "3.14.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-virtual": "3.14.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -18,6 +18,8 @@ const baseTimelineProps = {
 } as const;
 
 beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(800);
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(800);
   vi.stubGlobal(
     "IntersectionObserver",
     class {

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -60,6 +60,53 @@ function toolEvent(
 }
 
 describe("timeline auto-scrolling", () => {
+  it("keeps observing the history sentinel after the skeleton clears", () => {
+    const observedElements: Element[] = [];
+    let notifyIntersection = (_isIntersecting: boolean) => {};
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          notifyIntersection = (isIntersecting) => {
+            callback(
+              [{ isIntersecting } as IntersectionObserverEntry],
+              this as unknown as IntersectionObserver
+            );
+          };
+        }
+        observe(element: Element) {
+          observedElements.push(element);
+        }
+        disconnect() {}
+      }
+    );
+    const onLoadOlder = vi.fn();
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={[]} showSkeleton onLoadOlder={onLoadOlder} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, value: 800 },
+    });
+    const sentinel = observedElements[0];
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[]}
+        showSkeleton={false}
+        onLoadOlder={onLoadOlder}
+      />
+    );
+    fireEvent.scroll(timeline);
+    notifyIntersection(true);
+
+    expect(observedElements).toEqual([sentinel]);
+    expect(sentinel.isConnected).toBe(true);
+    expect(onLoadOlder).toHaveBeenCalledOnce();
+  });
+
   it("does not scroll the timeline when the pending prompt stack changes", () => {
     const events: SandboxEvent[] = [];
     const { container, rerender } = render(

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -60,6 +60,73 @@ function toolEvent(
 }
 
 describe("timeline auto-scrolling", () => {
+  it("preserves the visible row position when history is prepended", () => {
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (
+      this: HTMLElement
+    ) {
+      if (!this.hasAttribute("data-index")) return 800;
+      return Number(this.dataset.index) % 2 === 0 ? 80 : 160;
+    });
+    const messages = Array.from(
+      { length: 200 },
+      (_, index): SandboxEvent => ({
+        type: "user_message",
+        content: `Message ${index}`,
+        messageId: `message-${index}`,
+        timestamp: index + 10,
+      })
+    );
+    const { container, rerender } = render(
+      <SessionTimeline {...baseTimelineProps} events={messages} />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 500_000 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+      scrollTo: {
+        configurable: true,
+        value: ({ top }: ScrollToOptions) => {
+          if (typeof top === "number") timeline.scrollTop = top;
+        },
+      },
+    });
+    timeline.scrollTop = 20_000;
+    fireEvent.scroll(timeline);
+    const anchorContent = container.querySelector("[data-index] pre")?.textContent;
+    const anchorBefore = [...container.querySelectorAll<HTMLElement>("[data-index]")].find((row) =>
+      row.textContent?.includes(anchorContent ?? "")
+    )!;
+    const viewportOffsetBefore =
+      Number.parseFloat(anchorBefore.style.transform.slice(11)) - timeline.scrollTop;
+
+    rerender(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          ...Array.from(
+            { length: 3 },
+            (_, index): SandboxEvent => ({
+              type: "user_message",
+              content: `Older ${index}`,
+              messageId: `older-${index}`,
+              timestamp: index + 1,
+            })
+          ),
+          ...messages,
+        ]}
+      />
+    );
+    const anchorAfter = [...container.querySelectorAll<HTMLElement>("[data-index]")].find((row) =>
+      row.textContent?.includes(anchorContent ?? "")
+    )!;
+    const viewportOffsetAfter =
+      Number.parseFloat(anchorAfter.style.transform.slice(11)) - timeline.scrollTop;
+
+    expect(anchorContent).toBeTruthy();
+    expect(viewportOffsetAfter).toBe(viewportOffsetBefore);
+  });
+
   it("keeps observing the history sentinel after the skeleton clears", () => {
     const observedElements: Element[] = [];
     let notifyIntersection = (_isIntersecting: boolean) => {};
@@ -132,7 +199,7 @@ describe("timeline auto-scrolling", () => {
     expect(timeline.scrollTop).toBe(0);
   });
 
-  it("confines sub-task auto-scrolling to the timeline", () => {
+  it("follows appended activity when within the bottom threshold", () => {
     const task = toolEvent("task", "task-call", 1, {
       childSessionId: "child-1",
       status: "running",
@@ -144,7 +211,9 @@ describe("timeline auto-scrolling", () => {
     Object.defineProperties(timeline, {
       clientHeight: { configurable: true, value: 200 },
       scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 701, writable: true },
     });
+    fireEvent.scroll(timeline);
 
     rerender(
       <SessionTimeline

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -26,6 +26,8 @@ function mockScrollIntoView() {
   });
 }
 beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(800);
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(800);
   vi.stubGlobal(
     "IntersectionObserver",
     class {
@@ -1178,5 +1180,21 @@ describe("task activity grouping", () => {
       false
     );
     consoleError.mockRestore();
+  });
+});
+
+describe("timeline virtualization", () => {
+  it("mounts only a bounded window for large histories", () => {
+    const events: SandboxEvent[] = Array.from({ length: 500 }, (_, index) => ({
+      type: "user_message",
+      content: `Message ${index}`,
+      messageId: `message-${index}`,
+      timestamp: index + 1,
+    }));
+
+    const { container } = render(<SessionTimeline {...baseTimelineProps} events={events} />);
+
+    expect(container.querySelectorAll("[data-index]").length).toBeLessThanOrEqual(20);
+    expect(container).not.toHaveTextContent("Message 250");
   });
 });

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { buildTimelineItems } from "@/lib/timeline-items";
@@ -1196,5 +1196,118 @@ describe("timeline virtualization", () => {
 
     expect(container.querySelectorAll("[data-index]").length).toBeLessThanOrEqual(20);
     expect(container).not.toHaveTextContent("Message 250");
+  });
+
+  it("preserves task expansion after its row leaves the virtual window", async () => {
+    const task: SandboxEvent = {
+      type: "tool_call",
+      sandboxId: "sandbox-1",
+      messageId: "task-message",
+      callId: "task-call",
+      tool: "Task",
+      args: { description: "Inspect the timeline" },
+      timestamp: 1,
+    };
+    const events: SandboxEvent[] = [
+      task,
+      ...Array.from(
+        { length: 500 },
+        (_, index): SandboxEvent => ({
+          type: "user_message",
+          content: `Message ${index}`,
+          messageId: `message-${index}`,
+          timestamp: index + 2,
+        })
+      ),
+    ];
+    const { container } = render(<SessionTimeline {...baseTimelineProps} events={events} />);
+    const taskButton = screen.getByRole("button", { name: /Task Inspect the timeline/ });
+    await userEvent.click(taskButton);
+    expect(taskButton).toHaveAttribute("aria-expanded", "true");
+
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 500_000 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    });
+    await act(async () => {
+      timeline.scrollTop = 400_000;
+      fireEvent.scroll(timeline);
+    });
+    expect(screen.queryByRole("button", { name: /Task Inspect the timeline/ })).toBeNull();
+
+    await act(async () => {
+      timeline.scrollTop = 0;
+      fireEvent.scroll(timeline);
+    });
+    expect(screen.getByRole("button", { name: /Task Inspect the timeline/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("reattaches terminal read observation when its row re-enters the virtual window", async () => {
+    const observedTerminalTargets: Element[] = [];
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe(target: Element) {
+          if (target.hasAttribute("data-terminal-message-id")) {
+            observedTerminalTargets.push(target);
+          }
+        }
+        disconnect() {}
+      }
+    );
+    const events: SandboxEvent[] = [
+      {
+        type: "execution_complete",
+        sandboxId: "sandbox-1",
+        messageId: "terminal-message",
+        success: true,
+        timestamp: 1,
+      },
+      ...Array.from(
+        { length: 500 },
+        (_, index): SandboxEvent => ({
+          type: "user_message",
+          content: `Message ${index}`,
+          messageId: `message-${index}`,
+          timestamp: index + 2,
+        })
+      ),
+    ];
+    const { container } = render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={events}
+        terminalMessageReadObservationEnabled
+        onMarkMessageRead={async () => "complete"}
+      />
+    );
+    const firstTarget = container.querySelector('[data-terminal-message-id="terminal-message"]');
+    const timeline = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(timeline, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 500_000 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    });
+
+    await act(async () => {
+      timeline.scrollTop = 400_000;
+      fireEvent.scroll(timeline);
+    });
+    expect(container.querySelector('[data-terminal-message-id="terminal-message"]')).toBeNull();
+
+    await act(async () => {
+      timeline.scrollTop = 0;
+      fireEvent.scroll(timeline);
+    });
+    const remountedTarget = container.querySelector(
+      '[data-terminal-message-id="terminal-message"]'
+    );
+    expect(remountedTarget).not.toBe(firstTarget);
+    expect(observedTerminalTargets).toEqual([firstTarget, remountedTarget]);
   });
 });

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -28,6 +28,7 @@ import {
 import {
   buildTimelineVirtualRows,
   estimateTimelineRowSize,
+  TIMELINE_VIRTUALIZER_DEFAULTS,
   type TimelineVirtualRow,
 } from "@/lib/timeline-virtual-rows";
 import type { Artifact, SandboxEvent } from "@/types/session";
@@ -137,25 +138,20 @@ export function SessionTimeline({
     [virtualRows]
   );
   const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+    ...TIMELINE_VIRTUALIZER_DEFAULTS,
     count: showSkeleton ? 0 : virtualRows.length,
     getScrollElement: () => scrollContainerRef.current,
     getItemKey: getVirtualRowKey,
     estimateSize: estimateVirtualRowSize,
-    overscan: 8,
-    gap: 8,
-    paddingStart: 12,
-    paddingEnd: 8,
-    anchorTo: "end",
-    followOnAppend: "auto",
-    scrollEndThreshold: 100,
-    useAnimationFrameWithResizeObserver: true,
   });
 
   const handleScroll = useCallback(() => {
     hasScrolledRef.current = true;
     const el = scrollContainerRef.current;
     if (el) {
-      isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+      isNearBottomRef.current =
+        el.scrollHeight - el.scrollTop - el.clientHeight <
+        TIMELINE_VIRTUALIZER_DEFAULTS.scrollEndThreshold;
     }
   }, []);
 

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
 import { SessionWorkGroup } from "@/components/session-work-group";
@@ -24,6 +25,11 @@ import {
   type TimelineItem,
   type ToolCallEvent,
 } from "@/lib/timeline-items";
+import {
+  buildTimelineVirtualRows,
+  estimateTimelineRowSize,
+  type TimelineVirtualRow,
+} from "@/lib/timeline-virtual-rows";
 import type { Artifact, SandboxEvent } from "@/types/session";
 import type { SessionParticipantProfile } from "@open-inspect/shared/types/sessions";
 import { CheckIcon, CopyIcon, ErrorIcon } from "@/components/ui/icons";
@@ -70,6 +76,7 @@ export function SessionTimeline({
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
   const [expandedWorkGroups, setExpandedWorkGroups] = useState<Set<string>>(new Set());
+  const [expandedTaskSections, setExpandedTaskSections] = useState<Set<string>>(new Set());
   const latestTerminalMessageId = useMemo(() => {
     for (let index = events.length - 1; index >= 0; index -= 1) {
       const event = events[index];
@@ -100,10 +107,49 @@ export function SessionTimeline({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
-  const isPrependingRef = useRef(false);
-  const didPrependRef = useRef(false);
-  const prevScrollHeightRef = useRef(0);
   const isNearBottomRef = useRef(true);
+  const virtualRows = useMemo(
+    () =>
+      buildTimelineVirtualRows({
+        items: timelineItems,
+        pendingMessageIds,
+        terminalMessageId: onMarkMessageRead ? latestTerminalMessageId : null,
+        terminalRange: onMarkMessageRead ? latestTerminalMessageGroupRange : null,
+        loadingHistory,
+        isProcessing,
+      }),
+    [
+      isProcessing,
+      latestTerminalMessageGroupRange,
+      latestTerminalMessageId,
+      loadingHistory,
+      onMarkMessageRead,
+      pendingMessageIds,
+      timelineItems,
+    ]
+  );
+  const getVirtualRowKey = useCallback(
+    (index: number) => virtualRows[index]?.id ?? index,
+    [virtualRows]
+  );
+  const estimateVirtualRowSize = useCallback(
+    (index: number) => estimateTimelineRowSize(virtualRows[index]),
+    [virtualRows]
+  );
+  const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
+    count: showSkeleton ? 0 : virtualRows.length,
+    getScrollElement: () => scrollContainerRef.current,
+    getItemKey: getVirtualRowKey,
+    estimateSize: estimateVirtualRowSize,
+    overscan: 8,
+    gap: 8,
+    paddingStart: 12,
+    paddingEnd: 8,
+    anchorTo: "end",
+    followOnAppend: "auto",
+    scrollEndThreshold: 100,
+    useAnimationFrameWithResizeObserver: true,
+  });
 
   const handleScroll = useCallback(() => {
     hasScrolledRef.current = true;
@@ -125,8 +171,6 @@ export function SessionTimeline({
           hasScrolledRef.current &&
           container.scrollHeight > container.clientHeight
         ) {
-          prevScrollHeightRef.current = container.scrollHeight;
-          isPrependingRef.current = true;
           onLoadOlder();
         }
       },
@@ -138,19 +182,6 @@ export function SessionTimeline({
   }, [onLoadOlder]);
 
   useLayoutEffect(() => {
-    if (isPrependingRef.current && scrollContainerRef.current) {
-      const el = scrollContainerRef.current;
-      el.scrollTop += el.scrollHeight - prevScrollHeightRef.current;
-      isPrependingRef.current = false;
-      didPrependRef.current = true;
-    }
-  }, [events]);
-
-  useLayoutEffect(() => {
-    if (didPrependRef.current) {
-      didPrependRef.current = false;
-      return;
-    }
     if (isNearBottomRef.current) {
       const container = scrollContainerRef.current;
       if (container) container.scrollTop = container.scrollHeight;
@@ -189,6 +220,15 @@ export function SessionTimeline({
     });
   }, []);
 
+  const toggleTaskSection = useCallback((key: string) => {
+    setExpandedTaskSections((expanded) => {
+      const next = new Set(expanded);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
   const renderFlatItem = (item: FlatTimelineItem): ReactNode => {
     if (item.type === "tool_group") {
       return (
@@ -223,7 +263,14 @@ export function SessionTimeline({
 
   const renderBaseTimelineItem = (item: TimelineItem): ReactNode =>
     item.type === "task_group" ? (
-      <TaskActivityItem key={item.id} event={item.event} hasActivity={item.activity.length > 0}>
+      <TaskActivityItem
+        key={item.id}
+        event={item.event}
+        hasActivity={item.activity.length > 0}
+        expansionKey={item.id}
+        expandedSections={expandedTaskSections}
+        onToggleSection={toggleTaskSection}
+      >
         {item.activity.map(renderFlatItem)}
       </TaskActivityItem>
     ) : (
@@ -244,6 +291,27 @@ export function SessionTimeline({
       renderBaseTimelineItem(item)
     );
 
+  const renderVirtualRow = (row: TimelineVirtualRow): ReactNode => {
+    switch (row.type) {
+      case "loading":
+        return <div className="text-center text-muted-foreground text-sm py-2">Loading...</div>;
+      case "thinking":
+        return <ThinkingIndicator />;
+      case "terminal":
+        return (
+          <TerminalMessageReadObserver
+            messageId={row.messageId}
+            enabled={terminalMessageReadObservationEnabled}
+            onMarkMessageRead={onMarkMessageRead!}
+          >
+            {row.items.map(renderTimelineItem)}
+          </TerminalMessageReadObserver>
+        );
+      case "item":
+        return renderTimelineItem(row.item);
+    }
+  };
+
   return (
     <div
       ref={scrollContainerRef}
@@ -254,49 +322,31 @@ export function SessionTimeline({
       // ancestor overflow clip, and grow the page itself.
       className="relative h-full overflow-y-auto overflow-x-hidden p-3 sm:p-4"
     >
-      <div className="w-full min-w-0 max-w-3xl mx-auto space-y-2">
-        <div ref={topSentinelRef} className="h-1" />
-        {loadingHistory && (
-          <div className="text-center text-muted-foreground text-sm py-2">Loading...</div>
-        )}
+      <div className="w-full min-w-0 max-w-3xl mx-auto">
         {showSkeleton ? (
-          <TimelineSkeleton />
+          <>
+            <div ref={topSentinelRef} className="h-1" />
+            <TimelineSkeleton />
+          </>
         ) : (
-          timelineItems.map((item, index) => {
-            if (
-              latestTerminalMessageGroupRange &&
-              onMarkMessageRead &&
-              index === latestTerminalMessageGroupRange.start
-            ) {
+          <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+            <div ref={topSentinelRef} className="absolute left-0 top-0 h-1 w-full" />
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const row = virtualRows[virtualRow.index];
               return (
-                <TerminalMessageReadObserver
-                  key={`terminal-message-${latestTerminalMessageId}`}
-                  messageId={latestTerminalMessageId!}
-                  enabled={terminalMessageReadObservationEnabled}
-                  onMarkMessageRead={onMarkMessageRead}
+                <div
+                  key={virtualRow.key}
+                  ref={rowVirtualizer.measureElement}
+                  data-index={virtualRow.index}
+                  className="absolute left-0 top-0 w-full"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
                 >
-                  {timelineItems
-                    .slice(
-                      latestTerminalMessageGroupRange.start,
-                      latestTerminalMessageGroupRange.end + 1
-                    )
-                    .map(renderTimelineItem)}
-                </TerminalMessageReadObserver>
+                  {renderVirtualRow(row)}
+                </div>
               );
-            }
-            if (
-              latestTerminalMessageGroupRange &&
-              onMarkMessageRead &&
-              index > latestTerminalMessageGroupRange.start &&
-              index <= latestTerminalMessageGroupRange.end
-            ) {
-              return null;
-            }
-            return renderTimelineItem(item);
-          })
+            })}
+          </div>
         )}
-        {isProcessing && <ThinkingIndicator />}
-        <div />
       </div>
     </div>
   );

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -322,15 +322,12 @@ export function SessionTimeline({
       // ancestor overflow clip, and grow the page itself.
       className="relative h-full overflow-y-auto overflow-x-hidden p-3 sm:p-4"
     >
-      <div className="w-full min-w-0 max-w-3xl mx-auto">
+      <div className="relative w-full min-w-0 max-w-3xl mx-auto">
+        <div ref={topSentinelRef} className="absolute left-0 top-0 h-1 w-full" />
         {showSkeleton ? (
-          <>
-            <div ref={topSentinelRef} className="h-1" />
-            <TimelineSkeleton />
-          </>
+          <TimelineSkeleton />
         ) : (
           <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
-            <div ref={topSentinelRef} className="absolute left-0 top-0 h-1 w-full" />
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
               const row = virtualRows[virtualRow.index];
               return (

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -20,8 +20,11 @@ import { ToolCallGroup } from "@/components/tool-call-group";
 import { copyToClipboard } from "@/lib/format";
 import {
   buildSessionTimelineItems,
+  isRenderableTimelineEvent,
   toolCallKey,
+  type DirectTimelineEventType,
   type FlatTimelineItem,
+  type RenderableTimelineEvent,
   type TimelineItem,
   type ToolCallEvent,
 } from "@/lib/timeline-items";
@@ -66,13 +69,16 @@ export function SessionTimeline({
   terminalMessageReadObservationEnabled?: boolean;
   onMarkMessageRead?: (messageId: string) => Promise<SessionReadAttemptDisposition>;
 }) {
-  const timelineItems = useMemo(() => buildSessionTimelineItems(events), [events]);
   const pendingMessageIds = useMemo(
     () =>
       new Set(
         promptQueue.filter((item) => item.status === "pending").map((item) => item.messageId)
       ),
     [promptQueue]
+  );
+  const timelineItems = useMemo(
+    () => buildSessionTimelineItems(events, pendingMessageIds),
+    [events, pendingMessageIds]
   );
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
@@ -85,26 +91,6 @@ export function SessionTimeline({
     }
     return null;
   }, [events]);
-  const latestTerminalMessageGroupRange = useMemo(() => {
-    if (!latestTerminalMessageId) return null;
-    const completionIndex = timelineItems.findIndex(
-      (item) =>
-        item.type === "single" &&
-        item.event.type === "execution_complete" &&
-        item.event.messageId === latestTerminalMessageId
-    );
-    if (completionIndex < 0) return null;
-    const outputIndex = timelineItems.findIndex(
-      (item) =>
-        item.type === "single" &&
-        item.event.type === "token" &&
-        item.event.messageId === latestTerminalMessageId
-    );
-    return {
-      start: outputIndex >= 0 ? Math.min(outputIndex, completionIndex) : completionIndex,
-      end: Math.max(outputIndex, completionIndex),
-    };
-  }, [timelineItems, latestTerminalMessageId]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
@@ -113,21 +99,11 @@ export function SessionTimeline({
     () =>
       buildTimelineVirtualRows({
         items: timelineItems,
-        pendingMessageIds,
         terminalMessageId: onMarkMessageRead ? latestTerminalMessageId : null,
-        terminalRange: onMarkMessageRead ? latestTerminalMessageGroupRange : null,
         loadingHistory,
         isProcessing,
       }),
-    [
-      isProcessing,
-      latestTerminalMessageGroupRange,
-      latestTerminalMessageId,
-      loadingHistory,
-      onMarkMessageRead,
-      pendingMessageIds,
-      timelineItems,
-    ]
+    [isProcessing, latestTerminalMessageId, loadingHistory, onMarkMessageRead, timelineItems]
   );
   const getVirtualRowKey = useCallback(
     (index: number) => virtualRows[index]?.id ?? index,
@@ -238,13 +214,6 @@ export function SessionTimeline({
         />
       );
     }
-    if (
-      item.event.type === "user_message" &&
-      item.event.messageId &&
-      pendingMessageIds.has(item.event.messageId)
-    ) {
-      return null;
-    }
     return (
       <EventItem
         key={item.id}
@@ -294,11 +263,12 @@ export function SessionTimeline({
       case "thinking":
         return <ThinkingIndicator />;
       case "terminal":
+        if (!onMarkMessageRead) return row.items.map(renderTimelineItem);
         return (
           <TerminalMessageReadObserver
             messageId={row.messageId}
             enabled={terminalMessageReadObservationEnabled}
-            onMarkMessageRead={onMarkMessageRead!}
+            onMarkMessageRead={onMarkMessageRead}
           >
             {row.items.map(renderTimelineItem)}
           </TerminalMessageReadObserver>
@@ -375,7 +345,7 @@ function TimelineSkeleton() {
 }
 
 type EventRendererProps = {
-  event: SandboxEvent;
+  event: RenderableTimelineEvent;
   sessionId: string;
   currentParticipantId: string | null;
   participantProfiles: Record<string, SessionParticipantProfile>;
@@ -518,7 +488,6 @@ function UserMessageEvent({
 }: EventRendererProps) {
   if (event.type !== "user_message") return null;
   const attachments = event.attachments ?? [];
-  if (!event.content && attachments.length === 0) return null;
 
   const isCurrentUser =
     event.author?.participantId && currentParticipantId
@@ -582,7 +551,7 @@ function UserMessageEvent({
 }
 
 function AssistantMessageEvent({ event, copied, onCopyContent }: EventRendererProps) {
-  if (event.type !== "token" || !event.content) return null;
+  if (event.type !== "token") return null;
 
   return (
     <MessageFrame
@@ -600,7 +569,7 @@ function AssistantMessageEvent({ event, copied, onCopyContent }: EventRendererPr
 }
 
 function ToolResultEvent({ event }: EventRendererProps) {
-  if (event.type !== "tool_result" || !event.error) return null;
+  if (event.type !== "tool_result") return null;
 
   return (
     <div className="flex min-w-0 items-start gap-2 py-1 text-sm text-destructive">
@@ -621,13 +590,7 @@ function GitSyncEvent({ event }: EventRendererProps) {
 }
 
 function ArtifactEvent({ event, sessionId, onOpenMedia }: EventRendererProps) {
-  if (
-    event.type !== "artifact" ||
-    (event.artifactType !== "screenshot" && event.artifactType !== "video") ||
-    !event.artifactId
-  ) {
-    return null;
-  }
+  if (event.type !== "artifact") return null;
 
   return (
     <div className="space-y-2 border border-border-muted bg-card p-3 sm:p-4">
@@ -702,9 +665,7 @@ function formatEventTime(event: SandboxEvent): string {
   return new Date(event.timestamp * 1000).toLocaleTimeString();
 }
 
-const eventRenderers: Partial<
-  Record<SandboxEvent["type"], (props: EventRendererProps) => ReactNode>
-> = {
+const eventRenderers = {
   user_message: UserMessageEvent,
   token: AssistantMessageEvent,
   tool_result: ToolResultEvent,
@@ -714,7 +675,7 @@ const eventRenderers: Partial<
   warning: WarningEvent,
   execution_complete: ExecutionCompleteEvent,
   context_compacted: ContextCompactedEvent,
-};
+} satisfies Record<DirectTimelineEventType, (props: EventRendererProps) => ReactNode>;
 
 export const EventItem = memo(function EventItem({
   event,
@@ -754,8 +715,8 @@ export const EventItem = memo(function EventItem({
     }, 1500);
   }, []);
 
+  if (!isRenderableTimelineEvent(event) || event.type === "tool_call") return null;
   const render = eventRenderers[event.type];
-  if (!render) return null;
 
   return render({
     event,

--- a/packages/web/src/components/task-activity-item.test.tsx
+++ b/packages/web/src/components/task-activity-item.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ToolCallEvent } from "@/lib/timeline-items";
 import { TaskActivityItem } from "./task-activity-item";
 
@@ -24,7 +24,13 @@ describe("TaskActivityItem", () => {
     };
 
     render(
-      <TaskActivityItem event={event} hasActivity={false}>
+      <TaskActivityItem
+        event={event}
+        hasActivity={false}
+        expansionKey="task-1"
+        expandedSections={new Set()}
+        onToggleSection={vi.fn()}
+      >
         {null}
       </TaskActivityItem>
     );

--- a/packages/web/src/components/task-activity-item.tsx
+++ b/packages/web/src/components/task-activity-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { formatSessionEventTime } from "@/lib/time";
 import { formatToolCall } from "@/lib/tool-formatters";
 import type { ToolCallEvent } from "@/lib/timeline-items";
@@ -22,15 +22,23 @@ function cleanTaskResult(output: string | undefined): string | null {
   return envelope ? envelope[2].trim() : output;
 }
 
-function TaskDisclosure({ label, content }: { label: string; content: string }) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
+function TaskDisclosure({
+  label,
+  content,
+  isExpanded,
+  onToggle,
+}: {
+  label: string;
+  content: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
   return (
     <div className="border border-border-muted bg-card overflow-hidden">
       <button
         type="button"
         aria-expanded={isExpanded}
-        onClick={() => setIsExpanded((expanded) => !expanded)}
+        onClick={onToggle}
         className="w-full flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-left text-muted-foreground hover:text-foreground transition-colors"
       >
         <ChevronRightIcon
@@ -53,12 +61,19 @@ export function TaskActivityItem({
   event,
   hasActivity,
   children,
+  expansionKey,
+  expandedSections,
+  onToggleSection,
 }: {
   event: ToolCallEvent;
   hasActivity: boolean;
   children: ReactNode;
+  expansionKey: string;
+  expandedSections: ReadonlySet<string>;
+  onToggleSection: (key: string) => void;
 }) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const sectionKey = (section: "task" | "instructions" | "result") => `${expansionKey}:${section}`;
+  const isExpanded = expandedSections.has(sectionKey("task"));
   const formatted = formatToolCall(event);
   const prompt = stringArg(event, "prompt");
   const agent = stringArg(event, "subagent_type");
@@ -70,7 +85,7 @@ export function TaskActivityItem({
       <button
         type="button"
         aria-expanded={isExpanded}
-        onClick={() => setIsExpanded((expanded) => !expanded)}
+        onClick={() => onToggleSection(sectionKey("task"))}
         className="flex w-full min-w-0 items-start gap-1.5 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         <ChevronRightIcon
@@ -111,8 +126,22 @@ export function TaskActivityItem({
               {children}
             </div>
           )}
-          {prompt && <TaskDisclosure label="Instructions" content={prompt} />}
-          {result && <TaskDisclosure label="Result" content={result} />}
+          {prompt && (
+            <TaskDisclosure
+              label="Instructions"
+              content={prompt}
+              isExpanded={expandedSections.has(sectionKey("instructions"))}
+              onToggle={() => onToggleSection(sectionKey("instructions"))}
+            />
+          )}
+          {result && (
+            <TaskDisclosure
+              label="Result"
+              content={result}
+              isExpanded={expandedSections.has(sectionKey("result"))}
+              onToggle={() => onToggleSection(sectionKey("result"))}
+            />
+          )}
         </div>
       )}
     </div>

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -45,7 +45,7 @@ function groupFlatEvents(events: SandboxEvent[]): FlatTimelineItem[] {
     groups.push({
       type: "tool_group",
       events: tools,
-      id: `tools:${eventKey(tools[0])}`,
+      id: `tools:${eventKey(tools[tools.length - 1])}`,
     });
     tools = [];
   };

--- a/packages/web/src/lib/timeline-items.ts
+++ b/packages/web/src/lib/timeline-items.ts
@@ -21,6 +21,44 @@ export type SessionTimelineItem =
       id: string;
     };
 
+const directTimelineEventEligibility = {
+  user_message: (event: SandboxEvent) =>
+    event.type === "user_message" && Boolean(event.content || event.attachments?.length),
+  token: (event: SandboxEvent) => event.type === "token" && Boolean(event.content),
+  tool_result: (event: SandboxEvent) => event.type === "tool_result" && Boolean(event.error),
+  git_sync: () => true,
+  artifact: (event: SandboxEvent) =>
+    event.type === "artifact" &&
+    (event.artifactType === "screenshot" || event.artifactType === "video") &&
+    Boolean(event.artifactId),
+  error: () => true,
+  warning: () => true,
+  execution_complete: () => true,
+  context_compacted: () => true,
+} satisfies Partial<Record<SandboxEvent["type"], (event: SandboxEvent) => boolean>>;
+
+export type DirectTimelineEventType = keyof typeof directTimelineEventEligibility;
+export type RenderableTimelineEvent =
+  | Extract<SandboxEvent, { type: Exclude<DirectTimelineEventType, "artifact"> }>
+  | (Extract<SandboxEvent, { type: "artifact" }> & {
+      artifactId: string;
+      artifactType: "screenshot" | "video";
+    });
+
+const NO_PENDING_MESSAGES: ReadonlySet<string> = new Set();
+
+export function isRenderableTimelineEvent(
+  event: SandboxEvent,
+  pendingMessageIds: ReadonlySet<string> = NO_PENDING_MESSAGES
+): event is RenderableTimelineEvent | ToolCallEvent {
+  if (event.type === "tool_call") return true;
+  if (event.type === "user_message" && event.messageId && pendingMessageIds.has(event.messageId)) {
+    return false;
+  }
+  const eligibility = directTimelineEventEligibility[event.type as DirectTimelineEventType];
+  return eligibility?.(event) ?? false;
+}
+
 export function toolCallKey(event: ToolCallEvent): string {
   return toolCallIdentityKey(event);
 }
@@ -160,8 +198,13 @@ export function buildTimelineItems(events: SandboxEvent[]): TimelineItem[] {
  * Collapses completed turn activity while leaving in-flight and partial-history
  * events in their existing flat presentation.
  */
-export function buildSessionTimelineItems(events: SandboxEvent[]): SessionTimelineItem[] {
-  const items = buildTimelineItems(events);
+export function buildSessionTimelineItems(
+  events: SandboxEvent[],
+  pendingMessageIds: ReadonlySet<string> = NO_PENDING_MESSAGES
+): SessionTimelineItem[] {
+  const items = buildTimelineItems(
+    events.filter((event) => isRenderableTimelineEvent(event, pendingMessageIds))
+  );
   const result: SessionTimelineItem[] = [];
 
   for (let index = 0; index < items.length; index += 1) {

--- a/packages/web/src/lib/timeline-virtual-rows.test.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { SandboxEvent } from "@/types/session";
-import { buildTimelineItems, type SessionTimelineItem } from "./timeline-items";
+import {
+  buildSessionTimelineItems,
+  buildTimelineItems,
+  type SessionTimelineItem,
+} from "./timeline-items";
 import {
   buildTimelineVirtualRows,
   estimateTimelineRowSize,
@@ -14,28 +18,29 @@ function single(event: SandboxEvent): SessionTimelineItem {
 describe("buildTimelineVirtualRows", () => {
   it("excludes events that do not render and pending user messages", () => {
     const rows = buildTimelineVirtualRows({
-      items: [
-        single({ type: "heartbeat", sandboxId: "sandbox", timestamp: 1, status: "ready" }),
-        single({
-          type: "tool_result",
-          sandboxId: "sandbox",
-          messageId: "message",
-          timestamp: 2,
-          callId: "call",
-          result: "ok",
-        }),
-        single({ type: "user_message", messageId: "pending", timestamp: 3, content: "queued" }),
-        single({ type: "warning", timestamp: 4, scope: "setup", message: "visible" }),
-      ],
-      pendingMessageIds: new Set(["pending"]),
+      items: buildSessionTimelineItems(
+        [
+          { type: "heartbeat", sandboxId: "sandbox", timestamp: 1, status: "ready" },
+          {
+            type: "tool_result",
+            sandboxId: "sandbox",
+            messageId: "message",
+            timestamp: 2,
+            callId: "call",
+            result: "ok",
+          },
+          { type: "user_message", messageId: "pending", timestamp: 3, content: "queued" },
+          { type: "warning", timestamp: 4, scope: "setup", message: "visible" },
+        ],
+        new Set(["pending"])
+      ),
       terminalMessageId: null,
-      terminalRange: null,
       loadingHistory: false,
       isProcessing: false,
     });
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ type: "item", item: { id: "warning:4" } });
+    expect(rows[0]).toMatchObject({ type: "item", item: { id: "warning:session:4" } });
   });
 
   it("coalesces the terminal output and completion into one row", () => {
@@ -57,9 +62,7 @@ describe("buildTimelineVirtualRows", () => {
     ];
     const rows = buildTimelineVirtualRows({
       items,
-      pendingMessageIds: new Set(),
       terminalMessageId: "message",
-      terminalRange: { start: 0, end: 1 },
       loadingHistory: true,
       isProcessing: true,
     });

--- a/packages/web/src/lib/timeline-virtual-rows.test.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SandboxEvent } from "@/types/session";
 import { buildTimelineItems, type SessionTimelineItem } from "./timeline-items";
-import { buildTimelineVirtualRows, estimateTimelineRowSize } from "./timeline-virtual-rows";
+import {
+  buildTimelineVirtualRows,
+  estimateTimelineRowSize,
+  TIMELINE_ROW_SIZE_ESTIMATES,
+} from "./timeline-virtual-rows";
 
 function single(event: SandboxEvent): SessionTimelineItem {
   return { type: "single", event, id: `${event.type}:${event.timestamp}` };
@@ -62,7 +66,7 @@ describe("buildTimelineVirtualRows", () => {
 
     expect(rows.map((row) => row.type)).toEqual(["loading", "terminal", "thinking"]);
     expect(rows[1]).toMatchObject({ type: "terminal", items });
-    expect(estimateTimelineRowSize(rows[1])).toBe(220);
+    expect(estimateTimelineRowSize(rows[1])).toBe(TIMELINE_ROW_SIZE_ESTIMATES.terminal);
   });
 });
 

--- a/packages/web/src/lib/timeline-virtual-rows.test.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { SandboxEvent } from "@/types/session";
+import { buildTimelineItems, type SessionTimelineItem } from "./timeline-items";
+import { buildTimelineVirtualRows, estimateTimelineRowSize } from "./timeline-virtual-rows";
+
+function single(event: SandboxEvent): SessionTimelineItem {
+  return { type: "single", event, id: `${event.type}:${event.timestamp}` };
+}
+
+describe("buildTimelineVirtualRows", () => {
+  it("excludes events that do not render and pending user messages", () => {
+    const rows = buildTimelineVirtualRows({
+      items: [
+        single({ type: "heartbeat", sandboxId: "sandbox", timestamp: 1, status: "ready" }),
+        single({
+          type: "tool_result",
+          sandboxId: "sandbox",
+          messageId: "message",
+          timestamp: 2,
+          callId: "call",
+          result: "ok",
+        }),
+        single({ type: "user_message", messageId: "pending", timestamp: 3, content: "queued" }),
+        single({ type: "warning", timestamp: 4, scope: "setup", message: "visible" }),
+      ],
+      pendingMessageIds: new Set(["pending"]),
+      terminalMessageId: null,
+      terminalRange: null,
+      loadingHistory: false,
+      isProcessing: false,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ type: "item", item: { id: "warning:4" } });
+  });
+
+  it("coalesces the terminal output and completion into one row", () => {
+    const items = [
+      single({
+        type: "token",
+        sandboxId: "sandbox",
+        messageId: "message",
+        timestamp: 1,
+        content: "Done",
+      }),
+      single({
+        type: "execution_complete",
+        sandboxId: "sandbox",
+        messageId: "message",
+        timestamp: 2,
+        success: true,
+      }),
+    ];
+    const rows = buildTimelineVirtualRows({
+      items,
+      pendingMessageIds: new Set(),
+      terminalMessageId: "message",
+      terminalRange: { start: 0, end: 1 },
+      loadingHistory: true,
+      isProcessing: true,
+    });
+
+    expect(rows.map((row) => row.type)).toEqual(["loading", "terminal", "thinking"]);
+    expect(rows[1]).toMatchObject({ type: "terminal", items });
+    expect(estimateTimelineRowSize(rows[1])).toBe(220);
+  });
+});
+
+describe("tool group identity", () => {
+  it("stays stable when older calls merge into the first group", () => {
+    const tool = (callId: string, timestamp: number): SandboxEvent => ({
+      type: "tool_call",
+      sandboxId: "sandbox",
+      messageId: "message",
+      timestamp,
+      callId,
+      tool: "Read",
+      args: {},
+    });
+    const existing = buildTimelineItems([tool("newer", 2)])[0];
+    const prepended = buildTimelineItems([tool("older", 1), tool("newer", 2)])[0];
+
+    expect(prepended.id).toBe(existing.id);
+  });
+});

--- a/packages/web/src/lib/timeline-virtual-rows.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.ts
@@ -7,6 +7,27 @@ export type TimelineVirtualRow =
   | { type: "loading"; id: string }
   | { type: "thinking"; id: string };
 
+export const TIMELINE_ROW_SIZE_ESTIMATES = {
+  status: 40,
+  terminal: 220,
+  group: 44,
+  assistantMessage: 180,
+  userMessage: 100,
+  artifact: 420,
+  default: 36,
+} as const;
+
+export const TIMELINE_VIRTUALIZER_DEFAULTS = {
+  overscan: 8,
+  gap: 8,
+  paddingStart: 12,
+  paddingEnd: 8,
+  anchorTo: "end",
+  followOnAppend: "auto",
+  scrollEndThreshold: 100,
+  useAnimationFrameWithResizeObserver: true,
+} as const;
+
 export function buildTimelineVirtualRows({
   items,
   pendingMessageIds,
@@ -48,19 +69,21 @@ export function buildTimelineVirtualRows({
 }
 
 export function estimateTimelineRowSize(row: TimelineVirtualRow): number {
-  if (row.type === "loading" || row.type === "thinking") return 40;
-  if (row.type === "terminal") return 220;
-  if (row.item.type !== "single") return 44;
+  if (row.type === "loading" || row.type === "thinking") {
+    return TIMELINE_ROW_SIZE_ESTIMATES.status;
+  }
+  if (row.type === "terminal") return TIMELINE_ROW_SIZE_ESTIMATES.terminal;
+  if (row.item.type !== "single") return TIMELINE_ROW_SIZE_ESTIMATES.group;
 
   switch (row.item.event.type) {
     case "token":
-      return 180;
+      return TIMELINE_ROW_SIZE_ESTIMATES.assistantMessage;
     case "user_message":
-      return 100;
+      return TIMELINE_ROW_SIZE_ESTIMATES.userMessage;
     case "artifact":
-      return 420;
+      return TIMELINE_ROW_SIZE_ESTIMATES.artifact;
     default:
-      return 36;
+      return TIMELINE_ROW_SIZE_ESTIMATES.default;
   }
 }
 

--- a/packages/web/src/lib/timeline-virtual-rows.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.ts
@@ -1,4 +1,3 @@
-import type { SandboxEvent } from "@/types/session";
 import type { SessionTimelineItem } from "./timeline-items";
 
 export type TimelineVirtualRow =
@@ -30,42 +29,63 @@ export const TIMELINE_VIRTUALIZER_DEFAULTS = {
 
 export function buildTimelineVirtualRows({
   items,
-  pendingMessageIds,
   terminalMessageId,
-  terminalRange,
   loadingHistory,
   isProcessing,
 }: {
   items: SessionTimelineItem[];
-  pendingMessageIds: ReadonlySet<string>;
   terminalMessageId: string | null;
-  terminalRange: { start: number; end: number } | null;
   loadingHistory: boolean;
   isProcessing: boolean;
 }): TimelineVirtualRow[] {
   const rows: TimelineVirtualRow[] = [];
   if (loadingHistory) rows.push({ type: "loading", id: "history-loading" });
+  const terminal = terminalMessageId ? findTerminalMessageRange(items, terminalMessageId) : null;
 
   for (let index = 0; index < items.length; index += 1) {
-    if (terminalMessageId && terminalRange && index === terminalRange.start) {
+    if (terminal && index === terminal.start) {
       rows.push({
         type: "terminal",
-        id: `terminal:${terminalMessageId}`,
-        messageId: terminalMessageId,
-        items: items.slice(terminalRange.start, terminalRange.end + 1),
+        id: `terminal:${terminal.messageId}`,
+        messageId: terminal.messageId,
+        items: items.slice(terminal.start, terminal.end + 1),
       });
-      index = terminalRange.end;
+      index = terminal.end;
       continue;
     }
 
     const item = items[index];
-    if (isRenderableTimelineItem(item, pendingMessageIds)) {
-      rows.push({ type: "item", id: `item:${item.id}`, item });
-    }
+    rows.push({ type: "item", id: `item:${item.id}`, item });
   }
 
   if (isProcessing) rows.push({ type: "thinking", id: "thinking" });
   return rows;
+}
+
+function findTerminalMessageRange(
+  items: SessionTimelineItem[],
+  messageId: string
+): { messageId: string; start: number; end: number } | null {
+  const end = items.findIndex(
+    (item) =>
+      item.type === "single" &&
+      item.event.type === "execution_complete" &&
+      item.event.messageId === messageId
+  );
+  if (end < 0) return null;
+
+  let start = end;
+  for (let index = 0; index < end; index += 1) {
+    const item = items[index];
+    if (
+      item.type === "single" &&
+      item.event.type === "token" &&
+      item.event.messageId === messageId
+    ) {
+      start = index;
+    }
+  }
+  return { messageId, start, end };
 }
 
 export function estimateTimelineRowSize(row: TimelineVirtualRow): number {
@@ -84,41 +104,5 @@ export function estimateTimelineRowSize(row: TimelineVirtualRow): number {
       return TIMELINE_ROW_SIZE_ESTIMATES.artifact;
     default:
       return TIMELINE_ROW_SIZE_ESTIMATES.default;
-  }
-}
-
-function isRenderableTimelineItem(
-  item: SessionTimelineItem,
-  pendingMessageIds: ReadonlySet<string>
-): boolean {
-  if (item.type !== "single") return true;
-  const event = item.event;
-  if (event.type === "user_message" && event.messageId && pendingMessageIds.has(event.messageId)) {
-    return false;
-  }
-  return isRenderableEvent(event);
-}
-
-function isRenderableEvent(event: SandboxEvent): boolean {
-  switch (event.type) {
-    case "user_message":
-      return Boolean(event.content || event.attachments?.length);
-    case "token":
-      return Boolean(event.content);
-    case "tool_result":
-      return Boolean(event.error);
-    case "artifact":
-      return (
-        (event.artifactType === "screenshot" || event.artifactType === "video") &&
-        Boolean(event.artifactId)
-      );
-    case "git_sync":
-    case "error":
-    case "warning":
-    case "execution_complete":
-    case "context_compacted":
-      return true;
-    default:
-      return false;
   }
 }

--- a/packages/web/src/lib/timeline-virtual-rows.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.ts
@@ -1,0 +1,101 @@
+import type { SandboxEvent } from "@/types/session";
+import type { SessionTimelineItem } from "./timeline-items";
+
+export type TimelineVirtualRow =
+  | { type: "item"; id: string; item: SessionTimelineItem }
+  | { type: "terminal"; id: string; messageId: string; items: SessionTimelineItem[] }
+  | { type: "loading"; id: string }
+  | { type: "thinking"; id: string };
+
+export function buildTimelineVirtualRows({
+  items,
+  pendingMessageIds,
+  terminalMessageId,
+  terminalRange,
+  loadingHistory,
+  isProcessing,
+}: {
+  items: SessionTimelineItem[];
+  pendingMessageIds: ReadonlySet<string>;
+  terminalMessageId: string | null;
+  terminalRange: { start: number; end: number } | null;
+  loadingHistory: boolean;
+  isProcessing: boolean;
+}): TimelineVirtualRow[] {
+  const rows: TimelineVirtualRow[] = [];
+  if (loadingHistory) rows.push({ type: "loading", id: "history-loading" });
+
+  for (let index = 0; index < items.length; index += 1) {
+    if (terminalMessageId && terminalRange && index === terminalRange.start) {
+      rows.push({
+        type: "terminal",
+        id: `terminal:${terminalMessageId}`,
+        messageId: terminalMessageId,
+        items: items.slice(terminalRange.start, terminalRange.end + 1),
+      });
+      index = terminalRange.end;
+      continue;
+    }
+
+    const item = items[index];
+    if (isRenderableTimelineItem(item, pendingMessageIds)) {
+      rows.push({ type: "item", id: `item:${item.id}`, item });
+    }
+  }
+
+  if (isProcessing) rows.push({ type: "thinking", id: "thinking" });
+  return rows;
+}
+
+export function estimateTimelineRowSize(row: TimelineVirtualRow): number {
+  if (row.type === "loading" || row.type === "thinking") return 40;
+  if (row.type === "terminal") return 220;
+  if (row.item.type !== "single") return 44;
+
+  switch (row.item.event.type) {
+    case "token":
+      return 180;
+    case "user_message":
+      return 100;
+    case "artifact":
+      return 420;
+    default:
+      return 36;
+  }
+}
+
+function isRenderableTimelineItem(
+  item: SessionTimelineItem,
+  pendingMessageIds: ReadonlySet<string>
+): boolean {
+  if (item.type !== "single") return true;
+  const event = item.event;
+  if (event.type === "user_message" && event.messageId && pendingMessageIds.has(event.messageId)) {
+    return false;
+  }
+  return isRenderableEvent(event);
+}
+
+function isRenderableEvent(event: SandboxEvent): boolean {
+  switch (event.type) {
+    case "user_message":
+      return Boolean(event.content || event.attachments?.length);
+    case "token":
+      return Boolean(event.content);
+    case "tool_result":
+      return Boolean(event.error);
+    case "artifact":
+      return (
+        (event.artifactType === "screenshot" || event.artifactType === "video") &&
+        Boolean(event.artifactId)
+      );
+    case "git_sync":
+    case "error":
+    case "warning":
+    case "execution_complete":
+    case "context_compacted":
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
## Summary
- virtualize session timeline rows with TanStack Virtual and dynamic element measurement
- preserve history prepend anchoring, near-bottom append following, terminal read observation, and expansion state across row unmounts
- build a renderable row model that excludes hidden events and coalesces terminal output/completion
- stabilize tool group identity when older history is prepended
- add bounded-DOM and row-model regression coverage

## Performance validation
A temporary local route rendered 25,000 source events in a 1512x982 browser viewport:
- 22 virtual rows mounted
- 252 total DOM elements
- initial position opened at the latest turn
- scrolling to the first turn worked
- document height remained constrained to the viewport

The temporary validation route and benchmark tooling are not included in this PR.

## Verification
- `npm test -w @open-inspect/web` (165 files, 1,278 tests)
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `NODE_ENV=production npm run build -w @open-inspect/web`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ba5b7c0d26d8e9234dd5cd821eb9ab18)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session timeline performance by rendering only visible events, including large histories.
  * Added collapsible sections for task details, instructions, and results.
  * Improved handling of loading, processing, and terminal states.

* **Bug Fixes**
  * Preserved tool-group identity when older events are added.
  * Improved timeline scrolling and loading behavior when viewing earlier history.
  * Ensured older-history loading remains available after timeline placeholders disappear.
  * Prevented incomplete or pending events from appearing in the timeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->