### PR TITLE
refactor(control-plane): collapse image-build indirection

### DIFF
--- a/packages/control-plane/src/db/image-build-finalization.ts
+++ b/packages/control-plane/src/db/image-build-finalization.ts
@@ -23,8 +23,6 @@ interface CallbackTokenRow {
 export type ImageBuildCompletionAcceptance = "accepted" | "replayed" | "rejected";
 
 /** Whether callback credentials are fresh or belong to an accepted replay. */
-export type ImageBuildCallbackAuthorization = "fresh" | "accepted";
-
 /** Internal columns required to resume Queue finalization and session cleanup. */
 export interface ImageBuildFinalizationRow {
   id: string;
@@ -172,10 +170,7 @@ export class ImageBuildFinalizationStore {
     providerSessionId: string;
     tokenHash: string;
     now: number;
-  }): Promise<{
-    authorization: ImageBuildCallbackAuthorization;
-    build: ImageBuildCallbackBuild;
-  } | null> {
+  }): Promise<ImageBuildCallbackBuild | null> {
     const row = await this.readCallbackTokenRowByBuildId(params.buildId);
     if (!row || !row.callback_token_hash) return null;
     if (!timingSafeEqual(row.callback_token_hash, params.tokenHash)) return null;
@@ -185,12 +180,13 @@ export class ImageBuildFinalizationStore {
       id: row.id,
       scope: { kind: row.scope_kind, id: row.scope_id },
       provider: row.provider,
-      providerSessionId: row.provider_session_id,
       status: row.status,
     };
 
+    // An already-accepted callback (used token + persisted completion hash)
+    // stays authorizable so a lost HTTP response can republish safely.
     if (row.callback_token_used_at !== null && row.completion_hash) {
-      return { authorization: "accepted", build };
+      return build;
     }
     if (
       row.status === "building" &&
@@ -198,7 +194,7 @@ export class ImageBuildFinalizationStore {
       row.callback_token_expires_at !== null &&
       row.callback_token_expires_at >= params.now
     ) {
-      return { authorization: "fresh", build };
+      return build;
     }
     return null;
   }

--- a/packages/control-plane/src/image-builds/callback-auth.ts
+++ b/packages/control-plane/src/image-builds/callback-auth.ts
@@ -3,10 +3,9 @@
  *
  * Every build callback authenticates with the single-use bearer token minted
  * at trigger time; only its HMAC hash is stored on the build row. The store
- * additionally binds every token to the exact provider session.
- *
- * Helpers here are log-free and throw ImageBuildCallbackAuthError; callers
- * (the workflow) log and map to the route-facing error taxonomy.
+ * additionally binds every token to the exact provider session. Helpers here
+ * are log-free; the workflow logs failures and maps them to the route-facing
+ * error taxonomy.
  */
 
 import { computeHmacHex } from "@open-inspect/shared/auth";
@@ -57,14 +56,3 @@ export function getImageBuildCallbackBearerToken(request: Request): string | nul
  * callback-token pepper bound).
  */
 export type ImageBuildCallbackAuthFailure = "rejected" | "misconfigured";
-
-export class ImageBuildCallbackAuthError extends Error {
-  constructor(
-    readonly failure: ImageBuildCallbackAuthFailure,
-    message: string,
-    cause?: unknown
-  ) {
-    super(message, cause === undefined ? undefined : { cause });
-    this.name = "ImageBuildCallbackAuthError";
-  }
-}

--- a/packages/control-plane/src/image-builds/errors.ts
+++ b/packages/control-plane/src/image-builds/errors.ts
@@ -71,3 +71,8 @@ export class ImageBuildCompletionNotAcceptedError extends ImageBuildError {
 export class ImageBuildFailureNotAcceptedError extends ImageBuildError {
   readonly code = "failure_not_accepted";
 }
+
+/** The message of an unknown thrown value. */
+export function errorMessage(errorValue: unknown): string {
+  return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -19,15 +19,12 @@ export interface ImageBuildFinalizationQueue {
   send(job: ImageBuildFinalizationJob): Promise<unknown>;
 }
 
-/**
- * Rebuilds the Queue command for a completion that was already accepted and
- * persisted on the row (the cron republish path).
- */
-export function republishedImageBuildFinalizationJob(row: {
-  id: string;
-  completion_hash: string;
-}): ImageBuildFinalizationJob {
-  return { version: 1, buildId: row.id, completionHash: row.completion_hash };
+/** The one constructor of the versioned Queue command shape. */
+export function imageBuildFinalizationJob(
+  buildId: string,
+  completionHash: string
+): ImageBuildFinalizationJob {
+  return { version: 1, buildId, completionHash };
 }
 
 type FinalizationOutcome =
@@ -83,5 +80,5 @@ export async function createImageBuildFinalizationJob(
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
 
-  return { version: 1, buildId, completionHash };
+  return imageBuildFinalizationJob(buildId, completionHash);
 }

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -10,9 +10,24 @@ export const imageBuildFinalizationJobSchema = z.object({
 
 export type ImageBuildFinalizationJob = z.infer<typeof imageBuildFinalizationJobSchema>;
 
-/** Minimal producer boundary used by callback workflows. */
+/**
+ * Minimal producer boundary used by callback workflows, satisfied directly by
+ * the Queue binding. The send response is never consumed — callers only await
+ * delivery.
+ */
 export interface ImageBuildFinalizationQueue {
-  send(job: ImageBuildFinalizationJob): Promise<void>;
+  send(job: ImageBuildFinalizationJob): Promise<unknown>;
+}
+
+/**
+ * Rebuilds the Queue command for a completion that was already accepted and
+ * persisted on the row (the cron republish path).
+ */
+export function republishedImageBuildFinalizationJob(row: {
+  id: string;
+  completion_hash: string;
+}): ImageBuildFinalizationJob {
+  return { version: 1, buildId: row.id, completionHash: row.completion_hash };
 }
 
 type FinalizationOutcome =

--- a/packages/control-plane/src/image-builds/finalizer.test.ts
+++ b/packages/control-plane/src/image-builds/finalizer.test.ts
@@ -3,11 +3,8 @@ import type { ImageBuildFinalizationRow } from "../db/image-build-finalization";
 import type { ImageBuildStore } from "../db/image-builds";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
 import type { FinalizeImageBuildInput } from "./types";
-import {
-  IMAGE_BUILD_PROVIDER_ATTEMPT_MS,
-  ImageBuildFinalizationAttemptError,
-  ImageBuildFinalizer,
-} from "./finalizer";
+import { ImageBuildFinalizationAttemptError } from "./finalization-error";
+import { IMAGE_BUILD_PROVIDER_ATTEMPT_MS, ImageBuildFinalizer } from "./finalizer";
 
 const job = { version: 1 as const, buildId: "build-1", completionHash: "a".repeat(64) };
 const correlation = { request_id: "queue-1", trace_id: "queue-1" };

--- a/packages/control-plane/src/image-builds/finalizer.ts
+++ b/packages/control-plane/src/image-builds/finalizer.ts
@@ -7,10 +7,9 @@ import type { ImageBuildAdapterFactory } from "./provider-factory";
 import { ImageBuildReaper } from "./reaper";
 import { ImageBuildSessionCleanup } from "./session-cleanup";
 import type { ImageBuildAdapter } from "./types";
+import { errorMessage } from "./errors";
 import { ImageBuildFinalizationAttemptError } from "./finalization-error";
 import { parseRepositoryShasJson } from "./provenance";
-
-export { ImageBuildFinalizationAttemptError } from "./finalization-error";
 
 /** Lease exceeds the provider deadline so overlapping creation attempts cannot run. */
 const IMAGE_BUILD_FINALIZATION_LEASE_MS = 6 * 60 * 1000;
@@ -103,14 +102,14 @@ export class ImageBuildFinalizer {
     }
 
     if (expiredAttemptWithoutArtifact && !build.provider_image_id) {
-      await this.store.finalization.markFailed({
-        buildId: build.id,
-        leaseToken,
-        error: "Previous provider finalization attempt outcome unknown after lease expiry",
-      });
-      const failed = await this.store.finalization.getBuild(build.id);
-      if (failed) await this.cleanupTerminalBuild(failed, correlation);
-      return completed();
+      return this.failAndCleanup(
+        {
+          buildId: build.id,
+          leaseToken,
+          error: "Previous provider finalization attempt outcome unknown after lease expiry",
+        },
+        correlation
+      );
     }
 
     const adapter = this.adapterFactory.create(build.provider, "existing_session");
@@ -136,14 +135,7 @@ export class ImageBuildFinalizer {
           error instanceof ImageBuildFinalizationAttemptError && error.outcome === "ambiguous"
             ? `Provider finalization outcome unknown: ${errorMessage(error)}`
             : errorMessage(error);
-        await this.store.finalization.markFailed({
-          buildId: build.id,
-          leaseToken,
-          error: message,
-        });
-        const failed = await this.store.finalization.getBuild(build.id);
-        if (failed) await this.cleanupTerminalBuild(failed, correlation);
-        return completed();
+        return this.failAndCleanup({ buildId: build.id, leaseToken, error: message }, correlation);
       }
 
       let recorded: boolean;
@@ -194,14 +186,10 @@ export class ImageBuildFinalizer {
 
     const repositoryShas = parseRepositoryShasJson(build.repository_shas);
     if (!repositoryShas) {
-      await this.store.finalization.markFailed({
-        buildId: build.id,
-        leaseToken,
-        error: "Stored repository_shas is invalid",
-      });
-      const failed = await this.store.finalization.getBuild(build.id);
-      if (failed) await this.cleanupTerminalBuild(failed, correlation);
-      return completed();
+      return this.failAndCleanup(
+        { buildId: build.id, leaseToken, error: "Stored repository_shas is invalid" },
+        correlation
+      );
     }
     const ready = await this.store.tryMarkImageBuildReady(
       build.id,
@@ -296,14 +284,21 @@ export class ImageBuildFinalizer {
     }
   }
 
+  /** Marks the leased build failed, then runs terminal cleanup on the failed row. */
+  private async failAndCleanup(
+    params: { buildId: string; leaseToken: string; error: string },
+    correlation: CorrelationContext
+  ): Promise<ImageBuildFinalizationResult> {
+    await this.store.finalization.markFailed(params);
+    const failed = await this.store.finalization.getBuild(params.buildId);
+    if (failed) await this.cleanupTerminalBuild(failed, correlation);
+    return completed();
+  }
+
   private async cleanupTerminalBuild(
     build: ImageBuildFinalizationRow,
     correlation: CorrelationContext
   ): Promise<void> {
     await this.sessionCleanup.run(build, correlation);
   }
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -74,7 +74,6 @@ export interface ImageBuildCallbackBuild {
   id: string;
   scope: ImageBuildScope;
   provider: ImageBuildProvider;
-  providerSessionId: string | null;
   status: ImageBuildStatus;
 }
 

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -31,6 +31,24 @@ export interface PlannedCallbackAuth {
 
 export type { ResolvedImageBuildTarget } from "./scope";
 
+/** Inputs for planBuild; the target is resolved before registration, secrets after. */
+export interface ImageBuildPlanRequest {
+  buildId: string;
+  scope: ImageBuildScope;
+  callbackUrl: string;
+  failureCallbackUrl: string;
+  correlation: CorrelationContext;
+  target: ResolvedImageBuildTarget;
+  callbackAuth: PlannedCallbackAuth;
+}
+
+/** The planning operations the workflow sequences a build through. */
+export interface ImageBuildPlannerPort {
+  resolveTarget(scope: ImageBuildScope): Promise<ResolvedImageBuildTarget>;
+  createCallbackAuth(): Promise<PlannedCallbackAuth>;
+  planBuild(params: ImageBuildPlanRequest): Promise<ImageBuildPlan>;
+}
+
 /**
  * Resolves a trigger request into a concrete provider build plan.
  *
@@ -44,7 +62,7 @@ export type { ResolvedImageBuildTarget } from "./scope";
  * timeout honors the primary repository's sandbox settings with the scope's
  * own overrides layered on top.
  */
-export class ImageBuildPlanner {
+export class ImageBuildPlanner implements ImageBuildPlannerPort {
   constructor(
     private readonly env: Env,
     private readonly db: SqlDatabase
@@ -63,15 +81,7 @@ export class ImageBuildPlanner {
     };
   }
 
-  async planBuild(params: {
-    buildId: string;
-    scope: ImageBuildScope;
-    callbackUrl: string;
-    failureCallbackUrl: string;
-    correlation: CorrelationContext;
-    target: ResolvedImageBuildTarget;
-    callbackAuth: PlannedCallbackAuth;
-  }): Promise<ImageBuildPlan> {
+  async planBuild(params: ImageBuildPlanRequest): Promise<ImageBuildPlan> {
     const { repositories, repositoriesFingerprint } = params.target;
     const primary = repositories[0];
 

--- a/packages/control-plane/src/image-builds/reaper.test.ts
+++ b/packages/control-plane/src/image-builds/reaper.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ImageBuildStore } from "../db/image-builds";
+import type { ImageBuildAdapterFactory } from "./provider-factory";
+import { IMAGE_BUILD_CLEANUP_ATTEMPT_MS, ImageBuildReaper } from "./reaper";
+
+const ctx = { trace_id: "t", request_id: "r" };
+
+function createStore() {
+  return {
+    getFailedImagesWithArtifacts: vi.fn().mockResolvedValue([]),
+    deleteOldFailedBuilds: vi.fn().mockResolvedValue(0),
+    getSupersededImages: vi.fn().mockResolvedValue([]),
+    deleteSupersededImage: vi.fn().mockResolvedValue(true),
+    clearFailedImageArtifact: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createAdapter() {
+  return {
+    deleteImage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createReaper(options: {
+  store?: ReturnType<typeof createStore>;
+  adapter?: ReturnType<typeof createAdapter>;
+}) {
+  const store = options.store ?? createStore();
+  const adapter = options.adapter ?? createAdapter();
+  const factory = { create: vi.fn().mockReturnValue(adapter) };
+  const reaper = new ImageBuildReaper(
+    store as unknown as ImageBuildStore,
+    factory as unknown as ImageBuildAdapterFactory
+  );
+  return { reaper, store, adapter, factory };
+}
+
+function reapableRow(id: string, providerImageId: string | null) {
+  return {
+    id,
+    scope_kind: "environment" as const,
+    scope_id: "env_1",
+    provider: "modal" as const,
+    provider_image_id: providerImageId,
+    provider_session_id: null,
+    created_at: Number(id.replace(/\D/g, "")) || 1,
+  };
+}
+
+describe("ImageBuildReaper", () => {
+  describe("cleanupImages", () => {
+    it("deletes old failed rows and reaps superseded artifacts", async () => {
+      const store = createStore();
+      store.deleteOldFailedBuilds.mockResolvedValue(3);
+      store.getSupersededImages.mockResolvedValue([
+        reapableRow("s-artifact", "im-a"),
+        reapableRow("s-bare", null),
+        reapableRow("s-stuck", "im-stuck"),
+      ]);
+      const adapter = createAdapter();
+      adapter.deleteImage.mockImplementation(async ({ image }) => {
+        if (image.providerImageId === "im-stuck") throw new Error("provider 500");
+      });
+      const { reaper } = createReaper({ store, adapter });
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      // s-artifact: artifact deleted then row reaped. s-bare: no artifact, row
+      // reaped directly. s-stuck: artifact delete failed, row kept for retry.
+      expect(result).toEqual({ deletedFailed: 3, reapedFailed: 0, reapedSuperseded: 2 });
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-artifact", "im-a");
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-bare", null);
+      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("s-stuck", "im-stuck");
+    });
+
+    it("reaps a restore-failed row's artifact then clears its columns, keeping it failed", async () => {
+      const store = createStore();
+      store.getFailedImagesWithArtifacts.mockResolvedValue([
+        reapableRow("f-restore", "im-restore"),
+      ]);
+      const adapter = createAdapter();
+      const { reaper } = createReaper({ store, adapter });
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      expect(result.reapedFailed).toBe(1);
+      expect(adapter.deleteImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: { providerImageId: "im-restore", providerSessionId: null },
+        })
+      );
+      // The failed row itself is kept for visibility — only the artifact
+      // columns are nulled; it is never reaped as a superseded row.
+      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("f-restore", "im-restore");
+      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("f-restore");
+    });
+
+    it("keeps a failed row's artifact when the provider delete fails", async () => {
+      const store = createStore();
+      store.getFailedImagesWithArtifacts.mockResolvedValue([reapableRow("f-stuck", "im-stuck")]);
+      const adapter = createAdapter();
+      adapter.deleteImage.mockRejectedValue(new Error("provider 500"));
+      const { reaper } = createReaper({ store, adapter });
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      // Artifact not lost: the columns are left intact so the next tick retries.
+      expect(result.reapedFailed).toBe(0);
+      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
+    });
+
+    it("attempts every failed artifact in one cleanup scan", async () => {
+      const store = createStore();
+      const rows = Array.from({ length: 26 }, (_, index) =>
+        reapableRow(`failed-${index + 1}`, `im-${index + 1}`)
+      );
+      store.getFailedImagesWithArtifacts.mockResolvedValue(rows);
+      const adapter = createAdapter();
+      let inFlight = 0;
+      let peakInFlight = 0;
+      adapter.deleteImage.mockImplementation(async ({ image }) => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await Promise.resolve();
+        inFlight -= 1;
+        if (image.providerImageId === "im-1") throw new Error("provider unavailable");
+      });
+      const { reaper } = createReaper({ store, adapter });
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      expect(result.reapedFailed).toBe(25);
+      expect(peakInFlight).toBeLessThanOrEqual(4);
+      expect(store.getFailedImagesWithArtifacts).toHaveBeenCalledWith();
+      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("failed-26", "im-26");
+    });
+
+    it("does not select already-reaped failed rows (idempotent across ticks)", async () => {
+      const store = createStore();
+      // getFailedImagesWithArtifacts only returns artifact-bearing rows, so a
+      // previously-cleared failed row never reaches the adapter again.
+      store.getFailedImagesWithArtifacts.mockResolvedValue([]);
+      const adapter = createAdapter();
+      const { reaper } = createReaper({ store, adapter });
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      expect(result.reapedFailed).toBe(0);
+      expect(adapter.deleteImage).not.toHaveBeenCalled();
+      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
+    });
+
+    it("bounds a hung provider artifact deletion", async () => {
+      vi.useFakeTimers();
+      try {
+        const store = createStore();
+        store.getFailedImagesWithArtifacts.mockResolvedValue([reapableRow("f-hung", "im-hung")]);
+        const adapter = createAdapter();
+        adapter.deleteImage.mockImplementation(
+          async ({ signal }) =>
+            new Promise<void>((_, reject) => {
+              signal?.addEventListener("abort", () => reject(new Error("aborted")));
+            })
+        );
+        const { reaper } = createReaper({ store, adapter });
+
+        const cleanup = reaper.cleanupImages(86_400_000, ctx);
+        await vi.advanceTimersByTimeAsync(IMAGE_BUILD_CLEANUP_ATTEMPT_MS);
+
+        await expect(cleanup).resolves.toMatchObject({ reapedFailed: 0 });
+        expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/packages/control-plane/src/image-builds/reaper.ts
+++ b/packages/control-plane/src/image-builds/reaper.ts
@@ -1,5 +1,6 @@
 import type { ImageBuildStore, ReapableImageBuildRow } from "../db/image-builds";
 import { createLogger } from "../logger";
+import { errorMessage } from "./errors";
 import type { ImageBuildProvider, SupersededImageBuild } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
 import type { ImageBuildAdapter, ImageBuildWorkflowContext } from "./types";
@@ -156,7 +157,7 @@ export class ImageBuildReaper {
     ).then(() => undefined);
   }
 
-  async deleteImageBestEffort(
+  private async deleteImageBestEffort(
     provider: ImageBuildProvider,
     image: { providerImageId: string; providerSessionId?: string | null },
     ctx: ImageBuildWorkflowContext,
@@ -186,7 +187,7 @@ export class ImageBuildReaper {
   }
 
   /** Null (never throws) when the provider is unconfigured — cleanup is best-effort. */
-  createAdapterForBestEffortCleanup(
+  private createAdapterForBestEffortCleanup(
     provider: ImageBuildProvider,
     buildId: string,
     ctx: ImageBuildWorkflowContext
@@ -205,8 +206,4 @@ export class ImageBuildReaper {
       return null;
     }
   }
-}
-
-function errorMessage(errorValue: unknown): string {
-  return errorValue instanceof Error ? errorValue.message : String(errorValue);
 }

--- a/packages/control-plane/src/image-builds/scheduler.test.ts
+++ b/packages/control-plane/src/image-builds/scheduler.test.ts
@@ -5,6 +5,7 @@ import type { SourceControlProvider } from "../source-control";
 import type { Env } from "../types";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
+import type { ImageBuildReaper } from "./reaper";
 import { ImageBuildScheduler } from "./scheduler";
 import type { ResolvedImageBuildTarget } from "./scope";
 import { COMPATIBLE_RUNTIME_VERSION } from "./test-helpers";
@@ -73,6 +74,8 @@ function harness(
       type: "triggered" as const,
       buildId: "build-new",
     })),
+  };
+  const reaper = {
     cleanupImages: vi.fn(async () => ({
       deletedFailed: 2,
       reapedFailed: 1,
@@ -98,6 +101,7 @@ function harness(
     store as unknown as ImageBuildStore,
     workflow as unknown as ImageBuildWorkflow,
     { create: vi.fn(() => adapter) } as unknown as ImageBuildAdapterFactory,
+    reaper as unknown as ImageBuildReaper,
     options.sourceControl === undefined ? ({} as SourceControlProvider) : options.sourceControl,
     resolveTarget,
     listScopes
@@ -107,6 +111,7 @@ function harness(
     store,
     adapter,
     workflow,
+    reaper,
     resolveTarget,
     listScopes,
     listSessionCleanup,
@@ -179,14 +184,14 @@ describe("ImageBuildScheduler", () => {
   });
 
   it("continues reconciliation and artifact cleanup when a cleanup phase query fails", async () => {
-    const { scheduler, store, workflow } = harness();
+    const { scheduler, store, reaper } = harness();
     store.listSessionCleanup.mockRejectedValueOnce(new Error("D1 cleanup unavailable"));
 
     const stats = await scheduler.run({ request_id: "cron-1", trace_id: "cron-1" });
 
     expect(stats.scopesScanned).toBe(1);
     expect(stats.triggered).toBe(1);
-    expect(workflow.cleanupImages).toHaveBeenCalledOnce();
+    expect(reaper.cleanupImages).toHaveBeenCalledOnce();
   });
 
   it("checks every enabled scope in one full scan", async () => {
@@ -262,7 +267,7 @@ describe("ImageBuildScheduler", () => {
   });
 
   it("runs provider-neutral maintenance when rebuild reconciliation is unavailable", async () => {
-    const { scheduler, listScopes, workflow } = harness({
+    const { scheduler, listScopes, reaper } = harness({
       provider: null,
       sourceControl: null,
     });
@@ -273,7 +278,7 @@ describe("ImageBuildScheduler", () => {
     expect(stats.cleanupAttempted).toBe(2);
     expect(stats.scopesScanned).toBe(0);
     expect(listScopes).not.toHaveBeenCalled();
-    expect(workflow.cleanupImages).toHaveBeenCalledOnce();
+    expect(reaper.cleanupImages).toHaveBeenCalledOnce();
   });
 
   it("republishes persisted artifacts left behind by exhausted Queue delivery", async () => {

--- a/packages/control-plane/src/image-builds/scheduler.test.ts
+++ b/packages/control-plane/src/image-builds/scheduler.test.ts
@@ -5,7 +5,6 @@ import type { SourceControlProvider } from "../source-control";
 import type { Env } from "../types";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
-import type { ImageBuildReaper } from "./reaper";
 import { ImageBuildScheduler } from "./scheduler";
 import type { ResolvedImageBuildTarget } from "./scope";
 import { COMPATIBLE_RUNTIME_VERSION } from "./test-helpers";
@@ -56,6 +55,34 @@ function harness(
     listSessionCleanup,
     clearProviderSessionCleanup,
     listRecoverableFinalizations,
+    // The scheduler constructs its reaper internally, so the cleanup phase
+    // runs real reap logic over these rows: one failed and one superseded
+    // artifact delete → artifactsReaped 2, two aged rows → rowsAged 2.
+    getFailedImagesWithArtifacts: vi.fn(async () => [
+      {
+        id: "reap-failed",
+        scope_kind: "environment" as const,
+        scope_id: "env_1",
+        provider: "modal" as const,
+        provider_image_id: "im-failed",
+        provider_session_id: null,
+        created_at: 1,
+      },
+    ]),
+    clearFailedImageArtifact: vi.fn(async () => true),
+    deleteOldFailedBuilds: vi.fn(async () => 2),
+    getSupersededImages: vi.fn(async () => [
+      {
+        id: "reap-superseded",
+        scope_kind: "environment" as const,
+        scope_id: "env_1",
+        provider: "modal" as const,
+        provider_image_id: "im-superseded",
+        provider_session_id: null,
+        created_at: 2,
+      },
+    ]),
+    deleteSupersededImage: vi.fn(async () => true),
     finalization: {
       clearSessionCleanup: clearProviderSessionCleanup,
     },
@@ -73,13 +100,6 @@ function harness(
     triggerBuildWithTarget: vi.fn(async (_scope: ImageBuildScope) => ({
       type: "triggered" as const,
       buildId: "build-new",
-    })),
-  };
-  const reaper = {
-    cleanupImages: vi.fn(async () => ({
-      deletedFailed: 2,
-      reapedFailed: 1,
-      reapedSuperseded: 1,
     })),
   };
   const resolveTarget = vi.fn(
@@ -101,7 +121,6 @@ function harness(
     store as unknown as ImageBuildStore,
     workflow as unknown as ImageBuildWorkflow,
     { create: vi.fn(() => adapter) } as unknown as ImageBuildAdapterFactory,
-    reaper as unknown as ImageBuildReaper,
     options.sourceControl === undefined ? ({} as SourceControlProvider) : options.sourceControl,
     resolveTarget,
     listScopes
@@ -111,7 +130,6 @@ function harness(
     store,
     adapter,
     workflow,
-    reaper,
     resolveTarget,
     listScopes,
     listSessionCleanup,
@@ -184,14 +202,14 @@ describe("ImageBuildScheduler", () => {
   });
 
   it("continues reconciliation and artifact cleanup when a cleanup phase query fails", async () => {
-    const { scheduler, store, reaper } = harness();
+    const { scheduler, store } = harness();
     store.listSessionCleanup.mockRejectedValueOnce(new Error("D1 cleanup unavailable"));
 
     const stats = await scheduler.run({ request_id: "cron-1", trace_id: "cron-1" });
 
     expect(stats.scopesScanned).toBe(1);
     expect(stats.triggered).toBe(1);
-    expect(reaper.cleanupImages).toHaveBeenCalledOnce();
+    expect(store.deleteOldFailedBuilds).toHaveBeenCalledOnce();
   });
 
   it("checks every enabled scope in one full scan", async () => {
@@ -267,7 +285,7 @@ describe("ImageBuildScheduler", () => {
   });
 
   it("runs provider-neutral maintenance when rebuild reconciliation is unavailable", async () => {
-    const { scheduler, listScopes, reaper } = harness({
+    const { scheduler, store, listScopes } = harness({
       provider: null,
       sourceControl: null,
     });
@@ -278,7 +296,7 @@ describe("ImageBuildScheduler", () => {
     expect(stats.cleanupAttempted).toBe(2);
     expect(stats.scopesScanned).toBe(0);
     expect(listScopes).not.toHaveBeenCalled();
-    expect(reaper.cleanupImages).toHaveBeenCalledOnce();
+    expect(store.deleteOldFailedBuilds).toHaveBeenCalledOnce();
   });
 
   it("republishes persisted artifacts left behind by exhausted Queue delivery", async () => {

--- a/packages/control-plane/src/image-builds/scheduler.ts
+++ b/packages/control-plane/src/image-builds/scheduler.ts
@@ -1,10 +1,13 @@
 import { ImageBuildStore } from "../db/image-builds";
 import { createLogger, type CorrelationContext } from "../logger";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
+import { errorMessage } from "./errors";
+import { republishedImageBuildFinalizationJob } from "./finalization-job";
 import type { ImageBuildProvider } from "./model";
 import { createImageBuildAdapterFactory, type ImageBuildAdapterFactory } from "./provider-factory";
 import { DEFAULT_ARTIFACT_CLEANUP_MAX_AGE_MS, DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
 import { evaluateImageBuildRebuildPolicy } from "./rebuild-policy";
+import { ImageBuildReaper } from "./reaper";
 import { listEnabledScopes, resolveScopeTarget } from "./scope";
 import { ImageBuildSessionCleanup } from "./session-cleanup";
 import { createImageBuildWorkflowFromEnv, type ImageBuildWorkflow } from "./workflow";
@@ -46,6 +49,7 @@ export class ImageBuildScheduler {
     private readonly store: ImageBuildStore,
     private readonly workflow: ImageBuildWorkflow,
     adapterFactory: ImageBuildAdapterFactory,
+    private readonly reaper: ImageBuildReaper,
     private readonly sourceControl: SourceControlProvider | null,
     private readonly resolveTarget: typeof resolveScopeTarget = resolveScopeTarget,
     private readonly listScopes: typeof listEnabledScopes = listEnabledScopes
@@ -105,7 +109,7 @@ export class ImageBuildScheduler {
     }
 
     try {
-      const cleanup = await this.workflow.cleanupImages(
+      const cleanup = await this.reaper.cleanupImages(
         DEFAULT_ARTIFACT_CLEANUP_MAX_AGE_MS,
         correlation
       );
@@ -123,7 +127,6 @@ export class ImageBuildScheduler {
       cron: IMAGE_BUILD_SCHEDULER_CRON,
       duration_ms: Date.now() - startedAt,
       rebuild_enabled: this.provider !== null && this.sourceControl !== null,
-      orphan_sweep: this.provider === "modal" ? "timeout_bounded" : "not_applicable",
       request_id: correlation.request_id,
       trace_id: correlation.trace_id,
     });
@@ -138,11 +141,7 @@ export class ImageBuildScheduler {
     let published = 0;
     for (const row of rows) {
       try {
-        await queue.send({
-          version: 1,
-          buildId: row.id,
-          completionHash: row.completion_hash,
-        });
+        await queue.send(republishedImageBuildFinalizationJob(row));
         published += 1;
       } catch (error) {
         logger.warn("image_build.scheduler_finalization_republish_row_failed", {
@@ -269,17 +268,15 @@ export async function runImageBuildScheduler(
       });
     }
   }
+  const adapterFactory = createImageBuildAdapterFactory(env);
   return new ImageBuildScheduler(
     env,
     db,
     provider,
     store,
     createImageBuildWorkflowFromEnv(env, db),
-    createImageBuildAdapterFactory(env),
+    adapterFactory,
+    new ImageBuildReaper(store, adapterFactory),
     sourceControl
   ).run(correlation);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/control-plane/src/image-builds/scheduler.ts
+++ b/packages/control-plane/src/image-builds/scheduler.ts
@@ -2,7 +2,7 @@ import { ImageBuildStore } from "../db/image-builds";
 import { createLogger, type CorrelationContext } from "../logger";
 import { createSourceControlProviderFromEnv, type SourceControlProvider } from "../source-control";
 import { errorMessage } from "./errors";
-import { republishedImageBuildFinalizationJob } from "./finalization-job";
+import { imageBuildFinalizationJob } from "./finalization-job";
 import type { ImageBuildProvider } from "./model";
 import { createImageBuildAdapterFactory, type ImageBuildAdapterFactory } from "./provider-factory";
 import { DEFAULT_ARTIFACT_CLEANUP_MAX_AGE_MS, DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
@@ -41,6 +41,7 @@ export interface ImageBuildSchedulerStats {
 
 export class ImageBuildScheduler {
   private readonly sessionCleanup: ImageBuildSessionCleanup;
+  private readonly reaper: ImageBuildReaper;
 
   constructor(
     private readonly env: Env,
@@ -49,12 +50,12 @@ export class ImageBuildScheduler {
     private readonly store: ImageBuildStore,
     private readonly workflow: ImageBuildWorkflow,
     adapterFactory: ImageBuildAdapterFactory,
-    private readonly reaper: ImageBuildReaper,
     private readonly sourceControl: SourceControlProvider | null,
     private readonly resolveTarget: typeof resolveScopeTarget = resolveScopeTarget,
     private readonly listScopes: typeof listEnabledScopes = listEnabledScopes
   ) {
     this.sessionCleanup = new ImageBuildSessionCleanup(store, adapterFactory);
+    this.reaper = new ImageBuildReaper(store, adapterFactory);
   }
 
   async run(correlation: CorrelationContext): Promise<ImageBuildSchedulerStats> {
@@ -141,7 +142,7 @@ export class ImageBuildScheduler {
     let published = 0;
     for (const row of rows) {
       try {
-        await queue.send(republishedImageBuildFinalizationJob(row));
+        await queue.send(imageBuildFinalizationJob(row.id, row.completion_hash));
         published += 1;
       } catch (error) {
         logger.warn("image_build.scheduler_finalization_republish_row_failed", {
@@ -268,15 +269,13 @@ export async function runImageBuildScheduler(
       });
     }
   }
-  const adapterFactory = createImageBuildAdapterFactory(env);
   return new ImageBuildScheduler(
     env,
     db,
     provider,
     store,
     createImageBuildWorkflowFromEnv(env, db),
-    adapterFactory,
-    new ImageBuildReaper(store, adapterFactory),
+    createImageBuildAdapterFactory(env),
     sourceControl
   ).run(correlation);
 }

--- a/packages/control-plane/src/image-builds/scope.ts
+++ b/packages/control-plane/src/image-builds/scope.ts
@@ -29,7 +29,7 @@ import {
   type RepositoryAccessResult,
 } from "../source-control";
 import type { Env } from "../types";
-import { ImageBuildPlanningError, ImageBuildScopeNotFoundError } from "./errors";
+import { errorMessage, ImageBuildPlanningError, ImageBuildScopeNotFoundError } from "./errors";
 import { computeRepositoriesFingerprint } from "./fingerprint";
 import { parseRepoScopeId, repoImageBuildScope, type ImageBuildScope } from "./model";
 import type { ImageBuildRepository } from "./types";
@@ -379,8 +379,4 @@ async function loadScopeSecretSources(
       };
     }
   }
-}
-
-function errorMessage(errorValue: unknown): string {
-  return errorValue instanceof Error ? errorValue.message : String(errorValue);
 }

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -22,12 +22,16 @@ export type TriggerImageBuildResult =
   | { type: "already_building"; buildId: string }
   | { type: "up_to_date" };
 
-export type ImageBuildWorkflowResult =
-  | { type: "completion_accepted" }
-  | { type: "failure_accepted" };
+/** Clone auth handed to provider-session build sandboxes (provider-policy.ts). */
+export type ImageBuildCloneAuth =
+  | { type: "credential_helper"; host: string; username: string; token: string }
+  | { type: "unavailable" };
 
-/** Provider-neutral build request fields resolved before adapter-specific execution. */
-interface BaseImageBuildPlan {
+/**
+ * Provider-neutral build request resolved before adapter-specific execution.
+ * Every supported provider uses the same create-bind-launch session contract.
+ */
+export interface ImageBuildPlan {
   buildId: string;
   scope: ImageBuildScope;
   repositories: ImageBuildRepository[];
@@ -43,15 +47,6 @@ interface BaseImageBuildPlan {
   buildTimeoutMs: number;
   userEnvVars?: Record<string, string>;
   correlation: CorrelationContext;
-}
-
-/** Clone auth handed to provider-session build sandboxes (provider-policy.ts). */
-export type ImageBuildCloneAuth =
-  | { type: "credential_helper"; host: string; username: string; token: string }
-  | { type: "unavailable" };
-
-/** Every supported provider uses the same create-bind-launch session contract. */
-export interface ImageBuildPlan extends BaseImageBuildPlan {
   callbackToken: string;
   cloneAuth: ImageBuildCloneAuth;
 }

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -10,7 +10,6 @@ import {
   ImageBuildWorkflowUnavailableError,
 } from "./errors";
 import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
-import { IMAGE_BUILD_CLEANUP_ATTEMPT_MS } from "./reaper";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
 import type { ImageBuildFinalizationQueue } from "./finalization-job";
@@ -54,12 +53,7 @@ function createStore() {
     },
     tryMarkImageBuildReady: vi.fn(),
     markBuildFailed: vi.fn().mockResolvedValue(true),
-    deleteSupersededImage: vi.fn().mockResolvedValue(true),
     supersedeActiveImages: vi.fn().mockResolvedValue(0),
-    getSupersededImages: vi.fn().mockResolvedValue([]),
-    getFailedImagesWithArtifacts: vi.fn().mockResolvedValue([]),
-    clearFailedImageArtifact: vi.fn().mockResolvedValue(true),
-    deleteOldFailedBuilds: vi.fn().mockResolvedValue(0),
     markStaleBuildsAsFailed: vi.fn().mockResolvedValue(0),
     getStatus: vi.fn().mockResolvedValue([]),
     getStatusForEnabledScopes: vi.fn().mockResolvedValue([]),
@@ -468,14 +462,10 @@ describe("ImageBuildWorkflow", () => {
     function sessionBuildStore() {
       const store = createStore();
       store.authorizeCompletionCallback.mockResolvedValue({
-        authorization: "fresh",
-        build: {
-          id: "imgb-env_1-1-abcd",
-          scope: ENV_SCOPE,
-          provider: "vercel",
-          providerSessionId: "vercel-session-1",
-          status: "building",
-        },
+        id: "imgb-env_1-1-abcd",
+        scope: ENV_SCOPE,
+        provider: "vercel",
+        status: "building",
       });
       return store;
     }
@@ -573,7 +563,7 @@ describe("ImageBuildWorkflow", () => {
       const queue = { send: vi.fn().mockResolvedValue(undefined) };
       const { workflow } = createWorkflow({ store, queue });
 
-      const result = await workflow.acceptBuildComplete({
+      await workflow.acceptBuildComplete({
         completion: validCompletion({
           providerSessionId: "vercel-session-1",
         }),
@@ -581,7 +571,6 @@ describe("ImageBuildWorkflow", () => {
         context: ctx,
       });
 
-      expect(result.type).toBe("completion_accepted");
       expect(queue.send).toHaveBeenCalledWith({
         version: 1,
         buildId: "imgb-env_1-1-abcd",
@@ -662,7 +651,7 @@ describe("ImageBuildWorkflow", () => {
       const queue = { send: vi.fn().mockResolvedValue(undefined) };
       const { workflow } = createWorkflow({ store, queue });
 
-      const result = await workflow.acceptBuildFailed({
+      await workflow.acceptBuildFailed({
         failure: {
           buildId: "imgb-env_1-1-abcd",
           providerSessionId: "vercel-session-1",
@@ -672,7 +661,6 @@ describe("ImageBuildWorkflow", () => {
         context: ctx,
       });
 
-      expect(result.type).toBe("failure_accepted");
       expect(queue.send).toHaveBeenCalledWith({
         version: 1,
         buildId: "imgb-env_1-1-abcd",
@@ -694,14 +682,10 @@ describe("ImageBuildWorkflow", () => {
     it("republishes an exact accepted replay", async () => {
       const store = sessionBuildStore();
       store.authorizeCompletionCallback.mockResolvedValue({
-        authorization: "accepted",
-        build: {
-          id: "imgb-env_1-1-abcd",
-          scope: ENV_SCOPE,
-          provider: "vercel",
-          providerSessionId: "vercel-session-1",
-          status: "building",
-        },
+        id: "imgb-env_1-1-abcd",
+        scope: ENV_SCOPE,
+        provider: "vercel",
+        status: "building",
       });
       store.acceptSuccessfulCompletion.mockResolvedValue("replayed");
       const queue = { send: vi.fn().mockResolvedValue(undefined) };
@@ -715,7 +699,7 @@ describe("ImageBuildWorkflow", () => {
           callbackToken: "callback-token",
           context: ctx,
         })
-      ).resolves.toEqual({ type: "completion_accepted" });
+      ).resolves.toBeUndefined();
 
       expect(queue.send).toHaveBeenCalledWith({
         version: 1,
@@ -727,14 +711,10 @@ describe("ImageBuildWorkflow", () => {
     it("republishes an exact accepted failure replay", async () => {
       const store = sessionBuildStore();
       store.authorizeCompletionCallback.mockResolvedValue({
-        authorization: "accepted",
-        build: {
-          id: "imgb-env_1-1-abcd",
-          scope: ENV_SCOPE,
-          provider: "vercel",
-          providerSessionId: "vercel-session-1",
-          status: "failed",
-        },
+        id: "imgb-env_1-1-abcd",
+        scope: ENV_SCOPE,
+        provider: "vercel",
+        status: "failed",
       });
       store.acceptFailedCompletion.mockResolvedValue("replayed");
       const queue = { send: vi.fn().mockResolvedValue(undefined) };
@@ -750,7 +730,7 @@ describe("ImageBuildWorkflow", () => {
           callbackToken: "callback-token",
           context: ctx,
         })
-      ).resolves.toEqual({ type: "failure_accepted" });
+      ).resolves.toBeUndefined();
 
       expect(queue.send).toHaveBeenCalledWith({
         version: 1,
@@ -793,145 +773,6 @@ describe("ImageBuildWorkflow", () => {
           context: ctx,
         })
       ).rejects.toBeInstanceOf(ImageBuildCallbackAuthRejectedError);
-    });
-  });
-
-  describe("cleanupImages", () => {
-    function reapableRow(id: string, providerImageId: string | null) {
-      return {
-        id,
-        scope_kind: "environment" as const,
-        scope_id: "env_1",
-        provider: "modal" as const,
-        provider_image_id: providerImageId,
-        provider_session_id: null,
-        created_at: Number(id.replace(/\D/g, "")) || 1,
-      };
-    }
-
-    it("deletes old failed rows and reaps superseded artifacts", async () => {
-      const store = createStore();
-      store.deleteOldFailedBuilds.mockResolvedValue(3);
-      store.getSupersededImages.mockResolvedValue([
-        reapableRow("s-artifact", "im-a"),
-        reapableRow("s-bare", null),
-        reapableRow("s-stuck", "im-stuck"),
-      ]);
-      const adapter = createAdapter();
-      adapter.deleteImage.mockImplementation(async ({ image }) => {
-        if (image.providerImageId === "im-stuck") throw new Error("provider 500");
-      });
-      const { workflow } = createWorkflow({ store, adapter });
-
-      const result = await workflow.cleanupImages(86_400_000, ctx);
-
-      // s-artifact: artifact deleted then row reaped. s-bare: no artifact, row
-      // reaped directly. s-stuck: artifact delete failed, row kept for retry.
-      expect(result).toEqual({ deletedFailed: 3, reapedFailed: 0, reapedSuperseded: 2 });
-      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-artifact", "im-a");
-      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-bare", null);
-      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("s-stuck", "im-stuck");
-    });
-
-    it("reaps a restore-failed row's artifact then clears its columns, keeping it failed", async () => {
-      const store = createStore();
-      store.getFailedImagesWithArtifacts.mockResolvedValue([
-        reapableRow("f-restore", "im-restore"),
-      ]);
-      const adapter = createAdapter();
-      const { workflow } = createWorkflow({ store, adapter });
-
-      const result = await workflow.cleanupImages(86_400_000, ctx);
-
-      expect(result.reapedFailed).toBe(1);
-      expect(adapter.deleteImage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          image: { providerImageId: "im-restore", providerSessionId: null },
-        })
-      );
-      // The failed row itself is kept for visibility — only the artifact
-      // columns are nulled; it is never reaped as a superseded row.
-      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("f-restore", "im-restore");
-      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("f-restore");
-    });
-
-    it("keeps a failed row's artifact when the provider delete fails", async () => {
-      const store = createStore();
-      store.getFailedImagesWithArtifacts.mockResolvedValue([reapableRow("f-stuck", "im-stuck")]);
-      const adapter = createAdapter();
-      adapter.deleteImage.mockRejectedValue(new Error("provider 500"));
-      const { workflow } = createWorkflow({ store, adapter });
-
-      const result = await workflow.cleanupImages(86_400_000, ctx);
-
-      // Artifact not lost: the columns are left intact so the next tick retries.
-      expect(result.reapedFailed).toBe(0);
-      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
-    });
-
-    it("attempts every failed artifact in one cleanup scan", async () => {
-      const store = createStore();
-      const rows = Array.from({ length: 26 }, (_, index) =>
-        reapableRow(`failed-${index + 1}`, `im-${index + 1}`)
-      );
-      store.getFailedImagesWithArtifacts.mockResolvedValue(rows);
-      const adapter = createAdapter();
-      let inFlight = 0;
-      let peakInFlight = 0;
-      adapter.deleteImage.mockImplementation(async ({ image }) => {
-        inFlight += 1;
-        peakInFlight = Math.max(peakInFlight, inFlight);
-        await Promise.resolve();
-        inFlight -= 1;
-        if (image.providerImageId === "im-1") throw new Error("provider unavailable");
-      });
-      const { workflow } = createWorkflow({ store, adapter });
-
-      const result = await workflow.cleanupImages(86_400_000, ctx);
-
-      expect(result.reapedFailed).toBe(25);
-      expect(peakInFlight).toBeLessThanOrEqual(4);
-      expect(store.getFailedImagesWithArtifacts).toHaveBeenCalledWith();
-      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("failed-26", "im-26");
-    });
-
-    it("does not select already-reaped failed rows (idempotent across ticks)", async () => {
-      const store = createStore();
-      // getFailedImagesWithArtifacts only returns artifact-bearing rows, so a
-      // previously-cleared failed row never reaches the adapter again.
-      store.getFailedImagesWithArtifacts.mockResolvedValue([]);
-      const adapter = createAdapter();
-      const { workflow } = createWorkflow({ store, adapter });
-
-      const result = await workflow.cleanupImages(86_400_000, ctx);
-
-      expect(result.reapedFailed).toBe(0);
-      expect(adapter.deleteImage).not.toHaveBeenCalled();
-      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
-    });
-
-    it("bounds a hung provider artifact deletion", async () => {
-      vi.useFakeTimers();
-      try {
-        const store = createStore();
-        store.getFailedImagesWithArtifacts.mockResolvedValue([reapableRow("f-hung", "im-hung")]);
-        const adapter = createAdapter();
-        adapter.deleteImage.mockImplementation(
-          async ({ signal }) =>
-            new Promise<void>((_, reject) => {
-              signal?.addEventListener("abort", () => reject(new Error("aborted")));
-            })
-        );
-        const { workflow } = createWorkflow({ store, adapter });
-
-        const cleanup = workflow.cleanupImages(86_400_000, ctx);
-        await vi.advanceTimersByTimeAsync(IMAGE_BUILD_CLEANUP_ATTEMPT_MS);
-
-        await expect(cleanup).resolves.toMatchObject({ reapedFailed: 0 });
-        expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
     });
   });
 });

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -3,12 +3,13 @@ import { ImageBuildStore, type ImageBuildRegistration } from "../db/image-builds
 import { createLogger } from "../logger";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
-import { hashImageBuildCallbackToken, ImageBuildCallbackAuthError } from "./callback-auth";
+import { hashImageBuildCallbackToken, type ImageBuildCallbackAuthFailure } from "./callback-auth";
 import {
   createImageBuildFinalizationJob,
   type ImageBuildFinalizationQueue,
 } from "./finalization-job";
 import {
+  errorMessage,
   ImageBuildCallbackAuthRejectedError,
   ImageBuildCallbackAuthUnavailableError,
   ImageBuildCompletionNotAcceptedError,
@@ -23,10 +24,10 @@ import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
 import type { ImageBuildProvider, ImageBuildScope } from "./model";
 import {
   ImageBuildPlanner,
+  type ImageBuildPlannerPort,
   type PlannedCallbackAuth,
   type ResolvedImageBuildTarget,
 } from "./planner";
-import { ImageBuildReaper } from "./reaper";
 import { resolveImageBuildProvider } from "./provider-policy";
 import { createImageBuildAdapterFactory, type ImageBuildAdapterFactory } from "./provider-factory";
 import type {
@@ -34,16 +35,10 @@ import type {
   CompleteImageBuildCallback,
   FailImageBuildCallback,
   ImageBuildWorkflowContext,
-  ImageBuildWorkflowResult,
   TriggerImageBuildResult,
 } from "./types";
 
 const logger = createLogger("image-builds:workflow");
-
-type ImageBuildPlannerLike = Pick<
-  ImageBuildPlanner,
-  "resolveTarget" | "createCallbackAuth" | "planBuild"
->;
 
 export interface AcceptBuildCompleteCommand {
   completion: CompleteImageBuildCallback;
@@ -65,7 +60,7 @@ export interface AcceptBuildFailedCommand {
  */
 export type ImageBuildProviderDeps = {
   provider: ImageBuildProvider;
-  planner: ImageBuildPlannerLike;
+  planner: ImageBuildPlannerPort;
 } | null;
 
 /**
@@ -80,17 +75,13 @@ export type ImageBuildProviderDeps = {
  * subclasses for route-level error mapping.
  */
 export class ImageBuildWorkflow {
-  private readonly reaper: ImageBuildReaper;
-
   constructor(
     private readonly env: Env,
     private readonly store: ImageBuildStore,
     private readonly adapterFactory: ImageBuildAdapterFactory,
     private readonly providerDeps: ImageBuildProviderDeps,
     private readonly finalizationQueue: ImageBuildFinalizationQueue | null = null
-  ) {
-    this.reaper = new ImageBuildReaper(store, adapterFactory);
-  }
+  ) {}
 
   /**
    * Trigger a build for a scope. All trigger sources — the cron pass,
@@ -251,7 +242,6 @@ export class ImageBuildWorkflow {
     }
 
     let providerSessionIdForCleanup: string | null = null;
-    let startAdapter: ImageBuildAdapter | null = null;
     try {
       const registered = await this.store.registerBuild({
         id: buildId,
@@ -281,7 +271,6 @@ export class ImageBuildWorkflow {
         callbackAuth,
       });
 
-      startAdapter = adapter;
       await adapter.startBuild(plan, {
         bindProviderSession: async (providerSessionId) => {
           providerSessionIdForCleanup = providerSessionId;
@@ -303,8 +292,8 @@ export class ImageBuildWorkflow {
 
       return { type: "triggered", buildId };
     } catch (e) {
-      if (providerSessionIdForCleanup && startAdapter) {
-        await startAdapter
+      if (providerSessionIdForCleanup) {
+        await adapter
           .cleanupFailedBuild({
             buildId,
             providerSessionId: providerSessionIdForCleanup,
@@ -348,9 +337,7 @@ export class ImageBuildWorkflow {
    * Authenticates and durably accepts runtime success before publishing the
    * secret-free Queue command. Exact retries republish safely.
    */
-  async acceptBuildComplete(
-    command: AcceptBuildCompleteCommand
-  ): Promise<ImageBuildWorkflowResult> {
+  async acceptBuildComplete(command: AcceptBuildCompleteCommand): Promise<void> {
     const { completion, context: ctx } = command;
     const authenticated = await this.authorizeCompletionCallback(
       completion.buildId,
@@ -392,14 +379,13 @@ export class ImageBuildWorkflow {
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    return { type: "completion_accepted" };
   }
 
   /**
    * Persists runtime failure and its cleanup obligation before publishing the
    * Queue command that tears down the bound provider session.
    */
-  async acceptBuildFailed(command: AcceptBuildFailedCommand): Promise<ImageBuildWorkflowResult> {
+  async acceptBuildFailed(command: AcceptBuildFailedCommand): Promise<void> {
     const { failure, context: ctx } = command;
     const authenticated = await this.authorizeCompletionCallback(
       failure.buildId,
@@ -436,15 +422,6 @@ export class ImageBuildWorkflow {
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    return { type: "failure_accepted" };
-  }
-
-  /** Cleanup pass over failed and superseded rows (reaper.ts). */
-  async cleanupImages(
-    failedMaxAgeMs: number,
-    ctx: ImageBuildWorkflowContext
-  ): Promise<{ deletedFailed: number; reapedFailed: number; reapedSuperseded: number }> {
-    return this.reaper.cleanupImages(failedMaxAgeMs, ctx);
   }
 
   private async authorizeCompletionCallback(
@@ -454,35 +431,31 @@ export class ImageBuildWorkflow {
     ctx: ImageBuildWorkflowContext
   ) {
     if (!token) {
-      throw this.loggedCallbackAuthError(
-        new ImageBuildCallbackAuthError("rejected", "Unauthorized"),
-        { buildId, providerSessionId, ctx }
-      );
+      throw this.loggedCallbackAuthError("rejected", { buildId, providerSessionId, ctx });
     }
 
     let tokenHash: string;
     try {
       tokenHash = await hashImageBuildCallbackToken(token, this.env);
     } catch (error) {
-      throw this.loggedCallbackAuthError(
-        new ImageBuildCallbackAuthError("misconfigured", "Callback auth unavailable", error),
-        { buildId, providerSessionId, ctx }
-      );
+      throw this.loggedCallbackAuthError("misconfigured", {
+        buildId,
+        providerSessionId,
+        cause: error,
+        ctx,
+      });
     }
 
-    const authenticated = await this.store.finalization.authorizeCompletionCallback({
+    const build = await this.store.finalization.authorizeCompletionCallback({
       buildId,
       providerSessionId,
       tokenHash,
       now: Date.now(),
     });
-    if (!authenticated) {
-      throw this.loggedCallbackAuthError(
-        new ImageBuildCallbackAuthError("rejected", "Unauthorized"),
-        { buildId, providerSessionId, ctx }
-      );
+    if (!build) {
+      throw this.loggedCallbackAuthError("rejected", { buildId, providerSessionId, ctx });
     }
-    return { ...authenticated, tokenHash };
+    return { build, tokenHash };
   }
 
   private requireFinalizationQueue(): ImageBuildFinalizationQueue {
@@ -493,18 +466,18 @@ export class ImageBuildWorkflow {
   }
 
   private loggedCallbackAuthError(
-    error: ImageBuildCallbackAuthError,
+    failure: ImageBuildCallbackAuthFailure,
     params: {
       buildId: string;
-      provider?: ImageBuildProvider;
       providerSessionId?: string | null;
+      cause?: unknown;
       ctx: ImageBuildWorkflowContext;
     }
   ): Error {
-    if (error.failure === "misconfigured") {
+    if (failure === "misconfigured") {
       logger.error("image_build.callback_auth_misconfigured", {
         build_id: params.buildId,
-        error: error.cause instanceof Error ? error.cause.message : undefined,
+        error: params.cause instanceof Error ? params.cause.message : undefined,
         request_id: params.ctx.request_id,
         trace_id: params.ctx.trace_id,
       });
@@ -513,7 +486,6 @@ export class ImageBuildWorkflow {
 
     logger.warn("image_build.callback_auth_failed", {
       build_id: params.buildId,
-      provider: params.provider,
       provider_session_id: params.providerSessionId,
       request_id: params.ctx.request_id,
       trace_id: params.ctx.trace_id,
@@ -524,21 +496,12 @@ export class ImageBuildWorkflow {
 
 export function createImageBuildWorkflowFromEnv(env: Env, db: SqlDatabase): ImageBuildWorkflow {
   const provider = resolveImageBuildProvider(env.SANDBOX_PROVIDER);
-  const finalizationQueue = env.IMAGE_BUILD_FINALIZATION_QUEUE
-    ? {
-        async send(
-          job: Parameters<NonNullable<Env["IMAGE_BUILD_FINALIZATION_QUEUE"]>["send"]>[0]
-        ): Promise<void> {
-          await env.IMAGE_BUILD_FINALIZATION_QUEUE!.send(job);
-        },
-      }
-    : null;
   return new ImageBuildWorkflow(
     env,
     new ImageBuildStore(db),
     createImageBuildAdapterFactory(env),
     provider ? { provider, planner: new ImageBuildPlanner(env, db) } : null,
-    finalizationQueue
+    env.IMAGE_BUILD_FINALIZATION_QUEUE ?? null
   );
 }
 
@@ -558,8 +521,4 @@ function callbackAuthRegistration(
     callbackTokenHash: callbackAuth.tokenHash,
     callbackTokenExpiresAt: callbackAuth.expiresAt,
   };
-}
-
-function errorMessage(errorValue: unknown): string {
-  return errorValue instanceof Error ? errorValue.message : String(errorValue);
 }

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -35,7 +35,6 @@ import type {
   CompleteImageBuildCallback,
   FailImageBuildCallback,
   ImageBuildWorkflowContext,
-  ImageBuildWorkflowResult,
 } from "../image-builds/types";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
@@ -96,19 +95,6 @@ function workflowContext(ctx: RequestContext): ImageBuildWorkflowContext {
     request_id: ctx.request_id,
     trace_id: ctx.trace_id,
   };
-}
-
-function workflowResultToResponse(result: ImageBuildWorkflowResult): Response {
-  switch (result.type) {
-    case "completion_accepted":
-      return json({ ok: true, snapshotPending: true }, 202);
-    case "failure_accepted":
-      return json({ ok: true, cleanupPending: true }, 202);
-    default: {
-      const exhaustive: never = result;
-      return error(`Unhandled workflow result: ${String(exhaustive)}`, 500);
-    }
-  }
 }
 
 function imageBuildErrorToResponse(errorValue: unknown): Response {
@@ -207,12 +193,12 @@ async function handleBuildComplete(
   };
 
   try {
-    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildComplete({
+    await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildComplete({
       completion,
       callbackToken: getImageBuildCallbackBearerToken(request),
       context: workflowContext(ctx),
     });
-    return workflowResultToResponse(result);
+    return json({ ok: true, snapshotPending: true }, 202);
   } catch (e) {
     return imageBuildErrorToResponse(e);
   }
@@ -242,12 +228,12 @@ async function handleBuildFailed(
   };
 
   try {
-    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildFailed({
+    await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildFailed({
       failure,
       callbackToken: getImageBuildCallbackBearerToken(request),
       context: workflowContext(ctx),
     });
-    return workflowResultToResponse(result);
+    return json({ ok: true, cleanupPending: true }, 202);
   } catch (e) {
     return imageBuildErrorToResponse(e);
   }

--- a/packages/control-plane/test/integration/image-build-finalization-store.test.ts
+++ b/packages/control-plane/test/integration/image-build-finalization-store.test.ts
@@ -66,8 +66,10 @@ describe("ImageBuildStore finalization state", () => {
         tokenHash: "token-hash",
         now,
       })
-    ).toMatchObject({ authorization: "fresh" });
+    ).toMatchObject({ id: "build-1", status: "building" });
     expect(await store.finalization.acceptSuccessfulCompletion(completion)).toBe("accepted");
+    // The used token stays authorizable after acceptance so a lost HTTP
+    // response can republish the same Queue command.
     expect(
       await store.finalization.authorizeCompletionCallback({
         buildId: "build-1",
@@ -75,7 +77,7 @@ describe("ImageBuildStore finalization state", () => {
         tokenHash: "token-hash",
         now: now + 1,
       })
-    ).toMatchObject({ authorization: "accepted" });
+    ).toMatchObject({ id: "build-1" });
     expect(
       await store.finalization.acceptSuccessfulCompletion({ ...completion, now: now + 1 })
     ).toBe("replayed");

--- a/packages/control-plane/test/integration/image-build-scheduler.test.ts
+++ b/packages/control-plane/test/integration/image-build-scheduler.test.ts
@@ -3,6 +3,7 @@ import { createExecutionContext, env } from "cloudflare:test";
 import worker from "../../src/index";
 import { ImageBuildStore } from "../../src/db/image-builds";
 import type { ImageBuildAdapterFactory } from "../../src/image-builds/provider-factory";
+import type { ImageBuildReaper } from "../../src/image-builds/reaper";
 import { IMAGE_BUILD_SCHEDULER_CRON, ImageBuildScheduler } from "../../src/image-builds/scheduler";
 import type { ImageBuildWorkflow } from "../../src/image-builds/workflow";
 import type { Env } from "../../src/types";
@@ -52,13 +53,14 @@ describe("image build scheduler integration", () => {
       .run();
 
     const send = vi.fn(async () => undefined);
-    const workflow = {
+    const workflow = {} as unknown as ImageBuildWorkflow;
+    const reaper = {
       cleanupImages: vi.fn(async () => ({
         deletedFailed: 0,
         reapedFailed: 0,
         reapedSuperseded: 0,
       })),
-    } as unknown as ImageBuildWorkflow;
+    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
       env.DB,
@@ -66,6 +68,7 @@ describe("image build scheduler integration", () => {
       store,
       workflow,
       { create: vi.fn() } as unknown as ImageBuildAdapterFactory,
+      reaper,
       null
     );
 
@@ -113,13 +116,14 @@ describe("image build scheduler integration", () => {
     }
 
     const send = vi.fn(async () => undefined);
-    const workflow = {
+    const workflow = {} as unknown as ImageBuildWorkflow;
+    const reaper = {
       cleanupImages: vi.fn(async () => ({
         deletedFailed: 0,
         reapedFailed: 0,
         reapedSuperseded: 0,
       })),
-    } as unknown as ImageBuildWorkflow;
+    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
       env.DB,
@@ -127,6 +131,7 @@ describe("image build scheduler integration", () => {
       store,
       workflow,
       { create: vi.fn() } as unknown as ImageBuildAdapterFactory,
+      reaper,
       null
     );
 
@@ -152,13 +157,14 @@ describe("image build scheduler integration", () => {
     }
 
     const cleanupFailedBuild = vi.fn(async () => undefined);
-    const workflow = {
+    const workflow = {} as unknown as ImageBuildWorkflow;
+    const reaper = {
       cleanupImages: vi.fn(async () => ({
         deletedFailed: 0,
         reapedFailed: 0,
         reapedSuperseded: 0,
       })),
-    } as unknown as ImageBuildWorkflow;
+    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       {} as Env,
       env.DB,
@@ -171,6 +177,7 @@ describe("image build scheduler integration", () => {
           cleanupCompletedBuild: vi.fn(async () => undefined),
         })),
       } as unknown as ImageBuildAdapterFactory,
+      reaper,
       null
     );
 

--- a/packages/control-plane/test/integration/image-build-scheduler.test.ts
+++ b/packages/control-plane/test/integration/image-build-scheduler.test.ts
@@ -3,7 +3,6 @@ import { createExecutionContext, env } from "cloudflare:test";
 import worker from "../../src/index";
 import { ImageBuildStore } from "../../src/db/image-builds";
 import type { ImageBuildAdapterFactory } from "../../src/image-builds/provider-factory";
-import type { ImageBuildReaper } from "../../src/image-builds/reaper";
 import { IMAGE_BUILD_SCHEDULER_CRON, ImageBuildScheduler } from "../../src/image-builds/scheduler";
 import type { ImageBuildWorkflow } from "../../src/image-builds/workflow";
 import type { Env } from "../../src/types";
@@ -54,13 +53,6 @@ describe("image build scheduler integration", () => {
 
     const send = vi.fn(async () => undefined);
     const workflow = {} as unknown as ImageBuildWorkflow;
-    const reaper = {
-      cleanupImages: vi.fn(async () => ({
-        deletedFailed: 0,
-        reapedFailed: 0,
-        reapedSuperseded: 0,
-      })),
-    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
       env.DB,
@@ -68,7 +60,6 @@ describe("image build scheduler integration", () => {
       store,
       workflow,
       { create: vi.fn() } as unknown as ImageBuildAdapterFactory,
-      reaper,
       null
     );
 
@@ -117,13 +108,6 @@ describe("image build scheduler integration", () => {
 
     const send = vi.fn(async () => undefined);
     const workflow = {} as unknown as ImageBuildWorkflow;
-    const reaper = {
-      cleanupImages: vi.fn(async () => ({
-        deletedFailed: 0,
-        reapedFailed: 0,
-        reapedSuperseded: 0,
-      })),
-    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
       env.DB,
@@ -131,7 +115,6 @@ describe("image build scheduler integration", () => {
       store,
       workflow,
       { create: vi.fn() } as unknown as ImageBuildAdapterFactory,
-      reaper,
       null
     );
 
@@ -158,13 +141,6 @@ describe("image build scheduler integration", () => {
 
     const cleanupFailedBuild = vi.fn(async () => undefined);
     const workflow = {} as unknown as ImageBuildWorkflow;
-    const reaper = {
-      cleanupImages: vi.fn(async () => ({
-        deletedFailed: 0,
-        reapedFailed: 0,
-        reapedSuperseded: 0,
-      })),
-    } as unknown as ImageBuildReaper;
     const scheduler = new ImageBuildScheduler(
       {} as Env,
       env.DB,
@@ -177,7 +153,6 @@ describe("image build scheduler integration", () => {
           cleanupCompletedBuild: vi.fn(async () => undefined),
         })),
       } as unknown as ImageBuildAdapterFactory,
-      reaper,
       null
     );
 


### PR DESCRIPTION
## Summary

Behavior-preserving collapse of accumulated indirection in the image-build subsystem, from the recorded post-merge review of the standardization arc. Every finding was re-verified against current code before implementation; one was found to be load-bearing and is deliberately skipped (below).

**Dead middleman error class.** `ImageBuildCallbackAuthError` existed only to carry a `(failure, cause)` pair from `authorizeCompletionCallback` to `loggedCallbackAuthError`, which read exactly those two fields and returned a *different* error; its message was always discarded and its `provider?` log param never supplied. The logger helper now takes the `"rejected" | "misconfigured"` discriminant directly; the class is deleted (the `ImageBuildCallbackAuthFailure` type stays). Log delta: the always-`undefined` `provider` field is gone from `image_build.callback_auth_failed`; everything else is unchanged.

**Dead authorization state.** The store's `"fresh" | "accepted"` discriminant was computed and never read anywhere (the republish decision uses `build.status === "building"`), and `ImageBuildCallbackBuild.providerSessionId` had zero readers. `authorizeCompletionCallback` now returns `ImageBuildCallbackBuild | null`; the still-authorizable-after-acceptance branch is kept and now documented inline, and the integration test still pins that replay behavior (asserting on the returned build instead of the deleted discriminant).

**Workflow no longer owns a reaper it only forwarded.** `workflow.cleanupImages` was a one-line delegate whose sole caller was the scheduler. The scheduler now takes the reaper as a collaborator (constructed in `runImageBuildScheduler`, injected in tests — same seam shape the tests already used via the workflow mock); the workflow drops the field, the method, and the import. The cleanup suite moved from `workflow.test.ts` to a new `reaper.test.ts` with its own lean fixture, assertions unchanged.

**Queue adapter.** The `Parameters<NonNullable<...>>[0]` wrapper is gone; the binding is passed directly. One correction to the original finding: the wrapper *was* load-bearing under current workers-types (`Queue.send` returns `Promise<QueueSendResponse>`, not `void`), so instead of re-wrapping, the port's `send` now returns `Promise<unknown>` — callers only await delivery. The scheduler's republish path now builds its job via `republishedImageBuildFinalizationJob` in `finalization-job.ts`, so the `version: 1` shape has one owner.

**Repo-standards items.** The `ImageBuildPlannerLike = Pick<...>` projection became an explicit `ImageBuildPlannerPort` interface (with `ImageBuildPlanRequest` naming the planBuild input) that `ImageBuildPlanner` implements. `BaseImageBuildPlan` (single-extension leftover) is inlined into `ImageBuildPlan`. The reaper's two best-effort helpers with zero external callers are now private.

**Small collapses.** `errorMessage` was byte-identical in five modules — now one export in `errors.ts`. The finalizer's `markFailed → getBuild → cleanupTerminalBuild → completed()` ritual (×3) is now `failAndCleanup`. The unused-outside-its-own-test re-export of `ImageBuildFinalizationAttemptError` from `finalizer.ts` is gone (the test imports from `finalization-error.ts`). The `startAdapter` shadow of the in-scope `adapter` is gone. The `orphan_sweep` scheduler-tick log field — static narration about a sweep that no longer exists — is deleted.

**Result-union simplification.** `ImageBuildWorkflowResult` had two variants, each produced by exactly one method, forcing an unreachable-default switch in routes. `acceptBuildComplete`/`acceptBuildFailed` now return `void` and the two callback routes return their (byte-identical) 202 bodies directly.

## Deliberately skipped

`ImageBuildRegistration.callbackTokenHash?`/`callbackTokenExpiresAt?`: the one production caller always supplies both, but ~45 test call sites intentionally register token-less builds to exercise the unauthorizable-row paths — the optionality is load-bearing test surface, not dead generality.

## Verification

Net −33 lines with a new 180-line test file (i.e. ~−200 in src). Typecheck across all three programs (main, unit-test, `test/integration`), ESLint + Prettier clean, unit battery 3322/3322, integration battery 1006/1006. All HTTP responses, SQL, and log events byte-identical except the two documented log-field deletions (`orphan_sweep`, always-undefined `provider`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Completion callbacks can be safely republished, including after a prior acceptance.
  - Finalization jobs support reliable retry processing.
  - Image build planning supports provider-neutral plans and clone authorization states.

- **Bug Fixes**
  - Improved cleanup of failed and superseded image artifacts, including timeouts and provider deletion failures.
  - Standardized error handling across image build operations.
  - Callback responses remain consistent after completion or failure.

- **Tests**
  - Expanded coverage for cleanup retries, concurrency limits, timeouts, and idempotent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->