### PR TITLE
Refine new and active session experience

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -248,6 +248,8 @@ describe("Home", () => {
   it("disables autofill suggestions for the prompt", () => {
     render(<Home />);
 
+    expect(screen.getByRole("heading", { name: "New session" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Start with an outcome" })).toBeInTheDocument();
     expect(screen.getByPlaceholderText("What do you want to build?")).toHaveAttribute(
       "autocomplete",
       "off"
@@ -301,14 +303,15 @@ describe("Home", () => {
 
     await user.type(screen.getByPlaceholderText("What do you want to build?"), "I");
 
-    const warmingStatus = await screen.findByText("Warming sandbox...");
+    const warmingStatus = await screen.findByText("Preparing session...");
+    expect(warmingStatus).toHaveRole("status");
     const attachmentButton = screen.getByRole("button", { name: "Attach images" });
     expect(
       warmingStatus.compareDocumentPosition(attachmentButton) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 
     resolveCreate?.(Response.json({ sessionId: "session-1", status: "created" }));
-    await waitFor(() => expect(screen.queryByText("Warming sandbox...")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Preparing session...")).not.toBeInTheDocument());
   });
 
   it("does not warm a pending session from a malformed create response", async () => {
@@ -322,7 +325,7 @@ describe("Home", () => {
     render(<Home />);
 
     await user.type(screen.getByPlaceholderText("What do you want to build?"), "Investigate logs");
-    await waitFor(() => expect(screen.queryByText("Warming sandbox...")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Preparing session...")).not.toBeInTheDocument());
     await user.click(screen.getByRole("button", { name: /send/i }));
 
     await screen.findByText("Failed to create session");
@@ -652,8 +655,6 @@ describe("Home", () => {
     expect(
       branch.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
-    expect(repository.querySelectorAll("svg")).toHaveLength(1);
-    expect(branch.closest("button")?.querySelectorAll("svg")).toHaveLength(1);
     expect(branch).toHaveClass("max-w-[9rem]", "truncate");
     expect(screen.queryByText("build agent")).not.toBeInTheDocument();
   });

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -12,7 +12,6 @@ import { matchesShortcut } from "@/lib/keyboard-shortcuts";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { isSessionInboxKey } from "@/lib/session-inbox-api";
-import { APP_NAME } from "@/lib/site-config";
 import type { SessionAttachmentReference } from "@open-inspect/shared/types/session-attachments";
 import { MAX_WEB_PROMPT_CHARS } from "@open-inspect/shared/types/websocket";
 import {
@@ -462,28 +461,25 @@ function HomeContent({
   };
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Header with toggle when sidebar is closed */}
-      {!isOpen && (
-        <header className="border-b border-border-muted flex-shrink-0">
-          <div className="px-4 py-3">
-            <CollapsedSidebarControls />
-          </div>
-        </header>
-      )}
+    <div className="flex h-full flex-col bg-background">
+      <header className="h-14 flex-shrink-0 border-b border-border-muted">
+        <div className="flex h-full items-center gap-3 px-4">
+          {!isOpen && <CollapsedSidebarControls />}
+          <h1 className="text-sm font-medium text-foreground">New session</h1>
+        </div>
+      </header>
 
-      <div className="flex-1 flex flex-col items-center justify-center p-8">
-        <div className="w-full max-w-2xl">
-          {/* Welcome text */}
-          <div className="text-center mb-8">
-            <h1 className="text-3xl font-semibold text-foreground mb-2">Welcome to {APP_NAME}</h1>
-            {isAuthenticated ? (
-              <p className="text-muted-foreground">
-                Ask a question or describe what you want to build
-              </p>
-            ) : (
-              <p className="text-muted-foreground">Sign in to start a new session</p>
-            )}
+      <div className="flex flex-1 overflow-y-auto">
+        <div className="m-auto w-full max-w-3xl px-4 py-10 sm:px-8 sm:py-16">
+          <div className="mb-8 text-center sm:mb-10">
+            <h2 className="mb-2 text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+              Start with an outcome
+            </h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              {isAuthenticated
+                ? "What should the agent work on?"
+                : "Sign in to start a new session"}
+            </p>
           </div>
 
           {/* Input box - only show when authenticated */}
@@ -491,17 +487,30 @@ function HomeContent({
             <form onSubmit={handleSubmit}>
               {error && <ErrorBanner className="mb-4">{error}</ErrorBanner>}
 
-              <div className="mb-3 flex flex-wrap items-center gap-2 px-4 sm:gap-4">
-                <SessionTargetPicker {...picker.pickerProps} disabled={creating} />
-              </div>
-
               <div
-                className={`border border-border bg-input ${isDraggingOver ? "ring-2 ring-accent" : ""}`}
+                className={`rounded-xl border bg-input shadow-sm transition-shadow ${
+                  isDraggingOver
+                    ? "border-accent ring-2 ring-accent/30"
+                    : "border-border-muted focus-within:border-border"
+                }`}
                 onPaste={handlePaste}
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
               >
+                <div className="flex min-h-12 flex-wrap items-center justify-between gap-2 rounded-t-xl border-b border-border-muted bg-muted/20 px-4 py-2.5">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-4">
+                    <SessionTargetPicker {...picker.pickerProps} disabled={creating} />
+                  </div>
+                  {isCreatingSession && (
+                    <span
+                      role="status"
+                      className="sr-only whitespace-nowrap text-xs text-accent sm:not-sr-only"
+                    >
+                      Preparing session...
+                    </span>
+                  )}
+                </div>
                 <AttachmentPreviewStrip
                   items={attachments.items}
                   error={attachments.error}
@@ -516,7 +525,6 @@ function HomeContent({
                   className="hidden"
                   onChange={handleFileInputChange}
                 />
-                {/* Text input area */}
                 <div className="relative">
                   <PromptSkillTextarea
                     ref={inputRef}
@@ -528,51 +536,13 @@ function HomeContent({
                     disabled={creating}
                     placeholder="What do you want to build?"
                     autoComplete="off"
-                    className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground disabled:opacity-50"
-                    rows={3}
+                    className="min-h-36 w-full resize-none bg-transparent px-4 py-4 text-foreground placeholder:text-secondary-foreground focus:outline-none disabled:opacity-50 sm:min-h-44"
+                    rows={5}
                   />
-                  {/* Submit button */}
-                  <div className="absolute bottom-3 right-3 flex items-center gap-2">
-                    {isCreatingSession && (
-                      <span className="whitespace-nowrap text-xs text-accent">
-                        Warming sandbox...
-                      </span>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={attachmentsLocked}
-                      className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
-                      title="Attach images"
-                      aria-label="Attach images"
-                    >
-                      <PaperclipIcon className="w-5 h-5" />
-                    </button>
-                    <button
-                      type="submit"
-                      disabled={
-                        (!prompt.trim() && attachments.items.length === 0) ||
-                        attachmentsLocked ||
-                        !providerSelectionsHydrated ||
-                        providerAccounts.loading ||
-                        !isLaunchable
-                      }
-                      className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
-                      title={`Send (${labels["send-prompt"]})`}
-                      aria-label={`Send (${labels["send-prompt"]})`}
-                    >
-                      {creating ? (
-                        <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                      ) : (
-                        <SendIcon className="w-5 h-5" />
-                      )}
-                    </button>
-                  </div>
                 </div>
 
-                {/* Footer row with session controls */}
-                <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:gap-0">
-                  <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
+                <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border-muted px-3 py-2.5 sm:px-4">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-4">
                     <ModelReasoningSelector
                       selectedModel={selectedModel}
                       reasoningEffort={reasoningEffort}
@@ -606,6 +576,37 @@ function HomeContent({
                         }
                       />
                     )}
+                  </div>
+                  <div className="ml-auto flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={attachmentsLocked}
+                      className="rounded-md p-2 text-secondary-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+                      title="Attach images"
+                      aria-label="Attach images"
+                    >
+                      <PaperclipIcon className="h-5 w-5" />
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={
+                        (!prompt.trim() && attachments.items.length === 0) ||
+                        attachmentsLocked ||
+                        !providerSelectionsHydrated ||
+                        providerAccounts.loading ||
+                        !isLaunchable
+                      }
+                      className="rounded-md bg-primary p-2 text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-30"
+                      title={`Send (${labels["send-prompt"]})`}
+                      aria-label={`Send (${labels["send-prompt"]})`}
+                    >
+                      {creating ? (
+                        <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                      ) : (
+                        <SendIcon className="h-5 w-5" />
+                      )}
+                    </button>
                   </div>
                 </div>
               </div>

--- a/packages/web/src/app/(app)/session/[id]/loading.tsx
+++ b/packages/web/src/app/(app)/session/[id]/loading.tsx
@@ -2,7 +2,7 @@ export default function SessionLoading() {
   return (
     <div className="flex h-full flex-col" role="status" aria-label="Loading session">
       <div className="h-14 animate-pulse border-b border-border bg-muted/30" />
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-4 px-6 py-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 px-6 py-8">
         <div className="h-20 animate-pulse rounded-lg bg-muted/50" />
         <div className="h-32 animate-pulse rounded-lg bg-muted/40" />
         <div className="h-24 animate-pulse rounded-lg bg-muted/30" />

--- a/packages/web/src/components/prompt-skill-suggestion-panel.tsx
+++ b/packages/web/src/components/prompt-skill-suggestion-panel.tsx
@@ -54,7 +54,7 @@ export function PromptSkillSuggestionPanel({
         role="listbox"
         aria-label="Managed skills"
         aria-busy={source.status === "loading"}
-        className="max-h-[min(22rem,50vh)] overflow-y-auto"
+        className="max-h-[min(12rem,35vh)] overflow-y-auto sm:max-h-[min(22rem,50vh)]"
       >
         {source.status === "loading" ? (
           <div className="flex items-center gap-3 rounded-lg px-3 py-4 text-sm text-muted-foreground">

--- a/packages/web/src/components/queued-prompt-stack.tsx
+++ b/packages/web/src/components/queued-prompt-stack.tsx
@@ -16,7 +16,7 @@ export function QueuedPromptStack({
   if (pendingPrompts.length === 0) return null;
 
   return (
-    <section aria-label="Queued prompts" className="mx-auto w-full min-w-0 max-w-4xl px-4 pt-3">
+    <section aria-label="Queued prompts" className="mx-auto w-full min-w-0 max-w-3xl px-4 pt-3">
       <div className="max-h-48 overflow-y-auto rounded-t-xl border border-b-0 border-border bg-card/95 px-3 pb-3 pt-2 shadow-[0_-8px_30px_-22px_rgba(0,0,0,0.45)] backdrop-blur-sm">
         <ol className="divide-y divide-border-muted">
           {pendingPrompts.map((prompt) => (

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -209,6 +209,7 @@ describe("SessionHeader", () => {
     expect(connection.parentElement).not.toHaveClass("md:hidden");
     expect(connection).toHaveAttribute("tabindex", "0");
     expect(screen.getByRole("button", { name: "Sandbox status: Ready" })).toBeInTheDocument();
+    expect(screen.getByText("feature/status-icons")).toBeInTheDocument();
 
     fireEvent.pointerMove(connection, { pointerType: "mouse" });
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Connected");

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -5,7 +5,7 @@ import type { SandboxStatus as SandboxStatusValue } from "@open-inspect/shared/t
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { MobileSessionActions } from "@/components/mobile-session-actions";
 import type { SessionActionProps } from "@/components/session-actions";
-import { BoxIcon, RightSidebarIcon } from "@/components/ui/icons";
+import { BoxIcon, BranchIcon, RightSidebarIcon } from "@/components/ui/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
@@ -168,11 +168,11 @@ export function SessionHeader({
   }, [fallbackSessionInfo.title, sessionState?.title, isRenaming]);
 
   return (
-    <header className="border-b border-border-muted flex-shrink-0">
-      <div className="px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
+    <header className="h-14 flex-shrink-0 border-b border-border-muted">
+      <div className="flex h-full items-center justify-between gap-3 px-4">
+        <div className="flex min-w-0 items-center gap-3">
           {!isOpen && <CollapsedSidebarControls />}
-          <div>
+          <div className="min-w-0">
             {isRenaming ? (
               <input
                 autoFocus
@@ -190,10 +190,10 @@ export function SessionHeader({
                     setIsRenaming(false);
                   }
                 }}
-                className="text-sm bg-transparent text-foreground outline-none focus:ring-inset focus:ring-ring font-medium max-w-40 truncate"
+                className="max-w-64 truncate bg-transparent text-sm font-medium text-foreground outline-none focus:ring-inset focus:ring-ring"
               />
             ) : (
-              <h1 className="max-w-40 truncate text-sm font-medium text-foreground">
+              <h1 className="max-w-64 truncate text-sm font-medium text-foreground">
                 <button
                   type="button"
                   className="max-w-full truncate cursor-text text-left"
@@ -204,10 +204,23 @@ export function SessionHeader({
                 </button>
               </h1>
             )}
-            <p className="text-sm text-muted-foreground">{repoLabel}</p>
+            <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+              <span className="truncate">{repoLabel}</span>
+              {sessionState?.branchName && (
+                <>
+                  <span aria-hidden="true" className="text-border">
+                    /
+                  </span>
+                  <span className="flex min-w-0 items-center gap-1 font-mono">
+                    <BranchIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+                    <span className="max-w-48 truncate">{sessionState.branchName}</span>
+                  </span>
+                </>
+              )}
+            </div>
           </div>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex shrink-0 items-center gap-2">
           <button
             ref={detailsButtonRef}
             type="button"
@@ -225,7 +238,7 @@ export function SessionHeader({
             onOpenDetails={onOpenMobileDetails}
             onOpenMedia={onOpenMobileDetails}
           />
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1.5">
             <ConnectionStatusIcon connected={connected} connecting={connecting} />
             <SandboxStatusIcon
               status={sessionState?.sandboxStatus}
@@ -309,9 +322,10 @@ function SandboxStatusIcon({
         <button
           type="button"
           aria-label={`Sandbox status: ${presentation.label}`}
-          className={`relative flex h-8 w-8 items-center justify-center rounded-sm border border-border ${presentation.color} transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+          className={`relative flex h-8 items-center justify-center gap-2 rounded-md border border-border px-2 ${presentation.color} transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
         >
           <BoxIcon className="h-4 w-4" />
+          <span className="hidden text-xs font-medium sm:inline">{presentation.label}</span>
           <span
             aria-hidden="true"
             className={`absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full ${presentation.dot}${presentation.pulse ? " animate-pulse motion-reduce:animate-none" : ""}`}

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -94,8 +94,11 @@ export function SessionPromptComposer({
   }, [prompt.inputRef, prompt.value]);
 
   return (
-    <footer className="min-w-0 border-t border-border-muted flex-shrink-0">
-      <form onSubmit={prompt.onSubmit} className="w-full min-w-0 max-w-4xl mx-auto p-4 pb-6">
+    <footer className="min-w-0 flex-shrink-0 border-t border-border-muted bg-background/95 backdrop-blur-sm">
+      <form
+        onSubmit={prompt.onSubmit}
+        className="mx-auto w-full min-w-0 max-w-3xl p-3 pb-4 sm:p-4 sm:pb-5"
+      >
         {/* Action bar above input */}
         <div className="hidden mb-3 md:block">
           <ActionBar
@@ -110,7 +113,9 @@ export function SessionPromptComposer({
 
         {/* Input container */}
         <div
-          className={`border bg-input ${isDraggingOver ? "border-accent" : "border-border"}`}
+          className={`rounded-xl border bg-input shadow-sm transition-shadow ${
+            isDraggingOver ? "border-accent ring-2 ring-accent/30" : "border-border-muted"
+          }`}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
@@ -136,7 +141,7 @@ export function SessionPromptComposer({
               onPaste={handlePaste}
               autoComplete="off"
               placeholder={prompt.isProcessing ? "Add a follow-up..." : "Ask or build anything"}
-              className="min-h-12 max-h-40 w-0 min-w-48 flex-1 resize-none overflow-y-auto bg-transparent px-4 py-3 leading-6 text-foreground placeholder:text-secondary-foreground focus:outline-none sm:block sm:min-h-[7.75rem] sm:w-full sm:px-4 sm:pt-4 sm:pb-12"
+              className="min-h-12 max-h-40 w-0 min-w-48 flex-1 resize-none overflow-y-auto bg-transparent px-4 py-3 leading-6 text-foreground placeholder:text-secondary-foreground focus:outline-none sm:block sm:min-h-20 sm:w-full sm:px-4 sm:pt-4 sm:pb-12"
               rows={1}
             />
             {/* Floating action buttons */}
@@ -159,7 +164,7 @@ export function SessionPromptComposer({
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={attachmentsLocked}
-                className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
+                className="rounded-md p-2 text-secondary-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
                 title="Attach images"
                 aria-label="Attach images"
               >
@@ -169,7 +174,7 @@ export function SessionPromptComposer({
                 <button
                   type="button"
                   onClick={prompt.onStopExecution}
-                  className="p-2 text-destructive hover:bg-destructive-muted transition"
+                  className="rounded-md p-2 text-destructive transition hover:bg-destructive-muted"
                   title="Stop current prompt; queued prompts will continue"
                   aria-label="Stop current prompt; queued prompts will continue"
                 >
@@ -179,7 +184,7 @@ export function SessionPromptComposer({
               <button
                 type="submit"
                 disabled={sendDisabled}
-                className="flex items-center gap-1 p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
+                className="flex items-center gap-1 rounded-md bg-primary p-2 text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-30"
                 title={
                   prompt.isProcessing
                     ? "Queue follow-up; runs after the current prompt"
@@ -197,9 +202,7 @@ export function SessionPromptComposer({
             </div>
           </div>
 
-          {/* Footer row with model controls and agent label */}
-          <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
-            {/* Left side - Model controls */}
+          <div className="flex flex-col gap-2 border-t border-border-muted px-4 py-2 sm:flex-row sm:items-center sm:gap-0">
             <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
               <ModelReasoningSelector
                 selectedModel={model.selectedModel}
@@ -210,9 +213,6 @@ export function SessionPromptComposer({
                 disabled={prompt.draftLocked || !sessionPromptable}
               />
             </div>
-
-            {/* Right side - Agent label */}
-            <span className="hidden sm:inline text-sm text-muted-foreground">build agent</span>
           </div>
           {prompt.submitError && (
             <p

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -101,6 +101,12 @@ export function SessionRightSidebarContent({
 
   return (
     <>
+      <div className="border-b border-border-muted px-4 py-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Session context
+        </h2>
+      </div>
+
       {/* Participants */}
       <div className="px-4 py-4 border-b border-border-muted">
         <ParticipantsSection participants={participants} presenceSynced={presenceSynced} />
@@ -126,6 +132,13 @@ export function SessionRightSidebarContent({
           totalCost={sessionState.totalCost}
         />
       </div>
+
+      {/* Tasks */}
+      {tasks.length > 0 && (
+        <CollapsibleSection title="Progress" defaultOpen={true}>
+          <TasksSection tasks={tasks} />
+        </CollapsibleSection>
+      )}
 
       {/* Code Server */}
       {sessionState.codeServerUrl && (
@@ -189,13 +202,6 @@ export function SessionRightSidebarContent({
             sandboxStatus={sessionState.sandboxStatus}
           />
         </div>
-      )}
-
-      {/* Tasks */}
-      {tasks.length > 0 && (
-        <CollapsibleSection title="Tasks" defaultOpen={true}>
-          <TasksSection tasks={tasks} />
-        </CollapsibleSection>
       )}
 
       {/* Child Sessions */}

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -2,7 +2,7 @@
 
 import { RepositoryMultiSelect } from "@/components/repository-multi-select";
 import { Combobox } from "@/components/ui/combobox";
-import { ChevronDownIcon } from "@/components/ui/icons";
+import { BranchIcon, ChevronDownIcon, FolderIcon } from "@/components/ui/icons";
 import type { SessionTargetPickerProps } from "@/hooks/use-session-target-picker";
 
 /**
@@ -44,6 +44,7 @@ export function SessionTargetPicker({
         disabled={disabled || loadingRepos}
         triggerClassName="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
       >
+        <FolderIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
         <span className="truncate max-w-[12rem] sm:max-w-none">
           {loadingRepos ? "Loading..." : displayTargetName}
         </span>
@@ -84,6 +85,7 @@ export function SessionTargetPicker({
           disabled={disabled || loadingBranches}
           triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
         >
+          <BranchIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span className="max-w-[9rem] truncate">
             {loadingBranches ? "Loading..." : selectedBranch || "branch"}
           </span>

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -317,7 +317,7 @@ export function SessionTimeline({
 
 function ThinkingIndicator() {
   return (
-    <div className="bg-card p-4 flex items-center gap-2">
+    <div className="flex items-center gap-2 rounded-xl border border-border-muted bg-card p-4 shadow-sm">
       <span className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse" />
       <span className="text-sm text-muted-foreground">Thinking...</span>
     </div>
@@ -327,16 +327,16 @@ function ThinkingIndicator() {
 function TimelineSkeleton() {
   return (
     <div className="space-y-3 py-2 animate-pulse">
-      <div className="bg-card p-3 space-y-2 sm:p-4">
+      <div className="space-y-2 rounded-xl border border-border-muted bg-card p-3 sm:p-4">
         <div className="h-3 w-24 bg-muted rounded" />
         <div className="h-3 w-full bg-muted rounded" />
         <div className="h-3 w-5/6 bg-muted rounded" />
       </div>
-      <div className="bg-accent-muted p-3 space-y-2 sm:ml-8 sm:p-4">
+      <div className="space-y-2 rounded-xl border border-primary/10 bg-accent-muted p-3 sm:ml-8 sm:p-4">
         <div className="h-3 w-20 bg-muted rounded" />
         <div className="h-3 w-4/5 bg-muted rounded" />
       </div>
-      <div className="bg-card p-3 space-y-2 sm:p-4">
+      <div className="space-y-2 rounded-xl border border-border-muted bg-card p-3 sm:p-4">
         <div className="h-3 w-32 bg-muted rounded" />
         <div className="h-3 w-3/4 bg-muted rounded" />
       </div>
@@ -517,7 +517,7 @@ function UserMessageEvent({
       time={formatEventTime(event)}
       copied={copied}
       content={event.content}
-      className="group bg-accent-muted p-3 sm:ml-8 sm:p-4"
+      className="group rounded-xl border border-primary/10 bg-accent-muted p-3 shadow-sm sm:ml-8 sm:p-4"
       copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
       onCopyContent={onCopyContent}
     >
@@ -559,7 +559,7 @@ function AssistantMessageEvent({ event, copied, onCopyContent }: EventRendererPr
       time={formatEventTime(event)}
       copied={copied}
       content={event.content}
-      className="group bg-card p-3 sm:p-4"
+      className="group rounded-xl border border-border-muted bg-card p-3 shadow-sm sm:p-4"
       copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
       onCopyContent={onCopyContent}
     >
@@ -593,7 +593,7 @@ function ArtifactEvent({ event, sessionId, onOpenMedia }: EventRendererProps) {
   if (event.type !== "artifact") return null;
 
   return (
-    <div className="space-y-2 border border-border-muted bg-card p-3 sm:p-4">
+    <div className="space-y-2 rounded-xl border border-border-muted bg-card p-3 shadow-sm sm:p-4">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">
           {event.artifactType === "video" ? "Video" : "Screenshot"}


### PR DESCRIPTION
## Summary

- give new sessions a persistent page header, outcome-focused prompt hierarchy, and integrated repository, branch, model, skill, provider, attachment, and send controls
- align active-session metadata, timeline cards, queued prompts, follow-up composer, loading state, and context rail around a narrower reading width
- keep managed-skill suggestions visible outside rounded composer cards, cap their mobile height, and announce session preparation accessibly without shifting the mobile layout

## Reviewer Guide

### New session

- Confirm the `New session` header remains present with the sidebar open or collapsed.
- Check that repository/environment and branch context read as part of the composer rather than as detached controls.
- Verify the larger prompt area and consolidated footer controls still preserve repository, environment, provider-account, skills, attachment, warming, and send behavior.
- On mobile, confirm the composer remains usable at narrow heights and the managed-skill suggestion panel is not clipped.

### Active session

- Check branch context and the labeled sandbox state in the session header, including truncation at narrower widths.
- Confirm queued prompts, timeline content, loading skeleton, and follow-up composer share the `max-w-3xl` reading width.
- Review the lighter rounded timeline cards and the `Session context` rail, with tasks surfaced earlier under `Progress`.
- Verify queue, stop, attachments, model/reasoning controls, status diagnostics, and mobile actions are behaviorally unchanged.

## Validation

- `npm test -w @open-inspect/web` (165 files, 1,286 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-fix`
- targeted Prettier check for all changed files
- clean-checkout build: `npm run build -w @open-inspect/shared` then `NODE_ENV=production npm run build -w @open-inspect/web`

## Visual Evidence

- New session desktop, 1512x982: artifact `98b2fc63299a080028af24a59ccfc997`
- New session mobile, 390x844: artifact `bc692f557cf5c033f667af44e8bf5f6b`
- Active session desktop, 1512x982: artifact `487505624343e11a0049fac96eef64a5`
- Active session mobile, 390x844: artifact `d99400f4c000c054ec602bb7fc85d030`
- Managed-skill autocomplete after clipping fix, 390x667: artifact `f4288a6e94c13cf134223e52d6e7abf4`

The active-session captures use the local mock control plane, so connection banners in those images are expected.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3c43ceac7f30f69c8c4924a321088042)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed new-session layout with clearer “Start with an outcome” guidance.
  * Added repository and branch context to session headers and target selectors.
  * Added a “Session context” section and renamed “Tasks” to “Progress.”

* **Improvements**
  * Refined prompt composer controls, spacing, buttons, and drag-over styling.
  * Improved timeline cards with rounded corners, borders, and subtle shadows.
  * Narrowed content areas and adjusted suggestion panel sizing for better responsiveness.
  * Updated session preparation status messaging and accessibility labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->