### PR TITLE
fix(web): suppress expected sandbox access conflicts

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/sandbox-access/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/sandbox-access/route.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server-auth-session", () => ({ getServerAuthSession: vi.fn() }));
+vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
+
+import { controlPlaneUserFetch } from "@/lib/control-plane";
+import { getServerAuthSession } from "@/lib/server-auth-session";
+import { GET } from "./route";
+
+describe("sandbox access BFF", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+  });
+
+  it("returns no content when sandbox access is temporarily unavailable", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Sandbox access is unavailable" }, { status: 409 })
+    );
+
+    const response = await GET({} as Request, {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(await response.text()).toBe("");
+  });
+
+  it("preserves unexpected control-plane errors", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Session not found" }, { status: 404 })
+    );
+
+    const response = await GET({} as Request, {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Session not found" });
+  });
+});

--- a/packages/web/src/app/api/sessions/[id]/sandbox-access/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/sandbox-access/route.test.ts
@@ -14,9 +14,13 @@ describe("sandbox access BFF", () => {
   });
 
   it("returns no content when sandbox access is temporarily unavailable", async () => {
-    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
-      Response.json({ error: "Sandbox access is unavailable" }, { status: 409 })
-    );
+    const cancel = vi.fn();
+    const upstream = {
+      status: 409,
+      clone: () => Response.json({ error: "Sandbox access is unavailable" }),
+      body: { cancel },
+    } as unknown as Response;
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(upstream);
 
     const response = await GET({} as Request, {
       params: Promise.resolve({ id: "session-1" }),
@@ -25,6 +29,22 @@ describe("sandbox access BFF", () => {
     expect(response.status).toBe(204);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(await response.text()).toBe("");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("preserves access-change conflicts for retry", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ error: "Sandbox access changed; retry" }, { status: 409 })
+    );
+
+    const response = await GET({} as Request, {
+      params: Promise.resolve({ id: "session-1" }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Vary")).toBe("Cookie");
+    await expect(response.json()).resolves.toEqual({ error: "Sandbox access changed; retry" });
   });
 
   it("preserves unexpected control-plane errors", async () => {

--- a/packages/web/src/app/api/sessions/[id]/sandbox-access/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/sandbox-access/route.ts
@@ -16,6 +16,12 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
     `/sessions/${encodeURIComponent(id)}/sandbox-access`,
     { cache: "no-store" }
   );
+  if (response.status === 409) {
+    return new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "private, no-store", Vary: "Cookie" },
+    });
+  }
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/packages/web/src/app/api/sessions/[id]/sandbox-access/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/sandbox-access/route.ts
@@ -16,7 +16,15 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
     `/sessions/${encodeURIComponent(id)}/sandbox-access`,
     { cache: "no-store" }
   );
-  if (response.status === 409) {
+  const conflict =
+    response.status === 409
+      ? ((await response
+          .clone()
+          .json()
+          .catch(() => null)) as { error?: unknown } | null)
+      : null;
+  if (conflict?.error === "Sandbox access is unavailable") {
+    await response.body?.cancel();
     return new Response(null, {
       status: 204,
       headers: { "Cache-Control": "private, no-store", Vary: "Cookie" },

--- a/packages/web/src/hooks/use-sandbox-access.test.tsx
+++ b/packages/web/src/hooks/use-sandbox-access.test.tsx
@@ -43,7 +43,7 @@ describe("useSandboxAccess", () => {
     );
   });
 
-  it.each([404, 409])("authoritatively clears credentials on status %s", async (status) => {
+  it.each([204, 404])("authoritatively clears credentials on status %s", async (status) => {
     mocks.browserApiFetch.mockResolvedValue(new Response(null, { status }));
     const { result } = renderHook(() => useSandboxAccess("session-1"), { wrapper });
     await waitFor(() => expect(result.current.sandboxAccess).toBeNull());

--- a/packages/web/src/hooks/use-sandbox-access.test.tsx
+++ b/packages/web/src/hooks/use-sandbox-access.test.tsx
@@ -26,7 +26,7 @@ describe("useSandboxAccess", () => {
         ttyd: null,
       })
     );
-    const { result } = renderHook(() => useSandboxAccess("session/one"), { wrapper });
+    const { result } = renderHook(() => useSandboxAccess("session/one", true), { wrapper });
 
     await waitFor(() =>
       expect(result.current.sandboxAccess).toEqual(
@@ -45,7 +45,22 @@ describe("useSandboxAccess", () => {
 
   it.each([204, 404])("authoritatively clears credentials on status %s", async (status) => {
     mocks.browserApiFetch.mockResolvedValue(new Response(null, { status }));
-    const { result } = renderHook(() => useSandboxAccess("session-1"), { wrapper });
+    const { result } = renderHook(() => useSandboxAccess("session-1", true), { wrapper });
     await waitFor(() => expect(result.current.sandboxAccess).toBeNull());
+  });
+
+  it("does not fetch until the sandbox is ready", async () => {
+    mocks.browserApiFetch.mockResolvedValue(
+      Response.json({ codeServer: null, vnc: null, ttyd: null })
+    );
+    const { rerender } = renderHook(
+      ({ isSandboxReady }) => useSandboxAccess("session-1", isSandboxReady),
+      { wrapper, initialProps: { isSandboxReady: false } }
+    );
+
+    expect(mocks.browserApiFetch).not.toHaveBeenCalled();
+
+    rerender({ isSandboxReady: true });
+    await waitFor(() => expect(mocks.browserApiFetch).toHaveBeenCalledOnce());
   });
 });

--- a/packages/web/src/hooks/use-sandbox-access.ts
+++ b/packages/web/src/hooks/use-sandbox-access.ts
@@ -22,8 +22,10 @@ const sandboxAccessSchema = z
 
 type SandboxAccess = z.infer<typeof sandboxAccessSchema>;
 
-export function useSandboxAccess(sessionId: string) {
-  const key: BrowserApiPath = `/api/sessions/${encodeURIComponent(sessionId)}/sandbox-access`;
+export function useSandboxAccess(sessionId: string, isSandboxReady: boolean) {
+  const key: BrowserApiPath | null = isSandboxReady
+    ? `/api/sessions/${encodeURIComponent(sessionId)}/sandbox-access`
+    : null;
   const { data, mutate } = useSWR<SandboxAccess | null>(key, async (url: BrowserApiPath) => {
     const response = await browserApiFetch(url, { cache: "no-store" });
     if (response.status === 204 || response.status === 404) return null;

--- a/packages/web/src/hooks/use-sandbox-access.ts
+++ b/packages/web/src/hooks/use-sandbox-access.ts
@@ -26,7 +26,7 @@ export function useSandboxAccess(sessionId: string) {
   const key: BrowserApiPath = `/api/sessions/${encodeURIComponent(sessionId)}/sandbox-access`;
   const { data, mutate } = useSWR<SandboxAccess | null>(key, async (url: BrowserApiPath) => {
     const response = await browserApiFetch(url, { cache: "no-store" });
-    if (response.status === 404 || response.status === 409) return null;
+    if (response.status === 204 || response.status === 404) return null;
     if (!response.ok) throw new Error(`Sandbox access failed with status ${response.status}`);
     return sandboxAccessSchema.parse(await response.json());
   });

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -117,7 +117,7 @@ export function useSessionSocket(
     sandboxAccess,
     clear: clearSandboxAccess,
     refresh: refreshSandboxAccess,
-  } = useSandboxAccess(sessionId);
+  } = useSandboxAccess(sessionId, state.sessionState?.sandboxStatus === "ready");
 
   const settleSubscriptionWaiters = useCallback((subscribed: boolean) => {
     for (const resolve of subscriptionWaitersRef.current) {


### PR DESCRIPTION
## Summary
- translate expected sandbox-access `409 Conflict` responses to `204 No Content` at the browser-facing BFF
- preserve unexpected control-plane errors such as missing sessions
- update the sandbox-access hook contract and add route coverage

## Why
Sandbox access is unavailable during normal lifecycle transitions such as startup and snapshotting. The client handled the control plane's `409` correctly, but browsers still displayed every response as a console error. Returning `204` from the browser-facing route preserves the no-access state without creating misleading console noise.

## Verification
- `npm test -w @open-inspect/web -- --run 'src/hooks/use-sandbox-access.test.tsx' 'src/app/api/sessions/[id]/sandbox-access/route.test.ts'`
- `npm run typecheck -w @open-inspect/web`
- focused ESLint checks for changed files
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f8d2001318da2e00477b7981d3f32db0)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox access handling when access is unavailable, returning an empty response without displaying an error.
  * Requests now wait until the sandbox is ready before checking access.
  * Updated the application to recognize unavailable and not-found responses as having no sandbox access.
  * Preserved expected error responses and response headers for unexpected conditions.

* **Tests**
  * Added coverage for sandbox readiness, unavailable access responses, and preserved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->