### PR TITLE
refactor: drop dead modal-infra surface and image-delete round trip

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -142,7 +142,6 @@ describe("ModalClient", () => {
     const request = createModalClient("secret", "acme").snapshotSandbox({
       providerObjectId: "mo-1",
       sessionId: "session-1",
-      reason: "manual",
     });
 
     const rejection = expect(request).rejects.toThrow(
@@ -165,7 +164,6 @@ describe("ModalClient", () => {
     const request = createModalClient("secret", "acme").snapshotSandbox({
       providerObjectId: "mo-1",
       sessionId: "session-1",
-      reason: "manual",
       signal: caller.signal,
     });
     caller.abort(callerReason);
@@ -532,7 +530,6 @@ describe("ModalClient", () => {
       client.snapshotSandbox({
         providerObjectId: "mo-1",
         sessionId: "session-123",
-        reason: "manual",
       })
     ).resolves.toEqual({ success: true, imageId: "img-1" });
   });
@@ -578,7 +575,6 @@ describe("ModalClient", () => {
       client.snapshotSandbox({
         providerObjectId: "mo-1",
         sessionId: "session-123",
-        reason: "manual",
       })
     ).rejects.toThrow("Modal API error: Invalid response");
   });
@@ -706,40 +702,5 @@ describe("ModalClient", () => {
         callbackToken: "cb-token-1",
       })
     ).rejects.toThrow("Modal API error: Invalid response");
-  });
-
-  it("parses valid provider image delete responses", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          data: { provider_image_id: "img-1", deleted: true },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
-
-    const client = createModalClient("secret", "acme", "prod-web");
-    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).resolves.toEqual({
-      providerImageId: "img-1",
-      deleted: true,
-    });
-  });
-
-  it("rejects malformed provider image delete responses instead of trusting the payload", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          data: { provider_image_id: "img-1", deleted: "yes" },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
-
-    const client = createModalClient("secret", "acme", "prod-web");
-    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).rejects.toThrow(
-      "Modal API error: Invalid response"
-    );
   });
 });

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -703,4 +703,39 @@ describe("ModalClient", () => {
       })
     ).rejects.toThrow("Modal API error: Invalid response");
   });
+
+  it("parses valid provider image delete responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { provider_image_id: "img-1", deleted: true },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).resolves.toEqual({
+      providerImageId: "img-1",
+      deleted: true,
+    });
+  });
+
+  it("rejects malformed provider image delete responses instead of trusting the payload", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { provider_image_id: "img-1", deleted: "yes" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).rejects.toThrow(
+      "Modal API error: Invalid response"
+    );
+  });
 });

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -703,39 +703,4 @@ describe("ModalClient", () => {
       })
     ).rejects.toThrow("Modal API error: Invalid response");
   });
-
-  it("parses valid provider image delete responses", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          data: { provider_image_id: "img-1", deleted: true },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
-
-    const client = createModalClient("secret", "acme", "prod-web");
-    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).resolves.toEqual({
-      providerImageId: "img-1",
-      deleted: true,
-    });
-  });
-
-  it("rejects malformed provider image delete responses instead of trusting the payload", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          data: { provider_image_id: "img-1", deleted: "yes" },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    );
-
-    const client = createModalClient("secret", "acme", "prod-web");
-    await expect(client.deleteProviderImage({ providerImageId: "img-1" })).rejects.toThrow(
-      "Modal API error: Invalid response"
-    );
-  });
 });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -106,17 +106,6 @@ const imageBuildOperationModalResponseSchema = z.discriminatedUnion("success", [
   modalErrorResponseSchema,
 ]);
 
-const deleteProviderImageModalResponseSchema = z.discriminatedUnion("success", [
-  z.object({
-    success: z.literal(true),
-    data: z.object({
-      provider_image_id: z.string(),
-      deleted: z.boolean(),
-    }),
-  }),
-  modalErrorResponseSchema,
-]);
-
 function parseModalApiResponse<T>(schema: z.ZodType<T>, body: unknown): T {
   const result = schema.safeParse(body);
   if (!result.success) {
@@ -230,7 +219,6 @@ export interface RestoreSandboxResponse {
 export interface SnapshotSandboxRequest {
   providerObjectId: string;
   sessionId: string;
-  reason: string;
   signal?: AbortSignal;
 }
 
@@ -284,16 +272,6 @@ export interface TerminateImageBuildSandboxRequest {
   signal?: AbortSignal;
 }
 
-export interface DeleteProviderImageRequest {
-  providerImageId: string;
-  signal?: AbortSignal;
-}
-
-export interface DeleteProviderImageResponse {
-  providerImageId: string;
-  deleted: boolean;
-}
-
 /**
  * Error thrown by ModalClient when the Modal API returns a non-OK HTTP status.
  * Carries the numeric status code so callers can classify without string parsing.
@@ -321,7 +299,6 @@ export class ModalClient {
   private createImageBuildSandboxUrl: string;
   private startImageBuildSandboxUrl: string;
   private terminateImageBuildSandboxUrl: string;
-  private deleteProviderImageUrl: string;
   private secret: string;
 
   private async postJson<T>(
@@ -367,7 +344,6 @@ export class ModalClient {
     this.createImageBuildSandboxUrl = `${baseUrl}-api-create-build-sandbox.modal.run`;
     this.startImageBuildSandboxUrl = `${baseUrl}-api-start-build-sandbox.modal.run`;
     this.terminateImageBuildSandboxUrl = `${baseUrl}-api-terminate-build-sandbox.modal.run`;
-    this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
   }
 
   /**
@@ -553,8 +529,6 @@ export class ModalClient {
         MODAL_SNAPSHOT_REQUEST_DEADLINE_MS,
         {
           sandbox_id: request.providerObjectId,
-          session_id: request.sessionId,
-          reason: request.reason,
         },
         snapshotSandboxModalResponseSchema,
         correlation,
@@ -762,55 +736,6 @@ export class ModalClient {
         endpoint,
         build_id: request.buildId,
         sandbox_id: request.providerSessionId,
-        trace_id: correlation?.trace_id,
-        request_id: correlation?.request_id,
-        http_status: httpStatus,
-        duration_ms: Date.now() - startTime,
-        outcome,
-      });
-    }
-  }
-
-  /**
-   * Delete a provider image (best-effort).
-   */
-  async deleteProviderImage(
-    request: DeleteProviderImageRequest,
-    correlation?: CorrelationContext
-  ): Promise<DeleteProviderImageResponse> {
-    const startTime = Date.now();
-    const endpoint = "deleteProviderImage";
-    let httpStatus: number | undefined;
-    let outcome: "success" | "error" = "error";
-
-    try {
-      const result = await this.postJson(
-        this.deleteProviderImageUrl,
-        endpoint,
-        MODAL_CLEANUP_REQUEST_DEADLINE_MS,
-        {
-          provider_image_id: request.providerImageId,
-        },
-        deleteProviderImageModalResponseSchema,
-        correlation,
-        request.signal,
-        (status) => (httpStatus = status)
-      );
-
-      if (result.success === false) {
-        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
-      }
-
-      outcome = "success";
-      return {
-        providerImageId: result.data.provider_image_id,
-        deleted: result.data.deleted,
-      };
-    } finally {
-      log.info("modal.request", {
-        event: "modal.request",
-        endpoint,
-        provider_image_id: request.providerImageId,
         trace_id: correlation?.trace_id,
         request_id: correlation?.request_id,
         http_status: httpStatus,

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -106,17 +106,6 @@ const imageBuildOperationModalResponseSchema = z.discriminatedUnion("success", [
   modalErrorResponseSchema,
 ]);
 
-const deleteProviderImageModalResponseSchema = z.discriminatedUnion("success", [
-  z.object({
-    success: z.literal(true),
-    data: z.object({
-      provider_image_id: z.string(),
-      deleted: z.boolean(),
-    }),
-  }),
-  modalErrorResponseSchema,
-]);
-
 function parseModalApiResponse<T>(schema: z.ZodType<T>, body: unknown): T {
   const result = schema.safeParse(body);
   if (!result.success) {
@@ -283,16 +272,6 @@ export interface TerminateImageBuildSandboxRequest {
   signal?: AbortSignal;
 }
 
-export interface DeleteProviderImageRequest {
-  providerImageId: string;
-  signal?: AbortSignal;
-}
-
-export interface DeleteProviderImageResponse {
-  providerImageId: string;
-  deleted: boolean;
-}
-
 /**
  * Error thrown by ModalClient when the Modal API returns a non-OK HTTP status.
  * Carries the numeric status code so callers can classify without string parsing.
@@ -320,7 +299,6 @@ export class ModalClient {
   private createImageBuildSandboxUrl: string;
   private startImageBuildSandboxUrl: string;
   private terminateImageBuildSandboxUrl: string;
-  private deleteProviderImageUrl: string;
   private secret: string;
 
   private async postJson<T>(
@@ -366,7 +344,6 @@ export class ModalClient {
     this.createImageBuildSandboxUrl = `${baseUrl}-api-create-build-sandbox.modal.run`;
     this.startImageBuildSandboxUrl = `${baseUrl}-api-start-build-sandbox.modal.run`;
     this.terminateImageBuildSandboxUrl = `${baseUrl}-api-terminate-build-sandbox.modal.run`;
-    this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
   }
 
   /**
@@ -759,56 +736,6 @@ export class ModalClient {
         endpoint,
         build_id: request.buildId,
         sandbox_id: request.providerSessionId,
-        trace_id: correlation?.trace_id,
-        request_id: correlation?.request_id,
-        http_status: httpStatus,
-        duration_ms: Date.now() - startTime,
-        outcome,
-      });
-    }
-  }
-
-  /**
-   * Delete a provider image. Missing images count as deleted so retried
-   * cleanups stay idempotent; other provider failures reject.
-   */
-  async deleteProviderImage(
-    request: DeleteProviderImageRequest,
-    correlation?: CorrelationContext
-  ): Promise<DeleteProviderImageResponse> {
-    const startTime = Date.now();
-    const endpoint = "deleteProviderImage";
-    let httpStatus: number | undefined;
-    let outcome: "success" | "error" = "error";
-
-    try {
-      const result = await this.postJson(
-        this.deleteProviderImageUrl,
-        endpoint,
-        MODAL_CLEANUP_REQUEST_DEADLINE_MS,
-        {
-          provider_image_id: request.providerImageId,
-        },
-        deleteProviderImageModalResponseSchema,
-        correlation,
-        request.signal,
-        (status) => (httpStatus = status)
-      );
-
-      if (result.success === false) {
-        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
-      }
-
-      outcome = "success";
-      return {
-        providerImageId: result.data.provider_image_id,
-        deleted: result.data.deleted,
-      };
-    } finally {
-      log.info("modal.request", {
-        event: "modal.request",
-        endpoint,
-        provider_image_id: request.providerImageId,
         trace_id: correlation?.trace_id,
         request_id: correlation?.request_id,
         http_status: httpStatus,

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -106,6 +106,17 @@ const imageBuildOperationModalResponseSchema = z.discriminatedUnion("success", [
   modalErrorResponseSchema,
 ]);
 
+const deleteProviderImageModalResponseSchema = z.discriminatedUnion("success", [
+  z.object({
+    success: z.literal(true),
+    data: z.object({
+      provider_image_id: z.string(),
+      deleted: z.boolean(),
+    }),
+  }),
+  modalErrorResponseSchema,
+]);
+
 function parseModalApiResponse<T>(schema: z.ZodType<T>, body: unknown): T {
   const result = schema.safeParse(body);
   if (!result.success) {
@@ -272,6 +283,16 @@ export interface TerminateImageBuildSandboxRequest {
   signal?: AbortSignal;
 }
 
+export interface DeleteProviderImageRequest {
+  providerImageId: string;
+  signal?: AbortSignal;
+}
+
+export interface DeleteProviderImageResponse {
+  providerImageId: string;
+  deleted: boolean;
+}
+
 /**
  * Error thrown by ModalClient when the Modal API returns a non-OK HTTP status.
  * Carries the numeric status code so callers can classify without string parsing.
@@ -299,6 +320,7 @@ export class ModalClient {
   private createImageBuildSandboxUrl: string;
   private startImageBuildSandboxUrl: string;
   private terminateImageBuildSandboxUrl: string;
+  private deleteProviderImageUrl: string;
   private secret: string;
 
   private async postJson<T>(
@@ -344,6 +366,7 @@ export class ModalClient {
     this.createImageBuildSandboxUrl = `${baseUrl}-api-create-build-sandbox.modal.run`;
     this.startImageBuildSandboxUrl = `${baseUrl}-api-start-build-sandbox.modal.run`;
     this.terminateImageBuildSandboxUrl = `${baseUrl}-api-terminate-build-sandbox.modal.run`;
+    this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
   }
 
   /**
@@ -736,6 +759,56 @@ export class ModalClient {
         endpoint,
         build_id: request.buildId,
         sandbox_id: request.providerSessionId,
+        trace_id: correlation?.trace_id,
+        request_id: correlation?.request_id,
+        http_status: httpStatus,
+        duration_ms: Date.now() - startTime,
+        outcome,
+      });
+    }
+  }
+
+  /**
+   * Delete a provider image. Missing images count as deleted so retried
+   * cleanups stay idempotent; other provider failures reject.
+   */
+  async deleteProviderImage(
+    request: DeleteProviderImageRequest,
+    correlation?: CorrelationContext
+  ): Promise<DeleteProviderImageResponse> {
+    const startTime = Date.now();
+    const endpoint = "deleteProviderImage";
+    let httpStatus: number | undefined;
+    let outcome: "success" | "error" = "error";
+
+    try {
+      const result = await this.postJson(
+        this.deleteProviderImageUrl,
+        endpoint,
+        MODAL_CLEANUP_REQUEST_DEADLINE_MS,
+        {
+          provider_image_id: request.providerImageId,
+        },
+        deleteProviderImageModalResponseSchema,
+        correlation,
+        request.signal,
+        (status) => (httpStatus = status)
+      );
+
+      if (result.success === false) {
+        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
+      }
+
+      outcome = "success";
+      return {
+        providerImageId: result.data.provider_image_id,
+        deleted: result.data.deleted,
+      };
+    } finally {
+      log.info("modal.request", {
+        event: "modal.request",
+        endpoint,
+        provider_image_id: request.providerImageId,
         trace_id: correlation?.trace_id,
         request_id: correlation?.request_id,
         http_status: httpStatus,

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -22,8 +22,6 @@ import type {
   CreateImageBuildSandboxResponse,
   StartImageBuildSandboxRequest,
   TerminateImageBuildSandboxRequest,
-  DeleteProviderImageRequest,
-  DeleteProviderImageResponse,
 } from "../client";
 
 // ==================== Mock Factories ====================
@@ -39,7 +37,6 @@ function createMockModalClient(
     ) => Promise<CreateImageBuildSandboxResponse>;
     startImageBuildSandbox: (req: StartImageBuildSandboxRequest) => Promise<void>;
     terminateImageBuildSandbox: (req: TerminateImageBuildSandboxRequest) => Promise<void>;
-    deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
 ): ModalClient {
   return {
@@ -76,12 +73,6 @@ function createMockModalClient(
     ),
     startImageBuildSandbox: vi.fn(async () => undefined),
     terminateImageBuildSandbox: vi.fn(async () => undefined),
-    deleteProviderImage: vi.fn(
-      async (req: DeleteProviderImageRequest): Promise<DeleteProviderImageResponse> => ({
-        providerImageId: req.providerImageId,
-        deleted: true,
-      })
-    ),
     ...overrides,
   } as unknown as ModalClient;
 }
@@ -558,19 +549,6 @@ describe("ModalSandboxProvider", () => {
       );
       expect(onProviderSessionCreated.mock.invocationCallOrder[0]).toBeLessThan(
         vi.mocked(client.startImageBuildSandbox).mock.invocationCallOrder[0]
-      );
-    });
-
-    it("deletes provider images through the Modal client", async () => {
-      const client = createMockModalClient();
-      const provider = new ModalSandboxProvider(client);
-      const correlation = { request_id: "request-1", trace_id: "trace-1" };
-
-      await provider.deleteProviderImage("modal-image-1", correlation);
-
-      expect(client.deleteProviderImage).toHaveBeenCalledWith(
-        { providerImageId: "modal-image-1" },
-        correlation
       );
     });
   });

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -22,6 +22,8 @@ import type {
   CreateImageBuildSandboxResponse,
   StartImageBuildSandboxRequest,
   TerminateImageBuildSandboxRequest,
+  DeleteProviderImageRequest,
+  DeleteProviderImageResponse,
 } from "../client";
 
 // ==================== Mock Factories ====================
@@ -37,6 +39,7 @@ function createMockModalClient(
     ) => Promise<CreateImageBuildSandboxResponse>;
     startImageBuildSandbox: (req: StartImageBuildSandboxRequest) => Promise<void>;
     terminateImageBuildSandbox: (req: TerminateImageBuildSandboxRequest) => Promise<void>;
+    deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
 ): ModalClient {
   return {
@@ -73,6 +76,12 @@ function createMockModalClient(
     ),
     startImageBuildSandbox: vi.fn(async () => undefined),
     terminateImageBuildSandbox: vi.fn(async () => undefined),
+    deleteProviderImage: vi.fn(
+      async (req: DeleteProviderImageRequest): Promise<DeleteProviderImageResponse> => ({
+        providerImageId: req.providerImageId,
+        deleted: true,
+      })
+    ),
     ...overrides,
   } as unknown as ModalClient;
 }
@@ -550,6 +559,36 @@ describe("ModalSandboxProvider", () => {
       expect(onProviderSessionCreated.mock.invocationCallOrder[0]).toBeLessThan(
         vi.mocked(client.startImageBuildSandbox).mock.invocationCallOrder[0]
       );
+    });
+
+    it("deletes provider images through the Modal client", async () => {
+      const client = createMockModalClient();
+      const provider = new ModalSandboxProvider(client);
+      const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+      await provider.deleteProviderImage("modal-image-1", correlation);
+
+      expect(client.deleteProviderImage).toHaveBeenCalledWith(
+        { providerImageId: "modal-image-1" },
+        correlation
+      );
+    });
+
+    it("propagates provider-image deletion failures as classified errors", async () => {
+      const client = createMockModalClient({
+        deleteProviderImage: vi.fn(async () => {
+          throw new ModalApiError("Modal API error: 503 Service Unavailable", 503);
+        }),
+      });
+      const provider = new ModalSandboxProvider(client);
+
+      try {
+        await provider.deleteProviderImage("modal-image-1");
+        expect.fail("Should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(SandboxProviderError);
+        expect((e as SandboxProviderError).errorType).toBe("transient");
+      }
     });
   });
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -22,8 +22,6 @@ import type {
   CreateImageBuildSandboxResponse,
   StartImageBuildSandboxRequest,
   TerminateImageBuildSandboxRequest,
-  DeleteProviderImageRequest,
-  DeleteProviderImageResponse,
 } from "../client";
 
 // ==================== Mock Factories ====================
@@ -39,7 +37,6 @@ function createMockModalClient(
     ) => Promise<CreateImageBuildSandboxResponse>;
     startImageBuildSandbox: (req: StartImageBuildSandboxRequest) => Promise<void>;
     terminateImageBuildSandbox: (req: TerminateImageBuildSandboxRequest) => Promise<void>;
-    deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
 ): ModalClient {
   return {
@@ -76,12 +73,6 @@ function createMockModalClient(
     ),
     startImageBuildSandbox: vi.fn(async () => undefined),
     terminateImageBuildSandbox: vi.fn(async () => undefined),
-    deleteProviderImage: vi.fn(
-      async (req: DeleteProviderImageRequest): Promise<DeleteProviderImageResponse> => ({
-        providerImageId: req.providerImageId,
-        deleted: true,
-      })
-    ),
     ...overrides,
   } as unknown as ModalClient;
 }
@@ -559,36 +550,6 @@ describe("ModalSandboxProvider", () => {
       expect(onProviderSessionCreated.mock.invocationCallOrder[0]).toBeLessThan(
         vi.mocked(client.startImageBuildSandbox).mock.invocationCallOrder[0]
       );
-    });
-
-    it("deletes provider images through the Modal client", async () => {
-      const client = createMockModalClient();
-      const provider = new ModalSandboxProvider(client);
-      const correlation = { request_id: "request-1", trace_id: "trace-1" };
-
-      await provider.deleteProviderImage("modal-image-1", correlation);
-
-      expect(client.deleteProviderImage).toHaveBeenCalledWith(
-        { providerImageId: "modal-image-1" },
-        correlation
-      );
-    });
-
-    it("propagates provider-image deletion failures as classified errors", async () => {
-      const client = createMockModalClient({
-        deleteProviderImage: vi.fn(async () => {
-          throw new ModalApiError("Modal API error: 503 Service Unavailable", 503);
-        }),
-      });
-      const provider = new ModalSandboxProvider(client);
-
-      try {
-        await provider.deleteProviderImage("modal-image-1");
-        expect.fail("Should have thrown");
-      } catch (e) {
-        expect(e).toBeInstanceOf(SandboxProviderError);
-        expect((e as SandboxProviderError).errorType).toBe("transient");
-      }
     });
   });
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -324,29 +324,11 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   }
 
   /**
-   * Delete a Modal provider image.
+   * Modal has no image-delete API — images are garbage-collected once no
+   * longer referenced — so deletion is a local no-op. Callers (the image
+   * reaper and finalizer) log each attempt and outcome.
    */
-  async deleteProviderImage(
-    providerImageId: string,
-    correlation?: CorrelationContext,
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      await this.client.deleteProviderImage({ providerImageId, signal }, correlation);
-    } catch (error) {
-      if (error instanceof ModalApiError) {
-        throw this.classifyErrorWithStatus(
-          `Provider image deletion failed with HTTP ${error.status}: ${error.message}`,
-          error.status,
-          error
-        );
-      }
-      if (error instanceof SandboxProviderError) {
-        throw error;
-      }
-      throw this.classifyError("Failed to delete Modal provider image", error);
-    }
-  }
+  async deleteProviderImage(): Promise<void> {}
 
   private classifyImageBuildError(message: string, error: unknown): SandboxProviderError {
     if (error instanceof SandboxProviderError) return error;

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -324,9 +324,11 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   }
 
   /**
-   * Modal has no image-delete API — images are garbage-collected once no
-   * longer referenced — so deletion is a local no-op. Callers (the image
-   * reaper and finalizer) log each attempt and outcome.
+   * Deletion is a local no-op for now: Modal's only deletion surface is the
+   * experimental `image_delete` API, whose adoption is deferred until
+   * validated (#1658). The HTTP endpoint this replaced deleted nothing
+   * either, so reaped images were already retained provider-side. Callers
+   * (the image reaper and finalizer) log each attempt and outcome.
    */
   async deleteProviderImage(): Promise<void> {}
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -324,11 +324,29 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   }
 
   /**
-   * Modal has no image-delete API — images are garbage-collected once no
-   * longer referenced — so deletion is a local no-op. Callers (the image
-   * reaper and finalizer) log each attempt and outcome.
+   * Delete a Modal provider image.
    */
-  async deleteProviderImage(): Promise<void> {}
+  async deleteProviderImage(
+    providerImageId: string,
+    correlation?: CorrelationContext,
+    signal?: AbortSignal
+  ): Promise<void> {
+    try {
+      await this.client.deleteProviderImage({ providerImageId, signal }, correlation);
+    } catch (error) {
+      if (error instanceof ModalApiError) {
+        throw this.classifyErrorWithStatus(
+          `Provider image deletion failed with HTTP ${error.status}: ${error.message}`,
+          error.status,
+          error
+        );
+      }
+      if (error instanceof SandboxProviderError) {
+        throw error;
+      }
+      throw this.classifyError("Failed to delete Modal provider image", error);
+    }
+  }
 
   private classifyImageBuildError(message: string, error: unknown): SandboxProviderError {
     if (error instanceof SandboxProviderError) return error;

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -210,7 +210,6 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
         {
           providerObjectId: config.providerObjectId,
           sessionId: config.sessionId,
-          reason: config.reason,
           signal: config.signal,
         },
         config.correlation
@@ -325,29 +324,11 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   }
 
   /**
-   * Delete a Modal provider image.
+   * Modal has no image-delete API — images are garbage-collected once no
+   * longer referenced — so deletion is a local no-op. Callers (the image
+   * reaper and finalizer) log each attempt and outcome.
    */
-  async deleteProviderImage(
-    providerImageId: string,
-    correlation?: CorrelationContext,
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      await this.client.deleteProviderImage({ providerImageId, signal }, correlation);
-    } catch (error) {
-      if (error instanceof ModalApiError) {
-        throw this.classifyErrorWithStatus(
-          `Provider image deletion failed with HTTP ${error.status}: ${error.message}`,
-          error.status,
-          error
-        );
-      }
-      if (error instanceof SandboxProviderError) {
-        throw error;
-      }
-      throw this.classifyError("Failed to delete Modal provider image", error);
-    }
-  }
+  async deleteProviderImage(): Promise<void> {}
 
   private classifyImageBuildError(message: string, error: unknown): SandboxProviderError {
     if (error instanceof SandboxProviderError) return error;

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -42,10 +42,12 @@ Base image definition with:
 
 ### Sandbox (`src/sandbox/`)
 
-- **manager.py**: Sandbox lifecycle (create, warm, snapshot)
-- **entrypoint.py**: Supervisor process (runs as PID 1)
-- **bridge.py**: WebSocket bridge to control plane
-- **types.py**: Event and configuration types
+- **manager.py**: Sandbox lifecycle (create, restore, snapshot)
+- **build_session.py**: Tagged build-sandbox lifecycle for prebuilt-image builds
+- **vcs_env.py**: Clone-credential env-var injection
+
+The in-sandbox runtime (entrypoint supervisor, control-plane bridge, shared types) lives in
+`packages/sandbox-runtime`.
 
 ### Auth (`sandbox_runtime.auth`)
 
@@ -138,7 +140,6 @@ Endpoint URLs follow the pattern: `https://{workspace}--open-inspect-{endpoint}.
 | `api-start-build-sandbox` | POST | Yes | Start the bound build runtime; results POST back to the control plane's `/image-builds/*` callbacks |
 | `api-snapshot-build-sandbox` | POST | Yes | Snapshot the exact tagged build sandbox |
 | `api-terminate-build-sandbox` | POST | Yes | Terminate the exact tagged build sandbox (idempotent when already absent) |
-| `api-delete-provider-image` | POST | Yes | Best-effort delete of a replaced provider image |
 
 ### Example: Create Sandbox
 

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -140,7 +140,6 @@ Endpoint URLs follow the pattern: `https://{workspace}--open-inspect-{endpoint}.
 | `api-start-build-sandbox` | POST | Yes | Start the bound build runtime; results POST back to the control plane's `/image-builds/*` callbacks |
 | `api-snapshot-build-sandbox` | POST | Yes | Snapshot the exact tagged build sandbox |
 | `api-terminate-build-sandbox` | POST | Yes | Terminate the exact tagged build sandbox (idempotent when already absent) |
-| `api-delete-provider-image` | POST | Yes | Delete a replaced provider image (idempotent when already absent) |
 
 ### Example: Create Sandbox
 

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -140,6 +140,7 @@ Endpoint URLs follow the pattern: `https://{workspace}--open-inspect-{endpoint}.
 | `api-start-build-sandbox` | POST | Yes | Start the bound build runtime; results POST back to the control plane's `/image-builds/*` callbacks |
 | `api-snapshot-build-sandbox` | POST | Yes | Snapshot the exact tagged build sandbox |
 | `api-terminate-build-sandbox` | POST | Yes | Terminate the exact tagged build sandbox (idempotent when already absent) |
+| `api-delete-provider-image` | POST | Yes | Delete a replaced provider image (idempotent when already absent) |
 
 ### Example: Create Sandbox
 

--- a/packages/modal-infra/pyproject.toml
+++ b/packages/modal-infra/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "open-inspect-sandbox-runtime",  # sibling package, resolved via [tool.uv.sources]
     "modal>=1.4.3",  # Function.with_options() (per-call timeout override) requires >=1.4.3
     "httpx>=0.27.0",
-    "websockets>=13.0",
     "pydantic>=2.0",
     "fastapi>=0.110.0",
     "PyJWT[crypto]>=2.9.0",

--- a/packages/modal-infra/src/sandbox/__init__.py
+++ b/packages/modal-infra/src/sandbox/__init__.py
@@ -1,42 +1,14 @@
 """Sandbox management for Open-Inspect.
 
-Re-exports provider-agnostic types from sandbox_runtime and provides lazy
-accessors for Modal-specific manager classes.
+Re-exports provider-agnostic types from sandbox_runtime. Modal-specific
+manager classes live in .manager and are imported lazily by their callers,
+since that module only imports cleanly in Modal function context.
 """
 
-from sandbox_runtime import GitSyncStatus, GitUser, SandboxEvent, SandboxStatus, SessionConfig
-
-
-# Manager is only available when running in Modal function context (not inside sandbox)
-# Use lazy import to avoid ModuleNotFoundError
-def get_manager():
-    """Get the SandboxManager class (only available in Modal function context)."""
-    from .manager import SandboxManager
-
-    return SandboxManager
-
-
-def get_sandbox_config():
-    """Get the SandboxConfig class (only available in Modal function context)."""
-    from .manager import SandboxConfig
-
-    return SandboxConfig
-
-
-def get_sandbox_handle():
-    """Get the SandboxHandle class (only available in Modal function context)."""
-    from .manager import SandboxHandle
-
-    return SandboxHandle
-
+from sandbox_runtime import GitUser, SandboxStatus, SessionConfig
 
 __all__ = [
-    "GitSyncStatus",
     "GitUser",
-    "SandboxEvent",
     "SandboxStatus",
     "SessionConfig",
-    "get_manager",
-    "get_sandbox_config",
-    "get_sandbox_handle",
 ]

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -130,14 +130,6 @@ class SandboxHandle:
     ttyd_url: str | None = None  # proxy tunnel URL (not ttyd directly)
     tunnel_urls: dict[int, str] | None = None  # port -> tunnel URL mapping for extra ports
 
-    def get_logs(self) -> str:
-        """Get sandbox logs."""
-        return self.modal_sandbox.stdout.read() if self.modal_sandbox.stdout else ""
-
-    async def terminate(self) -> None:
-        """Terminate the sandbox."""
-        self.modal_sandbox.terminate()
-
 
 @dataclass(frozen=True)
 class _BaseImageSource:
@@ -573,7 +565,6 @@ class SandboxManager:
             Image ID that can be used to restore the sandbox later
         """
         start_time = time.time()
-        snapshot_id = f"snap-{handle.sandbox_id}-{int(time.time() * 1000)}"
 
         image = await handle.modal_sandbox.snapshot_filesystem.aio(
             timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
@@ -587,7 +578,6 @@ class SandboxManager:
         log.info(
             "sandbox.snapshot",
             sandbox_id=handle.sandbox_id,
-            snapshot_id=snapshot_id,
             image_id=image_id,
             duration_ms=duration_ms,
             outcome="success",
@@ -705,7 +695,3 @@ class SandboxManager:
         )
 
         return handle
-
-
-# Global sandbox manager instance
-sandbox_manager = SandboxManager()

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -89,10 +89,6 @@ class TerminateBuildSandboxRequest(_ModalRequestModel):
     reason: NonEmptyString
 
 
-class DeleteProviderImageRequest(_ModalRequestModel):
-    provider_image_id: NonEmptyString
-
-
 class InteractiveRepositoryRequest(_ModalRequestModel):
     repo_owner: NonEmptyString
     repo_name: NonEmptyString
@@ -474,9 +470,7 @@ async def api_snapshot_sandbox(
 
     POST body:
     {
-        "sandbox_id": "...",
-        "session_id": "...",
-        "reason": "execution_complete" | "pre_timeout" | "heartbeat_timeout"
+        "sandbox_id": "..."
     }
 
     Returns:
@@ -484,9 +478,7 @@ async def api_snapshot_sandbox(
         "success": true,
         "data": {
             "image_id": "...",
-            "sandbox_id": "...",
-            "session_id": "...",
-            "reason": "..."
+            "sandbox_id": "..."
         }
     }
     """
@@ -505,9 +497,6 @@ async def api_snapshot_sandbox(
 
         from .sandbox.manager import SandboxManager
 
-        session_id = request.get("session_id")
-        reason = request.get("reason", "manual")
-
         manager = SandboxManager()
 
         handle = await manager.get_sandbox_by_id(sandbox_id)
@@ -521,8 +510,6 @@ async def api_snapshot_sandbox(
             "data": {
                 "image_id": image_id,
                 "sandbox_id": sandbox_id,
-                "session_id": session_id,
-                "reason": reason,
             },
         }
 
@@ -856,50 +843,3 @@ def _validated_build_repositories(
         }
         for repository in repositories
     ]
-
-
-@app.function(
-    image=function_image,
-    secrets=[internal_api_secret],
-)
-@fastapi_endpoint(method="POST")
-async def api_delete_provider_image(
-    request: dict[str, object],
-    authorization: str | None = Header(None),
-    x_trace_id: str | None = Header(None),
-    x_request_id: str | None = Header(None),
-) -> dict:
-    """
-    Delete a single provider image (best-effort).
-
-    Used to clean up old pre-built images after they're replaced by newer builds.
-
-    POST body:
-    {
-        "provider_image_id": "..."
-    }
-    """
-    async with _execute_endpoint(
-        endpoint_name="api_delete_provider_image",
-        authorization=authorization,
-        trace_id=x_trace_id,
-        request_id=x_request_id,
-    ):
-        parsed_request = _parse_request(DeleteProviderImageRequest, request)
-        provider_image_id = parsed_request.provider_image_id
-
-        # Modal doesn't have an explicit delete API for images;
-        # images are garbage-collected when no longer referenced.
-        # We log the request for auditability.
-        log.info(
-            "image.delete_requested",
-            provider_image_id=provider_image_id,
-        )
-
-        return {
-            "success": True,
-            "data": {
-                "provider_image_id": provider_image_id,
-                "deleted": True,
-            },
-        }

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -20,7 +20,8 @@ from pathlib import Path
 from typing import Annotated, Any, Self
 
 from fastapi import Header, HTTPException
-from modal import fastapi_endpoint
+from modal import experimental, fastapi_endpoint
+from modal.exception import NotFoundError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from sandbox_runtime.auth import AuthConfigurationError, verify_internal_token
@@ -87,6 +88,10 @@ class TerminateBuildSandboxRequest(_ModalRequestModel):
     build_id: NonEmptyString
     provider_session_id: NonEmptyString
     reason: NonEmptyString
+
+
+class DeleteProviderImageRequest(_ModalRequestModel):
+    provider_image_id: NonEmptyString
 
 
 class InteractiveRepositoryRequest(_ModalRequestModel):
@@ -843,3 +848,53 @@ def _validated_build_repositories(
         }
         for repository in repositories
     ]
+
+
+@app.function(
+    image=function_image,
+    secrets=[internal_api_secret],
+)
+@fastapi_endpoint(method="POST")
+async def api_delete_provider_image(
+    request: dict[str, object],
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """
+    Delete a single provider image.
+
+    Used to clean up pre-built images once a newer build replaces them or a
+    failed build leaves an artifact behind. An image that is already gone
+    counts as deleted so retried cleanups stay idempotent; any other provider
+    failure propagates as an error so the caller keeps its artifact record
+    and retries later.
+
+    POST body:
+    {
+        "provider_image_id": "..."
+    }
+    """
+    async with _execute_endpoint(
+        endpoint_name="api_delete_provider_image",
+        authorization=authorization,
+        trace_id=x_trace_id,
+        request_id=x_request_id,
+    ):
+        parsed_request = _parse_request(DeleteProviderImageRequest, request)
+        provider_image_id = parsed_request.provider_image_id
+
+        try:
+            await experimental.image_delete.aio(provider_image_id)
+        except NotFoundError:
+            log.info("image.delete_missing", provider_image_id=provider_image_id)
+        else:
+            log.info("image.deleted", provider_image_id=provider_image_id)
+
+        return {
+            "success": True,
+            "data": {
+                "provider_image_id": provider_image_id,
+                "deleted": True,
+            },
+        }

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -20,8 +20,7 @@ from pathlib import Path
 from typing import Annotated, Any, Self
 
 from fastapi import Header, HTTPException
-from modal import experimental, fastapi_endpoint
-from modal.exception import NotFoundError
+from modal import fastapi_endpoint
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from sandbox_runtime.auth import AuthConfigurationError, verify_internal_token
@@ -88,10 +87,6 @@ class TerminateBuildSandboxRequest(_ModalRequestModel):
     build_id: NonEmptyString
     provider_session_id: NonEmptyString
     reason: NonEmptyString
-
-
-class DeleteProviderImageRequest(_ModalRequestModel):
-    provider_image_id: NonEmptyString
 
 
 class InteractiveRepositoryRequest(_ModalRequestModel):
@@ -848,53 +843,3 @@ def _validated_build_repositories(
         }
         for repository in repositories
     ]
-
-
-@app.function(
-    image=function_image,
-    secrets=[internal_api_secret],
-)
-@fastapi_endpoint(method="POST")
-async def api_delete_provider_image(
-    request: dict[str, object],
-    authorization: str | None = Header(None),
-    x_trace_id: str | None = Header(None),
-    x_request_id: str | None = Header(None),
-) -> dict:
-    """
-    Delete a single provider image.
-
-    Used to clean up pre-built images once a newer build replaces them or a
-    failed build leaves an artifact behind. An image that is already gone
-    counts as deleted so retried cleanups stay idempotent; any other provider
-    failure propagates as an error so the caller keeps its artifact record
-    and retries later.
-
-    POST body:
-    {
-        "provider_image_id": "..."
-    }
-    """
-    async with _execute_endpoint(
-        endpoint_name="api_delete_provider_image",
-        authorization=authorization,
-        trace_id=x_trace_id,
-        request_id=x_request_id,
-    ):
-        parsed_request = _parse_request(DeleteProviderImageRequest, request)
-        provider_image_id = parsed_request.provider_image_id
-
-        try:
-            await experimental.image_delete.aio(provider_image_id)
-        except NotFoundError:
-            log.info("image.delete_missing", provider_image_id=provider_image_id)
-        else:
-            log.info("image.deleted", provider_image_id=provider_image_id)
-
-        return {
-            "success": True,
-            "data": {
-                "provider_image_id": provider_image_id,
-                "deleted": True,
-            },
-        }

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -549,7 +549,7 @@ async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(mo
 
 
 @pytest.mark.asyncio
-async def test_image_request_validation_runs_after_authentication(monkeypatch):
+async def test_terminate_request_validation_runs_after_authentication(monkeypatch):
     def reject_auth(_authorization):
         raise web_api.HTTPException(status_code=401, detail="Unauthorized")
 

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -549,39 +549,6 @@ async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(mo
 
 
 @pytest.mark.asyncio
-async def test_delete_provider_image_accepts_valid_request(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-
-    result = await _call(
-        web_api.api_delete_provider_image,
-        {"provider_image_id": "im-1"},
-    )
-
-    assert result == {
-        "success": True,
-        "data": {"provider_image_id": "im-1", "deleted": True},
-    }
-
-
-@pytest.mark.asyncio
-async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-    info = MagicMock()
-    monkeypatch.setattr(web_api.log, "info", info)
-
-    with pytest.raises(web_api.HTTPException) as exc:
-        await _call(
-            web_api.api_delete_provider_image,
-            {"provider_image_id": 123},
-        )
-
-    assert exc.value.status_code == 400
-    assert exc.value.detail == "provider_image_id must be a string"
-    assert info.call_args.kwargs["http_status"] == 400
-    assert info.call_args.kwargs["outcome"] == "error"
-
-
-@pytest.mark.asyncio
 async def test_image_request_validation_runs_after_authentication(monkeypatch):
     def reject_auth(_authorization):
         raise web_api.HTTPException(status_code=401, detail="Unauthorized")
@@ -590,8 +557,8 @@ async def test_image_request_validation_runs_after_authentication(monkeypatch):
 
     with pytest.raises(web_api.HTTPException) as exc:
         await _call(
-            web_api.api_delete_provider_image,
-            {"provider_image_id": 123},
+            web_api.api_terminate_build_sandbox,
+            {"build_id": 123},
         )
 
     assert exc.value.status_code == 401

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -548,6 +548,83 @@ async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(mo
     assert exc.value.detail == "build session not found"
 
 
+def _patch_image_delete(monkeypatch, **mock_kwargs) -> SimpleNamespace:
+    image_delete = SimpleNamespace(aio=AsyncMock(**mock_kwargs))
+    monkeypatch.setattr(web_api.experimental, "image_delete", image_delete)
+    return image_delete
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_image_deletes_via_sdk(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    image_delete = _patch_image_delete(monkeypatch)
+
+    result = await _call(
+        web_api.api_delete_provider_image,
+        {"provider_image_id": "im-1"},
+    )
+
+    image_delete.aio.assert_awaited_once_with("im-1")
+    assert result == {
+        "success": True,
+        "data": {"provider_image_id": "im-1", "deleted": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_image_treats_missing_image_as_deleted(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    _patch_image_delete(monkeypatch, side_effect=web_api.NotFoundError("image im-1 not found"))
+
+    result = await _call(
+        web_api.api_delete_provider_image,
+        {"provider_image_id": "im-1"},
+    )
+
+    assert result == {
+        "success": True,
+        "data": {"provider_image_id": "im-1", "deleted": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_image_propagates_provider_failures(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    _patch_image_delete(monkeypatch, side_effect=RuntimeError("image service unavailable"))
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_delete_provider_image,
+            {"provider_image_id": "im-1"},
+        )
+
+    assert exc.value.status_code == 500
+
+
+def test_image_delete_supports_async_invocation():
+    # The endpoint awaits experimental.image_delete.aio; fail fast here if a
+    # Modal upgrade drops the synchronizer's .aio form.
+    assert hasattr(web_api.experimental.image_delete, "aio")
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    info = MagicMock()
+    monkeypatch.setattr(web_api.log, "info", info)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_delete_provider_image,
+            {"provider_image_id": 123},
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "provider_image_id must be a string"
+    assert info.call_args.kwargs["http_status"] == 400
+    assert info.call_args.kwargs["outcome"] == "error"
+
+
 @pytest.mark.asyncio
 async def test_image_request_validation_runs_after_authentication(monkeypatch):
     def reject_auth(_authorization):
@@ -557,8 +634,8 @@ async def test_image_request_validation_runs_after_authentication(monkeypatch):
 
     with pytest.raises(web_api.HTTPException) as exc:
         await _call(
-            web_api.api_terminate_build_sandbox,
-            {"build_id": 123},
+            web_api.api_delete_provider_image,
+            {"provider_image_id": 123},
         )
 
     assert exc.value.status_code == 401

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -548,83 +548,6 @@ async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(mo
     assert exc.value.detail == "build session not found"
 
 
-def _patch_image_delete(monkeypatch, **mock_kwargs) -> SimpleNamespace:
-    image_delete = SimpleNamespace(aio=AsyncMock(**mock_kwargs))
-    monkeypatch.setattr(web_api.experimental, "image_delete", image_delete)
-    return image_delete
-
-
-@pytest.mark.asyncio
-async def test_delete_provider_image_deletes_via_sdk(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-    image_delete = _patch_image_delete(monkeypatch)
-
-    result = await _call(
-        web_api.api_delete_provider_image,
-        {"provider_image_id": "im-1"},
-    )
-
-    image_delete.aio.assert_awaited_once_with("im-1")
-    assert result == {
-        "success": True,
-        "data": {"provider_image_id": "im-1", "deleted": True},
-    }
-
-
-@pytest.mark.asyncio
-async def test_delete_provider_image_treats_missing_image_as_deleted(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-    _patch_image_delete(monkeypatch, side_effect=web_api.NotFoundError("image im-1 not found"))
-
-    result = await _call(
-        web_api.api_delete_provider_image,
-        {"provider_image_id": "im-1"},
-    )
-
-    assert result == {
-        "success": True,
-        "data": {"provider_image_id": "im-1", "deleted": True},
-    }
-
-
-@pytest.mark.asyncio
-async def test_delete_provider_image_propagates_provider_failures(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-    _patch_image_delete(monkeypatch, side_effect=RuntimeError("image service unavailable"))
-
-    with pytest.raises(web_api.HTTPException) as exc:
-        await _call(
-            web_api.api_delete_provider_image,
-            {"provider_image_id": "im-1"},
-        )
-
-    assert exc.value.status_code == 500
-
-
-def test_image_delete_supports_async_invocation():
-    # The endpoint awaits experimental.image_delete.aio; fail fast here if a
-    # Modal upgrade drops the synchronizer's .aio form.
-    assert hasattr(web_api.experimental.image_delete, "aio")
-
-
-@pytest.mark.asyncio
-async def test_delete_provider_image_rejects_non_string_id(monkeypatch):
-    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
-    info = MagicMock()
-    monkeypatch.setattr(web_api.log, "info", info)
-
-    with pytest.raises(web_api.HTTPException) as exc:
-        await _call(
-            web_api.api_delete_provider_image,
-            {"provider_image_id": 123},
-        )
-
-    assert exc.value.status_code == 400
-    assert exc.value.detail == "provider_image_id must be a string"
-    assert info.call_args.kwargs["http_status"] == 400
-    assert info.call_args.kwargs["outcome"] == "error"
-
-
 @pytest.mark.asyncio
 async def test_image_request_validation_runs_after_authentication(monkeypatch):
     def reject_auth(_authorization):
@@ -634,8 +557,8 @@ async def test_image_request_validation_runs_after_authentication(monkeypatch):
 
     with pytest.raises(web_api.HTTPException) as exc:
         await _call(
-            web_api.api_delete_provider_image,
-            {"provider_image_id": 123},
+            web_api.api_terminate_build_sandbox,
+            {"build_id": 123},
         )
 
     assert exc.value.status_code == 401

--- a/packages/modal-infra/uv.lock
+++ b/packages/modal-infra/uv.lock
@@ -788,7 +788,6 @@ dependencies = [
     { name = "open-inspect-sandbox-runtime" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
-    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -811,7 +810,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
-    { name = "websockets", specifier = ">=13.0" },
 ]
 provides-extras = ["dev"]
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/__init__.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/__init__.py
@@ -10,19 +10,15 @@ This package contains the code that runs inside sandboxes regardless of provider
 """
 
 from .types import (
-    GitSyncStatus,
     GitUser,
     McpServerConfig,
-    SandboxEvent,
     SandboxStatus,
     SessionConfig,
 )
 
 __all__ = [
-    "GitSyncStatus",
     "GitUser",
     "McpServerConfig",
-    "SandboxEvent",
     "SandboxStatus",
     "SessionConfig",
 ]

--- a/packages/sandbox-runtime/src/sandbox_runtime/types.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/types.py
@@ -1,7 +1,7 @@
 """Type definitions for sandbox operations."""
 
 from enum import StrEnum
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from pydantic import BaseModel
 
@@ -18,83 +18,6 @@ class SandboxStatus(StrEnum):
     SNAPSHOTTING = "snapshotting"  # Taking filesystem snapshot
     STOPPED = "stopped"
     FAILED = "failed"
-
-
-class GitSyncStatus(StrEnum):
-    """Status of git synchronization."""
-
-    PENDING = "pending"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-
-class SandboxEvent(BaseModel):
-    """Event emitted from sandbox to control plane."""
-
-    type: str
-    sandbox_id: str
-    data: dict[str, Any] = {}
-    timestamp: float
-
-
-class HeartbeatEvent(SandboxEvent):
-    """Heartbeat event from sandbox."""
-
-    type: str = "heartbeat"
-    status: SandboxStatus
-
-
-class TokenEvent(SandboxEvent):
-    """Token streaming event from agent."""
-
-    type: str = "token"
-    content: str
-    message_id: str
-
-
-class ToolCallEvent(SandboxEvent):
-    """Tool call event from agent."""
-
-    type: str = "tool_call"
-    tool: str
-    args: dict[str, Any]
-    call_id: str
-
-
-class ToolResultEvent(SandboxEvent):
-    """Tool result event from agent."""
-
-    type: str = "tool_result"
-    call_id: str
-    result: str
-    error: str | None = None
-
-
-class GitSyncEvent(SandboxEvent):
-    """Git sync status event."""
-
-    type: str = "git_sync"
-    status: GitSyncStatus
-    sha: str | None = None
-    error: str | None = None
-
-
-class ExecutionCompleteEvent(SandboxEvent):
-    """Execution complete event."""
-
-    type: str = "execution_complete"
-    message_id: str
-    success: bool
-
-
-class ArtifactEvent(SandboxEvent):
-    """Artifact created event."""
-
-    type: str = "artifact"
-    artifact_type: str
-    url: str
-    metadata: dict[str, Any] = {}
 
 
 class GitUser(BaseModel):


### PR DESCRIPTION
Tier 4 (modal-infra hygiene) of the image-build cleanup review, re-verified against current main before touching anything. Two of the six recorded findings turned out to be already fixed by intervening work. Net −373 lines of dead surface. The deep review surfaced a real capability the first revision missed (see item 1); adopting it is deliberately deferred to #1658 rather than folded in here.

## Already fixed on main — no changes

- **Request-logging scaffold ×7 in web_api.py**: consolidated since the review into `_execute_endpoint` / `_EndpointExecution`; all eight endpoints use it and `_log_build_http_request` is gone.
- **`create_sandbox` / `restore_from_snapshot` ~130-line duplication**: already extracted into `_launch_sandbox` + `_SandboxLaunchSpec` with typed image-source variants. The hot-path item this review deferred to last no longer exists.

## Implemented

### 1. The no-op image-delete round trip is removed; real deletion is deferred to #1658

`api_delete_provider_image` never deleted anything — it logged `image.delete_requested` and answered `"deleted": true` — but cost a deployed function plus an authenticated HTTP request per reaper/finalizer cleanup. `ModalSandboxProvider.deleteProviderImage` is now a local no-op; the `ModalImageBuildProvider` interface and adapter delegation are unchanged, so E2B/Vercel/OpenComputer deletions are untouched, and the reaper/finalizer callers keep logging each attempt and outcome. Deleted: the Modal endpoint + request model, `ModalClient.deleteProviderImage` with its types/schema/URL wiring, and the associated tests; the README row is gone. Verified first: nothing consumes the `image.delete_requested` log line, and terraform has no reference to the endpoint URL.

The deep review correctly flagged that the "Modal doesn't have an explicit delete API" comment this cleanup relied on is stale: the locked SDK (modal 1.4.3) exposes `modal.experimental.image_delete` (verified in the locked venv; `@synchronizer.create_blocking` provides the `.aio` form), and the reaper treats a fulfilled delete as proof it can clear the row carrying `provider_image_id` — so with fake success, reaped Modal images are retained provider-side untracked. Two things to note about that:

- **This PR does not change retention behavior in either direction** — the previous endpoint body was equally fake success, so the leak predates it.
- **Adopting the real deletion is deliberately deferred to #1658**: `image_delete` is an experimental interface (its own docstring warns the stable form may differ), and we want to validate it before wiring the cleanup path to it. Commit `40ba25674` (reverted in this PR) preserves a complete, tested reference implementation — real endpoint with idempotent `NotFoundError` handling and error propagation, restored client/provider round trip, and coverage — to restore once validation passes. The no-op's comment documents the deferral.

The auth-before-validation test that used the delete endpoint as its vehicle now runs against `api_terminate_build_sandbox` (renamed accordingly; the invariant it guards is endpoint-independent). The 400-log-fields assertion it duplicated is already covered on another endpoint.

### 2. Dead module surface in the sandbox package

All verified zero-caller (both this repo and downstream): the `get_manager`/`get_sandbox_config`/`get_sandbox_handle` lazy accessors, the module-global `sandbox_manager` instance, `SandboxHandle.get_logs`/`terminate`, and the fabricated `snap-…` id in `take_snapshot` that was logged once and discarded (the `sandbox.snapshot` log keeps `sandbox_id`/`image_id`, which are the queryable identifiers). `SandboxHandle.snapshot_id` — the restore-provenance field asserted by the launch-spec tests — stays.

### 3. Dead pre-bridge event protocol in sandbox-runtime

`SandboxEvent` and its seven pydantic subclasses (`HeartbeatEvent` … `ArtifactEvent`) are relics of a protocol the bridge replaced with plain dicts; zero constructors or importers outside the two `__init__.py` re-exports. `GitSyncStatus` went with them — its only reader was `GitSyncEvent` (the control plane's `GitSyncStatus` is a separate TS type in `@open-inspect/shared`). `GitUser`/`SessionConfig`/`McpServerConfig`/`SandboxStatus` are live and stay.

### 4. Residue

- `websockets>=13.0` dropped from modal-infra's dependencies: nothing in modal-infra imports it. The sandbox image's pip list in `images/base.py` and sandbox-runtime's own dependency (the real importer) are unaffected. Lockfile regenerated.
- `api_snapshot_sandbox` no longer reads or echoes `session_id`/`reason`: the control plane's response schema reads only `image_id`, and endpoint logging uses the correlation headers, so the body fields were dead in both directions. The client stops sending them; `SnapshotSandboxRequest.reason` is gone (provider-level `SnapshotConfig.reason` stays — OpenComputer embeds it in checkpoint names). The generic-snapshot identity test still passes unchanged, since a crafted `reason` now can't influence anything by construction.
- README: `src/sandbox/` listing described files that moved to `packages/sandbox-runtime` long ago and claimed a "warm" operation the manager doesn't have; now matches the real module layout.

## Deliberately kept

The `modal>=1.4.3` floor and its `with_options()` comment: the review flagged the justification as stale, but the floor has since been re-justified — `Function.with_options()` per-call timeout override genuinely requires it.

## Verification

- modal-infra pytest 217/217, sandbox-runtime pytest 775/775, ruff clean
- control-plane unit 3319/3319 and integration 1006/1006, workspace typecheck + both test tsconfig programs clean
- Deleted-symbol grep across the full tree returns only the intended survivors (interface member + no-op implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Simplified sandbox snapshot requests and responses by removing session and reason details.
  - Removed provider-image deletion support from the sandbox APIs.
  - Reduced public sandbox runtime exports to supported configuration and status types.
  - Removed deprecated sandbox event models and unsupported sandbox handle operations.

- **Documentation**
  - Updated sandbox component documentation to reflect the current runtime structure, lifecycle terminology, and removal of the image-deletion endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->