### PR TITLE
Autofocus the home page prompt

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -245,6 +245,12 @@ function activeOpenAiAccount(id: string): (typeof mocks.providerAccountsValue)[n
 }
 
 describe("Home", () => {
+  it("focuses the prompt when the page loads", () => {
+    render(<Home />);
+
+    expect(screen.getByPlaceholderText("What do you want to build?")).toHaveFocus();
+  });
+
   it("disables autofill suggestions for the prompt", () => {
     render(<Home />);
 

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -527,6 +527,7 @@ function HomeContent({
                     maxLength={MAX_WEB_PROMPT_CHARS}
                     disabled={creating}
                     placeholder="What do you want to build?"
+                    autoFocus
                     autoComplete="off"
                     className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground disabled:opacity-50"
                     rows={3}


### PR DESCRIPTION
## Summary
- focus the new-session prompt automatically when the authenticated home page loads
- add a regression test for the initial focus behavior

## Testing
- `npm test -w @open-inspect/web -- "src/app/(app)/page.test.tsx"`
- `npx eslint "src/app/(app)/page.tsx" "src/app/(app)/page.test.tsx"`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/494241ec99e2c86f17d2bfe8898abfa2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The prompt input is now automatically focused when the home page loads, allowing users to start typing immediately.

* **Tests**
  * Added coverage to verify the prompt input receives focus on initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->