### PR TITLE
Fix PR Autofix attempt limit settings

### DIFF
--- a/packages/control-plane/src/autofix/handler.ts
+++ b/packages/control-plane/src/autofix/handler.ts
@@ -26,7 +26,7 @@ function completeAutofixSettings(
         prCommentsEnabled?: boolean;
         openInspectReviewsEnabled?: boolean;
         allowedReviewBots?: string[];
-        maxAttemptsPerPrPer24Hours?: number;
+        maxAttemptsPerPrPer24Hours?: number | null;
       }
     | undefined
 ): ResolvedGitHubAutofixSettings {

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -317,6 +317,26 @@ describe("IntegrationSettingsStore", () => {
       });
     });
 
+    it.each([75, null])("accepts an Autofix attempt limit of %s", async (attemptLimit) => {
+      await store.setGlobal("github", {
+        defaults: { autofix: { maxAttemptsPerPrPer24Hours: attemptLimit } },
+      });
+
+      const result = await store.getGlobal("github");
+      expect(result?.defaults?.autofix?.maxAttemptsPerPrPer24Hours).toBe(attemptLimit);
+    });
+
+    it.each([0, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+      "rejects an invalid Autofix attempt limit of %s",
+      async (attemptLimit) => {
+        await expect(
+          store.setGlobal("github", {
+            defaults: { autofix: { maxAttemptsPerPrPer24Hours: attemptLimit } },
+          })
+        ).rejects.toThrow(IntegrationSettingsValidationError);
+      }
+    );
+
     it("rejects non-array defaults.allowedTriggerUsers", async () => {
       await expect(
         store.setGlobal("github", {

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -507,13 +507,11 @@ export class IntegrationSettingsStore {
     const maxAttempts = settings.maxAttemptsPerPrPer24Hours;
     if (
       maxAttempts !== undefined &&
-      (typeof maxAttempts !== "number" ||
-        !Number.isInteger(maxAttempts) ||
-        maxAttempts < 1 ||
-        maxAttempts > 50)
+      maxAttempts !== null &&
+      (typeof maxAttempts !== "number" || !Number.isSafeInteger(maxAttempts) || maxAttempts < 1)
     ) {
       throw new IntegrationSettingsValidationError(
-        "autofix.maxAttemptsPerPrPer24Hours must be an integer from 1 to 50"
+        "autofix.maxAttemptsPerPrPer24Hours must be a positive safe integer or null"
       );
     }
 
@@ -526,7 +524,7 @@ export class IntegrationSettingsStore {
         new Set(allowedReviewBots.map((login) => login.trim().toLowerCase()).filter(Boolean))
       );
     }
-    if (typeof maxAttempts === "number") {
+    if (typeof maxAttempts === "number" || maxAttempts === null) {
       normalized.maxAttemptsPerPrPer24Hours = maxAttempts;
     }
     return normalized;

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -505,15 +505,6 @@ export class IntegrationSettingsStore {
     }
 
     const maxAttempts = settings.maxAttemptsPerPrPer24Hours;
-    if (
-      maxAttempts !== undefined &&
-      maxAttempts !== null &&
-      (typeof maxAttempts !== "number" || !Number.isSafeInteger(maxAttempts) || maxAttempts < 1)
-    ) {
-      throw new IntegrationSettingsValidationError(
-        "autofix.maxAttemptsPerPrPer24Hours must be a positive safe integer or null"
-      );
-    }
 
     const normalized: GitHubAutofixSettings = {};
     for (const key of booleanKeys) {

--- a/packages/control-plane/src/session/http/handlers/autofix.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/autofix.handler.test.ts
@@ -67,6 +67,36 @@ describe("AutofixHandler", () => {
     expect(messageQueue.lookupAutofix).toHaveBeenCalledWith("github:99:review:1234");
   });
 
+  it("accepts Autofix admission commands without an attempt limit", async () => {
+    const { handler, messageQueue, log } = createHandler();
+    messageQueue.enqueueAutofix.mockResolvedValue({ kind: "enqueued", messageId: "msg-autofix" });
+    const body = {
+      type: "enqueue_feedback",
+      feedbackKey: "github:99:review:1234",
+      pullRequest: { repositoryId: "99", number: 42, artifactId: "artifact-1" },
+      prompt: "Address the submitted review feedback.",
+      author: { id: "7", login: "alice" },
+      origin: {
+        kind: "review",
+        authorType: "human",
+        feedbackUrl: "https://github.com/acme/widgets/pull/42#pullrequestreview-1234",
+      },
+      attemptLimit: null,
+    };
+
+    const response = await handler.handle(
+      new Request("http://internal/internal/autofix", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      log
+    );
+
+    expect(response.status).toBe(200);
+    expect(messageQueue.enqueueAutofix).toHaveBeenCalledWith(body);
+  });
+
   it("rejects invalid Autofix commands before admission", async () => {
     const { handler, messageQueue, log } = createHandler();
     const response = await handler.handle(

--- a/packages/control-plane/src/session/message-repository.test.ts
+++ b/packages/control-plane/src/session/message-repository.test.ts
@@ -237,6 +237,30 @@ describe("MessageRepository", () => {
     expect(mock.calls).toHaveLength(3);
   });
 
+  it("admits Autofix feedback without checking the rolling count when there is no limit", () => {
+    mock.setOne({ count: 0 });
+
+    expect(
+      repository.admitAutofixMessage({
+        message: {
+          id: "msg-new",
+          authorId: "p-1",
+          content: "Fix feedback",
+          source: "github",
+          status: "pending",
+          createdAt: 2000,
+        },
+        feedbackKey: "github:review:1",
+        pullRequestKey: "github:99:42",
+        originContext: "{}",
+        attemptLimit: null,
+        windowStart: 1000,
+        sessionClosed: false,
+      })
+    ).toEqual({ kind: "enqueued", messageId: "msg-new" });
+    expect(mock.calls.some(({ query }) => query.includes("autofix_pr_key = ?"))).toBe(false);
+  });
+
   it("rejects Autofix admission when the session queue is full", () => {
     mock.setOne({ count: MAX_UNFINISHED_PROMPTS });
 

--- a/packages/control-plane/src/session/message-repository.ts
+++ b/packages/control-plane/src/session/message-repository.ts
@@ -43,7 +43,7 @@ export interface AdmitAutofixMessageData {
   feedbackKey: string;
   pullRequestKey: string;
   originContext: string;
-  attemptLimit: number;
+  attemptLimit: number | null;
   windowStart: number;
   sessionClosed: boolean;
 }
@@ -179,16 +179,18 @@ export class MessageRepository {
         return { kind: "rejected", reason: "queue_full" };
       }
 
-      const count = this.sql
-        .exec(
-          `SELECT COUNT(*) AS count FROM messages
-         WHERE autofix_pr_key = ? AND created_at >= ?`,
-          data.pullRequestKey,
-          data.windowStart
-        )
-        .one() as { count: number };
-      if (count.count >= data.attemptLimit) {
-        return { kind: "rejected", reason: "attempt_limit" };
+      if (data.attemptLimit !== null) {
+        const count = this.sql
+          .exec(
+            `SELECT COUNT(*) AS count FROM messages
+           WHERE autofix_pr_key = ? AND created_at >= ?`,
+            data.pullRequestKey,
+            data.windowStart
+          )
+          .one() as { count: number };
+        if (count.count >= data.attemptLimit) {
+          return { kind: "rejected", reason: "attempt_limit" };
+        }
       }
 
       this.createMessage({

--- a/packages/shared/src/types/github-autofix.ts
+++ b/packages/shared/src/types/github-autofix.ts
@@ -66,7 +66,7 @@ const enqueueFeedbackCommandSchema = z.object({
     login: z.string().min(1),
   }),
   origin: githubAutofixOriginSchema,
-  attemptLimit: z.number().int().min(1).max(50),
+  attemptLimit: z.number().int().positive().safe().nullable(),
 });
 
 const lookupFeedbackCommandSchema = z.object({

--- a/packages/shared/src/types/github-autofix.ts
+++ b/packages/shared/src/types/github-autofix.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { githubAutofixAttemptLimitSchema } from "./integrations";
 
 const repositorySchema = z.object({
   id: z.string().min(1),
@@ -66,7 +67,7 @@ const enqueueFeedbackCommandSchema = z.object({
     login: z.string().min(1),
   }),
   origin: githubAutofixOriginSchema,
-  attemptLimit: z.number().int().positive().safe().nullable(),
+  attemptLimit: githubAutofixAttemptLimitSchema,
 });
 
 const lookupFeedbackCommandSchema = z.object({

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -24,7 +24,7 @@ export const githubAutofixSettingsSchema = z.strictObject({
   prCommentsEnabled: z.boolean().optional(),
   openInspectReviewsEnabled: z.boolean().optional(),
   allowedReviewBots: z.array(z.string()).optional(),
-  maxAttemptsPerPrPer24Hours: z.number().optional(),
+  maxAttemptsPerPrPer24Hours: z.number().nullable().optional(),
 });
 
 export type GitHubAutofixSettings = z.infer<typeof githubAutofixSettingsSchema>;
@@ -35,8 +35,11 @@ export interface ResolvedGitHubAutofixSettings {
   prCommentsEnabled: boolean;
   openInspectReviewsEnabled: boolean;
   allowedReviewBots: string[];
-  maxAttemptsPerPrPer24Hours: number;
+  /** A positive attempt cap, or null for no rolling limit. */
+  maxAttemptsPerPrPer24Hours: number | null;
 }
+
+export const GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT = 30;
 
 export const GITHUB_AUTOFIX_DEFAULTS: ResolvedGitHubAutofixSettings = {
   enabled: false,
@@ -44,7 +47,7 @@ export const GITHUB_AUTOFIX_DEFAULTS: ResolvedGitHubAutofixSettings = {
   prCommentsEnabled: true,
   openInspectReviewsEnabled: true,
   allowedReviewBots: [],
-  maxAttemptsPerPrPer24Hours: 30,
+  maxAttemptsPerPrPer24Hours: GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT,
 };
 
 /** Overridable behavior settings for the GitHub bot. Used at both global and repo levels. */

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -18,13 +18,15 @@ export interface IntegrationEntry<
 }
 
 /** Overridable behavior settings for GitHub Autofix. */
+export const githubAutofixAttemptLimitSchema = z.number().int().positive().safe().nullable();
+
 export const githubAutofixSettingsSchema = z.strictObject({
   enabled: z.boolean().optional(),
   reviewsEnabled: z.boolean().optional(),
   prCommentsEnabled: z.boolean().optional(),
   openInspectReviewsEnabled: z.boolean().optional(),
   allowedReviewBots: z.array(z.string()).optional(),
-  maxAttemptsPerPrPer24Hours: z.number().nullable().optional(),
+  maxAttemptsPerPrPer24Hours: githubAutofixAttemptLimitSchema.optional(),
 });
 
 export type GitHubAutofixSettings = z.infer<typeof githubAutofixSettingsSchema>;

--- a/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
+++ b/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { GITHUB_AUTOFIX_DEFAULTS, type ResolvedGitHubAutofixSettings } from "@open-inspect/shared";
+import {
+  GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT,
+  type ResolvedGitHubAutofixSettings,
+} from "@open-inspect/shared";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 
@@ -14,6 +18,11 @@ function parseBotUsernames(value: string): string[] {
         .filter(Boolean)
     )
   );
+}
+
+function parseAttemptLimit(value: string): number | null {
+  const parsed = Number(value);
+  return value !== "" && Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
 }
 
 export function GitHubAutofixSettingsFields({
@@ -29,12 +38,21 @@ export function GitHubAutofixSettingsFields({
 }) {
   const [botUsernames, setBotUsernames] = useState(() => value.allowedReviewBots.join(", "));
   const editingBotUsernames = useRef(false);
+  const [attemptLimit, setAttemptLimit] = useState(() =>
+    String(value.maxAttemptsPerPrPer24Hours ?? GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT)
+  );
 
   useEffect(() => {
     if (!editingBotUsernames.current) {
       setBotUsernames(value.allowedReviewBots.join(", "));
     }
   }, [value.allowedReviewBots]);
+
+  useEffect(() => {
+    if (value.maxAttemptsPerPrPer24Hours !== null) {
+      setAttemptLimit(String(value.maxAttemptsPerPrPer24Hours));
+    }
+  }, [value.maxAttemptsPerPrPer24Hours]);
 
   const update = <K extends keyof ResolvedGitHubAutofixSettings>(
     key: K,
@@ -116,7 +134,7 @@ export function GitHubAutofixSettingsFields({
         )}
       </label>
 
-      <label className="block">
+      <div>
         <span className="block text-xs font-medium text-muted-foreground mb-1">
           Attempts per PR per 24 hours
         </span>
@@ -124,23 +142,47 @@ export function GitHubAutofixSettingsFields({
           aria-label="Attempts per PR per 24 hours"
           type="number"
           min={1}
-          max={50}
-          value={value.maxAttemptsPerPrPer24Hours}
+          step={1}
+          disabled={value.maxAttemptsPerPrPer24Hours === null}
+          value={attemptLimit}
           onChange={(event) => {
-            const parsed = Number(event.target.value);
-            if (Number.isInteger(parsed) && parsed >= 1 && parsed <= 50) {
+            const next = event.target.value;
+            setAttemptLimit(next);
+            const parsed = parseAttemptLimit(next);
+            if (parsed !== null) {
               update("maxAttemptsPerPrPer24Hours", parsed);
             }
           }}
+          onBlur={() => {
+            setAttemptLimit(
+              String(value.maxAttemptsPerPrPer24Hours ?? GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT)
+            );
+          }}
           className={compact ? "h-8 text-xs" : "max-w-32"}
         />
-        {value.maxAttemptsPerPrPer24Hours > GITHUB_AUTOFIX_DEFAULTS.maxAttemptsPerPrPer24Hours && (
+        <label className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <Checkbox
+            aria-label="No Autofix attempt limit"
+            checked={value.maxAttemptsPerPrPer24Hours === null}
+            onCheckedChange={(checked) => {
+              update(
+                "maxAttemptsPerPrPer24Hours",
+                checked
+                  ? null
+                  : (parseAttemptLimit(attemptLimit) ?? GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT)
+              );
+            }}
+          />
+          No limit
+        </label>
+        {(value.maxAttemptsPerPrPer24Hours === null ||
+          value.maxAttemptsPerPrPer24Hours > GITHUB_AUTOFIX_DEFAULT_ATTEMPT_LIMIT) && (
           <span className="block text-xs text-amber-600 dark:text-amber-400 mt-1">
-            Higher attempt caps increase autonomous work and spend. Raise this only after reviewing
-            dogfood volume and queue health.
+            Higher or unlimited attempts increase autonomous work and spend. Change this only after
+            reviewing dogfood volume and queue health.
           </span>
         )}
-      </label>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
+++ b/packages/web/src/components/settings/integrations/github-autofix-settings-fields.tsx
@@ -32,7 +32,10 @@ export function GitHubAutofixSettingsFields({
   compact = false,
 }: {
   value: ResolvedGitHubAutofixSettings;
-  onChange: (value: ResolvedGitHubAutofixSettings) => void;
+  onChange: (
+    value: ResolvedGitHubAutofixSettings,
+    changedKey: keyof ResolvedGitHubAutofixSettings
+  ) => void;
   onDirty: () => void;
   compact?: boolean;
 }) {
@@ -57,7 +60,7 @@ export function GitHubAutofixSettingsFields({
   const update = <K extends keyof ResolvedGitHubAutofixSettings>(
     key: K,
     next: ResolvedGitHubAutofixSettings[K]
-  ) => onChange({ ...value, [key]: next });
+  ) => onChange({ ...value, [key]: next }, key);
   const rowClass = compact
     ? "flex items-center justify-between gap-3 py-1"
     : "flex items-center justify-between gap-3 px-3 py-2 border border-border rounded-sm";

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -197,17 +197,45 @@ describe("GitHubIntegrationSettings", () => {
     expect(input).toHaveValue("coderabbitai[bot], renovate[bot]");
     expect(screen.getByText(/bot-authored feedback is untrusted input/i)).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole("spinbutton", { name: "Attempts per PR per 24 hours" }), {
-      target: { value: "40" },
+    const attemptLimit = screen.getByRole("spinbutton", {
+      name: "Attempts per PR per 24 hours",
     });
-    expect(screen.getByText(/higher attempt caps increase autonomous work/i)).toBeInTheDocument();
+    await user.clear(attemptLimit);
+    expect(attemptLimit).toHaveValue(null);
+    await user.type(attemptLimit, "75");
+    expect(attemptLimit).toHaveValue(75);
+    expect(
+      screen.getByText(/higher or unlimited attempts increase autonomous work/i)
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/integration-settings/github",
       expect.objectContaining({
-        body: expect.stringContaining('"allowedReviewBots":["coderabbitai[bot]","renovate[bot]"]'),
+        body: expect.stringContaining(
+          '"allowedReviewBots":["coderabbitai[bot]","renovate[bot]"],"maxAttemptsPerPrPer24Hours":75'
+        ),
+      })
+    );
+  });
+
+  it("persists an explicit unlimited Autofix attempt policy", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: { defaults: { autoReviewOnOpen: true } } });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<GitHubIntegrationSettings />);
+
+    await user.click(screen.getByRole("checkbox", { name: "No Autofix attempt limit" }));
+    expect(screen.getByRole("spinbutton", { name: "Attempts per PR per 24 hours" })).toBeDisabled();
+    expect(screen.getByText(/unlimited attempts increase autonomous work/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integration-settings/github",
+      expect.objectContaining({
+        body: expect.stringContaining('"maxAttemptsPerPrPer24Hours":null'),
       })
     );
   });

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -346,10 +346,15 @@ describe("GitHubIntegrationSettings", () => {
     );
   });
 
-  it("repo auto-review override without an explicit value seeds from global default when saved", async () => {
+  it("preserves sparse Autofix overrides when saving an unrelated repo setting", async () => {
     const user = userEvent.setup();
     setupSWR({
-      global: { defaults: { autoReviewOnOpen: false } },
+      global: {
+        defaults: {
+          autoReviewOnOpen: false,
+          autofix: { maxAttemptsPerPrPer24Hours: null },
+        },
+      },
       repos: [{ repo: "acme/web", settings: { autofix: { enabled: true } } }],
       availableRepos: [repo("acme/web")],
     });
@@ -374,7 +379,7 @@ describe("GitHubIntegrationSettings", () => {
         body: JSON.stringify({
           settings: {
             autoReviewOnOpen: false,
-            autofix: { ...GITHUB_AUTOFIX_DEFAULTS, enabled: true },
+            autofix: { enabled: true },
           },
         }),
       })

--- a/packages/web/src/components/settings/integrations/github-repo-overrides-section.tsx
+++ b/packages/web/src/components/settings/integrations/github-repo-overrides-section.tsx
@@ -7,6 +7,7 @@ import {
   encodeRepositoryPathSegments,
   parseRepositoryFullName,
   type EnrichedRepository,
+  type GitHubAutofixSettings,
   type GitHubBotSettings,
   type ResolvedGitHubAutofixSettings,
 } from "@open-inspect/shared";
@@ -168,10 +169,13 @@ function RepoOverrideRow({
   const [autofixMode, setAutofixMode] = useState<"global" | "override">(
     entry.settings.autofix === undefined ? "global" : "override"
   );
-  const [autofix, setAutofix] = useState<ResolvedGitHubAutofixSettings>({
+  const [autofixOverrides, setAutofixOverrides] = useState<GitHubAutofixSettings>(
+    entry.settings.autofix ?? {}
+  );
+  const autofix: ResolvedGitHubAutofixSettings = {
     ...defaultAutofix,
-    ...entry.settings.autofix,
-  });
+    ...autofixOverrides,
+  };
   const [newUsername, setNewUsername] = useState("");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -207,7 +211,7 @@ function RepoOverrideRow({
     if (commentActionMode === "override")
       settings.commentActionInstructions = commentActionInstructions;
     if (autoReviewMode === "override") settings.autoReviewOnOpen = autoReviewOnOpen;
-    if (autofixMode === "override") settings.autofix = autofix;
+    if (autofixMode === "override") settings.autofix = autofixOverrides;
 
     try {
       const res = await browserApiFetch(
@@ -357,7 +361,7 @@ function RepoOverrideRow({
             onValueChange={(value: "global" | "override") => {
               setAutofixMode(value);
               if (value === "override" && entry.settings.autofix === undefined) {
-                setAutofix({ ...defaultAutofix });
+                setAutofixOverrides({});
               }
               setDirty(true);
             }}
@@ -376,8 +380,11 @@ function RepoOverrideRow({
             value={autofix}
             compact
             onDirty={() => setDirty(true)}
-            onChange={(value) => {
-              setAutofix(value);
+            onChange={(value, changedKey) => {
+              setAutofixOverrides((current) => ({
+                ...current,
+                [changedKey]: value[changedKey],
+              }));
               setDirty(true);
             }}
           />


### PR DESCRIPTION
## Summary
- remove the hard-coded 50-attempt ceiling and accept any positive safe integer
- add an explicit `No limit` policy that persists as `null` and skips rolling-limit admission checks
- keep a local text draft for the number input so users can clear, backspace, and replace its value
- add UI, settings validation, command schema, and runtime admission coverage

## Testing
- `npm test -w @open-inspect/web -- --run src/components/settings/integrations/github-integration-settings.test.tsx`
- `npm test -w @open-inspect/control-plane -- --run src/db/integration-settings.test.ts src/session/message-repository.test.ts src/session/http/handlers/autofix.handler.test.ts`
- `npm run typecheck`
- `npm run lint`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a31e45edb59c2483bdf4689ef6626136)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “No limit” option for GitHub Autofix attempts per pull request.
  * Attempt limits can now be set above 50, including values such as 75.
  * Unlimited settings are preserved when saved and applied.

* **Bug Fixes**
  * Autofix no longer checks attempt counts when no limit is configured.
  * Improved validation for invalid, non-positive, fractional, or unsafe limits.
  * Repository-specific settings now preserve only explicitly configured overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->