### PR TITLE
Add settings destinations to global command search

### DIFF
--- a/packages/web/src/components/global-command-menu.test.tsx
+++ b/packages/web/src/components/global-command-menu.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GlobalCommandMenu } from "./global-command-menu";
+
+expect.extend(matchers);
+
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: vi.fn(),
+});
+
+const mocks = vi.hoisted(() => ({ repoImagesEnabled: true }));
+
+vi.mock("@/hooks/use-keyboard-shortcuts", () => ({
+  useKeyboardShortcuts: () => ({ labels: { "new-session": "Cmd/Ctrl+Shift+O" } }),
+}));
+
+vi.mock("@/lib/sandbox-provider", () => ({
+  supportsRepoImages: () => mocks.repoImagesEnabled,
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  mocks.repoImagesEnabled = true;
+  vi.unstubAllGlobals();
+});
+
+function renderMenu() {
+  const onOpenChange = vi.fn();
+  const onNavigate = vi.fn();
+  const props = {
+    onOpenChange,
+    onNavigate,
+    onNewSession: vi.fn(),
+    sessions: [],
+  };
+  const view = render(<GlobalCommandMenu open {...props} />);
+  return { ...view, onNavigate, onOpenChange, props };
+}
+
+describe("GlobalCommandMenu", () => {
+  it("navigates directly to a settings destination", async () => {
+    const user = userEvent.setup();
+    const { onNavigate, onOpenChange } = renderMenu();
+
+    await user.click(screen.getByText("Appearance"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onNavigate).toHaveBeenCalledWith("/settings?tab=appearance");
+  });
+
+  it("searches settings labels, descriptions, and keywords", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.type(
+      screen.getByPlaceholderText("Search sessions, settings, and commands..."),
+      "request source"
+    );
+
+    await waitFor(() => expect(screen.getByText("Source control")).toBeInTheDocument());
+    expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
+  });
+
+  it("does not show unrelated fuzzy settings matches", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.type(
+      screen.getByPlaceholderText("Search sessions, settings, and commands..."),
+      "theme"
+    );
+
+    await waitFor(() => expect(screen.getByText("Appearance")).toBeInTheDocument());
+    expect(screen.queryByText("Source control")).not.toBeInTheDocument();
+    expect(screen.queryByText("Models")).not.toBeInTheDocument();
+  });
+
+  it("clears settings filtering when the controlled dialog closes", async () => {
+    const user = userEvent.setup();
+    const { props, rerender } = renderMenu();
+    await user.type(
+      screen.getByPlaceholderText("Search sessions, settings, and commands..."),
+      "theme"
+    );
+    expect(screen.queryByText("Source control")).not.toBeInTheDocument();
+
+    rerender(<GlobalCommandMenu open={false} {...props} />);
+    rerender(<GlobalCommandMenu open {...props} />);
+
+    await waitFor(() => expect(screen.getByText("Source control")).toBeInTheDocument());
+  });
+
+  it("omits unavailable settings destinations", () => {
+    mocks.repoImagesEnabled = false;
+    renderMenu();
+
+    expect(screen.queryByText("Images")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -7,7 +7,7 @@ import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
 import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
-import { getSettingsGroups } from "@/components/settings/settings-registry";
+import { DEFAULT_SETTINGS_QUERY, getSettingsGroups } from "@/components/settings/settings-registry";
 import {
   Command,
   CommandDialog,
@@ -52,7 +52,7 @@ export function GlobalCommandMenu({
   sessions,
 }: GlobalCommandMenuProps) {
   const { labels } = useKeyboardShortcuts();
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(DEFAULT_SETTINGS_QUERY);
   const searchableSessions = useMemo(
     () => sessions.filter((session) => session.status !== "archived"),
     [sessions]
@@ -60,7 +60,7 @@ export function GlobalCommandMenu({
   const settingsGroups = getSettingsGroups({ query, includeGlobalAliases: true });
 
   useEffect(() => {
-    if (!open) setQuery("");
+    if (!open) setQuery(DEFAULT_SETTINGS_QUERY);
   }, [open]);
 
   const handleSelect = (callback: () => void) => {

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { formatRelativeTime } from "@/lib/time";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
 import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
+import { getSettingsGroups } from "@/components/settings/settings-registry";
 import {
   Command,
   CommandDialog,
@@ -51,10 +52,16 @@ export function GlobalCommandMenu({
   sessions,
 }: GlobalCommandMenuProps) {
   const { labels } = useKeyboardShortcuts();
+  const [query, setQuery] = useState("");
   const searchableSessions = useMemo(
     () => sessions.filter((session) => session.status !== "archived"),
     [sessions]
   );
+  const settingsGroups = getSettingsGroups({ query, includeGlobalAliases: true });
+
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
 
   const handleSelect = (callback: () => void) => {
     onOpenChange(false);
@@ -68,7 +75,10 @@ export function GlobalCommandMenu({
         Search and jump to sessions, settings, automations, and other destinations.
       </DialogDescription>
       <Command>
-        <CommandInput placeholder="Type a command or search sessions..." />
+        <CommandInput
+          placeholder="Search sessions, settings, and commands..."
+          onValueChange={setQuery}
+        />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
 
@@ -90,6 +100,33 @@ export function GlobalCommandMenu({
               <AutomationsIcon className="h-4 w-4" />
               <span>Automations</span>
             </CommandItem>
+          </CommandGroup>
+
+          <CommandSeparator />
+          <CommandGroup heading="Settings">
+            {settingsGroups.flatMap((group) =>
+              group.items.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <CommandItem
+                    key={item.id}
+                    forceMount
+                    value={`settings ${group.label} ${item.label} ${item.description} ${item.keywords}`}
+                    onSelect={() => handleSelect(() => onNavigate(`/settings?tab=${item.id}`))}
+                    className="items-start"
+                  >
+                    <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate">{item.label}</div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {item.description}
+                      </div>
+                    </div>
+                    <CommandShortcut>{group.label}</CommandShortcut>
+                  </CommandItem>
+                );
+              })
+            )}
           </CommandGroup>
 
           {searchableSessions.length > 0 && (

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -3,167 +3,15 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useIsMobile } from "@/hooks/use-media-query";
-import {
-  AppearanceIcon,
-  BackIcon,
-  BoxIcon,
-  ChevronRightIcon,
-  DataControlsIcon,
-  FolderIcon,
-  GitPrIcon,
-  IntegrationsIcon,
-  KeyboardIcon,
-  KeyIcon,
-  ModelIcon,
-  SearchIcon,
-  SparkleIcon,
-  TerminalIcon,
-} from "@/components/ui/icons";
-import { supportsRepoImages } from "@/lib/sandbox-provider";
+import { BackIcon, ChevronRightIcon, SearchIcon } from "@/components/ui/icons";
+import { getSettingsGroups, type SettingsCategory } from "./settings-registry";
 
-export const SETTINGS_GROUPS = [
-  {
-    label: "Personal",
-    items: [
-      {
-        id: "appearance",
-        label: "Appearance",
-        description: "Theme and code highlighting",
-        keywords: "theme dark light syntax",
-        icon: AppearanceIcon,
-      },
-      {
-        id: "keyboard-shortcuts",
-        label: "Keyboard",
-        description: "Customize keyboard shortcuts",
-        keywords: "keys commands hotkeys",
-        icon: KeyboardIcon,
-      },
-    ],
-  },
-  {
-    label: "Sessions",
-    items: [
-      {
-        id: "models",
-        label: "Models",
-        description: "Choose models available to agents",
-        keywords: "claude openai reasoning",
-        icon: ModelIcon,
-      },
-      {
-        id: "provider-accounts",
-        label: "Accounts",
-        description: "Connect model provider subscriptions",
-        keywords: "provider authentication credentials",
-        icon: KeyIcon,
-      },
-      {
-        id: "skills",
-        label: "Skills",
-        description: "Manage shared skills and profiles",
-        keywords: "agent instructions profiles",
-        icon: SparkleIcon,
-      },
-    ],
-  },
-  {
-    label: "Workspace",
-    items: [
-      {
-        id: "environments",
-        label: "Environments",
-        description: "Configure reusable repository setups",
-        keywords: "repositories branches prebuild",
-        icon: FolderIcon,
-      },
-      {
-        id: "secrets",
-        label: "Secrets",
-        description: "Manage global and repository secrets",
-        keywords: "environment variables credentials",
-        icon: KeyIcon,
-      },
-      {
-        id: "scm",
-        label: "Source control",
-        description: "Configure pull request behavior",
-        keywords: "scm git pull request merge draft",
-        icon: GitPrIcon,
-      },
-    ],
-  },
-  {
-    label: "System",
-    items: [
-      {
-        id: "sandbox",
-        label: "Sandbox",
-        description: "Set runtime resources and access",
-        keywords: "terminal ports cpu memory timeout",
-        icon: TerminalIcon,
-      },
-      {
-        id: "images",
-        label: "Images",
-        description: "Manage repository image builds",
-        keywords: "prebuild containers",
-        icon: BoxIcon,
-        requiresRepoImages: true,
-      },
-      {
-        id: "integrations",
-        label: "Integrations",
-        description: "Connect external tools and services",
-        keywords: "github slack linear vnc code server",
-        icon: IntegrationsIcon,
-      },
-      {
-        id: "mcp-servers",
-        label: "MCP Servers",
-        description: "Configure local and remote MCP servers",
-        keywords: "tools protocol command url",
-        icon: TerminalIcon,
-      },
-      {
-        id: "data-controls",
-        label: "Data Controls",
-        description: "Review and restore archived sessions",
-        keywords: "archive restore retention",
-        icon: DataControlsIcon,
-      },
-    ],
-  },
-] as const;
-
-type SettingsItem = (typeof SETTINGS_GROUPS)[number]["items"][number];
-export type SettingsCategory = SettingsItem["id"];
-export const DEFAULT_SETTINGS_CATEGORY: SettingsCategory = "secrets";
-
-function isSettingsItemAvailable(item: SettingsItem, repoImagesEnabled: boolean): boolean {
-  return !("requiresRepoImages" in item) || repoImagesEnabled;
-}
-
-export function getSettingsCategoryLabel(category: SettingsCategory): string {
-  for (const group of SETTINGS_GROUPS) {
-    for (const item of group.items) {
-      if (item.id === category) return item.label;
-    }
-  }
-  return category;
-}
-
-export function isSettingsCategory(
-  value: string | null,
-  repoImagesEnabled = supportsRepoImages()
-): value is SettingsCategory {
-  if (!value) return false;
-  return SETTINGS_GROUPS.some((group) =>
-    group.items.some(
-      (item) => item.id === value && isSettingsItemAvailable(item, repoImagesEnabled)
-    )
-  );
-}
+export {
+  DEFAULT_SETTINGS_CATEGORY,
+  getSettingsCategoryLabel,
+  isSettingsCategory,
+  type SettingsCategory,
+} from "./settings-registry";
 
 interface SettingsNavProps {
   activeCategory: SettingsCategory;
@@ -192,18 +40,8 @@ function SettingsSearch({ value, onChange }: { value: string; onChange: (value: 
 
 export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNavProps) {
   const isMobile = useIsMobile();
-  const repoImagesEnabled = supportsRepoImages();
   const [query, setQuery] = useState("");
-  const normalizedQuery = query.trim().toLowerCase();
-  const groups = SETTINGS_GROUPS.map((group) => ({
-    ...group,
-    items: group.items.filter((item) => {
-      if (!isSettingsItemAvailable(item, repoImagesEnabled)) return false;
-      if (!normalizedQuery) return true;
-      const searchText = `${item.label} ${item.description} ${item.keywords}`.toLowerCase();
-      return normalizedQuery.split(/\s+/).every((term) => searchText.includes(term));
-    }),
-  })).filter((group) => group.items.length > 0);
+  const groups = getSettingsGroups({ query });
 
   const navigation = (
     <div className="space-y-6">

--- a/packages/web/src/components/settings/settings-registry.ts
+++ b/packages/web/src/components/settings/settings-registry.ts
@@ -1,0 +1,180 @@
+import {
+  AppearanceIcon,
+  BoxIcon,
+  DataControlsIcon,
+  FolderIcon,
+  GitPrIcon,
+  IntegrationsIcon,
+  KeyboardIcon,
+  KeyIcon,
+  ModelIcon,
+  SparkleIcon,
+  TerminalIcon,
+} from "@/components/ui/icons";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+
+export const SETTINGS_GROUPS = [
+  {
+    label: "Personal",
+    items: [
+      {
+        id: "appearance",
+        label: "Appearance",
+        description: "Theme and code highlighting",
+        keywords: "theme dark light syntax",
+        icon: AppearanceIcon,
+      },
+      {
+        id: "keyboard-shortcuts",
+        label: "Keyboard",
+        description: "Customize keyboard shortcuts",
+        keywords: "keys commands hotkeys",
+        icon: KeyboardIcon,
+      },
+    ],
+  },
+  {
+    label: "Sessions",
+    items: [
+      {
+        id: "models",
+        label: "Models",
+        description: "Choose models available to agents",
+        keywords: "claude openai reasoning",
+        icon: ModelIcon,
+      },
+      {
+        id: "provider-accounts",
+        label: "Accounts",
+        description: "Connect model provider subscriptions",
+        keywords: "provider authentication credentials",
+        icon: KeyIcon,
+      },
+      {
+        id: "skills",
+        label: "Skills",
+        description: "Manage shared skills and profiles",
+        keywords: "agent instructions profiles",
+        icon: SparkleIcon,
+      },
+    ],
+  },
+  {
+    label: "Workspace",
+    items: [
+      {
+        id: "environments",
+        label: "Environments",
+        description: "Configure reusable repository setups",
+        keywords: "repositories branches prebuild",
+        icon: FolderIcon,
+      },
+      {
+        id: "secrets",
+        label: "Secrets",
+        description: "Manage global and repository secrets",
+        keywords: "environment variables credentials",
+        icon: KeyIcon,
+      },
+      {
+        id: "scm",
+        label: "Source control",
+        description: "Configure pull request behavior",
+        keywords: "scm git pull request merge draft",
+        icon: GitPrIcon,
+      },
+    ],
+  },
+  {
+    label: "System",
+    items: [
+      {
+        id: "sandbox",
+        label: "Sandbox",
+        description: "Set runtime resources and access",
+        keywords: "terminal ports cpu memory timeout",
+        icon: TerminalIcon,
+      },
+      {
+        id: "images",
+        label: "Images",
+        description: "Manage repository image builds",
+        keywords: "prebuild containers",
+        icon: BoxIcon,
+        requiresRepoImages: true,
+      },
+      {
+        id: "integrations",
+        label: "Integrations",
+        description: "Connect external tools and services",
+        keywords: "github slack linear vnc code server",
+        icon: IntegrationsIcon,
+      },
+      {
+        id: "mcp-servers",
+        label: "MCP Servers",
+        description: "Configure local and remote MCP servers",
+        keywords: "tools protocol command url",
+        icon: TerminalIcon,
+      },
+      {
+        id: "data-controls",
+        label: "Data Controls",
+        description: "Review and restore archived sessions",
+        keywords: "archive restore retention",
+        icon: DataControlsIcon,
+      },
+    ],
+  },
+] as const;
+
+type SettingsItem = (typeof SETTINGS_GROUPS)[number]["items"][number];
+export type SettingsCategory = SettingsItem["id"];
+export const DEFAULT_SETTINGS_CATEGORY: SettingsCategory = "secrets";
+
+function isSettingsItemAvailable(item: SettingsItem, repoImagesEnabled: boolean): boolean {
+  return !("requiresRepoImages" in item) || repoImagesEnabled;
+}
+
+export function getSettingsGroups({
+  query = "",
+  repoImagesEnabled = supportsRepoImages(),
+  includeGlobalAliases = false,
+}: {
+  query?: string;
+  repoImagesEnabled?: boolean;
+  includeGlobalAliases?: boolean;
+} = {}) {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  return SETTINGS_GROUPS.map((group) => ({
+    ...group,
+    items: group.items.filter((item) => {
+      if (!isSettingsItemAvailable(item, repoImagesEnabled)) return false;
+      const aliases = includeGlobalAliases ? `settings ${group.label}` : "";
+      const searchText =
+        `${aliases} ${item.label} ${item.description} ${item.keywords}`.toLowerCase();
+      return terms.every((term) => searchText.includes(term));
+    }),
+  })).filter((group) => group.items.length > 0);
+}
+
+export function getSettingsCategoryLabel(category: SettingsCategory): string {
+  for (const group of SETTINGS_GROUPS) {
+    for (const item of group.items) {
+      if (item.id === category) return item.label;
+    }
+  }
+  return category;
+}
+
+export function isSettingsCategory(
+  value: string | null,
+  repoImagesEnabled = supportsRepoImages()
+): value is SettingsCategory {
+  if (!value) return false;
+  return SETTINGS_GROUPS.some((group) =>
+    group.items.some(
+      (item) => item.id === value && isSettingsItemAvailable(item, repoImagesEnabled)
+    )
+  );
+}

--- a/packages/web/src/components/settings/settings-registry.ts
+++ b/packages/web/src/components/settings/settings-registry.ts
@@ -131,15 +131,17 @@ export const SETTINGS_GROUPS = [
 type SettingsItem = (typeof SETTINGS_GROUPS)[number]["items"][number];
 export type SettingsCategory = SettingsItem["id"];
 export const DEFAULT_SETTINGS_CATEGORY: SettingsCategory = "secrets";
+export const DEFAULT_SETTINGS_QUERY = "";
+export const DEFAULT_INCLUDE_GLOBAL_SETTINGS_ALIASES = false;
 
 function isSettingsItemAvailable(item: SettingsItem, repoImagesEnabled: boolean): boolean {
   return !("requiresRepoImages" in item) || repoImagesEnabled;
 }
 
 export function getSettingsGroups({
-  query = "",
+  query = DEFAULT_SETTINGS_QUERY,
   repoImagesEnabled = supportsRepoImages(),
-  includeGlobalAliases = false,
+  includeGlobalAliases = DEFAULT_INCLUDE_GLOBAL_SETTINGS_ALIASES,
 }: {
   query?: string;
   repoImagesEnabled?: boolean;


### PR DESCRIPTION
## Summary

- expose every available settings category as a direct destination in the global command menu
- search settings by label, description, group, and keywords while preserving existing fuzzy session and command search
- reuse the canonical settings registry for destination metadata and provider-gated availability
- reset settings filtering whenever the controlled dialog closes

## Reviewer Guide

- Open the command menu and confirm the Settings group lists direct destinations with descriptions and category labels.
- Search terms such as `theme`, `github`, `pull request`, or `request source` should surface the expected setting without unrelated fuzzy settings matches.
- Selecting a destination should close the command menu and navigate to `/settings?tab=<category>`.
- Confirm the existing root Settings link, New session, Home, Automations, and session search remain available.
- Repository Images should remain absent when the active sandbox provider does not support image builds.

## Validation

- `npm test -w @open-inspect/web` (169 files, 1,301 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-fix`
- Prettier and `git diff --check`
- clean-checkout build: `npm run build -w @open-inspect/shared` then `NODE_ENV=production npm run build -w @open-inspect/web`

## Visual Evidence

- Precise `theme` keyword result, viewport 1512x982: artifact `9194d504919262da53cdb3267109787b`

The capture uses the local mock control plane; the unrelated repository-loading warning in the background is expected.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3c43ceac7f30f69c8c4924a321088042)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings section to the global command menu.
  * Search settings by name, description, and keywords.
  * Select a result to navigate directly to the relevant settings page.
  * Unavailable options, such as repository image settings, are hidden automatically.
  * Updated the command menu search prompt for clearer guidance.

* **Bug Fixes**
  * Search filters now clear when the command menu closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->