### PR TITLE
perf(control-plane): put automation instructions before the event context block

### DIFF
--- a/packages/control-plane/src/scheduler/compose-automation-prompt.test.ts
+++ b/packages/control-plane/src/scheduler/compose-automation-prompt.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { composeAutomationPrompt } from "./scheduler";
+import type { Env } from "../types";
+
+const env = (value?: string) => ({ AUTOMATION_INSTRUCTIONS_FIRST: value }) as unknown as Env;
+
+describe("composeAutomationPrompt", () => {
+  it("puts instructions first by default", () => {
+    expect(composeAutomationPrompt(env(undefined), "CTX", "INSTRUCTIONS")).toBe(
+      "INSTRUCTIONS\n---\n\nCTX"
+    );
+  });
+
+  it("keeps the same leading span when only the context changes", () => {
+    const a = composeAutomationPrompt(env(undefined), "event one", "INSTRUCTIONS");
+    const b = composeAutomationPrompt(env(undefined), "event two", "INSTRUCTIONS");
+    const shared = "INSTRUCTIONS\n---\n\n".length;
+    expect(a.slice(0, shared)).toBe(b.slice(0, shared));
+  });
+
+  it('restores context-first ordering when the flag is "false"', () => {
+    expect(composeAutomationPrompt(env("false"), "CTX", "INSTRUCTIONS")).toBe(
+      "CTX\n---\n\nINSTRUCTIONS"
+    );
+  });
+
+  it("treats any other value as the default", () => {
+    expect(composeAutomationPrompt(env("true"), "CTX", "INSTRUCTIONS")).toBe(
+      "INSTRUCTIONS\n---\n\nCTX"
+    );
+    expect(composeAutomationPrompt(env(""), "CTX", "INSTRUCTIONS")).toBe(
+      "INSTRUCTIONS\n---\n\nCTX"
+    );
+  });
+});

--- a/packages/control-plane/src/scheduler/scheduler.test.ts
+++ b/packages/control-plane/src/scheduler/scheduler.test.ts
@@ -2480,7 +2480,7 @@ describe("Scheduler", () => {
       expect(result).toEqual({ triggered: 1, skipped: 0, steered: 0 });
       const prompt = await getPromptBody(vi.mocked(stub.fetch));
       expect(prompt.content).toBe(
-        `${sampleSlackContextBlock}\n---\n\nRun tests\n\n` +
+        `Run tests\n---\n\n${sampleSlackContextBlock}\n\n` +
           "## Additional Instructions\n\nAlways run tests."
       );
     });
@@ -2501,7 +2501,7 @@ describe("Scheduler", () => {
       });
 
       const prompt = await getPromptBody(vi.mocked(stub.fetch));
-      expect(prompt.content).toBe(`${sampleSlackContextBlock}\n---\n\nRun tests`);
+      expect(prompt.content).toBe(`Run tests\n---\n\n${sampleSlackContextBlock}`);
     });
 
     it("launches without workspace instructions when the settings read fails", async () => {
@@ -2517,7 +2517,7 @@ describe("Scheduler", () => {
 
       expect(result).toEqual({ triggered: 1, skipped: 0, steered: 0 });
       const prompt = await getPromptBody(vi.mocked(stub.fetch));
-      expect(prompt.content).toBe(`${sampleSlackContextBlock}\n---\n\nRun tests`);
+      expect(prompt.content).toBe(`Run tests\n---\n\n${sampleSlackContextBlock}`);
     });
 
     it("posts the already-active notice for a reply racing the initial trigger (no session yet)", async () => {

--- a/packages/control-plane/src/scheduler/scheduler.ts
+++ b/packages/control-plane/src/scheduler/scheduler.ts
@@ -247,6 +247,32 @@ export async function resolveAutomationProviderAuth(
   );
 }
 
+/**
+ * Compose an event-triggered automation's prompt.
+ *
+ * An automation's instructions are identical on every run; the event context
+ * block differs each time. Provider prompt caches key on byte-identical leading
+ * spans, so leading with the event context keeps the instructions off the cache
+ * boundary and every run pays full price for them. Instruction-first ordering
+ * holds the static portion at the head of each request for a given automation.
+ *
+ * This is the single composition point for both the plain event path and the
+ * Slack path that enriches the context block with thread history. New call
+ * sites belong here rather than in an inline template.
+ *
+ * Set AUTOMATION_INSTRUCTIONS_FIRST="false" to restore context-first ordering.
+ */
+export function composeAutomationPrompt(
+  env: Env,
+  contextBlock: string,
+  instructions: string
+): string {
+  if (env.AUTOMATION_INSTRUCTIONS_FIRST === "false") {
+    return `${contextBlock}\n---\n\n${instructions}`;
+  }
+  return `${instructions}\n---\n\n${contextBlock}`;
+}
+
 export class Scheduler {
   private readonly log: Logger;
 
@@ -958,7 +984,7 @@ export class Scheduler {
       // a reply racing the initial trigger gets the "already active" notice
       // instead of a second session.
       const instructionsOverride = appendSlackSessionInstructions(
-        `${event.contextBlock}\n---\n\n${automation.instructions}`,
+        composeAutomationPrompt(this.env, event.contextBlock, automation.instructions),
         slackSessionInstructions
       );
       const result = await this.startInvocation(store, {
@@ -972,7 +998,11 @@ export class Scheduler {
           ? {
               instructionsOverrideFactory: async () =>
                 appendSlackSessionInstructions(
-                  `${await slackContextBlock(event)}\n---\n\n${automation.instructions}`,
+                  composeAutomationPrompt(
+                    this.env,
+                    await slackContextBlock(event),
+                    automation.instructions
+                  ),
                   slackSessionInstructions
                 ),
             }

--- a/packages/control-plane/src/scheduler/scheduler.ts
+++ b/packages/control-plane/src/scheduler/scheduler.ts
@@ -880,6 +880,14 @@ export class Scheduler {
 
   // ─── Event handler ───────────────────────────────────────────────────────
 
+  /**
+   * Handle an inbound automation event: route Slack follow-ups into an
+   * already-active thread session when one exists, then match the event
+   * against enabled automations, apply concurrency and cooldown gates, and
+   * start an invocation for each automation that clears them. Prompts for
+   * those invocations are assembled by composeAutomationPrompt, so the
+   * ordering contract lives there rather than at the call sites.
+   */
   async event(event: AutomationEvent): Promise<SchedulerEventResult> {
     const store = new AutomationStore(this.db);
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -29,6 +29,10 @@ export interface Env {
   // R2 buckets
   MEDIA_BUCKET: R2Bucket;
 
+  // Automation behaviour
+  /** "false" restores context-first automation prompts. Default: instructions first. */
+  AUTOMATION_INSTRUCTIONS_FIRST?: string;
+
   // Secrets
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -707,6 +707,12 @@ variable "allowed_github_orgs" {
   default     = ""
 }
 
+variable "automation_instructions_first" {
+  description = "Compose event-triggered automation prompts with the automation's instructions before the event context block. Instruction-first ordering keeps the static half of the prompt at a stable offset so provider prompt caches can match it. Set to false to restore context-first ordering."
+  type        = bool
+  default     = true
+}
+
 variable "unsafe_allow_all_users" {
   description = "Bypass Terraform's access-control safety check and allow any authenticated user to sign in when all allowlists are empty. Set to true only for intentionally open deployments."
   type        = bool

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -101,6 +101,7 @@ module "control_plane_worker" {
       { name = "ALLOWED_EMAILS", value = var.allowed_emails },
       { name = "ALLOWED_GITHUB_ORGS", value = var.allowed_github_orgs },
       { name = "UNSAFE_ALLOW_ALL_USERS", value = tostring(var.unsafe_allow_all_users) },
+      { name = "AUTOMATION_INSTRUCTIONS_FIRST", value = tostring(var.automation_instructions_first) },
       { name = "WORKER_URL", value = local.control_plane_url },
       { name = "DEPLOYMENT_NAME", value = var.deployment_name },
       { name = "APP_NAME", value = var.app_name },


### PR DESCRIPTION
## Summary

- Automation prompts put the per-event context block before the instructions, so the static half of the prompt never sits at a stable offset.
- Routes both composition sites through one helper and puts instructions first by default.
- `AUTOMATION_INSTRUCTIONS_FIRST="false"` restores the previous ordering.

## Problem

`scheduler.ts` composed event-triggered automation prompts like this:

```js
`${event.contextBlock}\n---\n\n${automation.instructions}`
```

`contextBlock` is described in `shared/src/triggers/types.ts` as "Human-readable context prepended to automation instructions", so the ordering is intended rather than accidental.

An automation's `instructions` are the same on every run. The event context differs each time — PR number, actor, payload. Provider prompt caches match byte-identical leading spans, so a variable prefix keeps the instructions off the cache boundary and every run pays full input price for them.

The instruction bodies are large enough for this to matter. Three automations in my deployment carry 5.5k, 11k and 15k characters of instructions, re-sent uncached on every event.

Composed prompt head, two events for the same automation:

```
before                          after
──────────────────────────      ──────────────────────────
Slack thread #eng-1204...       You are the review agent...
---                             ---
You are the review agent...     Slack thread #eng-1204...

Slack thread #eng-1207...       You are the review agent...
---                             ---
You are the review agent...     Slack thread #eng-1207...
```

The shared leading span is empty on the left and the whole instruction body on the right.

## Change

`composeAutomationPrompt(env, contextBlock, instructions)` is now the single composition point for both paths: the plain event path and the Slack path that enriches the context block with thread history. The second one built its prompt inline and is easy to miss when grepping for the variable name.

The separator is unchanged, and the opt-out branch is character-identical to the previous line.

## Testing

```
npm run lint                                  exit 0
npm run typecheck                             clean
npm test -w @open-inspect/control-plane       3334 passed
```

The flag is declared as `automation_instructions_first` (bool, default `true`) in `terraform/environments/production/variables.tf` and bound as a plain-text worker var with `tostring()`, following `UNSAFE_ALLOW_ALL_USERS`.

Four new tests in `compose-automation-prompt.test.ts` cover the default, the opt-out, unrecognised flag values falling back to the default, and the property the change exists for: two events with different context produce the same leading span. Three existing Slack assertions in `scheduler.test.ts` encoded the old order and now assert the new one.

These tests exercise the helper directly. They do not cover the scheduler path end to end, so they would stay green if `startInvocation` stopped passing `this.env`, and they do not verify the production binding. Building that seam looked heavier than this change warrants.

## What I have not measured

I verified the ordering and the composed output. I have not measured a cache-hit rate or a token-cost delta, because my sessions route through a gateway that does not report per-request cache hits, I will likely attempt to measure this at some point. Until then, the reasoning above is about how prefix caching works, not an observed saving. If you have a deployment that reports cache hits, that number would be worth having before this merges.

I also haven't formally been able to verify the impact this ordering change has on quality/performance/output from the LLM/Agents. Anecdotally, it has been transparent to me, but if you have eval baselines you use we can run this against, that's really going to be the proper way to measure that. 

## One thing this does not reorder

On the Slack path, `appendSlackSessionInstructions` appends workspace-level instructions after composition, so that static text still trails the dynamic context block. Moving it would change that function's contract, which felt out of scope here. Worth a follow-up if the ordering matters to you.

## Draft

Opened as a draft. Happy to rename the flag, move it to a per-automation column instead of a deployment env var, or drop the flag and swap the order outright if you would rather not carry the configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-triggered automations now place instructions before event context by default, improving prompt clarity.
  * Added a configuration option to restore context-first ordering when needed.
  * Slack-based automation runs now follow the same prompt ordering behavior.

* **Tests**
  * Added coverage for default and configurable prompt ordering across event and Slack contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->