### PR TITLE
Refine settings interaction and accessibility patterns

### DIFF
--- a/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
@@ -6,7 +6,7 @@ import { INTEGRATION_DEFINITIONS } from "@open-inspect/shared/types/integrations
 import { BackIcon } from "@/components/ui/icons";
 import { integrationSettingsComponents } from "@/components/settings/integrations/integration-settings-registry";
 import { SettingsMobileHeader } from "@/components/settings/settings-mobile-header";
-import { useIsMobile } from "@/hooks/use-media-query";
+import { useSettingsIsMobile } from "@/components/settings/settings-viewport-context";
 
 function getIntegration(id: string) {
   return INTEGRATION_DEFINITIONS.find((d) => d.id === id);
@@ -14,7 +14,7 @@ function getIntegration(id: string) {
 
 export default function IntegrationDetailPage() {
   const params = useParams<{ id: string }>();
-  const isMobile = useIsMobile();
+  const isMobile = useSettingsIsMobile();
 
   const integration = getIntegration(params.id);
   const IntegrationDetail = integration ? integrationSettingsComponents[integration.id] : undefined;

--- a/packages/web/src/app/(app)/settings/page.test.tsx
+++ b/packages/web/src/app/(app)/settings/page.test.tsx
@@ -6,17 +6,22 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsPage from "./page";
+import { SettingsViewportProvider } from "@/components/settings/settings-viewport-context";
 
 expect.extend(matchers);
 
-const mocks = vi.hoisted(() => ({ tab: null as string | null }));
+const mocks = vi.hoisted(() => ({
+  tab: null as string | null,
+  repoImagesEnabled: true,
+}));
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(mocks.tab ? `tab=${mocks.tab}` : ""),
 }));
 
-vi.mock("@/hooks/use-media-query", () => ({ useIsMobile: () => true }));
-vi.mock("@/lib/sandbox-provider", () => ({ supportsRepoImages: () => true }));
+vi.mock("@/lib/sandbox-provider", () => ({
+  supportsRepoImages: () => mocks.repoImagesEnabled,
+}));
 
 vi.mock("@/components/settings/secrets-settings", () => ({
   SecretsSettings: () => <div>Secrets panel</div>,
@@ -60,12 +65,21 @@ vi.mock("@/components/settings/mcp-servers-settings", () => ({
 
 beforeEach(() => {
   mocks.tab = null;
+  mocks.repoImagesEnabled = true;
   window.history.replaceState(null, "", "/settings");
   vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
     callback(0);
     return 1;
   });
 });
+
+function renderSettingsPage() {
+  return render(
+    <SettingsViewportProvider value={true}>
+      <SettingsPage />
+    </SettingsViewportProvider>
+  );
+}
 
 afterEach(() => {
   cleanup();
@@ -76,7 +90,7 @@ afterEach(() => {
 describe("SettingsPage mobile navigation", () => {
   it("pushes category selections and follows browser Back and Forward state", async () => {
     const user = userEvent.setup();
-    render(<SettingsPage />);
+    renderSettingsPage();
 
     await user.click(screen.getByRole("button", { name: /Appearance/ }));
 
@@ -112,7 +126,7 @@ describe("SettingsPage mobile navigation", () => {
     window.history.replaceState(null, "", "/settings?tab=appearance");
     const user = userEvent.setup();
 
-    render(<SettingsPage />);
+    renderSettingsPage();
 
     expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();
     expect(screen.getByText("Appearance panel")).toBeInTheDocument();
@@ -128,7 +142,7 @@ describe("SettingsPage mobile navigation", () => {
   it("uses browser history for the in-app back action", async () => {
     const back = vi.spyOn(window.history, "back").mockImplementation(() => undefined);
     const user = userEvent.setup();
-    render(<SettingsPage />);
+    renderSettingsPage();
 
     await user.click(screen.getByRole("button", { name: /Appearance/ }));
     await user.click(screen.getByRole("button", { name: "Back to settings" }));
@@ -138,7 +152,7 @@ describe("SettingsPage mobile navigation", () => {
 
   it("preserves the mobile search and restores focus to the selected category", async () => {
     const user = userEvent.setup();
-    render(<SettingsPage />);
+    renderSettingsPage();
 
     const search = screen.getByRole("searchbox", { name: "Search settings" });
     await user.type(search, "theme");
@@ -151,5 +165,21 @@ describe("SettingsPage mobile navigation", () => {
 
     expect(screen.getByRole("searchbox", { name: "Search settings" })).toHaveValue("theme");
     expect(screen.getByRole("button", { name: /Appearance/ })).toHaveFocus();
+  });
+
+  it.each([
+    { description: "invalid", tab: "bogus", repoImagesEnabled: true },
+    { description: "unavailable", tab: "images", repoImagesEnabled: false },
+  ])("returns focus to the list for an $description history tab", ({ tab, repoImagesEnabled }) => {
+    mocks.repoImagesEnabled = repoImagesEnabled;
+    renderSettingsPage();
+
+    act(() => {
+      window.history.replaceState(null, "", `/settings?tab=${tab}`);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(screen.getByRole("heading", { name: "Settings" })).toHaveFocus();
+    expect(screen.getByRole("searchbox", { name: "Search settings" })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/(app)/settings/page.test.tsx
+++ b/packages/web/src/app/(app)/settings/page.test.tsx
@@ -90,7 +90,7 @@ describe("SettingsPage mobile navigation", () => {
       window.dispatchEvent(new PopStateEvent("popstate"));
     });
 
-    expect(screen.getByRole("heading", { name: "Settings" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: /Appearance/ })).toHaveFocus();
     expect(window.location.pathname).toBe("/settings");
     expect(window.location.search).toBe("");
 
@@ -134,5 +134,22 @@ describe("SettingsPage mobile navigation", () => {
     await user.click(screen.getByRole("button", { name: "Back to settings" }));
 
     expect(back).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the mobile search and restores focus to the selected category", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    const search = screen.getByRole("searchbox", { name: "Search settings" });
+    await user.type(search, "theme");
+    await user.click(screen.getByRole("button", { name: /Appearance/ }));
+
+    act(() => {
+      window.history.replaceState(null, "", "/settings");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(screen.getByRole("searchbox", { name: "Search settings" })).toHaveValue("theme");
+    expect(screen.getByRole("button", { name: /Appearance/ })).toHaveFocus();
   });
 });

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -10,6 +10,7 @@ import {
   type SettingsCategory,
 } from "@/components/settings/settings-nav";
 import { SettingsMobileHeader } from "@/components/settings/settings-mobile-header";
+import { useSettingsIsMobile } from "@/components/settings/settings-viewport-context";
 import { SecretsSettings } from "@/components/settings/secrets-settings";
 import { EnvironmentsSettings } from "@/components/settings/environments-settings";
 import { ModelsSettings } from "@/components/settings/models-settings";
@@ -23,7 +24,6 @@ import { McpServersSettings } from "@/components/settings/mcp-servers-settings";
 import { AppearanceSettings } from "@/components/settings/appearance-settings";
 import { ProviderAccountsSettings } from "@/components/settings/provider-accounts-settings";
 import { SkillsSettings } from "@/components/settings/skills-settings";
-import { useIsMobile } from "@/hooks/use-media-query";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 const SETTINGS_PANELS: Record<SettingsCategory, ComponentType> = {
@@ -46,7 +46,7 @@ function SettingsPageContent() {
   const searchParams = useSearchParams();
   const tabParam = searchParams.get("tab");
   const repoImagesEnabled = supportsRepoImages();
-  const isMobile = useIsMobile();
+  const isMobile = useSettingsIsMobile();
   const initialCategory = isSettingsCategory(tabParam, repoImagesEnabled)
     ? tabParam
     : DEFAULT_SETTINGS_CATEGORY;
@@ -68,11 +68,19 @@ function SettingsPageContent() {
   const [mobileView, setMobileView] = useState<"list" | "detail">(
     isSettingsCategory(tabParam, repoImagesEnabled) ? "detail" : "list"
   );
-  const mobileHeadingRef = useRef<HTMLHeadingElement>(null);
+  const mobileListHeadingRef = useRef<HTMLHeadingElement>(null);
+  const mobileDetailHeadingRef = useRef<HTMLHeadingElement>(null);
+  const mobileTriggerRef = useRef<HTMLButtonElement>(null);
 
   function showMobileView(view: "list" | "detail") {
     setMobileView(view);
-    requestAnimationFrame(() => mobileHeadingRef.current?.focus());
+    requestAnimationFrame(() => {
+      if (view === "list" && mobileTriggerRef.current) {
+        mobileTriggerRef.current.focus();
+      } else {
+        (view === "list" ? mobileListHeadingRef : mobileDetailHeadingRef).current?.focus();
+      }
+    });
   }
 
   function showMobileList() {
@@ -81,6 +89,7 @@ function SettingsPageContent() {
       return;
     }
     window.history.replaceState(window.history.state, "", "/settings");
+    setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
     showMobileView("list");
   }
 
@@ -93,10 +102,16 @@ function SettingsPageContent() {
         setActiveCategoryRaw(category);
         setMobileView("detail");
       } else {
-        setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
+        if (!mobileTriggerRef.current) setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
         setMobileView("list");
       }
-      requestAnimationFrame(() => mobileHeadingRef.current?.focus());
+      requestAnimationFrame(() => {
+        if (!category && mobileTriggerRef.current) {
+          mobileTriggerRef.current.focus();
+        } else {
+          (category ? mobileDetailHeadingRef : mobileListHeadingRef).current?.focus();
+        }
+      });
     };
 
     window.addEventListener("popstate", syncFromHistory);
@@ -111,9 +126,11 @@ function SettingsPageContent() {
       return;
     }
 
-    setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
+    if (!isMobile || !mobileTriggerRef.current) {
+      setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
+    }
     setMobileView("list");
-  }, [repoImagesEnabled, tabParam]);
+  }, [isMobile, repoImagesEnabled, tabParam]);
 
   const renderedCategory = isSettingsCategory(activeCategory, repoImagesEnabled)
     ? activeCategory
@@ -123,30 +140,36 @@ function SettingsPageContent() {
 
   if (isMobile) {
     return (
-      <div className="flex h-full flex-col bg-background">
-        {mobileView === "list" ? (
-          <>
-            <SettingsMobileHeader title="Settings" headingRef={mobileHeadingRef} />
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <SettingsNav
-                activeCategory={activeCategory}
-                onSelect={setActiveCategory}
-                onNavigate={() => showMobileView("detail")}
-              />
-            </div>
-          </>
-        ) : (
-          <>
-            <SettingsMobileHeader
-              title={getSettingsCategoryLabel(activeCategory)}
-              headingRef={mobileHeadingRef}
-              onBack={showMobileList}
+      <div className="h-full bg-background">
+        <div
+          hidden={mobileView !== "list"}
+          className={mobileView === "list" ? "flex h-full flex-col" : "hidden"}
+        >
+          <SettingsMobileHeader title="Settings" headingRef={mobileListHeadingRef} />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <SettingsNav
+              activeCategory={activeCategory}
+              onSelect={setActiveCategory}
+              onNavigate={(trigger) => {
+                mobileTriggerRef.current = trigger;
+                showMobileView("detail");
+              }}
             />
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6">
-              <div className="mx-auto max-w-3xl">{content}</div>
-            </div>
-          </>
-        )}
+          </div>
+        </div>
+        <div
+          hidden={mobileView !== "detail"}
+          className={mobileView === "detail" ? "flex h-full flex-col" : "hidden"}
+        >
+          <SettingsMobileHeader
+            title={getSettingsCategoryLabel(activeCategory)}
+            headingRef={mobileDetailHeadingRef}
+            onBack={showMobileList}
+          />
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6">
+            <div className="mx-auto max-w-3xl">{mobileView === "detail" ? content : null}</div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -52,15 +52,17 @@ function SettingsPageContent() {
     : DEFAULT_SETTINGS_CATEGORY;
   const [activeCategory, setActiveCategoryRaw] = useState<SettingsCategory>(initialCategory);
 
-  function setActiveCategory(category: SettingsCategory) {
+  function selectCategory(category: SettingsCategory, trigger: HTMLButtonElement) {
     setActiveCategoryRaw(category);
     const url = `/settings?tab=${category}`;
     if (isMobile) {
+      mobileTriggerRef.current = trigger;
       window.history.pushState(
         { ...window.history.state, openInspectSettingsDetail: true },
         "",
         url
       );
+      showMobileView("detail");
     } else {
       window.history.replaceState(window.history.state, "", url);
     }
@@ -97,19 +99,22 @@ function SettingsPageContent() {
     if (!isMobile) return;
 
     const syncFromHistory = () => {
-      const category = new URLSearchParams(window.location.search).get("tab");
-      if (isSettingsCategory(category, repoImagesEnabled)) {
-        setActiveCategoryRaw(category);
+      const requestedCategory = new URLSearchParams(window.location.search).get("tab");
+      const nextCategory = isSettingsCategory(requestedCategory, repoImagesEnabled)
+        ? requestedCategory
+        : null;
+      if (nextCategory) {
+        setActiveCategoryRaw(nextCategory);
         setMobileView("detail");
       } else {
         if (!mobileTriggerRef.current) setActiveCategoryRaw(DEFAULT_SETTINGS_CATEGORY);
         setMobileView("list");
       }
       requestAnimationFrame(() => {
-        if (!category && mobileTriggerRef.current) {
+        if (!nextCategory && mobileTriggerRef.current) {
           mobileTriggerRef.current.focus();
         } else {
-          (category ? mobileDetailHeadingRef : mobileListHeadingRef).current?.focus();
+          (nextCategory ? mobileDetailHeadingRef : mobileListHeadingRef).current?.focus();
         }
       });
     };
@@ -147,14 +152,7 @@ function SettingsPageContent() {
         >
           <SettingsMobileHeader title="Settings" headingRef={mobileListHeadingRef} />
           <div className="min-h-0 flex-1 overflow-y-auto">
-            <SettingsNav
-              activeCategory={activeCategory}
-              onSelect={setActiveCategory}
-              onNavigate={(trigger) => {
-                mobileTriggerRef.current = trigger;
-                showMobileView("detail");
-              }}
-            />
+            <SettingsNav activeCategory={activeCategory} onSelect={selectCategory} />
           </div>
         </div>
         <div

--- a/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
+++ b/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
@@ -107,9 +107,9 @@ export function CommitSigningSettings() {
 
   return (
     <section className="border-t border-border pt-6 mt-6" aria-labelledby="commit-signing-title">
-      <h4 id="commit-signing-title" className="text-base font-medium text-foreground">
+      <h3 id="commit-signing-title" className="text-base font-medium text-foreground">
         Commit signing
-      </h4>
+      </h3>
       <p className="mt-1 text-sm text-muted-foreground">
         Sign agent commits with one dedicated GitHub machine account while retaining trusted users
         as commit authors.

--- a/packages/web/src/components/settings/integrations/enablement-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/enablement-integration-settings.tsx
@@ -87,7 +87,7 @@ export function EnablementIntegrationSettings({ copy }: { copy: EnablementIntegr
 
   return (
     <div>
-      <h3 className="text-lg font-semibold text-foreground mb-1">{copy.title}</h3>
+      <h2 className="text-lg font-semibold text-foreground mb-1">{copy.title}</h2>
       <p className="text-sm text-muted-foreground mb-6">{copy.intro}</p>
 
       <GlobalSettingsSection
@@ -506,9 +506,9 @@ function Section({
 }) {
   return (
     <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
         {title}
-      </h4>
+      </h3>
       <p className="text-sm text-muted-foreground mb-4">{description}</p>
       {children}
     </section>

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -140,6 +140,15 @@ afterEach(() => {
 });
 
 describe("GitHubIntegrationSettings", () => {
+  it("starts integration content at heading level two", () => {
+    setupSWR({ global: null });
+
+    render(<GitHubIntegrationSettings />);
+
+    expect(screen.getByRole("heading", { name: "GitHub Bot", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Connection", level: 3 })).toBeInTheDocument();
+  });
+
   it("renders the default-off Autofix block and persists one complete global policy", async () => {
     const user = userEvent.setup();
     setupSWR({ global: { defaults: { autoReviewOnOpen: true } } });

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -51,7 +51,7 @@ export function GitHubIntegrationSettings() {
 
   return (
     <div>
-      <h3 className="text-lg font-semibold text-foreground mb-1">GitHub Bot</h3>
+      <h2 className="text-lg font-semibold text-foreground mb-1">GitHub Bot</h2>
       <p className="text-sm text-muted-foreground mb-6">
         Configure automated PR reviews and comment-triggered actions.
       </p>

--- a/packages/web/src/components/settings/integrations/integration-settings-section.tsx
+++ b/packages/web/src/components/settings/integrations/integration-settings-section.tsx
@@ -11,7 +11,7 @@ export function IntegrationSettingsSection({
 }) {
   return (
     <section className="mb-8">
-      <h4 className="text-base font-semibold text-foreground mb-1">{title}</h4>
+      <h3 className="text-base font-semibold text-foreground mb-1">{title}</h3>
       <p className="text-sm text-muted-foreground mb-4">{description}</p>
       {children}
     </section>

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -84,7 +84,7 @@ export function LinearIntegrationSettings() {
 
   return (
     <div>
-      <h3 className="text-lg font-semibold text-foreground mb-1">Linear Agent</h3>
+      <h2 className="text-lg font-semibold text-foreground mb-1">Linear Agent</h2>
       <p className="text-sm text-muted-foreground mb-6">
         Configure model defaults, repository scope, and runtime behavior for Linear-triggered
         sessions.
@@ -715,9 +715,9 @@ function Section({
 }) {
   return (
     <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
         {title}
-      </h4>
+      </h3>
       <p className="text-sm text-muted-foreground mb-4">{description}</p>
       {children}
     </section>

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -536,7 +536,9 @@ describe("SlackIntegrationSettings", () => {
       render(<SlackIntegrationSettings />);
 
       const section = routingSection();
-      expect(within(section).getByDisplayValue("frontend")).toBeInTheDocument();
+      const keyword = within(section).getByDisplayValue("frontend");
+      expect(keyword).toHaveClass("w-full", "sm:w-48");
+      expect(keyword.parentElement).toHaveClass("flex-col", "sm:flex-row");
       expect(within(section).getByText("acme/web")).toBeInTheDocument();
     });
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -136,7 +136,7 @@ export function SlackIntegrationSettings() {
 
   return (
     <div>
-      <h3 className="text-lg font-semibold text-foreground mb-1">Slack</h3>
+      <h2 className="text-lg font-semibold text-foreground mb-1">Slack</h2>
       <p className="text-sm text-muted-foreground mb-6">
         Let agents post Slack notifications when the user explicitly asks for them. Posts go through
         the control plane — the Slack token never enters the sandbox.
@@ -765,22 +765,25 @@ function RoutingRulesSection({
 
             return (
               <div key={rule.id}>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <input
                     aria-label="Routing keyword"
                     value={rule.keyword}
                     onChange={(e) => updateRule(rule.id, { keyword: e.target.value })}
                     placeholder="keyword"
-                    className="w-48 px-3 py-2 text-sm bg-input border border-border rounded-sm focus:outline-none focus:ring-2 focus:ring-ring text-foreground placeholder:text-secondary-foreground"
+                    className="w-full rounded-sm border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-secondary-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-48"
                   />
-                  <span className="text-muted-foreground" aria-hidden="true">
+                  <span
+                    className="self-center text-muted-foreground max-sm:rotate-90"
+                    aria-hidden="true"
+                  >
                     &rarr;
                   </span>
                   <Select
                     value={selectValue}
                     onValueChange={(v) => updateRule(rule.id, { target: v })}
                   >
-                    <SelectTrigger className="flex-1" aria-label="Routing target">
+                    <SelectTrigger className="w-full sm:flex-1" aria-label="Routing target">
                       <SelectValue placeholder="Select a target..." />
                     </SelectTrigger>
                     <SelectContent>
@@ -882,9 +885,9 @@ function Section({
 }) {
   return (
     <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
         {title}
-      </h4>
+      </h3>
       <p className="text-sm text-muted-foreground mb-4">{description}</p>
       {children}
     </section>

--- a/packages/web/src/components/settings/settings-mobile-header.tsx
+++ b/packages/web/src/components/settings/settings-mobile-header.tsx
@@ -3,6 +3,7 @@
 import type { RefObject } from "react";
 import Link from "next/link";
 import { BackIcon, XIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
 
 type SettingsMobileHeaderProps = {
   title: string;
@@ -17,24 +18,31 @@ export function SettingsMobileHeader({
   backHref,
   onBack,
 }: SettingsMobileHeaderProps) {
-  const backClassName =
-    "flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground";
+  const actionClassName = "h-11 w-11 rounded-md";
 
   return (
-    <header className="grid h-14 shrink-0 grid-cols-[2.5rem_1fr_2.5rem] items-center border-b border-border-muted px-3">
+    <header className="grid h-14 shrink-0 grid-cols-[2.75rem_1fr_2.75rem] items-center border-b border-border-muted px-3">
       {onBack ? (
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={onBack}
-          className={backClassName}
+          className={actionClassName}
           aria-label="Back to settings"
         >
-          <BackIcon className="h-4 w-4" />
-        </button>
+          <span aria-hidden="true">
+            <BackIcon className="h-4 w-4" />
+          </span>
+        </Button>
       ) : backHref ? (
-        <Link href={backHref} className={backClassName} aria-label="Back to integrations">
-          <BackIcon className="h-4 w-4" />
-        </Link>
+        <Button asChild variant="ghost" size="icon" className={actionClassName}>
+          <Link href={backHref} aria-label="Back to integrations">
+            <span aria-hidden="true">
+              <BackIcon className="h-4 w-4" />
+            </span>
+          </Link>
+        </Button>
       ) : (
         <span aria-hidden="true" />
       )}
@@ -45,13 +53,13 @@ export function SettingsMobileHeader({
       >
         {title}
       </h1>
-      <Link
-        href="/"
-        className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
-        aria-label="Close settings"
-      >
-        <XIcon className="h-4 w-4" />
-      </Link>
+      <Button asChild variant="ghost" size="icon" className={actionClassName}>
+        <Link href="/" aria-label="Close settings">
+          <span aria-hidden="true">
+            <XIcon className="h-4 w-4" />
+          </span>
+        </Link>
+      </Button>
     </header>
   );
 }

--- a/packages/web/src/components/settings/settings-nav.test.tsx
+++ b/packages/web/src/components/settings/settings-nav.test.tsx
@@ -59,7 +59,17 @@ describe("SettingsNav", () => {
     await user.click(screen.getByRole("button", { name: /Appearance/ }));
 
     expect(onSelect).toHaveBeenCalledWith("appearance");
-    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+    expect(screen.getByRole("button", { name: /Secrets/ })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("uses the shared focus treatment for navigation and search", () => {
+    render(<SettingsNav activeCategory="appearance" onSelect={vi.fn()} />);
+
+    expect(screen.getByRole("searchbox", { name: "Search settings" })).toHaveClass(
+      "focus-visible:ring-2"
+    );
+    expect(screen.getByRole("button", { name: "Appearance" })).toHaveClass("focus-visible:ring-2");
   });
 
   it("hides image settings when the sandbox provider does not support them", () => {

--- a/packages/web/src/components/settings/settings-nav.test.tsx
+++ b/packages/web/src/components/settings/settings-nav.test.tsx
@@ -4,18 +4,16 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SettingsNav } from "./settings-nav";
+import { SettingsViewportProvider } from "./settings-viewport-context";
 
 expect.extend(matchers);
 
 const mocks = vi.hoisted(() => ({
   isMobile: false,
   repoImagesEnabled: true,
-}));
-
-vi.mock("@/hooks/use-media-query", () => ({
-  useIsMobile: () => mocks.isMobile,
 }));
 
 vi.mock("@/lib/sandbox-provider", () => ({
@@ -28,10 +26,22 @@ afterEach(() => {
   mocks.repoImagesEnabled = true;
 });
 
+function renderSettingsNav(
+  props: Omit<ComponentProps<typeof SettingsNav>, "onSelect"> & {
+    onSelect?: ComponentProps<typeof SettingsNav>["onSelect"];
+  }
+) {
+  return render(
+    <SettingsViewportProvider value={mocks.isMobile}>
+      <SettingsNav onSelect={vi.fn()} {...props} />
+    </SettingsViewportProvider>
+  );
+}
+
 describe("SettingsNav", () => {
   it("groups settings and filters labels, descriptions, and keywords", async () => {
     const user = userEvent.setup();
-    render(<SettingsNav activeCategory="appearance" onSelect={vi.fn()} />);
+    renderSettingsNav({ activeCategory: "appearance" });
 
     expect(screen.getByRole("heading", { name: "Personal" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Sessions" })).toBeInTheDocument();
@@ -51,20 +61,18 @@ describe("SettingsNav", () => {
   it("shows descriptions and opens a selected setting on mobile", async () => {
     mocks.isMobile = true;
     const onSelect = vi.fn();
-    const onNavigate = vi.fn();
     const user = userEvent.setup();
-    render(<SettingsNav activeCategory="secrets" onSelect={onSelect} onNavigate={onNavigate} />);
+    renderSettingsNav({ activeCategory: "secrets", onSelect });
 
     expect(screen.getByText("Theme and code highlighting")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Appearance/ }));
 
-    expect(onSelect).toHaveBeenCalledWith("appearance");
-    expect(onNavigate).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+    expect(onSelect).toHaveBeenCalledWith("appearance", expect.any(HTMLButtonElement));
     expect(screen.getByRole("button", { name: /Secrets/ })).toHaveAttribute("aria-current", "page");
   });
 
   it("uses the shared focus treatment for navigation and search", () => {
-    render(<SettingsNav activeCategory="appearance" onSelect={vi.fn()} />);
+    renderSettingsNav({ activeCategory: "appearance" });
 
     expect(screen.getByRole("searchbox", { name: "Search settings" })).toHaveClass(
       "focus-visible:ring-2"
@@ -74,7 +82,7 @@ describe("SettingsNav", () => {
 
   it("hides image settings when the sandbox provider does not support them", () => {
     mocks.repoImagesEnabled = false;
-    render(<SettingsNav activeCategory="secrets" onSelect={vi.fn()} />);
+    renderSettingsNav({ activeCategory: "secrets" });
 
     expect(screen.queryByRole("button", { name: "Images" })).not.toBeInTheDocument();
   });

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -17,8 +17,7 @@ export {
 
 interface SettingsNavProps {
   activeCategory: SettingsCategory;
-  onSelect: (category: SettingsCategory) => void;
-  onNavigate?: (trigger: HTMLButtonElement) => void;
+  onSelect: (category: SettingsCategory, trigger: HTMLButtonElement) => void;
 }
 
 function SettingsSearch({ value, onChange }: { value: string; onChange: (value: string) => void }) {
@@ -39,7 +38,7 @@ function SettingsSearch({ value, onChange }: { value: string; onChange: (value: 
   );
 }
 
-export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNavProps) {
+export function SettingsNav({ activeCategory, onSelect }: SettingsNavProps) {
   const isMobile = useSettingsIsMobile();
   const [query, setQuery] = useState("");
   const groups = getSettingsGroups({ query });
@@ -70,8 +69,7 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
                     type="button"
                     variant="ghost"
                     onClick={(event) => {
-                      onSelect(item.id);
-                      onNavigate?.(event.currentTarget);
+                      onSelect(item.id, event.currentTarget);
                     }}
                     aria-current={isActive ? "page" : undefined}
                     className={`h-auto w-full justify-start gap-3 whitespace-normal rounded-md text-left ${

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { useIsMobile } from "@/hooks/use-media-query";
 import { BackIcon, ChevronRightIcon, SearchIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useSettingsIsMobile } from "./settings-viewport-context";
 import { getSettingsGroups, type SettingsCategory } from "./settings-registry";
 
 export {
@@ -16,30 +18,29 @@ export {
 interface SettingsNavProps {
   activeCategory: SettingsCategory;
   onSelect: (category: SettingsCategory) => void;
-  onNavigate?: () => void;
+  onNavigate?: (trigger: HTMLButtonElement) => void;
 }
 
 function SettingsSearch({ value, onChange }: { value: string; onChange: (value: string) => void }) {
   return (
     <label className="relative block">
       <span className="sr-only">Search settings</span>
-      <SearchIcon
-        aria-hidden="true"
-        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-      />
-      <input
+      <span aria-hidden="true">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      </span>
+      <Input
         type="search"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder="Search settings"
-        className="h-9 w-full rounded-md border border-border bg-input pl-9 pr-3 text-sm text-foreground shadow-sm outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/30"
+        className="pl-9"
       />
     </label>
   );
 }
 
 export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNavProps) {
-  const isMobile = useIsMobile();
+  const isMobile = useSettingsIsMobile();
   const [query, setQuery] = useState("");
   const groups = getSettingsGroups({ query });
 
@@ -65,27 +66,29 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
               const Icon = item.icon;
               return (
                 <li key={item.id}>
-                  <button
+                  <Button
                     type="button"
-                    onClick={() => {
+                    variant="ghost"
+                    onClick={(event) => {
                       onSelect(item.id);
-                      onNavigate?.();
+                      onNavigate?.(event.currentTarget);
                     }}
-                    aria-current={!isMobile && isActive ? "page" : undefined}
-                    className={`flex w-full items-center gap-3 text-left transition ${
+                    aria-current={isActive ? "page" : undefined}
+                    className={`h-auto w-full justify-start gap-3 whitespace-normal rounded-md text-left ${
                       isMobile
                         ? "px-4 py-3.5 text-foreground hover:bg-muted/60"
-                        : `rounded-md px-3 py-2 ${
+                        : `px-3 py-2 ${
                             isActive
                               ? "bg-muted font-medium text-foreground"
                               : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
                           }`
                     }`}
                   >
-                    <Icon
-                      aria-hidden="true"
-                      className={`h-4 w-4 shrink-0 ${isActive ? "text-foreground" : "text-muted-foreground"}`}
-                    />
+                    <span aria-hidden="true">
+                      <Icon
+                        className={`h-4 w-4 shrink-0 ${isActive ? "text-foreground" : "text-muted-foreground"}`}
+                      />
+                    </span>
                     <span className="min-w-0 flex-1">
                       <span className="block text-sm font-medium">{item.label}</span>
                       {isMobile && (
@@ -95,12 +98,11 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
                       )}
                     </span>
                     {isMobile && (
-                      <ChevronRightIcon
-                        aria-hidden="true"
-                        className="h-4 w-4 shrink-0 text-muted-foreground"
-                      />
+                      <span aria-hidden="true">
+                        <ChevronRightIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      </span>
                     )}
-                  </button>
+                  </Button>
                 </li>
               );
             })}
@@ -108,7 +110,10 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
         </section>
       ))}
       {groups.length === 0 && (
-        <p className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
+        <p
+          aria-live="polite"
+          className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground"
+        >
           No settings match “{query}”.
         </p>
       )}
@@ -135,13 +140,14 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
       className="flex w-60 shrink-0 flex-col border-r border-border-muted bg-muted/15"
     >
       <div className="border-b border-border-muted px-4 py-4">
-        <Link
-          href="/"
-          className="mb-5 flex items-center gap-2 text-sm text-muted-foreground transition hover:text-foreground"
-        >
-          <BackIcon aria-hidden="true" className="h-4 w-4" />
-          Back to app
-        </Link>
+        <Button asChild variant="ghost" size="sm" className="mb-5 -ml-3 gap-2">
+          <Link href="/">
+            <span aria-hidden="true">
+              <BackIcon className="h-4 w-4" />
+            </span>
+            Back to app
+          </Link>
+        </Button>
         <h1 className="mb-3 text-lg font-semibold text-foreground">Settings</h1>
         <SettingsSearch value={query} onChange={setQuery} />
       </div>

--- a/packages/web/src/components/settings/settings-shell.tsx
+++ b/packages/web/src/components/settings/settings-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
+import { SettingsViewportProvider } from "@/components/settings/settings-viewport-context";
 import {
   DEFAULT_SETTINGS_CATEGORY,
   isSettingsCategory,
@@ -14,6 +16,7 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
+  const [isHydrated, setIsHydrated] = useState(false);
   const tab = searchParams.get("tab");
   const activeCategory = pathname.startsWith("/settings/integrations/")
     ? "integrations"
@@ -21,17 +24,31 @@ export function SettingsShell({ children }: { children: React.ReactNode }) {
       ? tab
       : DEFAULT_SETTINGS_CATEGORY;
 
-  if (isMobile) return <main className="h-dvh overflow-hidden">{children}</main>;
+  useEffect(() => setIsHydrated(true), []);
+
+  if (!isHydrated) {
+    return <main className="h-dvh overflow-hidden bg-background" aria-busy="true" />;
+  }
+
+  if (isMobile) {
+    return (
+      <SettingsViewportProvider value={true}>
+        <main className="h-dvh overflow-hidden">{children}</main>
+      </SettingsViewportProvider>
+    );
+  }
 
   return (
-    <div className="flex h-dvh overflow-hidden bg-background">
-      <SettingsNav
-        activeCategory={activeCategory}
-        onSelect={(category) => router.push(`/settings?tab=${category}`)}
-      />
-      <main className="min-w-0 flex-1 overflow-y-auto px-8 py-10 lg:px-12">
-        <div className="mx-auto max-w-3xl">{children}</div>
-      </main>
-    </div>
+    <SettingsViewportProvider value={false}>
+      <div className="flex h-dvh overflow-hidden bg-background">
+        <SettingsNav
+          activeCategory={activeCategory}
+          onSelect={(category) => router.push(`/settings?tab=${category}`)}
+        />
+        <main className="min-w-0 flex-1 overflow-y-auto px-8 py-10 lg:px-12">
+          <div className="mx-auto max-w-3xl">{children}</div>
+        </main>
+      </div>
+    </SettingsViewportProvider>
   );
 }

--- a/packages/web/src/components/settings/settings-viewport-context.tsx
+++ b/packages/web/src/components/settings/settings-viewport-context.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import { useIsMobile } from "@/hooks/use-media-query";
 
-const SettingsViewportContext = createContext<boolean | null>(null);
+const SettingsViewportContext = createContext<boolean | undefined>(undefined);
 
 export const SettingsViewportProvider = SettingsViewportContext.Provider;
 
 export function useSettingsIsMobile(): boolean {
-  const shellValue = useContext(SettingsViewportContext);
-  const mediaQueryValue = useIsMobile();
-  return shellValue ?? mediaQueryValue;
+  const value = useContext(SettingsViewportContext);
+  if (value === undefined) {
+    throw new Error("useSettingsIsMobile must be used within SettingsViewportProvider");
+  }
+  return value;
 }

--- a/packages/web/src/components/settings/settings-viewport-context.tsx
+++ b/packages/web/src/components/settings/settings-viewport-context.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { useIsMobile } from "@/hooks/use-media-query";
+
+const SettingsViewportContext = createContext<boolean | null>(null);
+
+export const SettingsViewportProvider = SettingsViewportContext.Provider;
+
+export function useSettingsIsMobile(): boolean {
+  const shellValue = useContext(SettingsViewportContext);
+  const mediaQueryValue = useIsMobile();
+  return shellValue ?? mediaQueryValue;
+}


### PR DESCRIPTION
## Summary

- preserve mobile settings search and scroll context while opening detail panels, and restore focus to the originating category after browser or in-app Back navigation
- use shared input/button focus treatments, expose active mobile navigation semantics, announce empty search results, and increase mobile header actions to 44px touch targets
- avoid rendering the desktop settings structure during mobile hydration by sharing the resolved settings viewport through the route shell
- correct integration detail heading hierarchy and make Slack routing rules stack cleanly on narrow screens
- add regression coverage for focus restoration, retained search state, focus treatments, heading levels, and responsive routing controls

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-fix`
- `npm test -w @open-inspect/web -- --maxWorkers=4` (170 files, 1,308 tests)
- `NODE_ENV=production npm run build -w @open-inspect/web`
- `git diff --check`

## Manual Verification

Tested against a local mock control plane with an authenticated user:

- 390x844 mobile settings search → Appearance detail → browser Back
- confirmed the search query remains populated, focus returns to Appearance, and `aria-current` remains accurate
- confirmed the Appearance controls stack without compression
- confirmed the Slack integration at 320x844 has no horizontal overflow and follows `h1` → `h2` → `h3` heading order

Visual recording artifact: `7fe72d4f66822633d4cbc0aea64646bb`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/813b354124416569fd45908400e81c6c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved heading structure across integration settings for clearer screen-reader navigation.
  * Enhanced focus restoration when navigating mobile settings.
  * Improved accessibility semantics for active navigation items and mobile actions.

* **Mobile Experience**
  * Improved navigation between settings category lists and detail views.
  * Preserved mobile search state during browser-history navigation.
  * Updated mobile controls with larger, more consistent buttons.

* **Layout**
  * Improved Slack routing-rule layout on smaller screens.

* **Reliability**
  * Added a smoother loading state while settings finish initializing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->