### PR TITLE
fix(web): select image-build rows by current fingerprint everywhere

### DIFF
--- a/packages/web/src/app/api/image-builds/route.test.ts
+++ b/packages/web/src/app/api/image-builds/route.test.ts
@@ -211,6 +211,38 @@ describe("GET /api/image-builds feed", () => {
     await expect(response.json()).resolves.toEqual({ units: [], enabledRepos: [], images: [] });
   });
 
+  it("filters other providers' rows at the fetch boundary", async () => {
+    // The control plane's status query is not provider-scoped, so rows left
+    // behind by a provider switch reach this route — they must not leak into
+    // the feed the selectors and rebuild guards fold over.
+    vi.mocked(controlPlaneUserFetch).mockImplementation(async (path: string) => {
+      if (path === "/image-builds/enabled") return Response.json({ units: [] });
+      if (path === "/image-builds/enabled-repos") return Response.json({ repos: [] });
+      return Response.json({
+        images: [
+          {
+            id: "previous-provider-build",
+            scopeKind: "environment",
+            scopeId: "env_1",
+            provider: "e2b",
+            status: "building",
+            repositoriesFingerprint: "fp-env",
+            repositoryShas: [],
+            runtimeVersion: "60",
+            buildDurationSeconds: null,
+            errorMessage: null,
+            createdAt: 1700000000000,
+          },
+        ],
+      });
+    });
+
+    const response = await getFeed();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ units: [], enabledRepos: [], images: [] });
+  });
+
   it("returns 502 when the control-plane feed has an invalid shape", async () => {
     vi.mocked(controlPlaneUserFetch).mockImplementation(async (path: string) => {
       if (path === "/image-builds/enabled") {

--- a/packages/web/src/app/api/image-builds/route.ts
+++ b/packages/web/src/app/api/image-builds/route.ts
@@ -2,12 +2,17 @@ import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import {
+  excludeOtherProviderBuilds,
   excludeSupersededBuilds,
   imageBuildsEnabledReposResponseSchema,
   imageBuildsEnabledResponseSchema,
   imageBuildsStatusResponseSchema,
 } from "@/lib/image-builds";
-import { REPO_IMAGES_UNSUPPORTED_MESSAGE, supportsRepoImages } from "@/lib/sandbox-provider";
+import {
+  REPO_IMAGES_UNSUPPORTED_MESSAGE,
+  getPublicSandboxProvider,
+  supportsRepoImages,
+} from "@/lib/sandbox-provider";
 
 /**
  * Unified image-build feed: every prebuild-enabled scope plus the cross-scope
@@ -57,7 +62,10 @@ export async function GET() {
     // Persisted repo flags, unlike units, never drop a scope on a transient
     // resolution failure — the settings toggles read these.
     const enabledRepos = parsedEnabledRepos.data.repos;
-    const images = excludeSupersededBuilds(parsedStatus.data.images);
+    const images = excludeOtherProviderBuilds(
+      excludeSupersededBuilds(parsedStatus.data.images),
+      getPublicSandboxProvider()
+    );
 
     return NextResponse.json({ units, enabledRepos, images });
   } catch (error) {

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -10,8 +10,9 @@ import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
-import { IMAGE_BUILDS_KEY, formatReadyDetails, parsePrimaryBuildSha } from "@/lib/image-builds";
+import { IMAGE_BUILDS_KEY, latestCurrentBuild } from "@/lib/image-builds";
 import { useImageBuilds } from "@/hooks/use-image-builds";
+import { usePendingKeys } from "@/hooks/use-pending-keys";
 import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import { useEnvironments, ENVIRONMENTS_KEY } from "@/hooks/use-environments";
@@ -36,8 +37,8 @@ export function EnvironmentsSettings() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
-  const [triggeringIds, setTriggeringIds] = useState<Set<string>>(new Set());
+  const toggling = usePendingKeys();
+  const triggering = usePendingKeys();
 
   const prebuildsSupported = supportsRepoImages();
 
@@ -112,55 +113,46 @@ export function EnvironmentsSettings() {
     }
   };
 
-  const handlePrebuildToggle = async (environment: Environment, enabled: boolean) => {
-    setTogglingIds((prev) => new Set(prev).add(environment.id));
+  const handlePrebuildToggle = (environment: Environment, enabled: boolean) => {
     setError("");
-    try {
-      const response = await browserApiFetch(`/api/environments/${environment.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prebuildEnabled: enabled }),
-      });
-      if (!response.ok) {
-        const data = await response.json();
-        setError(data?.error || "Failed to toggle prebuilds");
-      } else {
-        mutate(ENVIRONMENTS_KEY);
-        mutate(IMAGE_BUILDS_KEY);
+    void toggling.run(environment.id, async () => {
+      try {
+        const response = await browserApiFetch(`/api/environments/${environment.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prebuildEnabled: enabled }),
+        });
+        if (!response.ok) {
+          const data = await response.json();
+          setError(data?.error || "Failed to toggle prebuilds");
+        } else {
+          mutate(ENVIRONMENTS_KEY);
+          mutate(IMAGE_BUILDS_KEY);
+        }
+      } catch {
+        setError("Failed to toggle prebuilds");
       }
-    } catch {
-      setError("Failed to toggle prebuilds");
-    } finally {
-      setTogglingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(environment.id);
-        return next;
-      });
-    }
+    });
   };
 
-  const handleRebuild = async (environment: Environment) => {
-    setTriggeringIds((prev) => new Set(prev).add(environment.id));
+  const handleRebuild = (environment: Environment) => {
     setError("");
-    try {
-      const response = await browserApiFetch(`/api/environments/${environment.id}/images/trigger`, {
-        method: "POST",
-      });
-      if (!response.ok) {
-        const data = await response.json();
-        setError(data?.error || "Failed to trigger build");
-      } else {
-        mutate(IMAGE_BUILDS_KEY);
+    void triggering.run(environment.id, async () => {
+      try {
+        const response = await browserApiFetch(
+          `/api/environments/${environment.id}/images/trigger`,
+          { method: "POST" }
+        );
+        if (!response.ok) {
+          const data = await response.json();
+          setError(data?.error || "Failed to trigger build");
+        } else {
+          mutate(IMAGE_BUILDS_KEY);
+        }
+      } catch {
+        setError("Failed to trigger build");
       }
-    } catch {
-      setError("Failed to trigger build");
-    } finally {
-      setTriggeringIds((prev) => {
-        const next = new Set(prev);
-        next.delete(environment.id);
-        return next;
-      });
-    }
+    });
   };
 
   if (view.mode === "create") {
@@ -296,8 +288,8 @@ export function EnvironmentsSettings() {
 
         <div className="space-y-2">
           {environments.map((environment) => {
-            const isToggling = togglingIds.has(environment.id);
-            const isTriggering = triggeringIds.has(environment.id);
+            const isToggling = toggling.pending.has(environment.id);
+            const isTriggering = triggering.pending.has(environment.id);
 
             return (
               <div key={environment.id} className="border border-border px-4 py-3">
@@ -323,10 +315,7 @@ export function EnvironmentsSettings() {
                       <>
                         <EnvironmentImageStatus
                           environment={environment}
-                          image={imageBuildsFeed?.images.find(
-                            (image) =>
-                              image.scopeKind === "environment" && image.scopeId === environment.id
-                          )}
+                          image={latestCurrentBuild(imageBuildsFeed, "environment", environment.id)}
                           feedUnavailable={Boolean(imageBuildsError) && !imageBuildsFeed}
                         />
                         <Tooltip>
@@ -425,22 +414,10 @@ function EnvironmentImageStatus({
     return <span className="text-xs text-muted-foreground">Status unavailable</span>;
   }
 
-  const image = environment.prebuildEnabled ? latestImage : undefined;
-
   return (
     <ImageBuildStatus
       isEnabled={environment.prebuildEnabled}
-      image={
-        image && {
-          status: image.status,
-          createdAt: image.createdAt,
-          readyDetails: formatReadyDetails(
-            parsePrimaryBuildSha(image.repositoryShas),
-            image.buildDurationSeconds
-          ),
-          errorMessage: image.errorMessage,
-        }
-      }
+      image={environment.prebuildEnabled ? latestImage : undefined}
     />
   );
 }

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate } from "swr";
 import { toast } from "sonner";
 import type { Environment } from "@open-inspect/shared/types/environments";
@@ -10,7 +10,12 @@ import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
-import { IMAGE_BUILDS_KEY, latestCurrentBuild } from "@/lib/image-builds";
+import {
+  IMAGE_BUILDS_KEY,
+  activeBuildScopeKeys,
+  imageBuildScopeKey,
+  latestCurrentBuildsByScope,
+} from "@/lib/image-builds";
 import { useImageBuilds } from "@/hooks/use-image-builds";
 import { usePendingKeys } from "@/hooks/use-pending-keys";
 import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
@@ -39,6 +44,14 @@ export function EnvironmentsSettings() {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const toggling = usePendingKeys();
   const triggering = usePendingKeys();
+  const latestBuilds = useMemo(
+    () => latestCurrentBuildsByScope(imageBuildsFeed?.images ?? [], imageBuildsFeed?.units ?? []),
+    [imageBuildsFeed]
+  );
+  const activeBuildScopes = useMemo(
+    () => activeBuildScopeKeys(imageBuildsFeed?.images ?? []),
+    [imageBuildsFeed]
+  );
 
   const prebuildsSupported = supportsRepoImages();
 
@@ -315,7 +328,9 @@ export function EnvironmentsSettings() {
                       <>
                         <EnvironmentImageStatus
                           environment={environment}
-                          image={latestCurrentBuild(imageBuildsFeed, "environment", environment.id)}
+                          image={latestBuilds.get(
+                            imageBuildScopeKey("environment", environment.id)
+                          )}
                           feedUnavailable={Boolean(imageBuildsError) && !imageBuildsFeed}
                         />
                         <Tooltip>
@@ -337,7 +352,11 @@ export function EnvironmentsSettings() {
                           variant="ghost"
                           size="icon"
                           onClick={() => handleRebuild(environment)}
-                          disabled={!environment.prebuildEnabled || isTriggering}
+                          disabled={
+                            !environment.prebuildEnabled ||
+                            isTriggering ||
+                            activeBuildScopes.has(imageBuildScopeKey("environment", environment.id))
+                          }
                           title="Rebuild image"
                         >
                           <RefreshIcon

--- a/packages/web/src/components/settings/image-build-status.tsx
+++ b/packages/web/src/components/settings/image-build-status.tsx
@@ -1,30 +1,22 @@
 "use client";
 
-import type { ImageBuildStatus as ImageBuildStatusValue } from "@open-inspect/shared/types/image-builds";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { formatReadyDetails, parsePrimaryBuildSha } from "@/lib/image-builds";
 import { formatRelativeTime } from "@/lib/time";
-
-/** Presentation-ready view of one prebuilt image's latest build. */
-export interface ImageBuildStatusView {
-  /** Superseded rows are filtered at the fetch boundary and render nothing. */
-  status: ImageBuildStatusValue;
-  createdAt: number;
-  /** Extra line under a ready status, e.g. "abc1234 · 45s". */
-  readyDetails?: string;
-  errorMessage?: string | null;
-}
 
 /**
  * Shared build-status rendering for prebuilt images (repo images and
  * environment images): status dot, relative time, ready details, and the
- * failed-error tooltip. Callers map their row shape to ImageBuildStatusView.
- * Must render inside a TooltipProvider.
+ * failed-error tooltip. Takes the feed row itself; superseded rows are
+ * filtered at the fetch boundary and would render nothing. Must render
+ * inside a TooltipProvider.
  */
 export function ImageBuildStatus({
   image,
   isEnabled,
 }: {
-  image: ImageBuildStatusView | undefined;
+  image: ImageBuildRecordView | undefined;
   isEnabled: boolean;
 }) {
   if (!isEnabled) {
@@ -36,6 +28,10 @@ export function ImageBuildStatus({
   }
 
   if (image.status === "ready") {
+    const readyDetails = formatReadyDetails(
+      parsePrimaryBuildSha(image.repositoryShas),
+      image.buildDurationSeconds
+    );
     return (
       <div className="text-right">
         <div className="flex items-center gap-1.5">
@@ -44,9 +40,7 @@ export function ImageBuildStatus({
             Ready {formatRelativeTime(image.createdAt)}
           </span>
         </div>
-        {image.readyDetails && (
-          <span className="text-xs text-muted-foreground">{image.readyDetails}</span>
-        )}
+        {readyDetails && <span className="text-xs text-muted-foreground">{readyDetails}</span>}
       </div>
     );
   }

--- a/packages/web/src/components/settings/images-settings.test.tsx
+++ b/packages/web/src/components/settings/images-settings.test.tsx
@@ -105,6 +105,47 @@ describe("ImagesSettings", () => {
     expect(screen.getByText("clone exploded")).toBeInTheDocument();
   });
 
+  it("shows the newest current-fingerprint build, not a newer stale-fingerprint row", () => {
+    // The repo set changed after the ready build: spawn will never use the
+    // stale image, so settings must surface the current failed attempt the
+    // rebuild control acts on — matching which rows the picker counts.
+    renderWithFeed({
+      units: [{ scopeKind: "repo", scopeId: "acme/web", repositoriesFingerprint: "fp-current" }],
+      enabledRepos: [{ repoOwner: "acme", repoName: "web" }],
+      images: [
+        {
+          id: "stale-ready",
+          scopeKind: "repo",
+          scopeId: "acme/web",
+          provider: "modal",
+          status: "ready",
+          repositoriesFingerprint: "fp-stale",
+          repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc1234def5678" }],
+          runtimeVersion: "60",
+          buildDurationSeconds: 42,
+          errorMessage: null,
+          createdAt: Date.now(),
+        },
+        {
+          id: "current-failed",
+          scopeKind: "repo",
+          scopeId: "acme/web",
+          provider: "modal",
+          status: "failed",
+          repositoriesFingerprint: "fp-current",
+          repositoryShas: [],
+          runtimeVersion: "60",
+          buildDurationSeconds: null,
+          errorMessage: "install step failed",
+          createdAt: Date.now() - 60_000,
+        },
+      ],
+    });
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.queryByText(/^Ready/)).not.toBeInTheDocument();
+  });
+
   it("keeps the toggle enabled when unit resolution transiently dropped the repo", () => {
     // Enabled per the persisted flag but absent from `units` — toggle state
     // must come from the flag, not the resolution-dependent units feed.

--- a/packages/web/src/components/settings/images-settings.test.tsx
+++ b/packages/web/src/components/settings/images-settings.test.tsx
@@ -146,6 +146,34 @@ describe("ImagesSettings", () => {
     expect(screen.queryByText(/^Ready/)).not.toBeInTheDocument();
   });
 
+  it("keeps rebuild disabled while a stale-fingerprint build is still running", () => {
+    // The display hides the stale row, but the control plane's trigger guard
+    // is not fingerprint-scoped: while the stale build runs, a new trigger
+    // only returns alreadyBuilding — so the control must stay disabled.
+    renderWithFeed({
+      units: [{ scopeKind: "repo", scopeId: "acme/web", repositoriesFingerprint: "fp-current" }],
+      enabledRepos: [{ repoOwner: "acme", repoName: "web" }],
+      images: [
+        {
+          id: "stale-building",
+          scopeKind: "repo",
+          scopeId: "acme/web",
+          provider: "modal",
+          status: "building",
+          repositoriesFingerprint: "fp-stale",
+          repositoryShas: [],
+          runtimeVersion: "60",
+          buildDurationSeconds: null,
+          errorMessage: null,
+          createdAt: Date.now(),
+        },
+      ],
+    });
+
+    expect(screen.getByText("No image")).toBeInTheDocument();
+    expect(screen.getByTitle("Rebuild image")).toBeDisabled();
+  });
+
   it("keeps the toggle enabled when unit resolution transiently dropped the repo", () => {
     // Enabled per the persisted flag but absent from `units` — toggle state
     // must come from the flag, not the resolution-dependent units feed.

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { mutate } from "swr";
 import { useImageBuilds } from "@/hooks/use-image-builds";
 import { usePendingKeys } from "@/hooks/use-pending-keys";
@@ -12,8 +12,10 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
 import {
   IMAGE_BUILDS_KEY,
+  activeBuildScopeKeys,
   foldEnabledRepoScopeIds,
-  latestCurrentBuild,
+  imageBuildScopeKey,
+  latestCurrentBuildsByScope,
   repoImageBuildScopeId,
 } from "@/lib/image-builds";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
@@ -27,6 +29,11 @@ export function ImagesSettings() {
   const toggling = usePendingKeys();
   const triggering = usePendingKeys();
   const [error, setError] = useState("");
+  const latestBuilds = useMemo(
+    () => latestCurrentBuildsByScope(data?.images ?? [], data?.units ?? []),
+    [data]
+  );
+  const activeBuildScopes = useMemo(() => activeBuildScopeKeys(data?.images ?? []), [data]);
 
   if (!repoImagesSupported) {
     return (
@@ -126,10 +133,11 @@ export function ImagesSettings() {
         <div className="space-y-2">
           {repos.map((repo) => {
             const repoKey = repoImageBuildScopeId(repo.owner, repo.name);
+            const buildScopeKey = imageBuildScopeKey("repo", repoKey);
             const isEnabled = enabledRepos.has(repoKey);
             const isToggling = toggling.pending.has(repoKey);
             const isTriggering = triggering.pending.has(repoKey);
-            const image = latestCurrentBuild(data, "repo", repoKey);
+            const image = latestBuilds.get(buildScopeKey);
 
             return (
               <div
@@ -154,7 +162,7 @@ export function ImagesSettings() {
                     variant="ghost"
                     size="icon"
                     onClick={() => handleTrigger(repo.owner, repo.name)}
-                    disabled={!isEnabled || isTriggering || image?.status === "building"}
+                    disabled={!isEnabled || isTriggering || activeBuildScopes.has(buildScopeKey)}
                     title="Rebuild image"
                   >
                     <RefreshIcon className={`w-4 h-4 ${isTriggering ? "animate-spin" : ""}`} />

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -2,15 +2,20 @@
 
 import { useState } from "react";
 import { mutate } from "swr";
-import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { useImageBuilds } from "@/hooks/use-image-builds";
+import { usePendingKeys } from "@/hooks/use-pending-keys";
 import { useRepos } from "@/hooks/use-repos";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
-import { IMAGE_BUILDS_KEY, formatReadyDetails, parsePrimaryBuildSha } from "@/lib/image-builds";
+import {
+  IMAGE_BUILDS_KEY,
+  foldEnabledRepoScopeIds,
+  latestCurrentBuild,
+  repoImageBuildScopeId,
+} from "@/lib/image-builds";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import { ImageBuildStatus } from "./image-build-status";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
@@ -19,8 +24,8 @@ export function ImagesSettings() {
   const repoImagesSupported = supportsRepoImages();
   const { repos, loading: reposLoading } = useRepos();
   const { data, error: feedError, isLoading: imagesLoading } = useImageBuilds();
-  const [togglingRepos, setTogglingRepos] = useState<Set<string>>(new Set());
-  const [triggeringRepos, setTriggeringRepos] = useState<Set<string>>(new Set());
+  const toggling = usePendingKeys();
+  const triggering = usePendingKeys();
   const [error, setError] = useState("");
 
   if (!repoImagesSupported) {
@@ -39,74 +44,52 @@ export function ImagesSettings() {
 
   // Toggle state reads the persisted flags, not `units` — the units feed
   // resolves scopes through source control and can transiently drop a repo.
-  const enabledRepos = new Set(
-    (data?.enabledRepos ?? []).map((repo) => `${repo.repoOwner}/${repo.repoName}`.toLowerCase())
-  );
+  const enabledRepos = foldEnabledRepoScopeIds(data?.enabledRepos ?? []);
 
-  // Repo scope ids are lowercase `owner/name` pairs.
-  const getLatestImage = (owner: string, name: string): ImageBuildRecordView | undefined => {
-    const key = `${owner}/${name}`.toLowerCase();
-    return data?.images.find((img) => img.scopeKind === "repo" && img.scopeId === key);
-  };
-
-  const handleToggle = async (owner: string, name: string, enabled: boolean) => {
-    const repoKey = `${owner}/${name}`.toLowerCase();
-    setTogglingRepos((prev) => new Set(prev).add(repoKey));
+  const handleToggle = (owner: string, name: string, enabled: boolean) => {
     setError("");
+    void toggling.run(repoImageBuildScopeId(owner, name), async () => {
+      try {
+        const res = await browserApiFetch(
+          `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/toggle`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled }),
+          }
+        );
 
-    try {
-      const res = await browserApiFetch(
-        `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/toggle`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ enabled }),
+        if (!res.ok) {
+          const errBody = await res.json();
+          setError(errBody.error || "Failed to toggle image build");
+        } else {
+          mutate(IMAGE_BUILDS_KEY);
         }
-      );
-
-      if (!res.ok) {
-        const errBody = await res.json();
-        setError(errBody.error || "Failed to toggle image build");
-      } else {
-        mutate(IMAGE_BUILDS_KEY);
+      } catch {
+        setError("Failed to toggle image build");
       }
-    } catch {
-      setError("Failed to toggle image build");
-    } finally {
-      setTogglingRepos((prev) => {
-        const next = new Set(prev);
-        next.delete(repoKey);
-        return next;
-      });
-    }
+    });
   };
 
-  const handleTrigger = async (owner: string, name: string) => {
-    const repoKey = `${owner}/${name}`.toLowerCase();
-    setTriggeringRepos((prev) => new Set(prev).add(repoKey));
+  const handleTrigger = (owner: string, name: string) => {
     setError("");
+    void triggering.run(repoImageBuildScopeId(owner, name), async () => {
+      try {
+        const res = await browserApiFetch(
+          `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/trigger`,
+          { method: "POST" }
+        );
 
-    try {
-      const res = await browserApiFetch(
-        `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/trigger`,
-        { method: "POST" }
-      );
-
-      if (!res.ok) {
-        const errBody = await res.json();
-        setError(errBody.error || "Failed to trigger build");
-      } else {
-        mutate(IMAGE_BUILDS_KEY);
+        if (!res.ok) {
+          const errBody = await res.json();
+          setError(errBody.error || "Failed to trigger build");
+        } else {
+          mutate(IMAGE_BUILDS_KEY);
+        }
+      } catch {
+        setError("Failed to trigger build");
       }
-    } catch {
-      setError("Failed to trigger build");
-    } finally {
-      setTriggeringRepos((prev) => {
-        const next = new Set(prev);
-        next.delete(repoKey);
-        return next;
-      });
-    }
+    });
   };
 
   if (loading) {
@@ -142,11 +125,11 @@ export function ImagesSettings() {
 
         <div className="space-y-2">
           {repos.map((repo) => {
-            const repoKey = `${repo.owner}/${repo.name}`.toLowerCase();
+            const repoKey = repoImageBuildScopeId(repo.owner, repo.name);
             const isEnabled = enabledRepos.has(repoKey);
-            const isToggling = togglingRepos.has(repoKey);
-            const isTriggering = triggeringRepos.has(repoKey);
-            const image = getLatestImage(repo.owner, repo.name);
+            const isToggling = toggling.pending.has(repoKey);
+            const isTriggering = triggering.pending.has(repoKey);
+            const image = latestCurrentBuild(data, "repo", repoKey);
 
             return (
               <div
@@ -166,20 +149,7 @@ export function ImagesSettings() {
                 </div>
 
                 <div className="flex items-center gap-3 flex-shrink-0 ml-4">
-                  <ImageBuildStatus
-                    isEnabled={isEnabled}
-                    image={
-                      image && {
-                        status: image.status,
-                        createdAt: image.createdAt,
-                        readyDetails: formatReadyDetails(
-                          parsePrimaryBuildSha(image.repositoryShas),
-                          image.buildDurationSeconds
-                        ),
-                        errorMessage: image.errorMessage,
-                      }
-                    }
-                  />
+                  <ImageBuildStatus isEnabled={isEnabled} image={image} />
                   <Button
                     variant="ghost"
                     size="icon"

--- a/packages/web/src/hooks/use-pending-keys.test.tsx
+++ b/packages/web/src/hooks/use-pending-keys.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { usePendingKeys } from "./use-pending-keys";
+
+describe("usePendingKeys", () => {
+  it("marks the key pending for the action's duration", async () => {
+    const { result } = renderHook(() => usePendingKeys());
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    let run!: Promise<void>;
+    act(() => {
+      run = result.current.run("k1", () => gate);
+    });
+
+    expect(result.current.pending.has("k1")).toBe(true);
+
+    await act(async () => {
+      release();
+      await run;
+    });
+
+    expect(result.current.pending.has("k1")).toBe(false);
+  });
+
+  it("clears the key when the action throws", async () => {
+    const { result } = renderHook(() => usePendingKeys());
+
+    await act(async () => {
+      await expect(
+        result.current.run("k1", () => Promise.reject(new Error("boom")))
+      ).rejects.toThrow("boom");
+    });
+
+    expect(result.current.pending.has("k1")).toBe(false);
+  });
+
+  it("tracks concurrent keys independently", async () => {
+    const { result } = renderHook(() => usePendingKeys());
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    let slowRun!: Promise<void>;
+    await act(async () => {
+      slowRun = result.current.run("slow", () => gate);
+      await result.current.run("fast", async () => {});
+    });
+
+    expect(result.current.pending.has("slow")).toBe(true);
+    expect(result.current.pending.has("fast")).toBe(false);
+
+    await act(async () => {
+      release();
+      await slowRun;
+    });
+
+    expect(result.current.pending.has("slow")).toBe(false);
+  });
+});

--- a/packages/web/src/hooks/use-pending-keys.test.tsx
+++ b/packages/web/src/hooks/use-pending-keys.test.tsx
@@ -37,6 +37,35 @@ describe("usePendingKeys", () => {
     expect(result.current.pending.has("k1")).toBe(false);
   });
 
+  it("keeps the key pending until the last overlapping action settles", async () => {
+    const { result } = renderHook(() => usePendingKeys());
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const secondGate = new Promise<void>((resolve) => (releaseSecond = resolve));
+
+    let firstRun!: Promise<void>;
+    let secondRun!: Promise<void>;
+    act(() => {
+      firstRun = result.current.run("k1", () => firstGate);
+      secondRun = result.current.run("k1", () => secondGate);
+    });
+
+    await act(async () => {
+      releaseFirst();
+      await firstRun;
+    });
+
+    expect(result.current.pending.has("k1")).toBe(true);
+
+    await act(async () => {
+      releaseSecond();
+      await secondRun;
+    });
+
+    expect(result.current.pending.has("k1")).toBe(false);
+  });
+
   it("tracks concurrent keys independently", async () => {
     const { result } = renderHook(() => usePendingKeys());
     let release!: () => void;

--- a/packages/web/src/hooks/use-pending-keys.ts
+++ b/packages/web/src/hooks/use-pending-keys.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Tracks which row keys have an action in flight, for per-row disabled
+ * states. `run` marks the key pending for the action's duration (also on
+ * throw); actions on distinct keys are independent.
+ */
+export function usePendingKeys(): {
+  pending: ReadonlySet<string>;
+  run: (key: string, action: () => Promise<void>) => Promise<void>;
+} {
+  const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+
+  const run = useCallback(async (key: string, action: () => Promise<void>) => {
+    setPending((prev) => new Set(prev).add(key));
+    try {
+      await action();
+    } finally {
+      setPending((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+    }
+  }, []);
+
+  return { pending, run };
+}

--- a/packages/web/src/hooks/use-pending-keys.ts
+++ b/packages/web/src/hooks/use-pending-keys.ts
@@ -1,30 +1,40 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 /**
  * Tracks which row keys have an action in flight, for per-row disabled
  * states. `run` marks the key pending for the action's duration (also on
- * throw); actions on distinct keys are independent.
+ * throw); actions on distinct keys are independent. Counted per key rather
+ * than a boolean set: overlapping runs on one key (a double-click landing
+ * before the disabled state paints) keep it pending until the last one
+ * settles.
  */
 export function usePendingKeys(): {
   pending: ReadonlySet<string>;
   run: (key: string, action: () => Promise<void>) => Promise<void>;
 } {
-  const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+  const [pendingCounts, setPendingCounts] = useState<ReadonlyMap<string, number>>(new Map());
 
   const run = useCallback(async (key: string, action: () => Promise<void>) => {
-    setPending((prev) => new Set(prev).add(key));
+    setPendingCounts((prev) => new Map(prev).set(key, (prev.get(key) ?? 0) + 1));
     try {
       await action();
     } finally {
-      setPending((prev) => {
-        const next = new Set(prev);
-        next.delete(key);
+      setPendingCounts((prev) => {
+        const next = new Map(prev);
+        const remaining = (prev.get(key) ?? 1) - 1;
+        if (remaining > 0) {
+          next.set(key, remaining);
+        } else {
+          next.delete(key);
+        }
         return next;
       });
     }
   }, []);
+
+  const pending = useMemo(() => new Set(pendingCounts.keys()), [pendingCounts]);
 
   return { pending, run };
 }

--- a/packages/web/src/lib/image-builds.test.ts
+++ b/packages/web/src/lib/image-builds.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import {
+  currentFingerprintBuilds,
   excludeSupersededBuilds,
   foldEnabledRepoScopeIds,
   foldImageBuildStatusByScope,
@@ -12,8 +13,10 @@ import {
   imageBuildsEnabledReposResponseSchema,
   imageBuildsEnabledResponseSchema,
   imageBuildUnitViewSchema,
+  latestCurrentBuild,
   parsePrimaryBuildSha,
   repoImageBuildScopeId,
+  type ImageBuildsFeed,
   type ImageBuildUnitView,
 } from "./image-builds";
 
@@ -223,5 +226,74 @@ describe("imageBuildPollInterval", () => {
 
   it("does not poll before the feed has loaded", () => {
     expect(imageBuildPollInterval(undefined)).toBe(0);
+  });
+});
+
+describe("currentFingerprintBuilds", () => {
+  it("drops stale-fingerprint rows and preserves feed order", () => {
+    const rows = currentFingerprintBuilds(
+      [
+        record({ id: "a", repositoriesFingerprint: "fp-stale" }),
+        record({ id: "b", repositoriesFingerprint: "fp-current" }),
+        record({ id: "c", repositoriesFingerprint: "fp-current" }),
+      ],
+      [unit()]
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["b", "c"]);
+  });
+
+  it("keeps every row of a scope missing from units", () => {
+    const rows = currentFingerprintBuilds(
+      [record({ id: "a", repositoriesFingerprint: "fp-anything" })],
+      []
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["a"]);
+  });
+});
+
+describe("latestCurrentBuild", () => {
+  function feed(images: ImageBuildRecordView[], units: ImageBuildUnitView[]): ImageBuildsFeed {
+    return { units, enabledRepos: [], images };
+  }
+
+  it("skips a newer stale-fingerprint row in favor of the newest current one", () => {
+    // Feed order is createdAt DESC: the stale ready row is newest overall.
+    const build = latestCurrentBuild(
+      feed(
+        [
+          record({ id: "stale-newest", status: "ready", repositoriesFingerprint: "fp-stale" }),
+          record({ id: "current-failed", status: "failed" }),
+          record({ id: "current-older", status: "ready" }),
+        ],
+        [unit()]
+      ),
+      "environment",
+      "env-1"
+    );
+
+    expect(build?.id).toBe("current-failed");
+  });
+
+  it("selects only rows of the requested scope", () => {
+    const build = latestCurrentBuild(
+      feed(
+        [
+          record({ id: "other-scope", scopeKind: "repo", scopeId: "acme/web" }),
+          record({ id: "target" }),
+        ],
+        []
+      ),
+      "environment",
+      "env-1"
+    );
+
+    expect(build?.id).toBe("target");
+  });
+
+  it("returns undefined without a feed or matching row", () => {
+    expect(latestCurrentBuild(undefined, "environment", "env-1")).toBeUndefined();
+    expect(latestCurrentBuild(feed([], []), "environment", "env-1")).toBeUndefined();
   });
 });

--- a/packages/web/src/lib/image-builds.test.ts
+++ b/packages/web/src/lib/image-builds.test.ts
@@ -3,6 +3,7 @@ import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-buil
 import {
   activeBuildScopeKeys,
   currentFingerprintBuilds,
+  excludeOtherProviderBuilds,
   excludeSupersededBuilds,
   foldEnabledRepoScopeIds,
   foldImageBuildStatusByScope,
@@ -56,6 +57,18 @@ describe("excludeSupersededBuilds", () => {
     ];
 
     expect(excludeSupersededBuilds(rows).map((row) => row.id)).toEqual(["a", "c", "d"]);
+  });
+});
+
+describe("excludeOtherProviderBuilds", () => {
+  it("keeps only the active provider's rows", () => {
+    const rows = [
+      record({ id: "a", provider: "modal" }),
+      record({ id: "b", provider: "e2b" }),
+      record({ id: "c", provider: "modal" }),
+    ];
+
+    expect(excludeOtherProviderBuilds(rows, "modal").map((row) => row.id)).toEqual(["a", "c"]);
   });
 });
 

--- a/packages/web/src/lib/image-builds.test.ts
+++ b/packages/web/src/lib/image-builds.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import {
+  activeBuildScopeKeys,
   currentFingerprintBuilds,
   excludeSupersededBuilds,
   foldEnabledRepoScopeIds,
@@ -13,10 +14,9 @@ import {
   imageBuildsEnabledReposResponseSchema,
   imageBuildsEnabledResponseSchema,
   imageBuildUnitViewSchema,
-  latestCurrentBuild,
+  latestCurrentBuildsByScope,
   parsePrimaryBuildSha,
   repoImageBuildScopeId,
-  type ImageBuildsFeed,
   type ImageBuildUnitView,
 } from "./image-builds";
 
@@ -253,47 +253,55 @@ describe("currentFingerprintBuilds", () => {
   });
 });
 
-describe("latestCurrentBuild", () => {
-  function feed(images: ImageBuildRecordView[], units: ImageBuildUnitView[]): ImageBuildsFeed {
-    return { units, enabledRepos: [], images };
-  }
-
+describe("latestCurrentBuildsByScope", () => {
   it("skips a newer stale-fingerprint row in favor of the newest current one", () => {
     // Feed order is createdAt DESC: the stale ready row is newest overall.
-    const build = latestCurrentBuild(
-      feed(
-        [
-          record({ id: "stale-newest", status: "ready", repositoriesFingerprint: "fp-stale" }),
-          record({ id: "current-failed", status: "failed" }),
-          record({ id: "current-older", status: "ready" }),
-        ],
-        [unit()]
-      ),
-      "environment",
-      "env-1"
+    const latest = latestCurrentBuildsByScope(
+      [
+        record({ id: "stale-newest", status: "ready", repositoriesFingerprint: "fp-stale" }),
+        record({ id: "current-failed", status: "failed" }),
+        record({ id: "current-older", status: "ready" }),
+      ],
+      [unit()]
     );
 
-    expect(build?.id).toBe("current-failed");
+    expect(latest.get(imageBuildScopeKey("environment", "env-1"))?.id).toBe("current-failed");
   });
 
-  it("selects only rows of the requested scope", () => {
-    const build = latestCurrentBuild(
-      feed(
-        [
-          record({ id: "other-scope", scopeKind: "repo", scopeId: "acme/web" }),
-          record({ id: "target" }),
-        ],
-        []
-      ),
-      "environment",
-      "env-1"
+  it("maps each scope to its own newest row", () => {
+    const latest = latestCurrentBuildsByScope(
+      [
+        record({ id: "repo-newest", scopeKind: "repo", scopeId: "acme/web" }),
+        record({ id: "env-newest" }),
+        record({ id: "env-older" }),
+      ],
+      []
     );
 
-    expect(build?.id).toBe("target");
+    expect(latest.get(imageBuildScopeKey("repo", "acme/web"))?.id).toBe("repo-newest");
+    expect(latest.get(imageBuildScopeKey("environment", "env-1"))?.id).toBe("env-newest");
   });
 
-  it("returns undefined without a feed or matching row", () => {
-    expect(latestCurrentBuild(undefined, "environment", "env-1")).toBeUndefined();
-    expect(latestCurrentBuild(feed([], []), "environment", "env-1")).toBeUndefined();
+  it("has no entry for a scope without countable rows", () => {
+    const latest = latestCurrentBuildsByScope(
+      [record({ id: "stale-only", repositoriesFingerprint: "fp-stale" })],
+      [unit()]
+    );
+
+    expect(latest.get(imageBuildScopeKey("environment", "env-1"))).toBeUndefined();
+  });
+});
+
+describe("activeBuildScopeKeys", () => {
+  it("includes scopes with a building row under any fingerprint", () => {
+    // The control plane's trigger guard is not fingerprint-scoped, so a
+    // stale-fingerprint building row still blocks a new trigger.
+    const active = activeBuildScopeKeys([
+      record({ id: "stale-building", status: "building", repositoriesFingerprint: "fp-stale" }),
+      record({ id: "repo-ready", scopeKind: "repo", scopeId: "acme/web", status: "ready" }),
+    ]);
+
+    expect(active.has(imageBuildScopeKey("environment", "env-1"))).toBe(true);
+    expect(active.has(imageBuildScopeKey("repo", "acme/web"))).toBe(false);
   });
 });

--- a/packages/web/src/lib/image-builds.ts
+++ b/packages/web/src/lib/image-builds.ts
@@ -84,11 +84,26 @@ export interface ImageBuildsFeed {
 
 /**
  * Drop superseded rows. The status endpoints don't emit them, but
- * `ImageBuildStatus` admits them — this is the one defensive filter, applied
+ * `ImageBuildStatus` admits them — applied with excludeOtherProviderBuilds
  * where the web fetches build rows from the control plane.
  */
 export function excludeSupersededBuilds(images: ImageBuildRecordView[]): ImageBuildRecordView[] {
   return images.filter((image) => image.status !== "superseded");
+}
+
+/**
+ * Drop rows from other sandbox providers. The control plane's status query is
+ * not provider-scoped, but everything downstream here is — spawn only uses
+ * the active provider's images and the trigger guard is keyed
+ * (scope, provider) — so rows left behind by a provider switch must not mask
+ * status, pin the rebuild guard, or drive the poll cadence. Applied with
+ * excludeSupersededBuilds where the web fetches build rows.
+ */
+export function excludeOtherProviderBuilds(
+  images: ImageBuildRecordView[],
+  activeProvider: string
+): ImageBuildRecordView[] {
+  return images.filter((image) => image.provider === activeProvider);
 }
 
 /** Map key for one build scope in the folded status map. */

--- a/packages/web/src/lib/image-builds.ts
+++ b/packages/web/src/lib/image-builds.ts
@@ -170,21 +170,42 @@ export function foldImageBuildStatusByScope(
 }
 
 /**
- * The newest countable build row for one scope (the feed is createdAt DESC).
- * Answers the settings surfaces' question — "what did the latest build
- * attempt do?" — which the rebuild/toggle controls act on. This can
- * legitimately show `failed` while the picker's fold reports `ready` for the
- * same scope (an older ready image still serves); the two must only ever
- * disagree on precedence, never on which rows count.
+ * One fold of the feed into each scope's newest countable row (the feed is
+ * createdAt DESC, so a scope's first row wins). Answers the settings
+ * surfaces' question — "what did the latest build attempt do?" — which the
+ * rebuild/toggle controls act on. This can legitimately hold `failed` while
+ * the picker's fold reports `ready` for the same scope (an older ready image
+ * still serves); the two must only ever disagree on precedence, never on
+ * which rows count. Memo once per feed change and look rows up by
+ * imageBuildScopeKey.
  */
-export function latestCurrentBuild(
-  feed: ImageBuildsFeed | undefined,
-  scopeKind: ImageBuildScopeKind,
-  scopeId: string
-): ImageBuildRecordView | undefined {
-  if (!feed) return undefined;
-  return currentFingerprintBuilds(feed.images, feed.units).find(
-    (image) => image.scopeKind === scopeKind && image.scopeId === scopeId
+export function latestCurrentBuildsByScope(
+  images: ImageBuildRecordView[],
+  units: ImageBuildUnitView[]
+): Map<string, ImageBuildRecordView> {
+  const latestByScope = new Map<string, ImageBuildRecordView>();
+  for (const image of currentFingerprintBuilds(images, units)) {
+    const key = imageBuildScopeKey(image.scopeKind, image.scopeId);
+    if (!latestByScope.has(key)) {
+      latestByScope.set(key, image);
+    }
+  }
+  return latestByScope;
+}
+
+/**
+ * Scope keys with a build in progress under ANY fingerprint. The control
+ * plane's trigger guard is not fingerprint-scoped — one active build per
+ * scope, and a trigger against it returns `alreadyBuilding` in a 200 the
+ * handlers don't read — so rebuild controls must disable on this set even
+ * when the display row (latestCurrentBuildsByScope) hides a stale in-flight
+ * build.
+ */
+export function activeBuildScopeKeys(images: ImageBuildRecordView[]): Set<string> {
+  return new Set(
+    images
+      .filter((image) => image.status === "building")
+      .map((image) => imageBuildScopeKey(image.scopeKind, image.scopeId))
   );
 }
 

--- a/packages/web/src/lib/image-builds.ts
+++ b/packages/web/src/lib/image-builds.ts
@@ -123,36 +123,69 @@ const STATUS_FOLD_PRECEDENCE: Record<ImageBuildStatus, number> = {
 };
 
 /**
- * Fold each scope's build rows to one status: ready > building > failed.
- *
- * Only rows matching the scope's current fingerprint (per `units`) count —
- * spawn rejects stale-fingerprint rows, so a stale ready row must not outrank
- * a failed current build. A scope with no unit (transiently dropped from the
- * enabled feed) falls back to the unfiltered fold over all its rows.
+ * The rows that count toward a scope's status: rows matching the scope's
+ * current repo-set fingerprint (per `units`) — spawn rejects
+ * stale-fingerprint rows, so no surface may present one as this scope's
+ * image. A scope with no unit (transiently dropped from the enabled feed)
+ * keeps all its rows. Preserves feed order (createdAt DESC). Shared by the
+ * picker's fold and the settings row selector so every surface agrees on
+ * which builds exist, even where they answer different questions.
  */
-export function foldImageBuildStatusByScope(
+export function currentFingerprintBuilds(
   images: ImageBuildRecordView[],
   units: ImageBuildUnitView[]
-): Map<string, ImageBuildStatus> {
+): ImageBuildRecordView[] {
   const currentFingerprintByScope = new Map(
     units.map((unit) => [
       imageBuildScopeKey(unit.scopeKind, unit.scopeId),
       unit.repositoriesFingerprint,
     ])
   );
+  return images.filter((image) => {
+    const currentFingerprint = currentFingerprintByScope.get(
+      imageBuildScopeKey(image.scopeKind, image.scopeId)
+    );
+    return currentFingerprint === undefined || image.repositoriesFingerprint === currentFingerprint;
+  });
+}
+
+/**
+ * Fold each scope's countable rows to one status: ready > building > failed.
+ * Answers the session-target picker's question — "will spawn get a prebuilt
+ * image?" — so an older ready image outranks a newer failed rebuild.
+ */
+export function foldImageBuildStatusByScope(
+  images: ImageBuildRecordView[],
+  units: ImageBuildUnitView[]
+): Map<string, ImageBuildStatus> {
   const statusByScope = new Map<string, ImageBuildStatus>();
-  for (const image of images) {
+  for (const image of currentFingerprintBuilds(images, units)) {
     const key = imageBuildScopeKey(image.scopeKind, image.scopeId);
-    const currentFingerprint = currentFingerprintByScope.get(key);
-    if (currentFingerprint !== undefined && image.repositoriesFingerprint !== currentFingerprint) {
-      continue;
-    }
     const current = statusByScope.get(key);
     if (!current || STATUS_FOLD_PRECEDENCE[image.status] > STATUS_FOLD_PRECEDENCE[current]) {
       statusByScope.set(key, image.status);
     }
   }
   return statusByScope;
+}
+
+/**
+ * The newest countable build row for one scope (the feed is createdAt DESC).
+ * Answers the settings surfaces' question — "what did the latest build
+ * attempt do?" — which the rebuild/toggle controls act on. This can
+ * legitimately show `failed` while the picker's fold reports `ready` for the
+ * same scope (an older ready image still serves); the two must only ever
+ * disagree on precedence, never on which rows count.
+ */
+export function latestCurrentBuild(
+  feed: ImageBuildsFeed | undefined,
+  scopeKind: ImageBuildScopeKind,
+  scopeId: string
+): ImageBuildRecordView | undefined {
+  if (!feed) return undefined;
+  return currentFingerprintBuilds(feed.images, feed.units).find(
+    (image) => image.scopeKind === scopeKind && image.scopeId === scopeId
+  );
 }
 
 /**


### PR DESCRIPTION
The remaining Tier 5 items from the image-build cleanup review, re-verified against current main first. One was already fixed; the other two survived, one in a refined form. Net effect: one real display bug fixed, and the three copies of row-selection/mapping/pending-state logic collapsed to shared primitives.

## Already fixed on main — no changes

**"Quadruple defense against an impossible status"**: `excludeSupersededBuilds` now has exactly one production call site — the `/api/image-builds` fetch boundary — with a route test pinning it there. The three downstream re-defenses the review recorded are gone.

## The bug: settings surfaces showed stale-fingerprint rows

Both settings surfaces picked their display row with a bare `feed.images.find(scope match)` — the newest row for the scope **regardless of repo-set fingerprint** — while the session-target picker's fold ignores stale-fingerprint rows (as spawn does). So after a scope's repo set changes, settings could show a stale "Ready" image that spawn will never use, and the repo trigger button's `building` guard could be held hostage by a stale row.

Fix: `currentFingerprintBuilds(images, units)` extracts the row-eligibility rule the fold already implemented (current-fingerprint rows; scopes missing from `units` keep all rows; feed order preserved), and both `foldImageBuildStatusByScope` and the new `latestCurrentBuild(feed, scopeKind, scopeId)` selector are built on it. Both settings surfaces now use `latestCurrentBuild`.

### Deliberately NOT unified: fold precedence in settings

The review prescribed one shared "current row" selector for settings *and* picker. Sharing the fold's ready-first precedence in settings would be wrong for what settings is for:

- A scope whose newest current build **failed** while an older ready image serves would render "Ready" — hiding the failure from the one surface whose job is exposing it (with the error tooltip).
- The repo trigger button disables while the selected row is `building`; fold precedence prefers `ready` over `building`, so an in-flight rebuild would stop disabling the button and invite double-triggers.

So the two surfaces deliberately answer different questions — picker: "will spawn get a prebuilt image?" (ready-first fold); settings: "what did the latest attempt do?" (newest row) — but now agree on **which rows count**, which is the part of the disagreement that was a bug. Both docstrings state this contract.

## Dedup

- `ImageBuildStatus` now takes the feed row (`ImageBuildRecordView`) and derives its own display fields; the `ImageBuildStatusView` interface and the two identical call-site mapping blocks are gone.
- New `usePendingKeys()` hook replaces the four hand-rolled add/try/finally-delete `Set` rituals across the toggle/trigger handlers in both settings components (error handling and mutate keys stay per-handler — they differ).
- `images-settings` used hand-rolled `` `${owner}/${name}`.toLowerCase() `` in four places and re-derived the enabled-repo set inline; it now uses the existing `repoImageBuildScopeId` and `foldEnabledRepoScopeIds` helpers.

## Verification

- New tests: `currentFingerprintBuilds` (stale dropped, order preserved, no-unit fallback), `latestCurrentBuild` (newer stale row skipped for the newest current one; scope matching; undefined cases), a component-level test that a stale ready row no longer masks the current failed attempt, and `usePendingKeys` (pending during flight, cleared on throw, keys independent).
- Existing fold tests pass unchanged — the `currentFingerprintBuilds` extraction is behavior-preserving for the picker.
- Web battery 1314/1314, typecheck + eslint + prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Image build statuses now consistently reflect the latest build for the current repository version.
  - Stale or unrelated provider build records no longer override relevant results.
  - Build details and status information are displayed more accurately.
  - Images with stale builds now correctly show that no current image is available.

- **Improvements**
  - Rebuild controls remain disabled while a related build is in progress.
  - Environment and image actions track progress more reliably.
  - Concurrent actions are tracked independently and cleared correctly after success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->