### PR TITLE
Fix global command settings search

### DIFF
--- a/packages/web/src/components/global-command-menu.test.tsx
+++ b/packages/web/src/components/global-command-menu.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionListItem } from "@/lib/session-list";
 import { GlobalCommandMenu } from "./global-command-menu";
 
 expect.extend(matchers);
@@ -41,14 +42,14 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function renderMenu() {
+function renderMenu(sessions: SessionListItem[] = []) {
   const onOpenChange = vi.fn();
   const onNavigate = vi.fn();
   const props = {
     onOpenChange,
     onNavigate,
     onNewSession: vi.fn(),
-    sessions: [],
+    sessions,
   };
   const view = render(<GlobalCommandMenu open {...props} />);
   return { ...view, onNavigate, onOpenChange, props };
@@ -112,5 +113,27 @@ describe("GlobalCommandMenu", () => {
     renderMenu();
 
     expect(screen.queryByText("Images")).not.toBeInTheDocument();
+  });
+
+  it("preserves order-independent session search", async () => {
+    const user = userEvent.setup();
+    renderMenu([
+      {
+        id: "session-1",
+        title: "Investigate command search",
+        repoOwner: "open-inspect",
+        repoName: "background-agents",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ]);
+
+    await user.type(
+      screen.getByPlaceholderText("Search sessions, settings, and commands..."),
+      "background investigate"
+    );
+
+    await waitFor(() => expect(screen.getByText("Investigate command search")).toBeInTheDocument());
   });
 });

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { formatRelativeTime } from "@/lib/time";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
 import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
-import { DEFAULT_SETTINGS_QUERY, getSettingsGroups } from "@/components/settings/settings-registry";
+import { getSettingsGroups } from "@/components/settings/settings-registry";
 import {
   Command,
   CommandDialog,
@@ -44,6 +44,12 @@ function buildSessionUrl(session: SessionListItem): string {
   return query ? `/session/${session.id}?${query}` : `/session/${session.id}`;
 }
 
+function filterCommandItem(value: string, search: string, keywords?: string[]): number {
+  const searchText = `${value} ${keywords?.join(" ") ?? ""}`.toLowerCase();
+  const terms = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  return terms.every((term) => searchText.includes(term)) ? 1 : 0;
+}
+
 export function GlobalCommandMenu({
   open,
   onOpenChange,
@@ -52,16 +58,11 @@ export function GlobalCommandMenu({
   sessions,
 }: GlobalCommandMenuProps) {
   const { labels } = useKeyboardShortcuts();
-  const [query, setQuery] = useState(DEFAULT_SETTINGS_QUERY);
   const searchableSessions = useMemo(
     () => sessions.filter((session) => session.status !== "archived"),
     [sessions]
   );
-  const settingsGroups = getSettingsGroups({ query, includeGlobalAliases: true });
-
-  useEffect(() => {
-    if (!open) setQuery(DEFAULT_SETTINGS_QUERY);
-  }, [open]);
+  const settingsGroups = getSettingsGroups({ includeGlobalAliases: true });
 
   const handleSelect = (callback: () => void) => {
     onOpenChange(false);
@@ -74,11 +75,8 @@ export function GlobalCommandMenu({
       <DialogDescription className="sr-only">
         Search and jump to sessions, settings, automations, and other destinations.
       </DialogDescription>
-      <Command>
-        <CommandInput
-          placeholder="Search sessions, settings, and commands..."
-          onValueChange={setQuery}
-        />
+      <Command filter={filterCommandItem}>
+        <CommandInput placeholder="Search sessions, settings, and commands..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
 
@@ -110,7 +108,6 @@ export function GlobalCommandMenu({
                 return (
                   <CommandItem
                     key={item.id}
-                    forceMount
                     value={`settings ${group.label} ${item.label} ${item.description} ${item.keywords}`}
                     onSelect={() => handleSelect(() => onNavigate(`/settings?tab=${item.id}`))}
                     className="items-start"

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -5,6 +5,7 @@ import { formatRelativeTime } from "@/lib/time";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
+import { matchesSearchTerms } from "@/lib/search";
 import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
 import { getSettingsGroups } from "@/components/settings/settings-registry";
@@ -45,9 +46,7 @@ function buildSessionUrl(session: SessionListItem): string {
 }
 
 function filterCommandItem(value: string, search: string, keywords?: string[]): number {
-  const searchText = `${value} ${keywords?.join(" ") ?? ""}`.toLowerCase();
-  const terms = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
-  return terms.every((term) => searchText.includes(term)) ? 1 : 0;
+  return matchesSearchTerms(`${value} ${keywords?.join(" ") ?? ""}`, search) ? 1 : 0;
 }
 
 export function GlobalCommandMenu({
@@ -62,7 +61,7 @@ export function GlobalCommandMenu({
     () => sessions.filter((session) => session.status !== "archived"),
     [sessions]
   );
-  const settingsGroups = getSettingsGroups({ includeGlobalAliases: true });
+  const settingsGroups = getSettingsGroups();
 
   const handleSelect = (callback: () => void) => {
     onOpenChange(false);

--- a/packages/web/src/components/settings/settings-registry.ts
+++ b/packages/web/src/components/settings/settings-registry.ts
@@ -12,6 +12,7 @@ import {
   TerminalIcon,
 } from "@/components/ui/icons";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
+import { matchesSearchTerms } from "@/lib/search";
 
 export const SETTINGS_GROUPS = [
   {
@@ -132,7 +133,6 @@ type SettingsItem = (typeof SETTINGS_GROUPS)[number]["items"][number];
 export type SettingsCategory = SettingsItem["id"];
 export const DEFAULT_SETTINGS_CATEGORY: SettingsCategory = "secrets";
 export const DEFAULT_SETTINGS_QUERY = "";
-export const DEFAULT_INCLUDE_GLOBAL_SETTINGS_ALIASES = false;
 
 function isSettingsItemAvailable(item: SettingsItem, repoImagesEnabled: boolean): boolean {
   return !("requiresRepoImages" in item) || repoImagesEnabled;
@@ -141,21 +141,15 @@ function isSettingsItemAvailable(item: SettingsItem, repoImagesEnabled: boolean)
 export function getSettingsGroups({
   query = DEFAULT_SETTINGS_QUERY,
   repoImagesEnabled = supportsRepoImages(),
-  includeGlobalAliases = DEFAULT_INCLUDE_GLOBAL_SETTINGS_ALIASES,
 }: {
   query?: string;
   repoImagesEnabled?: boolean;
-  includeGlobalAliases?: boolean;
 } = {}) {
-  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
   return SETTINGS_GROUPS.map((group) => ({
     ...group,
     items: group.items.filter((item) => {
       if (!isSettingsItemAvailable(item, repoImagesEnabled)) return false;
-      const aliases = includeGlobalAliases ? `settings ${group.label}` : "";
-      const searchText =
-        `${aliases} ${item.label} ${item.description} ${item.keywords}`.toLowerCase();
-      return terms.every((term) => searchText.includes(term));
+      return matchesSearchTerms(`${item.label} ${item.description} ${item.keywords}`, query);
     }),
   })).filter((group) => group.items.length > 0);
 }

--- a/packages/web/src/lib/search.ts
+++ b/packages/web/src/lib/search.ts
@@ -1,0 +1,5 @@
+export function matchesSearchTerms(searchText: string, query: string): boolean {
+  const normalizedSearchText = searchText.toLowerCase();
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  return terms.every((term) => normalizedSearchText.includes(term));
+}


### PR DESCRIPTION
## Summary
- replace competing React and cmdk settings filters with one command-level all-term filter
- remove forced settings item mounting and query reset state
- preserve order-independent search for settings, navigation commands, and sessions
- add regression coverage for session search through the shared filter

## Verification
- `npm test -w @open-inspect/web` (170 files, 1,311 tests)
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-fix`
- browser verification at desktop viewport: searching `appearance` returns the Appearance settings destination
- production build compiles and passes TypeScript; prerender remains blocked by the existing `/ui-prototypes/provider-accounts` crash unrelated to this diff

## Artifact
![Global command search returning Appearance](linear-attachment://135ba03e208d3a3a43ffcd5cd969cefc)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3c43ceac7f30f69c8c4924a321088042)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command menu search to match multiple search terms regardless of their order.
  * Search now considers item names and available keywords for more accurate results.
  * Improved consistency across command menu and settings searches.
  * Simplified search behavior when closing and reopening the command menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->