### PR TITLE
feat(web): distinguish open details sidebar icon

### DIFF
--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -69,7 +69,7 @@ describe("SessionHeader", () => {
     expect(hideButton).toHaveClass("hidden", "lg:block");
     expect(hideButton).toHaveAttribute("aria-controls", "session-details-sidebar");
     expect(hideButton).toHaveAttribute("aria-expanded", "true");
-    expect(hideButton.querySelector('line[x1="15"][x2="15"]')).toBeInTheDocument();
+    expect(hideButton.querySelector('path[fill="currentColor"]')).toBeInTheDocument();
     expect(
       connectedStatus.compareDocumentPosition(hideButton) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
@@ -95,10 +95,10 @@ describe("SessionHeader", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: "Show session details" })).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
+    const showButton = screen.getByRole("button", { name: "Show session details" });
+    expect(showButton).toHaveAttribute("aria-expanded", "false");
+    expect(showButton.querySelector('line[x1="15"][x2="15"]')).toBeInTheDocument();
+    expect(showButton.querySelector('path[fill="currentColor"]')).not.toBeInTheDocument();
   });
 
   it("hides the desktop details toggle while changes own the right-hand surface", () => {

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -5,7 +5,7 @@ import type { SandboxStatus as SandboxStatusValue } from "@open-inspect/shared/t
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { MobileSessionActions } from "@/components/mobile-session-actions";
 import type { SessionActionProps } from "@/components/session-actions";
-import { BoxIcon, RightSidebarIcon } from "@/components/ui/icons";
+import { BoxIcon, RightSidebarIcon, RightSidebarOpenIcon } from "@/components/ui/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
@@ -242,7 +242,11 @@ export function SessionHeader({
               aria-controls="session-details-sidebar"
               aria-expanded={isDesktopDetailsOpen}
             >
-              <RightSidebarIcon className="h-4 w-4" />
+              {isDesktopDetailsOpen ? (
+                <RightSidebarOpenIcon className="h-4 w-4" />
+              ) : (
+                <RightSidebarIcon className="h-4 w-4" />
+              )}
             </button>
           )}
         </div>

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -39,6 +39,23 @@ export function RightSidebarIcon({ className }: IconProps) {
   );
 }
 
+export function RightSidebarOpenIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4z" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function BackIcon({ className }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
## Summary

- show a filled right rail when the desktop session-details sidebar is open
- preserve the existing outlined icon when the sidebar is closed
- keep the existing accessible labels, expanded state, and toggle behavior
- cover both icon states in the existing `SessionHeader` test

## Context

This is a maintainer-owned replacement for #1652 because the original contributor branch cannot be modified. It preserves the feature proposed by @ravidsrk while incorporating the requested formatting fix and aligning the implementation with the existing shared icon module and test suite.

Fixes #1476.

## Verification

- `npm test -w @open-inspect/web -- --run src/components/session-header.test.tsx`
- `npm test -w @open-inspect/web` (170 files, 1,311 tests)
- `npm run lint`
- `npm run typecheck -w @open-inspect/web`
- changed files pass Prettier

Repository-wide `npm run format:check` still reports the pre-existing `.opencode/package.json`, which is not modified by this PR.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8ca45b4473ac9e414919c05605d217b7)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct icon for the session details panel toggle when the panel is open.
  * The toggle now clearly indicates whether session details are shown or hidden.

* **Tests**
  * Updated coverage to verify the correct icon appears for each panel state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->