### PR TITLE
Refine settings and command composition

### DIFF
--- a/packages/web/src/components/app-destinations.ts
+++ b/packages/web/src/components/app-destinations.ts
@@ -1,0 +1,25 @@
+import { AutomationsIcon, DataControlsIcon, SettingsIcon } from "@/components/ui/icons";
+
+export const SETTINGS_DESTINATION = {
+  label: "Settings",
+  description: "Configure Open Inspect",
+  href: "/settings",
+  icon: SettingsIcon,
+} as const;
+
+export const PRIMARY_APP_DESTINATIONS = [
+  {
+    label: "Automations",
+    description: "Manage scheduled and event-triggered work",
+    href: "/automations",
+    icon: AutomationsIcon,
+  },
+  {
+    label: "Analytics",
+    description: "View usage across sessions, repositories, and users",
+    href: "/analytics",
+    icon: DataControlsIcon,
+  },
+] as const;
+
+export const APP_DESTINATIONS = [SETTINGS_DESTINATION, ...PRIMARY_APP_DESTINATIONS] as const;

--- a/packages/web/src/components/global-command-menu.test.tsx
+++ b/packages/web/src/components/global-command-menu.test.tsx
@@ -56,6 +56,52 @@ function renderMenu(sessions: SessionListItem[] = []) {
 }
 
 describe("GlobalCommandMenu", () => {
+  it("shows complete navigation with descriptions", () => {
+    renderMenu();
+
+    expect(screen.getByText("Start a coding session")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask a question or describe what you want to build")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Configure Open Inspect")).toBeInTheDocument();
+    expect(screen.getByText("Manage scheduled and event-triggered work")).toBeInTheDocument();
+    expect(
+      screen.getByText("View usage across sessions, repositories, and users")
+    ).toBeInTheDocument();
+  });
+
+  it("selects Analytics from the keyboard", async () => {
+    const user = userEvent.setup();
+    const { onNavigate, onOpenChange } = renderMenu();
+    const input = screen.getByRole("combobox", {
+      name: "Search commands, settings, and sessions",
+    });
+
+    await user.type(input, "analytics{Enter}");
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onNavigate).toHaveBeenCalledWith("/analytics");
+  });
+
+  it("shows keyboard guidance and updates the result count", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+    const input = screen.getByRole("combobox", {
+      name: "Search commands, settings, and sessions",
+    });
+    const count = screen.getByRole("status");
+
+    expect(count).toHaveTextContent(`${screen.getAllByRole("option").length} results`);
+    expect(screen.getByText("Navigate")).toBeInTheDocument();
+    expect(screen.getByText("Select")).toBeInTheDocument();
+    expect(screen.getByText("Close")).toBeInTheDocument();
+
+    await user.type(input, "no matching command destination");
+
+    await waitFor(() => expect(count).toHaveTextContent("0 results"));
+    expect(screen.getByText("No results found.")).toBeInTheDocument();
+  });
+
   it("navigates directly to a settings destination", async () => {
     const user = userEvent.setup();
     const { onNavigate, onOpenChange } = renderMenu();

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useMemo } from "react";
+import { useCommandState } from "cmdk";
 import { formatRelativeTime } from "@/lib/time";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
 import { matchesSearchTerms } from "@/lib/search";
-import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
+import {
+  AutomationsIcon,
+  BranchIcon,
+  DataControlsIcon,
+  PlusIcon,
+  SettingsIcon,
+} from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
 import { getSettingsGroups } from "@/components/settings/settings-registry";
 import {
@@ -49,6 +56,27 @@ function filterCommandItem(value: string, search: string, keywords?: string[]): 
   return matchesSearchTerms(`${value} ${keywords?.join(" ") ?? ""}`, search) ? 1 : 0;
 }
 
+function CommandMenuFooter() {
+  const count = useCommandState((state) => state.filtered.count);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t px-3 py-2 text-[11px] text-muted-foreground">
+      <span role="status" aria-live="polite" className="mr-auto">
+        {count} {count === 1 ? "result" : "results"}
+      </span>
+      <span>
+        <kbd className="font-sans text-foreground">↑↓</kbd> Navigate
+      </span>
+      <span>
+        <kbd className="font-sans text-foreground">Enter</kbd> Select
+      </span>
+      <span>
+        <kbd className="font-sans text-foreground">Esc</kbd> Close
+      </span>
+    </div>
+  );
+}
+
 export function GlobalCommandMenu({
   open,
   onOpenChange,
@@ -68,35 +96,73 @@ export function GlobalCommandMenu({
     callback();
   };
 
+  const navigationItems = [
+    {
+      label: "New session",
+      description: "Start a coding session",
+      Icon: PlusIcon,
+      onSelect: onNewSession,
+      shortcut: labels["new-session"],
+    },
+    {
+      label: "Home",
+      description: "Ask a question or describe what you want to build",
+      Icon: AppIcon,
+      onSelect: () => onNavigate("/"),
+      shortcut: undefined,
+    },
+    {
+      label: "Settings",
+      description: "Configure Open Inspect",
+      Icon: SettingsIcon,
+      onSelect: () => onNavigate("/settings"),
+      shortcut: undefined,
+    },
+    {
+      label: "Automations",
+      description: "Manage scheduled and event-triggered work",
+      Icon: AutomationsIcon,
+      onSelect: () => onNavigate("/automations"),
+      shortcut: undefined,
+    },
+    {
+      label: "Analytics",
+      description: "View usage across sessions, repositories, and users",
+      Icon: DataControlsIcon,
+      onSelect: () => onNavigate("/analytics"),
+      shortcut: undefined,
+    },
+  ];
+
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <DialogTitle className="sr-only">Command menu</DialogTitle>
       <DialogDescription className="sr-only">
         Search and jump to sessions, settings, automations, and other destinations.
       </DialogDescription>
-      <Command filter={filterCommandItem}>
+      <Command filter={filterCommandItem} label="Search commands, settings, and sessions">
         <CommandInput placeholder="Search sessions, settings, and commands..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
 
           <CommandGroup heading="Navigation">
-            <CommandItem onSelect={() => handleSelect(onNewSession)}>
-              <PlusIcon className="h-4 w-4" />
-              <span>New session</span>
-              <CommandShortcut>{labels["new-session"]}</CommandShortcut>
-            </CommandItem>
-            <CommandItem onSelect={() => handleSelect(() => onNavigate("/"))}>
-              <AppIcon className="h-4 w-4" />
-              <span>Home</span>
-            </CommandItem>
-            <CommandItem onSelect={() => handleSelect(() => onNavigate("/settings"))}>
-              <SettingsIcon className="h-4 w-4" />
-              <span>Settings</span>
-            </CommandItem>
-            <CommandItem onSelect={() => handleSelect(() => onNavigate("/automations"))}>
-              <AutomationsIcon className="h-4 w-4" />
-              <span>Automations</span>
-            </CommandItem>
+            {navigationItems.map(({ label, description, Icon, onSelect, shortcut }) => (
+              <CommandItem
+                key={label}
+                value={`${label} ${description}`}
+                onSelect={() => handleSelect(onSelect)}
+                className="items-start"
+              >
+                <span aria-hidden="true" className="mt-0.5 shrink-0">
+                  <Icon className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate">{label}</div>
+                  <div className="truncate text-xs text-muted-foreground">{description}</div>
+                </div>
+                {shortcut && <CommandShortcut>{shortcut}</CommandShortcut>}
+              </CommandItem>
+            ))}
           </CommandGroup>
 
           <CommandSeparator />
@@ -154,6 +220,7 @@ export function GlobalCommandMenu({
             </>
           )}
         </CommandList>
+        <CommandMenuFooter />
       </Command>
     </CommandDialog>
   );

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -7,14 +7,9 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 import { buildSessionSearchValue, type SessionListItem } from "@/lib/session-list";
 import { matchesSearchTerms } from "@/lib/search";
-import {
-  AutomationsIcon,
-  BranchIcon,
-  DataControlsIcon,
-  PlusIcon,
-  SettingsIcon,
-} from "@/components/ui/icons";
+import { BranchIcon, PlusIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
+import { APP_DESTINATIONS } from "@/components/app-destinations";
 import { getSettingsGroups } from "@/components/settings/settings-registry";
 import {
   Command,
@@ -111,27 +106,13 @@ export function GlobalCommandMenu({
       onSelect: () => onNavigate("/"),
       shortcut: undefined,
     },
-    {
-      label: "Settings",
-      description: "Configure Open Inspect",
-      Icon: SettingsIcon,
-      onSelect: () => onNavigate("/settings"),
+    ...APP_DESTINATIONS.map(({ label, description, href, icon: Icon }) => ({
+      label,
+      description,
+      Icon,
+      onSelect: () => onNavigate(href),
       shortcut: undefined,
-    },
-    {
-      label: "Automations",
-      description: "Manage scheduled and event-triggered work",
-      Icon: AutomationsIcon,
-      onSelect: () => onNavigate("/automations"),
-      shortcut: undefined,
-    },
-    {
-      label: "Analytics",
-      description: "View usage across sessions, repositories, and users",
-      Icon: DataControlsIcon,
-      onSelect: () => onNavigate("/analytics"),
-      shortcut: undefined,
-    },
+    })),
   ];
 
   return (

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -90,6 +90,17 @@ afterEach(() => {
 });
 
 describe("SessionSidebar", () => {
+  it("renders the shared application destinations", () => {
+    render(<SessionSidebar />);
+
+    expect(screen.getByTitle("Settings")).toHaveAttribute("href", "/settings");
+    expect(screen.getByRole("link", { name: "Automations" })).toHaveAttribute(
+      "href",
+      "/automations"
+    );
+    expect(screen.getByRole("link", { name: "Analytics" })).toHaveAttribute("href", "/analytics");
+  });
+
   it("renders server-classified sections and nested descendants", () => {
     render(<SessionSidebar />);
 

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -9,15 +9,8 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useSidebarSessions } from "@/hooks/use-sidebar-sessions";
 import type { SessionItem } from "@/hooks/use-sidebar-sessions";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import {
-  SidebarIcon,
-  PlusIcon,
-  SearchIcon,
-  SettingsIcon,
-  AutomationsIcon,
-  DataControlsIcon,
-  ChevronRightIcon,
-} from "@/components/ui/icons";
+import { SidebarIcon, PlusIcon, SearchIcon, ChevronRightIcon } from "@/components/ui/icons";
+import { PRIMARY_APP_DESTINATIONS, SETTINGS_DESTINATION } from "@/components/app-destinations";
 import { Button } from "@/components/ui/button";
 import { useEnvironments } from "@/hooks/use-environments";
 import { SessionWithChildren } from "@/components/session-with-children";
@@ -126,6 +119,7 @@ export function SessionSidebar({
       onSessionSelect?.();
     }
   }, [isMobile, onSessionSelect]);
+  const SettingsDestinationIcon = SETTINGS_DESTINATION.icon;
 
   const renderSessionGroup = (
     title: string,
@@ -210,46 +204,37 @@ export function SessionSidebar({
         <div className="flex shrink-0 items-center gap-2">
           <NewSessionButton onClick={onNewSession} />
           <Link
-            href="/settings"
+            href={SETTINGS_DESTINATION.href}
             onClick={handleNavigationSelect}
             className={`p-1.5 transition ${
-              pathname === "/settings"
+              pathname === SETTINGS_DESTINATION.href
                 ? "text-foreground bg-muted"
                 : "text-muted-foreground hover:text-foreground hover:bg-muted"
             }`}
-            title="Settings"
+            title={SETTINGS_DESTINATION.label}
           >
-            <SettingsIcon className="w-4 h-4" />
+            <SettingsDestinationIcon className="w-4 h-4" />
           </Link>
         </div>
       </div>
 
       {/* Nav links */}
       <div className="px-3 pt-2 pb-1 flex flex-col gap-0.5">
-        <Link
-          href="/automations"
-          onClick={handleNavigationSelect}
-          className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
-            pathname?.startsWith("/automations")
-              ? "text-foreground bg-muted"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted"
-          }`}
-        >
-          <AutomationsIcon className="w-4 h-4" />
-          Automations
-        </Link>
-        <Link
-          href="/analytics"
-          onClick={handleNavigationSelect}
-          className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
-            pathname?.startsWith("/analytics")
-              ? "text-foreground bg-muted"
-              : "text-muted-foreground hover:text-foreground hover:bg-muted"
-          }`}
-        >
-          <DataControlsIcon className="w-4 h-4" />
-          Analytics
-        </Link>
+        {PRIMARY_APP_DESTINATIONS.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            onClick={handleNavigationSelect}
+            className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
+              pathname?.startsWith(href)
+                ? "text-foreground bg-muted"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            <Icon className="w-4 h-4" />
+            {label}
+          </Link>
+        ))}
       </div>
 
       <div className="px-3 py-2">

--- a/packages/web/src/components/settings/integrations/enablement-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/enablement-integration-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
@@ -10,6 +10,7 @@ import {
 import type { EnrichedRepository } from "@open-inspect/shared/types/repository-catalog";
 import type { IntegrationId, IntegrationEntry } from "@open-inspect/shared/types/integrations";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
+import { SettingsCardSection } from "../settings-card-section";
 import { Button } from "@/components/ui/button";
 import { RadioCard } from "@/components/ui/form-controls";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
@@ -97,14 +98,14 @@ export function EnablementIntegrationSettings({ copy }: { copy: EnablementIntegr
         copy={copy}
       />
 
-      <Section title="Repository Overrides" description={copy.overrideDescription}>
+      <SettingsCardSection title="Repository Overrides" description={copy.overrideDescription}>
         <RepoOverridesSection
           overrides={repoOverrides}
           availableRepos={availableRepos}
           settingsKey={repoSettingsKey}
           copy={copy}
         />
-      </Section>
+      </SettingsCardSection>
     </div>
   );
 }
@@ -207,7 +208,7 @@ function GlobalSettingsSection({
   };
 
   return (
-    <Section title="Defaults & Scope" description={copy.scopeDescription}>
+    <SettingsCardSection title="Defaults & Scope" description={copy.scopeDescription}>
       <div className="mb-4">
         <label className="flex items-center justify-between px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
           <div>
@@ -312,7 +313,7 @@ function GlobalSettingsSection({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Section>
+    </SettingsCardSection>
   );
 }
 
@@ -492,25 +493,5 @@ function RepoOverrideRow({
         </Button>
       </div>
     </div>
-  );
-}
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
-        {title}
-      </h3>
-      <p className="text-sm text-muted-foreground mb-4">{description}</p>
-      {children}
-    </section>
   );
 }

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
@@ -21,6 +21,7 @@ import {
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
+import { SettingsCardSection } from "../settings-card-section";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
@@ -90,7 +91,10 @@ export function LinearIntegrationSettings() {
         sessions.
       </p>
 
-      <Section title="Connection" description="Linear uses control-plane repository access.">
+      <SettingsCardSection
+        title="Connection"
+        description="Linear uses control-plane repository access."
+      >
         {availableRepos.length > 0 ? (
           <p className="text-sm text-muted-foreground">
             Repository access is available. You can target all repos or limit the integration to a
@@ -102,7 +106,7 @@ export function LinearIntegrationSettings() {
             unavailable until repository access is configured.
           </p>
         )}
-      </Section>
+      </SettingsCardSection>
 
       <GlobalSettingsSection
         settings={settings}
@@ -110,7 +114,7 @@ export function LinearIntegrationSettings() {
         enabledModelOptions={enabledModelOptions}
       />
 
-      <Section
+      <SettingsCardSection
         title="Repository Overrides"
         description="Override model selection and behavior for specific repositories."
       >
@@ -119,7 +123,7 @@ export function LinearIntegrationSettings() {
           availableRepos={availableRepos}
           enabledModelOptions={enabledModelOptions}
         />
-      </Section>
+      </SettingsCardSection>
     </div>
   );
 }
@@ -262,7 +266,7 @@ function GlobalSettingsSection({
   };
 
   return (
-    <Section
+    <SettingsCardSection
       title="Defaults & Scope"
       description="Global model, fallback behavior, and repository scope."
     >
@@ -433,7 +437,7 @@ function GlobalSettingsSection({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Section>
+    </SettingsCardSection>
   );
 }
 
@@ -701,26 +705,6 @@ function RepoOverrideRow({
         </Button>
       </div>
     </div>
-  );
-}
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
-        {title}
-      </h3>
-      <p className="text-sm text-muted-foreground mb-4">{description}</p>
-      {children}
-    </section>
   );
 }
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import { DEFAULT_MENTIONS_POLICY } from "@open-inspect/shared/slack";
@@ -28,6 +28,7 @@ import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { ENVIRONMENTS_KEY } from "@/hooks/use-environments";
 import { environmentOptionValue, parseEnvironmentOptionValue } from "@/lib/session-target";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
+import { SettingsCardSection } from "../settings-card-section";
 import { Button } from "@/components/ui/button";
 import { APP_NAME } from "@/lib/site-config";
 import { RadioCard } from "@/components/ui/form-controls";
@@ -142,7 +143,7 @@ export function SlackIntegrationSettings() {
         the control plane — the Slack token never enters the sandbox.
       </p>
 
-      <Section
+      <SettingsCardSection
         title="Channel access"
         description={`${APP_NAME} does not maintain its own channel allowlist.`}
       >
@@ -151,7 +152,7 @@ export function SlackIntegrationSettings() {
           Slack. The bot can post only to channels it&apos;s a member of; remove access by kicking
           the bot from the channel.
         </p>
-      </Section>
+      </SettingsCardSection>
 
       <GlobalSettingsSection settings={settings} />
 
@@ -163,12 +164,12 @@ export function SlackIntegrationSettings() {
         environmentsLoaded={environmentsLoaded}
       />
 
-      <Section
+      <SettingsCardSection
         title="Repository overrides"
         description="Override the master switch for specific repositories. Mentions policy is workspace-wide and is not overridable per repo."
       >
         <RepoOverridesSection overrides={repoOverrides} availableRepos={availableRepos} />
-      </Section>
+      </SettingsCardSection>
     </div>
   );
 }
@@ -278,7 +279,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   };
 
   return (
-    <Section
+    <SettingsCardSection
       title="Defaults"
       description="Workspace-wide settings for agent-initiated Slack posts."
     >
@@ -428,7 +429,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Section>
+    </SettingsCardSection>
   );
 }
 
@@ -743,7 +744,7 @@ function RoutingRulesSection({
   ));
 
   return (
-    <Section
+    <SettingsCardSection
       title="Routing rules"
       description="Map keywords to repositories or environments. When a Slack message contains a keyword, the agent is routed to that target before falling back to channel association or automatic detection."
     >
@@ -870,26 +871,6 @@ function RoutingRulesSection({
         Keywords match whole words, case-insensitively. Point each keyword at one repository or
         environment; the same keyword on two targets will prompt for a choice instead of guessing.
       </p>
-    </Section>
-  );
-}
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h3 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
-        {title}
-      </h3>
-      <p className="text-sm text-muted-foreground mb-4">{description}</p>
-      {children}
-    </section>
+    </SettingsCardSection>
   );
 }

--- a/packages/web/src/components/settings/scm-settings.tsx
+++ b/packages/web/src/components/settings/scm-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
@@ -10,6 +10,7 @@ import {
 } from "@open-inspect/shared/types/integrations";
 import type { EnrichedRepository } from "@open-inspect/shared/types/repository-catalog";
 import { IntegrationSettingsSkeleton } from "./integrations/integration-settings-skeleton";
+import { SettingsCardSection } from "./settings-card-section";
 import {
   getScmRepoSettingsPath,
   SCM_GLOBAL_SETTINGS_KEY,
@@ -142,7 +143,7 @@ export function ScmSettingsPage() {
 
       <GlobalSettingsSection settings={settings} />
 
-      <Section
+      <SettingsCardSection
         title="Repository Overrides"
         description="Override pull and merge request defaults for specific repositories."
       >
@@ -152,7 +153,7 @@ export function ScmSettingsPage() {
           globalDefault={settings?.defaults?.alwaysUseDraftMode ?? DEFAULT_ALWAYS_USE_DRAFT_MODE}
           globalLabel={settings?.defaults?.pullRequestLabel}
         />
-      </Section>
+      </SettingsCardSection>
     </div>
   );
 }
@@ -236,7 +237,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
   };
 
   return (
-    <Section
+    <SettingsCardSection
       title="Defaults"
       description="Apply to pull and merge requests created by sessions across all repositories."
     >
@@ -305,7 +306,7 @@ function GlobalSettingsSection({ settings }: { settings: ScmGlobalConfig | null 
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Section>
+    </SettingsCardSection>
   );
 }
 
@@ -532,25 +533,5 @@ function RepoOverrideRow({
         </label>
       </div>
     </div>
-  );
-}
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="border border-border-muted rounded-md p-5 mb-5">
-      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
-        {title}
-      </h4>
-      <p className="text-sm text-muted-foreground mb-4">{description}</p>
-      {children}
-    </section>
   );
 }

--- a/packages/web/src/components/settings/settings-card-section.tsx
+++ b/packages/web/src/components/settings/settings-card-section.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function SettingsCardSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mb-5 rounded-md border border-border-muted p-5">
+      <h3 className="mb-1 text-sm font-semibold uppercase tracking-wider text-foreground">
+        {title}
+      </h3>
+      <p className="mb-4 text-sm text-muted-foreground">{description}</p>
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- extract a shared settings card section and replace four duplicate implementations across SCM, Code Server/VNC, Slack, and Linear settings
- add Analytics and supporting descriptions to global command navigation
- add an accessible command-search label, live result count, and keyboard guidance
- cover destination parity, keyboard selection, descriptions, and count updates

## Validation
- `npm test -w @open-inspect/web` (170 files, 1,314 tests)
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-fix`
- Prettier and `git diff --check`
- desktop and mobile browser verification for the command menu and Slack settings cards

## Visuals

### Command menu
![Desktop command menu](linear-attachment://8929c62c0bab8d6475ef00741508b7b5)

![Mobile command menu](linear-attachment://6d840efcd8ff1e4c7a6c640790c0f5a8)

### Shared settings cards
![Desktop settings cards](linear-attachment://fca172df88fb037ffde7c7c16e847fe3)

![Mobile settings cards](linear-attachment://d8887793d77af5c67033078805e0102b)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3c43ceac7f30f69c8c4924a321088042)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified navigation destinations across the command menu and sidebar, including Settings, Automations, and Analytics.
  - Added descriptive navigation text, improved icons, keyboard guidance, live result counts, and an empty-results message.
  - Selecting a matching command now navigates to the destination and closes the menu.
  - Standardized settings sections with consistent card-style presentation across integrations and source-control settings.

- **Tests**
  - Added coverage for navigation links, descriptions, keyboard interactions, result counts, and empty search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->