### PR TITLE
fix: allow bot completion event reads

### DIFF
--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -78,6 +78,8 @@ describe("route policy table", () => {
     ],
     ["GET", "/integration-settings/slack/watched-channels", [{ service: "slack-bot" }]],
     ["GET", "/model-preferences", [{ service: "slack-bot" }]],
+    ["GET", "/sessions/session-1/events", [{ service: "slack-bot" }, { service: "linear-bot" }]],
+    ["GET", "/sessions/session-1/artifacts", [{ service: "slack-bot" }, { service: "linear-bot" }]],
   ])("declares the exact actorless grants for %s %s", (method, path, expected) => {
     const authorization = routeFor(method, path)?.authorization;
     expect(["active-user", "active-global"]).toContain(authorization?.kind);
@@ -99,6 +101,8 @@ describe("route policy table", () => {
       routeFor("GET", "/integration-settings/github/resolved/acme/widgets"),
       routeFor("GET", "/integration-settings/slack/watched-channels"),
       routeFor("GET", "/model-preferences"),
+      routeFor("GET", "/sessions/session-1/events"),
+      routeFor("GET", "/sessions/session-1/artifacts"),
       routeFor("POST", "/sessions/session-1/stop"),
       routeFor("GET", "/sessions/session-1/media/artifact-1"),
     ]);

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -357,7 +357,9 @@ export const sessionRuntimeProxyRoutes: Route[] = [
     method: "GET",
     routePath: "/sessions/:id/events",
     internalPath: SessionInternalPaths.events,
-    authorization: requirePermission("sessions.read"),
+    authorization: requirePermission("sessions.read", {
+      actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
+    }),
     forwardSearch: true,
   }),
   simpleProxyRoute({
@@ -365,7 +367,9 @@ export const sessionRuntimeProxyRoutes: Route[] = [
     method: "GET",
     routePath: "/sessions/:id/artifacts",
     internalPath: SessionInternalPaths.artifacts,
-    authorization: requirePermission("sessions.read"),
+    authorization: requirePermission("sessions.read", {
+      actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
+    }),
   }),
   simpleProxyRoute({
     policy: GITHUB_USER_OR_SERVICE_ROUTE,

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -327,7 +327,7 @@ describe("sig1 service-credential authentication", () => {
     });
   });
 
-  it("allows only narrow actorless session callbacks", async () => {
+  it("allows only narrow actorless session callbacks and completion reads", async () => {
     const created = await signedFetch({
       service: "linear-bot",
       method: "POST",
@@ -347,6 +347,17 @@ describe("sig1 service-credential authentication", () => {
       url: `https://test.local/sessions/${sessionId}/stop`,
     });
     expect(linearStop.status).not.toBe(403);
+
+    for (const service of ["slack-bot", "linear-bot"] as const) {
+      for (const path of ["events", "artifacts"] as const) {
+        const completionRead = await signedFetch({
+          service,
+          method: "GET",
+          url: `https://test.local/sessions/${sessionId}/${path}`,
+        });
+        expect(completionRead.status, `${service} GET ${path}`).not.toBe(403);
+      }
+    }
 
     const slackMedia = await signedFetch({
       service: "slack-bot",


### PR DESCRIPTION
## Summary

- allow the Slack and Linear bot services to read session events and artifacts without an asserted user actor
- keep the exception scoped to the two completion-extractor endpoints and protected by each service's `sessions.read` permission ceiling
- add route-policy and integration coverage for the exact actorless allowlist

## Root cause

The RBAC HTTP-boundary change made `GET /sessions/:id/events` and `GET /sessions/:id/artifacts` actor-required routes. Slack and Linear completion callbacks use the shared extractor after the original request has completed, and the queued callback does not carry an actor assertion. Production telemetry confirmed Slack authenticated successfully as a service principal but was rejected with HTTP 403 before any D1 query.

The media endpoint already has the equivalent narrow Slack actorless grant; this change restores the prerequisite completion reads without weakening other session routes.

## Validation

- `npm test -w @open-inspect/control-plane -- src/router.policy.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/service-auth.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- ESLint and Prettier checks on changed files

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6c1b1679156a928d0aa8a590ceeb3029)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack and Linear bot integrations can now access session event and artifact completion-read endpoints without a user actor.

* **Bug Fixes**
  * Corrected authorization for actorless session completion reads while preserving existing restrictions on unrelated callbacks and media access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->