### PR TITLE
fix: improve RBAC audit event fidelity

### DIFF
--- a/packages/control-plane/src/db/authorization-store.test.ts
+++ b/packages/control-plane/src/db/authorization-store.test.ts
@@ -64,6 +64,7 @@ describe("AuthorizationStore", () => {
 
   it.each([
     "applied",
+    "no_op",
     "actor_authorization_changed",
     "role_not_found",
     "member_not_found",

--- a/packages/control-plane/src/db/authorization-store.ts
+++ b/packages/control-plane/src/db/authorization-store.ts
@@ -59,6 +59,7 @@ interface AuditInput {
   targetUserId?: string | null;
   reasonCode: string;
   occurredAt: number;
+  metadata: SqlCondition;
 }
 
 interface SqlCondition {
@@ -91,6 +92,7 @@ function anotherUnsuspendedOwner(targetUserId: string): SqlCondition {
 /** Result of an atomic RBAC mutation after authorization and invariant checks. */
 export type AuthorizationMutationOutcome =
   | { status: "applied" }
+  | { status: "no_op" }
   | { status: "actor_authorization_changed" }
   | { status: "role_not_found" }
   | { status: "member_not_found" }
@@ -222,20 +224,28 @@ export class AuthorizationStore {
     const transferGuard = rolePermissionPredicate("workspace.transfer_ownership");
     const targetIsOwner = userIsOwner(input.targetUserId);
     const otherOwnerExists = anotherUnsuspendedOwner(input.targetUserId);
+    const stateChanged: SqlCondition = {
+      sql: `EXISTS (
+        SELECT 1 FROM user_role_assignments
+        WHERE user_id = ? AND role_id <> ?
+      )`,
+      values: [input.targetUserId, input.roleId],
+    };
     const mutation = this.mutationConditions(
       input.actorUserId,
       ["workspace.members.manage"],
       {
         sql: `EXISTS (SELECT 1 FROM roles WHERE id = ?)
             AND EXISTS (SELECT 1 FROM user_role_assignments WHERE user_id = ?)
-            AND (
+            AND (NOT (${stateChanged.sql}) OR (
               ? = ?
               OR NOT (${targetIsOwner.sql})
               OR (${otherOwnerExists.sql})
-            )`,
+            ))`,
         values: [
           input.roleId,
           input.targetUserId,
+          ...stateChanged.values,
           input.roleId,
           OWNER_ROLE_ID,
           ...targetIsOwner.values,
@@ -244,8 +254,16 @@ export class AuthorizationStore {
       },
       {
         actor: {
-          sql: `(? <> ? AND NOT (${targetIsOwner.sql})) OR ${transferGuard.sql}`,
-          values: [input.roleId, OWNER_ROLE_ID, ...targetIsOwner.values, ...transferGuard.values],
+          sql: `NOT (${stateChanged.sql})
+            OR (? <> ? AND NOT (${targetIsOwner.sql}))
+            OR ${transferGuard.sql}`,
+          values: [
+            ...stateChanged.values,
+            input.roleId,
+            OWNER_ROLE_ID,
+            ...targetIsOwner.values,
+            ...transferGuard.values,
+          ],
         },
         notFound: [
           {
@@ -263,7 +281,8 @@ export class AuthorizationStore {
             },
           },
         ],
-      }
+      },
+      stateChanged
     );
     const results = await this.db.batch([
       mutation.outcome,
@@ -277,8 +296,19 @@ export class AuthorizationStore {
           targetUserId: input.targetUserId,
           reasonCode: "member_role_updated",
           occurredAt: input.now,
+          metadata: {
+            sql: `json_object(
+              'before', json_object('roleId', (
+                SELECT role_id FROM user_role_assignments WHERE user_id = ?
+              )),
+              'requested', json_object('roleId', ?),
+              'after', json_object('roleId', ?)
+            )`,
+            values: [input.targetUserId, input.roleId, input.roleId],
+          },
         },
-        mutation.applied,
+        mutation.audit,
+        stateChanged,
         mutation.auditId
       ),
       this.db
@@ -305,6 +335,13 @@ export class AuthorizationStore {
     const transferGuard = rolePermissionPredicate("workspace.transfer_ownership");
     const targetIsOwner = userIsOwner(input.targetUserId);
     const otherOwnerExists = anotherUnsuspendedOwner(input.targetUserId);
+    const stateChanged: SqlCondition = {
+      sql: `EXISTS (
+        SELECT 1 FROM users WHERE id = ?
+          AND ((? = 1 AND suspended_at IS NULL) OR (? = 0 AND suspended_at IS NOT NULL))
+      )`,
+      values: [input.targetUserId, input.suspended ? 1 : 0, input.suspended ? 1 : 0],
+    };
     const mutation = this.mutationConditions(
       input.actorUserId,
       ["workspace.members.manage"],
@@ -314,13 +351,14 @@ export class AuthorizationStore {
             JOIN user_role_assignments ON user_role_assignments.user_id = users.id
             WHERE users.id = ?
           )
-          AND (
+          AND (NOT (${stateChanged.sql}) OR (
             ? = 0
             OR NOT (${targetIsOwner.sql})
             OR (${otherOwnerExists.sql})
-          )`,
+          ))`,
         values: [
           input.targetUserId,
+          ...stateChanged.values,
           input.suspended ? 1 : 0,
           ...targetIsOwner.values,
           ...otherOwnerExists.values,
@@ -328,8 +366,8 @@ export class AuthorizationStore {
       },
       {
         actor: {
-          sql: `NOT (${targetIsOwner.sql}) OR ${transferGuard.sql}`,
-          values: [...targetIsOwner.values, ...transferGuard.values],
+          sql: `NOT (${stateChanged.sql}) OR NOT (${targetIsOwner.sql}) OR ${transferGuard.sql}`,
+          values: [...stateChanged.values, ...targetIsOwner.values, ...transferGuard.values],
         },
         notFound: [
           {
@@ -344,7 +382,8 @@ export class AuthorizationStore {
             },
           },
         ],
-      }
+      },
+      stateChanged
     );
     const statements: SqlStatement[] = [
       mutation.outcome,
@@ -358,8 +397,36 @@ export class AuthorizationStore {
           targetUserId: input.targetUserId,
           reasonCode: "member_status_updated",
           occurredAt: input.now,
+          metadata: {
+            sql: `json_object(
+              'before', json_object(
+                'suspended', CASE
+                  WHEN (SELECT suspended_at FROM users WHERE id = ?) IS NULL
+                  THEN json('false') ELSE json('true') END,
+                'suspendedAt', (SELECT suspended_at FROM users WHERE id = ?)
+              ),
+              'requested', json_object('suspended', json(?)),
+              'after', json_object(
+                'suspended', json(?),
+                'suspendedAt', CASE
+                  WHEN ${stateChanged.sql} THEN ?
+                  ELSE (SELECT suspended_at FROM users WHERE id = ?)
+                END
+              )
+            )`,
+            values: [
+              input.targetUserId,
+              input.targetUserId,
+              input.suspended ? "true" : "false",
+              input.suspended ? "true" : "false",
+              ...stateChanged.values,
+              input.suspended ? input.now : null,
+              input.targetUserId,
+            ],
+          },
         },
-        mutation.applied,
+        mutation.audit,
+        stateChanged,
         mutation.auditId
       ),
     ];
@@ -391,13 +458,14 @@ export class AuthorizationStore {
     actorUserId: string,
     permissions: PermissionId[],
     resourceCondition: SqlCondition,
-    options?: {
+    options: {
       actor?: SqlCondition;
       notFound?: Array<{ status: NotFoundStatus; condition: SqlCondition }>;
-    }
+    },
+    stateChanged: SqlCondition
   ): {
     outcome: SqlStatement;
-    applied: SqlCondition;
+    audit: SqlCondition;
     writes: SqlCondition;
     auditId: string;
   } {
@@ -409,21 +477,21 @@ export class AuthorizationStore {
            JOIN roles r ON r.id = ura.role_id
            WHERE u.id = ? AND u.suspended_at IS NULL
                AND ${permissionGuards.map((guard) => guard.sql).join(" AND ")}
-               ${options?.actor ? `AND (${options.actor.sql})` : ""}
+                ${options.actor ? `AND (${options.actor.sql})` : ""}
          )`,
       values: [
         actorUserId,
         ...permissionGuards.flatMap((guard) => guard.values),
-        ...(options?.actor?.values ?? []),
+        ...(options.actor?.values ?? []),
       ],
     };
-    const applied: SqlCondition = {
+    const audit: SqlCondition = {
       sql: `(${actor.sql}) AND (${resourceCondition.sql})`,
       values: [...actor.values, ...resourceCondition.values],
     };
     const auditId = crypto.randomUUID();
     const notFoundCases =
-      options?.notFound
+      options.notFound
         ?.map(({ status, condition }) => `WHEN (${condition.sql}) THEN '${status}'`)
         .join("\n             ") ?? "";
     return {
@@ -433,17 +501,22 @@ export class AuthorizationStore {
              WHEN NOT (${actor.sql}) THEN 'actor_authorization_changed'
              ${notFoundCases}
              WHEN NOT (${resourceCondition.sql}) THEN 'conflict'
+             WHEN NOT (${stateChanged.sql}) THEN 'no_op'
              ELSE 'applied'
            END AS status`
         )
         .bind(
           ...actor.values,
-          ...(options?.notFound?.flatMap(({ condition }) => condition.values) ?? []),
-          ...resourceCondition.values
+          ...(options.notFound?.flatMap(({ condition }) => condition.values) ?? []),
+          ...resourceCondition.values,
+          ...stateChanged.values
         ),
-      applied,
+      audit,
       writes: {
-        sql: "EXISTS (SELECT 1 FROM authorization_audit_events WHERE id = ?)",
+        sql: `EXISTS (
+          SELECT 1 FROM authorization_audit_events
+          WHERE id = ? AND operation_result = 'applied'
+        )`,
         values: [auditId],
       },
       auditId,
@@ -454,6 +527,7 @@ export class AuthorizationStore {
     const status = (result.results[0] as { status?: unknown } | undefined)?.status;
     if (
       status !== "applied" &&
+      status !== "no_op" &&
       status !== "actor_authorization_changed" &&
       status !== "role_not_found" &&
       status !== "member_not_found" &&
@@ -467,6 +541,7 @@ export class AuthorizationStore {
   private auditStatement(
     input: AuditInput,
     condition: SqlCondition,
+    stateChanged: SqlCondition,
     auditId: string
   ): SqlStatement {
     return this.db
@@ -474,8 +549,11 @@ export class AuthorizationStore {
         `INSERT INTO authorization_audit_events
           (id, occurred_at, request_id, principal_kind,
            actor_user_id_snapshot, action, resource_type, resource_id,
-           target_user_id_snapshot, reason_code)
-         SELECT ?, ?, ?, 'user', ?, ?, ?, ?, ?, ? WHERE ${condition.sql}`
+            target_user_id_snapshot, reason_code, operation_result, metadata_json)
+         SELECT ?, ?, ?, 'user', ?, ?, ?, ?, ?, ?,
+                CASE WHEN ${stateChanged.sql} THEN 'applied' ELSE 'no_op' END,
+                ${input.metadata.sql}
+         WHERE ${condition.sql}`
       )
       .bind(
         auditId,
@@ -487,6 +565,8 @@ export class AuthorizationStore {
         input.resourceId ?? null,
         input.targetUserId ?? null,
         input.reasonCode,
+        ...stateChanged.values,
+        ...input.metadata.values,
         ...condition.values
       );
   }

--- a/packages/control-plane/src/db/user-merge.ts
+++ b/packages/control-plane/src/db/user-merge.ts
@@ -363,7 +363,7 @@ export async function mergeUsers(
         `INSERT INTO authorization_audit_events
             (id, occurred_at, request_id, principal_kind,
              actor_service_snapshot, action, resource_type, resource_id,
-             target_user_id_snapshot, reason_code)
+             target_user_id_snapshot, reason_code, operation_result, metadata_json)
          VALUES (
            ?,
            CASE WHEN EXISTS (
@@ -380,11 +380,53 @@ export async function mergeUsers(
                AND (survivor.suspended_at IS NULL) = (loser.suspended_at IS NULL)
                AND (role.key IS NULL OR role.key <> 'owner' OR survivor.suspended_at IS NULL)
            ) THEN ? ELSE NULL END,
-           'user-merge', 'service', 'control-plane',
-           'workspace.user_merged', 'user', ?, ?, 'operator_merge'
-         )`
+            'operator-cli:' || ?, 'service', 'operator-cli',
+            'workspace.user_merged', 'user', ?, ?, 'operator_merge', 'applied',
+            json_object(
+              'before', json_object(
+                'survivor', json_object(
+                  'userId', ?,
+                  'roleId', (SELECT role_id FROM user_role_assignments WHERE user_id = ?),
+                  'suspendedAt', (SELECT suspended_at FROM users WHERE id = ?)
+                ),
+                'loser', json_object(
+                  'userId', ?,
+                  'roleId', (SELECT role_id FROM user_role_assignments WHERE user_id = ?),
+                  'suspendedAt', (SELECT suspended_at FROM users WHERE id = ?)
+                )
+              ),
+              'requested', json_object('survivorUserId', ?, 'loserUserId', ?),
+              'after', json_object(
+                'survivor', json_object(
+                  'userId', ?,
+                  'roleId', (SELECT role_id FROM user_role_assignments WHERE user_id = ?),
+                  'suspendedAt', (SELECT suspended_at FROM users WHERE id = ?)
+                ),
+                'loser', NULL
+              )
+            )
+          )`
       )
-      .bind(auditId, loserId, survivorId, occurredAt, survivorId, loserId)
+      .bind(
+        auditId,
+        loserId,
+        survivorId,
+        occurredAt,
+        auditId,
+        survivorId,
+        loserId,
+        survivorId,
+        survivorId,
+        survivorId,
+        loserId,
+        loserId,
+        loserId,
+        survivorId,
+        loserId,
+        survivorId,
+        survivorId,
+        survivorId
+      )
   );
 
   // Dedup before re-pointing: drop loser rows whose target slot the survivor

--- a/packages/control-plane/test/integration/migration-0072-rbac-audit-fidelity.test.ts
+++ b/packages/control-plane/test/integration/migration-0072-rbac-audit-fidelity.test.ts
@@ -30,27 +30,32 @@ afterEach(async () => {
 
 describe("migration 0072: RBAC audit fidelity", () => {
   it("adds result metadata and atomically audits default role assignments", async () => {
-    await env.DB.prepare("DROP TRIGGER assign_default_role_after_user_insert").run();
-    await env.DB.prepare("ALTER TABLE authorization_audit_events DROP COLUMN metadata_json").run();
-    await env.DB.prepare(
-      "ALTER TABLE authorization_audit_events DROP COLUMN operation_result"
-    ).run();
-    await env.DB.prepare(
-      `CREATE TRIGGER assign_default_role_after_user_insert
-       AFTER INSERT ON users
-       BEGIN
-         INSERT INTO user_role_assignments (user_id, role_id)
-         VALUES (NEW.id, 'role_builtin_member')
-         ON CONFLICT(user_id) DO NOTHING;
-       END`
-    ).run();
-    await env.DB.prepare(
-      `INSERT INTO authorization_audit_events
-        (id, occurred_at, request_id, principal_kind, actor_service_snapshot,
-         action, resource_type, reason_code)
-       VALUES ('legacy-audit', 1, 'legacy-request', 'service', 'control-plane',
-         'legacy.action', 'workspace', 'legacy')`
-    ).run();
+    await env.DB.batch([
+      env.DB.prepare("DROP TRIGGER assign_default_role_after_user_insert"),
+      env.DB.prepare("DROP TABLE authorization_audit_events"),
+      env.DB.prepare(
+        `CREATE TABLE authorization_audit_events (
+          id TEXT PRIMARY KEY,
+          occurred_at INTEGER NOT NULL,
+          request_id TEXT NOT NULL,
+          principal_kind TEXT NOT NULL,
+          actor_user_id_snapshot TEXT,
+          actor_service_snapshot TEXT,
+          action TEXT NOT NULL,
+          resource_type TEXT NOT NULL,
+          resource_id TEXT,
+          target_user_id_snapshot TEXT,
+          reason_code TEXT NOT NULL
+        )`
+      ),
+      env.DB.prepare(
+        `INSERT INTO authorization_audit_events
+          (id, occurred_at, request_id, principal_kind, actor_service_snapshot,
+           action, resource_type, reason_code)
+         VALUES ('legacy-audit', 1, 'legacy-request', 'service', 'control-plane',
+           'legacy.action', 'workspace', 'legacy')`
+      ),
+    ]);
 
     await env.DB.batch(migration().queries.map((query) => env.DB.prepare(query)));
 
@@ -73,7 +78,44 @@ describe("migration 0072: RBAC audit fidelity", () => {
       await env.DB.prepare(
         "SELECT operation_result, metadata_json FROM authorization_audit_events WHERE id = 'legacy-audit'"
       ).first()
-    ).toEqual({ operation_result: "applied", metadata_json: "{}" });
+    ).toEqual({ operation_result: "applied", metadata_json: '{"legacy":true}' });
+
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO authorization_audit_events
+          (id, occurred_at, request_id, principal_kind, action, resource_type,
+           reason_code, operation_result, metadata_json)
+         VALUES ('invalid-result', 1, 'invalid-result', 'service', 'invalid', 'workspace',
+           'invalid', 'denied', '{"legacy":true}')`
+      ).run()
+    ).rejects.toThrow();
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO authorization_audit_events
+          (id, occurred_at, request_id, principal_kind, action, resource_type,
+           reason_code, operation_result, metadata_json)
+         VALUES ('empty-metadata', 1, 'empty-metadata', 'service', 'invalid', 'workspace',
+           'invalid', 'applied', '{}')`
+      ).run()
+    ).rejects.toThrow();
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO authorization_audit_events
+          (id, occurred_at, request_id, principal_kind, action, resource_type,
+           reason_code, operation_result, metadata_json)
+         VALUES ('invalid-metadata', 1, 'invalid-metadata', 'service', 'invalid', 'workspace',
+           'invalid', 'applied', 'true')`
+      ).run()
+    ).rejects.toThrow();
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO authorization_audit_events
+          (id, occurred_at, request_id, principal_kind, action, resource_type,
+           reason_code, operation_result)
+         VALUES ('missing-metadata', 1, 'missing-metadata', 'service', 'invalid', 'workspace',
+           'invalid', 'applied')`
+      ).run()
+    ).rejects.toThrow();
 
     await env.DB.prepare(
       `INSERT INTO users

--- a/packages/control-plane/test/integration/migration-0072-rbac-audit-fidelity.test.ts
+++ b/packages/control-plane/test/integration/migration-0072-rbac-audit-fidelity.test.ts
@@ -1,0 +1,129 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanD1Tables } from "./cleanup";
+
+const migration = () => {
+  const entry = env.TEST_MIGRATIONS.find((candidate) => candidate.name.startsWith("0072"));
+  if (!entry) throw new Error("Migration 0072 not found in TEST_MIGRATIONS");
+  return entry;
+};
+
+async function tableColumns(): Promise<string[]> {
+  const result = await env.DB.prepare("PRAGMA table_info(authorization_audit_events)").all<{
+    name: string;
+  }>();
+  return result.results.map((column) => column.name);
+}
+
+async function restoreMigration(): Promise<void> {
+  if (!(await tableColumns()).includes("operation_result")) {
+    await env.DB.batch(migration().queries.map((query) => env.DB.prepare(query)));
+  }
+}
+
+beforeEach(cleanD1Tables);
+afterEach(async () => {
+  await env.DB.prepare("DROP TRIGGER IF EXISTS fail_default_role_audit").run();
+  await restoreMigration();
+  await cleanD1Tables();
+});
+
+describe("migration 0072: RBAC audit fidelity", () => {
+  it("adds result metadata and atomically audits default role assignments", async () => {
+    await env.DB.prepare("DROP TRIGGER assign_default_role_after_user_insert").run();
+    await env.DB.prepare("ALTER TABLE authorization_audit_events DROP COLUMN metadata_json").run();
+    await env.DB.prepare(
+      "ALTER TABLE authorization_audit_events DROP COLUMN operation_result"
+    ).run();
+    await env.DB.prepare(
+      `CREATE TRIGGER assign_default_role_after_user_insert
+       AFTER INSERT ON users
+       BEGIN
+         INSERT INTO user_role_assignments (user_id, role_id)
+         VALUES (NEW.id, 'role_builtin_member')
+         ON CONFLICT(user_id) DO NOTHING;
+       END`
+    ).run();
+    await env.DB.prepare(
+      `INSERT INTO authorization_audit_events
+        (id, occurred_at, request_id, principal_kind, actor_service_snapshot,
+         action, resource_type, reason_code)
+       VALUES ('legacy-audit', 1, 'legacy-request', 'service', 'control-plane',
+         'legacy.action', 'workspace', 'legacy')`
+    ).run();
+
+    await env.DB.batch(migration().queries.map((query) => env.DB.prepare(query)));
+
+    expect(await tableColumns()).toEqual([
+      "id",
+      "occurred_at",
+      "request_id",
+      "principal_kind",
+      "actor_user_id_snapshot",
+      "actor_service_snapshot",
+      "action",
+      "resource_type",
+      "resource_id",
+      "target_user_id_snapshot",
+      "reason_code",
+      "operation_result",
+      "metadata_json",
+    ]);
+    expect(
+      await env.DB.prepare(
+        "SELECT operation_result, metadata_json FROM authorization_audit_events WHERE id = 'legacy-audit'"
+      ).first()
+    ).toEqual({ operation_result: "applied", metadata_json: "{}" });
+
+    await env.DB.prepare(
+      `INSERT INTO users
+        (id, display_name, email, email_verified, avatar_url, created_at, updated_at)
+       VALUES ('33333333333333333333333333333333', 'New User', NULL, 0, NULL, 500, 500)`
+    ).run();
+
+    const audit = await env.DB.prepare(
+      `SELECT occurred_at, request_id, actor_service_snapshot, action, resource_id,
+              target_user_id_snapshot, reason_code, operation_result, metadata_json
+       FROM authorization_audit_events
+       WHERE request_id = 'default-role:33333333333333333333333333333333'`
+    ).first<Record<string, unknown>>();
+    expect(audit).toMatchObject({
+      occurred_at: 500,
+      actor_service_snapshot: "database-trigger",
+      action: "workspace.default_role_assigned",
+      resource_id: "33333333333333333333333333333333",
+      target_user_id_snapshot: "33333333333333333333333333333333",
+      reason_code: "default_role",
+      operation_result: "applied",
+    });
+    expect(JSON.parse(audit!.metadata_json as string)).toEqual({
+      before: { roleId: null },
+      requested: { roleId: "role_builtin_member" },
+      after: { roleId: "role_builtin_member" },
+    });
+  });
+
+  it("rolls back user creation when the default-role audit cannot be written", async () => {
+    await env.DB.prepare(
+      `CREATE TRIGGER fail_default_role_audit
+       BEFORE INSERT ON authorization_audit_events
+       WHEN NEW.action = 'workspace.default_role_assigned'
+       BEGIN
+         SELECT RAISE(ABORT, 'forced audit failure');
+       END`
+    ).run();
+
+    await expect(
+      env.DB.prepare(
+        `INSERT INTO users
+          (id, display_name, email, email_verified, avatar_url, created_at, updated_at)
+         VALUES ('44444444444444444444444444444444', 'Failed User', NULL, 0, NULL, 600, 600)`
+      ).run()
+    ).rejects.toThrow("forced audit failure");
+    expect(
+      await env.DB.prepare(
+        "SELECT id FROM users WHERE id = '44444444444444444444444444444444'"
+      ).first()
+    ).toBeNull();
+  });
+});

--- a/packages/control-plane/test/integration/rbac-foundation.test.ts
+++ b/packages/control-plane/test/integration/rbac-foundation.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { AuthorizationStore } from "../../src/db/authorization-store";
 import { AuthorizationService } from "../../src/authorization/service";
 import { cleanD1Tables } from "./cleanup";
-import { insertCanonicalUser } from "./identity-seed-helpers";
+import { insertAuthSession, insertCanonicalUser } from "./identity-seed-helpers";
 
 const ACTOR_ID = "11111111111111111111111111111111";
 const TARGET_ID = "22222222222222222222222222222222";
@@ -131,13 +131,113 @@ describe("RBAC foundation migration", () => {
     ).resolves.toEqual({ status: "applied" });
     await expect(
       env.DB.prepare(
-        `SELECT action, request_id, target_user_id_snapshot
+        `SELECT action, request_id, target_user_id_snapshot, operation_result, metadata_json
          FROM authorization_audit_events WHERE request_id = 'apply-role'`
       ).first()
     ).resolves.toEqual({
       action: "workspace.member_role_updated",
       request_id: "apply-role",
       target_user_id_snapshot: TARGET_ID,
+      operation_result: "applied",
+      metadata_json: JSON.stringify({
+        before: { roleId: BUILT_IN_ROLE_REGISTRY.member.id },
+        requested: { roleId: BUILT_IN_ROLE_REGISTRY.viewer.id },
+        after: { roleId: BUILT_IN_ROLE_REGISTRY.viewer.id },
+      }),
     });
+
+    await expect(
+      store.replaceMemberStatus({
+        actorUserId: ACTOR_ID,
+        targetUserId: TARGET_ID,
+        suspended: true,
+        requestId: "apply-status",
+        now: 201,
+      })
+    ).resolves.toEqual({ status: "applied" });
+    const statusAudit = await env.DB.prepare(
+      `SELECT operation_result, metadata_json
+       FROM authorization_audit_events WHERE request_id = 'apply-status'`
+    ).first<{ operation_result: string; metadata_json: string }>();
+    expect(statusAudit?.operation_result).toBe("applied");
+    expect(JSON.parse(statusAudit!.metadata_json)).toEqual({
+      before: { suspended: false, suspendedAt: null },
+      requested: { suspended: true },
+      after: { suspended: true, suspendedAt: 201 },
+    });
+  });
+
+  it("audits identical role and status requests without touching state or sessions", async () => {
+    await insertCanonicalUser({ id: ACTOR_ID, email: "owner@example.com" });
+    await insertCanonicalUser({ id: TARGET_ID, email: "member@example.com" });
+    await env.DB.batch([
+      env.DB.prepare("UPDATE user_role_assignments SET role_id = ? WHERE user_id = ?").bind(
+        BUILT_IN_ROLE_REGISTRY.owner.id,
+        ACTOR_ID
+      ),
+      env.DB.prepare("UPDATE users SET suspended_at = 150, updated_at = 150 WHERE id = ?").bind(
+        TARGET_ID
+      ),
+    ]);
+    await insertAuthSession({ id: "target-session", userId: TARGET_ID });
+    const store = new AuthorizationStore(env.DB);
+
+    await expect(
+      store.replaceMemberRole({
+        actorUserId: ACTOR_ID,
+        targetUserId: TARGET_ID,
+        roleId: BUILT_IN_ROLE_REGISTRY.member.id,
+        requestId: "same-role",
+        now: 200,
+      })
+    ).resolves.toEqual({ status: "no_op" });
+    await expect(
+      store.replaceMemberStatus({
+        actorUserId: ACTOR_ID,
+        targetUserId: TARGET_ID,
+        suspended: true,
+        requestId: "same-status",
+        now: 201,
+      })
+    ).resolves.toEqual({ status: "no_op" });
+
+    expect(
+      await env.DB.prepare("SELECT suspended_at, updated_at FROM users WHERE id = ?")
+        .bind(TARGET_ID)
+        .first()
+    ).toEqual({ suspended_at: 150, updated_at: 150 });
+    expect(
+      await env.DB.prepare("SELECT id FROM auth_sessions WHERE id = 'target-session'").first()
+    ).toEqual({ id: "target-session" });
+    const audits = await env.DB.prepare(
+      `SELECT request_id, operation_result, metadata_json
+       FROM authorization_audit_events
+       WHERE request_id IN ('same-role', 'same-status') ORDER BY request_id`
+    ).all<{ request_id: string; operation_result: string; metadata_json: string }>();
+    expect(
+      audits.results.map((audit) => ({
+        ...audit,
+        metadata_json: JSON.parse(audit.metadata_json),
+      }))
+    ).toEqual([
+      {
+        request_id: "same-role",
+        operation_result: "no_op",
+        metadata_json: {
+          before: { roleId: BUILT_IN_ROLE_REGISTRY.member.id },
+          requested: { roleId: BUILT_IN_ROLE_REGISTRY.member.id },
+          after: { roleId: BUILT_IN_ROLE_REGISTRY.member.id },
+        },
+      },
+      {
+        request_id: "same-status",
+        operation_result: "no_op",
+        metadata_json: {
+          before: { suspended: true, suspendedAt: 150 },
+          requested: { suspended: true },
+          after: { suspended: true, suspendedAt: 150 },
+        },
+      },
+    ]);
   });
 });

--- a/packages/control-plane/test/integration/user-merge.test.ts
+++ b/packages/control-plane/test/integration/user-merge.test.ts
@@ -167,16 +167,29 @@ describe("mergeUsers", () => {
     ).toEqual({ generation: 1 });
     expect(
       await env.DB.prepare(
-        `SELECT principal_kind, actor_user_id_snapshot, actor_service_snapshot,
-                resource_id, target_user_id_snapshot
+        `SELECT request_id, principal_kind, actor_user_id_snapshot, actor_service_snapshot,
+                resource_id, target_user_id_snapshot, operation_result, metadata_json
          FROM authorization_audit_events WHERE action = 'workspace.user_merged'`
       ).first()
     ).toEqual({
+      request_id: expect.stringMatching(/^operator-cli:[0-9a-f-]+$/),
       principal_kind: "service",
       actor_user_id_snapshot: null,
-      actor_service_snapshot: "control-plane",
+      actor_service_snapshot: "operator-cli",
       resource_id: SURVIVOR,
       target_user_id_snapshot: LOSER,
+      operation_result: "applied",
+      metadata_json: JSON.stringify({
+        before: {
+          survivor: { userId: SURVIVOR, roleId: "role_builtin_member", suspendedAt: null },
+          loser: { userId: LOSER, roleId: "role_builtin_member", suspendedAt: null },
+        },
+        requested: { survivorUserId: SURVIVOR, loserUserId: LOSER },
+        after: {
+          survivor: { userId: SURVIVOR, roleId: "role_builtin_member", suspendedAt: null },
+          loser: null,
+        },
+      }),
     });
   });
 

--- a/scripts/bootstrap-workspace-owner.test.ts
+++ b/scripts/bootstrap-workspace-owner.test.ts
@@ -35,7 +35,9 @@ function createDatabase(): DatabaseSync {
       resource_type TEXT NOT NULL,
       resource_id TEXT,
       target_user_id_snapshot TEXT,
-      reason_code TEXT NOT NULL
+      reason_code TEXT NOT NULL,
+      operation_result TEXT NOT NULL DEFAULT 'applied',
+      metadata_json TEXT NOT NULL DEFAULT '{}'
     );
     INSERT INTO roles (id, key, is_system) VALUES
       ('role_builtin_owner', 'owner', 1),
@@ -155,7 +157,7 @@ describe("Owner bootstrap SQL", () => {
           .prepare(
             `SELECT id, occurred_at, request_id, principal_kind, actor_user_id_snapshot,
                     actor_service_snapshot, action, resource_type, resource_id,
-                    target_user_id_snapshot, reason_code
+                    target_user_id_snapshot, reason_code, operation_result, metadata_json
              FROM authorization_audit_events`
           )
           .get(),
@@ -172,6 +174,12 @@ describe("Owner bootstrap SQL", () => {
         resource_id: null,
         target_user_id_snapshot: USER_ID,
         reason_code: "operator_cli",
+        operation_result: "applied",
+        metadata_json: JSON.stringify({
+          before: { roleId: "role_builtin_member" },
+          requested: { roleId: "role_builtin_owner" },
+          after: { roleId: "role_builtin_owner" },
+        }),
       }
     );
   });
@@ -304,8 +312,10 @@ describe("Owner bootstrap SQL", () => {
 
     assert.doesNotMatch(
       generated,
-      /workspace_bootstrap|authorization_version|access_status|mutation_id|policy_id|operation_result|decision_outcome|metadata_json|actor_provider|assigned_by|assigned_at/
+      /workspace_bootstrap|authorization_version|access_status|mutation_id|policy_id|decision_outcome|actor_provider|assigned_by|assigned_at/
     );
+    assert.match(generated, /operation_result/);
+    assert.match(generated, /metadata_json/);
     assert.match(generated, /SELECT 1 FROM authorization_audit_events WHERE id = 'audit-exact'/);
   });
 });

--- a/scripts/bootstrap-workspace-owner.test.ts
+++ b/scripts/bootstrap-workspace-owner.test.ts
@@ -36,8 +36,8 @@ function createDatabase(): DatabaseSync {
       resource_id TEXT,
       target_user_id_snapshot TEXT,
       reason_code TEXT NOT NULL,
-      operation_result TEXT NOT NULL DEFAULT 'applied',
-      metadata_json TEXT NOT NULL DEFAULT '{}'
+      operation_result TEXT NOT NULL,
+      metadata_json TEXT NOT NULL
     );
     INSERT INTO roles (id, key, is_system) VALUES
       ('role_builtin_owner', 'owner', 1),
@@ -71,10 +71,10 @@ function insertPriorAudit(
       `INSERT INTO authorization_audit_events
         (id, occurred_at, request_id, principal_kind,
          actor_service_snapshot, action, resource_type, target_user_id_snapshot,
-         reason_code)
+          reason_code, operation_result, metadata_json)
        VALUES (?, 1, 'operator-cli:history', 'service',
-          'operator-cli', 'workspace.owner_bootstrapped', 'workspace', ?,
-          'operator_cli')`
+           'operator-cli', 'workspace.owner_bootstrapped', 'workspace', ?,
+           'operator_cli', 'applied', '{"legacy":true}')`
     )
     .run(id, targetUserId);
 }

--- a/scripts/bootstrap-workspace-owner.ts
+++ b/scripts/bootstrap-workspace-owner.ts
@@ -109,9 +109,10 @@ export function buildBootstrapSql(options: BootstrapSqlOptions): string {
   AND (SELECT COUNT(*) FROM pragma_table_info('authorization_audit_events')
     WHERE name IN (
       'id', 'occurred_at', 'request_id', 'principal_kind',
-      'actor_user_id_snapshot', 'actor_service_snapshot', 'action', 'resource_type',
-      'resource_id', 'target_user_id_snapshot', 'reason_code'
-    )) = 11`;
+       'actor_user_id_snapshot', 'actor_service_snapshot', 'action', 'resource_type',
+       'resource_id', 'target_user_id_snapshot', 'reason_code',
+       'operation_result', 'metadata_json'
+    )) = 13`;
   const commonPreconditions = `${schemaReady}
   AND (SELECT COUNT(*) FROM users WHERE id = ${userId}) = 1
   AND (SELECT COUNT(*) FROM user_role_assignments WHERE user_id = ${userId}) = 1
@@ -138,6 +139,10 @@ export function buildBootstrapSql(options: BootstrapSqlOptions): string {
       AND resource_id IS NULL
       AND target_user_id_snapshot = ${userId}
       AND reason_code = 'operator_cli'
+      AND operation_result = 'applied'
+      AND json_extract(metadata_json, '$.before.roleId') <> ${ownerRoleId}
+      AND json_extract(metadata_json, '$.requested.roleId') = ${ownerRoleId}
+      AND json_extract(metadata_json, '$.after.roleId') = ${ownerRoleId}
   )`;
 
   const preflight = `SELECT 'preflight' AS report,
@@ -176,10 +181,17 @@ export function buildBootstrapSql(options: BootstrapSqlOptions): string {
 INSERT INTO authorization_audit_events
   (id, occurred_at, request_id, principal_kind,
    actor_service_snapshot, action, resource_type,
-   target_user_id_snapshot, reason_code)
+    target_user_id_snapshot, reason_code, operation_result, metadata_json)
 SELECT ${auditId}, ${now}, ${requestId}, 'service',
        'operator-cli', 'workspace.owner_bootstrapped', 'workspace',
-       ${userId}, 'operator_cli'
+       ${userId}, 'operator_cli', 'applied',
+       json_object(
+         'before', json_object('roleId', (
+           SELECT role_id FROM user_role_assignments WHERE user_id = ${userId}
+         )),
+         'requested', json_object('roleId', ${ownerRoleId}),
+         'after', json_object('roleId', ${ownerRoleId})
+       )
 WHERE ${ready};
 
 UPDATE user_role_assignments

--- a/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
+++ b/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
@@ -1,12 +1,47 @@
-ALTER TABLE authorization_audit_events
-ADD COLUMN operation_result TEXT NOT NULL DEFAULT 'applied'
-CHECK (operation_result IN ('applied', 'no_op', 'denied', 'rejected'));
-
-ALTER TABLE authorization_audit_events
-ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
-CHECK (json_valid(metadata_json));
-
 DROP TRIGGER IF EXISTS assign_default_role_after_user_insert;
+
+CREATE TABLE authorization_audit_events_v2 (
+  id TEXT PRIMARY KEY,
+  occurred_at INTEGER NOT NULL,
+  request_id TEXT NOT NULL,
+  principal_kind TEXT NOT NULL,
+  actor_user_id_snapshot TEXT,
+  actor_service_snapshot TEXT,
+  action TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id TEXT,
+  target_user_id_snapshot TEXT,
+  reason_code TEXT NOT NULL,
+  operation_result TEXT NOT NULL CHECK (operation_result IN ('applied', 'no_op')),
+  metadata_json TEXT NOT NULL CHECK (
+    json_valid(metadata_json)
+    AND json_type(metadata_json) = 'object'
+    AND COALESCE(
+      json_type(metadata_json, '$.legacy') = 'true'
+      OR (
+        json_type(metadata_json, '$.before') = 'object'
+        AND json_type(metadata_json, '$.requested') = 'object'
+        AND json_type(metadata_json, '$.after') = 'object'
+      ),
+      0
+    )
+  )
+);
+
+INSERT INTO authorization_audit_events_v2 (
+  id, occurred_at, request_id, principal_kind,
+  actor_user_id_snapshot, actor_service_snapshot, action, resource_type,
+  resource_id, target_user_id_snapshot, reason_code, operation_result, metadata_json
+)
+SELECT
+  id, occurred_at, request_id, principal_kind,
+  actor_user_id_snapshot, actor_service_snapshot, action, resource_type,
+  resource_id, target_user_id_snapshot, reason_code, 'applied',
+  json_object('legacy', json('true'))
+FROM authorization_audit_events;
+
+DROP TABLE authorization_audit_events;
+ALTER TABLE authorization_audit_events_v2 RENAME TO authorization_audit_events;
 
 CREATE TRIGGER assign_default_role_after_user_insert
 AFTER INSERT ON users

--- a/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
+++ b/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
@@ -6,7 +6,7 @@ ALTER TABLE authorization_audit_events
 ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
 CHECK (json_valid(metadata_json));
 
-DROP TRIGGER assign_default_role_after_user_insert;
+DROP TRIGGER IF EXISTS assign_default_role_after_user_insert;
 
 CREATE TRIGGER assign_default_role_after_user_insert
 AFTER INSERT ON users

--- a/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
+++ b/terraform/d1/migrations/0072_rbac_audit_fidelity.sql
@@ -1,0 +1,32 @@
+ALTER TABLE authorization_audit_events
+ADD COLUMN operation_result TEXT NOT NULL DEFAULT 'applied'
+CHECK (operation_result IN ('applied', 'no_op', 'denied', 'rejected'));
+
+ALTER TABLE authorization_audit_events
+ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+CHECK (json_valid(metadata_json));
+
+DROP TRIGGER assign_default_role_after_user_insert;
+
+CREATE TRIGGER assign_default_role_after_user_insert
+AFTER INSERT ON users
+BEGIN
+  INSERT INTO user_role_assignments (user_id, role_id)
+  VALUES (NEW.id, 'role_builtin_member')
+  ON CONFLICT(user_id) DO NOTHING;
+
+  INSERT INTO authorization_audit_events (
+    id, occurred_at, request_id, principal_kind,
+    actor_service_snapshot, action, resource_type, resource_id,
+    target_user_id_snapshot, reason_code, operation_result, metadata_json
+  ) VALUES (
+    lower(hex(randomblob(16))), NEW.created_at, 'default-role:' || NEW.id, 'service',
+    'database-trigger', 'workspace.default_role_assigned', 'user', NEW.id,
+    NEW.id, 'default_role', 'applied',
+    json_object(
+      'before', json_object('roleId', NULL),
+      'requested', json_object('roleId', 'role_builtin_member'),
+      'after', json_object('roleId', 'role_builtin_member')
+    )
+  );
+END;


### PR DESCRIPTION
## Summary

- add explicit audit outcomes and structured before/requested/after metadata
- record default Member role assignments atomically from the database trigger
- treat repeated role and suspension requests as audited no-ops without touching state or sessions
- improve Owner bootstrap and user-merge provenance, including affected role and suspension state
- preserve the existing atomic coupling between successful RBAC mutations and their audit records

## Why

The initial RBAC audit events identified who acted and which user was targeted, but did not record the actual authorization change. Repeated writes were also indistinguishable from real changes, default grants were absent, and operator-driven user merges lacked unique provenance.

## Testing

- `npm run test:integration -w @open-inspect/control-plane` (87 files, 1075 tests)
- `npm test -w @open-inspect/control-plane -- src/db/authorization-store.test.ts`
- `npm run test:rbac-bootstrap-owner`
- `npm run test:user-merge-cli`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/97badb97b9dc770a3214927e8ed1bd16)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization updates now report when a request makes no changes.
  * Audit records include operation results and structured before, requested, and after state details.
  * User merges and automatic role assignments provide richer audit information.

* **Bug Fixes**
  * Identical role or status updates no longer alter user state or authentication sessions.
  * Audit failures now prevent related user changes from being saved.
  * Existing audit data is preserved and upgraded during migration.
  * Bootstrap and migration processes now record complete role-assignment audit details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->