### PR TITLE
Increase unfinished prompt limit to 50

### DIFF
--- a/packages/shared/src/types/prompts.ts
+++ b/packages/shared/src/types/prompts.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { sessionAttachmentReferencesSchema } from "./session-attachments";
 
 export const MAX_WEB_PROMPT_CHARS = 64_000;
-export const MAX_UNFINISHED_PROMPTS = 10;
+export const MAX_UNFINISHED_PROMPTS = 50;
 export const BLANK_PROMPT_MESSAGE = "Prompt content must not be blank without attachments";
 
 export const clientRequestIdSchema = z.string().min(1).max(128);


### PR DESCRIPTION
## Summary

- increase the per-session unfinished prompt limit from 10 to 50
- retain the existing centralized admission checks and queue-full behavior

## Testing

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/session/message-queue.test.ts src/session/message-repository.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-client.test.ts test/integration/prompt-enqueue.test.ts`
- `npx prettier --check packages/shared/src/types/prompts.ts`
- `npx eslint packages/shared/src/types/prompts.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9493ea6b540d830f764d2ae560c79043)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Increased the maximum number of unfinished prompts that can be retained from 10 to 50.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->