### PR TITLE
fix: preserve images on initial Slack mentions

### DIFF
--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -896,9 +896,20 @@ describe("getMessageDetails", () => {
     expect(String(url)).toContain("conversations.history");
   });
 
-  it("returns empty files when the message has none or is not found", async () => {
+  it("returns message_not_found when the target is absent from the response", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({ ok: true, messages: [{ ts: "9.9" }] })
+    );
+
+    expect(await getMessageDetails("xoxb-token", "C123", "1.0")).toEqual({
+      ok: false,
+      error: "message_not_found",
+    });
+  });
+
+  it("returns empty details when the target message has no files or attachments", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: true, messages: [{ ts: "1.0" }] })
     );
 
     expect(await getMessageDetails("xoxb-token", "C123", "1.0")).toEqual({

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -621,8 +621,8 @@ const messageWindowPayloadSchema = z.object({
  * `attachments` too — so when an event arrives without them we recover them
  * from conversation history. Pass `threadTs` when the message is a thread
  * reply; otherwise the top-level message at `ts` is fetched. Returns the
- * failure arm on API errors so callers can distinguish "the message has none"
- * from "the lookup failed".
+ * failure arm on API errors or when the target message is absent so callers can
+ * distinguish "the message has none" from "the lookup failed".
  */
 export async function getMessageDetails(
   token: string,
@@ -655,7 +655,8 @@ export async function getMessageDetails(
         });
   if (!res.ok) return res;
   const message = res.messages.find((m) => m.ts === ts);
-  return { ok: true, files: message?.files ?? [], attachments: message?.attachments ?? [] };
+  if (!message) return { ok: false, error: "message_not_found" };
+  return { ok: true, files: message.files ?? [], attachments: message.attachments ?? [] };
 }
 
 const slackUserSchema = z.object({

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -53,6 +53,7 @@ import { resolveSlackActorIdentity, type SlackActorIdentity } from "../user-iden
 
 const log = createLogger("handler");
 const THREAD_HISTORY_MESSAGE_LIMIT = 10;
+const MESSAGE_DETAILS_RETRY_DELAYS_MS = [100, 250] as const;
 
 interface ThreadHistoryOptions {
   /** ts of the message currently being handled, excluded from the history. */
@@ -117,6 +118,21 @@ interface IncomingMessageContent {
 
 function hasRunnableContent(content: IncomingMessageContent): boolean {
   return Boolean(content.text) || content.images.length > 0 || content.forwarded.hasBody;
+}
+
+function mergeMessageFiles(
+  eventFiles: SlackMessageFile[],
+  lookupFiles: SlackMessageFile[]
+): SlackMessageFile[] {
+  const lookupById = new Map<string, SlackMessageFile>();
+  for (const file of lookupFiles) {
+    if (file.id) lookupById.set(file.id, file);
+  }
+  const eventIds = new Set(eventFiles.map((file) => file.id).filter(Boolean));
+  return [
+    ...eventFiles.map((file) => (file.id ? { ...lookupById.get(file.id), ...file } : file)),
+    ...lookupFiles.filter((file) => !file.id || !eventIds.has(file.id)),
+  ];
 }
 
 interface IncomingMessageParams {
@@ -378,27 +394,41 @@ export async function handleAppMention(
   const detailsPromise: Promise<MessageDetails> =
     eventDetails.files.length && eventDetails.attachments.length
       ? Promise.resolve(eventDetails)
-      : getMessageDetails(env.SLACK_BOT_TOKEN, event.channel, event.ts, event.thread_ts).then(
-          (lookup) => {
-            if (lookup.ok) {
-              return {
-                files: eventDetails.files.length ? eventDetails.files : lookup.files,
-                attachments: eventDetails.attachments.length
-                  ? eventDetails.attachments
-                  : lookup.attachments,
-              };
-            }
-            // Failure is not "the message has none": any images and forwarded
-            // messages are lost here, so make the drop visible in logs.
-            log.warn("slack.attachment.file_lookup_failed", {
-              trace_id: traceId,
-              channel: event.channel,
-              message_ts: event.ts,
-              slack_error: lookup.error,
-            });
-            return eventDetails;
+      : (async () => {
+          let lookup = await getMessageDetails(
+            env.SLACK_BOT_TOKEN,
+            event.channel,
+            event.ts,
+            event.thread_ts
+          );
+          for (const delayMs of MESSAGE_DETAILS_RETRY_DELAYS_MS) {
+            if (lookup.ok || lookup.error !== "message_not_found") break;
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            lookup = await getMessageDetails(
+              env.SLACK_BOT_TOKEN,
+              event.channel,
+              event.ts,
+              event.thread_ts
+            );
           }
-        );
+          if (lookup.ok) {
+            return {
+              files: mergeMessageFiles(eventDetails.files, lookup.files),
+              attachments: eventDetails.attachments.length
+                ? eventDetails.attachments
+                : lookup.attachments,
+            };
+          }
+          // Failure is not "the message has none": any images and forwarded
+          // messages are lost here, so make the drop visible in logs.
+          log.warn("slack.attachment.file_lookup_failed", {
+            trace_id: traceId,
+            channel: event.channel,
+            message_ts: event.ts,
+            slack_error: lookup.error,
+          });
+          return eventDetails;
+        })();
   // Fetched unconditionally: image-only mentions rely on channel context as
   // their main classifier signal, and detailsPromise is awaited anyway.
   const channelInfoPromise = getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -391,44 +391,49 @@ export async function handleAppMention(
     files: event.files ?? [],
     attachments: event.attachments ?? [],
   };
-  const detailsPromise: Promise<MessageDetails> =
-    eventDetails.files.length && eventDetails.attachments.length
-      ? Promise.resolve(eventDetails)
-      : (async () => {
-          let lookup = await getMessageDetails(
+  const hasCompleteEventDetails =
+    eventDetails.files.length > 0 &&
+    eventDetails.attachments.length > 0 &&
+    eventDetails.files.every(
+      (file) => file.mimetype && (file.url_private_download || file.url_private)
+    );
+  const detailsPromise: Promise<MessageDetails> = hasCompleteEventDetails
+    ? Promise.resolve(eventDetails)
+    : (async () => {
+        let lookup = await getMessageDetails(
+          env.SLACK_BOT_TOKEN,
+          event.channel,
+          event.ts,
+          event.thread_ts
+        );
+        for (const delayMs of MESSAGE_DETAILS_RETRY_DELAYS_MS) {
+          if (lookup.ok || lookup.error !== "message_not_found") break;
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          lookup = await getMessageDetails(
             env.SLACK_BOT_TOKEN,
             event.channel,
             event.ts,
             event.thread_ts
           );
-          for (const delayMs of MESSAGE_DETAILS_RETRY_DELAYS_MS) {
-            if (lookup.ok || lookup.error !== "message_not_found") break;
-            await new Promise((resolve) => setTimeout(resolve, delayMs));
-            lookup = await getMessageDetails(
-              env.SLACK_BOT_TOKEN,
-              event.channel,
-              event.ts,
-              event.thread_ts
-            );
-          }
-          if (lookup.ok) {
-            return {
-              files: mergeMessageFiles(eventDetails.files, lookup.files),
-              attachments: eventDetails.attachments.length
-                ? eventDetails.attachments
-                : lookup.attachments,
-            };
-          }
-          // Failure is not "the message has none": any images and forwarded
-          // messages are lost here, so make the drop visible in logs.
-          log.warn("slack.attachment.file_lookup_failed", {
-            trace_id: traceId,
-            channel: event.channel,
-            message_ts: event.ts,
-            slack_error: lookup.error,
-          });
-          return eventDetails;
-        })();
+        }
+        if (lookup.ok) {
+          return {
+            files: mergeMessageFiles(eventDetails.files, lookup.files),
+            attachments: eventDetails.attachments.length
+              ? eventDetails.attachments
+              : lookup.attachments,
+          };
+        }
+        // Failure is not "the message has none": any images and forwarded
+        // messages are lost here, so make the drop visible in logs.
+        log.warn("slack.attachment.file_lookup_failed", {
+          trace_id: traceId,
+          channel: event.channel,
+          message_ts: event.ts,
+          slack_error: lookup.error,
+        });
+        return eventDetails;
+      })();
   // Fetched unconditionally: image-only mentions rely on channel context as
   // their main classifier signal, and detailsPromise is awaited anyway.
   const channelInfoPromise = getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -381,59 +381,49 @@ export async function handleAppMention(
   if (messageText)
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
 
-  // app_mention events don't carry the message's `files` array and may arrive
-  // without its `attachments`, so when either is missing we recover the message
-  // from conversation history — overlapped with the channel-info fetch to keep
-  // the extra round trip off the critical path. Whatever the event did carry
-  // wins; the lookup only fills gaps.
+  // app_mention events can omit or truncate file and attachment metadata, so
+  // always recover the canonical message from conversation history. Event
+  // values still win when present, and remain the fallback if lookup fails.
   type MessageDetails = { files: SlackMessageFile[]; attachments: SlackMessageAttachment[] };
   const eventDetails: MessageDetails = {
     files: event.files ?? [],
     attachments: event.attachments ?? [],
   };
-  const hasCompleteEventDetails =
-    eventDetails.files.length > 0 &&
-    eventDetails.attachments.length > 0 &&
-    eventDetails.files.every(
-      (file) => file.mimetype && (file.url_private_download || file.url_private)
+  const detailsPromise: Promise<MessageDetails> = (async () => {
+    let lookup = await getMessageDetails(
+      env.SLACK_BOT_TOKEN,
+      event.channel,
+      event.ts,
+      event.thread_ts
     );
-  const detailsPromise: Promise<MessageDetails> = hasCompleteEventDetails
-    ? Promise.resolve(eventDetails)
-    : (async () => {
-        let lookup = await getMessageDetails(
-          env.SLACK_BOT_TOKEN,
-          event.channel,
-          event.ts,
-          event.thread_ts
-        );
-        for (const delayMs of MESSAGE_DETAILS_RETRY_DELAYS_MS) {
-          if (lookup.ok || lookup.error !== "message_not_found") break;
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-          lookup = await getMessageDetails(
-            env.SLACK_BOT_TOKEN,
-            event.channel,
-            event.ts,
-            event.thread_ts
-          );
-        }
-        if (lookup.ok) {
-          return {
-            files: mergeMessageFiles(eventDetails.files, lookup.files),
-            attachments: eventDetails.attachments.length
-              ? eventDetails.attachments
-              : lookup.attachments,
-          };
-        }
-        // Failure is not "the message has none": any images and forwarded
-        // messages are lost here, so make the drop visible in logs.
-        log.warn("slack.attachment.file_lookup_failed", {
-          trace_id: traceId,
-          channel: event.channel,
-          message_ts: event.ts,
-          slack_error: lookup.error,
-        });
-        return eventDetails;
-      })();
+    for (const delayMs of MESSAGE_DETAILS_RETRY_DELAYS_MS) {
+      if (lookup.ok || lookup.error !== "message_not_found") break;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      lookup = await getMessageDetails(
+        env.SLACK_BOT_TOKEN,
+        event.channel,
+        event.ts,
+        event.thread_ts
+      );
+    }
+    if (lookup.ok) {
+      return {
+        files: mergeMessageFiles(eventDetails.files, lookup.files),
+        attachments: eventDetails.attachments.length
+          ? eventDetails.attachments
+          : lookup.attachments,
+      };
+    }
+    // Failure is not "the message has none": any images and forwarded
+    // messages are lost here, so make the drop visible in logs.
+    log.warn("slack.attachment.file_lookup_failed", {
+      trace_id: traceId,
+      channel: event.channel,
+      message_ts: event.ts,
+      slack_error: lookup.error,
+    });
+    return eventDetails;
+  })();
   // Fetched unconditionally: image-only mentions rely on channel context as
   // their main classifier signal, and detailsPromise is awaited anyway.
   const channelInfoPromise = getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -257,13 +257,15 @@ function makeSessionEnv(
   return env;
 }
 
+const DEFAULT_FILE_DOWNLOAD_STATUS = 200;
+
 function mockSlackFetch(
   order: string[] = [],
   options: {
     threadMessages?: unknown[];
     threadRepliesError?: string;
     messageHistoryResponses?: unknown[][];
-    /** HTTP status for files.slack.com downloads (default 200 with bytes). */
+    /** HTTP status for files.slack.com downloads. Defaults to DEFAULT_FILE_DOWNLOAD_STATUS. */
     fileDownloadStatus?: number;
   } = {}
 ) {
@@ -321,10 +323,11 @@ function mockSlackFetch(
 
     if (url.includes("files.slack.com")) {
       order.push("filedownload");
-      if (options.fileDownloadStatus && options.fileDownloadStatus !== 200) {
-        return new Response("denied", { status: options.fileDownloadStatus });
+      const status = options.fileDownloadStatus ?? DEFAULT_FILE_DOWNLOAD_STATUS;
+      if (status !== DEFAULT_FILE_DOWNLOAD_STATUS) {
+        return new Response("denied", { status });
       }
-      return new Response(new Uint8Array(16).fill(1), { status: 200 });
+      return new Response(new Uint8Array(16).fill(1), { status: DEFAULT_FILE_DOWNLOAD_STATUS });
     }
 
     if (url.includes("chat.postMessage")) {

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -262,10 +262,12 @@ function mockSlackFetch(
   options: {
     threadMessages?: unknown[];
     threadRepliesError?: string;
+    messageHistoryResponses?: unknown[][];
     /** HTTP status for files.slack.com downloads (default 200 with bytes). */
     fileDownloadStatus?: number;
   } = {}
 ) {
+  let messageHistoryResponseIndex = 0;
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = typeof input === "string" ? input : input.toString();
     if (url.includes("assistant.threads.setStatus")) {
@@ -288,10 +290,30 @@ function mockSlackFetch(
     }
 
     if (url.includes("conversations.replies")) {
+      const targetTs = new URL(url).searchParams.get("oldest");
       const payload = options.threadRepliesError
         ? { ok: false, error: options.threadRepliesError }
-        : { ok: true, messages: options.threadMessages ?? [] };
+        : {
+            ok: true,
+            messages:
+              options.threadMessages ??
+              (url.includes("inclusive=true") && targetTs ? [{ ts: targetTs }] : []),
+          };
       return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.includes("conversations.history")) {
+      const targetTs = new URL(url).searchParams.get("latest");
+      const configuredResponses = options.messageHistoryResponses;
+      const messages = configuredResponses
+        ? (configuredResponses[
+            Math.min(messageHistoryResponseIndex++, configuredResponses.length - 1)
+          ] ?? [])
+        : [{ ts: targetTs }];
+      return new Response(JSON.stringify({ ok: true, messages }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -1135,6 +1157,105 @@ describe("POST /events", () => {
     expect(promptBodies).toHaveLength(1);
     expect(promptBodies[0].attachments).toEqual([
       { attachmentId: "att-1", name: "screenshot.png" },
+    ]);
+
+    slackFetch.mockRestore();
+  });
+
+  it("retries top-level mention file lookup before sending the initial prompt", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, {
+      messageHistoryResponses: [
+        [],
+        [
+          {
+            ts: "111.222",
+            files: [
+              {
+                id: "F1",
+                name: "bug.png",
+                mimetype: "image/png",
+                url_private: "https://files.slack.com/files-pri/T1-F1/bug.png",
+                size: 16,
+              },
+            ],
+          },
+        ],
+      ],
+    });
+    const env = makeSessionEnv(order);
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> inspect this screenshot in acme/app",
+        user: "U123",
+        channel: "C123",
+        ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const historyCalls = slackFetch.mock.calls.filter(([input]) =>
+      String(input).includes("conversations.history")
+    );
+    expect(historyCalls).toHaveLength(2);
+    expect(order).toContain("filedownload");
+    expect(order.indexOf("attachment")).toBeLessThan(order.indexOf("prompt"));
+    expect(promptFetchBodies(env.CONTROL_PLANE.fetch)[0]?.attachments).toEqual([
+      { attachmentId: "att-1", name: "bug.png" },
+    ]);
+
+    slackFetch.mockRestore();
+  });
+
+  it("fills partial event file metadata from the top-level message lookup", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, {
+      messageHistoryResponses: [
+        [
+          {
+            ts: "111.222",
+            files: [
+              {
+                id: "F1",
+                name: "lookup-name.png",
+                mimetype: "image/png",
+                url_private: "https://files.slack.com/files-pri/T1-F1/bug.png",
+                size: 16,
+              },
+            ],
+          },
+        ],
+      ],
+    });
+    const env = makeSessionEnv(order);
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> inspect this screenshot in acme/app",
+        user: "U123",
+        channel: "C123",
+        ts: "111.222",
+        files: [{ id: "F1", name: "event-name.png" }],
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(order).toContain("filedownload");
+    expect(promptFetchBodies(env.CONTROL_PLANE.fetch)[0]?.attachments).toEqual([
+      { attachmentId: "att-1", name: "event-name.png" },
     ]);
 
     slackFetch.mockRestore();

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1214,7 +1214,7 @@ describe("POST /events", () => {
     slackFetch.mockRestore();
   });
 
-  it("fills partial event file metadata from the top-level message lookup", async () => {
+  it("fills partial event file metadata when the event also carries attachments", async () => {
     const order: string[] = [];
     const slackFetch = mockSlackFetch(order, {
       messageHistoryResponses: [
@@ -1245,6 +1245,7 @@ describe("POST /events", () => {
         channel: "C123",
         ts: "111.222",
         files: [{ id: "F1", name: "event-name.png" }],
+        attachments: [{ is_msg_unfurl: true }],
       }),
       env,
       ctx

--- a/public/docs/internal/2026-09-01-slack-initial-mention-images-research.md
+++ b/public/docs/internal/2026-09-01-slack-initial-mention-images-research.md
@@ -1,10 +1,13 @@
 # Research: Slack Initial Mention Images
 
-**Date:** 2026-09-01 **Status:** Research only **Scope:** Trace image handling for Slack mentions
-that create a session and compare it with image handling on follow-up mentions.
+**Date:** 2026-09-01 **Status:** Historical pre-fix research **Scope:** Trace image handling for
+Slack mentions that create a session and compare it with image handling on follow-up mentions.
 
 This document is intentionally research-only. It does not include recommendations, implementation
 plans, proposed code/API/schema changes, task breakdowns, estimates, or rollout steps.
+
+The behavior, gaps, and test coverage below describe the repository before PR #1693. They are
+retained as historical evidence for the investigation and do not describe the post-fix branch.
 
 ## Summary
 
@@ -29,7 +32,7 @@ objects without a supported MIME type.
 2. How does the follow-up path differ from the first-mention path?
 3. Which existing tests cover these workflows, and which reported scenario is not covered?
 
-## Current Behavior
+## Pre-Fix Behavior
 
 Every `app_mention` is validated with optional `files` and `attachments` arrays. The handler strips
 the bot mention and attempts a one-message Slack API lookup when either array is absent or empty.
@@ -98,7 +101,7 @@ follow-up branch is present in this downstream path.
 - A separately delivered channel-message event cannot recover an image omitted by the mention path
   because bot mentions are filtered from channel-trigger processing.
 
-## Known Gaps and Risks
+## Pre-Fix Gaps and Risks
 
 - A successful one-message lookup that does not contain the target timestamp is indistinguishable
   from a target message that contains no files.

--- a/public/docs/internal/2026-09-01-slack-initial-mention-images-research.md
+++ b/public/docs/internal/2026-09-01-slack-initial-mention-images-research.md
@@ -1,0 +1,153 @@
+# Research: Slack Initial Mention Images
+
+**Date:** 2026-09-01 **Status:** Research only **Scope:** Trace image handling for Slack mentions
+that create a session and compare it with image handling on follow-up mentions.
+
+This document is intentionally research-only. It does not include recommendations, implementation
+plans, proposed code/API/schema changes, task breakdowns, estimates, or rollout steps.
+
+## Summary
+
+Initial mentions and follow-up mentions use the same image download, session upload,
+prompt-reference, and sandbox hydration pipeline. Their relevant difference occurs when the Slack
+bot recovers file metadata that is absent from an `app_mention` event: top-level mentions use
+`conversations.history`, while thread replies use `conversations.replies`.
+
+The top-level lookup can return a successful result containing no files when its response does not
+contain the exact target timestamp. The mention handler then sends the user's text as a text-only
+prompt. Because no candidate image reaches image preparation, this condition does not produce an
+attachment-drop notice. This behavior is consistent with the reported first-message symptom.
+
+A separate metadata-loss path exists when an event contains a nonempty but partial `files` array.
+The event array takes precedence over lookup results as a whole. The inbound schema permits file
+objects without a MIME type or private download URL, and image normalization silently excludes
+objects without a supported MIME type.
+
+## Research Questions
+
+1. How are Slack image files recovered and delivered on the first mention?
+2. How does the follow-up path differ from the first-mention path?
+3. Which existing tests cover these workflows, and which reported scenario is not covered?
+
+## Current Behavior
+
+Every `app_mention` is validated with optional `files` and `attachments` arrays. The handler strips
+the bot mention and attempts a one-message Slack API lookup when either array is absent or empty.
+
+For a top-level mention, `getMessageDetails` requests `conversations.history` with
+`latest=<message ts>`, `inclusive=true`, and `limit=1`. For a reply, it requests
+`conversations.replies` with the thread timestamp, `oldest=<message ts>`, `inclusive=true`, and
+`limit=2`. Both responses are searched for an exact timestamp match.
+
+When the Slack API call itself fails, the failure result reaches the mention handler and produces a
+`slack.attachment.file_lookup_failed` warning. When the API call succeeds but the exact message is
+absent, `getMessageDetails` returns `{ ok: true, files: [], attachments: [] }`. The handler treats
+that result as a message with no files and emits no lookup warning.
+
+When text remains after mention stripping, an empty recovered file list does not stop processing.
+The classifier receives the text, a session can be created, and the prompt is delivered without an
+`attachments` property. Attachment-drop reporting does not run because no file entered image
+preparation or upload.
+
+When file metadata is available, only supported image MIME types with trusted Slack-hosted private
+URLs become image attachments. The bot downloads those files before initial session creation,
+uploads the bytes to the created session, and sends attachment references with the prompt.
+
+## Relevant Workflows
+
+### Initial top-level mention
+
+1. The events route validates optional file metadata and dispatches `app_mention`.
+2. The mention handler calls `getMessageDetails` if event file or attachment metadata is missing.
+3. `getMessageDetails` uses `conversations.history` for the top-level message.
+4. Valid Slack-hosted image metadata is normalized and passed into session launch.
+5. Session launch downloads images, creates the session, uploads prepared bytes, and includes the
+   resulting references in the first prompt.
+
+### Follow-up mention
+
+1. The same event and mention handling applies.
+2. File recovery for a thread reply uses `conversations.replies`.
+3. If the thread already maps to a session, the handler downloads and uploads images directly to
+   that session.
+4. The same `deliverPrompt` function used by initial session launch adds attachment references to
+   the follow-up prompt.
+
+### Agent delivery
+
+The control plane stores and resolves prompt attachment references. The sandbox runtime downloads
+the stored bytes, base64-encodes them, and constructs OpenCode `file` parts. No initial-versus-
+follow-up branch is present in this downstream path.
+
+## Existing Patterns
+
+- Both new-session and existing-session prompt paths converge on `deliverPrompt`.
+- Images are downloaded before initial session creation so an image-only request cannot create an
+  unprompted session when every known image fails.
+- Known download and upload failures are accumulated and can produce a Slack notice.
+- Slack API envelope failures are represented separately from successful API responses.
+- A Slack channel `message` event that mentions the bot is suppressed because the corresponding
+  `app_mention` path is authoritative.
+
+## Constraints and Invariants
+
+- Only supported image MIME types enter the attachment pipeline.
+- Download URLs must use HTTPS and a `slack.com` host; external-mode files are excluded.
+- The bot token is used to download private Slack files.
+- Prompt JSON omits `attachments` when there are no uploaded references.
+- A separately delivered channel-message event cannot recover an image omitted by the mention path
+  because bot mentions are filtered from channel-trigger processing.
+
+## Known Gaps and Risks
+
+- A successful one-message lookup that does not contain the target timestamp is indistinguishable
+  from a target message that contains no files.
+- A text-bearing mention continues as text-only when lookup returns no candidate files, so the user
+  receives no indication that an expected image was absent.
+- A nonempty event `files` array wins over lookup files as a complete collection. Partial event file
+  objects can therefore displace richer lookup objects.
+- The event schema makes every field within a Slack file object optional. A file object without
+  `mimetype` is silently ignored by image normalization; an otherwise supported image without a
+  private URL is logged as an untrusted URL and ignored.
+- Slack-bot integration coverage includes follow-up images carried by an event and follow-up images
+  recovered through `conversations.replies`, but not a new top-level text-and-image mention.
+- Shared-client coverage explicitly records the current not-found behavior as a successful empty
+  result.
+- The session-launcher image test mocks both image preparation and prompt delivery, so it verifies
+  orchestration rather than the complete first-message path.
+
+## Open Questions
+
+- Production logs would show whether affected mentions have a successful empty history response, an
+  API failure warning, partial event metadata, or a later download/upload failure.
+- The repository does not establish what Slack returned for the affected production events, so the
+  precise trigger among the observed loss paths remains an inference.
+
+## Evidence
+
+- `packages/slack-bot/src/events/payload.ts:20-40`: inbound Slack events accept optional file and
+  attachment arrays.
+- `packages/shared/src/slack/client.ts:552-562`: every retained Slack file field is optional.
+- `packages/slack-bot/src/events/message-handler.ts:368-411`: event metadata precedence, message
+  lookup, logging, and image normalization for mentions.
+- `packages/shared/src/slack/client.ts:627-658`: top-level and reply lookup endpoints and successful
+  empty return when the target timestamp is absent.
+- `packages/slack-bot/src/attachments.ts:109-137`: MIME and trusted-URL filtering.
+- `packages/slack-bot/src/events/message-handler.ts:176-218`: existing-session follow-up delivery.
+- `packages/slack-bot/src/events/message-handler.ts:306-328`: new-session launch receives normalized
+  images.
+- `packages/slack-bot/src/sessions/session-launcher.ts:59-133`: initial image preparation, session
+  creation, and shared prompt delivery.
+- `packages/slack-bot/src/sessions/prompt-delivery.ts:47-90`: common upload-then-prompt sequence.
+- `packages/slack-bot/src/sessions/control-plane-client.ts:121-145`: empty attachment references are
+  omitted from prompt JSON.
+- `packages/slack-bot/src/dm-utils.ts:75-95`: channel messages mentioning the bot are suppressed.
+- `packages/sandbox-runtime/src/sandbox_runtime/attachment_processor.py:107-197`: stored session
+  images become OpenCode file parts.
+- `packages/slack-bot/src/index.test.ts:1078-1211`: follow-up image coverage.
+- `packages/shared/src/slack/client.test.ts:825-909`: endpoint selection and successful-empty lookup
+  coverage.
+- `packages/slack-bot/src/sessions/session-launcher.test.ts:306-347`: mocked initial image
+  orchestration coverage.
+- `packages/slack-bot/src/routes/events.test.ts:123-158`: partial file metadata is accepted at the
+  event boundary.


### PR DESCRIPTION
## Summary

- distinguish a missing Slack history target from a message that legitimately has no files
- retry briefly when a newly mentioned top-level message is not yet present in conversation history
- merge partial event file objects with richer history metadata by Slack file ID
- add end-to-end coverage for initial text-and-image mentions and partial event metadata
- document the investigation and affected data flow

## Root cause

`app_mention` events can omit file metadata, so the bot recovers it from conversation history. A successful history response without the exact target timestamp was previously treated as a message with no files, causing the first prompt to continue as text-only. Separately, a partial event `files` array replaced richer lookup metadata wholesale and could then be discarded by image validation.

## Verification

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (795 tests)
- `npm test -w @open-inspect/slack-bot` (434 tests)
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/slack-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/840514fa0e5f166cb9bdc29212b11483)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Slack mention handling when attached files are temporarily unavailable.
  - Automatically retries file lookups and combines attachment details from multiple sources.
  - Recovers missing file information when an initial mention includes incomplete attachment metadata.
  - Correctly distinguishes between a missing message and a message that has no attachments.
- **Documentation**
  - Added research documentation covering Slack image handling and known metadata recovery scenarios.
- **Tests**
  - Added coverage for attachment recovery, retries, and partial metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->