### PR TITLE
fix: keep resized session timelines at bottom

### DIFF
--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -59,61 +59,108 @@ function toolEvent(
   };
 }
 
+function mockResizeObservers() {
+  const observers: Array<{ callback: ResizeObserverCallback; targets: Set<Element> }> = [];
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      readonly targets = new Set<Element>();
+
+      constructor(callback: ResizeObserverCallback) {
+        observers.push({ callback, targets: this.targets });
+      }
+
+      observe(target: Element) {
+        this.targets.add(target);
+      }
+
+      unobserve(target: Element) {
+        this.targets.delete(target);
+      }
+
+      disconnect() {
+        this.targets.clear();
+      }
+    }
+  );
+  return (target: Element, blockSize = 0) => {
+    for (const observer of observers) {
+      if (observer.targets.has(target)) {
+        observer.callback(
+          [
+            {
+              target,
+              borderBoxSize: [{ inlineSize: 800, blockSize }],
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver
+        );
+      }
+    }
+  };
+}
+
+function mockTimelineScrollMetrics(metrics: {
+  clientHeight: number;
+  scrollHeight: number | (() => number);
+  scrollTop: number;
+}) {
+  const value = () =>
+    typeof metrics.scrollHeight === "function" ? metrics.scrollHeight() : metrics.scrollHeight;
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.classList.contains("overflow-y-auto") ? metrics.clientHeight : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.classList.contains("overflow-y-auto") ? value() : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollTop", "get").mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.classList.contains("overflow-y-auto") ? metrics.scrollTop : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollTop", "set").mockImplementation(function (
+    this: HTMLElement,
+    next: number
+  ) {
+    if (this.classList.contains("overflow-y-auto")) {
+      metrics.scrollTop = Math.min(next, Math.max(0, value() - metrics.clientHeight));
+    }
+  });
+}
+
+function mockAnimationFrames() {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  return () => {
+    for (const frame of frames.splice(0)) frame(0);
+  };
+}
+
 describe("timeline auto-scrolling", () => {
-  it("stays at the bottom through viewport and content resizing", () => {
-    const observers: Array<{
-      callback: ResizeObserverCallback;
-      targets: Set<Element>;
-    }> = [];
-    vi.stubGlobal(
-      "ResizeObserver",
-      class {
-        readonly targets = new Set<Element>();
-
-        constructor(callback: ResizeObserverCallback) {
-          observers.push({ callback, targets: this.targets });
-        }
-
-        observe(target: Element) {
-          this.targets.add(target);
-        }
-
-        unobserve(target: Element) {
-          this.targets.delete(target);
-        }
-
-        disconnect() {
-          this.targets.clear();
-        }
-      }
-    );
-
-    let clientHeight = 600;
-    let scrollHeight = 1_000;
-    let scrollTop = 0;
-    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function (
+  it("follows measured row growth through the virtualizer", () => {
+    const notifyResize = mockResizeObservers();
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (
       this: HTMLElement
     ) {
-      return this.classList.contains("overflow-y-auto") ? clientHeight : 0;
+      return this.hasAttribute("data-index") ? 100 : 800;
     });
-    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function (
-      this: HTMLElement
-    ) {
-      return this.classList.contains("overflow-y-auto") ? scrollHeight : 0;
-    });
-    vi.spyOn(HTMLElement.prototype, "scrollTop", "get").mockImplementation(function (
-      this: HTMLElement
-    ) {
-      return this.classList.contains("overflow-y-auto") ? scrollTop : 0;
-    });
-    vi.spyOn(HTMLElement.prototype, "scrollTop", "set").mockImplementation(function (
-      this: HTMLElement,
-      value: number
-    ) {
-      if (this.classList.contains("overflow-y-auto")) {
-        scrollTop = Math.min(value, scrollHeight - clientHeight);
-      }
-    });
+    const flushAnimationFrames = mockAnimationFrames();
+    const metrics = {
+      clientHeight: 50,
+      scrollHeight: () => {
+        const spacer = document.querySelector<HTMLElement>("[data-index]")?.parentElement;
+        return Number.parseFloat(spacer?.style.height ?? "0");
+      },
+      scrollTop: 0,
+    };
+    mockTimelineScrollMetrics(metrics);
 
     const { container } = render(
       <SessionTimeline
@@ -129,32 +176,55 @@ describe("timeline auto-scrolling", () => {
       />
     );
     const timeline = container.firstElementChild as HTMLDivElement;
-    const content = timeline.querySelector<HTMLElement>("[data-index]")!.parentElement!;
-    const notifyResize = (target: Element) => {
-      for (const observer of observers) {
-        if (observer.targets.has(target)) {
-          observer.callback([{ target } as ResizeObserverEntry], {} as ResizeObserver);
-        }
-      }
-    };
-    expect(scrollTop).toBe(400);
-
-    clientHeight = 300;
-    act(() => notifyResize(timeline));
-
-    expect(scrollTop).toBe(700);
-
-    scrollHeight = 1_300;
-    act(() => notifyResize(content));
-
-    expect(scrollTop).toBe(1_000);
-
-    scrollTop = 200;
+    const row = timeline.querySelector<HTMLElement>("[data-index]")!;
+    const spacer = row.parentElement!;
+    const estimatedHeight = Number.parseFloat(spacer.style.height);
+    expect(estimatedHeight).toBe(120);
+    metrics.scrollTop = 70;
     fireEvent.scroll(timeline);
-    scrollHeight = 1_500;
-    act(() => notifyResize(content));
 
-    expect(scrollTop).toBe(200);
+    act(() => {
+      notifyResize(row, 500);
+      flushAnimationFrames();
+    });
+
+    expect(Number.parseFloat(spacer.style.height)).toBe(520);
+    expect(metrics.scrollTop).toBe(470);
+  });
+
+  it("stays at the bottom when the timeline viewport shrinks", () => {
+    const notifyResize = mockResizeObservers();
+    const metrics = { clientHeight: 600, scrollHeight: 1_000, scrollTop: 0 };
+    mockTimelineScrollMetrics(metrics);
+
+    const { container } = render(
+      <SessionTimeline {...baseTimelineProps} events={[]} isProcessing />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    expect(metrics.scrollTop).toBe(400);
+
+    metrics.clientHeight = 300;
+    act(() => notifyResize(timeline, 300));
+
+    expect(metrics.scrollTop).toBe(700);
+  });
+
+  it("preserves user scroll position when the timeline viewport resizes", () => {
+    const notifyResize = mockResizeObservers();
+    const metrics = { clientHeight: 300, scrollHeight: 1_000, scrollTop: 700 };
+    mockTimelineScrollMetrics(metrics);
+
+    const { container } = render(
+      <SessionTimeline {...baseTimelineProps} events={[]} isProcessing />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+
+    metrics.scrollTop = 200;
+    fireEvent.scroll(timeline);
+    metrics.clientHeight = 200;
+    act(() => notifyResize(timeline, 200));
+
+    expect(metrics.scrollTop).toBe(200);
   });
 
   it("preserves the visible row position when history is prepended", () => {
@@ -297,6 +367,8 @@ describe("timeline auto-scrolling", () => {
   });
 
   it("follows appended activity when within the bottom threshold", () => {
+    const notifyResize = mockResizeObservers();
+    const flushAnimationFrames = mockAnimationFrames();
     const task = toolEvent("task", "task-call", 1, {
       childSessionId: "child-1",
       status: "running",
@@ -325,12 +397,19 @@ describe("timeline auto-scrolling", () => {
         ]}
       />
     );
+    const row = timeline.querySelector<HTMLElement>("[data-index]")!;
+    act(() => {
+      notifyResize(row, 900);
+      flushAnimationFrames();
+    });
 
     expect(timeline.scrollTop).toBe(1_000);
     expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
 
   it("does not move the timeline when the user has scrolled away from the bottom", () => {
+    const notifyResize = mockResizeObservers();
+    const flushAnimationFrames = mockAnimationFrames();
     const task = toolEvent("task", "task-call", 1, {
       childSessionId: "child-1",
       status: "running",
@@ -359,6 +438,11 @@ describe("timeline auto-scrolling", () => {
         ]}
       />
     );
+    const row = timeline.querySelector<HTMLElement>("[data-index]")!;
+    act(() => {
+      notifyResize(row, 900);
+      flushAnimationFrames();
+    });
 
     expect(timeline.scrollTop).toBe(300);
   });

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { useLayoutEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SandboxEvent } from "@/types/session";
@@ -60,6 +60,103 @@ function toolEvent(
 }
 
 describe("timeline auto-scrolling", () => {
+  it("stays at the bottom through viewport and content resizing", () => {
+    const observers: Array<{
+      callback: ResizeObserverCallback;
+      targets: Set<Element>;
+    }> = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        readonly targets = new Set<Element>();
+
+        constructor(callback: ResizeObserverCallback) {
+          observers.push({ callback, targets: this.targets });
+        }
+
+        observe(target: Element) {
+          this.targets.add(target);
+        }
+
+        unobserve(target: Element) {
+          this.targets.delete(target);
+        }
+
+        disconnect() {
+          this.targets.clear();
+        }
+      }
+    );
+
+    let clientHeight = 600;
+    let scrollHeight = 1_000;
+    let scrollTop = 0;
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(function (
+      this: HTMLElement
+    ) {
+      return this.classList.contains("overflow-y-auto") ? clientHeight : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(function (
+      this: HTMLElement
+    ) {
+      return this.classList.contains("overflow-y-auto") ? scrollHeight : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollTop", "get").mockImplementation(function (
+      this: HTMLElement
+    ) {
+      return this.classList.contains("overflow-y-auto") ? scrollTop : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, "scrollTop", "set").mockImplementation(function (
+      this: HTMLElement,
+      value: number
+    ) {
+      if (this.classList.contains("overflow-y-auto")) {
+        scrollTop = Math.min(value, scrollHeight - clientHeight);
+      }
+    });
+
+    const { container } = render(
+      <SessionTimeline
+        {...baseTimelineProps}
+        events={[
+          {
+            type: "user_message",
+            content: "hello",
+            messageId: "message-1",
+            timestamp: 1,
+          },
+        ]}
+      />
+    );
+    const timeline = container.firstElementChild as HTMLDivElement;
+    const content = timeline.querySelector<HTMLElement>("[data-index]")!.parentElement!;
+    const notifyResize = (target: Element) => {
+      for (const observer of observers) {
+        if (observer.targets.has(target)) {
+          observer.callback([{ target } as ResizeObserverEntry], {} as ResizeObserver);
+        }
+      }
+    };
+    expect(scrollTop).toBe(400);
+
+    clientHeight = 300;
+    act(() => notifyResize(timeline));
+
+    expect(scrollTop).toBe(700);
+
+    scrollHeight = 1_300;
+    act(() => notifyResize(content));
+
+    expect(scrollTop).toBe(1_000);
+
+    scrollTop = 200;
+    fireEvent.scroll(timeline);
+    scrollHeight = 1_500;
+    act(() => notifyResize(content));
+
+    expect(scrollTop).toBe(200);
+  });
+
   it("preserves the visible row position when history is prepended", () => {
     vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (
       this: HTMLElement

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -92,6 +92,7 @@ export function SessionTimeline({
     return null;
   }, [events]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollContentRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
   const isNearBottomRef = useRef(true);
@@ -152,6 +153,19 @@ export function SessionTimeline({
     observer.observe(sentinel);
     return () => observer.disconnect();
   }, [onLoadOlder]);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const content = scrollContentRef.current;
+    if (!container || !content || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      if (isNearBottomRef.current) container.scrollTop = container.scrollHeight;
+    });
+    observer.observe(container);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [showSkeleton]);
 
   useLayoutEffect(() => {
     if (isNearBottomRef.current) {
@@ -293,7 +307,11 @@ export function SessionTimeline({
         {showSkeleton ? (
           <TimelineSkeleton />
         ) : (
-          <div className="relative w-full" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+          <div
+            ref={scrollContentRef}
+            className="relative w-full"
+            style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+          >
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
               const row = virtualRows[virtualRow.index];
               return (

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -92,7 +92,6 @@ export function SessionTimeline({
     return null;
   }, [events]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const scrollContentRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
   const isNearBottomRef = useRef(true);
@@ -121,6 +120,7 @@ export function SessionTimeline({
     getItemKey: getVirtualRowKey,
     estimateSize: estimateVirtualRowSize,
   });
+  const totalSize = rowVirtualizer.getTotalSize();
 
   const handleScroll = useCallback(() => {
     hasScrolledRef.current = true;
@@ -156,23 +156,21 @@ export function SessionTimeline({
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
-    const content = scrollContentRef.current;
-    if (!container || !content || typeof ResizeObserver === "undefined") return;
+    if (!container || typeof ResizeObserver === "undefined") return;
 
     const observer = new ResizeObserver(() => {
       if (isNearBottomRef.current) container.scrollTop = container.scrollHeight;
     });
     observer.observe(container);
-    observer.observe(content);
     return () => observer.disconnect();
-  }, [showSkeleton]);
+  }, []);
 
   useLayoutEffect(() => {
     if (isNearBottomRef.current) {
       const container = scrollContainerRef.current;
       if (container) container.scrollTop = container.scrollHeight;
     }
-  }, [events, isProcessing]);
+  }, [totalSize]);
 
   const toggleToolCall = useCallback((event: ToolCallEvent) => {
     const key = toolCallKey(event);
@@ -307,11 +305,7 @@ export function SessionTimeline({
         {showSkeleton ? (
           <TimelineSkeleton />
         ) : (
-          <div
-            ref={scrollContentRef}
-            className="relative w-full"
-            style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
-          >
+          <div className="relative w-full" style={{ height: `${totalSize}px` }}>
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
               const row = virtualRows[virtualRow.index];
               return (


### PR DESCRIPTION
## Summary
- keep a sticky session timeline pinned to the physical bottom when its viewport changes, including terminal preference restoration and panel resizing
- keep the timeline pinned while virtual row measurements correct the synthetic content height
- preserve the current position after a user intentionally scrolls away from the bottom
- add a regression experiment covering viewport shrink, delayed content growth, and user-scroll preservation

## Root cause
Timeline virtualization scrolls against estimated row heights. Measurements can update the synthetic content height after the existing `[events, isProcessing]` layout effect has run. Restoring an open terminal after hydration also shrinks the timeline viewport without changing either dependency, leaving the session above its new bottom.

## Validation
- `npm test -w @open-inspect/web -- src/components/session-timeline-scroll.test.tsx src/components/session-timeline.test.tsx src/lib/timeline-virtual-rows.test.ts` (44 tests passed)
- `npm run typecheck -w @open-inspect/web`
- ESLint on changed files
- full web suite: 1,396 tests passed; two concurrent resource-related timeouts passed when rerun independently
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/12148d875927d2f52aa3a39f9b69d1af)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session timeline scrolling so it stays anchored at the bottom as the viewport or content resizes.
  * Preserved a user’s manual scroll position when they move away from the bottom.
  * Improved scrolling behavior as timeline content grows or new activity is appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->