### PR TITLE
feat: add workspace audit log viewer

### DIFF
--- a/packages/control-plane/src/db/audit-event-cursor.test.ts
+++ b/packages/control-plane/src/db/audit-event-cursor.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { encodeAuditEventCursor, parseAuditEventCursor } from "./audit-event-cursor";
 
 describe("audit event cursor", () => {
-  it("round-trips generated cursors and rejects malformed or non-canonical cursors", () => {
+  it("round-trips generated cursors and rejects malformed cursors", () => {
     const cursor = encodeAuditEventCursor({ occurredAt: 100, id: "event:1" });
+    expect(cursor).toBe("100:event%3A1");
     expect(parseAuditEventCursor(cursor)).toEqual({
       ok: true,
       cursor: { occurredAt: 100, id: "event:1" },
     });
-    for (const malformed of ["", "100:event-1", "v2.e30", "v1.%%%", "v1.e30"]) {
+    for (const malformed of ["", "event-1", "100:", "100:%", "-1:event-1"]) {
       expect(parseAuditEventCursor(malformed)).toEqual({ ok: false, error: "Invalid cursor" });
     }
   });

--- a/packages/control-plane/src/db/audit-event-cursor.test.ts
+++ b/packages/control-plane/src/db/audit-event-cursor.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { encodeAuditEventCursor, parseAuditEventCursor } from "./audit-event-cursor";
+
+describe("audit event cursor", () => {
+  it("round-trips generated cursors and rejects malformed or non-canonical cursors", () => {
+    const cursor = encodeAuditEventCursor({ occurredAt: 100, id: "event:1" });
+    expect(parseAuditEventCursor(cursor)).toEqual({
+      ok: true,
+      cursor: { occurredAt: 100, id: "event:1" },
+    });
+    for (const malformed of ["", "100:event-1", "v2.e30", "v1.%%%", "v1.e30"]) {
+      expect(parseAuditEventCursor(malformed)).toEqual({ ok: false, error: "Invalid cursor" });
+    }
+  });
+});

--- a/packages/control-plane/src/db/audit-event-cursor.ts
+++ b/packages/control-plane/src/db/audit-event-cursor.ts
@@ -1,0 +1,50 @@
+import { auditEventTimestampSchema } from "@open-inspect/shared/types/audit-events";
+import { z } from "zod";
+
+const auditEventCursorSchema = z
+  .object({
+    occurredAt: auditEventTimestampSchema,
+    id: z.string().min(1),
+  })
+  .strict();
+
+export type AuditEventCursor = z.infer<typeof auditEventCursorSchema>;
+
+type ParseAuditEventCursorResult =
+  | { ok: true; cursor: AuditEventCursor | null }
+  | { ok: false; error: "Invalid cursor" };
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+function decodeBase64Url(value: string): string {
+  const padded = value
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+export function encodeAuditEventCursor(cursor: AuditEventCursor): string {
+  return `v1.${encodeBase64Url(JSON.stringify(auditEventCursorSchema.parse(cursor)))}`;
+}
+
+export function parseAuditEventCursor(raw: string | null): ParseAuditEventCursorResult {
+  if (raw === null) return { ok: true, cursor: null };
+  if (!/^v1\.[A-Za-z0-9_-]+$/.test(raw)) return { ok: false, error: "Invalid cursor" };
+
+  try {
+    const cursor = auditEventCursorSchema.parse(JSON.parse(decodeBase64Url(raw.slice(3))));
+    return encodeAuditEventCursor(cursor) === raw
+      ? { ok: true, cursor }
+      : { ok: false, error: "Invalid cursor" };
+  } catch {
+    return { ok: false, error: "Invalid cursor" };
+  }
+}

--- a/packages/control-plane/src/db/audit-event-cursor.ts
+++ b/packages/control-plane/src/db/audit-event-cursor.ts
@@ -1,48 +1,31 @@
 import { auditEventTimestampSchema } from "@open-inspect/shared/types/audit-events";
-import { z } from "zod";
 
-const auditEventCursorSchema = z
-  .object({
-    occurredAt: auditEventTimestampSchema,
-    id: z.string().min(1),
-  })
-  .strict();
-
-export type AuditEventCursor = z.infer<typeof auditEventCursorSchema>;
+export interface AuditEventCursor {
+  occurredAt: number;
+  id: string;
+}
 
 type ParseAuditEventCursorResult =
   | { ok: true; cursor: AuditEventCursor | null }
   | { ok: false; error: "Invalid cursor" };
 
-function encodeBase64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  return btoa(String.fromCharCode(...bytes))
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replace(/=+$/, "");
-}
-
-function decodeBase64Url(value: string): string {
-  const padded = value
-    .replaceAll("-", "+")
-    .replaceAll("_", "/")
-    .padEnd(Math.ceil(value.length / 4) * 4, "=");
-  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
-
 export function encodeAuditEventCursor(cursor: AuditEventCursor): string {
-  return `v1.${encodeBase64Url(JSON.stringify(auditEventCursorSchema.parse(cursor)))}`;
+  return `${cursor.occurredAt}:${encodeURIComponent(cursor.id)}`;
 }
 
 export function parseAuditEventCursor(raw: string | null): ParseAuditEventCursorResult {
   if (raw === null) return { ok: true, cursor: null };
-  if (!/^v1\.[A-Za-z0-9_-]+$/.test(raw)) return { ok: false, error: "Invalid cursor" };
+
+  const separator = raw.indexOf(":");
+  if (separator <= 0) return { ok: false, error: "Invalid cursor" };
+
+  const occurredAt = auditEventTimestampSchema.safeParse(Number(raw.slice(0, separator)));
+  if (!occurredAt.success) return { ok: false, error: "Invalid cursor" };
 
   try {
-    const cursor = auditEventCursorSchema.parse(JSON.parse(decodeBase64Url(raw.slice(3))));
-    return encodeAuditEventCursor(cursor) === raw
-      ? { ok: true, cursor }
+    const id = decodeURIComponent(raw.slice(separator + 1));
+    return id
+      ? { ok: true, cursor: { occurredAt: occurredAt.data, id } }
       : { ok: false, error: "Invalid cursor" };
   } catch {
     return { ok: false, error: "Invalid cursor" };

--- a/packages/control-plane/src/db/audit-event-store.test.ts
+++ b/packages/control-plane/src/db/audit-event-store.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  InvalidAuditEventCursorError,
-  encodeAuditEventCursor,
-  parseAuditEventCursor,
-  toAuditEvent,
-  type AuditEventRow,
-} from "./audit-event-store";
+import { toAuditEvent, type AuditEventRow } from "./audit-event-store";
 
 const row: AuditEventRow = {
   id: "event-1",
@@ -40,13 +34,5 @@ describe("AuditEventStore boundaries", () => {
       operationResult: "no_op",
       metadata: { future: { value: true } },
     });
-  });
-
-  it("round-trips generated cursors and rejects malformed or non-canonical cursors", () => {
-    const cursor = encodeAuditEventCursor({ occurredAt: 100, id: "event:1" });
-    expect(parseAuditEventCursor(cursor)).toEqual({ occurredAt: 100, id: "event:1" });
-    for (const malformed of ["", "100:event-1", "v2.e30", "v1.%%%", "v1.e30"]) {
-      expect(() => parseAuditEventCursor(malformed)).toThrow(InvalidAuditEventCursorError);
-    }
   });
 });

--- a/packages/control-plane/src/db/audit-event-store.test.ts
+++ b/packages/control-plane/src/db/audit-event-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  InvalidAuditEventCursorError,
+  encodeAuditEventCursor,
+  parseAuditEventCursor,
+  toAuditEvent,
+  type AuditEventRow,
+} from "./audit-event-store";
+
+const row: AuditEventRow = {
+  id: "event-1",
+  occurred_at: 100,
+  request_id: "request-1",
+  principal_kind: "user",
+  actor_user_id_snapshot: "user-1",
+  actor_service_snapshot: null,
+  action: "workspace.member_role_updated",
+  resource_type: "user",
+  resource_id: "user-2",
+  target_user_id_snapshot: "user-2",
+  reason_code: "role_replaced",
+  operation_result: "no_op",
+  metadata_json: '{"future":{"value":true}}',
+};
+
+describe("AuditEventStore boundaries", () => {
+  it("maps database rows and parses metadata", () => {
+    expect(toAuditEvent(row)).toEqual({
+      id: "event-1",
+      occurredAt: 100,
+      requestId: "request-1",
+      principalKind: "user",
+      actorUserIdSnapshot: "user-1",
+      actorServiceSnapshot: null,
+      action: "workspace.member_role_updated",
+      resourceType: "user",
+      resourceId: "user-2",
+      targetUserIdSnapshot: "user-2",
+      reasonCode: "role_replaced",
+      operationResult: "no_op",
+      metadata: { future: { value: true } },
+    });
+  });
+
+  it("round-trips generated cursors and rejects malformed or non-canonical cursors", () => {
+    const cursor = encodeAuditEventCursor({ occurredAt: 100, id: "event:1" });
+    expect(parseAuditEventCursor(cursor)).toEqual({ occurredAt: 100, id: "event:1" });
+    for (const malformed of ["", "100:event-1", "v2.e30", "v1.%%%", "v1.e30"]) {
+      expect(() => parseAuditEventCursor(malformed)).toThrow(InvalidAuditEventCursorError);
+    }
+  });
+});

--- a/packages/control-plane/src/db/audit-event-store.ts
+++ b/packages/control-plane/src/db/audit-event-store.ts
@@ -1,19 +1,6 @@
-import {
-  auditEventSchema,
-  type AuditEvent,
-  type AuditEventListResponse,
-} from "@open-inspect/shared/types/audit-events";
-import { z } from "zod";
+import { auditEventSchema, type AuditEvent } from "@open-inspect/shared/types/audit-events";
+import type { AuditEventCursor } from "./audit-event-cursor";
 import type { SqlDatabase } from "./sql-database";
-
-const auditEventCursorSchema = z
-  .object({
-    occurredAt: z.number().int().nonnegative().safe(),
-    id: z.string().min(1),
-  })
-  .strict();
-
-type AuditEventCursor = z.infer<typeof auditEventCursorSchema>;
 
 export interface AuditEventRow {
   id: string;
@@ -29,45 +16,6 @@ export interface AuditEventRow {
   reason_code: string;
   operation_result: string;
   metadata_json: string;
-}
-
-export class InvalidAuditEventCursorError extends Error {
-  constructor() {
-    super("Invalid cursor");
-    this.name = "InvalidAuditEventCursorError";
-  }
-}
-
-function encodeBase64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  return btoa(String.fromCharCode(...bytes))
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replace(/=+$/, "");
-}
-
-function decodeBase64Url(value: string): string {
-  const padded = value
-    .replaceAll("-", "+")
-    .replaceAll("_", "/")
-    .padEnd(Math.ceil(value.length / 4) * 4, "=");
-  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
-
-export function encodeAuditEventCursor(cursor: AuditEventCursor): string {
-  return `v1.${encodeBase64Url(JSON.stringify(cursor))}`;
-}
-
-export function parseAuditEventCursor(raw: string): AuditEventCursor {
-  if (!/^v1\.[A-Za-z0-9_-]+$/.test(raw)) throw new InvalidAuditEventCursorError();
-  try {
-    const cursor = auditEventCursorSchema.parse(JSON.parse(decodeBase64Url(raw.slice(3))));
-    if (encodeAuditEventCursor(cursor) !== raw) throw new InvalidAuditEventCursorError();
-    return cursor;
-  } catch {
-    throw new InvalidAuditEventCursorError();
-  }
 }
 
 export function toAuditEvent(row: AuditEventRow): AuditEvent {
@@ -92,16 +40,15 @@ export function toAuditEvent(row: AuditEventRow): AuditEvent {
 export class AuditEventStore {
   constructor(private readonly db: SqlDatabase) {}
 
-  async list(options: { limit: number; cursor?: string | null }): Promise<AuditEventListResponse> {
-    const cursor = options.cursor ? parseAuditEventCursor(options.cursor) : null;
-    const result = cursor
+  async list(options: { limit: number; cursor: AuditEventCursor | null }) {
+    const result = options.cursor
       ? await this.db
           .prepare(
             `SELECT * FROM authorization_audit_events
-             WHERE occurred_at < ? OR (occurred_at = ? AND id < ?)
+             WHERE (occurred_at, id) < (?, ?)
              ORDER BY occurred_at DESC, id DESC LIMIT ?`
           )
-          .bind(cursor.occurredAt, cursor.occurredAt, cursor.id, options.limit + 1)
+          .bind(options.cursor.occurredAt, options.cursor.id, options.limit + 1)
           .all<AuditEventRow>()
       : await this.db
           .prepare(
@@ -113,13 +60,13 @@ export class AuditEventStore {
 
     const rows = result.results ?? [];
     const hasMore = rows.length > options.limit;
-    const events = (hasMore ? rows.slice(0, options.limit) : rows).map(toAuditEvent);
-    if (!hasMore) return { events, hasMore: false, nextCursor: null };
-    const last = events[events.length - 1];
+    const pageRows = hasMore ? rows.slice(0, options.limit) : rows;
+    if (!hasMore) return { rows: pageRows, hasMore: false as const, nextCursor: null };
+    const last = pageRows[pageRows.length - 1];
     return {
-      events,
-      hasMore: true,
-      nextCursor: encodeAuditEventCursor({ occurredAt: last.occurredAt, id: last.id }),
+      rows: pageRows,
+      hasMore: true as const,
+      nextCursor: { occurredAt: last.occurred_at, id: last.id },
     };
   }
 }

--- a/packages/control-plane/src/db/audit-event-store.ts
+++ b/packages/control-plane/src/db/audit-event-store.ts
@@ -1,0 +1,125 @@
+import {
+  auditEventSchema,
+  type AuditEvent,
+  type AuditEventListResponse,
+} from "@open-inspect/shared/types/audit-events";
+import { z } from "zod";
+import type { SqlDatabase } from "./sql-database";
+
+const auditEventCursorSchema = z
+  .object({
+    occurredAt: z.number().int().nonnegative().safe(),
+    id: z.string().min(1),
+  })
+  .strict();
+
+type AuditEventCursor = z.infer<typeof auditEventCursorSchema>;
+
+export interface AuditEventRow {
+  id: string;
+  occurred_at: number;
+  request_id: string;
+  principal_kind: string;
+  actor_user_id_snapshot: string | null;
+  actor_service_snapshot: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  target_user_id_snapshot: string | null;
+  reason_code: string;
+  operation_result: string;
+  metadata_json: string;
+}
+
+export class InvalidAuditEventCursorError extends Error {
+  constructor() {
+    super("Invalid cursor");
+    this.name = "InvalidAuditEventCursorError";
+  }
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+function decodeBase64Url(value: string): string {
+  const padded = value
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+export function encodeAuditEventCursor(cursor: AuditEventCursor): string {
+  return `v1.${encodeBase64Url(JSON.stringify(cursor))}`;
+}
+
+export function parseAuditEventCursor(raw: string): AuditEventCursor {
+  if (!/^v1\.[A-Za-z0-9_-]+$/.test(raw)) throw new InvalidAuditEventCursorError();
+  try {
+    const cursor = auditEventCursorSchema.parse(JSON.parse(decodeBase64Url(raw.slice(3))));
+    if (encodeAuditEventCursor(cursor) !== raw) throw new InvalidAuditEventCursorError();
+    return cursor;
+  } catch {
+    throw new InvalidAuditEventCursorError();
+  }
+}
+
+export function toAuditEvent(row: AuditEventRow): AuditEvent {
+  return auditEventSchema.parse({
+    id: row.id,
+    occurredAt: row.occurred_at,
+    requestId: row.request_id,
+    principalKind: row.principal_kind,
+    actorUserIdSnapshot: row.actor_user_id_snapshot,
+    actorServiceSnapshot: row.actor_service_snapshot,
+    action: row.action,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    targetUserIdSnapshot: row.target_user_id_snapshot,
+    reasonCode: row.reason_code,
+    operationResult: row.operation_result,
+    metadata: JSON.parse(row.metadata_json),
+  });
+}
+
+/** Read-only D1 access for the workspace audit log. */
+export class AuditEventStore {
+  constructor(private readonly db: SqlDatabase) {}
+
+  async list(options: { limit: number; cursor?: string | null }): Promise<AuditEventListResponse> {
+    const cursor = options.cursor ? parseAuditEventCursor(options.cursor) : null;
+    const result = cursor
+      ? await this.db
+          .prepare(
+            `SELECT * FROM authorization_audit_events
+             WHERE occurred_at < ? OR (occurred_at = ? AND id < ?)
+             ORDER BY occurred_at DESC, id DESC LIMIT ?`
+          )
+          .bind(cursor.occurredAt, cursor.occurredAt, cursor.id, options.limit + 1)
+          .all<AuditEventRow>()
+      : await this.db
+          .prepare(
+            `SELECT * FROM authorization_audit_events
+             ORDER BY occurred_at DESC, id DESC LIMIT ?`
+          )
+          .bind(options.limit + 1)
+          .all<AuditEventRow>();
+
+    const rows = result.results ?? [];
+    const hasMore = rows.length > options.limit;
+    const events = (hasMore ? rows.slice(0, options.limit) : rows).map(toAuditEvent);
+    if (!hasMore) return { events, hasMore: false, nextCursor: null };
+    const last = events[events.length - 1];
+    return {
+      events,
+      hasMore: true,
+      nextCursor: encodeAuditEventCursor({ occurredAt: last.occurredAt, id: last.id }),
+    };
+  }
+}

--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -161,6 +161,16 @@ describe("route policy table", () => {
       allOf: [{ kind: "permission", permission: "sessions.read" }],
       service: { kind: "deny" },
     });
+    expect(routeFor("GET", "/audit-events")).toMatchObject({
+      authentication: { kind: "user" },
+      authorization: {
+        kind: "active-user",
+        allOf: [{ kind: "permission", permission: "workspace.audit.read" }],
+        service: { kind: "deny" },
+        auditAllowed: false,
+      },
+      cacheControl: "private, no-store",
+    });
     expect(routeFor("POST", "/sessions/session-1/ws-token")?.authorization).toMatchObject({
       kind: "active-user",
       allOf: [{ kind: "permission", permission: "sessions.read" }],

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -61,6 +61,7 @@ import { imageBuildRoutes } from "./routes/image-builds";
 import { automationRoutes } from "./routes/automations";
 import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
+import { auditEventRoutes } from "./routes/audit-events";
 import { autofixRoutes } from "./routes/autofix";
 import { skillRoutes } from "./routes/skills";
 import { keyboardShortcutRoutes } from "./routes/keyboard-shortcuts";
@@ -839,6 +840,9 @@ export const routes: Route[] = [
 
   // Analytics
   ...analyticsRoutes,
+
+  // Workspace audit log
+  ...auditEventRoutes,
 
   // Pull request feedback Autofix activity
   ...autofixRoutes,

--- a/packages/control-plane/src/routes/audit-events.ts
+++ b/packages/control-plane/src/routes/audit-events.ts
@@ -1,0 +1,58 @@
+import { AuditEventStore, InvalidAuditEventCursorError } from "../db/audit-event-store";
+import type { Env } from "../types";
+import {
+  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
+  defineRoutes,
+  error,
+  json,
+  parsePattern,
+  requirePermission,
+  type RequestContext,
+  type Route,
+} from "./shared";
+
+const DEFAULT_AUDIT_EVENT_LIMIT = 25;
+const MAX_AUDIT_EVENT_LIMIT = 100;
+
+function singleQueryValue(searchParams: URLSearchParams, name: string): string | null | Response {
+  const values = searchParams.getAll(name);
+  if (values.length > 1) return error(`Invalid ${name}`, 400);
+  return values[0] ?? null;
+}
+
+async function handleListAuditEvents(
+  request: Request,
+  _env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const searchParams = new URL(request.url).searchParams;
+  const rawLimit = singleQueryValue(searchParams, "limit");
+  if (rawLimit instanceof Response) return rawLimit;
+  const cursor = singleQueryValue(searchParams, "cursor");
+  if (cursor instanceof Response) return cursor;
+
+  if (rawLimit !== null && !/^[1-9]\d*$/.test(rawLimit)) return error("Invalid limit", 400);
+  const limit = rawLimit === null ? DEFAULT_AUDIT_EVENT_LIMIT : Number(rawLimit);
+  if (!Number.isSafeInteger(limit) || limit > MAX_AUDIT_EVENT_LIMIT) {
+    return error("Invalid limit", 400);
+  }
+  if (cursor === "") return error("Invalid cursor", 400);
+
+  try {
+    return json(await new AuditEventStore(ctx.db).list({ limit, cursor }));
+  } catch (cause) {
+    if (cause instanceof InvalidAuditEventCursorError) return error(cause.message, 400);
+    throw cause;
+  }
+}
+
+export const auditEventRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_HUMAN_USER_ROUTE, [
+  {
+    method: "GET",
+    pattern: parsePattern("/audit-events"),
+    authorization: requirePermission("workspace.audit.read", { service: "deny" }),
+    cacheControl: "private, no-store",
+    handler: handleListAuditEvents,
+  },
+]);

--- a/packages/control-plane/src/routes/audit-events.ts
+++ b/packages/control-plane/src/routes/audit-events.ts
@@ -1,4 +1,5 @@
-import { AuditEventStore, InvalidAuditEventCursorError } from "../db/audit-event-store";
+import { encodeAuditEventCursor, parseAuditEventCursor } from "../db/audit-event-cursor";
+import { AuditEventStore, toAuditEvent } from "../db/audit-event-store";
 import type { Env } from "../types";
 import {
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
@@ -37,14 +38,15 @@ async function handleListAuditEvents(
   if (!Number.isSafeInteger(limit) || limit > MAX_AUDIT_EVENT_LIMIT) {
     return error("Invalid limit", 400);
   }
-  if (cursor === "") return error("Invalid cursor", 400);
+  const parsedCursor = parseAuditEventCursor(cursor);
+  if (!parsedCursor.ok) return error(parsedCursor.error, 400);
 
-  try {
-    return json(await new AuditEventStore(ctx.db).list({ limit, cursor }));
-  } catch (cause) {
-    if (cause instanceof InvalidAuditEventCursorError) return error(cause.message, 400);
-    throw cause;
-  }
+  const result = await new AuditEventStore(ctx.db).list({ limit, cursor: parsedCursor.cursor });
+  return json({
+    events: result.rows.map(toAuditEvent),
+    hasMore: result.hasMore,
+    nextCursor: result.nextCursor ? encodeAuditEventCursor(result.nextCursor) : null,
+  });
 }
 
 export const auditEventRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_HUMAN_USER_ROUTE, [

--- a/packages/control-plane/test/integration/audit-event-store.test.ts
+++ b/packages/control-plane/test/integration/audit-event-store.test.ts
@@ -1,0 +1,39 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuditEventStore } from "../../src/db/audit-event-store";
+import { cleanD1Tables } from "./cleanup";
+import { sqlDatabase } from "./helpers";
+
+function insertEvent(id: string, occurredAt: number, metadata: Record<string, unknown> = {}) {
+  return env.DB.prepare(
+    `INSERT INTO authorization_audit_events
+      (id, occurred_at, request_id, principal_kind, action, resource_type,
+       reason_code, operation_result, metadata_json)
+     VALUES (?, ?, ?, 'service', 'test.event', 'workspace', 'test', 'applied', ?)`
+  )
+    .bind(id, occurredAt, `request-${id}`, JSON.stringify({ legacy: true, ...metadata }))
+    .run();
+}
+
+describe("AuditEventStore integration", () => {
+  beforeEach(cleanD1Tables);
+  afterEach(cleanD1Tables);
+
+  it("lists newest-first, parses metadata, and paginates timestamp ties without gaps", async () => {
+    await insertEvent("event-a", 100, { sequence: "a" });
+    await insertEvent("event-b", 100, { sequence: "b" });
+    await insertEvent("event-c", 100, { sequence: "c" });
+    await insertEvent("event-newest", 200, { sequence: "newest" });
+    const store = new AuditEventStore(sqlDatabase(env.DB));
+
+    const first = await store.list({ limit: 2 });
+    expect(first.events.map((event) => event.id)).toEqual(["event-newest", "event-c"]);
+    expect(first.events[0].metadata).toMatchObject({ sequence: "newest" });
+    expect(first.hasMore).toBe(true);
+    expect(first.nextCursor).toEqual(expect.any(String));
+
+    const second = await store.list({ limit: 2, cursor: first.nextCursor });
+    expect(second.events.map((event) => event.id)).toEqual(["event-b", "event-a"]);
+    expect(second).toMatchObject({ hasMore: false, nextCursor: null });
+  });
+});

--- a/packages/control-plane/test/integration/audit-event-store.test.ts
+++ b/packages/control-plane/test/integration/audit-event-store.test.ts
@@ -19,21 +19,20 @@ describe("AuditEventStore integration", () => {
   beforeEach(cleanD1Tables);
   afterEach(cleanD1Tables);
 
-  it("lists newest-first, parses metadata, and paginates timestamp ties without gaps", async () => {
+  it("lists newest-first and paginates timestamp ties without gaps", async () => {
     await insertEvent("event-a", 100, { sequence: "a" });
     await insertEvent("event-b", 100, { sequence: "b" });
     await insertEvent("event-c", 100, { sequence: "c" });
     await insertEvent("event-newest", 200, { sequence: "newest" });
     const store = new AuditEventStore(sqlDatabase(env.DB));
 
-    const first = await store.list({ limit: 2 });
-    expect(first.events.map((event) => event.id)).toEqual(["event-newest", "event-c"]);
-    expect(first.events[0].metadata).toMatchObject({ sequence: "newest" });
+    const first = await store.list({ limit: 2, cursor: null });
+    expect(first.rows.map((event) => event.id)).toEqual(["event-newest", "event-c"]);
     expect(first.hasMore).toBe(true);
-    expect(first.nextCursor).toEqual(expect.any(String));
+    expect(first.nextCursor).toEqual({ occurredAt: 100, id: "event-c" });
 
     const second = await store.list({ limit: 2, cursor: first.nextCursor });
-    expect(second.events.map((event) => event.id)).toEqual(["event-b", "event-a"]);
+    expect(second.rows.map((event) => event.id)).toEqual(["event-b", "event-a"]);
     expect(second).toMatchObject({ hasMore: false, nextCursor: null });
   });
 });

--- a/packages/control-plane/test/integration/audit-events-route.test.ts
+++ b/packages/control-plane/test/integration/audit-events-route.test.ts
@@ -1,0 +1,121 @@
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanD1Tables } from "./cleanup";
+import { serviceFetch } from "./helpers";
+
+const BROWSER_USER_ID = "11111111111111111111111111111111";
+
+async function assignRole(roleId: string): Promise<void> {
+  await env.DB.prepare("UPDATE user_role_assignments SET role_id = ? WHERE user_id = ?")
+    .bind(roleId, BROWSER_USER_ID)
+    .run();
+}
+
+describe("GET /audit-events", () => {
+  beforeEach(cleanD1Tables);
+  afterEach(cleanD1Tables);
+
+  it("allows Owner, Administrator, and a granted custom role but denies Member and Viewer", async () => {
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(200);
+
+    await assignRole("role_builtin_administrator");
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(200);
+
+    await assignRole("role_builtin_member");
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(403);
+
+    await assignRole("role_builtin_viewer");
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(403);
+
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO roles (id, key, name, normalized_name, description, is_system)
+         VALUES ('role_custom_auditor', NULL, 'Auditor', 'auditor', NULL, 0)`
+      ),
+      env.DB.prepare(
+        `INSERT INTO role_permissions (role_id, permission_id)
+         VALUES ('role_custom_auditor', 'workspace.audit.read')`
+      ),
+    ]);
+    await assignRole("role_custom_auditor");
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(200);
+  });
+
+  it("uses strict query parsing, defaults to 25, caps at 100, and prevents caching", async () => {
+    await env.DB.batch(
+      Array.from({ length: 26 }, (_, index) =>
+        env.DB.prepare(
+          `INSERT INTO authorization_audit_events
+            (id, occurred_at, request_id, principal_kind, action, resource_type,
+             reason_code, operation_result, metadata_json)
+           VALUES (?, ?, ?, 'service', 'test.event', 'workspace', 'test', 'applied', '{"legacy":true}')`
+        ).bind(`event-${String(index).padStart(2, "0")}`, index, `request-${index}`)
+      )
+    );
+    const response = await serviceFetch("https://cp.test/audit-events");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    const body = await response.json<{ events: unknown[]; hasMore: boolean; nextCursor: string }>();
+    expect(body).toMatchObject({
+      hasMore: true,
+      nextCursor: expect.any(String),
+    });
+    expect(body.events).toHaveLength(25);
+    expect((await serviceFetch("https://cp.test/audit-events?limit=100")).status).toBe(200);
+
+    for (const query of [
+      "limit=0",
+      "limit=101",
+      "limit=1.5",
+      "limit=1e2",
+      "limit=1&limit=2",
+      "cursor=",
+      "cursor=not-a-cursor",
+      "cursor=one&cursor=two",
+    ]) {
+      const invalid = await serviceFetch(`https://cp.test/audit-events?${query}`);
+      expect(invalid.status, query).toBe(400);
+      expect(invalid.headers.get("Cache-Control"), query).toBe("private, no-store");
+    }
+  });
+
+  it("does not audit successful reads and records denied read authorization", async () => {
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(200);
+    expect(
+      await env.DB.prepare(
+        `SELECT COUNT(*) AS count FROM authorization_audit_events
+         WHERE action = 'authorization.request_allowed' AND resource_id = '/audit-events'`
+      ).first()
+    ).toEqual({ count: 0 });
+
+    await assignRole("role_builtin_member");
+    expect((await serviceFetch("https://cp.test/audit-events")).status).toBe(403);
+    const denied = await env.DB.prepare(
+      `SELECT principal_kind, action, resource_type, resource_id, reason_code,
+              operation_result, metadata_json
+       FROM authorization_audit_events
+       WHERE action = 'authorization.request_denied' AND resource_id = '/audit-events'`
+    ).first<{
+      principal_kind: string;
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      reason_code: string;
+      operation_result: string;
+      metadata_json: string;
+    }>();
+    expect(denied).toMatchObject({
+      principal_kind: "user",
+      action: "authorization.request_denied",
+      resource_type: "http_route",
+      resource_id: "/audit-events",
+      reason_code: "permission_required",
+      operation_result: "denied",
+    });
+    expect(JSON.parse(denied!.metadata_json)).toMatchObject({
+      httpMethod: "GET",
+      httpPath: "/audit-events",
+      requiredPermission: "workspace.audit.read",
+    });
+  });
+});

--- a/packages/control-plane/test/integration/migration-0074-audit-event-list-index.test.ts
+++ b/packages/control-plane/test/integration/migration-0074-audit-event-list-index.test.ts
@@ -1,0 +1,21 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+describe("migration 0074: audit event list index", () => {
+  it("creates the descending occurred-at and ID index", async () => {
+    const indexes = await env.DB.prepare("PRAGMA index_list('authorization_audit_events')").all<{
+      name: string;
+    }>();
+    expect(indexes.results.map((index) => index.name)).toContain(
+      "idx_authorization_audit_events_occurred_at_id"
+    );
+
+    const columns = await env.DB.prepare(
+      "PRAGMA index_xinfo('idx_authorization_audit_events_occurred_at_id')"
+    ).all<{ name: string | null; desc: number; key: number }>();
+    expect(columns.results.filter((column) => column.key === 1)).toMatchObject([
+      { name: "occurred_at", desc: 1 },
+      { name: "id", desc: 1 },
+    ]);
+  });
+});

--- a/packages/control-plane/test/integration/migration-0074-audit-event-list-index.test.ts
+++ b/packages/control-plane/test/integration/migration-0074-audit-event-list-index.test.ts
@@ -18,4 +18,19 @@ describe("migration 0074: audit event list index", () => {
       { name: "id", desc: 1 },
     ]);
   });
+
+  it("uses the index to seek from a pagination cursor", async () => {
+    const plan = await env.DB.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT * FROM authorization_audit_events
+       WHERE (occurred_at, id) < (?, ?)
+       ORDER BY occurred_at DESC, id DESC LIMIT ?`
+    )
+      .bind(100, "event-1", 25)
+      .all<{ detail: string }>();
+
+    expect(plan.results.map((step) => step.detail).join("\n")).toMatch(
+      /SEARCH authorization_audit_events USING INDEX idx_authorization_audit_events_occurred_at_id/
+    );
+  });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -185,6 +185,10 @@
     "./types/analytics": {
       "import": "./dist/types/analytics.js",
       "types": "./dist/types/analytics.d.ts"
+    },
+    "./types/audit-events": {
+      "import": "./dist/types/audit-events.js",
+      "types": "./dist/types/audit-events.d.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/rbac.test.ts
+++ b/packages/shared/src/rbac.test.ts
@@ -61,7 +61,7 @@ describe("RBAC registry", () => {
   });
 
   it("contains unique, sorted permission identifiers", () => {
-    expect(PERMISSION_IDS).toHaveLength(42);
+    expect(PERMISSION_IDS).toHaveLength(43);
     expect(new Set(PERMISSION_IDS).size).toBe(PERMISSION_IDS.length);
     expect(PERMISSION_IDS).toEqual([...PERMISSION_IDS].sort());
   });
@@ -118,6 +118,13 @@ describe("RBAC registry", () => {
   it("grants workspace analytics to Members and Viewers", () => {
     expect(permissionsForBuiltInRole("member")).toContain("analytics.read");
     expect(permissionsForBuiltInRole("viewer")).toContain("analytics.read");
+  });
+
+  it("reserves workspace audit reads for Owner, Administrator, and eligible custom roles", () => {
+    expect(permissionsForBuiltInRole("owner")).toContain("workspace.audit.read");
+    expect(permissionsForBuiltInRole("administrator")).toContain("workspace.audit.read");
+    expect(permissionsForBuiltInRole("member")).not.toContain("workspace.audit.read");
+    expect(permissionsForBuiltInRole("viewer")).not.toContain("workspace.audit.read");
   });
 
   it("makes Member a superset of Viewer", () => {

--- a/packages/shared/src/rbac.ts
+++ b/packages/shared/src/rbac.ts
@@ -68,6 +68,7 @@ export const PERMISSION_IDS = [
   "skill_profiles.manage_own",
   "skills.manage",
   "skills.read",
+  "workspace.audit.read",
   "workspace.members.manage",
   "workspace.members.read",
   "workspace.roles.read",

--- a/packages/shared/src/types/audit-events.test.ts
+++ b/packages/shared/src/types/audit-events.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { auditEventListResponseSchema, auditEventSchema } from "./audit-events";
+
+const event = {
+  id: "event-1",
+  occurredAt: 123,
+  requestId: "request-1",
+  principalKind: "service",
+  actorUserIdSnapshot: null,
+  actorServiceSnapshot: "github-bot",
+  action: "workspace.member_role_updated",
+  resourceType: "user",
+  resourceId: null,
+  targetUserIdSnapshot: null,
+  reasonCode: "role_replaced",
+  operationResult: "applied",
+  metadata: { schema: "future.v2", nested: { additions: [true, 1, null] } },
+} as const;
+
+describe("audit event contracts", () => {
+  it("accepts current principals, outcomes, nullable snapshots, and forward-compatible metadata", () => {
+    for (const principalKind of ["user", "service", "sandbox"]) {
+      for (const operationResult of ["applied", "no_op", "denied", "rejected"]) {
+        expect(auditEventSchema.parse({ ...event, principalKind, operationResult })).toMatchObject({
+          principalKind,
+          operationResult,
+          metadata: event.metadata,
+        });
+      }
+    }
+  });
+
+  it("rejects unsupported principal and outcome values", () => {
+    expect(() => auditEventSchema.parse({ ...event, principalKind: "automation" })).toThrow();
+    expect(() => auditEventSchema.parse({ ...event, operationResult: "failed" })).toThrow();
+  });
+
+  it("enforces the pagination cursor invariant", () => {
+    expect(
+      auditEventListResponseSchema.parse({ events: [event], hasMore: false, nextCursor: null })
+    ).toMatchObject({ hasMore: false, nextCursor: null });
+    expect(
+      auditEventListResponseSchema.parse({ events: [event], hasMore: true, nextCursor: "opaque" })
+    ).toMatchObject({ hasMore: true, nextCursor: "opaque" });
+    expect(() =>
+      auditEventListResponseSchema.parse({ events: [], hasMore: true, nextCursor: null })
+    ).toThrow();
+    expect(() =>
+      auditEventListResponseSchema.parse({ events: [], hasMore: false, nextCursor: "unexpected" })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/types/audit-events.test.ts
+++ b/packages/shared/src/types/audit-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { auditEventListResponseSchema, auditEventSchema } from "./audit-events";
+import {
+  MAX_AUDIT_EVENT_TIMESTAMP_MS,
+  auditEventListResponseSchema,
+  auditEventSchema,
+} from "./audit-events";
 
 const event = {
   id: "event-1",
@@ -33,6 +37,19 @@ describe("audit event contracts", () => {
   it("rejects unsupported principal and outcome values", () => {
     expect(() => auditEventSchema.parse({ ...event, principalKind: "automation" })).toThrow();
     expect(() => auditEventSchema.parse({ ...event, operationResult: "failed" })).toThrow();
+  });
+
+  it("rejects timestamps that cannot be paginated or rendered as dates", () => {
+    expect(auditEventSchema.parse({ ...event, occurredAt: MAX_AUDIT_EVENT_TIMESTAMP_MS })).toEqual({
+      ...event,
+      occurredAt: MAX_AUDIT_EVENT_TIMESTAMP_MS,
+    });
+    expect(() =>
+      auditEventSchema.parse({ ...event, occurredAt: MAX_AUDIT_EVENT_TIMESTAMP_MS + 1 })
+    ).toThrow();
+    expect(() =>
+      auditEventSchema.parse({ ...event, occurredAt: Number.MAX_SAFE_INTEGER })
+    ).toThrow();
   });
 
   it("enforces the pagination cursor invariant", () => {

--- a/packages/shared/src/types/audit-events.ts
+++ b/packages/shared/src/types/audit-events.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+/** Outcomes recorded for workspace operations and authorization decisions. */
+export const auditOperationResultSchema = z.enum(["applied", "no_op", "denied", "rejected"]);
+
+/** Principal categories currently emitted by the control plane. */
+export const auditPrincipalKindSchema = z.enum(["user", "service", "sandbox"]);
+
+/** Forward-compatible structured metadata attached to an audit event. */
+export const auditEventMetadataSchema = z.record(z.string(), z.unknown());
+
+/** A durable workspace audit event exposed by the audit log API. */
+export const auditEventSchema = z
+  .object({
+    id: z.string().min(1),
+    occurredAt: z.number().int().nonnegative(),
+    requestId: z.string().min(1),
+    principalKind: auditPrincipalKindSchema,
+    actorUserIdSnapshot: z.string().nullable(),
+    actorServiceSnapshot: z.string().nullable(),
+    action: z.string().min(1),
+    resourceType: z.string().min(1),
+    resourceId: z.string().nullable(),
+    targetUserIdSnapshot: z.string().nullable(),
+    reasonCode: z.string().min(1),
+    operationResult: auditOperationResultSchema,
+    metadata: auditEventMetadataSchema,
+  })
+  .strict();
+
+/** A newest-first audit event page with a cursor exactly when another page exists. */
+export const auditEventListResponseSchema = z.discriminatedUnion("hasMore", [
+  z
+    .object({
+      events: z.array(auditEventSchema),
+      hasMore: z.literal(false),
+      nextCursor: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      events: z.array(auditEventSchema),
+      hasMore: z.literal(true),
+      nextCursor: z.string().min(1),
+    })
+    .strict(),
+]);
+
+export type AuditOperationResult = z.infer<typeof auditOperationResultSchema>;
+export type AuditPrincipalKind = z.infer<typeof auditPrincipalKindSchema>;
+export type AuditEventMetadata = z.infer<typeof auditEventMetadataSchema>;
+export type AuditEvent = z.infer<typeof auditEventSchema>;
+export type AuditEventListResponse = z.infer<typeof auditEventListResponseSchema>;

--- a/packages/shared/src/types/audit-events.ts
+++ b/packages/shared/src/types/audit-events.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+export const MAX_AUDIT_EVENT_TIMESTAMP_MS = 8_640_000_000_000_000;
+
+/** Nonnegative millisecond timestamp safe for cursors and JavaScript Date rendering. */
+export const auditEventTimestampSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .safe()
+  .max(MAX_AUDIT_EVENT_TIMESTAMP_MS);
+
 /** Outcomes recorded for workspace operations and authorization decisions. */
 export const auditOperationResultSchema = z.enum(["applied", "no_op", "denied", "rejected"]);
 
@@ -13,7 +23,7 @@ export const auditEventMetadataSchema = z.record(z.string(), z.unknown());
 export const auditEventSchema = z
   .object({
     id: z.string().min(1),
-    occurredAt: z.number().int().nonnegative(),
+    occurredAt: auditEventTimestampSchema,
     requestId: z.string().min(1),
     principalKind: auditPrincipalKindSchema,
     actorUserIdSnapshot: z.string().nullable(),

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -170,6 +170,21 @@ export type {
 export type { AutomationTriggerType } from "../triggers/types";
 
 export {
+  auditOperationResultSchema,
+  auditPrincipalKindSchema,
+  auditEventMetadataSchema,
+  auditEventSchema,
+  auditEventListResponseSchema,
+} from "./audit-events";
+export type {
+  AuditOperationResult,
+  AuditPrincipalKind,
+  AuditEventMetadata,
+  AuditEvent,
+  AuditEventListResponse,
+} from "./audit-events";
+
+export {
   MAX_AUTOMATION_REPOSITORIES,
   toRepositoryRef,
   automationRepositoryInputSchema,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -170,6 +170,8 @@ export type {
 export type { AutomationTriggerType } from "../triggers/types";
 
 export {
+  MAX_AUDIT_EVENT_TIMESTAMP_MS,
+  auditEventTimestampSchema,
   auditOperationResultSchema,
   auditPrincipalKindSchema,
   auditEventMetadataSchema,

--- a/packages/web/src/app/api/audit-events/route.test.ts
+++ b/packages/web/src/app/api/audit-events/route.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { controlPlaneUserFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
+
+describe("GET /api/audit-events", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("forwards only limit and cursor query parameters", async () => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValue(
+      Response.json({ events: [], hasMore: false, nextCursor: null })
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/audit-events?limit=25&cursor=opaque%2Fcursor&filter=denied&limit=10"
+      ),
+      { params: Promise.resolve({}) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
+      "/audit-events?limit=25&limit=10&cursor=opaque%2Fcursor",
+      undefined
+    );
+  });
+});

--- a/packages/web/src/app/api/audit-events/route.ts
+++ b/packages/web/src/app/api/audit-events/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from "next/server";
+import { buildControlPlanePath } from "@/lib/control-plane-query";
+import { settingsProxy } from "@/lib/settings-proxy";
+
+export const { GET } = settingsProxy(
+  (_params: Record<string, never>, request: NextRequest) =>
+    buildControlPlanePath("/audit-events", new URL(request.url).searchParams, ["limit", "cursor"]),
+  "audit events"
+);

--- a/packages/web/src/components/settings/audit-log-settings.test.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +23,12 @@ const hook = vi.hoisted(() => ({
 }));
 
 vi.mock("@/hooks/use-audit-events", () => ({ useAuditEvents: () => hook }));
+
+const scrollIntoView = vi.fn();
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: scrollIntoView,
+});
 
 function createEvent(
   operationResult: "applied" | "no_op" | "denied" | "rejected",
@@ -59,6 +65,7 @@ beforeEach(() => {
   hook.previous.mockReset();
   hook.next.mockReset();
   hook.retry.mockReset();
+  scrollIntoView.mockReset();
 });
 
 afterEach(cleanup);
@@ -109,6 +116,20 @@ describe("AuditLogSettings", () => {
     expect(hook.retry).toHaveBeenCalledOnce();
   });
 
+  it("keeps cached events visible when a background refresh fails", async () => {
+    hook.events = [createEvent("applied")];
+    hook.error = new Error("failed");
+    render(<AuditLogSettings />);
+
+    expect(screen.getByRole("article")).toBeInTheDocument();
+    expect(screen.queryByText("Unable to load the audit log.")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Unable to refresh the audit log. Showing the most recently loaded events."
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(hook.retry).toHaveBeenCalledOnce();
+  });
+
   it("allows returning to a previous page after a later page fails", async () => {
     hook.error = new Error("failed");
     hook.page = 2;
@@ -150,5 +171,25 @@ describe("AuditLogSettings", () => {
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(hook.previous).toHaveBeenCalledOnce();
     expect(hook.next).toHaveBeenCalledOnce();
+  });
+
+  it("moves focus and scroll context after a requested page loads", async () => {
+    hook.events = [createEvent("applied")];
+    hook.hasNext = true;
+    const { rerender } = render(<AuditLogSettings />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    hook.page = 2;
+    hook.loading = true;
+    hook.events = [];
+    rerender(<AuditLogSettings />);
+    expect(screen.getByRole("heading", { name: "Audit log" })).not.toHaveFocus();
+
+    hook.loading = false;
+    hook.events = [createEvent("applied", { id: "event-page-2" })];
+    rerender(<AuditLogSettings />);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Audit log" })).toHaveFocus());
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
   });
 });

--- a/packages/web/src/components/settings/audit-log-settings.test.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuditLogSettings } from "./audit-log-settings";
+
+expect.extend(matchers);
+
+const hook = vi.hoisted(() => ({
+  events: [] as Record<string, unknown>[],
+  loading: false,
+  validating: false,
+  error: undefined as unknown,
+  page: 1,
+  hasPrevious: false,
+  hasNext: false,
+  previous: vi.fn(),
+  next: vi.fn(),
+  retry: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-audit-events", () => ({ useAuditEvents: () => hook }));
+
+function createEvent(
+  operationResult: "applied" | "no_op" | "denied" | "rejected",
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id: `event-${operationResult}`,
+    occurredAt: 1_700_000_000_000,
+    requestId: `request-${operationResult}`,
+    principalKind: "user",
+    actorUserIdSnapshot: "actor-snapshot-id",
+    actorServiceSnapshot: null,
+    action: "workspace.member_role_updated",
+    resourceType: "user",
+    resourceId: "resource-snapshot-id",
+    targetUserIdSnapshot: "target-snapshot-id",
+    reasonCode: "member_role_updated",
+    operationResult,
+    metadata: { before: { roleId: "role-old" }, after: { roleId: "role-new" } },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  Object.assign(hook, {
+    events: [],
+    loading: false,
+    validating: false,
+    error: undefined,
+    page: 1,
+    hasPrevious: false,
+    hasNext: false,
+  });
+  hook.previous.mockReset();
+  hook.next.mockReset();
+  hook.retry.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("AuditLogSettings", () => {
+  it("renders outcomes, stable summaries, timestamps, and expandable structured details", async () => {
+    hook.events = [
+      createEvent("applied"),
+      createEvent("no_op"),
+      createEvent("denied"),
+      createEvent("rejected", {
+        action: "future_namespace.custom_action",
+        actorServiceSnapshot: "github-bot",
+      }),
+    ];
+    const { container } = render(<AuditLogSettings />);
+
+    expect(screen.getByRole("heading", { name: "Audit log" })).toBeInTheDocument();
+    expect(screen.getAllByRole("article")).toHaveLength(4);
+    for (const label of ["Applied", "No change", "Denied", "Rejected"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText(/actor-snapshot-id/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/resource-snapshot-id/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/target-snapshot-id/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Custom action")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Service \/ github-bot \/ User actor \/ actor-snapshot-id/)
+    ).toBeInTheDocument();
+
+    const timestamp = screen.getAllByRole("time")[0];
+    expect(timestamp).toHaveAttribute("title", new Date(1_700_000_000_000).toLocaleString());
+    await userEvent.click(screen.getAllByText("Structured details")[0]);
+    expect(screen.getAllByText(/"roleId": "role-old"/)[0]).toBeVisible();
+
+    expect(container.querySelector("ul")).toHaveClass("min-w-0");
+    expect(screen.getByText("request-applied")).toHaveClass("break-all");
+  });
+
+  it("renders empty and error states with a working retry action", async () => {
+    const { rerender } = render(<AuditLogSettings />);
+    expect(screen.getByText("No audit events yet")).toBeInTheDocument();
+
+    hook.error = new Error("failed");
+    rerender(<AuditLogSettings />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to load the audit log.");
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(hook.retry).toHaveBeenCalledOnce();
+  });
+
+  it("allows returning to a previous page after a later page fails", async () => {
+    hook.error = new Error("failed");
+    hook.page = 2;
+    hook.hasPrevious = true;
+    render(<AuditLogSettings />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to load the audit log.");
+    await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+    expect(hook.previous).toHaveBeenCalledOnce();
+  });
+
+  it("announces the loading state", () => {
+    hook.loading = true;
+    render(<AuditLogSettings />);
+
+    expect(screen.getByText("Loading audit events...")).toBeInTheDocument();
+  });
+
+  it("keeps pagination mounted while loading a later page", () => {
+    hook.loading = true;
+    hook.page = 2;
+    hook.hasPrevious = true;
+    render(<AuditLogSettings />);
+
+    expect(screen.getByRole("navigation", { name: "Audit log pagination" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+  });
+
+  it("provides semantic Previous/Next pagination and page status", async () => {
+    hook.events = [createEvent("applied")];
+    hook.page = 3;
+    hook.hasPrevious = true;
+    hook.hasNext = true;
+    render(<AuditLogSettings />);
+
+    const pagination = screen.getByRole("navigation", { name: "Audit log pagination" });
+    expect(pagination).toHaveTextContent("Page 3");
+    await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(hook.previous).toHaveBeenCalledOnce();
+    expect(hook.next).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/components/settings/audit-log-settings.test.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.test.tsx
@@ -91,7 +91,7 @@ describe("AuditLogSettings", () => {
     expect(screen.getAllByText(/actor-snapshot-id/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/resource-snapshot-id/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/target-snapshot-id/).length).toBeGreaterThan(0);
-    expect(screen.getByText("Custom action")).toBeInTheDocument();
+    expect(screen.getByText("future_namespace.custom_action")).toBeInTheDocument();
     expect(
       screen.getByText(/Service \/ github-bot \/ User actor \/ actor-snapshot-id/)
     ).toBeInTheDocument();
@@ -119,6 +119,7 @@ describe("AuditLogSettings", () => {
   it("keeps cached events visible when a background refresh fails", async () => {
     hook.events = [createEvent("applied")];
     hook.error = new Error("failed");
+    hook.hasNext = true;
     render(<AuditLogSettings />);
 
     expect(screen.getByRole("article")).toBeInTheDocument();
@@ -128,6 +129,7 @@ describe("AuditLogSettings", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(hook.retry).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
   });
 
   it("allows returning to a previous page after a later page fails", async () => {

--- a/packages/web/src/components/settings/audit-log-settings.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import type { AuditEvent, AuditOperationResult } from "@open-inspect/shared/types/audit-events";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useAuditEvents } from "@/hooks/use-audit-events";
+import { formatRelativeTime } from "@/lib/time";
+
+const OUTCOMES: Record<AuditOperationResult, { label: string; className: string }> = {
+  applied: { label: "Applied", className: "bg-success-muted text-success" },
+  no_op: { label: "No change", className: "bg-muted text-muted-foreground" },
+  denied: { label: "Denied", className: "bg-destructive-muted text-destructive" },
+  rejected: { label: "Rejected", className: "bg-warning-muted text-warning" },
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  "authorization.request_allowed": "Request authorized",
+  "authorization.request_denied": "Request denied",
+  "workspace.member_role_updated": "Member role updated",
+  "workspace.member_status_updated": "Member status updated",
+};
+
+export function auditActionLabel(action: string): string {
+  if (ACTION_LABELS[action]) return ACTION_LABELS[action];
+  const segment = action.split(".").at(-1) ?? action;
+  const words = segment.replaceAll("_", " ").trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : action;
+}
+
+function actorSummary(event: AuditEvent): string {
+  if (event.actorServiceSnapshot && event.actorUserIdSnapshot) {
+    return `Service / ${event.actorServiceSnapshot} / User actor / ${event.actorUserIdSnapshot}`;
+  }
+  if (event.actorServiceSnapshot) return `Service / ${event.actorServiceSnapshot}`;
+  if (event.actorUserIdSnapshot) return `User / ${event.actorUserIdSnapshot}`;
+  return `${event.principalKind.charAt(0).toUpperCase()}${event.principalKind.slice(1)} principal`;
+}
+
+function resourceSummary(event: AuditEvent): string {
+  const resource = event.resourceId
+    ? `${event.resourceType} / ${event.resourceId}`
+    : event.resourceType;
+  return event.targetUserIdSnapshot
+    ? `${resource} / Target user ${event.targetUserIdSnapshot}`
+    : resource;
+}
+
+function AuditEventCard({ event }: { event: AuditEvent }) {
+  const outcome = OUTCOMES[event.operationResult];
+  const localTimestamp = new Date(event.occurredAt).toLocaleString();
+
+  return (
+    <li className="min-w-0 px-4 py-4 sm:px-5">
+      <article aria-labelledby={`audit-event-${event.id}`}>
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h3 id={`audit-event-${event.id}`} className="text-sm font-medium text-foreground">
+              {auditActionLabel(event.action)}
+            </h3>
+            <time
+              dateTime={new Date(event.occurredAt).toISOString()}
+              title={localTimestamp}
+              className="mt-0.5 block text-xs text-muted-foreground"
+            >
+              {localTimestamp} / {formatRelativeTime(event.occurredAt)}
+            </time>
+          </div>
+          <Badge className={`w-fit shrink-0 ${outcome.className}`}>{outcome.label}</Badge>
+        </div>
+
+        <dl className="mt-3 grid min-w-0 gap-x-5 gap-y-2 text-xs sm:grid-cols-2">
+          <div className="min-w-0">
+            <dt className="text-muted-foreground">Actor</dt>
+            <dd className="break-words font-mono text-foreground">{actorSummary(event)}</dd>
+          </div>
+          <div className="min-w-0">
+            <dt className="text-muted-foreground">Resource</dt>
+            <dd className="break-words font-mono text-foreground">{resourceSummary(event)}</dd>
+          </div>
+          <div className="min-w-0">
+            <dt className="text-muted-foreground">Request</dt>
+            <dd className="break-all font-mono text-foreground">{event.requestId}</dd>
+          </div>
+          <div className="min-w-0">
+            <dt className="text-muted-foreground">Reason</dt>
+            <dd className="break-words font-mono text-foreground">{event.reasonCode}</dd>
+          </div>
+        </dl>
+
+        <details className="mt-3 text-xs">
+          <summary className="w-fit cursor-pointer rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
+            Structured details
+          </summary>
+          <pre className="mt-2 max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-mono text-[11px] leading-5 text-foreground">
+            {JSON.stringify(
+              {
+                eventId: event.id,
+                action: event.action,
+                principalKind: event.principalKind,
+                metadata: event.metadata,
+              },
+              null,
+              2
+            )}
+          </pre>
+        </details>
+      </article>
+    </li>
+  );
+}
+
+/** Read-only, cursor-paginated view of durable workspace audit events. */
+export function AuditLogSettings() {
+  const audit = useAuditEvents();
+
+  return (
+    <section aria-labelledby="audit-log-heading">
+      <h2 id="audit-log-heading" className="mb-1 text-xl font-semibold text-foreground">
+        Audit log
+      </h2>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Review workspace operations and authorization decisions. Events are shown newest first.
+      </p>
+
+      {audit.loading ? (
+        <div className="rounded-md border border-border-muted py-12 text-center" aria-live="polite">
+          <div
+            className="mx-auto size-6 animate-spin rounded-full border-2 border-current border-t-transparent text-muted-foreground"
+            aria-hidden="true"
+          />
+          <p className="mt-3 text-sm text-muted-foreground">Loading audit events...</p>
+        </div>
+      ) : audit.error ? (
+        <div role="alert" className="rounded-md border border-destructive-border p-5">
+          <p className="text-sm font-medium text-destructive">Unable to load the audit log.</p>
+          <p className="mt-1 text-xs text-muted-foreground">Try the request again.</p>
+          <Button className="mt-4" size="sm" variant="outline" onClick={() => void audit.retry()}>
+            Retry
+          </Button>
+        </div>
+      ) : audit.events.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border py-12 text-center">
+          <p className="text-sm font-medium text-foreground">No audit events yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Workspace activity will appear here as it is recorded.
+          </p>
+        </div>
+      ) : (
+        <ul className="min-w-0 divide-y divide-border-muted rounded-md border border-border-muted">
+          {audit.events.map((event) => (
+            <AuditEventCard key={event.id} event={event} />
+          ))}
+        </ul>
+      )}
+
+      {(audit.events.length > 0 || audit.hasPrevious) && (
+        <nav
+          className="mt-4 flex items-center justify-between gap-3"
+          aria-label="Audit log pagination"
+        >
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!audit.hasPrevious || audit.loading || audit.validating}
+            onClick={audit.previous}
+          >
+            Previous
+          </Button>
+          <span className="text-xs text-muted-foreground" aria-live="polite">
+            Page {audit.page}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!audit.hasNext || audit.loading || audit.validating}
+            onClick={audit.next}
+          >
+            Next
+          </Button>
+        </nav>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/settings/audit-log-settings.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.tsx
@@ -22,10 +22,7 @@ const ACTION_LABELS: Record<string, string> = {
 };
 
 export function auditActionLabel(action: string): string {
-  if (ACTION_LABELS[action]) return ACTION_LABELS[action];
-  const segment = action.split(".").at(-1) ?? action;
-  const words = segment.replaceAll("_", " ").trim();
-  return words ? words.charAt(0).toUpperCase() + words.slice(1) : action;
+  return ACTION_LABELS[action] ?? action;
 }
 
 function actorSummary(event: AuditEvent): string {
@@ -206,7 +203,7 @@ export function AuditLogSettings() {
           <Button
             size="sm"
             variant="outline"
-            disabled={!audit.hasNext || audit.loading || audit.validating}
+            disabled={!audit.hasNext || audit.loading || audit.validating || Boolean(audit.error)}
             onClick={() => changePage(audit.next)}
           >
             Next

--- a/packages/web/src/components/settings/audit-log-settings.tsx
+++ b/packages/web/src/components/settings/audit-log-settings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { AuditEvent, AuditOperationResult } from "@open-inspect/shared/types/audit-events";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -112,15 +113,48 @@ function AuditEventCard({ event }: { event: AuditEvent }) {
 /** Read-only, cursor-paginated view of durable workspace audit events. */
 export function AuditLogSettings() {
   const audit = useAuditEvents();
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const focusAfterPaginationRef = useRef(false);
+
+  useEffect(() => {
+    if (!focusAfterPaginationRef.current || audit.loading || audit.error) return;
+    focusAfterPaginationRef.current = false;
+    headingRef.current?.focus({ preventScroll: true });
+    headingRef.current?.scrollIntoView({ block: "start" });
+  }, [audit.error, audit.loading, audit.page]);
+
+  const changePage = (navigate: () => void) => {
+    focusAfterPaginationRef.current = true;
+    navigate();
+  };
 
   return (
     <section aria-labelledby="audit-log-heading">
-      <h2 id="audit-log-heading" className="mb-1 text-xl font-semibold text-foreground">
+      <h2
+        ref={headingRef}
+        id="audit-log-heading"
+        tabIndex={-1}
+        className="mb-1 rounded-sm text-xl font-semibold text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         Audit log
       </h2>
       <p className="mb-6 text-sm text-muted-foreground">
         Review workspace operations and authorization decisions. Events are shown newest first.
       </p>
+
+      {audit.error && audit.events.length > 0 && (
+        <div
+          role="status"
+          className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-destructive-border px-4 py-3"
+        >
+          <p className="text-sm text-destructive">
+            Unable to refresh the audit log. Showing the most recently loaded events.
+          </p>
+          <Button size="sm" variant="outline" onClick={() => void audit.retry()}>
+            Retry
+          </Button>
+        </div>
+      )}
 
       {audit.loading ? (
         <div className="rounded-md border border-border-muted py-12 text-center" aria-live="polite">
@@ -130,7 +164,7 @@ export function AuditLogSettings() {
           />
           <p className="mt-3 text-sm text-muted-foreground">Loading audit events...</p>
         </div>
-      ) : audit.error ? (
+      ) : audit.error && audit.events.length === 0 ? (
         <div role="alert" className="rounded-md border border-destructive-border p-5">
           <p className="text-sm font-medium text-destructive">Unable to load the audit log.</p>
           <p className="mt-1 text-xs text-muted-foreground">Try the request again.</p>
@@ -162,7 +196,7 @@ export function AuditLogSettings() {
             size="sm"
             variant="outline"
             disabled={!audit.hasPrevious || audit.loading || audit.validating}
-            onClick={audit.previous}
+            onClick={() => changePage(audit.previous)}
           >
             Previous
           </Button>
@@ -173,7 +207,7 @@ export function AuditLogSettings() {
             size="sm"
             variant="outline"
             disabled={!audit.hasNext || audit.loading || audit.validating}
-            onClick={audit.next}
+            onClick={() => changePage(audit.next)}
           >
             Next
           </Button>

--- a/packages/web/src/components/settings/settings-registry.test.ts
+++ b/packages/web/src/components/settings/settings-registry.test.ts
@@ -42,6 +42,13 @@ describe("settings registry", () => {
     }
   });
 
+  it("shows the Audit log only with workspace audit read permission", () => {
+    expect(canViewSettingsCategory("audit-log", () => false)).toBe(false);
+    expect(
+      canViewSettingsCategory("audit-log", (permission) => permission === "workspace.audit.read")
+    ).toBe(true);
+  });
+
   it("requires repository visibility alongside image-build read access", () => {
     expect(
       canViewSettingsCategory("images", (permission) => permission === "image_builds.read")

--- a/packages/web/src/components/settings/settings-registry.ts
+++ b/packages/web/src/components/settings/settings-registry.ts
@@ -1,6 +1,7 @@
 import {
   AppearanceIcon,
   BoxIcon,
+  ClockIcon,
   DataControlsIcon,
   FolderIcon,
   GitPrIcon,
@@ -134,6 +135,17 @@ export const SETTINGS_GROUPS = [
         visibility: anyOf("workspace.members.read", "workspace.roles.read"),
         panel: lazyPanel(() =>
           import("./workspace-settings").then(({ WorkspaceSettings }) => WorkspaceSettings)
+        ),
+      },
+      {
+        id: "audit-log",
+        label: "Audit log",
+        description: "Review workspace activity and access decisions",
+        keywords: "audit security history events authorization operations compliance",
+        icon: ClockIcon,
+        visibility: anyOf("workspace.audit.read"),
+        panel: lazyPanel(() =>
+          import("./audit-log-settings").then(({ AuditLogSettings }) => AuditLogSettings)
         ),
       },
       {

--- a/packages/web/src/hooks/use-audit-events.test.tsx
+++ b/packages/web/src/hooks/use-audit-events.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { AUDIT_EVENT_PAGE_SIZE, auditEventsKey, useAuditEvents } from "./use-audit-events";
+
+vi.mock("@/lib/browser-api-fetch", () => ({ browserApiFetch: vi.fn() }));
+
+const event = {
+  id: "event-1",
+  occurredAt: 1_700_000_000_000,
+  requestId: "request-1",
+  principalKind: "user" as const,
+  actorUserIdSnapshot: "user-1",
+  actorServiceSnapshot: null,
+  action: "workspace.member_role_updated",
+  resourceType: "user",
+  resourceId: "user-2",
+  targetUserIdSnapshot: "user-2",
+  reasonCode: "member_role_updated",
+  operationResult: "applied" as const,
+  metadata: {},
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+  );
+}
+
+describe("useAuditEvents", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("uses a page-size-25 key and encodes opaque cursors", () => {
+    expect(AUDIT_EVENT_PAGE_SIZE).toBe(25);
+    expect(auditEventsKey()).toBe("/api/audit-events?limit=25");
+    expect(auditEventsKey("v1.cursor/+ value")).toBe(
+      "/api/audit-events?limit=25&cursor=v1.cursor%2F%2B+value"
+    );
+  });
+
+  it("validates pages and navigates through cursor history", async () => {
+    vi.mocked(browserApiFetch)
+      .mockResolvedValueOnce(
+        Response.json({ events: [event], hasMore: true, nextCursor: "cursor-2" })
+      )
+      .mockResolvedValueOnce(
+        Response.json({ events: [{ ...event, id: "event-2" }], hasMore: false, nextCursor: null })
+      );
+    const { result } = renderHook(useAuditEvents, { wrapper });
+
+    await waitFor(() => expect(result.current.events[0]?.id).toBe("event-1"));
+    expect(browserApiFetch).toHaveBeenCalledWith("/api/audit-events?limit=25");
+
+    act(() => result.current.next());
+    await waitFor(() => expect(result.current.events[0]?.id).toBe("event-2"));
+    expect(result.current.page).toBe(2);
+    expect(result.current.hasPrevious).toBe(true);
+    expect(browserApiFetch).toHaveBeenCalledWith("/api/audit-events?limit=25&cursor=cursor-2");
+
+    act(() => result.current.previous());
+    await waitFor(() => expect(result.current.events[0]?.id).toBe("event-1"));
+    expect(result.current.page).toBe(1);
+    expect(browserApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces invalid shared-contract responses as errors", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValue(
+      Response.json({ events: [], hasMore: true, nextCursor: null })
+    );
+    const { result } = renderHook(useAuditEvents, { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error).toMatchObject({ message: "Invalid audit log response" });
+  });
+});

--- a/packages/web/src/hooks/use-audit-events.ts
+++ b/packages/web/src/hooks/use-audit-events.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import {
+  auditEventListResponseSchema,
+  type AuditEventListResponse,
+} from "@open-inspect/shared/types/audit-events";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
+
+export const AUDIT_EVENT_PAGE_SIZE = 25;
+
+export function auditEventsKey(cursor?: string): BrowserApiPath {
+  const params = new URLSearchParams({ limit: String(AUDIT_EVENT_PAGE_SIZE) });
+  if (cursor) params.set("cursor", cursor);
+  return `/api/audit-events?${params.toString()}`;
+}
+
+async function fetchAuditEvents(path: BrowserApiPath): Promise<AuditEventListResponse> {
+  const response = await browserApiFetch(path);
+  if (!response.ok) throw new Error(`Audit log request failed (${response.status})`);
+  const parsed = auditEventListResponseSchema.safeParse(await response.json().catch(() => null));
+  if (!parsed.success) throw new Error("Invalid audit log response");
+  return parsed.data;
+}
+
+/** Loads one audit page and retains opaque cursors for bidirectional navigation. */
+export function useAuditEvents() {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [cursors, setCursors] = useState<(string | undefined)[]>([undefined]);
+  const result = useSWR(auditEventsKey(cursors[pageIndex]), fetchAuditEvents);
+
+  return {
+    events: result.data?.events ?? [],
+    loading: result.isLoading,
+    validating: result.isValidating,
+    error: result.error,
+    page: pageIndex + 1,
+    hasPrevious: pageIndex > 0,
+    hasNext: result.data?.hasMore ?? false,
+    previous: () => setPageIndex(Math.max(0, pageIndex - 1)),
+    next: () => {
+      if (!result.data?.hasMore) return;
+      const nextCursor = result.data.nextCursor;
+      setCursors((current) => {
+        if (current[pageIndex + 1] === nextCursor) return current;
+        return [...current.slice(0, pageIndex + 1), nextCursor];
+      });
+      setPageIndex(pageIndex + 1);
+    },
+    retry: result.mutate,
+  };
+}

--- a/packages/web/src/hooks/use-audit-events.ts
+++ b/packages/web/src/hooks/use-audit-events.ts
@@ -26,27 +26,25 @@ async function fetchAuditEvents(path: BrowserApiPath): Promise<AuditEventListRes
 
 /** Loads one audit page and retains opaque cursors for bidirectional navigation. */
 export function useAuditEvents() {
-  const [pageIndex, setPageIndex] = useState(0);
-  const [cursors, setCursors] = useState<(string | undefined)[]>([undefined]);
-  const result = useSWR(auditEventsKey(cursors[pageIndex]), fetchAuditEvents);
+  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
+  const result = useSWR(auditEventsKey(cursorHistory.at(-1)), fetchAuditEvents);
 
   return {
     events: result.data?.events ?? [],
     loading: result.isLoading,
     validating: result.isValidating,
     error: result.error,
-    page: pageIndex + 1,
-    hasPrevious: pageIndex > 0,
+    page: cursorHistory.length + 1,
+    hasPrevious: cursorHistory.length > 0,
     hasNext: result.data?.hasMore ?? false,
-    previous: () => setPageIndex(Math.max(0, pageIndex - 1)),
+    previous: () => setCursorHistory((current) => current.slice(0, -1)),
     next: () => {
       if (!result.data?.hasMore) return;
       const nextCursor = result.data.nextCursor;
-      setCursors((current) => {
-        if (current[pageIndex + 1] === nextCursor) return current;
-        return [...current.slice(0, pageIndex + 1), nextCursor];
+      setCursorHistory((current) => {
+        if (current.at(-1) === nextCursor) return current;
+        return [...current, nextCursor];
       });
-      setPageIndex(pageIndex + 1);
     },
     retry: result.mutate,
   };

--- a/terraform/d1/migrations/0074_audit_event_list_index.sql
+++ b/terraform/d1/migrations/0074_audit_event_list_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_authorization_audit_events_occurred_at_id
+ON authorization_audit_events(occurred_at DESC, id DESC);


### PR DESCRIPTION
## Summary
- add the `workspace.audit.read` permission and shared schemas for durable audit event pages
- expose a human-user-only, permission-gated `GET /audit-events` endpoint with strict query validation, no-store caching, and opaque newest-first keyset pagination
- add the supporting D1 index plus a web BFF, validated SWR hook, and dedicated responsive Workspace Audit Log settings page
- show outcome, timestamp, actor/resource snapshots, request/reason context, expandable structured metadata, and Previous/Next navigation

## Authorization and behavior
- Owner and Administrator inherit audit-read access; Member and Viewer do not
- custom roles may be granted audit-read access
- successful audit reads are not recursively audited, while denied reads remain recorded
- historical snapshot values are displayed directly without joining mutable user records

## Testing
- `npm test -w @open-inspect/shared` (798 tests)
- `npm test -w @open-inspect/control-plane` (3,415 tests)
- `npm run test:integration -w @open-inspect/control-plane` (1,082 tests)
- focused audit web tests (20 tests)
- web auth-boundary tests individually (12 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run lint:complexity`
- `NODE_ENV=production npm run build -w @open-inspect/web`
- changed-file Prettier check and `git diff --check`

## Verification note
The aggregate web suite passed 1,406 tests but its two ESLint-boundary tests exceeded their existing 5-second per-test timeout under full-suite load; both files passed when rerun individually. Browser verification of the authenticated panel was not possible locally because the sandbox has no configured OAuth/control-plane session.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/97badb97b9dc770a3214927e8ed1bd16)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace **Audit log** view for authorized users.
  * Display event details, including timestamps, outcomes, actors, resources, request IDs, reason codes, and expandable structured details.
  * Added cursor-based pagination with Previous and Next controls, loading, empty, and retry states.
  * Added a protected audit-events API endpoint and workspace audit-read permission.
* **Bug Fixes**
  * Improved validation for pagination parameters and malformed cursors.
* **Tests**
  * Added coverage for authorization, pagination, validation, rendering, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->