### PR TITLE
fix: preserve request options in Codex auth proxy

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -112,63 +112,28 @@ export const CodexAuthProxy = async (input) => {
         return {
           apiKey: OAUTH_DUMMY_KEY,
           async fetch(requestInput, init) {
-            // Remove dummy API key authorization header
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.delete("authorization");
-                init.headers.delete("Authorization");
-              } else if (Array.isArray(init.headers)) {
-                init.headers = init.headers.filter(
-                  ([key]) => key.toLowerCase() !== "authorization"
-                );
-              } else {
-                delete init.headers["authorization"];
-                delete init.headers["Authorization"];
-              }
-            }
+            const request = new Request(requestInput, init);
+            request.headers.delete("authorization");
 
             const currentAuth = await getAuth();
-            if (currentAuth.type !== "oauth") return fetch(requestInput, init);
+            if (currentAuth.type !== "oauth") return fetch(request);
 
             // Ensure we have a valid access token
             const { accessToken, accountId } = await ensureAccessToken(getAuth, setAuth);
 
-            // Build headers
-            const headers = new Headers();
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.forEach((value, key) => headers.set(key, value));
-              } else if (Array.isArray(init.headers)) {
-                for (const [key, value] of init.headers) {
-                  if (value !== undefined) headers.set(key, String(value));
-                }
-              } else {
-                for (const [key, value] of Object.entries(init.headers)) {
-                  if (value !== undefined) headers.set(key, String(value));
-                }
-              }
-            }
-
-            // Set real authorization
-            headers.set("authorization", `Bearer ${accessToken}`);
-
-            // Set ChatGPT-Account-Id header
-            if (accountId) {
-              headers.set("ChatGPT-Account-Id", accountId);
-            }
-
-            // Rewrite URL to Codex endpoint
-            const parsed =
-              requestInput instanceof URL
-                ? requestInput
-                : new URL(typeof requestInput === "string" ? requestInput : requestInput.url);
+            const parsed = new URL(request.url);
             const url =
               parsed.pathname.includes("/v1/responses") ||
               parsed.pathname.includes("/chat/completions")
                 ? new URL(CODEX_API_ENDPOINT)
                 : parsed;
+            const proxiedRequest = new Request(url, request);
 
-            return fetch(url, { ...init, headers });
+            // Replace the dummy API key without discarding source Request options.
+            proxiedRequest.headers.set("authorization", `Bearer ${accessToken}`);
+            if (accountId) proxiedRequest.headers.set("ChatGPT-Account-Id", accountId);
+
+            return fetch(proxiedRequest);
           },
         };
       },

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -113,10 +113,11 @@ export const CodexAuthProxy = async (input) => {
           apiKey: OAUTH_DUMMY_KEY,
           async fetch(requestInput, init) {
             const request = new Request(requestInput, init);
-            request.headers.delete("authorization");
 
             const currentAuth = await getAuth();
             if (currentAuth.type !== "oauth") return fetch(request);
+
+            request.headers.delete("authorization");
 
             // Ensure we have a valid access token
             const { accessToken, accountId } = await ensureAccessToken(getAuth, setAuth);

--- a/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
+++ b/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CodexAuthProxy } from "../src/sandbox_runtime/plugins/codex-auth-plugin.js";
+
+test("preserves a source Request while proxying Codex authentication", async () => {
+  process.env.CONTROL_PLANE_URL = "https://control.test";
+  process.env.SANDBOX_AUTH_TOKEN = "sandbox-token";
+  process.env.SESSION_CONFIG = JSON.stringify({ sessionId: "session-1" });
+  let upstreamRequest;
+  globalThis.fetch = async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    if (request.url.startsWith("https://control.test/")) {
+      return Response.json({
+        accessToken: "access-token",
+        expiresIn: 3600,
+        providerMetadata: { accountId: "account-1" },
+      });
+    }
+    upstreamRequest = request;
+    return new Response(null, { status: 200 });
+  };
+  const plugin = await CodexAuthProxy({ client: { auth: { set: async () => undefined } } });
+  const loaded = await plugin.auth.loader(async () => ({ type: "oauth", refresh: "managed" }), {
+    models: {},
+  });
+
+  await loaded.fetch(
+    new Request("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: { Authorization: "Bearer dummy", "X-Request-Header": "preserved" },
+      body: "request-body",
+    })
+  );
+
+  assert.equal(upstreamRequest.url, "https://chatgpt.com/backend-api/codex/responses");
+  assert.equal(upstreamRequest.method, "POST");
+  assert.equal(upstreamRequest.headers.get("authorization"), "Bearer access-token");
+  assert.equal(upstreamRequest.headers.get("chatgpt-account-id"), "account-1");
+  assert.equal(upstreamRequest.headers.get("x-request-header"), "preserved");
+  assert.equal(await upstreamRequest.text(), "request-body");
+});

--- a/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
+++ b/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
@@ -40,3 +40,24 @@ test("preserves a source Request while proxying Codex authentication", async () 
   assert.equal(upstreamRequest.headers.get("x-request-header"), "preserved");
   assert.equal(await upstreamRequest.text(), "request-body");
 });
+
+test("preserves caller authorization after switching away from OAuth", async () => {
+  let upstreamRequest;
+  globalThis.fetch = async (input, init) => {
+    upstreamRequest = input instanceof Request ? input : new Request(input, init);
+    return new Response(null, { status: 200 });
+  };
+  let authReadCount = 0;
+  const getAuth = async () =>
+    authReadCount++ === 0 ? { type: "oauth", refresh: "managed" } : { type: "api" };
+  const plugin = await CodexAuthProxy({ client: { auth: { set: async () => undefined } } });
+  const loaded = await plugin.auth.loader(getAuth, { models: {} });
+
+  await loaded.fetch(
+    new Request("https://api.openai.com/v1/responses", {
+      headers: { Authorization: "Bearer caller-token" },
+    })
+  );
+
+  assert.equal(upstreamRequest.headers.get("authorization"), "Bearer caller-token");
+});


### PR DESCRIPTION
## Summary
- normalize proxied Codex calls to a `Request` before rewriting the endpoint
- preserve source request methods, bodies, headers, signals, and other Fetch options
- replace the dummy authorization value with broker-provided account credentials
- add regression coverage for a POST supplied as a source `Request`

## Testing
- `node --test tests/*.test.mjs` (19 passed)
- `uv run --extra dev pytest tests/test_codex_auth_plugin_setup.py -q` (6 passed)
- `npx prettier --check packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e0f189f3c5f4602c3e3cab2b983e7587)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication handling for proxied API requests.
  - Preserved caller-provided authorization credentials for non-OAuth requests.
  - Ensured OAuth requests use refreshed credentials and account information correctly.
  - Preserved request methods, custom headers, and request bodies when routing requests through the proxy.

- **Tests**
  - Added coverage for OAuth credential replacement and request rewriting.
  - Verified non-OAuth requests retain their original authorization headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->