### PR TITLE
fix: reconcile sidebar read-state caches

### DIFF
--- a/packages/web/src/hooks/use-sidebar-sessions.test.tsx
+++ b/packages/web/src/hooks/use-sidebar-sessions.test.tsx
@@ -10,10 +10,7 @@ import type {
   SessionInboxSnapshot,
 } from "@open-inspect/shared/types/session-inbox";
 import { useSidebarSessions } from "./use-sidebar-sessions";
-import {
-  SESSION_READ_STATE_RECONCILED_EVENT,
-  type SessionReadStateReconciledDetail,
-} from "@/lib/session-read-state";
+import { reconcileSessionReadState } from "@/lib/session-read-state";
 
 vi.mock("@/lib/auth-session", () => ({
   useAuthSession: () => ({ data: { user: { id: "github:123", name: "Test User" } } }),
@@ -421,7 +418,7 @@ describe("useSidebarSessions", () => {
     expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention", "tail-b"]);
   });
 
-  it("reconciles read state on retained pages when a session is marked read", async () => {
+  it("resets retained pages when a session is marked read", async () => {
     const fetcher = vi.fn(async (key: string) =>
       key.includes("category=")
         ? {
@@ -438,11 +435,7 @@ describe("useSidebarSessions", () => {
 
     await act(async () => result.current.handleMarkLatestMessageRead("tail-unread"));
 
-    // The freshly read hierarchy leaves the retained attention page; the still
-    // unread one stays with its read state intact.
-    expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention", "tail-other"]);
-    const remainingTail = result.current.needsAttention.find(({ id }) => id === "tail-other");
-    expect(remainingTail?.readState.unread).toBe(true);
+    expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"]);
   });
 
   it("reconciles retained pages when read state changes outside the sidebar", async () => {
@@ -456,18 +449,72 @@ describe("useSidebarSessions", () => {
     act(() => result.current.sectionPagination.needsAttention.loadMore());
     await waitFor(() => expect(result.current.needsAttention).toHaveLength(2));
 
-    act(() =>
-      window.dispatchEvent(
-        new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
-          detail: {
-            sessionId: "tail-unread",
-            readState: { latestMessageId: "msg-1", unread: false },
-          },
-        })
-      )
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "tail-unread",
+        outcome: "marked_read",
+        latestMessageId: "msg-1",
+        unread: false,
+      })
     );
 
     expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"]);
+  });
+
+  it("resets destination pagination when an attention tail changes category", async () => {
+    let sessionRead = false;
+    const fetcher = vi.fn(async (key: string) => {
+      if (key.includes("category=needs_attention")) {
+        return { items: [unreadItem("moving")], hasMore: false, nextCursor: null };
+      }
+      if (key.includes("category=in_progress")) {
+        return page([
+          key.includes("new-progress-next") ? "new-progress-tail" : "old-progress-tail",
+        ]);
+      }
+      return sessionRead
+        ? snapshot({
+            needs_attention: page(["attention"]),
+            in_progress: page(["moving", "running"], "new-progress-next"),
+          })
+        : snapshot({
+            needs_attention: page(["attention"], "attention-next"),
+            in_progress: page(["running"], "progress-next"),
+          });
+    });
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.needsAttention.loadMore());
+    act(() => result.current.sectionPagination.inProgress.loadMore());
+    await waitFor(() => expect(result.current.needsAttention).toHaveLength(2));
+    await waitFor(() => expect(result.current.inProgress).toHaveLength(2));
+
+    sessionRead = true;
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "moving",
+        outcome: "marked_read",
+        latestMessageId: "msg-2",
+        unread: false,
+      })
+    );
+
+    await waitFor(() =>
+      expect(result.current.inProgress.map(({ id }) => id)).toEqual(["moving", "running"])
+    );
+    expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"]);
+
+    act(() => result.current.sectionPagination.inProgress.loadMore());
+    await waitFor(() =>
+      expect(result.current.inProgress.map(({ id }) => id)).toEqual([
+        "moving",
+        "running",
+        "new-progress-tail",
+      ])
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/sessions/inbox?category=in_progress&cursor=new-progress-next"
+    );
   });
 
   it("invalidates cached pagination before a remount can restore stale unread state", async () => {
@@ -490,15 +537,13 @@ describe("useSidebarSessions", () => {
     await waitFor(() => expect(first.result.current.needsAttention).toHaveLength(2));
 
     sessionRead = true;
-    act(() =>
-      window.dispatchEvent(
-        new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
-          detail: {
-            sessionId: "tail-unread",
-            readState: { latestMessageId: "msg-1", unread: false },
-          },
-        })
-      )
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "tail-unread",
+        outcome: "marked_read",
+        latestMessageId: "msg-1",
+        unread: false,
+      })
     );
     first.unmount();
 

--- a/packages/web/src/hooks/use-sidebar-sessions.test.tsx
+++ b/packages/web/src/hooks/use-sidebar-sessions.test.tsx
@@ -418,7 +418,7 @@ describe("useSidebarSessions", () => {
     expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention", "tail-b"]);
   });
 
-  it("resets retained pages when a session is marked read", async () => {
+  it("reconciles read state on retained pages when a session is marked read", async () => {
     const fetcher = vi.fn(async (key: string) =>
       key.includes("category=")
         ? {
@@ -435,7 +435,136 @@ describe("useSidebarSessions", () => {
 
     await act(async () => result.current.handleMarkLatestMessageRead("tail-unread"));
 
+    // The freshly read hierarchy leaves the retained attention page; the still
+    // unread one stays with its read state intact.
+    expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention", "tail-other"]);
+    const remainingTail = result.current.needsAttention.find(({ id }) => id === "tail-other");
+    expect(remainingTail?.readState.unread).toBe(true);
+  });
+
+  it("keeps retained pages when an already-read session is acknowledged", async () => {
+    let snapshotFetches = 0;
+    const fetcher = vi.fn(async (key: string) => {
+      if (key.includes("category=finished")) return page(["finished-tail-a", "finished-tail-b"]);
+      if (key.includes("category=in_progress")) return page(["progress-tail"]);
+      snapshotFetches += 1;
+      return snapshot({
+        in_progress: page(["running"], "progress-next"),
+        finished: page(["finished"], "finished-next"),
+      });
+    });
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.finished.loadMore());
+    act(() => result.current.sectionPagination.inProgress.loadMore());
+    await waitFor(() => expect(result.current.finished).toHaveLength(3));
+    await waitFor(() => expect(result.current.inProgress).toHaveLength(2));
+    const fetchesBefore = snapshotFetches;
+
+    // Opening a session acknowledges its terminal message even when it is
+    // already read. Nothing changed, so nothing in the sidebar should move.
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "finished-tail-b",
+        outcome: "already_read",
+        latestMessageId: "msg-1",
+        unread: false,
+      })
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 20)));
+
+    expect(result.current.finished.map(({ id }) => id)).toEqual([
+      "finished",
+      "finished-tail-a",
+      "finished-tail-b",
+    ]);
+    expect(result.current.inProgress.map(({ id }) => id)).toEqual(["running", "progress-tail"]);
+    expect(snapshotFetches).toBe(fetchesBefore);
+  });
+
+  it("keeps retained pages for a not_latest result", async () => {
+    const fetcher = vi.fn(async (key: string) =>
+      key.includes("category=")
+        ? page(["finished-tail"])
+        : snapshot({ finished: page(["finished"], "finished-next") })
+    );
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.finished.loadMore());
+    await waitFor(() => expect(result.current.finished).toHaveLength(2));
+
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "finished-tail",
+        outcome: "not_latest",
+        latestMessageId: "msg-9",
+        unread: true,
+      })
+    );
+
+    expect(result.current.finished.map(({ id }) => id)).toEqual(["finished", "finished-tail"]);
+  });
+
+  it("updates a read tail row in place instead of dropping it", async () => {
+    const fetcher = vi.fn(async (key: string) =>
+      key.includes("category=")
+        ? { items: [unreadItem("finished-tail")], hasMore: false, nextCursor: null }
+        : snapshot({ finished: page(["finished"], "finished-next") })
+    );
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.finished.loadMore());
+    await waitFor(() => expect(result.current.finished).toHaveLength(2));
+
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "finished-tail",
+        outcome: "marked_read",
+        latestMessageId: "msg-1",
+        unread: false,
+      })
+    );
+
+    const tail = result.current.finished.find(({ id }) => id === "finished-tail");
+    expect(tail?.readState).toEqual({ latestMessageId: "msg-1", unread: false });
+  });
+
+  it("resets only the destination chain when an attention tail leaves attention", async () => {
+    const fetcher = vi.fn(async (key: string) => {
+      if (key.includes("category=needs_attention")) {
+        return { items: [unreadItem("moving")], hasMore: false, nextCursor: null };
+      }
+      if (key.includes("category=in_progress")) return page(["progress-tail"]);
+      if (key.includes("category=finished")) return page(["finished-tail"]);
+      return snapshot({
+        needs_attention: page(["attention"], "attention-next"),
+        in_progress: page(["running"], "progress-next"),
+        finished: page(["finished"], "finished-next"),
+      });
+    });
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.needsAttention.loadMore());
+    act(() => result.current.sectionPagination.inProgress.loadMore());
+    act(() => result.current.sectionPagination.finished.loadMore());
+    await waitFor(() => expect(result.current.needsAttention).toHaveLength(2));
+    await waitFor(() => expect(result.current.inProgress).toHaveLength(2));
+    await waitFor(() => expect(result.current.finished).toHaveLength(2));
+
+    await act(() =>
+      reconcileSessionReadState({
+        sessionId: "moving",
+        outcome: "marked_read",
+        latestMessageId: "msg-1",
+        unread: false,
+      })
+    );
+
+    // "moving" is active, so it heads for in_progress: that chain restarts from
+    // the head page. The finished chain is unaffected and keeps its tail.
     expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"]);
+    expect(result.current.inProgress.map(({ id }) => id)).toEqual(["running"]);
+    expect(result.current.finished.map(({ id }) => id)).toEqual(["finished", "finished-tail"]);
   });
 
   it("reconciles retained pages when read state changes outside the sidebar", async () => {

--- a/packages/web/src/hooks/use-sidebar-sessions.test.tsx
+++ b/packages/web/src/hooks/use-sidebar-sessions.test.tsx
@@ -10,6 +10,10 @@ import type {
   SessionInboxSnapshot,
 } from "@open-inspect/shared/types/session-inbox";
 import { useSidebarSessions } from "./use-sidebar-sessions";
+import {
+  SESSION_READ_STATE_RECONCILED_EVENT,
+  type SessionReadStateReconciledDetail,
+} from "@/lib/session-read-state";
 
 vi.mock("@/lib/auth-session", () => ({
   useAuthSession: () => ({ data: { user: { id: "github:123", name: "Test User" } } }),
@@ -25,7 +29,6 @@ vi.mock("@/lib/session-read-state", async (importOriginal) => {
       unread: false,
       latestMessageId: "msg-1",
     }),
-    reconcileSessionReadState: async () => undefined,
   };
 });
 
@@ -53,7 +56,7 @@ function unreadItem(id: string): SessionInboxItem {
   const base = item(id);
   return {
     ...base,
-    rootSession: { ...base.rootSession, readState: { latestMessageId: "msg-0", unread: true } },
+    rootSession: { ...base.rootSession, readState: { latestMessageId: "msg-1", unread: true } },
   };
 }
 
@@ -74,12 +77,12 @@ function snapshot(
   };
 }
 
-function wrapper(fetcher: (key: string) => unknown) {
+function wrapper(fetcher: (key: string) => unknown, cache = new Map()) {
   return function TestWrapper({ children }: { children: ReactNode }) {
     return (
       <SWRConfig
         value={{
-          provider: () => new Map(),
+          provider: () => cache,
           fetcher,
           dedupingInterval: 0,
           focusThrottleInterval: 0,
@@ -440,5 +443,72 @@ describe("useSidebarSessions", () => {
     expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention", "tail-other"]);
     const remainingTail = result.current.needsAttention.find(({ id }) => id === "tail-other");
     expect(remainingTail?.readState.unread).toBe(true);
+  });
+
+  it("reconciles retained pages when read state changes outside the sidebar", async () => {
+    const fetcher = vi.fn(async (key: string) =>
+      key.includes("category=")
+        ? { items: [unreadItem("tail-unread")], hasMore: false, nextCursor: null }
+        : snapshot({ needs_attention: page(["attention"], "next") })
+    );
+    const { result } = renderHook(() => useSidebarSessions(), { wrapper: wrapper(fetcher) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.sectionPagination.needsAttention.loadMore());
+    await waitFor(() => expect(result.current.needsAttention).toHaveLength(2));
+
+    act(() =>
+      window.dispatchEvent(
+        new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
+          detail: {
+            sessionId: "tail-unread",
+            readState: { latestMessageId: "msg-1", unread: false },
+          },
+        })
+      )
+    );
+
+    expect(result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"]);
+  });
+
+  it("invalidates cached pagination before a remount can restore stale unread state", async () => {
+    let sessionRead = false;
+    let paginationRequests = 0;
+    const fetcher = vi.fn(async (key: string) => {
+      if (!key.includes("category=")) {
+        return snapshot({ needs_attention: page(["attention"], "next") });
+      }
+      paginationRequests += 1;
+      return sessionRead
+        ? { items: [], hasMore: false, nextCursor: null }
+        : { items: [unreadItem("tail-unread")], hasMore: false, nextCursor: null };
+    });
+    const cache = new Map();
+    const TestWrapper = wrapper(fetcher, cache);
+    const first = renderHook(() => useSidebarSessions(), { wrapper: TestWrapper });
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    act(() => first.result.current.sectionPagination.needsAttention.loadMore());
+    await waitFor(() => expect(first.result.current.needsAttention).toHaveLength(2));
+
+    sessionRead = true;
+    act(() =>
+      window.dispatchEvent(
+        new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
+          detail: {
+            sessionId: "tail-unread",
+            readState: { latestMessageId: "msg-1", unread: false },
+          },
+        })
+      )
+    );
+    first.unmount();
+
+    const second = renderHook(() => useSidebarSessions(), { wrapper: TestWrapper });
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+    act(() => second.result.current.sectionPagination.needsAttention.loadMore());
+
+    await waitFor(() => expect(paginationRequests).toBe(2));
+    await waitFor(() =>
+      expect(second.result.current.needsAttention.map(({ id }) => id)).toEqual(["attention"])
+    );
   });
 });

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -11,18 +11,21 @@ import type {
   SessionInboxSnapshot,
   SessionListItem,
 } from "@open-inspect/shared/types/session-inbox";
-import type { SessionReadState } from "@open-inspect/shared/types/sessions";
 import {
+  applySessionInboxItemReadState,
   applySessionInboxReadStateUpdate,
   buildSessionInboxKey,
   buildSessionInboxSnapshotKey,
+  isSessionInboxItemFullyRead,
   isSessionInboxKey,
   isSessionInboxPaginationKey,
+  sessionInboxDestinationCategory,
 } from "@/lib/session-inbox-api";
 import {
   markLatestMessageRead,
   reconcileSessionReadState,
   subscribeSessionReadStateReconciliation,
+  type SessionReadStateReconciledDetail,
 } from "@/lib/session-read-state";
 
 const VISIBLE_INBOX_POLL_MS = 30_000;
@@ -134,7 +137,9 @@ function useCategoryPagination(
     [error, paginationRequest, refreshSnapshot, retryPage]
   );
 
-  // Pages loaded through `Load more` live only in this retained state.
+  // Mutations revalidate the head snapshot, but pages loaded through `Load
+  // more` live only in this retained state. Reconcile them in place or they
+  // keep rendering the pre-mutation rows.
   const updateRetainedItems = useCallback(
     (update: (item: SessionInboxItem) => SessionInboxItem | null) => {
       setAdditionalPagesState((state) => ({
@@ -347,24 +352,73 @@ export function useSidebarSessions() {
     [updateAttentionRetained, updateFinishedRetained, updateInProgressRetained]
   );
 
+  // Every session open acknowledges its terminal message, read or not, so
+  // this runs far more often than read state actually changes. Retained pages
+  // are updated in place; only a hierarchy leaving attention restarts a chain.
   const reconcileSidebarReadState = useCallback(
-    ({ sessionId, readState }: { sessionId: string; readState: SessionReadState }) => {
-      resetAttentionRetained();
-      resetInProgressRetained();
-      resetFinishedRetained();
+    ({ sessionId, outcome, readState }: SessionReadStateReconciledDetail) => {
+      const applyReadState = (item: SessionInboxItem) =>
+        applySessionInboxItemReadState(item, sessionId, readState);
+      updateAttentionRetained((item) => {
+        const updated = applyReadState(item);
+        return isSessionInboxItemFullyRead(updated) ? null : updated;
+      });
+      updateInProgressRetained(applyReadState);
+      updateFinishedRetained(applyReadState);
+
+      // The destination chain was paged without the arriving hierarchy, so a
+      // rank between its head and retained tail would never render. Restart
+      // that one chain from the head.
+      const attentionItem = attentionItems.find(
+        (item) =>
+          item.rootSession.id === sessionId ||
+          item.descendantSessions.some((session) => session.id === sessionId)
+      );
+      if (attentionItem && !readState.unread) {
+        const acknowledged = [attentionItem.rootSession, ...attentionItem.descendantSessions].find(
+          (session) => session.id === sessionId
+        );
+        const cachedMessageId = acknowledged?.readState.latestMessageId ?? null;
+        // A row holding a different message declined the in-place update
+        // (message IDs are not orderable). It may be stale or newer, so drop
+        // the retained attention rows and let revalidation place it.
+        const unreconcilable =
+          cachedMessageId !== null && cachedMessageId !== readState.latestMessageId;
+        if (unreconcilable) resetAttentionRetained();
+        if (unreconcilable || isSessionInboxItemFullyRead(applyReadState(attentionItem))) {
+          if (sessionInboxDestinationCategory(attentionItem) === "in_progress") {
+            resetInProgressRetained();
+          } else {
+            resetFinishedRetained();
+          }
+        }
+      }
+
       return Promise.all([
         mutateCache<SessionInboxSnapshot | SessionInboxPage>(
           isSessionInboxKey,
           (current) => applySessionInboxReadStateUpdate(current, sessionId, readState),
-          { populateCache: true, revalidate: true }
+          // `already_read` confirms the cached state; any other outcome may
+          // carry a change the snapshot has not seen yet.
+          { populateCache: true, revalidate: outcome !== "already_read" }
         ),
+        // Cached cursor pages would restore pre-acknowledgement rows on remount.
         mutateCache<SessionInboxPage | undefined>(isSessionInboxPaginationKey, () => undefined, {
           populateCache: true,
-          revalidate: true,
+          revalidate: false,
         }),
       ]);
     },
-    [mutateCache, resetAttentionRetained, resetFinishedRetained, resetInProgressRetained]
+    [
+      attentionItems,
+      mutateCache,
+      resetAttentionRetained,
+      resetFinishedRetained,
+      resetInProgressRetained,
+      updateAttentionRetained,
+      updateFinishedRetained,
+      updateInProgressRetained,
+    ]
   );
 
   useEffect(() => {

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -11,15 +11,20 @@ import type {
   SessionInboxSnapshot,
   SessionListItem,
 } from "@open-inspect/shared/types/session-inbox";
+import type { SessionReadState } from "@open-inspect/shared/types/sessions";
 import {
+  applySessionInboxItemReadState,
+  applySessionInboxReadStateUpdate,
   buildSessionInboxKey,
   buildSessionInboxSnapshotKey,
   isSessionInboxKey,
+  isSessionInboxPaginationKey,
 } from "@/lib/session-inbox-api";
 import {
   markLatestMessageRead,
   reconcileSessionReadState,
-  readStateFromResult,
+  SESSION_READ_STATE_RECONCILED_EVENT,
+  type SessionReadStateReconciledDetail,
 } from "@/lib/session-read-state";
 
 const VISIBLE_INBOX_POLL_MS = 30_000;
@@ -168,6 +173,7 @@ function useCategoryPagination(
 
 export function useSidebarSessions() {
   const { data: authSession } = useAuthSession();
+  const { mutate: mutateCache } = useSWRConfig();
   const [sessionCreatorFilter, setSessionCreatorFilterState] =
     useState<SessionCreatorFilter | null>(null);
 
@@ -337,6 +343,47 @@ export function useSidebarSessions() {
     [updateAttentionRetained, updateFinishedRetained, updateInProgressRetained]
   );
 
+  const reconcileSidebarReadState = useCallback(
+    (sessionId: string, readState: SessionReadState) => {
+      const applyReadState = (item: SessionInboxItem) =>
+        applySessionInboxItemReadState(item, sessionId, readState);
+      updateAttentionRetained((item) => {
+        const updated = applyReadState(item);
+        return updated.rootSession.readState.unread ||
+          updated.descendantSessions.some((session) => session.readState.unread)
+          ? updated
+          : null;
+      });
+      updateInProgressRetained(applyReadState);
+      updateFinishedRetained(applyReadState);
+      void Promise.all([
+        mutateCache<SessionInboxSnapshot | SessionInboxPage>(
+          isSessionInboxKey,
+          (current) => applySessionInboxReadStateUpdate(current, sessionId, readState),
+          { populateCache: true, revalidate: true }
+        ),
+        mutateCache<SessionInboxPage | undefined>(isSessionInboxPaginationKey, () => undefined, {
+          populateCache: true,
+          revalidate: true,
+        }),
+      ]).catch((error) => {
+        console.error("Failed to refresh session inbox after read-state update", error);
+      });
+    },
+    [mutateCache, updateAttentionRetained, updateFinishedRetained, updateInProgressRetained]
+  );
+
+  useEffect(() => {
+    const handleReadStateReconciled = (event: Event) => {
+      const { sessionId, readState } = (event as CustomEvent<SessionReadStateReconciledDetail>)
+        .detail;
+      reconcileSidebarReadState(sessionId, readState);
+    };
+    window.addEventListener(SESSION_READ_STATE_RECONCILED_EVENT, handleReadStateReconciled);
+    return () =>
+      window.removeEventListener(SESSION_READ_STATE_RECONCILED_EVENT, handleReadStateReconciled);
+  }, [reconcileSidebarReadState]);
+
   const handleSessionArchived = useCallback(
     async (sessionId: string) => {
       updateAllRetainedItems((item) =>
@@ -356,33 +403,10 @@ export function useSidebarSessions() {
     [refreshInbox, updateAllRetainedItems]
   );
 
-  const handleMarkLatestMessageRead = useCallback(
-    async (sessionId: string) => {
-      const result = await markLatestMessageRead(sessionId);
-      await reconcileSessionReadState(result);
-      const readState = readStateFromResult(result);
-      const applyReadState = (item: SessionInboxItem): SessionInboxItem => ({
-        rootSession:
-          item.rootSession.id === sessionId ? { ...item.rootSession, readState } : item.rootSession,
-        descendantSessions: item.descendantSessions.map((session) =>
-          session.id === sessionId ? { ...session, readState } : session
-        ),
-      });
-      // Attention membership is unread-driven, so a hierarchy whose last unread
-      // session was just read no longer belongs in a retained attention page.
-      updateAttentionRetained((item) => {
-        const updated = applyReadState(item);
-        return updated.rootSession.readState.unread ||
-          updated.descendantSessions.some((session) => session.readState.unread)
-          ? updated
-          : null;
-      });
-      updateInProgressRetained(applyReadState);
-      updateFinishedRetained(applyReadState);
-      await refreshInbox();
-    },
-    [refreshInbox, updateAttentionRetained, updateFinishedRetained, updateInProgressRetained]
-  );
+  const handleMarkLatestMessageRead = useCallback(async (sessionId: string) => {
+    const result = await markLatestMessageRead(sessionId);
+    await reconcileSessionReadState(result);
+  }, []);
 
   return {
     needsAttention: attentionItems.map((item) => item.rootSession),

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -13,7 +13,6 @@ import type {
 } from "@open-inspect/shared/types/session-inbox";
 import type { SessionReadState } from "@open-inspect/shared/types/sessions";
 import {
-  applySessionInboxItemReadState,
   applySessionInboxReadStateUpdate,
   buildSessionInboxKey,
   buildSessionInboxSnapshotKey,
@@ -23,8 +22,7 @@ import {
 import {
   markLatestMessageRead,
   reconcileSessionReadState,
-  SESSION_READ_STATE_RECONCILED_EVENT,
-  type SessionReadStateReconciledDetail,
+  subscribeSessionReadStateReconciliation,
 } from "@/lib/session-read-state";
 
 const VISIBLE_INBOX_POLL_MS = 30_000;
@@ -136,9 +134,7 @@ function useCategoryPagination(
     [error, paginationRequest, refreshSnapshot, retryPage]
   );
 
-  // Archive and read-state mutations revalidate the head snapshot, but pages
-  // loaded through `Load more` live only in this retained state — reconcile
-  // them in place or they keep rendering the pre-mutation rows.
+  // Pages loaded through `Load more` live only in this retained state.
   const updateRetainedItems = useCallback(
     (update: (item: SessionInboxItem) => SessionInboxItem | null) => {
       setAdditionalPagesState((state) => ({
@@ -157,6 +153,10 @@ function useCategoryPagination(
     },
     []
   );
+  const resetRetainedPages = useCallback(() => {
+    setAdditionalPagesState({ filterIdentity, pages: [] });
+    setPaginationRequest(null);
+  }, [filterIdentity]);
 
   return {
     firstPageItems: firstPage?.items ?? [],
@@ -168,6 +168,7 @@ function useCategoryPagination(
     loadMore,
     retry,
     updateRetainedItems,
+    resetRetainedPages,
   };
 }
 
@@ -334,6 +335,9 @@ export function useSidebarSessions() {
   const updateAttentionRetained = attention.updateRetainedItems;
   const updateInProgressRetained = inProgress.updateRetainedItems;
   const updateFinishedRetained = finished.updateRetainedItems;
+  const resetAttentionRetained = attention.resetRetainedPages;
+  const resetInProgressRetained = inProgress.resetRetainedPages;
+  const resetFinishedRetained = finished.resetRetainedPages;
   const updateAllRetainedItems = useCallback(
     (update: (item: SessionInboxItem) => SessionInboxItem | null) => {
       updateAttentionRetained(update);
@@ -344,19 +348,11 @@ export function useSidebarSessions() {
   );
 
   const reconcileSidebarReadState = useCallback(
-    (sessionId: string, readState: SessionReadState) => {
-      const applyReadState = (item: SessionInboxItem) =>
-        applySessionInboxItemReadState(item, sessionId, readState);
-      updateAttentionRetained((item) => {
-        const updated = applyReadState(item);
-        return updated.rootSession.readState.unread ||
-          updated.descendantSessions.some((session) => session.readState.unread)
-          ? updated
-          : null;
-      });
-      updateInProgressRetained(applyReadState);
-      updateFinishedRetained(applyReadState);
-      void Promise.all([
+    ({ sessionId, readState }: { sessionId: string; readState: SessionReadState }) => {
+      resetAttentionRetained();
+      resetInProgressRetained();
+      resetFinishedRetained();
+      return Promise.all([
         mutateCache<SessionInboxSnapshot | SessionInboxPage>(
           isSessionInboxKey,
           (current) => applySessionInboxReadStateUpdate(current, sessionId, readState),
@@ -366,22 +362,13 @@ export function useSidebarSessions() {
           populateCache: true,
           revalidate: true,
         }),
-      ]).catch((error) => {
-        console.error("Failed to refresh session inbox after read-state update", error);
-      });
+      ]);
     },
-    [mutateCache, updateAttentionRetained, updateFinishedRetained, updateInProgressRetained]
+    [mutateCache, resetAttentionRetained, resetFinishedRetained, resetInProgressRetained]
   );
 
   useEffect(() => {
-    const handleReadStateReconciled = (event: Event) => {
-      const { sessionId, readState } = (event as CustomEvent<SessionReadStateReconciledDetail>)
-        .detail;
-      reconcileSidebarReadState(sessionId, readState);
-    };
-    window.addEventListener(SESSION_READ_STATE_RECONCILED_EVENT, handleReadStateReconciled);
-    return () =>
-      window.removeEventListener(SESSION_READ_STATE_RECONCILED_EVENT, handleReadStateReconciled);
+    return subscribeSessionReadStateReconciliation(reconcileSidebarReadState);
   }, [reconcileSidebarReadState]);
 
   const handleSessionArchived = useCallback(

--- a/packages/web/src/lib/session-inbox-api.test.ts
+++ b/packages/web/src/lib/session-inbox-api.test.ts
@@ -129,6 +129,46 @@ describe("applySessionInboxReadStateUpdate", () => {
     );
   });
 
+  it("moves a fully read active hierarchy from attention to in progress", () => {
+    const data: SessionInboxSnapshot = {
+      categories: {
+        needs_attention: page("target"),
+        in_progress: page("progress-root"),
+        finished: page("finished-root"),
+      },
+    };
+
+    const result = applySessionInboxReadStateUpdate(data, "target", readState);
+
+    expect(result?.categories.needs_attention.items).toEqual([]);
+    expect(result?.categories.in_progress.items.map((item) => item.rootSession.id)).toEqual([
+      "target",
+      "progress-root",
+    ]);
+  });
+
+  it("moves a fully read finished descendant hierarchy from attention to finished", () => {
+    const attentionPage = page("target-root", ["target-child"]);
+    attentionPage.items[0].rootSession.status = "completed";
+    attentionPage.items[0].rootSession.readState.unread = false;
+    attentionPage.items[0].descendantSessions[0].status = "completed";
+    const data: SessionInboxSnapshot = {
+      categories: {
+        needs_attention: attentionPage,
+        in_progress: page("progress-root"),
+        finished: page("finished-root"),
+      },
+    };
+
+    const result = applySessionInboxReadStateUpdate(data, "target-child", readState);
+
+    expect(result?.categories.needs_attention.items).toEqual([]);
+    expect(result?.categories.finished.items.map((item) => item.rootSession.id)).toEqual([
+      "target-root",
+      "finished-root",
+    ]);
+  });
+
   it("does not let an older result overwrite a newer cached terminal message", () => {
     const data = page("target");
     data.items[0].rootSession.readState = {

--- a/packages/web/src/lib/session-inbox-api.test.ts
+++ b/packages/web/src/lib/session-inbox-api.test.ts
@@ -1,5 +1,43 @@
 import { describe, expect, it } from "vitest";
-import { buildSessionInboxKey, isSessionInboxKey } from "./session-inbox-api";
+import type { SessionListItem } from "@open-inspect/shared/types/session-inbox";
+import {
+  applySessionInboxReadStateUpdate,
+  buildSessionInboxKey,
+  isSessionInboxKey,
+  isSessionInboxPaginationKey,
+  type SessionInboxPage,
+  type SessionInboxSnapshot,
+} from "./session-inbox-api";
+
+function session(id: string, parentSessionId: string | null = null): SessionListItem {
+  return {
+    id,
+    title: id,
+    repoOwner: null,
+    repoName: null,
+    baseBranch: null,
+    status: "active",
+    parentSessionId,
+    spawnSource: parentSessionId ? "agent" : "user",
+    environmentId: null,
+    createdAt: 1,
+    updatedAt: 2,
+    readState: { latestMessageId: "old-message", unread: true },
+  };
+}
+
+function page(rootId: string, descendantIds: string[] = []): SessionInboxPage {
+  return {
+    items: [
+      {
+        rootSession: session(rootId),
+        descendantSessions: descendantIds.map((id) => session(id, rootId)),
+      },
+    ],
+    hasMore: false,
+    nextCursor: null,
+  };
+}
 
 describe("session inbox API keys", () => {
   it("builds canonical category cursor keys", () => {
@@ -31,5 +69,78 @@ describe("session inbox API keys", () => {
     null,
   ])("does not match unrelated key %s", (key) => {
     expect(isSessionInboxKey(key)).toBe(false);
+  });
+
+  it("matches cached pagination tuple keys", () => {
+    expect(
+      isSessionInboxPaginationKey([
+        "/api/sessions/inbox?category=needs_attention&cursor=next",
+        '["user-1",false]',
+      ])
+    ).toBe(true);
+    expect(isSessionInboxPaginationKey(["/api/sessions?status=active", "filter"])).toBe(false);
+  });
+});
+
+describe("applySessionInboxReadStateUpdate", () => {
+  const readState = { latestMessageId: "old-message", unread: false } as const;
+
+  it("updates a matching root session in a page without disturbing unrelated sessions", () => {
+    const data: SessionInboxPage = {
+      ...page("target", ["target-child"]),
+      items: [...page("target", ["target-child"]).items, ...page("unrelated").items],
+    };
+
+    const result = applySessionInboxReadStateUpdate(data, "target", readState);
+
+    expect(result?.items[0].rootSession.readState).toEqual(readState);
+    expect(result?.items[0].descendantSessions[0].readState).toEqual({
+      latestMessageId: "old-message",
+      unread: true,
+    });
+    expect(result?.items[1].rootSession.readState).toEqual({
+      latestMessageId: "old-message",
+      unread: true,
+    });
+    expect(data.items[0].rootSession.readState.unread).toBe(true);
+  });
+
+  it("updates a matching descendant in a snapshot without disturbing other sessions", () => {
+    const data: SessionInboxSnapshot = {
+      categories: {
+        needs_attention: page("attention-root", ["target-child", "sibling-child"]),
+        in_progress: page("progress-root", ["progress-child"]),
+        finished: page("finished-root"),
+      },
+    };
+
+    const result = applySessionInboxReadStateUpdate(data, "target-child", readState);
+
+    expect(result?.categories.needs_attention.items[0].descendantSessions[0].readState).toEqual(
+      readState
+    );
+    expect(result?.categories.needs_attention.items[0].rootSession.readState.unread).toBe(true);
+    expect(result?.categories.needs_attention.items[0].descendantSessions[1].readState.unread).toBe(
+      true
+    );
+    expect(result?.categories.in_progress.items[0].rootSession.readState.unread).toBe(true);
+    expect(data.categories.needs_attention.items[0].descendantSessions[0].readState.unread).toBe(
+      true
+    );
+  });
+
+  it("does not let an older result overwrite a newer cached terminal message", () => {
+    const data = page("target");
+    data.items[0].rootSession.readState = {
+      latestMessageId: "newer-message",
+      unread: true,
+    };
+
+    const result = applySessionInboxReadStateUpdate(data, "target", readState);
+
+    expect(result?.items[0].rootSession.readState).toEqual({
+      latestMessageId: "newer-message",
+      unread: true,
+    });
   });
 });

--- a/packages/web/src/lib/session-inbox-api.ts
+++ b/packages/web/src/lib/session-inbox-api.ts
@@ -77,7 +77,16 @@ function latestHierarchyUpdate(item: SessionInboxItem): number {
   );
 }
 
-function destinationCategory(
+/** Attention membership is unread-driven: a hierarchy stays while any session is unread. */
+export function isSessionInboxItemFullyRead(item: SessionInboxItem): boolean {
+  return (
+    !item.rootSession.readState.unread &&
+    item.descendantSessions.every((session) => !session.readState.unread)
+  );
+}
+
+/** Where a fully read hierarchy lands; mirrors the category rule in the inbox query. */
+export function sessionInboxDestinationCategory(
   item: SessionInboxItem
 ): Exclude<SessionInboxCategory, "needs_attention"> {
   return item.rootSession.status === "active" ||
@@ -142,18 +151,14 @@ export function applySessionInboxReadStateUpdate<T extends SessionInboxSnapshot 
         item.rootSession.id === sessionId ||
         item.descendantSessions.some((session) => session.id === sessionId)
     );
-    if (
-      attentionItem &&
-      !attentionItem.rootSession.readState.unread &&
-      attentionItem.descendantSessions.every((session) => !session.readState.unread)
-    ) {
+    if (attentionItem && isSessionInboxItemFullyRead(attentionItem)) {
       categories.needs_attention = {
         ...categories.needs_attention,
         items: categories.needs_attention.items.filter(
           (item) => item.rootSession.id !== attentionItem.rootSession.id
         ),
       };
-      const destination = destinationCategory(attentionItem);
+      const destination = sessionInboxDestinationCategory(attentionItem);
       categories[destination] = {
         ...categories[destination],
         items: [

--- a/packages/web/src/lib/session-inbox-api.ts
+++ b/packages/web/src/lib/session-inbox-api.ts
@@ -1,10 +1,13 @@
 import type {
   SessionInboxCategory,
+  SessionInboxItem,
   SessionInboxPage,
   SessionInboxSnapshot,
   SessionListItem,
 } from "@open-inspect/shared/types/session-inbox";
+import type { SessionReadState } from "@open-inspect/shared/types/sessions";
 import type { BrowserApiPath } from "./browser-api-fetch";
+import { applySessionReadStateToItem } from "./session-list";
 
 const SESSION_INBOX_API_PATH = "/api/sessions/inbox";
 
@@ -32,6 +35,10 @@ export function isSessionInboxKey(key: unknown): key is string {
   );
 }
 
+export function isSessionInboxPaginationKey(key: unknown): boolean {
+  return Array.isArray(key) && isSessionInboxKey(key[0]);
+}
+
 function applyTitleToSession(session: SessionListItem, sessionId: string, title: string | null) {
   return session.id === sessionId ? { ...session, title } : session;
 }
@@ -49,6 +56,30 @@ function applyTitleToPage(
         applyTitleToSession(session, sessionId, title)
       ),
     })),
+  };
+}
+
+function applyReadStateToPage(
+  page: SessionInboxPage,
+  sessionId: string,
+  readState: SessionReadState
+): SessionInboxPage {
+  return {
+    ...page,
+    items: page.items.map((item) => applySessionInboxItemReadState(item, sessionId, readState)),
+  };
+}
+
+export function applySessionInboxItemReadState(
+  item: SessionInboxItem,
+  sessionId: string,
+  readState: SessionReadState
+): SessionInboxItem {
+  return {
+    rootSession: applySessionReadStateToItem(item.rootSession, sessionId, readState),
+    descendantSessions: item.descendantSessions.map((session) =>
+      applySessionReadStateToItem(session, sessionId, readState)
+    ),
   };
 }
 
@@ -77,4 +108,24 @@ export function applySessionInboxTitleUpdate<T extends SessionInboxSnapshot | Se
   return applyTitleToPage(data, sessionId, title) as T;
 }
 
-export type { SessionInboxPage, SessionInboxSnapshot };
+export function applySessionInboxReadStateUpdate<T extends SessionInboxSnapshot | SessionInboxPage>(
+  data: T | undefined,
+  sessionId: string,
+  readState: SessionReadState
+): T | undefined {
+  if (!data) return data;
+  if ("categories" in data) {
+    return {
+      ...data,
+      categories: Object.fromEntries(
+        Object.entries(data.categories).map(([category, page]) => [
+          category,
+          applyReadStateToPage(page, sessionId, readState),
+        ])
+      ) as Record<SessionInboxCategory, SessionInboxPage>,
+    } as T;
+  }
+  return applyReadStateToPage(data, sessionId, readState) as T;
+}
+
+export type { SessionInboxItem, SessionInboxPage, SessionInboxSnapshot };

--- a/packages/web/src/lib/session-inbox-api.ts
+++ b/packages/web/src/lib/session-inbox-api.ts
@@ -70,6 +70,22 @@ function applyReadStateToPage(
   };
 }
 
+function latestHierarchyUpdate(item: SessionInboxItem): number {
+  return Math.max(
+    item.rootSession.updatedAt,
+    ...item.descendantSessions.map(({ updatedAt }) => updatedAt)
+  );
+}
+
+function destinationCategory(
+  item: SessionInboxItem
+): Exclude<SessionInboxCategory, "needs_attention"> {
+  return item.rootSession.status === "active" ||
+    item.descendantSessions.some(({ status }) => status === "active")
+    ? "in_progress"
+    : "finished";
+}
+
 export function applySessionInboxItemReadState(
   item: SessionInboxItem,
   sessionId: string,
@@ -115,14 +131,42 @@ export function applySessionInboxReadStateUpdate<T extends SessionInboxSnapshot 
 ): T | undefined {
   if (!data) return data;
   if ("categories" in data) {
+    const categories = Object.fromEntries(
+      Object.entries(data.categories).map(([category, page]) => [
+        category,
+        applyReadStateToPage(page, sessionId, readState),
+      ])
+    ) as Record<SessionInboxCategory, SessionInboxPage>;
+    const attentionItem = categories.needs_attention.items.find(
+      (item) =>
+        item.rootSession.id === sessionId ||
+        item.descendantSessions.some((session) => session.id === sessionId)
+    );
+    if (
+      attentionItem &&
+      !attentionItem.rootSession.readState.unread &&
+      attentionItem.descendantSessions.every((session) => !session.readState.unread)
+    ) {
+      categories.needs_attention = {
+        ...categories.needs_attention,
+        items: categories.needs_attention.items.filter(
+          (item) => item.rootSession.id !== attentionItem.rootSession.id
+        ),
+      };
+      const destination = destinationCategory(attentionItem);
+      categories[destination] = {
+        ...categories[destination],
+        items: [
+          attentionItem,
+          ...categories[destination].items.filter(
+            (item) => item.rootSession.id !== attentionItem.rootSession.id
+          ),
+        ].sort((a, b) => latestHierarchyUpdate(b) - latestHierarchyUpdate(a)),
+      };
+    }
     return {
       ...data,
-      categories: Object.fromEntries(
-        Object.entries(data.categories).map(([category, page]) => [
-          category,
-          applyReadStateToPage(page, sessionId, readState),
-        ])
-      ) as Record<SessionInboxCategory, SessionInboxPage>,
+      categories,
     } as T;
   }
   return applyReadStateToPage(data, sessionId, readState) as T;

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -126,6 +126,23 @@ describe("applySessionReadState", () => {
     });
   });
 
+  it("accepts the first terminal message when the cache had none", () => {
+    const data: SessionListResponse = {
+      sessions: [session("session-1", { readState: { unread: false, latestMessageId: null } })],
+      hasMore: false,
+    };
+
+    expect(
+      applySessionReadState(data, "session-1", {
+        unread: false,
+        latestMessageId: "message-a",
+      })?.sessions[0].readState
+    ).toEqual({
+      unread: false,
+      latestMessageId: "message-a",
+    });
+  });
+
   it("does not restore unread state for the same terminal message", () => {
     const data: SessionListResponse = {
       sessions: [

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -125,6 +125,30 @@ describe("applySessionReadState", () => {
       latestMessageId: "message-b",
     });
   });
+
+  it("does not restore unread state for the same terminal message", () => {
+    const data: SessionListResponse = {
+      sessions: [
+        session("session-1", {
+          readState: {
+            unread: false,
+            latestMessageId: "message-a",
+          },
+        }),
+      ],
+      hasMore: false,
+    };
+
+    expect(
+      applySessionReadState(data, "session-1", {
+        unread: true,
+        latestMessageId: "message-a",
+      })?.sessions[0].readState
+    ).toEqual({
+      unread: false,
+      latestMessageId: "message-a",
+    });
+  });
 });
 
 describe("buildSessionSearchValue", () => {

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -120,19 +120,22 @@ export function applySessionReadState(
   if (!data) return data;
   return {
     ...data,
-    sessions: data.sessions.map((session) => {
-      if (session.id !== sessionId) return session;
-      if (!readState) return session;
-      const currentMessageId = session.readState?.latestMessageId;
-      if (currentMessageId !== undefined && currentMessageId !== readState.latestMessageId) {
-        return session;
-      }
-      return {
-        ...session,
-        readState,
-      };
-    }),
+    sessions: data.sessions.map((session) =>
+      applySessionReadStateToItem(session, sessionId, readState)
+    ),
   };
+}
+
+export function applySessionReadStateToItem<T extends { id: string; readState?: SessionReadState }>(
+  session: T,
+  sessionId: string,
+  readState: SessionReadState | undefined
+): T {
+  if (session.id !== sessionId || !readState) return session;
+  const currentMessageId = session.readState?.latestMessageId;
+  if (currentMessageId !== undefined && currentMessageId !== readState.latestMessageId)
+    return session;
+  return { ...session, readState };
 }
 
 export function removeSessionFromList(sessions: SessionListItem[], sessionId: string) {

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -135,6 +135,7 @@ export function applySessionReadStateToItem<T extends { id: string; readState?: 
   const currentMessageId = session.readState?.latestMessageId;
   if (currentMessageId !== undefined && currentMessageId !== readState.latestMessageId)
     return session;
+  if (session.readState?.unread === false && readState.unread) return session;
   return { ...session, readState };
 }
 

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -132,9 +132,11 @@ export function applySessionReadStateToItem<T extends { id: string; readState?: 
   readState: SessionReadState | undefined
 ): T {
   if (session.id !== sessionId || !readState) return session;
+  // Message IDs are not orderable, so a cached row holding a different message
+  // is left alone: it may already reflect a newer terminal message. A row with
+  // no terminal message yet has nothing newer to protect.
   const currentMessageId = session.readState?.latestMessageId;
-  if (currentMessageId !== undefined && currentMessageId !== readState.latestMessageId)
-    return session;
+  if (currentMessageId != null && currentMessageId !== readState.latestMessageId) return session;
   if (session.readState?.unread === false && readState.unread) return session;
   return { ...session, readState };
 }

--- a/packages/web/src/lib/session-read-state.test.ts
+++ b/packages/web/src/lib/session-read-state.test.ts
@@ -1,6 +1,10 @@
 import { mutate } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { classifySessionReadAttempt, reconcileSessionReadState } from "./session-read-state";
+import {
+  classifySessionReadAttempt,
+  reconcileSessionReadState,
+  subscribeSessionReadStateReconciliation,
+} from "./session-read-state";
 
 vi.mock("swr", () => ({ mutate: vi.fn(() => Promise.resolve()) }));
 
@@ -56,5 +60,32 @@ describe("reconcileSessionReadState", () => {
       populateCache: true,
       revalidate: false,
     });
+  });
+
+  it("waits for registered cache reconcilers", async () => {
+    let finishReconciliation!: () => void;
+    const pendingReconciliation = new Promise<void>((resolve) => {
+      finishReconciliation = resolve;
+    });
+    const reconcile = vi.fn(() => pendingReconciliation);
+    const unsubscribe = subscribeSessionReadStateReconciliation(reconcile);
+
+    const result = reconcileSessionReadState({
+      sessionId: "session-1",
+      outcome: "marked_read",
+      unread: false,
+      latestMessageId: "message-1",
+    });
+    await vi.waitFor(() => expect(reconcile).toHaveBeenCalledOnce());
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    finishReconciliation();
+    await result;
+    unsubscribe();
   });
 });

--- a/packages/web/src/lib/session-read-state.test.ts
+++ b/packages/web/src/lib/session-read-state.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { classifySessionReadAttempt } from "./session-read-state";
+import { mutate } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { classifySessionReadAttempt, reconcileSessionReadState } from "./session-read-state";
+
+vi.mock("swr", () => ({ mutate: vi.fn(() => Promise.resolve()) }));
+
+beforeEach(() => {
+  vi.mocked(mutate).mockClear();
+});
 
 describe("classifySessionReadAttempt", () => {
   it.each(["marked_read", "already_read"] as const)("completes after a %s result", (outcome) => {
@@ -33,4 +40,21 @@ describe("classifySessionReadAttempt", () => {
       expect(classifySessionReadAttempt(result)).toBe("retry");
     }
   );
+});
+
+describe("reconcileSessionReadState", () => {
+  it("updates session-list caches", async () => {
+    await reconcileSessionReadState({
+      sessionId: "session-1",
+      outcome: "marked_read",
+      unread: false,
+      latestMessageId: "message-1",
+    });
+
+    expect(mutate).toHaveBeenCalledOnce();
+    expect(vi.mocked(mutate).mock.calls[0]?.[2]).toEqual({
+      populateCache: true,
+      revalidate: false,
+    });
+  });
 });

--- a/packages/web/src/lib/session-read-state.test.ts
+++ b/packages/web/src/lib/session-read-state.test.ts
@@ -62,6 +62,25 @@ describe("reconcileSessionReadState", () => {
     });
   });
 
+  it("tells reconcilers what the server decided", async () => {
+    const reconcile = vi.fn();
+    const unsubscribe = subscribeSessionReadStateReconciliation(reconcile);
+
+    await reconcileSessionReadState({
+      sessionId: "session-1",
+      outcome: "already_read",
+      unread: false,
+      latestMessageId: "message-1",
+    });
+    unsubscribe();
+
+    expect(reconcile).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      outcome: "already_read",
+      readState: { unread: false, latestMessageId: "message-1" },
+    });
+  });
+
   it("waits for registered cache reconcilers", async () => {
     let finishReconciliation!: () => void;
     const pendingReconciliation = new Promise<void>((resolve) => {

--- a/packages/web/src/lib/session-read-state.ts
+++ b/packages/web/src/lib/session-read-state.ts
@@ -11,6 +11,7 @@ import {
 export type SessionReadAttemptDisposition = "complete" | "retry" | "permanent_failure";
 export interface SessionReadStateReconciledDetail {
   sessionId: string;
+  outcome: SessionReadResult["outcome"];
   readState: SessionReadState;
 }
 type SessionReadStateReconciler = (
@@ -87,7 +88,7 @@ export async function reconcileSessionReadState(result: SessionReadResult): Prom
   );
   await Promise.all(
     [...readStateReconcilers].map((reconcile) =>
-      reconcile({ sessionId: result.sessionId, readState })
+      reconcile({ sessionId: result.sessionId, outcome: result.outcome, readState })
     )
   );
   return mutation;

--- a/packages/web/src/lib/session-read-state.ts
+++ b/packages/web/src/lib/session-read-state.ts
@@ -9,10 +9,20 @@ import {
 } from "@open-inspect/shared/types/sessions";
 
 export type SessionReadAttemptDisposition = "complete" | "retry" | "permanent_failure";
-export const SESSION_READ_STATE_RECONCILED_EVENT = "open-inspect:session-read-state-reconciled";
 export interface SessionReadStateReconciledDetail {
   sessionId: string;
   readState: SessionReadState;
+}
+type SessionReadStateReconciler = (
+  detail: SessionReadStateReconciledDetail
+) => Promise<unknown> | unknown;
+const readStateReconcilers = new Set<SessionReadStateReconciler>();
+
+export function subscribeSessionReadStateReconciliation(
+  reconcile: SessionReadStateReconciler
+): () => void {
+  readStateReconcilers.add(reconcile);
+  return () => readStateReconcilers.delete(reconcile);
 }
 
 export class SessionReadRequestError extends Error {
@@ -75,12 +85,10 @@ export async function reconcileSessionReadState(result: SessionReadResult): Prom
     (current) => applySessionReadState(current, result.sessionId, readState),
     { populateCache: true, revalidate: false }
   );
-  if (typeof window !== "undefined") {
-    window.dispatchEvent(
-      new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
-        detail: { sessionId: result.sessionId, readState },
-      })
-    );
-  }
+  await Promise.all(
+    [...readStateReconcilers].map((reconcile) =>
+      reconcile({ sessionId: result.sessionId, readState })
+    )
+  );
   return mutation;
 }

--- a/packages/web/src/lib/session-read-state.ts
+++ b/packages/web/src/lib/session-read-state.ts
@@ -9,6 +9,11 @@ import {
 } from "@open-inspect/shared/types/sessions";
 
 export type SessionReadAttemptDisposition = "complete" | "retry" | "permanent_failure";
+export const SESSION_READ_STATE_RECONCILED_EVENT = "open-inspect:session-read-state-reconciled";
+export interface SessionReadStateReconciledDetail {
+  sessionId: string;
+  readState: SessionReadState;
+}
 
 export class SessionReadRequestError extends Error {
   constructor(readonly status: number) {
@@ -63,11 +68,19 @@ export function readStateFromResult(result: SessionReadResult): SessionReadState
       };
 }
 
-export function reconcileSessionReadState(result: SessionReadResult): Promise<unknown> {
+export async function reconcileSessionReadState(result: SessionReadResult): Promise<unknown> {
   const readState = readStateFromResult(result);
-  return mutate<SessionListResponse>(
+  const mutation = await mutate<SessionListResponse>(
     isSessionListKey,
     (current) => applySessionReadState(current, result.sessionId, readState),
     { populateCache: true, revalidate: false }
   );
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<SessionReadStateReconciledDetail>(SESSION_READ_STATE_RECONCILED_EVENT, {
+        detail: { sessionId: result.sessionId, readState },
+      })
+    );
+  }
+  return mutation;
 }


### PR DESCRIPTION
## Summary

- extract the existing race-safe session read-state item transform so legacy lists and inbox caches share the newer-message guard
- reconcile read-state changes across retained sidebar pages, string-keyed inbox snapshots/pages, and tuple-keyed pagination caches
- dispatch a browser-local reconciliation event after legacy list cache updates and route explicit sidebar mark-read actions through that shared path
- revalidate canonical inbox state while removing attention hierarchies only after their root and descendants are all read

## Preserved behavior

This intentionally brings over only the cache synchronization portion of #1695. It does not change session-page observer ownership, `TerminalMessageReadObserver`, `SessionTimeline` observer props, virtualized scrolling, or visible-message read semantics from #1694.

## Verification

- `npm test -w @open-inspect/web -- src/lib/session-list.test.ts src/lib/session-inbox-api.test.ts src/lib/session-read-state.test.ts src/hooks/use-sidebar-sessions.test.tsx src/components/session-timeline.test.tsx src/components/session-timeline-scroll.test.tsx` (99 tests passed)
- `npm test -w @open-inspect/web` (1,407 tests passed)
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `NODE_ENV=production npm run build -w @open-inspect/web`
- `git diff --check main...HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/88dd42370a25b83c45c2b65f8f484c48)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of session read status across the sidebar, inbox, and paginated results.
  - Prevented stale unread indicators from reappearing after session updates or remounts.
  - Preserved newer message and read-state information when updating cached session data.
  - Updated pagination when read sessions change categories, ensuring refreshed results use the correct position.

- **Tests**
  - Added coverage for read-state reconciliation, pagination resets, category transitions, caching, and protection against stale updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->