### PR TITLE
fix: improve Modal snapshot error diagnostics

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -1144,6 +1144,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.log.error("Snapshot request failed", {
         error: error instanceof Error ? error : String(error),
         reason,
+        modal_object_id: sandbox.modal_object_id,
       });
     }
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -609,9 +609,10 @@ describe("ModalSandboxProvider", () => {
     });
 
     it("classifies HTTP 503 from takeSnapshot as transient", async () => {
+      const modalError = new ModalApiError("Modal API error: 503 Service Unavailable", 503);
       const client = createMockModalClient({
         snapshotSandbox: vi.fn(async () => {
-          throw new ModalApiError("Modal API error: 503 Service Unavailable", 503);
+          throw modalError;
         }),
       });
       const provider = new ModalSandboxProvider(client);
@@ -626,6 +627,10 @@ describe("ModalSandboxProvider", () => {
       } catch (e) {
         expect(e).toBeInstanceOf(SandboxProviderError);
         expect((e as SandboxProviderError).errorType).toBe("transient");
+        expect(e).toMatchObject({
+          message: "Snapshot failed with HTTP 503: Modal API error: 503 Service Unavailable",
+          cause: modalError,
+        });
       }
     });
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -229,8 +229,9 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
     } catch (error) {
       if (error instanceof ModalApiError) {
         throw this.classifyErrorWithStatus(
-          `Snapshot failed with HTTP ${error.status}`,
-          error.status
+          `Snapshot failed with HTTP ${error.status}: ${error.message}`,
+          error.status,
+          error
         );
       }
       if (error instanceof SandboxProviderError) {

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -206,7 +206,14 @@ async def _execute_endpoint(
     except Exception as e:
         execution.http_status = 500
         execution.outcome = "error"
-        log.error("api.error", exc=e, endpoint_name=endpoint_name)
+        log.error(
+            "api.error",
+            exc=e,
+            endpoint_name=execution.endpoint_name,
+            trace_id=execution.trace_id,
+            request_id=execution.request_id,
+            **execution.log_fields,
+        )
         raise HTTPException(status_code=500, detail="Internal server error") from e
     finally:
         log.info(

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -249,7 +249,15 @@ async def test_sandbox_generic_failures_raise_500_and_log_request(monkeypatch, c
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == "Internal server error"
-    error.assert_called_once()
+    error.assert_called_once_with(
+        "api.error",
+        exc=ANY,
+        endpoint_name=endpoint,
+        trace_id="trace-1",
+        request_id="request-1",
+        session_id="sess-1",
+        sandbox_id="sandbox-1",
+    )
     info.assert_called_once_with(
         "modal.http_request",
         http_method="POST",


### PR DESCRIPTION
## Summary
- preserve Modal snapshot API response details and the original error cause in control-plane failures
- include the Modal object ID in lifecycle snapshot failure logs
- attach trace, request, session, and sandbox context to Modal `api.error` events while keeping HTTP 500 responses sanitized

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/modal-provider.test.ts src/sandbox/lifecycle/manager.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `uv run pytest tests/test_web_api_create_sandbox.py tests/test_snapshot_timeout.py -q`
- `uv run ruff check src/web_api.py tests/test_web_api_create_sandbox.py`
- `uv run ruff format --check src/web_api.py tests/test_web_api_create_sandbox.py`
- Prettier and `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/82f8df8e91602e10aaae5b700c2e0c79)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot failure messages by including the underlying error details.
  * Preserved original error information to support more accurate diagnosis of transient failures.

* **Monitoring**
  * Enhanced error logging with sandbox identification and request correlation details, making failed operations easier to trace and investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->