### PR TITLE
Fix child session action menu positioning

### DIFF
--- a/packages/web/src/components/session-list-item.test.tsx
+++ b/packages/web/src/components/session-list-item.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { beforeEach, expect, it, vi } from "vitest";
 import type { SessionItem } from "@/hooks/use-sidebar-sessions";
-import { SessionListItem } from "./session-list-item";
+import { ChildSessionListItem, SessionListItem } from "./session-list-item";
 
 expect.extend(matchers);
 
@@ -92,4 +92,24 @@ it("keeps mark-as-read available without sessions.lifecycle", async () => {
   expect(await screen.findByRole("menuitem", { name: "Mark as read" })).toBeInTheDocument();
   expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument();
   expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
+});
+
+it("keeps an open child session menu trigger measurable", async () => {
+  render(
+    <ChildSessionListItem
+      session={{ ...session(true), parentSessionId: "parent-session" }}
+      isActive={false}
+      isMobile={false}
+      depth={1}
+      onMarkLatestMessageRead={vi.fn()}
+    />
+  );
+
+  const trigger = screen.getByRole("button", { name: "Session actions" });
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+
+  expect(await screen.findByRole("menuitem", { name: "Mark as read" })).toBeInTheDocument();
+  expect(trigger).toHaveAttribute("data-state", "open");
+  expect(trigger).toHaveClass("flex");
+  expect(trigger).not.toHaveClass("hidden");
 });

--- a/packages/web/src/components/session-list-item.tsx
+++ b/packages/web/src/components/session-list-item.tsx
@@ -447,7 +447,7 @@ export function ChildSessionListItem({
               className={`absolute right-0 top-0 h-10 w-10 items-center justify-center text-muted-foreground ${
                 isMobile
                   ? "flex"
-                  : "hidden opacity-0 group-hover:flex group-hover:opacity-100 group-focus-within:flex group-focus-within:opacity-100"
+                  : "invisible flex opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 data-[state=open]:visible data-[state=open]:opacity-100"
               }`}
             >
               <MoreIcon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- keep child session action triggers measurable while their portaled dropdown is open
- preserve the existing hover/focus visibility behavior without removing the trigger from layout
- add regression coverage for the open child-session menu anchor state

## Root cause
The desktop child-session trigger used `display: none` outside the row's hover/focus states. Dropdown content is rendered in a portal, so moving into the open menu could clear those row states, hide the trigger, and leave Radix without a measurable anchor. The menu would then reposition at the far-left viewport origin.

## Verification
- `npm test -w @open-inspect/web -- src/components/session-list-item.test.tsx`
- `npm test -w @open-inspect/web -- --testTimeout=15000` (185 files, 1,414 tests)
- `npm run typecheck -w @open-inspect/web`
- `npx eslint src/components/session-list-item.tsx src/components/session-list-item.test.tsx`
- `npx prettier --check src/components/session-list-item.tsx src/components/session-list-item.test.tsx`
- `git diff --check`

## Visual verification
The local app reached its authentication boundary, but no local control-plane credentials/session were configured, so an authenticated child-session sidebar could not be opened in the browser. The interaction is covered at the component level by asserting that the open Radix trigger remains rendered and measurable.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9be673f97d1332c19681e2b4264a07b6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop child-session actions button so it remains properly positioned and measurable when hidden.
  * The button now appears reliably on hover, focus, or when its menu is open.
  * Mobile behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->