### PR TITLE
Fix queued prompt cancellation state synchronization

### DIFF
--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -294,6 +294,7 @@ async function handleSpawnChild(
       authorId: spawnContext.promptAuthor.userId,
       canonicalUserId: spawnContext.promptAuthor.canonicalUserId ?? undefined,
       source: "agent",
+      cancellableByUser: false,
     } satisfies EnqueuePromptRequest;
 
     promptResponse = await ctx.sessionRuntime.fetch(childId, SessionInternalPaths.prompt, {

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -135,6 +135,7 @@ async function handleSessionPrompt(
     authorId,
     canonicalUserId,
     source: body.source || "web",
+    cancellableByUser: ctx.principal?.kind === "user",
     model: body.model,
     reasoningEffort: body.reasoningEffort,
     attachments,

--- a/packages/control-plane/src/scheduler/scheduler.ts
+++ b/packages/control-plane/src/scheduler/scheduler.ts
@@ -1605,7 +1605,7 @@ export class Scheduler {
     const promptResponse = await stub.fetch("http://internal/internal/prompt", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ ...body, cancellableByUser: false }),
     });
 
     if (!promptResponse.ok) {

--- a/packages/control-plane/src/session/enqueue-prompt-contract.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.ts
@@ -13,6 +13,7 @@ export const enqueuePromptRequestSchema = z
     authorId: z.string(),
     canonicalUserId: z.string().nullable().optional(),
     source: messageSourceSchema,
+    cancellableByUser: z.boolean().default(false),
     model: z.string().optional(),
     reasoningEffort: z.string().optional(),
     attachments: sessionAttachmentReferencesSchema.optional(),

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -136,6 +136,7 @@ describe("ChildSessionsHandler", () => {
         authorId: "owner-1",
         canonicalUserId: "canonical-1",
         source: "agent",
+        cancellableByUser: false,
         scmEnrichment: {
           userId: null,
           login: null,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -150,6 +150,7 @@ export class ChildSessionsHandler {
           authorId: parsed.data.author.userId,
           canonicalUserId: parsed.data.author.canonicalUserId ?? undefined,
           source: "agent",
+          cancellableByUser: false,
           scmEnrichment: {
             userId: parsed.data.author.scmUserId,
             login: parsed.data.author.scmLogin,

--- a/packages/control-plane/src/session/http/handlers/child-summary.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-summary.handler.test.ts
@@ -105,6 +105,7 @@ function createMessage(overrides: Partial<MessageRow> = {}): MessageRow {
     reasoning_effort: null,
     attachments: null,
     callback_context: null,
+    cancellable_by_user: 1,
     client_request_id: null,
     request_fingerprint: null,
     autofix_feedback_key: null,

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -55,6 +55,7 @@ describe("MessagesHandler", () => {
       content: "hello",
       authorId: "user-1",
       source: "web",
+      cancellableByUser: false,
     });
   });
 
@@ -94,7 +95,10 @@ describe("MessagesHandler", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(messageService.enqueuePrompt).toHaveBeenCalledWith(body);
+    expect(messageService.enqueuePrompt).toHaveBeenCalledWith({
+      ...body,
+      cancellableByUser: false,
+    });
   });
 
   it("returns 400 for malformed prompt bodies", async () => {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -427,12 +427,15 @@ describe("SessionMessageQueue", () => {
     });
 
     expect(h.repository.cancelPendingMessage).toHaveBeenCalledWith("msg-1");
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "prompt_queue_updated", promptQueue: [] });
     expect(h.wsManager.send).toHaveBeenCalledWith(ws, {
       type: "prompt_cancelled",
       clientRequestId: "request-1",
       messageId: "msg-1",
     });
-    expect(h.broadcast).toHaveBeenCalledWith({ type: "prompt_queue_updated", promptQueue: [] });
+    expect(h.broadcast.mock.invocationCallOrder[0]).toBeLessThan(
+      h.wsManager.send.mock.invocationCallOrder[0]
+    );
     expect(h.sessionStatus.reconcileAfterQueueRemoval).toHaveBeenCalledOnce();
   });
 
@@ -451,7 +454,10 @@ describe("SessionMessageQueue", () => {
       message: "This prompt is no longer pending and cannot be removed",
       clientRequestId: "request-1",
     });
-    expect(h.broadcast).not.toHaveBeenCalled();
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "prompt_queue_updated", promptQueue: [] });
+    expect(h.broadcast.mock.invocationCallOrder[0]).toBeLessThan(
+      h.wsManager.send.mock.invocationCallOrder[0]
+    );
   });
 
   it("reconciles session status after removing a prompt", async () => {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -80,6 +80,7 @@ function createMessage(overrides: Partial<MessageRow> = {}): MessageRow {
     reasoning_effort: null,
     attachments: null,
     callback_context: null,
+    cancellable_by_user: 1,
     client_request_id: null,
     request_fingerprint: null,
     autofix_feedback_key: null,
@@ -1520,6 +1521,7 @@ describe("SessionMessageQueue", () => {
             content: "Continue",
             authorId: "user-1",
             source: "agent",
+            cancellableByUser: false,
           })
         ).rejects.toMatchObject({ sessionStatus: status });
 
@@ -1553,6 +1555,7 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github",
+        cancellableByUser: false,
         scmEnrichment: {
           userId: "1001",
           login: "octocat",
@@ -1575,6 +1578,7 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github",
+        cancellableByUser: false,
       });
 
       expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "github:1001");
@@ -1587,6 +1591,7 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github",
+        cancellableByUser: false,
         scmEnrichment: {
           userId: "1001",
           login: "octocat",
@@ -1616,6 +1621,7 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github",
+        cancellableByUser: false,
       });
 
       expect(h.repository.updateParticipantCoalesce).not.toHaveBeenCalled();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -328,7 +328,9 @@ export class SessionMessageQueue {
     ws: WebSocket,
     data: { messageId: string; clientRequestId: string }
   ): Promise<void> {
-    if (!this.messageRepository.cancelPendingMessage(data.messageId)) {
+    const cancelled = this.messageRepository.cancelPendingMessage(data.messageId);
+    this.broadcastPromptQueue();
+    if (!cancelled) {
       this.wsManager.send(ws, {
         type: "error",
         code: "PROMPT_NOT_CANCELLABLE",
@@ -343,7 +345,6 @@ export class SessionMessageQueue {
       clientRequestId: data.clientRequestId,
       messageId: data.messageId,
     });
-    this.broadcastPromptQueue();
     this.log.info("prompt.cancelled", {
       event: "prompt.cancelled",
       message_id: data.messageId,

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -65,6 +65,7 @@ interface EnqueuePromptCoreData {
   userId: string;
   content: string;
   source: MessageSource;
+  cancellableByUser: boolean;
   model?: string;
   reasoningEffort?: string;
   attachments?: SessionAttachmentReference[];
@@ -194,6 +195,7 @@ export class SessionMessageQueue {
         authorId: participant.id,
         content: command.prompt,
         source: "github",
+        cancellableByUser: false,
         status: "pending",
         createdAt: now,
       },
@@ -257,6 +259,7 @@ export class SessionMessageQueue {
         userId: client.userId,
         content: data.content,
         source: "web",
+        cancellableByUser: true,
         model: data.model,
         reasoningEffort: data.reasoningEffort,
         attachments: data.attachments,
@@ -741,6 +744,7 @@ export class SessionMessageQueue {
       userId: data.authorId,
       content: data.content,
       source: data.source,
+      cancellableByUser: data.cancellableByUser,
       model: data.model,
       reasoningEffort: data.reasoningEffort,
       attachments: data.attachments,
@@ -823,6 +827,7 @@ export class SessionMessageQueue {
           authorId: data.participant.id,
           content: data.content,
           source: data.source,
+          cancellableByUser: data.cancellableByUser,
           model: messageModel,
           reasoningEffort: messageReasoningEffort,
           attachments: attachments ? JSON.stringify(attachments) : null,

--- a/packages/control-plane/src/session/message-repository.test.ts
+++ b/packages/control-plane/src/session/message-repository.test.ts
@@ -129,15 +129,17 @@ describe("MessageRepository", () => {
         id: "msg-1",
         content: "Continue",
         status: "pending",
-        source: "web",
-        callback_context: null,
+        source: "linear",
+        callback_context: "{}",
+        cancellable_by_user: 1,
       } as never,
       {
         id: "msg-2",
         content: "Reply in Linear",
         status: "pending",
-        source: "linear",
+        source: "web",
         callback_context: null,
+        cancellable_by_user: 0,
       } as never,
     ]);
     expect(repository.listPromptQueue()).toEqual([
@@ -157,6 +159,7 @@ describe("MessageRepository", () => {
       authorId: "p-1",
       content: "Hello",
       source: "web",
+      cancellableByUser: true,
       model: "claude-sonnet-4",
       attachments: "[]",
       callbackContext: '{"channel":"C123"}',
@@ -173,6 +176,7 @@ describe("MessageRepository", () => {
       null,
       "[]",
       '{"channel":"C123"}',
+      1,
       null,
       null,
       null,
@@ -195,6 +199,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -218,6 +223,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -242,6 +248,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -266,6 +273,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -290,6 +298,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -319,6 +328,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Fix feedback",
           source: "github",
+          cancellableByUser: false,
           status: "pending",
           createdAt: 2000,
         },
@@ -345,6 +355,7 @@ describe("MessageRepository", () => {
         authorId: "p-1",
         content: "Look",
         source: "web",
+        cancellableByUser: true,
         status: "pending",
         createdAt: 1,
       },
@@ -364,6 +375,7 @@ describe("MessageRepository", () => {
           authorId: "p-1",
           content: "Look",
           source: "web",
+          cancellableByUser: true,
           status: "pending",
           createdAt: 1,
         },
@@ -373,23 +385,20 @@ describe("MessageRepository", () => {
     expect(mock.calls).toHaveLength(1);
   });
 
-  it("atomically releases attachments and cancels a pending web message", () => {
-    mock.setData(`SELECT status, source, callback_context FROM messages WHERE id = ?`, [
-      { status: "pending", source: "web", callback_context: null },
+  it("atomically cancels a user-cancellable pending message and releases attachments", () => {
+    mock.setMatchingData(/DELETE FROM messages[\s\S]*cancellable_by_user = 1[\s\S]*RETURNING id/, [
+      { id: "msg-1" },
     ]);
-    mock.setRowsWritten(1);
     expect(repository.cancelPendingMessage("msg-1")).toBe(true);
     expect(transactionSyncCalls).toBe(1);
+    expect(mock.calls[0].query).toContain("DELETE FROM messages");
     expect(mock.calls[1].query).toContain("UPDATE attachments SET message_id = NULL");
-    expect(mock.calls[2].query).toContain("DELETE FROM messages");
   });
 
-  it("rejects cancellation for messages that may need callbacks", () => {
-    mock.setData(`SELECT status, source, callback_context FROM messages WHERE id = ?`, [
-      { status: "pending", source: "linear", callback_context: null },
-    ]);
+  it("rejects cancellation without canonical user ownership", () => {
     expect(repository.cancelPendingMessage("msg-1")).toBe(false);
     expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0].query).toContain("cancellable_by_user = 1");
   });
 
   it("atomically starts processing and creates the canonical user event", () => {

--- a/packages/control-plane/src/session/message-repository.test.ts
+++ b/packages/control-plane/src/session/message-repository.test.ts
@@ -125,10 +125,29 @@ describe("MessageRepository", () => {
 
   it("projects unfinished messages into the prompt queue", () => {
     vi.spyOn(repository, "listUnfinishedMessages").mockReturnValue([
-      { id: "msg-1", content: "Continue", status: "pending" } as never,
+      {
+        id: "msg-1",
+        content: "Continue",
+        status: "pending",
+        source: "web",
+        callback_context: null,
+      } as never,
+      {
+        id: "msg-2",
+        content: "Reply in Linear",
+        status: "pending",
+        source: "linear",
+        callback_context: null,
+      } as never,
     ]);
     expect(repository.listPromptQueue()).toEqual([
-      { messageId: "msg-1", content: "Continue", status: "pending" },
+      { messageId: "msg-1", content: "Continue", status: "pending", cancellable: true },
+      {
+        messageId: "msg-2",
+        content: "Reply in Linear",
+        status: "pending",
+        cancellable: false,
+      },
     ]);
   });
 

--- a/packages/control-plane/src/session/message-repository.ts
+++ b/packages/control-plane/src/session/message-repository.ts
@@ -227,6 +227,10 @@ export class MessageRepository {
       messageId: message.id,
       content: message.content,
       status: message.status as "pending" | "processing",
+      cancellable:
+        message.status === "pending" &&
+        message.source === "web" &&
+        message.callback_context === null,
     }));
   }
 

--- a/packages/control-plane/src/session/message-repository.ts
+++ b/packages/control-plane/src/session/message-repository.ts
@@ -29,6 +29,7 @@ export interface CreateMessageData {
   reasoningEffort?: string | null;
   attachments?: string | null;
   callbackContext?: string | null;
+  cancellableByUser: boolean;
   clientRequestId?: string | null;
   requestFingerprint?: string | null;
   autofixFeedbackKey?: string | null;
@@ -227,41 +228,22 @@ export class MessageRepository {
       messageId: message.id,
       content: message.content,
       status: message.status as "pending" | "processing",
-      cancellable:
-        message.status === "pending" &&
-        message.source === "web" &&
-        message.callback_context === null,
+      cancellable: message.status === "pending" && message.cancellable_by_user === 1,
     }));
   }
 
   cancelPendingMessage(messageId: string): boolean {
     return this.transactionSync(() => {
-      const result = this.sql.exec(
-        `SELECT status, source, callback_context FROM messages WHERE id = ?`,
+      const deleted = this.sql.exec(
+        `DELETE FROM messages
+         WHERE id = ? AND status = 'pending' AND cancellable_by_user = 1
+         RETURNING id`,
         messageId
       );
-      const message = (
-        result.toArray() as Array<{
-          status: MessageStatus;
-          source: string;
-          callback_context: string | null;
-        }>
-      )[0];
-      if (
-        message?.status !== "pending" ||
-        message.source !== "web" ||
-        message.callback_context !== null
-      ) {
-        return false;
-      }
+      if (deleted.toArray().length !== 1) return false;
 
       this.attachments.releaseForMessage(messageId);
-      const deleted = this.sql.exec(
-        `DELETE FROM messages WHERE id = ? AND status = 'pending'`,
-        messageId
-      );
-      deleted.toArray();
-      return deleted.rowsWritten === 1;
+      return true;
     });
   }
 
@@ -283,9 +265,9 @@ export class MessageRepository {
     this.sql.exec(
       `INSERT INTO messages (
          id, author_id, content, source, model, reasoning_effort, attachments,
-         callback_context, client_request_id, request_fingerprint, autofix_feedback_key,
+         callback_context, cancellable_by_user, client_request_id, request_fingerprint, autofix_feedback_key,
          autofix_pr_key, origin_context, status, created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       data.id,
       data.authorId,
       data.content,
@@ -294,6 +276,7 @@ export class MessageRepository {
       data.reasoningEffort ?? null,
       data.attachments ?? null,
       data.callbackContext ?? null,
+      data.cancellableByUser ? 1 : 0,
       data.clientRequestId ?? null,
       data.requestFingerprint ?? null,
       data.autofixFeedbackKey ?? null,

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -416,6 +416,33 @@ describe("applyMigrations", () => {
     }
   });
 
+  it("adds canonical prompt cancellation ownership and backfills eligible legacy messages", () => {
+    expect(SCHEMA_SQL).toContain("cancellable_by_user INTEGER NOT NULL DEFAULT 0");
+    const migration = MIGRATIONS.find((entry) => entry.id === 47);
+    const db = new DatabaseSync(":memory:");
+    const sql = createDatabaseSql(db);
+    try {
+      db.exec(`CREATE TABLE messages (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        callback_context TEXT
+      )`);
+      db.exec(`INSERT INTO messages VALUES
+        ('web', 'web', NULL),
+        ('linear', 'linear', NULL),
+        ('callback', 'web', '{}')`);
+      (migration!.run as (sql: SqlStorage) => void)(sql);
+
+      expect(db.prepare("SELECT id, cancellable_by_user FROM messages ORDER BY id").all()).toEqual([
+        { id: "callback", cancellable_by_user: 0 },
+        { id: "linear", cancellable_by_user: 0 },
+        { id: "web", cancellable_by_user: 1 },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("initializes a legacy messages table before creating indexes for new columns", () => {
     expect(SCHEMA_SQL).not.toMatch(/\bCREATE (?:UNIQUE )?INDEX\b/);
 
@@ -453,6 +480,7 @@ describe("applyMigrations", () => {
           expect.objectContaining({ name: "client_request_id", type: "TEXT" }),
           expect.objectContaining({ name: "request_fingerprint", type: "TEXT" }),
           expect.objectContaining({ name: "stop_confirmation_deadline", type: "INTEGER" }),
+          expect.objectContaining({ name: "cancellable_by_user", type: "INTEGER" }),
         ])
       );
       expect(

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -114,6 +114,7 @@ CREATE TABLE IF NOT EXISTS messages (
   reasoning_effort TEXT,                            -- Per-message reasoning effort override
   attachments TEXT,                                 -- JSON array
   callback_context TEXT,                            -- JSON callback context for Slack follow-up notifications
+  cancellable_by_user INTEGER NOT NULL DEFAULT 0,   -- Set only by authenticated user ingress
   client_request_id TEXT,                           -- Web-client idempotency key
   request_fingerprint TEXT,                         -- Participant-scoped canonical request hash
   autofix_feedback_key TEXT,                        -- Stable provider feedback identity for idempotency
@@ -628,6 +629,18 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
         sql,
         `ALTER TABLE ws_client_mapping ADD COLUMN authorization_expires_at INTEGER NOT NULL DEFAULT 0`
       );
+    },
+  },
+  {
+    id: 47,
+    description: "Add canonical prompt cancellation ownership",
+    run: (sql) => {
+      runMigration(
+        sql,
+        `ALTER TABLE messages ADD COLUMN cancellable_by_user INTEGER NOT NULL DEFAULT 0`
+      );
+      sql.exec(`UPDATE messages SET cancellable_by_user = 1
+        WHERE source = 'web' AND callback_context IS NULL`);
     },
   },
 ];

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -55,6 +55,7 @@ describe("MessageService", () => {
       content: "hello",
       authorId: "user-1",
       source: "web",
+      cancellableByUser: true,
     });
 
     expect(result).toEqual({ messageId: "msg-1", status: "queued" });
@@ -62,6 +63,7 @@ describe("MessageService", () => {
       content: "hello",
       authorId: "user-1",
       source: "web",
+      cancellableByUser: true,
     });
   });
 
@@ -193,6 +195,7 @@ describe("MessageService", () => {
           },
         ]),
         callback_context: null,
+        cancellable_by_user: 1,
         client_request_id: null,
         request_fingerprint: null,
         autofix_feedback_key: null,
@@ -214,6 +217,7 @@ describe("MessageService", () => {
         reasoning_effort: null,
         attachments: "invalid-json",
         callback_context: null,
+        cancellable_by_user: 1,
         client_request_id: null,
         request_fingerprint: null,
         autofix_feedback_key: null,
@@ -235,6 +239,7 @@ describe("MessageService", () => {
         reasoning_effort: null,
         attachments: null,
         callback_context: null,
+        cancellable_by_user: 1,
         client_request_id: null,
         request_fingerprint: null,
         autofix_feedback_key: null,
@@ -282,6 +287,7 @@ describe("MessageService", () => {
         reasoning_effort: null,
         attachments: "[]",
         callback_context: null,
+        cancellable_by_user: 1,
         client_request_id: null,
         request_fingerprint: null,
         autofix_feedback_key: null,

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -103,6 +103,7 @@ export interface MessageRow {
   reasoning_effort: string | null; // Reasoning effort for per-message override
   attachments: string | null; // JSON
   callback_context: string | null; // JSON: { channel, threadTs, repoFullName, model }
+  cancellable_by_user: number;
   client_request_id: string | null;
   request_fingerprint: string | null;
   autofix_feedback_key: string | null;

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -321,18 +321,22 @@ export async function seedMessage(
     status: string;
     createdAt: number;
     startedAt?: number;
+    cancellableByUser?: boolean;
   }
 ): Promise<void> {
   await runInSessionDO(stub, (instance: SessionDO, state) => {
     state.storage.sql.exec(
-      "INSERT INTO messages (id, author_id, content, source, status, created_at, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      `INSERT INTO messages
+         (id, author_id, content, source, status, created_at, started_at, cancellable_by_user)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       msg.id,
       msg.authorId,
       msg.content,
       msg.source,
       msg.status,
       msg.createdAt,
-      msg.startedAt ?? null
+      msg.startedAt ?? null,
+      msg.cancellableByUser ? 1 : 0
     );
   });
 }

--- a/packages/control-plane/test/integration/prompt-enqueue.test.ts
+++ b/packages/control-plane/test/integration/prompt-enqueue.test.ts
@@ -6,6 +6,7 @@ import {
   openSandboxWs,
   queryDO,
   seedSandboxAuth,
+  serviceFetch,
 } from "./helpers";
 
 const SANDBOX_TOKEN = "prompt-order-sandbox-token";
@@ -50,6 +51,25 @@ describe("POST /internal/prompt", () => {
     expect(messages[0].source).toBe("web");
     // Status may be "pending" or "processing" depending on queue processing
     expect(["pending", "processing"]).toContain(messages[0].status);
+  });
+
+  it("derives user cancellation ownership independently of caller-supplied source", async () => {
+    const { stub, sessionName } = await initSession();
+
+    const response = await serviceFetch(`https://cp.test/sessions/${sessionName}/prompt`, {
+      method: "POST",
+      body: JSON.stringify({ content: "Browser prompt", source: "linear" }),
+    });
+
+    expect(response.status).toBe(200);
+    const { messageId } = await response.json<{ messageId: string }>();
+    expect(
+      await queryDO<{ source: string; cancellable_by_user: number }>(
+        stub,
+        "SELECT source, cancellable_by_user FROM messages WHERE id = ?",
+        messageId
+      )
+    ).toEqual([{ source: "linear", cancellable_by_user: 1 }]);
   });
 
   it("persists queued prompts in FIFO order", async () => {

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -11,6 +11,7 @@ import { generateInternalToken } from "@open-inspect/shared/auth";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { UserStore } from "../../src/db/user-store";
 import { cleanD1Tables } from "./cleanup";
+import { queryDO } from "./helpers";
 import { insertCanonicalUser } from "./identity-seed-helpers";
 
 const SERVICE_SECRET: Record<ServiceName, string> = {
@@ -311,9 +312,50 @@ describe("sig1 service-credential authentication", () => {
       method: "POST",
       url: `https://test.local/sessions/${createdBody.sessionId}/prompt`,
       actor: "slack:U0002",
-      body: JSON.stringify({ content: "Cross-session prompt" }),
+      body: JSON.stringify({ content: "Integration source prompt", source: "linear" }),
     });
     expect(collaborator.status).toBe(200);
+
+    const callbackPrompt = await signedFetch({
+      service: "slack-bot",
+      method: "POST",
+      url: `https://test.local/sessions/${createdBody.sessionId}/prompt`,
+      actor: "slack:U0002",
+      body: JSON.stringify({
+        content: "Integration callback prompt",
+        source: "web",
+        callbackContext: {
+          source: "slack",
+          channel: "C1",
+          threadTs: "1.0",
+          repoFullName: "acme/repo",
+          model: "anthropic/claude-haiku-4-5",
+        },
+      }),
+    });
+    expect(callbackPrompt.status).toBe(200);
+
+    const stub = env.SESSION.get(env.SESSION.idFromName(createdBody.sessionId));
+    expect(
+      await queryDO<{ content: string; source: string; cancellable_by_user: number }>(
+        stub,
+        `SELECT content, source, cancellable_by_user FROM messages
+         WHERE content IN (?, ?) ORDER BY content`,
+        "Integration source prompt",
+        "Integration callback prompt"
+      )
+    ).toEqual([
+      {
+        content: "Integration callback prompt",
+        source: "web",
+        cancellable_by_user: 0,
+      },
+      {
+        content: "Integration source prompt",
+        source: "linear",
+        cancellable_by_user: 0,
+      },
+    ]);
 
     const deniedByServiceCeiling = await signedFetch({
       service: "slack-bot",

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -753,6 +753,7 @@ describe("Client WebSocket (via SELF.fetch)", () => {
         source: "web",
         status: "pending",
         createdAt: now + index,
+        cancellableByUser: true,
       });
     }
     await queryDO(
@@ -905,8 +906,11 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
-  it("does not allow web clients to cancel integration-owned prompts", async () => {
-    const name = `ws-client-cancel-integration-${Date.now()}`;
+  it.each([
+    { ownership: "integration source", source: "linear", callbackContext: null },
+    { ownership: "callback context", source: "web", callbackContext: { channel: "C1" } },
+  ])("does not allow web clients to cancel prompts owned by $ownership", async (testCase) => {
+    const name = `ws-client-cancel-integration-${crypto.randomUUID()}`;
     const { stub } = await initNamedSession(name);
     const [{ id: participantId }] = await queryDO<{ id: string }>(
       stub,
@@ -916,16 +920,18 @@ describe("Client WebSocket (via SELF.fetch)", () => {
       id: "message-linear",
       authorId: participantId,
       content: "Reply in Linear",
-      source: "linear",
+      source: testCase.source,
       status: "pending",
       createdAt: Date.now(),
     });
-    await queryDO(
-      stub,
-      "UPDATE messages SET source = 'web', callback_context = ? WHERE id = ?",
-      JSON.stringify({ channel: "C1", threadTs: "1.0" }),
-      "message-linear"
-    );
+    if (testCase.callbackContext) {
+      await queryDO(
+        stub,
+        "UPDATE messages SET callback_context = ? WHERE id = ?",
+        JSON.stringify(testCase.callbackContext),
+        "message-linear"
+      );
+    }
     const { ws, messages } = await openClientWs(name, { subscribe: true });
     const subscribed = messages.find((message) => message.type === "subscribed") as {
       promptQueue: Array<{ messageId: string }>;

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -634,7 +634,7 @@ describe("Client WebSocket (via SELF.fetch)", () => {
       promptQueue: Array<Record<string, unknown>>;
     };
     expect(subscribed.promptQueue).toEqual([
-      expect.objectContaining({ content: "Only once", status: "pending" }),
+      expect.objectContaining({ content: "Only once", status: "pending", cancellable: true }),
     ]);
     expect(subscribed.promptQueue[0]).not.toHaveProperty("model");
     expect(subscribed.promptQueue[0]).not.toHaveProperty("reasoningEffort");
@@ -931,7 +931,7 @@ describe("Client WebSocket (via SELF.fetch)", () => {
       promptQueue: Array<{ messageId: string }>;
     };
     expect(subscribed.promptQueue).toContainEqual(
-      expect.objectContaining({ messageId: "message-linear" })
+      expect.objectContaining({ messageId: "message-linear", cancellable: false })
     );
     const clientRequestId = crypto.randomUUID();
     const rejected = collectMessages(ws, {

--- a/packages/shared/src/types/server-messages.test.ts
+++ b/packages/shared/src/types/server-messages.test.ts
@@ -167,11 +167,13 @@ describe("session view contracts", () => {
         messageId: "message-running",
         content: "Run this",
         status: "processing",
+        cancellable: false,
       },
       {
         messageId: "message-pending",
         content: "Then this",
         status: "pending",
+        cancellable: true,
       },
     ];
 
@@ -186,6 +188,18 @@ describe("session view contracts", () => {
     expect(
       serverMessageSchema.parse({ type: "prompt_queue_updated", promptQueue }).promptQueue
     ).toEqual(promptQueue);
+  });
+
+  it("treats queue items from older servers as non-cancellable", () => {
+    const message = serverMessageSchema.parse({
+      type: "prompt_queue_updated",
+      promptQueue: [{ messageId: "message-1", content: "Wait", status: "pending" }],
+    });
+
+    expect(message).toMatchObject({
+      type: "prompt_queue_updated",
+      promptQueue: [{ cancellable: false }],
+    });
   });
 
   it("echoes prompt request correlation", () => {

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -11,6 +11,7 @@ export const promptQueueItemSchema = z.object({
   messageId: z.string(),
   content: z.string(),
   status: z.enum(["pending", "processing"]),
+  cancellable: z.boolean().default(false),
 });
 export type PromptQueueItem = z.infer<typeof promptQueueItemSchema>;
 

--- a/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
@@ -157,7 +157,7 @@ export default function SessionPage() {
       if (!capabilities.lifecycle) return;
       if (cancellingPromptIdsRef.current.has(messageId)) return;
       const queuedPrompt = promptQueue.find((item) => item.messageId === messageId);
-      if (!queuedPrompt || queuedPrompt.status !== "pending") return;
+      if (!queuedPrompt?.cancellable) return;
 
       cancellingPromptIdsRef.current.add(messageId);
       setCancellingPromptIds(new Set(cancellingPromptIdsRef.current));

--- a/packages/web/src/components/queued-prompt-stack.test.tsx
+++ b/packages/web/src/components/queued-prompt-stack.test.tsx
@@ -22,7 +22,9 @@ describe("QueuedPromptStack", () => {
   it("shows queued prompts without removal controls in read-only mode", () => {
     render(
       <QueuedPromptStack
-        promptQueue={[{ messageId: "queued-1", content: "Review this", status: "pending" }]}
+        promptQueue={[
+          { messageId: "queued-1", content: "Review this", status: "pending", cancellable: true },
+        ]}
         cancellingPromptIds={new Set()}
         onRemove={vi.fn()}
         capabilities={{ ...FULL_CAPABILITIES, lifecycle: false }}
@@ -39,9 +41,14 @@ describe("QueuedPromptStack", () => {
         onRemove={vi.fn()}
         capabilities={FULL_CAPABILITIES}
         promptQueue={[
-          { messageId: "running", content: "Already running", status: "processing" },
-          { messageId: "next", content: "Run next", status: "pending" },
-          { messageId: "later", content: "Run after that", status: "pending" },
+          {
+            messageId: "running",
+            content: "Already running",
+            status: "processing",
+            cancellable: false,
+          },
+          { messageId: "next", content: "Run next", status: "pending", cancellable: true },
+          { messageId: "later", content: "Run after that", status: "pending", cancellable: true },
         ]}
       />
     );
@@ -60,7 +67,14 @@ describe("QueuedPromptStack", () => {
         cancellingPromptIds={new Set()}
         onRemove={vi.fn()}
         capabilities={FULL_CAPABILITIES}
-        promptQueue={[{ messageId: "running", content: "Already running", status: "processing" }]}
+        promptQueue={[
+          {
+            messageId: "running",
+            content: "Already running",
+            status: "processing",
+            cancellable: false,
+          },
+        ]}
       />
     );
 
@@ -71,7 +85,9 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        promptQueue={[
+          { messageId: "next", content: "Run next", status: "pending", cancellable: true },
+        ]}
         cancellingPromptIds={new Set(["next"])}
         onRemove={onRemove}
         capabilities={FULL_CAPABILITIES}
@@ -88,7 +104,9 @@ describe("QueuedPromptStack", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
-        promptQueue={[{ messageId: "next", content: "Run next", status: "pending" }]}
+        promptQueue={[
+          { messageId: "next", content: "Run next", status: "pending", cancellable: true },
+        ]}
         cancellingPromptIds={new Set()}
         onRemove={onRemove}
         capabilities={FULL_CAPABILITIES}
@@ -99,7 +117,7 @@ describe("QueuedPromptStack", () => {
     expect(onRemove).toHaveBeenCalledWith("next");
   });
 
-  it("offers removal for pending prompts whose eligibility is server-owned", () => {
+  it("does not offer removal for a server-owned prompt", () => {
     const onRemove = vi.fn();
     render(
       <QueuedPromptStack
@@ -108,6 +126,7 @@ describe("QueuedPromptStack", () => {
             messageId: "linear-prompt",
             content: "Reply in Linear",
             status: "pending",
+            cancellable: false,
           },
         ]}
         cancellingPromptIds={new Set()}
@@ -116,7 +135,10 @@ describe("QueuedPromptStack", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove queued prompt: Reply in Linear" }));
-    expect(onRemove).toHaveBeenCalledWith("linear-prompt");
+    expect(screen.getByText("Reply in Linear")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove queued prompt: Reply in Linear" })
+    ).not.toBeInTheDocument();
+    expect(onRemove).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/queued-prompt-stack.tsx
+++ b/packages/web/src/components/queued-prompt-stack.tsx
@@ -31,7 +31,7 @@ export function QueuedPromptStack({
               <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-secondary-foreground">
                 {prompt.content}
               </p>
-              {capabilities.lifecycle && (
+              {capabilities.lifecycle && prompt.cancellable && (
                 <button
                   type="button"
                   onClick={() => onRemove(prompt.messageId)}

--- a/packages/web/src/components/session-timeline-scroll.test.tsx
+++ b/packages/web/src/components/session-timeline-scroll.test.tsx
@@ -359,7 +359,14 @@ describe("timeline auto-scrolling", () => {
       <SessionTimeline
         {...baseTimelineProps}
         events={events}
-        promptQueue={[{ messageId: "queued", content: "Next prompt", status: "pending" }]}
+        promptQueue={[
+          {
+            messageId: "queued",
+            content: "Next prompt",
+            status: "pending",
+            cancellable: true,
+          },
+        ]}
       />
     );
 

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -246,9 +246,9 @@ describe("prompt queue status", () => {
         {...baseTimelineProps}
         events={events}
         promptQueue={[
-          { messageId: "running", content: "First", status: "processing" },
-          { messageId: "next", content: "Second", status: "pending" },
-          { messageId: "later", content: "Third", status: "pending" },
+          { messageId: "running", content: "First", status: "processing", cancellable: false },
+          { messageId: "next", content: "Second", status: "pending", cancellable: true },
+          { messageId: "later", content: "Third", status: "pending", cancellable: true },
         ]}
       />
     );
@@ -268,11 +268,13 @@ describe("prompt queue status", () => {
             messageId: "canonical",
             content: "Canonical prompt",
             status: "processing",
+            cancellable: false,
           },
           {
             messageId: "outside-replay",
             content: "Queued outside replay",
             status: "pending",
+            cancellable: true,
           },
         ]}
       />

--- a/packages/web/src/lib/session-socket/reducer.test.ts
+++ b/packages/web/src/lib/session-socket/reducer.test.ts
@@ -93,6 +93,7 @@ describe("sessionSocketReducer", () => {
           messageId: "message-1",
           content: "Running",
           status: "processing" as const,
+          cancellable: false,
         },
       ];
       const state = createSessionSocketState({
@@ -166,6 +167,7 @@ describe("sessionSocketReducer", () => {
         messageId: "message-2",
         content: "Next",
         status: "pending" as const,
+        cancellable: true,
       },
     ];
     const state = reduce(
@@ -177,7 +179,9 @@ describe("sessionSocketReducer", () => {
 
   it("waits for the authoritative queue update after cancellation acknowledgement", () => {
     const initial = subscribedState({
-      promptQueue: [{ messageId: "message-2", content: "Next", status: "pending" }],
+      promptQueue: [
+        { messageId: "message-2", content: "Next", status: "pending", cancellable: true },
+      ],
     });
     const state = reduce(
       initial,


### PR DESCRIPTION
## Summary
- expose server-authoritative cancellability on prompt queue items
- hide removal controls for processing and integration-owned prompts
- broadcast the authoritative queue before cancellation acknowledgements and rejections to prevent stale client state
- default missing cancellability to false for rolling-deployment compatibility

## Testing
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/shared -- --run src/types/server-messages.test.ts`
- `npm test -w @open-inspect/control-plane -- --run src/session/message-repository.test.ts src/session/message-queue.test.ts`
- `npm test -w @open-inspect/web -- --run src/components/queued-prompt-stack.test.tsx src/components/session-timeline.test.tsx src/components/session-timeline-scroll.test.tsx src/lib/session-socket/reducer.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/websocket-client.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f854b29ec9f20c788bb9680ddefd2362)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt queue items now indicate whether they can be cancelled.
  * Cancellation eligibility is determined consistently for user-created, automated, and integration-owned prompts.
  * Older server responses remain compatible by treating missing cancellability information as non-cancellable.

* **Bug Fixes**
  * Remove controls are shown only for cancellable prompts, preventing unsupported cancellation attempts.
  * Prompt queue updates are broadcast before cancellation results, including when cancellation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->