### PR TITLE
fix(control-plane): retry terminal message projection from the alarm

### DIFF
--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -17,6 +17,9 @@ function createHandler() {
   const lifecycleManager = {
     handleAlarm: vi.fn<() => Promise<SandboxAlarmResult>>().mockResolvedValue("no_action"),
   };
+  const terminalMessageProjection = {
+    flushPending: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  };
   const alarmScheduler = {
     schedule: vi.fn<(timestamp: number) => Promise<void>>().mockResolvedValue(),
     cancel: vi.fn<() => Promise<void>>().mockResolvedValue(),
@@ -35,6 +38,7 @@ function createHandler() {
     repository: repository as unknown as MessageRepository,
     messageQueue,
     lifecycleManager,
+    terminalMessageProjection,
     alarmScheduler,
     getExecutionTimeoutMs: () => 1000,
     now,
@@ -46,6 +50,7 @@ function createHandler() {
     repository,
     messageQueue,
     lifecycleManager,
+    terminalMessageProjection,
     alarmScheduler,
     now,
     log,
@@ -65,6 +70,18 @@ describe("createAlarmHandler", () => {
     expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
     expect(messageQueue.recoverStopConfirmationTimeout).toHaveBeenCalledOnce();
     expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a deferred terminal message projection before anything else", async () => {
+    const { handler, repository, messageQueue, terminalMessageProjection } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+
+    await handler.handle();
+
+    expect(terminalMessageProjection.flushPending).toHaveBeenCalledOnce();
+    expect(terminalMessageProjection.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
+      messageQueue.recoverStopConfirmationTimeout.mock.invocationCallOrder[0]
+    );
   });
 
   it("does not fail processing message when execution timeout is not reached", async () => {
@@ -126,6 +143,7 @@ describe("createAlarmHandler", () => {
       repository: repository as unknown as MessageRepository,
       messageQueue,
       lifecycleManager,
+      terminalMessageProjection: { flushPending: vi.fn(async () => {}) },
       alarmScheduler,
       getExecutionTimeoutMs: () => 1000,
       now: () => 2000,

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -4,6 +4,7 @@ import type { SandboxLifecycleManager } from "../../sandbox/lifecycle/manager";
 import type { AlarmScheduler } from "../../platform-ports";
 import type { SessionMessageQueue } from "../message-queue";
 import type { MessageRepository } from "../message-repository";
+import type { SessionTerminalMessageProjection } from "../terminal-message-projection";
 
 export interface AlarmHandlerDeps {
   repository: MessageRepository;
@@ -14,6 +15,7 @@ export interface AlarmHandlerDeps {
     | "resumeAfterSandboxTermination"
   >;
   lifecycleManager: Pick<SandboxLifecycleManager, "handleAlarm">;
+  terminalMessageProjection: Pick<SessionTerminalMessageProjection, "flushPending">;
   alarmScheduler: AlarmScheduler;
   /** Resolved per use so it honors settings persisted after construction. */
   getExecutionTimeoutMs: () => number;
@@ -29,12 +31,14 @@ export interface AlarmHandler {
 /**
  * Durable Object alarm handler.
  *
- * Checks for stuck processing messages (defense-in-depth execution timeout)
- * before delegating to lifecycle alarm processing.
+ * Retries a deferred terminal message projection and checks for stuck
+ * processing messages (defense-in-depth execution timeout) before delegating
+ * to lifecycle alarm processing.
  */
 export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
   return {
     async handle(): Promise<void> {
+      await deps.terminalMessageProjection.flushPending();
       await deps.messageQueue.recoverStopConfirmationTimeout();
       // Execution timeout check: if a message has been in 'processing' longer than
       // the configured timeout, fail it. This is idempotent - if the message was

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -90,6 +90,7 @@ import { SandboxRuntimeEventHandler } from "./sandbox-events/runtime.handler";
 import { SandboxStreamingEventHandler } from "./sandbox-events/streaming.handler";
 import { SandboxPushService } from "./sandbox-push-service";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
+import { PersistedTerminalMessageProjectionStore } from "./terminal-message-projection-store";
 import { SessionEventStream } from "./event-stream";
 import { AutofixHandler } from "./http/handlers/autofix.handler";
 import { MessagesHandler } from "./http/handlers/messages.handler";
@@ -228,6 +229,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   const wsClientMappingRepository = new WsClientMappingRepository(sql);
   const sessionCoreRepository = new SessionCoreRepository(sql, transaction);
   const alarmDeadlines = new PersistedAlarmDeadlineStore(sql);
+  const terminalMessageProjectionStore = new PersistedTerminalMessageProjectionStore(sql);
 
   // Secrets-at-rest encryption is not optional. Every consumer below takes
   // the validated key, so no fallback path can persist a secret in plaintext.
@@ -308,14 +310,17 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     log,
   });
 
-  const terminalMessageProjection = new SessionTerminalMessageProjection(
-    sessionIndexStore,
-    () => {
+  const terminalMessageProjection = new SessionTerminalMessageProjection({
+    sessionIndex: sessionIndexStore,
+    getSessionId: () => {
       const current = sessionCoreRepository.getSession();
       return current ? resolvePublicSessionId(current, durableObjectId) : null;
     },
-    log
-  );
+    store: terminalMessageProjectionStore,
+    alarmScheduler,
+    now: () => Date.now(),
+    log,
+  });
   const recordTerminalMessage = (
     messageId: string,
     messageCreatedAt: number,
@@ -491,6 +496,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     repository: messageRepository,
     messageQueue,
     lifecycleManager,
+    terminalMessageProjection,
     alarmScheduler,
     getExecutionTimeoutMs,
     now: () => Date.now(),
@@ -849,6 +855,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
           async () => {
             await wsManager.expireAuthorizationLeases(Date.now());
             await alarmScheduler.rehydrate();
+            await terminalMessageProjection.rearm();
           },
           {
             name: "alarm.rehydrate",

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -1356,6 +1356,20 @@ describe("SessionMessageQueue", () => {
     expect(h.repository.getNextPendingMessage).toHaveBeenCalled();
   });
 
+  it("re-arms a future stop confirmation deadline when an earlier alarm fired", async () => {
+    const h = buildQueue();
+    const deadline = Date.now() + 10_000;
+    h.repository.getMessageAwaitingStopConfirmation.mockReturnValue({
+      id: "msg-stopped",
+      deadline,
+    });
+
+    await h.queue.recoverStopConfirmationTimeout();
+
+    expect(h.sandboxLifecycle.terminateUnresponsiveSandbox).not.toHaveBeenCalled();
+    expect(h.setAlarm).toHaveBeenCalledExactlyOnceWith(deadline);
+  });
+
   it("clears the marker and resumes only after definitive sandbox termination", async () => {
     const h = buildQueue();
     h.repository.getMessageAwaitingStopConfirmation

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -555,7 +555,13 @@ export class SessionMessageQueue {
 
   async recoverStopConfirmationTimeout(): Promise<void> {
     const awaitingStop = this.messageRepository.getMessageAwaitingStopConfirmation();
-    if (!awaitingStop || awaitingStop.deadline > Date.now()) return;
+    if (!awaitingStop) return;
+    if (awaitingStop.deadline > Date.now()) {
+      // An earlier deadline may have consumed the single alarm slot; keep
+      // this one armed so the stop cannot wait on unrelated work.
+      await this.alarmScheduler.schedule(awaitingStop.deadline);
+      return;
+    }
     this.log.warn("Sandbox did not confirm stop before deadline", {
       event: "prompt.stop_confirmation_timeout",
       message_id: awaitingStop.id,

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -47,6 +47,15 @@ const SESSION_ALARM_STATE_TABLE_SQL = `CREATE TABLE IF NOT EXISTS session_alarm_
   cancelled INTEGER NOT NULL DEFAULT 0
 );`;
 
+const TERMINAL_MESSAGE_PROJECTION_TABLE_SQL = `CREATE TABLE IF NOT EXISTS terminal_message_projection_pending (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  message_id TEXT NOT NULL,
+  message_created_at INTEGER NOT NULL,
+  completed_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at INTEGER NOT NULL
+);`;
+
 export const SCHEMA_SQL = `
 -- Core session state
 CREATE TABLE IF NOT EXISTS session (
@@ -196,6 +205,10 @@ ${SESSION_DIFF_TABLE_SQL}
 
 -- Runtime alarm recovery source for hosts that can be adopted by another process.
 ${SESSION_ALARM_STATE_TABLE_SQL}
+
+-- A terminal message whose D1 projection has not landed yet. Only the newest
+-- is kept: the projection is monotonic, so an older one would be a no-op.
+${TERMINAL_MESSAGE_PROJECTION_TABLE_SQL}
 
 -- WebSocket client mapping for hibernation recovery
 CREATE TABLE IF NOT EXISTS ws_client_mapping (
@@ -629,6 +642,11 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
         `ALTER TABLE ws_client_mapping ADD COLUMN authorization_expires_at INTEGER NOT NULL DEFAULT 0`
       );
     },
+  },
+  {
+    id: 47,
+    description: "Persist terminal message projections awaiting retry",
+    run: TERMINAL_MESSAGE_PROJECTION_TABLE_SQL,
   },
 ];
 

--- a/packages/control-plane/src/session/terminal-message-projection-store.test.ts
+++ b/packages/control-plane/src/session/terminal-message-projection-store.test.ts
@@ -50,24 +50,26 @@ describe("PersistedTerminalMessageProjectionStore", () => {
     expect(store.pending()).toEqual(older);
   });
 
-  it("keeps only the newest message", () => {
+  it("keeps only the newest message and its retry metadata", () => {
     const store = createStore();
-    store.setPending(newer);
+    store.setPending({ ...newer, attempts: 3, nextAttemptAt: 9_000 });
     store.setPending(older);
-    expect(store.pending()).toEqual(newer);
+    expect(store.pending()).toEqual({ ...newer, attempts: 3, nextAttemptAt: 9_000 });
 
-    const restarted = { ...newer, attempts: 3, nextAttemptAt: 9_000 };
-    store.setPending(restarted);
-    expect(store.pending()).toEqual(restarted);
+    store.setPending(newer);
+    expect(store.pending()).toEqual({ ...newer, attempts: 3, nextAttemptAt: 9_000 });
   });
 
-  it("records failed attempts in place", () => {
+  it("records a failed attempt only for the message that was attempted", () => {
     const store = createStore();
     store.setPending(older);
 
-    store.recordFailedAttempt({ attempts: 2, nextAttemptAt: 20_000 });
-
+    store.recordFailedAttempt({ ...older, attempts: 2, nextAttemptAt: 20_000 });
     expect(store.pending()).toEqual({ ...older, attempts: 2, nextAttemptAt: 20_000 });
+
+    store.setPending(newer);
+    store.recordFailedAttempt({ ...older, attempts: 3, nextAttemptAt: 40_000 });
+    expect(store.pending()).toEqual(newer);
   });
 
   it("clears through a landed message but not past a newer one", () => {

--- a/packages/control-plane/src/session/terminal-message-projection-store.test.ts
+++ b/packages/control-plane/src/session/terminal-message-projection-store.test.ts
@@ -1,0 +1,83 @@
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { initSchema } from "./schema";
+import type { SqlResult, SqlStorage } from "./sql-storage";
+import { PersistedTerminalMessageProjectionStore } from "./terminal-message-projection-store";
+
+function createDatabaseSql(db: DatabaseSync): SqlStorage {
+  return {
+    exec(query: string, ...params: unknown[]): SqlResult {
+      const sqliteParams = params as SQLInputValue[];
+      if (/^\s*(?:PRAGMA|SELECT)\b/i.test(query)) {
+        const rows = db.prepare(query).all(...sqliteParams);
+        return { toArray: () => rows, one: () => rows[0] ?? null };
+      }
+      if (params.length > 0) db.prepare(query).run(...sqliteParams);
+      else db.exec(query);
+      return { toArray: () => [], one: () => null };
+    },
+  };
+}
+
+function createStore() {
+  const sql = createDatabaseSql(new DatabaseSync(":memory:"));
+  initSchema(sql);
+  return new PersistedTerminalMessageProjectionStore(sql);
+}
+
+const older = {
+  messageId: "message-1",
+  messageCreatedAt: 1_000,
+  terminalMessageCompletedAt: 2_000,
+  attempts: 0,
+  nextAttemptAt: 5_000,
+};
+const newer = {
+  messageId: "message-2",
+  messageCreatedAt: 3_000,
+  terminalMessageCompletedAt: 4_000,
+  attempts: 0,
+  nextAttemptAt: 6_000,
+};
+
+describe("PersistedTerminalMessageProjectionStore", () => {
+  it("starts empty and round-trips a pending projection", () => {
+    const store = createStore();
+    expect(store.pending()).toBeNull();
+
+    store.setPending(older);
+
+    expect(store.pending()).toEqual(older);
+  });
+
+  it("keeps only the newest message", () => {
+    const store = createStore();
+    store.setPending(newer);
+    store.setPending(older);
+    expect(store.pending()).toEqual(newer);
+
+    const restarted = { ...newer, attempts: 3, nextAttemptAt: 9_000 };
+    store.setPending(restarted);
+    expect(store.pending()).toEqual(restarted);
+  });
+
+  it("records failed attempts in place", () => {
+    const store = createStore();
+    store.setPending(older);
+
+    store.recordFailedAttempt({ attempts: 2, nextAttemptAt: 20_000 });
+
+    expect(store.pending()).toEqual({ ...older, attempts: 2, nextAttemptAt: 20_000 });
+  });
+
+  it("clears through a landed message but not past a newer one", () => {
+    const store = createStore();
+    store.setPending(newer);
+
+    store.clearThrough(older);
+    expect(store.pending()).toEqual(newer);
+
+    store.clearThrough(newer);
+    expect(store.pending()).toBeNull();
+  });
+});

--- a/packages/control-plane/src/session/terminal-message-projection-store.ts
+++ b/packages/control-plane/src/session/terminal-message-projection-store.ts
@@ -1,0 +1,97 @@
+import type { SqlStorage } from "./sql-storage";
+
+export interface PendingTerminalMessageProjection {
+  messageId: string;
+  messageCreatedAt: number;
+  terminalMessageCompletedAt: number;
+  /** Alarm-driven attempts so far; the inline attempts are not counted. */
+  attempts: number;
+  nextAttemptAt: number;
+}
+
+export interface TerminalMessageProjectionStore {
+  pending(): PendingTerminalMessageProjection | null;
+  /** Keeps whichever message is newer by `(createdAt, id)`. */
+  setPending(entry: PendingTerminalMessageProjection): void;
+  recordFailedAttempt(update: { attempts: number; nextAttemptAt: number }): void;
+  /** Drops the pending entry unless it is newer than the message that landed. */
+  clearThrough(message: { messageId: string; messageCreatedAt: number }): void;
+}
+
+interface PendingRow {
+  message_id: string;
+  message_created_at: number;
+  completed_at: number;
+  attempts: number;
+  next_attempt_at: number;
+}
+
+export class PersistedTerminalMessageProjectionStore implements TerminalMessageProjectionStore {
+  constructor(private readonly sql: SqlStorage) {}
+
+  pending(): PendingTerminalMessageProjection | null {
+    const rows = this.sql
+      .exec(
+        `SELECT message_id, message_created_at, completed_at, attempts, next_attempt_at
+         FROM terminal_message_projection_pending WHERE singleton = 1`
+      )
+      .toArray() as PendingRow[];
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      messageId: row.message_id,
+      messageCreatedAt: row.message_created_at,
+      terminalMessageCompletedAt: row.completed_at,
+      attempts: row.attempts,
+      nextAttemptAt: row.next_attempt_at,
+    };
+  }
+
+  setPending(entry: PendingTerminalMessageProjection): void {
+    this.sql.exec(
+      `INSERT INTO terminal_message_projection_pending
+         (singleton, message_id, message_created_at, completed_at, attempts, next_attempt_at)
+       VALUES (1, ?, ?, ?, ?, ?)
+       ON CONFLICT(singleton) DO UPDATE SET
+         message_id = excluded.message_id,
+         message_created_at = excluded.message_created_at,
+         completed_at = excluded.completed_at,
+         attempts = excluded.attempts,
+         next_attempt_at = excluded.next_attempt_at
+       WHERE excluded.message_created_at > message_created_at
+          OR (
+            excluded.message_created_at = message_created_at
+            AND excluded.message_id >= message_id
+          )`,
+      entry.messageId,
+      entry.messageCreatedAt,
+      entry.terminalMessageCompletedAt,
+      entry.attempts,
+      entry.nextAttemptAt
+    );
+  }
+
+  recordFailedAttempt(update: { attempts: number; nextAttemptAt: number }): void {
+    this.sql.exec(
+      `UPDATE terminal_message_projection_pending
+       SET attempts = ?, next_attempt_at = ?
+       WHERE singleton = 1`,
+      update.attempts,
+      update.nextAttemptAt
+    );
+  }
+
+  clearThrough(message: { messageId: string; messageCreatedAt: number }): void {
+    this.sql.exec(
+      `DELETE FROM terminal_message_projection_pending
+       WHERE singleton = 1
+         AND (
+           message_created_at < ?
+           OR (message_created_at = ? AND message_id <= ?)
+         )`,
+      message.messageCreatedAt,
+      message.messageCreatedAt,
+      message.messageId
+    );
+  }
+}

--- a/packages/control-plane/src/session/terminal-message-projection-store.ts
+++ b/packages/control-plane/src/session/terminal-message-projection-store.ts
@@ -11,9 +11,15 @@ export interface PendingTerminalMessageProjection {
 
 export interface TerminalMessageProjectionStore {
   pending(): PendingTerminalMessageProjection | null;
-  /** Keeps whichever message is newer by `(createdAt, id)`. */
+  /** Keeps whichever message is newer by `(createdAt, id)`; the same message keeps its retry metadata. */
   setPending(entry: PendingTerminalMessageProjection): void;
-  recordFailedAttempt(update: { attempts: number; nextAttemptAt: number }): void;
+  /** Applies only while the named message is still the pending one. */
+  recordFailedAttempt(update: {
+    messageId: string;
+    messageCreatedAt: number;
+    attempts: number;
+    nextAttemptAt: number;
+  }): void;
   /** Drops the pending entry unless it is newer than the message that landed. */
   clearThrough(message: { messageId: string; messageCreatedAt: number }): void;
 }
@@ -61,7 +67,7 @@ export class PersistedTerminalMessageProjectionStore implements TerminalMessageP
        WHERE excluded.message_created_at > message_created_at
           OR (
             excluded.message_created_at = message_created_at
-            AND excluded.message_id >= message_id
+            AND excluded.message_id > message_id
           )`,
       entry.messageId,
       entry.messageCreatedAt,
@@ -71,13 +77,20 @@ export class PersistedTerminalMessageProjectionStore implements TerminalMessageP
     );
   }
 
-  recordFailedAttempt(update: { attempts: number; nextAttemptAt: number }): void {
+  recordFailedAttempt(update: {
+    messageId: string;
+    messageCreatedAt: number;
+    attempts: number;
+    nextAttemptAt: number;
+  }): void {
     this.sql.exec(
       `UPDATE terminal_message_projection_pending
        SET attempts = ?, next_attempt_at = ?
-       WHERE singleton = 1`,
+       WHERE singleton = 1 AND message_id = ? AND message_created_at = ?`,
       update.attempts,
-      update.nextAttemptAt
+      update.nextAttemptAt,
+      update.messageId,
+      update.messageCreatedAt
     );
   }
 

--- a/packages/control-plane/src/session/terminal-message-projection.test.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.test.ts
@@ -18,10 +18,22 @@ function createMemoryStore(initial: PendingTerminalMessageProjection | null = nu
   const store: TerminalMessageProjectionStore = {
     pending: () => entry,
     setPending: (next) => {
-      entry = next;
+      if (
+        !entry ||
+        next.messageCreatedAt > entry.messageCreatedAt ||
+        (next.messageCreatedAt === entry.messageCreatedAt && next.messageId > entry.messageId)
+      ) {
+        entry = next;
+      }
     },
     recordFailedAttempt: (update) => {
-      if (entry) entry = { ...entry, ...update };
+      if (
+        entry &&
+        entry.messageId === update.messageId &&
+        entry.messageCreatedAt === update.messageCreatedAt
+      ) {
+        entry = { ...entry, attempts: update.attempts, nextAttemptAt: update.nextAttemptAt };
+      }
     },
     clearThrough: (message) => {
       if (
@@ -56,7 +68,7 @@ function createProjection(
     now: () => options.now ?? 10_000,
     log: log as unknown as Logger,
   });
-  return { projection, log, alarmScheduler, pending: memory.pending };
+  return { projection, log, alarmScheduler, pending: memory.pending, store: memory.store };
 }
 
 describe("SessionTerminalMessageProjection", () => {
@@ -101,6 +113,23 @@ describe("SessionTerminalMessageProjection", () => {
       "session_terminal_message.projection_deferred",
       expect.objectContaining({ message_id: "message-1", next_attempt_at: 15_000 })
     );
+  });
+
+  it("keeps turn settlement alive when arming the retry alarm fails", async () => {
+    const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("unavailable"));
+    const { projection, log, alarmScheduler, pending } = createProjection(
+      recordLatestTerminalMessage
+    );
+    alarmScheduler.schedule.mockRejectedValue(new Error("alarm storage down"));
+
+    await expect(projection.recordTerminalMessage(input)).resolves.toBeUndefined();
+
+    expect(pending()).toEqual({ ...input, attempts: 0, nextAttemptAt: 15_000 });
+    expect(log.warn).toHaveBeenCalledWith(
+      "session_terminal_message.projection_retry_arm_failed",
+      expect.objectContaining({ message_id: "message-1", next_attempt_at: 15_000 })
+    );
+    expect(log.error).not.toHaveBeenCalled();
   });
 
   it("clears a deferred projection once a newer message lands inline", async () => {
@@ -190,6 +219,47 @@ describe("SessionTerminalMessageProjection", () => {
       expect(pending()).toEqual({ ...input, attempts: 3, nextAttemptAt: 50_000 });
       expect(alarmScheduler.schedule).toHaveBeenCalledExactlyOnceWith(50_000);
       expect(log.error).not.toHaveBeenCalled();
+    });
+
+    it("leaves a newer message that replaced the entry mid-attempt untouched", async () => {
+      let rejectAttempt!: (error: Error) => void;
+      const recordLatestTerminalMessage = vi.fn(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectAttempt = reject;
+          })
+      );
+      const { projection, pending, store } = createProjection(recordLatestTerminalMessage, {
+        pending: { ...input, attempts: 6, nextAttemptAt: 10_000 },
+      });
+      const newer = {
+        messageId: "message-2",
+        messageCreatedAt: 3_000,
+        terminalMessageCompletedAt: 4_000,
+        attempts: 0,
+        nextAttemptAt: 15_000,
+      };
+
+      const flush = projection.flushPending();
+      await vi.waitFor(() => expect(recordLatestTerminalMessage).toHaveBeenCalledOnce());
+      store.setPending(newer);
+      rejectAttempt(new Error("still down"));
+      await flush;
+
+      expect(pending()).toEqual(newer);
+    });
+
+    it("survives a failed alarm arm after a failed retry", async () => {
+      const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("still down"));
+      const { projection, alarmScheduler, pending } = createProjection(
+        recordLatestTerminalMessage,
+        { pending: { ...input, attempts: 1, nextAttemptAt: 10_000 } }
+      );
+      alarmScheduler.schedule.mockRejectedValue(new Error("alarm storage down"));
+
+      await expect(projection.flushPending()).resolves.toBeUndefined();
+
+      expect(pending()).toEqual({ ...input, attempts: 2, nextAttemptAt: 30_000 });
     });
 
     it("caps the backoff delay", async () => {

--- a/packages/control-plane/src/session/terminal-message-projection.test.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.test.ts
@@ -2,15 +2,61 @@ import { describe, expect, it, vi } from "vitest";
 import type { SessionIndexStore } from "../db/session-index";
 import type { Logger } from "../logger";
 import { SessionTerminalMessageProjection } from "./terminal-message-projection";
+import type {
+  PendingTerminalMessageProjection,
+  TerminalMessageProjectionStore,
+} from "./terminal-message-projection-store";
 
-function createProjection(recordLatestTerminalMessage: ReturnType<typeof vi.fn>) {
-  const log = { warn: vi.fn(), error: vi.fn() };
-  const projection = new SessionTerminalMessageProjection(
-    { recordLatestTerminalMessage } as unknown as SessionIndexStore,
-    () => "session-1",
-    log as unknown as Logger
-  );
-  return { projection, log };
+const input = {
+  messageId: "message-1",
+  messageCreatedAt: 1_000,
+  terminalMessageCompletedAt: 2_000,
+};
+
+function createMemoryStore(initial: PendingTerminalMessageProjection | null = null) {
+  let entry = initial;
+  const store: TerminalMessageProjectionStore = {
+    pending: () => entry,
+    setPending: (next) => {
+      entry = next;
+    },
+    recordFailedAttempt: (update) => {
+      if (entry) entry = { ...entry, ...update };
+    },
+    clearThrough: (message) => {
+      if (
+        entry &&
+        (entry.messageCreatedAt < message.messageCreatedAt ||
+          (entry.messageCreatedAt === message.messageCreatedAt &&
+            entry.messageId <= message.messageId))
+      ) {
+        entry = null;
+      }
+    },
+  };
+  return { store, pending: () => entry };
+}
+
+function createProjection(
+  recordLatestTerminalMessage: ReturnType<typeof vi.fn>,
+  options: { pending?: PendingTerminalMessageProjection | null; now?: number } = {}
+) {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const memory = createMemoryStore(options.pending ?? null);
+  const alarmScheduler = {
+    schedule: vi.fn<(at: number) => Promise<void>>().mockResolvedValue(),
+    cancel: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    current: vi.fn<() => Promise<number | null>>().mockResolvedValue(null),
+  };
+  const projection = new SessionTerminalMessageProjection({
+    sessionIndex: { recordLatestTerminalMessage } as unknown as SessionIndexStore,
+    getSessionId: () => "session-1",
+    store: memory.store,
+    alarmScheduler,
+    now: () => options.now ?? 10_000,
+    log: log as unknown as Logger,
+  });
+  return { projection, log, alarmScheduler, pending: memory.pending };
 }
 
 describe("SessionTerminalMessageProjection", () => {
@@ -19,39 +65,169 @@ describe("SessionTerminalMessageProjection", () => {
       .fn()
       .mockRejectedValueOnce(new Error("temporary"))
       .mockResolvedValueOnce(true);
-    const { projection, log } = createProjection(recordLatestTerminalMessage);
+    const { projection, log, alarmScheduler, pending } = createProjection(
+      recordLatestTerminalMessage
+    );
 
-    await projection.recordTerminalMessage({
-      messageId: "message-1",
-      messageCreatedAt: 1_000,
-      terminalMessageCompletedAt: 2_000,
-    });
+    await projection.recordTerminalMessage(input);
 
     expect(recordLatestTerminalMessage).toHaveBeenCalledTimes(2);
     expect(recordLatestTerminalMessage).toHaveBeenNthCalledWith(1, {
       sessionId: "session-1",
-      messageId: "message-1",
-      messageCreatedAt: 1_000,
-      terminalMessageCompletedAt: 2_000,
+      ...input,
     });
     expect(recordLatestTerminalMessage.mock.calls[1]).toEqual(
       recordLatestTerminalMessage.mock.calls[0]
     );
     expect(log.warn).toHaveBeenCalledOnce();
     expect(log.error).not.toHaveBeenCalled();
+    expect(alarmScheduler.schedule).not.toHaveBeenCalled();
+    expect(pending()).toBeNull();
   });
 
-  it("stops after the bounded retry and records the failure", async () => {
+  it("defers a projection that fails twice and arms the alarm for it", async () => {
     const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("unavailable"));
-    const { projection, log } = createProjection(recordLatestTerminalMessage);
+    const { projection, log, alarmScheduler, pending } = createProjection(
+      recordLatestTerminalMessage
+    );
 
-    await projection.recordTerminalMessage({
-      messageId: "message-1",
-      messageCreatedAt: 1_000,
-      terminalMessageCompletedAt: 2_000,
-    });
+    await projection.recordTerminalMessage(input);
 
     expect(recordLatestTerminalMessage).toHaveBeenCalledTimes(2);
-    expect(log.error).toHaveBeenCalledOnce();
+    expect(pending()).toEqual({ ...input, attempts: 0, nextAttemptAt: 15_000 });
+    expect(alarmScheduler.schedule).toHaveBeenCalledExactlyOnceWith(15_000);
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenLastCalledWith(
+      "session_terminal_message.projection_deferred",
+      expect.objectContaining({ message_id: "message-1", next_attempt_at: 15_000 })
+    );
+  });
+
+  it("clears a deferred projection once a newer message lands inline", async () => {
+    const recordLatestTerminalMessage = vi.fn().mockResolvedValue(true);
+    const { projection, pending } = createProjection(recordLatestTerminalMessage, {
+      pending: { ...input, attempts: 2, nextAttemptAt: 9_000 },
+    });
+
+    await projection.recordTerminalMessage({
+      messageId: "message-2",
+      messageCreatedAt: 3_000,
+      terminalMessageCompletedAt: 4_000,
+    });
+
+    expect(pending()).toBeNull();
+  });
+
+  it("keeps a deferred projection that is newer than the message that landed", async () => {
+    const recordLatestTerminalMessage = vi.fn().mockResolvedValue(true);
+    const deferred = {
+      messageId: "message-2",
+      messageCreatedAt: 3_000,
+      terminalMessageCompletedAt: 4_000,
+      attempts: 0,
+      nextAttemptAt: 9_000,
+    };
+    const { projection, pending } = createProjection(recordLatestTerminalMessage, {
+      pending: deferred,
+    });
+
+    await projection.recordTerminalMessage(input);
+
+    expect(pending()).toEqual(deferred);
+  });
+
+  describe("flushPending", () => {
+    it("does nothing without a deferred projection", async () => {
+      const recordLatestTerminalMessage = vi.fn();
+      const { projection, alarmScheduler } = createProjection(recordLatestTerminalMessage);
+
+      await projection.flushPending();
+
+      expect(recordLatestTerminalMessage).not.toHaveBeenCalled();
+      expect(alarmScheduler.schedule).not.toHaveBeenCalled();
+    });
+
+    it("re-arms the alarm when another deadline fired first", async () => {
+      const recordLatestTerminalMessage = vi.fn();
+      const { projection, alarmScheduler } = createProjection(recordLatestTerminalMessage, {
+        pending: { ...input, attempts: 0, nextAttemptAt: 12_000 },
+      });
+
+      await projection.flushPending();
+
+      expect(recordLatestTerminalMessage).not.toHaveBeenCalled();
+      expect(alarmScheduler.schedule).toHaveBeenCalledExactlyOnceWith(12_000);
+    });
+
+    it("projects a due message and clears it", async () => {
+      const recordLatestTerminalMessage = vi.fn().mockResolvedValue(true);
+      const { projection, log, pending } = createProjection(recordLatestTerminalMessage, {
+        pending: { ...input, attempts: 1, nextAttemptAt: 10_000 },
+      });
+
+      await projection.flushPending();
+
+      expect(recordLatestTerminalMessage).toHaveBeenCalledExactlyOnceWith({
+        sessionId: "session-1",
+        ...input,
+      });
+      expect(pending()).toBeNull();
+      expect(log.info).toHaveBeenCalledWith(
+        "session_terminal_message.projection_recovered",
+        expect.objectContaining({ message_id: "message-1", attempts: 1 })
+      );
+    });
+
+    it("backs off after a failed retry", async () => {
+      const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("still down"));
+      const { projection, alarmScheduler, pending, log } = createProjection(
+        recordLatestTerminalMessage,
+        { pending: { ...input, attempts: 2, nextAttemptAt: 10_000 } }
+      );
+
+      await projection.flushPending();
+
+      expect(pending()).toEqual({ ...input, attempts: 3, nextAttemptAt: 50_000 });
+      expect(alarmScheduler.schedule).toHaveBeenCalledExactlyOnceWith(50_000);
+      expect(log.error).not.toHaveBeenCalled();
+    });
+
+    it("caps the backoff delay", async () => {
+      const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("still down"));
+      const { projection, pending } = createProjection(recordLatestTerminalMessage, {
+        pending: { ...input, attempts: 6, nextAttemptAt: 10_000 },
+      });
+
+      await projection.flushPending();
+
+      expect(pending()?.nextAttemptAt).toBe(10_000 + 5 * 60_000);
+    });
+
+    it("abandons a projection after the last attempt and records the failure", async () => {
+      const recordLatestTerminalMessage = vi.fn().mockRejectedValue(new Error("still down"));
+      const { projection, alarmScheduler, pending, log } = createProjection(
+        recordLatestTerminalMessage,
+        { pending: { ...input, attempts: 7, nextAttemptAt: 10_000 } }
+      );
+
+      await projection.flushPending();
+
+      expect(pending()).toBeNull();
+      expect(alarmScheduler.schedule).not.toHaveBeenCalled();
+      expect(log.error).toHaveBeenCalledExactlyOnceWith(
+        "session_terminal_message.projection_abandoned",
+        expect.objectContaining({ message_id: "message-1", attempts: 8 })
+      );
+    });
+  });
+
+  it("re-arms a deferred projection's deadline on rehydration", async () => {
+    const { projection, alarmScheduler } = createProjection(vi.fn(), {
+      pending: { ...input, attempts: 0, nextAttemptAt: 12_000 },
+    });
+
+    await projection.rearm();
+
+    expect(alarmScheduler.schedule).toHaveBeenCalledExactlyOnceWith(12_000);
   });
 });

--- a/packages/control-plane/src/session/terminal-message-projection.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.ts
@@ -1,5 +1,7 @@
 import type { SessionIndexStore } from "../db/session-index";
 import type { Logger } from "../logger";
+import type { AlarmScheduler } from "../platform-ports";
+import type { TerminalMessageProjectionStore } from "./terminal-message-projection-store";
 
 export interface TerminalMessageProjectionInput {
   messageId: string;
@@ -7,23 +9,43 @@ export interface TerminalMessageProjectionInput {
   terminalMessageCompletedAt: number;
 }
 
+export interface SessionTerminalMessageProjectionDeps {
+  sessionIndex: SessionIndexStore | null;
+  getSessionId: () => string | null;
+  store: TerminalMessageProjectionStore;
+  alarmScheduler: AlarmScheduler;
+  now: () => number;
+  log: Logger;
+}
+
+const DEFERRED_RETRY_BASE_MS = 5_000;
+const DEFERRED_RETRY_MAX_MS = 5 * 60_000;
+const DEFERRED_RETRY_MAX_ATTEMPTS = 8;
+
+function deferredRetryDelayMs(attempts: number): number {
+  return Math.min(DEFERRED_RETRY_BASE_MS * 2 ** attempts, DEFERRED_RETRY_MAX_MS);
+}
+
+/**
+ * Projects each completed turn's terminal message onto the D1 session row
+ * that the inbox and read state are computed from. A projection that fails
+ * inline is persisted and retried from the Durable Object alarm with
+ * backoff, so a D1 outage delays unread state instead of losing it.
+ */
 export class SessionTerminalMessageProjection {
-  constructor(
-    private readonly sessionIndex: SessionIndexStore | null,
-    private readonly getSessionId: () => string | null,
-    private readonly log: Logger
-  ) {}
+  constructor(private readonly deps: SessionTerminalMessageProjectionDeps) {}
 
   async recordTerminalMessage(input: TerminalMessageProjectionInput): Promise<void> {
-    const sessionId = this.getSessionId();
-    if (!this.sessionIndex || !sessionId) return;
+    const sessionId = this.deps.getSessionId();
+    if (!this.deps.sessionIndex || !sessionId) return;
 
     const storeInput = { sessionId, ...input };
     try {
-      await this.sessionIndex.recordLatestTerminalMessage(storeInput);
+      await this.deps.sessionIndex.recordLatestTerminalMessage(storeInput);
+      this.deps.store.clearThrough(input);
       return;
     } catch (firstError) {
-      this.log.warn("session_terminal_message.projection_retry", {
+      this.deps.log.warn("session_terminal_message.projection_retry", {
         session_id: sessionId,
         message_id: input.messageId,
         error: firstError,
@@ -31,13 +53,77 @@ export class SessionTerminalMessageProjection {
     }
 
     try {
-      await this.sessionIndex.recordLatestTerminalMessage(storeInput);
+      await this.deps.sessionIndex.recordLatestTerminalMessage(storeInput);
+      this.deps.store.clearThrough(input);
     } catch (error) {
-      this.log.error("session_terminal_message.projection_failed", {
+      const nextAttemptAt = this.deps.now() + deferredRetryDelayMs(0);
+      this.deps.store.setPending({ ...input, attempts: 0, nextAttemptAt });
+      await this.deps.alarmScheduler.schedule(nextAttemptAt);
+      this.deps.log.warn("session_terminal_message.projection_deferred", {
         session_id: sessionId,
         message_id: input.messageId,
+        next_attempt_at: nextAttemptAt,
         error,
       });
     }
+  }
+
+  /** Alarm entry point: retry a deferred projection once it is due. */
+  async flushPending(): Promise<void> {
+    const pending = this.deps.store.pending();
+    if (!pending) return;
+    const now = this.deps.now();
+    if (pending.nextAttemptAt > now) {
+      // The alarm slot is shared; whoever fired it may have consumed this deadline.
+      await this.deps.alarmScheduler.schedule(pending.nextAttemptAt);
+      return;
+    }
+    const sessionId = this.deps.getSessionId();
+    if (!this.deps.sessionIndex || !sessionId) return;
+
+    const { messageId, messageCreatedAt, terminalMessageCompletedAt } = pending;
+    try {
+      await this.deps.sessionIndex.recordLatestTerminalMessage({
+        sessionId,
+        messageId,
+        messageCreatedAt,
+        terminalMessageCompletedAt,
+      });
+    } catch (error) {
+      const attempts = pending.attempts + 1;
+      if (attempts >= DEFERRED_RETRY_MAX_ATTEMPTS) {
+        this.deps.store.clearThrough(pending);
+        this.deps.log.error("session_terminal_message.projection_abandoned", {
+          session_id: sessionId,
+          message_id: messageId,
+          attempts,
+          error,
+        });
+        return;
+      }
+      const nextAttemptAt = now + deferredRetryDelayMs(attempts);
+      this.deps.store.recordFailedAttempt({ attempts, nextAttemptAt });
+      await this.deps.alarmScheduler.schedule(nextAttemptAt);
+      this.deps.log.warn("session_terminal_message.projection_retry_scheduled", {
+        session_id: sessionId,
+        message_id: messageId,
+        attempts,
+        next_attempt_at: nextAttemptAt,
+        error,
+      });
+      return;
+    }
+    this.deps.store.clearThrough(pending);
+    this.deps.log.info("session_terminal_message.projection_recovered", {
+      session_id: sessionId,
+      message_id: messageId,
+      attempts: pending.attempts,
+    });
+  }
+
+  /** Re-arm the retry deadline after the runtime restarts. */
+  async rearm(): Promise<void> {
+    const pending = this.deps.store.pending();
+    if (pending) await this.deps.alarmScheduler.schedule(pending.nextAttemptAt);
   }
 }

--- a/packages/control-plane/src/session/terminal-message-projection.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.ts
@@ -58,7 +58,7 @@ export class SessionTerminalMessageProjection {
     } catch (error) {
       const nextAttemptAt = this.deps.now() + deferredRetryDelayMs(0);
       this.deps.store.setPending({ ...input, attempts: 0, nextAttemptAt });
-      await this.deps.alarmScheduler.schedule(nextAttemptAt);
+      await this.armRetry(nextAttemptAt, sessionId, input.messageId);
       this.deps.log.warn("session_terminal_message.projection_deferred", {
         session_id: sessionId,
         message_id: input.messageId,
@@ -75,7 +75,7 @@ export class SessionTerminalMessageProjection {
     const now = this.deps.now();
     if (pending.nextAttemptAt > now) {
       // The alarm slot is shared; whoever fired it may have consumed this deadline.
-      await this.deps.alarmScheduler.schedule(pending.nextAttemptAt);
+      await this.armRetry(pending.nextAttemptAt, this.deps.getSessionId(), pending.messageId);
       return;
     }
     const sessionId = this.deps.getSessionId();
@@ -102,8 +102,10 @@ export class SessionTerminalMessageProjection {
         return;
       }
       const nextAttemptAt = now + deferredRetryDelayMs(attempts);
-      this.deps.store.recordFailedAttempt({ attempts, nextAttemptAt });
-      await this.deps.alarmScheduler.schedule(nextAttemptAt);
+      // A newer message may have replaced the entry during the await; its
+      // own retry metadata must survive this attempt.
+      this.deps.store.recordFailedAttempt({ messageId, messageCreatedAt, attempts, nextAttemptAt });
+      await this.armRetry(nextAttemptAt, sessionId, messageId);
       this.deps.log.warn("session_terminal_message.projection_retry_scheduled", {
         session_id: sessionId,
         message_id: messageId,
@@ -124,6 +126,26 @@ export class SessionTerminalMessageProjection {
   /** Re-arm the retry deadline after the runtime restarts. */
   async rearm(): Promise<void> {
     const pending = this.deps.store.pending();
-    if (pending) await this.deps.alarmScheduler.schedule(pending.nextAttemptAt);
+    if (pending) {
+      await this.armRetry(pending.nextAttemptAt, this.deps.getSessionId(), pending.messageId);
+    }
+  }
+
+  /**
+   * The pending entry is already persisted, so a failed arm is recoverable
+   * by rehydration or the next alarm. It must never fail the caller: on the
+   * completion path that would abort turn settlement after the local commit.
+   */
+  private async armRetry(at: number, sessionId: string | null, messageId: string): Promise<void> {
+    try {
+      await this.deps.alarmScheduler.schedule(at);
+    } catch (error) {
+      this.deps.log.warn("session_terminal_message.projection_retry_arm_failed", {
+        session_id: sessionId,
+        message_id: messageId,
+        next_attempt_at: at,
+        error,
+      });
+    }
   }
 }


### PR DESCRIPTION
## Why

`SessionTerminalMessageProjection` writes each completed turn's terminal message onto the D1 session row that the inbox categories and read state are computed from. When that write failed twice inline it was logged as `session_terminal_message.projection_failed` and dropped. The session then showed no unread state and stayed in the wrong inbox category until its next turn happened to succeed. This was the one server-side gap found in the read-state architecture review that produced #1710.

## What changes

- **Pending projection is persisted.** New Durable Object table `terminal_message_projection_pending` (migration 47) holds the single newest message awaiting projection. The projection is monotonic by `(created_at, id)`, so an older pending message would be a no-op and is never kept over a newer one.
- **Retry runs from the alarm.** After the inline attempts fail, the projection persists the message and arms the shared alarm slot. `createAlarmHandler` calls `flushPending()` first. Backoff starts at 5s, doubles, caps at 5min, and gives up after 8 alarm attempts with `session_terminal_message.projection_abandoned`.
- **Deadline survives other alarms and restarts.** The alarm slot is shared with lifecycle checks, and `beginDelivery` clears the pending deadline when any alarm fires, so `flushPending` re-schedules its own deadline when it runs early. `rearm()` runs on Durable Object rehydration.
- **A newer message landing inline clears the pending one.** `clearThrough` only drops an entry at or below the message that landed.
- `SessionTerminalMessageProjection` now takes a deps object (`sessionIndex`, `getSessionId`, `store`, `alarmScheduler`, `now`, `log`).

Log events: `projection_deferred` (warn), `projection_retry_scheduled` (warn), `projection_recovered` (info), `projection_abandoned` (error).

## Tests

- `terminal-message-projection.test.ts`: inline retry unchanged; defer + arm on double failure; newer inline success clears the pending entry, older does not; `flushPending` no-op / re-arm when not due / recover / backoff / cap / abandon; `rearm`.
- `terminal-message-projection-store.test.ts`: real SQLite via `node:sqlite` against `initSchema`, covering newest-wins upsert and `clearThrough`.
- `alarm/handler.test.ts`: `flushPending` runs before stop-confirmation recovery.
- Control-plane unit (3444) and integration (1084) suites, typecheck, lint, prettier all green.

Independent of #1710; both branch from `main`.

https://claude.ai/code/session_017wKwqfn4aE7BjV9PgdwraF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of terminal messages when immediate delivery fails.
  - Failed terminal-message updates are retried automatically with increasing delays.
  - Pending updates resume after service restarts and are processed before stop-confirmation recovery.
  - Retry metadata remains associated with the correct pending message.
  - Retry attempts are capped, while successful updates clear pending state.
  - Stop-confirmation timeouts remain scheduled when earlier alarms fire.

- **Maintenance**
  - Added persistent tracking for terminal-message updates awaiting delivery, including retry status and scheduling information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->