### PR TITLE
Ignore Open Inspect review thread replies in Autofix

### DIFF
--- a/packages/control-plane/src/autofix/service.test.ts
+++ b/packages/control-plane/src/autofix/service.test.ts
@@ -635,25 +635,13 @@ describe("AutofixService", () => {
     expect(h.sessions.fetch).not.toHaveBeenCalled();
   });
 
-  it("dispatches an Open Inspect App review containing top-level findings and replies", async () => {
+  it("dispatches an Open Inspect App review with a body and only thread replies", async () => {
     const h = buildService();
     h.github.getPullRequestFeedback.mockResolvedValueOnce(
       openInspectReview({
-        body: "",
+        body: "Please address the remaining issue.",
         state: "COMMENTED",
         comments: [
-          {
-            id: "9001",
-            inReplyToId: null,
-            body: "Handle the nullable value.",
-            url: "https://github.com/acme/widgets/pull/42#discussion_r9001",
-            path: "src/input.ts",
-            line: 12,
-            startLine: null,
-            side: "RIGHT",
-            startSide: null,
-            diffHunk: "@@ -10,3 +10,3 @@",
-          },
           {
             id: "9002",
             inReplyToId: "8001",

--- a/packages/control-plane/src/autofix/service.test.ts
+++ b/packages/control-plane/src/autofix/service.test.ts
@@ -343,6 +343,7 @@ describe("AutofixService", () => {
       comments: [
         {
           id: "9001",
+          inReplyToId: null,
           body: "Preserve this complete comment.",
           url: "https://github.com/acme/widgets/pull/42#discussion_r9001",
           path: "src/input.ts",
@@ -419,6 +420,7 @@ describe("AutofixService", () => {
       author: { id: "8", login: "alice", type: "User" },
       comments: Array.from({ length: 101 }, (_, index) => ({
         id: String(index),
+        inReplyToId: null,
         body: `Comment ${index}`,
         url: `https://github.com/acme/widgets/pull/42#discussion_r${index}`,
         path: "src/input.ts",
@@ -580,6 +582,7 @@ describe("AutofixService", () => {
         comments: [
           {
             id: "9001",
+            inReplyToId: null,
             body: "Handle the nullable value.",
             url: "https://github.com/acme/widgets/pull/42#discussion_r9001",
             path: "src/input.ts",
@@ -601,6 +604,76 @@ describe("AutofixService", () => {
       expect.any(String),
       expect.objectContaining({ body: expect.stringContaining("Handle the nullable value.") })
     );
+  });
+
+  it("does not dispatch an Open Inspect App review containing only thread replies", async () => {
+    const h = buildService();
+    h.github.getPullRequestFeedback.mockResolvedValueOnce(
+      openInspectReview({
+        body: "",
+        state: "COMMENTED",
+        comments: [
+          {
+            id: "9002",
+            inReplyToId: "8001",
+            body: "Fixed in 49716d0.",
+            url: "https://github.com/acme/widgets/pull/42#discussion_r9002",
+            path: "src/input.ts",
+            line: null,
+            startLine: null,
+            side: "RIGHT",
+            startSide: null,
+            diffHunk: "@@ -10,3 +10,3 @@",
+          },
+        ],
+      })
+    );
+
+    const result = await h.service.process(OPEN_INSPECT_REVIEW_ENVELOPE);
+
+    expect(result).toMatchObject({ decision: "skipped", reason: "own_review_replies" });
+    expect(h.sessions.fetch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an Open Inspect App review containing top-level findings and replies", async () => {
+    const h = buildService();
+    h.github.getPullRequestFeedback.mockResolvedValueOnce(
+      openInspectReview({
+        body: "",
+        state: "COMMENTED",
+        comments: [
+          {
+            id: "9001",
+            inReplyToId: null,
+            body: "Handle the nullable value.",
+            url: "https://github.com/acme/widgets/pull/42#discussion_r9001",
+            path: "src/input.ts",
+            line: 12,
+            startLine: null,
+            side: "RIGHT",
+            startSide: null,
+            diffHunk: "@@ -10,3 +10,3 @@",
+          },
+          {
+            id: "9002",
+            inReplyToId: "8001",
+            body: "Fixed in 49716d0.",
+            url: "https://github.com/acme/widgets/pull/42#discussion_r9002",
+            path: "src/other.ts",
+            line: null,
+            startLine: null,
+            side: "RIGHT",
+            startSide: null,
+            diffHunk: "@@ -20,3 +20,3 @@",
+          },
+        ],
+      })
+    );
+
+    const result = await h.service.process(OPEN_INSPECT_REVIEW_ENVELOPE);
+
+    expect(result).toMatchObject({ decision: "queued", messageId: "message-1" });
+    expect(h.sessions.fetch).toHaveBeenCalledOnce();
   });
 
   it("does not dispatch an approved Open Inspect App review", async () => {

--- a/packages/control-plane/src/autofix/service.ts
+++ b/packages/control-plane/src/autofix/service.ts
@@ -426,6 +426,12 @@ export class AutofixService {
     if (authorType === "bot" && authorLogin === this.botUsername.toLowerCase()) {
       if (feedback.kind !== "review") return "bot_pr_comment";
       if (!settings.openInspectReviewsEnabled) return "own_reviews_disabled";
+      if (
+        feedback.comments.length > 0 &&
+        feedback.comments.every((comment) => comment.inReplyToId !== null)
+      ) {
+        return "own_review_replies";
+      }
     } else if (authorType === "user") {
       if (
         feedback.kind === "pr_comment" &&

--- a/packages/control-plane/src/autofix/service.ts
+++ b/packages/control-plane/src/autofix/service.ts
@@ -427,6 +427,7 @@ export class AutofixService {
       if (feedback.kind !== "review") return "bot_pr_comment";
       if (!settings.openInspectReviewsEnabled) return "own_reviews_disabled";
       if (
+        !feedback.body.trim() &&
         feedback.comments.length > 0 &&
         feedback.comments.every((comment) => comment.inReplyToId !== null)
       ) {

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -1037,6 +1037,7 @@ describe("getPullRequestFeedback", () => {
         makeJsonResponse([
           {
             id: 9001,
+            in_reply_to_id: null,
             body: "Handle null here.",
             html_url: "https://github.com/acme/web/pull/7#discussion_r9001",
             path: "src/input.ts",
@@ -1048,6 +1049,7 @@ describe("getPullRequestFeedback", () => {
           },
           {
             id: 9002,
+            in_reply_to_id: 8002,
             body: "Add a regression test.",
             html_url: "https://github.com/acme/web/pull/7#discussion_r9002",
             path: "test/input.test.ts",
@@ -1077,12 +1079,14 @@ describe("getPullRequestFeedback", () => {
       comments: [
         {
           id: "9001",
+          inReplyToId: null,
           body: "Handle null here.",
           path: "src/input.ts",
           line: 12,
         },
         {
           id: "9002",
+          inReplyToId: "8002",
           body: "Add a regression test.",
           path: "test/input.test.ts",
           startLine: 20,

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -149,6 +149,7 @@ const githubPullRequestReviewSchema = z.object({
 
 const githubReviewCommentSchema = z.object({
   id: z.number(),
+  in_reply_to_id: z.number().nullable().optional(),
   body: z.string(),
   html_url: z.url(),
   path: z.string(),
@@ -201,6 +202,7 @@ export type GitHubPullRequestFeedback =
 
 interface GitHubReviewComment {
   id: string;
+  inReplyToId: string | null;
   body: string;
   url: string;
   path: string;
@@ -360,6 +362,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       comments.push(
         ...pageComments.map((comment) => ({
           id: String(comment.id),
+          inReplyToId: comment.in_reply_to_id?.toString() ?? null,
           body: comment.body,
           url: comment.html_url,
           path: comment.path,


### PR DESCRIPTION
## Summary
- preserve GitHub review comment `in_reply_to_id` in Autofix feedback
- skip Open Inspect App reviews composed entirely of thread replies
- continue admitting App reviews that contain top-level findings, including mixed finding/reply reviews
- add provider mapping and Autofix eligibility regression coverage

## Why
GitHub associates App-authored inline thread responses such as “Fixed” with new submitted review IDs. Autofix treated each reply-only review as new actionable feedback, causing response loops and serialized session backlogs.

## Verification
- `npm test -w @open-inspect/control-plane` (230 files, 3,450 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e25e3d6a3c59c23e963719d27425faae)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub review comments now preserve reply relationships.
  * Reviews with a non-empty body and only thread replies continue to be processed and queued.
* **Bug Fixes**
  * Reviews containing only replies to the bot’s own empty review are skipped to avoid unnecessary processing.
  * Reviews containing both top-level findings and replies continue to be processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->