### PR TITLE
docs: document session inbox contracts and the provider accounts secret

### DIFF
--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -444,6 +444,7 @@ All secrets are configured via Terraform. Required secrets include:
 - `GITHUB_APP_PRIVATE_KEY` - GitHub App private key (PKCS#8 format)
 - `GITHUB_APP_INSTALLATION_ID` - Single installation for all users
 - `REPO_SECRETS_ENCRYPTION_KEY` - AES-GCM key for encrypting repo secrets in D1
+- `PROVIDER_ACCOUNTS_ENCRYPTION_KEY` - Dedicated key for provider account credentials in D1
 
 Optional variables:
 

--- a/packages/control-plane/src/db/session-inbox-store.ts
+++ b/packages/control-plane/src/db/session-inbox-store.ts
@@ -9,6 +9,7 @@ import type { SessionInboxCursor } from "./session-inbox-cursor";
 import { readStateFromRow, unreadSql, type ViewerReadStateRow } from "./session-read-state";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
 
+/** Viewer, filtering, and pagination inputs for an inbox query. */
 export interface ListSessionInboxOptions {
   category: SessionInboxCategory;
   createdByUserIds?: readonly string[];
@@ -69,9 +70,11 @@ function toListItem(row: InboxSessionRow): SessionListItem {
   };
 }
 
+/** Builds viewer-specific session inbox pages from the D1 session index. */
 export class SessionInboxStore {
   constructor(private readonly db: SqlDatabase) {}
 
+  /** List one inbox category with viewer-specific read state. */
   async list(options: ListSessionInboxOptions): Promise<ListSessionInboxResult> {
     const result = await this.bindInboxQuery(options).all<InboxSessionRow>();
     const page = this.buildPageData(options.limit, result.results ?? []);
@@ -85,6 +88,7 @@ export class SessionInboxStore {
     );
   }
 
+  /** List every inbox category with viewer-specific read state. */
   async snapshot(
     options: Omit<ListSessionInboxOptions, "category" | "cursor">
   ): Promise<ListSessionInboxSnapshotResult> {

--- a/packages/shared/src/types/session-inbox.ts
+++ b/packages/shared/src/types/session-inbox.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { PullRequestSummary, SessionReadState, SessionStatus, SpawnSource } from "./sessions";
 import type { SessionListRepository } from "./repositories";
 
+/** Viewer-specific session row returned by list and inbox APIs. */
 export interface SessionListItem {
   id: string;
   title: string | null;

--- a/packages/shared/src/types/session-inbox.ts
+++ b/packages/shared/src/types/session-inbox.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { PullRequestSummary, SessionReadState, SessionStatus, SpawnSource } from "./sessions";
 import type { SessionListRepository } from "./repositories";
 
-/** Viewer-specific session row returned by list and inbox APIs. */
+/** Viewer-specific session row in session inbox page and snapshot payloads. */
 export interface SessionListItem {
   id: string;
   title: string | null;


### PR DESCRIPTION
## Summary

Documentation only — no behavior, type, or API changes.

- Add contract doc comments to `SessionListItem`, `ListSessionInboxOptions`, `SessionInboxStore`, and its `list` / `snapshot` methods.
- Add `PROVIDER_ACCOUNTS_ENCRYPTION_KEY` to the control plane's required secrets list.

## Why

**Inbox contracts.** The inbox `list` and `snapshot` paths return *viewer-specific* rows — read state is resolved per requesting user — and that scoping is not evident from the type names alone. The comments state what each type and method returns, rather than narrating how it is built.

**Required secret.** `PROVIDER_ACCOUNTS_ENCRYPTION_KEY` is a required Worker secret binding. The README already says so indirectly, under the *optional* `provider_accounts_encryption_key` Terraform variable ("Terraform supplies the required `PROVIDER_ACCOUNTS_ENCRYPTION_KEY` Worker secret binding"), but the key itself was missing from the "Required secrets include:" list alongside `REPO_SECRETS_ENCRYPTION_KEY`. Someone reading that list to provision a deployment would miss it.

## Testing

- `prettier --check` on all three changed files — clean.
- No typecheck/test run is meaningful here: the TypeScript changes are five comment lines and the README change is one list entry. This exact content is already carried downstream and passed a full `eslint .`, `typecheck`, and the control-plane unit + integration suites there.

https://claude.ai/code/session_01TeNKccdwt3TVeVo7pHqxSC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented the required encryption key used to protect provider account credentials in the database.
  - Added developer documentation describing session inbox storage, session listings, snapshots, and viewer-specific session list items.
  - Clarified the information represented on the session inbox page and in snapshot payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->