### PR TITLE
refactor: convert the first route modules to Hono sub-apps

### DIFF
--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { routes } from "./routes/catalog";
 import {
   handleRequest,
   matchRoute,
   signedServiceRequest,
   TEST_BACKGROUND_TASK_CONTEXT,
   TEST_SERVICE_SECRETS,
+  routeContracts as routes,
 } from "./router.test-support";
 
 function routeFor(method: string, path: string) {

--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { enforceRoutePrincipal } from "./routing/route-admission";
-import { routes } from "./routes/catalog";
-import { handleRequest, matchRoute, TEST_BACKGROUND_TASK_CONTEXT } from "./router.test-support";
+import {
+  handleRequest,
+  legacyRoutes,
+  matchRoute,
+  routeContracts as routes,
+  TEST_BACKGROUND_TASK_CONTEXT,
+} from "./router.test-support";
 import { serviceAllowsPermission } from "./authorization/service-permissions";
 import { SCOPED_PERMISSION_PAIRS } from "@open-inspect/shared/rbac";
 
@@ -241,7 +246,7 @@ describe("route policy table", () => {
 
   it("returns 400 for a malformed percent-encoded role ID before querying D1", async () => {
     const path = "/roles/%E0%A4%A";
-    const { route, match } = matchRoute(routes, "GET", path)!;
+    const { route, match } = matchRoute(legacyRoutes(), "GET", path)!;
     const prepare = vi.fn();
 
     const response = await route.handler(

--- a/packages/control-plane/src/router.scm-credentials.test.ts
+++ b/packages/control-plane/src/router.scm-credentials.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { routes } from "./routes/catalog";
 import {
   handleRequest,
   matchRoute,
   signedServiceRequest,
   TEST_BACKGROUND_TASK_CONTEXT,
   TEST_SERVICE_SECRETS,
+  routeContracts as routes,
 } from "./router.test-support";
 
 function routeFor(method: string, path: string) {

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -9,8 +9,12 @@
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
 import type { BackgroundTasks } from "./platform-ports";
 import { createTestBackgroundTasks } from "./background-tasks.test-support";
-import { cloudflareHost, createControlPlaneApp } from "./routing/hono-app";
-import { routes } from "./routes/catalog";
+import { Hono } from "hono";
+import { BUILT_IN_ROLE_REGISTRY } from "@open-inspect/shared/rbac";
+import type { SqlDatabase, SqlStatement } from "./db/sql-database";
+import { cloudflareHost, createControlPlaneApp, type RouteCatalogEntry } from "./routing/hono-app";
+import { listRouteContracts, type RouteContract } from "./routing/route-contracts";
+import { catalog } from "./routes/catalog";
 import type { Route, RouteParams } from "./routes/shared";
 import type { Env } from "./types";
 
@@ -41,14 +45,62 @@ function executionContextFromBackgroundTasks(tasks: BackgroundTasks): ExecutionC
  * synthetic routes construct their own handler instead of mutating the
  * production catalog.
  */
-export function createTestRequestHandler(catalog: readonly Route[]): TestRequestHandler {
-  const app = createControlPlaneApp(catalog, cloudflareHost);
+export function createTestRequestHandler(
+  entries: readonly RouteCatalogEntry[]
+): TestRequestHandler {
+  const app = createControlPlaneApp(entries, cloudflareHost);
   return (request, env, backgroundTasks) =>
     Promise.resolve(app.fetch(request, env, executionContextFromBackgroundTasks(backgroundTasks)));
 }
 
 /** Test-only adapter over the production catalog. */
-export const handleRequest: TestRequestHandler = createTestRequestHandler(routes);
+export const handleRequest: TestRequestHandler = createTestRequestHandler(catalog);
+
+/** Every production route with its policy, in precedence order, as Hono registered it. */
+export const routeContracts: readonly RouteContract[] = listRouteContracts(
+  createControlPlaneApp(catalog, cloudflareHost)
+);
+
+/** The catalog entries still registered through the legacy adapter. */
+export function legacyRoutes(entries: readonly RouteCatalogEntry[] = catalog): Route[] {
+  return entries.filter((entry): entry is Route => !(entry instanceof Hono));
+}
+
+/** The production contract selected for a concrete method and path. */
+export function contractFor(method: string, path: string): RouteContract | undefined {
+  return routeContracts.find(
+    (contract) => contract.method === method && routePathPattern(contract.path).test(path)
+  );
+}
+
+/**
+ * A database whose effective-authorization lookup answers with an active
+ * workspace owner, for request-level unit tests of admitted handlers whose
+ * data access is mocked at the store.
+ */
+export function ownerAuthorizationDatabase(userId = "user-1"): SqlDatabase {
+  return {
+    prepare(sql: string) {
+      const statement: SqlStatement = {
+        bind: () => statement,
+        first: async <T>() =>
+          (sql.includes("FROM users u")
+            ? {
+                user_id: userId,
+                suspended_at: null,
+                role_id: BUILT_IN_ROLE_REGISTRY.owner.id,
+                role_key: "owner",
+                role_name: "Owner",
+              }
+            : null) as T | null,
+        all: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+        run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+      };
+      return statement;
+    },
+    batch: async () => [],
+  };
+}
 
 /** Compile a catalog path into the legacy raw-path matcher, for handler-level fixtures. */
 export function routePathPattern(path: string): RegExp {
@@ -56,12 +108,12 @@ export function routePathPattern(path: string): RegExp {
 }
 
 /** Select the catalog route for a concrete path and rebuild what the adapter hands its handler. */
-export function matchRoute(
-  catalog: readonly Route[],
+export function matchRoute<Entry extends { method: string; path: string }>(
+  entries: readonly Entry[],
   method: string,
   path: string
-): { route: Route; match: RegExpMatchArray; params: RouteParams } | undefined {
-  for (const route of catalog) {
+): { route: Entry; match: RegExpMatchArray; params: RouteParams } | undefined {
+  for (const route of entries) {
     if (route.method !== method) continue;
     const match = path.match(routePathPattern(route.path));
     if (match) return { route, match, params: { ...match.groups } };

--- a/packages/control-plane/src/routes/analytics.test.ts
+++ b/packages/control-plane/src/routes/analytics.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { analyticsRoutes } from "./analytics";
+import type * as AuthenticateModule from "../auth/authenticate";
 import { HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
-import type { RequestContext } from "./shared";
-import type { SqlDatabase } from "../db/sql-database";
+import {
+  createTestRequestHandler,
+  ownerAuthorizationDatabase,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "../router.test-support";
 import type { Env } from "../types";
-import { routePathPattern, TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
+import { analyticsRoutes } from "./analytics";
 
 const FIXED_NOW = 1_700_000_000_000;
 
@@ -17,6 +21,13 @@ const mockStore = {
 const mockDashboardStore = {
   get: vi.fn(),
 };
+
+const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
 
 vi.mock("../db/analytics-store", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -34,46 +45,14 @@ vi.mock("../db/analytics-dashboard-store", () => ({
   }),
 }));
 
-function getHandler(method: string, path: string) {
-  const pathname = new URL(`https://test.local${path}`).pathname;
-  for (const route of analyticsRoutes) {
-    if (route.method === method && routePathPattern(route.path).test(pathname)) {
-      const match = pathname.match(routePathPattern(route.path))!;
-      return { handler: route.handler, match };
-    }
-  }
-
-  throw new Error(`No route found for ${method} ${path}`);
-}
-
-function createEnv(): Env {
-  return {
-    DB: {} as D1Database,
-  } as Env;
-}
-
-function createCtx(): RequestContext {
-  return {
-    trace_id: "trace-1",
-    request_id: "req-1",
-    db: {} as SqlDatabase,
-    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
-    metrics: {
-      d1Queries: [],
-      spans: {},
-      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
-      summarize: () => ({}),
-    },
-  };
-}
+const handleRequest = createTestRequestHandler([analyticsRoutes]);
+const env = { ...TEST_SERVICE_SECRETS, DB: ownerAuthorizationDatabase() } as unknown as Env;
 
 async function callRoute(method: string, path: string): Promise<Response> {
-  const { handler, match } = getHandler(method, path);
-  return handler(
+  return handleRequest(
     new Request(`https://test.local${path}`, { method }),
-    createEnv(),
-    match,
-    createCtx()
+    env,
+    TEST_BACKGROUND_TASK_CONTEXT
   );
 }
 
@@ -82,9 +61,17 @@ describe("analytics route handlers", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
+    mocks.authenticate.mockImplementation(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    }));
   });
 
-  describe("GET /analytics/dashboard", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("dashboard", () => {
     it("anchors one shared dashboard window", async () => {
       mockDashboardStore.get.mockResolvedValue({ generatedAt: FIXED_NOW });
 
@@ -107,26 +94,21 @@ describe("analytics route handlers", () => {
     });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  describe("GET /analytics/summary", () => {
+  describe("summary", () => {
     it("defaults days to 30", async () => {
       mockStore.getSummary.mockResolvedValue({
-        totalSessions: 12,
-        activeUsers: 4,
-        totalCost: 1.5,
-        avgCost: 0.125,
-        totalPrs: 2,
-        statusBreakdown: {
-          created: 1,
-          active: 2,
-          completed: 5,
-          failed: 2,
-          archived: 1,
-          cancelled: 1,
-        },
+        totalSessions: 0,
+        activeUsers: 0,
+        prsOpened: 0,
+        prsMerged: 0,
+        mergeRate: 0,
+        avgSessionDurationMs: 0,
+        sessionsByStatus: [],
+        sessionsByRepo: [],
+        sessionsByUser: [],
+        sessionsByModel: [],
+        prBreakdown: [],
+        recentSessions: [],
       });
 
       const response = await callRoute("GET", "/analytics/summary");
@@ -148,9 +130,9 @@ describe("analytics route handlers", () => {
     });
   });
 
-  describe("GET /analytics/timeseries", () => {
+  describe("timeseries", () => {
     it("passes the requested range to the store", async () => {
-      mockStore.getTimeseries.mockResolvedValue({ series: [] });
+      mockStore.getTimeseries.mockResolvedValue([]);
 
       const response = await callRoute("GET", "/analytics/timeseries?days=14");
       expect(response.status).toBe(200);
@@ -162,7 +144,7 @@ describe("analytics route handlers", () => {
     });
   });
 
-  describe("GET /analytics/breakdown", () => {
+  describe("breakdown", () => {
     it("requires a valid by parameter", async () => {
       const response = await callRoute("GET", "/analytics/breakdown?days=30");
       expect(response.status).toBe(400);
@@ -179,5 +161,32 @@ describe("analytics route handlers", () => {
       });
       expect(mockStore.getBreakdown).not.toHaveBeenCalled();
     });
+
+    it("passes the breakdown dimension to the store", async () => {
+      mockStore.getBreakdown.mockResolvedValue([]);
+
+      const response = await callRoute("GET", "/analytics/breakdown?days=7&by=repo");
+      expect(response.status).toBe(200);
+      expect(mockStore.getBreakdown).toHaveBeenCalledWith(
+        {
+          startAt: FIXED_NOW - 7 * 24 * 60 * 60 * 1000,
+          endAt: FIXED_NOW,
+          spawnSources: HUMAN_SPAWN_SOURCES,
+        },
+        "repo"
+      );
+    });
+  });
+
+  it("denies a request without analytics permission before touching a store", async () => {
+    mocks.authenticate.mockImplementation(async () => ({
+      reason: "Unauthorized",
+      status: 401,
+      failedScheme: "none",
+    }));
+
+    const response = await callRoute("GET", "/analytics/summary");
+    expect(response.status).toBe(401);
+    expect(mockStore.getSummary).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -10,12 +10,12 @@ import {
   type PullRequestAnalyticsFilters,
   PullRequestAnalyticsStore,
 } from "../db/pull-request-analytics-store";
-import type { Env } from "../types";
+import { Hono } from "hono";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   type RequestContext,
-  type Route,
   SCM_AGNOSTIC_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   error,
   json,
   requirePermission,
@@ -51,12 +51,7 @@ function getPullRequestFilters(days: AnalyticsDays): PullRequestAnalyticsFilters
   return { startAt: now - days * 24 * 60 * 60 * 1000, endAt: now, now };
 }
 
-async function handleDashboard(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleDashboard(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
   if (!days) {
@@ -74,12 +69,7 @@ async function handleDashboard(
   );
 }
 
-async function handleSummary(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleSummary(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
   if (!days) {
@@ -90,12 +80,7 @@ async function handleSummary(
   return json(await store.getSummary(getFilters(days)));
 }
 
-async function handleTimeseries(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleTimeseries(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
   if (!days) {
@@ -106,12 +91,7 @@ async function handleTimeseries(
   return json(await store.getTimeseries(getFilters(days)));
 }
 
-async function handleBreakdown(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleBreakdown(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
   if (!days) {
@@ -128,12 +108,7 @@ async function handleBreakdown(
   return json(await store.getBreakdown(getFilters(days), by));
 }
 
-async function handlePullRequests(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handlePullRequests(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
   if (!days) {
@@ -144,35 +119,25 @@ async function handlePullRequests(
   return json(await store.get(getPullRequestFilters(days)));
 }
 
-export const analyticsRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/analytics/dashboard",
-    authorization: requirePermission("analytics.read"),
-    handler: handleDashboard,
-  },
-  {
-    method: "GET",
-    path: "/analytics/summary",
-    authorization: requirePermission("analytics.read"),
-    handler: handleSummary,
-  },
-  {
-    method: "GET",
-    path: "/analytics/timeseries",
-    authorization: requirePermission("analytics.read"),
-    handler: handleTimeseries,
-  },
-  {
-    method: "GET",
-    path: "/analytics/breakdown",
-    authorization: requirePermission("analytics.read"),
-    handler: handleBreakdown,
-  },
-  {
-    method: "GET",
-    path: "/analytics/pull-requests",
-    authorization: requirePermission("analytics.read"),
-    handler: handlePullRequests,
-  },
-]);
+const ANALYTICS_READ = admit({
+  ...SCM_AGNOSTIC_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("analytics.read"),
+});
+
+export const analyticsRoutes = new Hono<ControlPlaneHonoEnv>();
+
+analyticsRoutes.get("/analytics/dashboard", ANALYTICS_READ, (c) =>
+  handleDashboard(c.var.admitted.request, c.var.admitted.ctx)
+);
+analyticsRoutes.get("/analytics/summary", ANALYTICS_READ, (c) =>
+  handleSummary(c.var.admitted.request, c.var.admitted.ctx)
+);
+analyticsRoutes.get("/analytics/timeseries", ANALYTICS_READ, (c) =>
+  handleTimeseries(c.var.admitted.request, c.var.admitted.ctx)
+);
+analyticsRoutes.get("/analytics/breakdown", ANALYTICS_READ, (c) =>
+  handleBreakdown(c.var.admitted.request, c.var.admitted.ctx)
+);
+analyticsRoutes.get("/analytics/pull-requests", ANALYTICS_READ, (c) =>
+  handlePullRequests(c.var.admitted.request, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/routes/audit-events.ts
+++ b/packages/control-plane/src/routes/audit-events.ts
@@ -1,15 +1,9 @@
+import { Hono } from "hono";
 import { encodeAuditEventCursor, parseAuditEventCursor } from "../db/audit-event-cursor";
 import { AuditEventStore, toAuditEvent } from "../db/audit-event-store";
-import type { Env } from "../types";
-import {
-  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
-  defineRoutes,
-  error,
-  json,
-  requirePermission,
-  type RequestContext,
-  type Route,
-} from "./shared";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { error, json, requirePermission, SCM_AGNOSTIC_HUMAN_USER_ROUTE } from "./shared";
 
 const DEFAULT_AUDIT_EVENT_LIMIT = 25;
 const MAX_AUDIT_EVENT_LIMIT = 100;
@@ -20,40 +14,36 @@ function singleQueryValue(searchParams: URLSearchParams, name: string): string |
   return values[0] ?? null;
 }
 
-async function handleListAuditEvents(
-  request: Request,
-  _env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
-  const searchParams = new URL(request.url).searchParams;
-  const rawLimit = singleQueryValue(searchParams, "limit");
-  if (rawLimit instanceof Response) return rawLimit;
-  const cursor = singleQueryValue(searchParams, "cursor");
-  if (cursor instanceof Response) return cursor;
+export const auditEventRoutes = new Hono<ControlPlaneHonoEnv>();
 
-  if (rawLimit !== null && !/^[1-9]\d*$/.test(rawLimit)) return error("Invalid limit", 400);
-  const limit = rawLimit === null ? DEFAULT_AUDIT_EVENT_LIMIT : Number(rawLimit);
-  if (!Number.isSafeInteger(limit) || limit > MAX_AUDIT_EVENT_LIMIT) {
-    return error("Invalid limit", 400);
-  }
-  const parsedCursor = parseAuditEventCursor(cursor);
-  if (!parsedCursor.ok) return error(parsedCursor.error, 400);
-
-  const result = await new AuditEventStore(ctx.db).list({ limit, cursor: parsedCursor.cursor });
-  return json({
-    events: result.rows.map(toAuditEvent),
-    hasMore: result.hasMore,
-    nextCursor: result.nextCursor ? encodeAuditEventCursor(result.nextCursor) : null,
-  });
-}
-
-export const auditEventRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_HUMAN_USER_ROUTE, [
-  {
-    method: "GET",
-    path: "/audit-events",
+auditEventRoutes.get(
+  "/audit-events",
+  admit({
+    ...SCM_AGNOSTIC_HUMAN_USER_ROUTE,
     authorization: requirePermission("workspace.audit.read", { service: "deny" }),
     cacheControl: "private, no-store",
-    handler: handleListAuditEvents,
-  },
-]);
+  }),
+  async (c) => {
+    const { request, ctx } = c.var.admitted;
+    const searchParams = new URL(request.url).searchParams;
+    const rawLimit = singleQueryValue(searchParams, "limit");
+    if (rawLimit instanceof Response) return rawLimit;
+    const cursor = singleQueryValue(searchParams, "cursor");
+    if (cursor instanceof Response) return cursor;
+
+    if (rawLimit !== null && !/^[1-9]\d*$/.test(rawLimit)) return error("Invalid limit", 400);
+    const limit = rawLimit === null ? DEFAULT_AUDIT_EVENT_LIMIT : Number(rawLimit);
+    if (!Number.isSafeInteger(limit) || limit > MAX_AUDIT_EVENT_LIMIT) {
+      return error("Invalid limit", 400);
+    }
+    const parsedCursor = parseAuditEventCursor(cursor);
+    if (!parsedCursor.ok) return error(parsedCursor.error, 400);
+
+    const result = await new AuditEventStore(ctx.db).list({ limit, cursor: parsedCursor.cursor });
+    return json({
+      events: result.rows.map(toAuditEvent),
+      hasMore: result.hasMore,
+      nextCursor: result.nextCursor ? encodeAuditEventCursor(result.nextCursor) : null,
+    });
+  }
+);

--- a/packages/control-plane/src/routes/catalog.ts
+++ b/packages/control-plane/src/routes/catalog.ts
@@ -5,6 +5,7 @@
  * and parameterized paths.
  */
 
+import type { RouteCatalogEntry } from "../routing/hono-env";
 import { webhookRoutes } from "../webhooks";
 import { analyticsRoutes } from "./analytics";
 import { auditEventRoutes } from "./audit-events";
@@ -14,6 +15,7 @@ import { browserAuthRoutes } from "./browser-auth";
 import { commitSigningRoutes } from "./commit-signing";
 import { environmentSecretsRoutes } from "./environment-secrets";
 import { environmentRoutes } from "./environments";
+import { healthRoutes } from "./health";
 import { imageBuildRoutes } from "./image-builds";
 import { integrationSettingsRoutes } from "./integration-settings";
 import { keyboardShortcutRoutes } from "./keyboard-shortcuts";
@@ -28,33 +30,17 @@ import { sessionRoutes } from "./sessions";
 import { handleSlackNotify } from "./slack-notify";
 import { signInProviderRoutes } from "./sign-in-providers";
 import { skillRoutes } from "./skills";
-import {
-  defineRoute,
-  GITHUB_SANDBOX_FALLBACK_ROUTE,
-  json,
-  NO_AUTHORIZATION,
-  requirePermission,
-  type Route,
-} from "./shared";
+import { defineRoute, GITHUB_SANDBOX_FALLBACK_ROUTE, requirePermission } from "./shared";
 
-export const routes: Route[] = [
-  // Health check
-  defineRoute(
-    { authentication: { kind: "public" }, supportedScmProviders: "all" },
-    {
-      method: "GET",
-      path: "/health",
-      authorization: NO_AUTHORIZATION,
-      handler: async () =>
-        json({
-          status: "healthy",
-          service: "open-inspect-control-plane",
-        }),
-    }
-  ),
+/**
+ * Registration order is the precedence order. A Hono sub-app is mounted where
+ * it appears; a legacy route is registered through the catalog adapter.
+ */
+export const catalog: RouteCatalogEntry[] = [
+  healthRoutes,
 
   ...browserAuthRoutes,
-  ...signInProviderRoutes,
+  signInProviderRoutes,
 
   // Session management
   ...sessionRoutes,
@@ -80,7 +66,7 @@ export const routes: Route[] = [
   ...imageBuildRoutes,
 
   // Model preferences
-  ...modelPreferencesRoutes,
+  modelPreferencesRoutes,
 
   // Subscription provider account management and sandbox access broker
   ...modelProviderAccountRoutes,
@@ -101,10 +87,10 @@ export const routes: Route[] = [
   ...mcpServerRoutes,
 
   // Analytics
-  ...analyticsRoutes,
+  analyticsRoutes,
 
   // Workspace audit log
-  ...auditEventRoutes,
+  auditEventRoutes,
 
   // Pull request feedback Autofix activity
   ...autofixRoutes,
@@ -113,7 +99,7 @@ export const routes: Route[] = [
   ...skillRoutes,
 
   // Personal keyboard shortcuts
-  ...keyboardShortcutRoutes,
+  keyboardShortcutRoutes,
 
   // Workspace roles, members, and current-user authorization
   ...rbacRoutes,

--- a/packages/control-plane/src/routes/health.ts
+++ b/packages/control-plane/src/routes/health.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { json, NO_AUTHORIZATION } from "./shared";
+
+export const healthRoutes = new Hono<ControlPlaneHonoEnv>();
+
+healthRoutes.get(
+  "/health",
+  admit({
+    authentication: { kind: "public" },
+    supportedScmProviders: "all",
+    authorization: NO_AUTHORIZATION,
+  }),
+  () => json({ status: "healthy", service: "open-inspect-control-plane" })
+);

--- a/packages/control-plane/src/routes/keyboard-shortcuts.ts
+++ b/packages/control-plane/src/routes/keyboard-shortcuts.ts
@@ -1,59 +1,39 @@
+import { Hono } from "hono";
 import { keyboardShortcutPreferencesPayloadSchema } from "@open-inspect/shared/types/keyboard-shortcuts";
 import { KeyboardShortcutPreferencesStore } from "../db/keyboard-shortcut-preferences";
-import type { Env } from "../types";
-import {
-  ACTIVE_SELF,
-  activeSelf,
-  defineRoutes,
-  error,
-  json,
-  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
-  type Route,
-  type UserRouteContext,
-} from "./shared";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { ACTIVE_SELF, activeSelf, error, json, SCM_AGNOSTIC_HUMAN_USER_ROUTE } from "./shared";
 
-async function getPreferences(
-  _request: Request,
-  _env: Env,
-  _match: RegExpMatchArray,
-  ctx: UserRouteContext
-): Promise<Response> {
-  const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).get(ctx.principal.userId);
-  return json({ shortcuts });
-}
+export const keyboardShortcutRoutes = new Hono<ControlPlaneHonoEnv>();
 
-async function updatePreferences(
-  request: Request,
-  _env: Env,
-  _match: RegExpMatchArray,
-  ctx: UserRouteContext
-): Promise<Response> {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
+keyboardShortcutRoutes.get(
+  "/keyboard-shortcuts",
+  admit({ ...SCM_AGNOSTIC_HUMAN_USER_ROUTE, authorization: ACTIVE_SELF }),
+  async (c) => {
+    const { ctx } = c.var.admitted;
+    const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).get(ctx.principal.userId);
+    return json({ shortcuts });
   }
-  const parsed = keyboardShortcutPreferencesPayloadSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid keyboard shortcuts", 400);
-  const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).set(
-    ctx.principal.userId,
-    parsed.data.shortcuts
-  );
-  return json({ shortcuts });
-}
+);
 
-export const keyboardShortcutRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_HUMAN_USER_ROUTE, [
-  {
-    method: "GET",
-    path: "/keyboard-shortcuts",
-    authorization: ACTIVE_SELF,
-    handler: getPreferences,
-  },
-  {
-    method: "PUT",
-    path: "/keyboard-shortcuts",
-    authorization: activeSelf({ auditAllowed: true }),
-    handler: updatePreferences,
-  },
-]);
+keyboardShortcutRoutes.put(
+  "/keyboard-shortcuts",
+  admit({ ...SCM_AGNOSTIC_HUMAN_USER_ROUTE, authorization: activeSelf({ auditAllowed: true }) }),
+  async (c) => {
+    const { request, ctx } = c.var.admitted;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return error("Invalid JSON body", 400);
+    }
+    const parsed = keyboardShortcutPreferencesPayloadSchema.safeParse(body);
+    if (!parsed.success) return error("Invalid keyboard shortcuts", 400);
+    const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).set(
+      ctx.principal.userId,
+      parsed.data.shortcuts
+    );
+    return json({ shortcuts });
+  }
+);

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -2,14 +2,14 @@
  * Model-preferences routes and handlers.
  */
 
+import { Hono } from "hono";
 import { DEFAULT_ENABLED_MODELS, normalizeValidModels } from "@open-inspect/shared/models";
 import { ModelPreferencesStore, ModelPreferencesValidationError } from "../db/model-preferences";
 import { createLogger } from "../logger";
-import type { Env } from "../types";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
-  type Route,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   type RequestContext,
   json,
   error,
@@ -20,12 +20,7 @@ import {
 
 const logger = createLogger("router:model-preferences");
 
-async function handleGetModelPreferences(
-  _request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function getModelPreferences(ctx: RequestContext): Promise<Response> {
   if (!ctx.db) {
     return json({ enabledModels: DEFAULT_ENABLED_MODELS });
   }
@@ -60,12 +55,7 @@ async function handleGetModelPreferences(
   }
 }
 
-async function handleSetModelPreferences(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function setModelPreferences(request: Request, ctx: RequestContext): Promise<Response> {
   if (!ctx.db) {
     return error("Model preferences storage is not configured", 503);
   }
@@ -106,19 +96,22 @@ async function handleSetModelPreferences(
   }
 }
 
-export const modelPreferencesRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/model-preferences",
-    authorization: activeGlobal({
-      actorlessGrants: [{ service: "slack-bot" }],
-    }),
-    handler: handleGetModelPreferences,
-  },
-  {
-    method: "PUT",
-    path: "/model-preferences",
+export const modelPreferencesRoutes = new Hono<ControlPlaneHonoEnv>();
+
+modelPreferencesRoutes.get(
+  "/model-preferences",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
+    authorization: activeGlobal({ actorlessGrants: [{ service: "slack-bot" }] }),
+  }),
+  (c) => getModelPreferences(c.var.admitted.ctx)
+);
+
+modelPreferencesRoutes.put(
+  "/model-preferences",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("models.preferences.manage"),
-    handler: handleSetModelPreferences,
-  },
-]);
+  }),
+  (c) => setModelPreferences(c.var.admitted.request, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/routes/sign-in-providers.ts
+++ b/packages/control-plane/src/routes/sign-in-providers.ts
@@ -1,45 +1,37 @@
+import { Hono } from "hono";
 import { UserAuthConfigurationError } from "../auth/user/runtime";
 import { createLogger } from "../logger";
-import {
-  defineRoutes,
-  error,
-  json,
-  NO_AUTHORIZATION,
-  SCM_AGNOSTIC_WEB_SERVICE_ROUTE,
-  type Route,
-} from "./shared";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { error, json, NO_AUTHORIZATION, SCM_AGNOSTIC_WEB_SERVICE_ROUTE } from "./shared";
 
 const logger = createLogger("sign-in-providers");
 
-const handleSignInProviders: Route["handler"] = async (_request, _env, _match, ctx) => {
-  try {
-    if (!ctx.getUserAuthRuntime) {
-      throw new UserAuthConfigurationError("User authentication runtime is unavailable");
-    }
-    const response = json({
-      providers: ctx.getUserAuthRuntime().enabledProviders,
-    });
-    response.headers.set("Cache-Control", "no-store");
-    return response;
-  } catch (cause) {
-    if (cause instanceof UserAuthConfigurationError) {
-      logger.error("Sign-in provider configuration is unavailable", {
-        event: "auth.providers.misconfigured",
-        error: cause,
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-      return error("Sign-in providers are not configured", 503);
-    }
-    throw cause;
-  }
-};
+export const signInProviderRoutes = new Hono<ControlPlaneHonoEnv>();
 
-export const signInProviderRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_WEB_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/internal/auth/sign-in-providers",
-    authorization: NO_AUTHORIZATION,
-    handler: handleSignInProviders,
-  },
-]);
+signInProviderRoutes.get(
+  "/internal/auth/sign-in-providers",
+  admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION }),
+  (c) => {
+    const { ctx } = c.var.admitted;
+    try {
+      if (!ctx.getUserAuthRuntime) {
+        throw new UserAuthConfigurationError("User authentication runtime is unavailable");
+      }
+      const response = json({ providers: ctx.getUserAuthRuntime().enabledProviders });
+      response.headers.set("Cache-Control", "no-store");
+      return response;
+    } catch (cause) {
+      if (cause instanceof UserAuthConfigurationError) {
+        logger.error("Sign-in provider configuration is unavailable", {
+          event: "auth.providers.misconfigured",
+          error: cause,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+        return error("Sign-in providers are not configured", 503);
+      }
+      throw cause;
+    }
+  }
+);

--- a/packages/control-plane/src/routing/admit.ts
+++ b/packages/control-plane/src/routing/admit.ts
@@ -2,7 +2,14 @@
 
 import type { MiddlewareHandler } from "hono";
 import { auditRouteAuthorizationDecision } from "../authorization/request-audit";
-import type { RouteAdmissionPolicy, RouteDefinition, RouteParams } from "../routes/shared";
+import type {
+  RouteAdmissionPolicy,
+  RouteAuthentication,
+  RouteContext,
+  RouteDefinition,
+  RouteParams,
+} from "../routes/shared";
+import type { Env } from "../types";
 import type { ControlPlaneHonoEnv } from "./hono-env";
 import { admitRoute, type RouteAdmissionResult } from "./route-admission";
 import { rawRouteParams } from "./route-params";
@@ -10,12 +17,29 @@ import { rawRouteParams } from "./route-params";
 /** Everything admission and response policy need to know about a route. */
 export type AdmissionPolicy = RouteAdmissionPolicy & Pick<RouteDefinition, "cacheControl">;
 
-/** The evaluated policy for the current request, read by the handler and the lifecycle. */
+/** The evaluated policy for the current request, read by the lifecycle. */
 export interface RouteAdmission {
   policy: AdmissionPolicy;
   params: RouteParams;
   result: RouteAdmissionResult;
 }
+
+/** What an admitted handler receives: the request as authenticated, and the context narrowed by the policy. */
+export interface Admitted<Authentication extends RouteAuthentication> {
+  request: Request;
+  ctx: RouteContext<Authentication>;
+}
+
+/** The Hono environment a handler behind `admit(policy)` sees. */
+export type AdmittedEnv<Policy extends AdmissionPolicy> = {
+  Bindings: Env;
+  Variables: ControlPlaneHonoEnv["Variables"] & { admitted: Admitted<Policy["authentication"]> };
+};
+
+/** The middleware `admit()` returns, carrying the policy it enforces for route enumeration. */
+export type AdmitMiddleware<Policy extends AdmissionPolicy> = MiddlewareHandler<
+  AdmittedEnv<Policy>
+> & { readonly policy: Policy };
 
 /**
  * Evaluate `policy` for the selected route before its handler runs.
@@ -25,7 +49,9 @@ export interface RouteAdmission {
  * The middleware is built once per route at app construction, which is when
  * a policy that cannot be enforced is refused.
  */
-export function admit(policy: AdmissionPolicy): MiddlewareHandler<ControlPlaneHonoEnv> {
+export function admit<const Policy extends AdmissionPolicy>(
+  policy: Policy
+): AdmitMiddleware<Policy> {
   const principalless =
     policy.authentication.kind === "public" ||
     policy.authentication.kind === "handler-authenticated";
@@ -33,7 +59,7 @@ export function admit(policy: AdmissionPolicy): MiddlewareHandler<ControlPlaneHo
     throw new Error("Route without a verified principal cannot require authorization");
   }
 
-  return async (c, next) => {
+  const middleware: MiddlewareHandler<AdmittedEnv<Policy>> = async (c, next) => {
     const context = c.get("requestContext");
     const pathname = c.req.path;
     // Recorded before anything can fail so the lifecycle finalizes an
@@ -62,6 +88,11 @@ export function admit(policy: AdmissionPolicy): MiddlewareHandler<ControlPlaneHo
       }
       return result.response;
     }
+    c.set("admitted", {
+      request: result.handlerRequest,
+      ctx: context as RouteContext<Policy["authentication"]>,
+    });
     await next();
   };
+  return Object.assign(middleware, { policy });
 }

--- a/packages/control-plane/src/routing/hono-app.test.ts
+++ b/packages/control-plane/src/routing/hono-app.test.ts
@@ -159,6 +159,34 @@ describe("control-plane Hono app lifecycle", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 
+  it("refuses a module whose route does not begin with admit(), before any request can run", () => {
+    const sideEffect = vi.fn();
+    const naked = new Hono<ControlPlaneHonoEnv>();
+    naked.post("/naked", (c) => {
+      sideEffect();
+      return c.text("wrote");
+    });
+    expect(() => createControlPlaneApp([naked], host)).toThrow(
+      "Module route does not begin with admit(): POST /naked"
+    );
+
+    const late = new Hono<ControlPlaneHonoEnv>();
+    late.post("/late", (c) => c.text("open"));
+    late.post("/late", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () => json({}));
+    expect(() => createControlPlaneApp([late], host)).toThrow(
+      "Module route does not begin with admit(): POST /late"
+    );
+
+    const withMiddleware = new Hono<ControlPlaneHonoEnv>();
+    withMiddleware.use("*", async (_c, next) => next());
+    withMiddleware.get("/x", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () => json({}));
+    expect(() => createControlPlaneApp([withMiddleware], host)).toThrow(
+      "Module registers middleware outside admit(): /*"
+    );
+
+    expect(sideEffect).not.toHaveBeenCalled();
+  });
+
   it("refuses a module route outside the path grammar when the app is built", () => {
     const module = new Hono<ControlPlaneHonoEnv>();
     module.get("/files/*", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () => json({}));

--- a/packages/control-plane/src/routing/hono-app.test.ts
+++ b/packages/control-plane/src/routing/hono-app.test.ts
@@ -4,7 +4,9 @@ import { TEST_SERVICE_SECRETS } from "../router.test-support";
 import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import { defineRoute, NO_AUTHORIZATION, type Route } from "../routes/shared";
 import type { Env } from "../types";
-import { createControlPlaneApp, type ControlPlaneHost } from "./hono-app";
+import { Hono } from "hono";
+import { admit } from "./admit";
+import { createControlPlaneApp, type ControlPlaneHonoEnv, type ControlPlaneHost } from "./hono-app";
 
 const PUBLIC = { authentication: { kind: "public" }, supportedScmProviders: "all" } as const;
 
@@ -130,6 +132,37 @@ describe("control-plane Hono app lifecycle", () => {
     expect(loggedEvents(errors).map((line) => [line.event, line.http_status])).toEqual([
       ["http.request", 500],
     ]);
+  });
+
+  it("mounts a route module and hands its handler the admitted request and context", async () => {
+    const module = new Hono<ControlPlaneHonoEnv>();
+    module.get("/module/:id", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), (c) => {
+      const { request, ctx } = c.var.admitted;
+      return json({
+        id: c.req.param("id"),
+        url: request.url,
+        requestId: ctx.request_id,
+        principal: ctx.principal ?? null,
+      });
+    });
+    const app = createControlPlaneApp([module], host);
+
+    const response = await app.fetch(new Request("https://cp.test/module/m-1?x=1"), env);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      id: "m-1",
+      url: "https://cp.test/module/m-1?x=1",
+      principal: null,
+    });
+    expect(body.requestId).toBe(response.headers.get("x-request-id"));
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("refuses a module route outside the path grammar when the app is built", () => {
+    const module = new Hono<ControlPlaneHonoEnv>();
+    module.get("/files/*", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () => json({}));
+    expect(() => createControlPlaneApp([module], host)).toThrow("outside the supported grammar");
   });
 
   it("refuses a route that declares the same parameter twice", () => {

--- a/packages/control-plane/src/routing/hono-app.ts
+++ b/packages/control-plane/src/routing/hono-app.ts
@@ -11,14 +11,25 @@ import { createRequestContext } from "../http/create-request-context";
 import type { RequestContext } from "../http/request-context";
 import { error, HttpError } from "../http/responses";
 import { createLogger } from "../logger";
-import { routes } from "../routes/catalog";
+import { catalog } from "../routes/catalog";
 import type { Route, RouteParams } from "../routes/shared";
 import type { Env } from "../types";
 import { admit } from "./admit";
-import type { ControlPlaneHonoEnv, ControlPlaneHost, PlatformExecutionContext } from "./hono-env";
+import type {
+  ControlPlaneHonoEnv,
+  ControlPlaneHost,
+  PlatformExecutionContext,
+  RouteCatalogEntry,
+} from "./hono-env";
 import { finalizeRouteResponse, logRequest, withCorsAndTraceHeaders } from "./request-lifecycle";
 
-export type { ControlPlaneHonoEnv, ControlPlaneHost, PlatformExecutionContext } from "./hono-env";
+export type {
+  ControlPlaneHonoEnv,
+  ControlPlaneHost,
+  PlatformExecutionContext,
+  RouteCatalogEntry,
+  RouteModule,
+} from "./hono-env";
 
 /** Ordinary HTTP entrypoint signature shared by the Worker and test adapters. */
 export type ControlPlaneHttpHandler = (
@@ -36,15 +47,28 @@ const logger = createLogger("router");
  */
 const ROUTE_PATH_GRAMMAR = /^(\/([A-Za-z0-9_-]+|:\w+))+$/;
 
-function assertRoutePath(route: Route): void {
-  if (!ROUTE_PATH_GRAMMAR.test(route.path)) {
-    throw new Error(`Route path is outside the supported grammar: ${route.method} ${route.path}`);
+function assertRoutePath(method: string, path: string): void {
+  if (!ROUTE_PATH_GRAMMAR.test(path)) {
+    throw new Error(`Route path is outside the supported grammar: ${method} ${path}`);
   }
-  const names = route.path.split("/").filter((segment) => segment.startsWith(":"));
+  const names = path.split("/").filter((segment) => segment.startsWith(":"));
   const duplicate = names.find((name, index) => names.indexOf(name) !== index);
   if (duplicate) {
-    throw new Error(`Route declares parameter ${duplicate} twice: ${route.method} ${route.path}`);
+    throw new Error(`Route declares parameter ${duplicate} twice: ${method} ${path}`);
   }
+}
+
+/** Mount a module or register a legacy route, checking every admitted path's grammar first. */
+function register(app: Hono<ControlPlaneHonoEnv>, entry: RouteCatalogEntry): void {
+  if (entry instanceof Hono) {
+    for (const route of entry.routes) {
+      if ("policy" in route.handler) assertRoutePath(route.method, route.path);
+    }
+    app.route("/", entry);
+    return;
+  }
+  assertRoutePath(entry.method, entry.path);
+  app.on(entry.method, entry.path, admit(entry), legacy(entry));
 }
 
 /** The execution context the platform passed to `app.fetch`, if any. */
@@ -105,11 +129,9 @@ function replaceResponse(
  * handler that answers without admission having run is refused.
  */
 export function createControlPlaneApp(
-  catalog: readonly Route[],
+  entries: readonly RouteCatalogEntry[],
   host: ControlPlaneHost
 ): Hono<ControlPlaneHonoEnv> {
-  for (const route of catalog) assertRoutePath(route);
-
   const app = new Hono<ControlPlaneHonoEnv>({
     strict: true,
     getPath: (request) => new URL(request.url).pathname,
@@ -217,9 +239,7 @@ export function createControlPlaneApp(
     });
   });
 
-  for (const route of catalog) {
-    app.on(route.method, route.path, admit(route), legacy(route));
-  }
+  for (const entry of entries) register(app, entry);
 
   app.notFound((c) => {
     c.set("admissionExempt", true);
@@ -267,11 +287,13 @@ export const cloudflareHost: ControlPlaneHost = {
 };
 
 /** Build the Worker's ordinary HTTP entrypoint over a route catalog. */
-export function createControlPlaneHttpHandler(catalog: readonly Route[]): ControlPlaneHttpHandler {
-  const app = createControlPlaneApp(catalog, cloudflareHost);
+export function createControlPlaneHttpHandler(
+  entries: readonly RouteCatalogEntry[]
+): ControlPlaneHttpHandler {
+  const app = createControlPlaneApp(entries, cloudflareHost);
   return (request, env, executionCtx) => Promise.resolve(app.fetch(request, env, executionCtx));
 }
 
 /** Production entrypoint over the canonical route catalog. */
 export const handleControlPlaneHttp: ControlPlaneHttpHandler =
-  createControlPlaneHttpHandler(routes);
+  createControlPlaneHttpHandler(catalog);

--- a/packages/control-plane/src/routing/hono-app.ts
+++ b/packages/control-plane/src/routing/hono-app.ts
@@ -1,6 +1,7 @@
 /** Hono application for ordinary control-plane HTTP requests. */
 
 import { Hono, type Handler } from "hono";
+import type { RouterRoute } from "hono/types";
 import { TrieRouter } from "hono/router/trie-router";
 import {
   auditRouteAuthorizationDecision,
@@ -58,12 +59,36 @@ function assertRoutePath(method: string, path: string): void {
   }
 }
 
-/** Mount a module or register a legacy route, checking every admitted path's grammar first. */
+/**
+ * Refuse a module unless every route it registers begins with `admit()`.
+ *
+ * Hono runs a route's handlers in registration order and stops at the first
+ * one that answers, so a handler registered ahead of the policy, or with no
+ * policy at all, would run its side effects before the lifecycle's default
+ * deny could replace the response. Module-level middleware (`app.use`) is
+ * refused for the same reason: nothing in a module runs before admission.
+ */
+function assertModuleAdmits(module: Hono<ControlPlaneHonoEnv>): void {
+  const first = new Map<string, RouterRoute>();
+  for (const route of module.routes) {
+    if (route.method === "ALL") {
+      throw new Error(`Module registers middleware outside admit(): ${route.path}`);
+    }
+    const identity = `${route.method} ${route.path}`;
+    if (!first.has(identity)) first.set(identity, route);
+  }
+  for (const [identity, route] of first) {
+    if (!("policy" in route.handler)) {
+      throw new Error(`Module route does not begin with admit(): ${identity}`);
+    }
+    assertRoutePath(route.method, route.path);
+  }
+}
+
+/** Mount a module or register a legacy route, refusing either before it can serve a request. */
 function register(app: Hono<ControlPlaneHonoEnv>, entry: RouteCatalogEntry): void {
   if (entry instanceof Hono) {
-    for (const route of entry.routes) {
-      if ("policy" in route.handler) assertRoutePath(route.method, route.path);
-    }
+    assertModuleAdmits(entry);
     app.route("/", entry);
     return;
   }

--- a/packages/control-plane/src/routing/hono-env.ts
+++ b/packages/control-plane/src/routing/hono-env.ts
@@ -1,7 +1,9 @@
 /** Hono environment shared by the control-plane app, its middleware, and its hosts. */
 
+import type { Hono } from "hono";
 import type { RequestContext } from "../http/request-context";
 import type { BackgroundTasks } from "../platform-ports";
+import type { Route } from "../routes/shared";
 import type { Env } from "../types";
 import type { AdmissionPolicy, RouteAdmission } from "./admit";
 
@@ -29,3 +31,9 @@ export interface ControlPlaneHost {
   /** Background-task port for one request. Cloudflare extends the event through `waitUntil`; a host without one supplies its own. */
   backgroundTasks(executionCtx: PlatformExecutionContext | undefined): BackgroundTasks;
 }
+
+/** A route module: a Hono sub-app whose every route is registered behind `admit()`. */
+export type RouteModule = Hono<ControlPlaneHonoEnv>;
+
+/** What the catalog lists, in precedence order: converted modules and, until they convert, legacy routes. */
+export type RouteCatalogEntry = Route | RouteModule;

--- a/packages/control-plane/src/routing/route-contracts.test.ts
+++ b/packages/control-plane/src/routing/route-contracts.test.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { createTestBackgroundTasks } from "../background-tasks.test-support";
+import { defineRoute, json, NO_AUTHORIZATION, requirePermission } from "../routes/shared";
+import { admit } from "./admit";
+import { createControlPlaneApp, type ControlPlaneHonoEnv, type ControlPlaneHost } from "./hono-app";
+import { listRouteContracts } from "./route-contracts";
+
+const PUBLIC = { authentication: { kind: "public" }, supportedScmProviders: "all" } as const;
+const host: ControlPlaneHost = { backgroundTasks: () => createTestBackgroundTasks() };
+
+describe("listRouteContracts", () => {
+  it("lists modules and legacy routes in registration order with their policies", () => {
+    const module = new Hono<ControlPlaneHonoEnv>();
+    module.get("/module/:id", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () =>
+      json({})
+    );
+    module.post(
+      "/module/:id",
+      admit({
+        authentication: { kind: "user" },
+        supportedScmProviders: ["github"],
+        authorization: requirePermission("sessions.create"),
+        cacheControl: "no-store",
+      }),
+      () => json({})
+    );
+    const legacy = defineRoute(PUBLIC, {
+      method: "GET",
+      path: "/legacy",
+      authorization: NO_AUTHORIZATION,
+      handler: async () => json({}),
+    });
+
+    const app = createControlPlaneApp([legacy, module], host);
+    const contracts = listRouteContracts(app);
+
+    expect(contracts.map((contract) => `${contract.method} ${contract.path}`)).toEqual([
+      "GET /legacy",
+      "GET /module/:id",
+      "POST /module/:id",
+    ]);
+    expect(contracts[2]).toMatchObject({
+      authentication: { kind: "user" },
+      supportedScmProviders: ["github"],
+      authorization: { kind: "active-user" },
+      cacheControl: "no-store",
+    });
+    expect(contracts[0].cacheControl).toBeUndefined();
+  });
+});

--- a/packages/control-plane/src/routing/route-contracts.test.ts
+++ b/packages/control-plane/src/routing/route-contracts.test.ts
@@ -48,4 +48,16 @@ describe("listRouteContracts", () => {
     });
     expect(contracts[0].cacheControl).toBeUndefined();
   });
+
+  it("refuses to enumerate an app whose route does not begin with admit()", () => {
+    // Built by hand, since createControlPlaneApp refuses such a module outright.
+    const app = new Hono();
+    app.use("*", async (_c, next) => next());
+    app.options("*", (c) => c.body(null));
+    app.get("/admitted", admit({ ...PUBLIC, authorization: NO_AUTHORIZATION }), () => json({}));
+    expect(listRouteContracts(app).map((contract) => contract.path)).toEqual(["/admitted"]);
+
+    app.get("/naked", () => json({}));
+    expect(() => listRouteContracts(app)).toThrow("Route does not begin with admit(): GET /naked");
+  });
 });

--- a/packages/control-plane/src/routing/route-contracts.ts
+++ b/packages/control-plane/src/routing/route-contracts.ts
@@ -10,14 +10,30 @@ function admissionPolicyOf(handler: RouterRoute["handler"]): AdmissionPolicy | u
   return "policy" in handler ? (handler.policy as AdmissionPolicy) : undefined;
 }
 
+/** App-owned responders that answer without a route policy, by `METHOD /path`. */
+const APP_OWNED_RESPONDERS: ReadonlySet<string> = new Set(["OPTIONS /*"]);
+
 /**
  * Every route in registration order, read from Hono's own route list: the
- * entry whose handler is the `admit()` middleware names the method, the
- * mounted path, and the policy.
+ * first entry registered for a method and path must be the `admit()`
+ * middleware, which names the policy. A route whose first handler is not
+ * the policy is refused rather than skipped, so the enumeration cannot hide
+ * an unadmitted route from the suites that iterate it.
  */
 export function listRouteContracts(app: { routes: readonly RouterRoute[] }): RouteContract[] {
-  return app.routes.flatMap((route) => {
+  const contracts: RouteContract[] = [];
+  const seen = new Set<string>();
+  for (const route of app.routes) {
+    if (route.method === "ALL") continue;
+    const identity = `${route.method} ${route.path}`;
+    if (seen.has(identity)) continue;
+    seen.add(identity);
     const policy = admissionPolicyOf(route.handler);
-    return policy ? [{ method: route.method, path: route.path, ...policy }] : [];
-  });
+    if (policy) {
+      contracts.push({ method: route.method, path: route.path, ...policy });
+    } else if (!APP_OWNED_RESPONDERS.has(identity)) {
+      throw new Error(`Route does not begin with admit(): ${identity}`);
+    }
+  }
+  return contracts;
 }

--- a/packages/control-plane/src/routing/route-contracts.ts
+++ b/packages/control-plane/src/routing/route-contracts.ts
@@ -1,0 +1,23 @@
+/** Enumerate the routes an app registered, with the policy each admits under. */
+
+import type { RouterRoute } from "hono/types";
+import type { AdmissionPolicy } from "./admit";
+
+/** One registered route as the policy tests and the boundary suites see it. */
+export type RouteContract = { method: string; path: string } & AdmissionPolicy;
+
+function admissionPolicyOf(handler: RouterRoute["handler"]): AdmissionPolicy | undefined {
+  return "policy" in handler ? (handler.policy as AdmissionPolicy) : undefined;
+}
+
+/**
+ * Every route in registration order, read from Hono's own route list: the
+ * entry whose handler is the `admit()` middleware names the method, the
+ * mounted path, and the policy.
+ */
+export function listRouteContracts(app: { routes: readonly RouterRoute[] }): RouteContract[] {
+  return app.routes.flatMap((route) => {
+    const policy = admissionPolicyOf(route.handler);
+    return policy ? [{ method: route.method, path: route.path, ...policy }] : [];
+  });
+}

--- a/packages/control-plane/test/integration/hono-route-catalog-conformance.test.ts
+++ b/packages/control-plane/test/integration/hono-route-catalog-conformance.test.ts
@@ -1,11 +1,17 @@
 import { createExecutionContext, env } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
-import { routes } from "../../src/routes/catalog";
+import { catalog } from "../../src/routes/catalog";
 import { NO_AUTHORIZATION, type Route } from "../../src/routes/shared";
-import { createControlPlaneHttpHandler } from "../../src/routing/hono-app";
+import {
+  cloudflareHost,
+  createControlPlaneApp,
+  createControlPlaneHttpHandler,
+} from "../../src/routing/hono-app";
+import { listRouteContracts } from "../../src/routing/route-contracts";
 import type { Env } from "../../src/types";
 
 const PARAMETER = /:(\w+)/g;
+const routes = listRouteContracts(createControlPlaneApp(catalog, cloudflareHost));
 
 function materializePath(
   routePath: string,

--- a/packages/control-plane/test/integration/route-admission-matrix.test.ts
+++ b/packages/control-plane/test/integration/route-admission-matrix.test.ts
@@ -12,10 +12,15 @@ import { SELF, env } from "cloudflare:test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import { createExecutionContext } from "cloudflare:test";
-import { createControlPlaneHttpHandler } from "../../src/routing/hono-app";
+import {
+  cloudflareHost,
+  createControlPlaneApp,
+  createControlPlaneHttpHandler,
+} from "../../src/routing/hono-app";
+import { listRouteContracts, type RouteContract } from "../../src/routing/route-contracts";
 import type { Env } from "../../src/types";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";
-import { routes } from "../../src/routes/catalog";
+import { catalog } from "../../src/routes/catalog";
 import type { Route } from "../../src/routes/shared";
 import { cleanD1Tables } from "./cleanup";
 import {
@@ -36,6 +41,10 @@ const ROUTE_MISS_BODY = JSON.stringify({ error: "Not found" });
 // mutating session route, so the default per-test budget is too small under
 // full-suite load.
 const MATRIX_TIMEOUT_MS = 60_000;
+/** Every production route with its policy, in precedence order, as Hono registered it. */
+const routes: readonly RouteContract[] = listRouteContracts(
+  createControlPlaneApp(catalog, cloudflareHost)
+);
 
 interface MatrixFixtures {
   readonlySessionId: string;
@@ -74,17 +83,17 @@ const PARAMETER_VALUES: Record<string, string> = {
   key: "MATRIX_KEY",
 };
 
-function materialize(route: Route, values: Record<string, string>): string {
+function materialize(route: RouteContract, values: Record<string, string>): string {
   return route.path.replace(/:(\w+)/g, (_parameter, parameter: string) => {
     return values[parameter] ?? PARAMETER_VALUES[parameter] ?? `matrix-${parameter}`;
   });
 }
 
-function isSessionRoute(route: Route): boolean {
+function isSessionRoute(route: RouteContract): boolean {
   return route.path.startsWith("/sessions/:id");
 }
 
-function isAutomationRoute(route: Route): boolean {
+function isAutomationRoute(route: RouteContract): boolean {
   return route.path.startsWith("/automations/:id");
 }
 
@@ -95,7 +104,7 @@ async function createAutomation(): Promise<string> {
   return id;
 }
 
-function isMutation(route: Route): boolean {
+function isMutation(route: RouteContract): boolean {
   return route.method !== "GET";
 }
 


### PR DESCRIPTION
## Summary

Third step of the series retiring the routing adapter (#1720 guardrails, #1721 mechanism). This PR converts the first six route modules to native Hono sub-apps and establishes the pattern the remaining module PRs follow. 12 routes convert; the other 159 still go through the catalog adapter.

**A converted module** is a `Hono` sub-app whose routes register with `admit(policy)` as their first middleware and a native handler behind it:

```ts
export const keyboardShortcutRoutes = new Hono<ControlPlaneHonoEnv>();

keyboardShortcutRoutes.get(
  "/keyboard-shortcuts",
  admit({ ...SCM_AGNOSTIC_HUMAN_USER_ROUTE, authorization: ACTIVE_SELF }),
  async (c) => {
    const { ctx } = c.var.admitted;   // ctx.principal is typed UserPrincipal by the policy
    ...
  }
);
```

`admit()` is now generic over its policy and sets `c.var.admitted` as `{ request, ctx }`, where `request` is the request as authentication returned it (sig1 verification consumes the original body) and `ctx` is the request context narrowed by the policy's authentication kind, exactly as `RouteContext<Authentication>` narrowed the legacy handler's fourth argument. Handlers use `c.req.param()` for path parameters; none of the six modules has one, so no decoding question arises in this PR.

**The catalog mounts modules in place.** `catalog` (renamed from `routes`) is an ordered list of `Route | RouteModule`. `createControlPlaneApp` mounts a sub-app with `app.route("/", module)` where it appears and registers a legacy route through the adapter where it appears, so registration order, and therefore precedence, is unchanged. The path grammar and duplicate-parameter checks run for module routes too.

**Route contracts come from Hono's own route list.** `listRouteContracts(app)` walks `app.routes` and yields `{ method, path, ...policy }` for every entry whose handler is the `admit()` middleware, which carries the policy it enforces. The policy tests, the route-admission matrix, its sentinel suite, and the conformance suite iterate that list instead of the catalog array, so they cover converted and legacy routes alike. Both integration snapshots are byte-identical to `main`.

**Handler-level tests become request-level.** `analytics.test.ts` went through `createTestRequestHandler([analyticsRoutes])` with `authenticate` mocked to return a user and `ownerAuthorizationDatabase()` answering the effective-authorization lookup, which is the pattern `router.authorization-audit.test.ts` already used. Same assertions, plus a denial case that proves no store is touched. The remaining 26 handler-level test files convert with their modules.

Converted: `health` (moved out of `catalog.ts` into its own module), `keyboard-shortcuts`, `model-preferences`, `sign-in-providers`, `audit-events`, `analytics`.

## Verification

- Unit: 234 files, 3,474 passed.
- Integration (workerd, real D1): 96 files, 1,128 passed. Route-matrix and conformance snapshots unchanged.
- Typecheck (`src`, `tsconfig.test.json`, `test/integration`), ESLint, and Prettier clean.

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a health check endpoint reporting service availability.
  - Expanded support for modular route handling while preserving existing endpoint access policies.
  - Added route contract reporting for endpoint methods, paths, and access requirements.

- **Bug Fixes**
  - Preserved authentication, authorization, caching, and request-context behavior across updated endpoints.
  - Improved validation for unsupported route patterns and improperly configured routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->