### PR TITLE
refactor: convert the browser auth passthrough to a Hono sub-app

### DIFF
--- a/packages/control-plane/src/routes/browser-auth.test.ts
+++ b/packages/control-plane/src/routes/browser-auth.test.ts
@@ -1,5 +1,53 @@
-import { describe, expect, it, vi } from "vitest";
-import { forwardBrowserAuthRequest } from "./browser-auth";
+import { BROWSER_AUTH_PROXY_ROUTES } from "@open-inspect/shared/browser-auth-routes";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as AuthenticateModule from "../auth/authenticate";
+import { UserAuthConfigurationError } from "../auth/user/runtime";
+import type * as UserRuntimeModule from "../auth/user/runtime";
+import {
+  createTestRequestHandler,
+  ownerAuthorizationDatabase,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "../router.test-support";
+import type { Env } from "../types";
+import { browserAuthRoutes, forwardBrowserAuthRequest } from "./browser-auth";
+
+const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  getUserAuth: vi.fn(),
+}));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
+
+vi.mock("../auth/user/runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof UserRuntimeModule>()),
+  getUserAuth: mocks.getUserAuth,
+}));
+
+const handleRequest = createTestRequestHandler([browserAuthRoutes]);
+const env = {
+  ...TEST_SERVICE_SECRETS,
+  SCM_PROVIDER: "github",
+  DB: ownerAuthorizationDatabase(),
+} as unknown as Env;
+
+function webServicePrincipal() {
+  mocks.authenticate.mockImplementation(async (request: Request) => ({
+    principal: { kind: "service", service: "web", actor: null },
+    request,
+  }));
+}
+
+function callRoute(method: string, path: string): Promise<Response> {
+  return handleRequest(
+    new Request(`https://test.local${path}`, { method }),
+    env,
+    TEST_BACKGROUND_TASK_CONTEXT
+  );
+}
 
 describe("forwardBrowserAuthRequest", () => {
   it("uses the direct API wrapper for session lookup", async () => {
@@ -23,5 +71,96 @@ describe("forwardBrowserAuthRequest", () => {
       asResponse: true,
     });
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser auth routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServicePrincipal();
+  });
+
+  it.each(BROWSER_AUTH_PROXY_ROUTES.map(([method, path]) => [method, path]))(
+    "proxies %s %s to Better Auth",
+    async (method, path) => {
+      const handler = vi.fn(async (request: Request) =>
+        Response.json({ path: new URL(request.url).pathname }, { status: 202 })
+      );
+      const getSession = vi.fn(async () =>
+        Response.json({ path: "/api/auth/get-session" }, { status: 202 })
+      );
+      mocks.getUserAuth.mockReturnValue({ api: { getSession }, handler });
+
+      const response = await callRoute(method, path);
+
+      expect(response.status).toBe(202);
+      await expect(response.json()).resolves.toEqual({ path });
+      // Session reads take Better Auth's direct API; everything else its HTTP handler.
+      const direct = method === "GET" && path === "/api/auth/get-session";
+      expect(getSession).toHaveBeenCalledTimes(direct ? 1 : 0);
+      expect(handler).toHaveBeenCalledTimes(direct ? 0 : 1);
+    }
+  );
+
+  it("passes Better Auth's status through with no-store and no-referrer headers", async () => {
+    const handler = vi.fn(
+      async () =>
+        new Response("redirecting", {
+          status: 302,
+          headers: {
+            Location: "https://web.test/",
+            "Set-Cookie": "session=abc; Path=/; HttpOnly",
+          },
+        })
+    );
+    mocks.getUserAuth.mockReturnValue({ api: { getSession: vi.fn() }, handler });
+
+    const response = await callRoute("GET", "/api/auth/callback/github");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("https://web.test/");
+    expect(response.headers.get("Set-Cookie")).toBe("session=abc; Path=/; HttpOnly");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("answers 503 when browser authentication is not configured", async () => {
+    mocks.getUserAuth.mockImplementation(() => {
+      throw new UserAuthConfigurationError("missing secret");
+    });
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await callRoute("GET", "/api/auth/get-session");
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Browser authentication is not configured",
+    });
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  it("refuses a caller that is not the signed web service", async () => {
+    mocks.authenticate.mockImplementation(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    }));
+    mocks.getUserAuth.mockReturnValue({ api: { getSession: vi.fn() }, handler: vi.fn() });
+
+    const response = await callRoute("GET", "/api/auth/get-session");
+
+    expect(response.status).toBe(401);
+    expect(mocks.getUserAuth).not.toHaveBeenCalled();
+  });
+
+  it("does not expose paths outside the allowlist", async () => {
+    mocks.getUserAuth.mockReturnValue({ api: { getSession: vi.fn() }, handler: vi.fn() });
+
+    const response = await callRoute("GET", "/api/auth/sign-in/social");
+
+    expect(response.status).toBe(404);
+    expect(mocks.getUserAuth).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/routes/browser-auth.ts
+++ b/packages/control-plane/src/routes/browser-auth.ts
@@ -1,12 +1,15 @@
 import { BROWSER_AUTH_PROXY_ROUTES } from "@open-inspect/shared/browser-auth-routes";
+import { Hono } from "hono";
 import { type BetterAuthRuntime, UserAuthConfigurationError } from "../auth/user/runtime";
 import { createLogger } from "../logger";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { Env } from "../types";
 import {
-  defineRoutes,
   error,
   NO_AUTHORIZATION,
+  type RequestContext,
   SCM_AGNOSTIC_WEB_SERVICE_ROUTE,
-  type Route,
 } from "./shared";
 
 const logger = createLogger("browser-auth");
@@ -49,7 +52,12 @@ export async function forwardBrowserAuthRequest(
   return auth.handler(request);
 }
 
-const handleBrowserAuth: Route["handler"] = async (request, _env, _match, ctx) => {
+async function handleBrowserAuth(
+  request: Request,
+  _env: Env,
+  _params: Record<string, never>,
+  ctx: RequestContext
+): Promise<Response> {
   try {
     if (!ctx.getUserAuth) {
       throw new UserAuthConfigurationError("User authentication runtime is unavailable");
@@ -76,18 +84,16 @@ const handleBrowserAuth: Route["handler"] = async (request, _env, _match, ctx) =
     }
     throw cause;
   }
-};
+}
 
 /**
  * The browser can reach only this positive Better Auth allowlist, and only
  * through a freshly signed service:web proxy request.
  */
-export const browserAuthRoutes: Route[] = defineRoutes(
-  SCM_AGNOSTIC_WEB_SERVICE_ROUTE,
-  BROWSER_AUTH_PROXY_ROUTES.map(([method, path]) => ({
-    method,
-    path: path,
-    authorization: NO_AUTHORIZATION,
-    handler: handleBrowserAuth,
-  }))
-);
+export const browserAuthRoutes = new Hono<ControlPlaneHonoEnv>();
+
+const BROWSER_AUTH = admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION });
+
+for (const [method, path] of BROWSER_AUTH_PROXY_ROUTES) {
+  browserAuthRoutes.on(method, path, BROWSER_AUTH, (c) => dispatch(c, handleBrowserAuth));
+}

--- a/packages/control-plane/src/routes/catalog.ts
+++ b/packages/control-plane/src/routes/catalog.ts
@@ -38,7 +38,7 @@ import { skillRoutes } from "./skills";
 export const catalog: RouteCatalogEntry[] = [
   healthRoutes,
 
-  ...browserAuthRoutes,
+  browserAuthRoutes,
   signInProviderRoutes,
 
   // Session management, then the agent-initiated Slack notification


### PR DESCRIPTION
Rebased onto `main` after #1724 merged; the diff is this PR alone.

PR 7 of the Hono follow-up series (plan: `docs/internal/2026-09-02-control-plane-hono-follow-ups.md` in prod).

## What changed

- `src/routes/browser-auth.ts` is a Hono sub-app. The six routes in `BROWSER_AUTH_PROXY_ROUTES` register in the allowlist's order, each behind `admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION })`, and reach `handleBrowserAuth` through `dispatch()`. The handler body is unchanged: it still owns Better Auth's status codes and headers.
- `routes/catalog.ts` mounts the module where the spread was (after health, before sign-in providers), so precedence is unchanged.
- `src/routes/browser-auth.test.ts` dispatches through the production sub-app: one row per allowlisted route asserting which Better Auth entry point served it (direct `getSession` for the session read, the HTTP handler otherwise), the status and cookie passthrough with `no-store` / `no-referrer`, the 503 when the runtime is not configured, the 401 for a non-web caller, and the 404 for a method outside the allowlist.

Routes converted: 6 (running total 60 of 171).

## Verification

| Check | Result |
|---|---|
| Unit | 234 files, 3,505 passed |
| Integration (workerd, real D1) | 96 files, 1,129 passed |
| Matrix and conformance snapshots | both integration snapshots byte-identical |
| Typecheck, ESLint, Prettier | clean |

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser authentication request handling across supported routes.
  * Preserved upstream response statuses and headers when proxying authentication requests.
  * Added clear responses for unconfigured authentication, unauthorized callers, and unsupported paths.
* **Tests**
  * Expanded coverage for browser authentication routing, authorization, proxying, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->