### PR TITLE
refactor: convert the repository family to Hono sub-apps

### DIFF
--- a/packages/control-plane/src/routes/catalog.ts
+++ b/packages/control-plane/src/routes/catalog.ts
@@ -46,17 +46,17 @@ export const catalog: RouteCatalogEntry[] = [
   slackNotifyRoutes,
 
   // Repository management
-  ...reposRoutes,
+  reposRoutes,
 
   // Secrets
-  ...secretsRoutes,
+  secretsRoutes,
 
   // Environments (Phase-2 session target; internal-HMAC only, web BFF proxied)
-  ...environmentRoutes,
-  ...environmentSecretsRoutes,
+  environmentRoutes,
+  environmentSecretsRoutes,
 
   // Image builds (scope-generic)
-  ...imageBuildRoutes,
+  imageBuildRoutes,
 
   // Model preferences
   modelPreferencesRoutes,

--- a/packages/control-plane/src/routes/environment-secrets.test.ts
+++ b/packages/control-plane/src/routes/environment-secrets.test.ts
@@ -1,19 +1,36 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as AuthenticateModule from "../auth/authenticate";
 import { generateEncryptionKey } from "../auth/crypto";
+import type { SqlDatabase } from "../db/sql-database";
 import { environmentSecretsRoutes } from "./environment-secrets";
-import type { RequestContext, Route } from "./shared";
-import { routePathPattern, TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
+import {
+  createTestRequestHandler,
+  ownerAuthorizationDatabase,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "../router.test-support";
+import type { Env } from "../types";
 
-function findRoute(method: string, path: string): { route: Route; match: RegExpMatchArray } {
-  const route = environmentSecretsRoutes.find(
-    (candidate) => candidate.method === method && path.match(routePathPattern(candidate.path))
-  );
-  if (!route) throw new Error(`Missing ${method} ${path} route`);
-  return { route, match: path.match(routePathPattern(route.path))! };
+const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
+
+const handleRequest = createTestRequestHandler([environmentSecretsRoutes]);
+
+/** Admission's role lookup is answered for the owner; every other statement reaches the test's database. */
+function withOwnerAuthorization(delegate: SqlDatabase): SqlDatabase {
+  const authorization = ownerAuthorizationDatabase();
+  return {
+    prepare: (sql) => (sql.includes("FROM users u") ? authorization : delegate).prepare(sql),
+    batch: (statements) => delegate.batch(statements),
+  };
 }
 
-function createContext() {
-  const batch = vi.fn(async () => undefined);
+function createEnv(encryptionKey: string) {
+  const batch = vi.fn(async () => []);
   const run = vi.fn(async () => ({ meta: { changes: 0 } }));
   const all = vi.fn(async () => ({ results: [] }));
   const first = vi.fn(async () => ({
@@ -26,35 +43,42 @@ function createContext() {
     updated_at: 1,
   }));
   const bind = vi.fn(() => ({ first, all, run }));
+  const db = { batch, prepare: vi.fn(() => ({ bind })) } as unknown as SqlDatabase;
   return {
-    ctx: {
-      request_id: "request-1",
-      trace_id: "trace-1",
-      executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
-      db: {
-        batch,
-        prepare: vi.fn(() => ({ bind })),
-      },
-    } as unknown as RequestContext,
+    env: {
+      ...TEST_SERVICE_SECRETS,
+      SCM_PROVIDER: "github",
+      REPO_SECRETS_ENCRYPTION_KEY: encryptionKey,
+      DB: withOwnerAuthorization(db),
+    } as unknown as Env,
     batch,
   };
 }
 
-describe("environment secrets routes", () => {
-  it("rejects malformed secret values before persistence", async () => {
-    const { route, match } = findRoute("PUT", "/environments/env-1/secrets");
-    const { ctx, batch } = createContext();
+function putSecrets(env: Env, body: string): Promise<Response> {
+  return handleRequest(
+    new Request("https://test.local/environments/env-1/secrets", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }),
+    env,
+    TEST_BACKGROUND_TASK_CONTEXT
+  );
+}
 
-    const response = await route.handler(
-      new Request("https://test.local/environments/env-1/secrets", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ secrets: { API_KEY: 123 } }),
-      }),
-      { REPO_SECRETS_ENCRYPTION_KEY: "test-key" } as never,
-      match,
-      ctx
-    );
+describe("environment secrets routes", () => {
+  beforeEach(() => {
+    mocks.authenticate.mockImplementation(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    }));
+  });
+
+  it("rejects malformed secret values before persistence", async () => {
+    const { env, batch } = createEnv("test-key");
+
+    const response = await putSecrets(env, JSON.stringify({ secrets: { API_KEY: 123 } }));
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
@@ -64,19 +88,9 @@ describe("environment secrets routes", () => {
   });
 
   it("rejects array-shaped secrets before persistence", async () => {
-    const { route, match } = findRoute("PUT", "/environments/env-1/secrets");
-    const { ctx, batch } = createContext();
+    const { env, batch } = createEnv("test-key");
 
-    const response = await route.handler(
-      new Request("https://test.local/environments/env-1/secrets", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ secrets: [] }),
-      }),
-      { REPO_SECRETS_ENCRYPTION_KEY: "test-key" } as never,
-      match,
-      ctx
-    );
+    const response = await putSecrets(env, JSON.stringify({ secrets: [] }));
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
@@ -86,19 +100,9 @@ describe("environment secrets routes", () => {
   });
 
   it("preserves an own __proto__ secret key for canonical normalization", async () => {
-    const { route, match } = findRoute("PUT", "/environments/env-1/secrets");
-    const { ctx, batch } = createContext();
+    const { env, batch } = createEnv(generateEncryptionKey());
 
-    const response = await route.handler(
-      new Request("https://test.local/environments/env-1/secrets", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: '{"secrets":{"__proto__":"value"}}',
-      }),
-      { REPO_SECRETS_ENCRYPTION_KEY: generateEncryptionKey() } as never,
-      match,
-      ctx
-    );
+    const response = await putSecrets(env, '{"secrets":{"__proto__":"value"}}');
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ keys: ["__PROTO__"], created: 1 });
@@ -106,19 +110,9 @@ describe("environment secrets routes", () => {
   });
 
   it("accepts valid secret records", async () => {
-    const { route, match } = findRoute("PUT", "/environments/env-1/secrets");
-    const { ctx, batch } = createContext();
+    const { env, batch } = createEnv(generateEncryptionKey());
 
-    const response = await route.handler(
-      new Request("https://test.local/environments/env-1/secrets", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ secrets: { API_KEY: "secret" } }),
-      }),
-      { REPO_SECRETS_ENCRYPTION_KEY: generateEncryptionKey() } as never,
-      match,
-      ctx
-    );
+    const response = await putSecrets(env, JSON.stringify({ secrets: { API_KEY: "secret" } }));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -4,6 +4,9 @@
  * Split from ./environments so each routes file stays focused.
  */
 
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import { EnvironmentStore, type EnvironmentRow } from "../db/environments";
 import { EnvironmentSecretsStore } from "../db/environment-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
@@ -14,10 +17,8 @@ import {
 } from "../image-builds/save-hooks";
 import { createLogger } from "../logger";
 import {
-  type Route,
   type RequestContext,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   json,
   error,
   parseJsonBody,
@@ -78,13 +79,13 @@ function requireSecretsConfig(env: Env): { key: string } | Response {
 async function handleListEnvironmentSecrets(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
   const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -118,13 +119,13 @@ async function handleListEnvironmentSecrets(
 async function handleSetEnvironmentSecrets(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
   const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -175,14 +176,14 @@ async function handleSetEnvironmentSecrets(
 async function handleDeleteEnvironmentSecret(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string; key: string },
   ctx: RequestContext
 ): Promise<Response> {
   const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
-  const id = match.groups?.id;
-  const key = match.groups?.key;
+  const id = params.id;
+  const key = params.key;
   if (!id || !key) return error("Environment ID and key are required", 400);
 
   const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
@@ -226,13 +227,13 @@ async function handleDeleteEnvironmentSecret(
 async function handleImportEnvironmentSecrets(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
   const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -300,29 +301,22 @@ async function handleImportEnvironmentSecrets(
   }
 }
 
-export const environmentSecretsRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/environments/:id/secrets",
-    authorization: requirePermission("environments.secrets.manage"),
-    handler: handleListEnvironmentSecrets,
-  },
-  {
-    method: "PUT",
-    path: "/environments/:id/secrets",
-    authorization: requirePermission("environments.secrets.manage"),
-    handler: handleSetEnvironmentSecrets,
-  },
-  {
-    method: "POST",
-    path: "/environments/:id/secrets/import",
-    authorization: requirePermission("environments.secrets.manage"),
-    handler: handleImportEnvironmentSecrets,
-  },
-  {
-    method: "DELETE",
-    path: "/environments/:id/secrets/:key",
-    authorization: requirePermission("environments.secrets.manage"),
-    handler: handleDeleteEnvironmentSecret,
-  },
-]);
+const ENVIRONMENT_SECRETS_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("environments.secrets.manage"),
+});
+
+export const environmentSecretsRoutes = new Hono<ControlPlaneHonoEnv>();
+
+environmentSecretsRoutes.get("/environments/:id/secrets", ENVIRONMENT_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleListEnvironmentSecrets)
+);
+environmentSecretsRoutes.put("/environments/:id/secrets", ENVIRONMENT_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleSetEnvironmentSecrets)
+);
+environmentSecretsRoutes.post("/environments/:id/secrets/import", ENVIRONMENT_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleImportEnvironmentSecrets)
+);
+environmentSecretsRoutes.delete("/environments/:id/secrets/:key", ENVIRONMENT_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleDeleteEnvironmentSecret)
+);

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -6,6 +6,9 @@
  * live in ./environment-secrets.
  */
 
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   createEnvironmentInputSchema,
   updateEnvironmentInputSchema,
@@ -22,9 +25,7 @@ import { scheduleImageBuildOnSave } from "../image-builds/save-hooks";
 import { createLogger } from "../logger";
 import { resolveSessionRepositories } from "../repos/resolve";
 import {
-  type Route,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   type RequestContext,
   json,
   error,
@@ -82,7 +83,6 @@ export async function resolveEnvironmentRepositories(
 async function handleListEnvironments(
   _request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const store = new EnvironmentStore(ctx.db);
@@ -100,7 +100,6 @@ async function handleListEnvironments(
 async function handleCreateEnvironment(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await parseJsonBody<unknown>(request);
@@ -153,10 +152,10 @@ async function handleCreateEnvironment(
 async function handleGetEnvironment(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -169,10 +168,10 @@ async function handleGetEnvironment(
 async function handleUpdateEnvironment(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -230,10 +229,10 @@ async function handleUpdateEnvironment(
 async function handleDeleteEnvironment(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
+  const id = params.id;
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
@@ -250,39 +249,39 @@ async function handleDeleteEnvironment(
   return json({ status: "deleted", id });
 }
 
-export const environmentRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/environments",
+const ENVIRONMENTS_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("environments.manage"),
+});
+
+export const environmentRoutes = new Hono<ControlPlaneHonoEnv>();
+
+environmentRoutes.get(
+  "/environments",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("environments.read", {
       actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
     }),
-    handler: handleListEnvironments,
-  },
-  {
-    method: "POST",
-    path: "/environments",
-    authorization: requirePermission("environments.manage"),
-    handler: handleCreateEnvironment,
-  },
-  {
-    method: "GET",
-    path: "/environments/:id",
+  }),
+  (c) => handleListEnvironments(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+environmentRoutes.post("/environments", ENVIRONMENTS_MANAGE, (c) =>
+  handleCreateEnvironment(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+environmentRoutes.get(
+  "/environments/:id",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("environments.read", {
       actorlessGrants: [{ service: "github-bot" }],
     }),
-    handler: handleGetEnvironment,
-  },
-  {
-    method: "PUT",
-    path: "/environments/:id",
-    authorization: requirePermission("environments.manage"),
-    handler: handleUpdateEnvironment,
-  },
-  {
-    method: "DELETE",
-    path: "/environments/:id",
-    authorization: requirePermission("environments.manage"),
-    handler: handleDeleteEnvironment,
-  },
-]);
+  }),
+  (c) => dispatch(c, handleGetEnvironment)
+);
+environmentRoutes.put("/environments/:id", ENVIRONMENTS_MANAGE, (c) =>
+  dispatch(c, handleUpdateEnvironment)
+);
+environmentRoutes.delete("/environments/:id", ENVIRONMENTS_MANAGE, (c) =>
+  dispatch(c, handleDeleteEnvironment)
+);

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createRequestMetrics } from "../db/instrumented-d1";
+import type * as AuthenticateModule from "../auth/authenticate";
+import {
+  createTestBackgroundTasks,
+  type TestBackgroundTasks,
+} from "../background-tasks.test-support";
 import { ImageBuildStore } from "../db/image-builds";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import { imageBuildRoutes } from "./image-builds";
 import type { Env } from "../types";
-import type { RequestContext, Route } from "./shared";
-import type { SqlDatabase } from "../db/sql-database";
 import type { RepositoryAccessResult } from "../source-control";
 import type * as SourceControlModule from "../source-control";
 import type * as SandboxClientModule from "../sandbox/client";
@@ -14,7 +16,11 @@ import type * as VercelClientModule from "../sandbox/providers/vercel/client";
 import type * as OpenComputerProviderModule from "../sandbox/providers/opencomputer-provider";
 import type * as OpenComputerClientModule from "../sandbox/opencomputer-rest-client";
 import type * as IntegrationSettingsResolutionModule from "../session/integration-settings-resolution";
-import { routePathPattern } from "../router.test-support";
+import {
+  createTestRequestHandler,
+  ownerAuthorizationDatabase,
+  TEST_BACKGROUND_TASK_CONTEXT,
+} from "../router.test-support";
 
 // The repo trigger resolves the repo's actual default branch (never assumes
 // "main") and threads it into the build's repository set + fingerprint + the
@@ -23,6 +29,13 @@ import { routePathPattern } from "../router.test-support";
 // backend, and that a repo which can't be resolved fails instead of building
 // "main". The toggle tests pin the save-hook parity change: toggling a repo's
 // prebuild on triggers a build immediately instead of waiting for the cron.
+
+const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
 
 const scmProvider = vi.hoisted(() => ({
   checkRepositoryAccess: vi.fn(),
@@ -110,46 +123,11 @@ vi.mock("../session/integration-settings-resolution", async (importOriginal) => 
 const TRIGGER_PATH = "/image-builds/trigger/repo/acme/repo";
 const TOGGLE_PATH = "/image-builds/toggle/repo/acme/repo";
 
-function findRoute(method: string, path: string): Route {
-  // Match on method as well as pattern so a same-pattern route of another
-  // method (or a reordering) can never resolve to the wrong handler.
-  const route = imageBuildRoutes.find(
-    (candidate) => candidate.method === method && routePathPattern(candidate.path).test(path)
-  );
-  if (!route) throw new Error(`route not found: ${method} ${path}`);
-  return route;
-}
-
-function matchFor(route: Route, path: string): RegExpMatchArray {
-  const match = path.match(routePathPattern(route.path));
-  if (!match) throw new Error("path did not match route pattern");
-  return match;
-}
-
-function createContext(waitUntilTasks?: Promise<unknown>[]): RequestContext {
-  return {
-    request_id: "request-1",
-    trace_id: "trace-1",
-    db: {} as SqlDatabase,
-    metrics: createRequestMetrics(),
-    executionCtx: {
-      submit: (task: () => Promise<unknown>) => {
-        // Contract-faithful: run the factory even without a collector, and
-        // absorb synchronous throws like the production boundary does.
-        try {
-          const pending = task();
-          waitUntilTasks?.push(pending);
-        } catch {
-          // Absorbed like background_task.failed.
-        }
-      },
-    },
-  };
-}
+const handleRequest = createTestRequestHandler([imageBuildRoutes]);
 
 function createModalEnv(): Env {
   return {
-    DB: {} as unknown as D1Database,
+    DB: ownerAuthorizationDatabase(),
     SANDBOX_PROVIDER: "modal",
     WORKER_URL: "https://cp.test",
     MODAL_API_SECRET: "modal-secret",
@@ -162,7 +140,7 @@ function createModalEnv(): Env {
 
 function createVercelEnv(): Env {
   return {
-    DB: {} as unknown as D1Database,
+    DB: ownerAuthorizationDatabase(),
     SANDBOX_PROVIDER: "vercel",
     SCM_PROVIDER: "github",
     WORKER_URL: "https://cp.test",
@@ -175,7 +153,7 @@ function createVercelEnv(): Env {
 
 function createOpenComputerEnv(): Env {
   return {
-    DB: {} as unknown as D1Database,
+    DB: ownerAuthorizationDatabase(),
     SANDBOX_PROVIDER: "opencomputer",
     SCM_PROVIDER: "github",
     WORKER_URL: "https://cp.test",
@@ -188,30 +166,26 @@ function createOpenComputerEnv(): Env {
 }
 
 async function callTrigger(env: Env): Promise<Response> {
-  const route = findRoute("POST", TRIGGER_PATH);
-  return route.handler(
+  return handleRequest(
     new Request(`https://test.local${TRIGGER_PATH}`, { method: "POST" }),
     env,
-    matchFor(route, TRIGGER_PATH),
-    createContext()
+    TEST_BACKGROUND_TASK_CONTEXT
   );
 }
 
 async function callToggle(
   env: Env,
   body: unknown,
-  waitUntilTasks?: Promise<unknown>[]
+  backgroundTasks: TestBackgroundTasks = createTestBackgroundTasks()
 ): Promise<Response> {
-  const route = findRoute("PUT", TOGGLE_PATH);
-  return route.handler(
+  return handleRequest(
     new Request(`https://test.local${TOGGLE_PATH}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }),
     env,
-    matchFor(route, TOGGLE_PATH),
-    createContext(waitUntilTasks)
+    backgroundTasks
   );
 }
 
@@ -235,6 +209,10 @@ const setImageBuildEnabledSpy = vi.spyOn(RepoMetadataStore.prototype, "setImageB
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.authenticate.mockImplementation(async (request: Request) => ({
+    principal: { kind: "user", userId: "user-1" },
+    request,
+  }));
   registerBuildSpy.mockResolvedValue(true);
   getActiveBuildSpy.mockResolvedValue(null);
   hasReadyImageSpy.mockResolvedValue(false);
@@ -408,9 +386,9 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
 describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
   it("writes the flag and triggers a stale-checked build on toggle-on", async () => {
     scmProvider.checkRepositoryAccess.mockResolvedValue(RESOLVED_REPO);
-    const waitUntilTasks: Promise<unknown>[] = [];
+    const backgroundTasks = createTestBackgroundTasks();
 
-    const response = await callToggle(createModalEnv(), { enabled: true }, waitUntilTasks);
+    const response = await callToggle(createModalEnv(), { enabled: true }, backgroundTasks);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, enabled: true });
@@ -418,8 +396,8 @@ describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
 
     // Save-hook parity with environments: the detached triggerBuildIfStale
     // runs behind waitUntil.
-    expect(waitUntilTasks).toHaveLength(1);
-    await Promise.all(waitUntilTasks);
+    expect(backgroundTasks.submissions).toHaveLength(1);
+    await backgroundTasks.settle();
     expect(registerBuildSpy).toHaveBeenCalledWith(
       expect.objectContaining({ scope: { kind: "repo", id: "acme/repo" } })
     );
@@ -429,25 +407,25 @@ describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
   it("skips the build when a ready image already matches the repository set", async () => {
     scmProvider.checkRepositoryAccess.mockResolvedValue(RESOLVED_REPO);
     hasReadyImageSpy.mockResolvedValue(true);
-    const waitUntilTasks: Promise<unknown>[] = [];
+    const backgroundTasks = createTestBackgroundTasks();
 
-    const response = await callToggle(createModalEnv(), { enabled: true }, waitUntilTasks);
+    const response = await callToggle(createModalEnv(), { enabled: true }, backgroundTasks);
 
     expect(response.status).toBe(200);
-    await Promise.all(waitUntilTasks);
+    await backgroundTasks.settle();
     expect(registerBuildSpy).not.toHaveBeenCalled();
     expect(modalClient.createImageBuildSandbox).not.toHaveBeenCalled();
   });
 
   it("writes the flag without triggering on toggle-off", async () => {
-    const waitUntilTasks: Promise<unknown>[] = [];
+    const backgroundTasks = createTestBackgroundTasks();
 
-    const response = await callToggle(createModalEnv(), { enabled: false }, waitUntilTasks);
+    const response = await callToggle(createModalEnv(), { enabled: false }, backgroundTasks);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, enabled: false });
     expect(setImageBuildEnabledSpy).toHaveBeenCalledWith("acme", "repo", false);
-    expect(waitUntilTasks).toHaveLength(0);
+    expect(backgroundTasks.submissions).toHaveLength(0);
     expect(scmProvider.checkRepositoryAccess).not.toHaveBeenCalled();
   });
 
@@ -468,24 +446,24 @@ describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
 
   it("returns 404 without writing the flag when enabling an uninstalled repo", async () => {
     scmProvider.checkRepositoryAccess.mockResolvedValue(null);
-    const waitUntilTasks: Promise<unknown>[] = [];
+    const backgroundTasks = createTestBackgroundTasks();
 
-    const response = await callToggle(createModalEnv(), { enabled: true }, waitUntilTasks);
+    const response = await callToggle(createModalEnv(), { enabled: true }, backgroundTasks);
 
     expect(response.status).toBe(404);
     expect(setImageBuildEnabledSpy).not.toHaveBeenCalled();
-    expect(waitUntilTasks).toHaveLength(0);
+    expect(backgroundTasks.submissions).toHaveLength(0);
   });
 
   it("returns 500 without writing the flag when enabling and resolution fails", async () => {
     scmProvider.checkRepositoryAccess.mockRejectedValue(new Error("github unavailable"));
-    const waitUntilTasks: Promise<unknown>[] = [];
+    const backgroundTasks = createTestBackgroundTasks();
 
-    const response = await callToggle(createModalEnv(), { enabled: true }, waitUntilTasks);
+    const response = await callToggle(createModalEnv(), { enabled: true }, backgroundTasks);
 
     expect(response.status).toBe(500);
     expect(setImageBuildEnabledSpy).not.toHaveBeenCalled();
-    expect(waitUntilTasks).toHaveLength(0);
+    expect(backgroundTasks.submissions).toHaveLength(0);
   });
 
   it("disables without resolving so an unresolvable repo stays disableable", async () => {

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -8,6 +8,10 @@
  * - Enabled-scope and status queries
  */
 
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { repositoryParams } from "./repository-params";
 import {
   type ImageBuildStatusResponse,
   repositoryShaEntrySchema,
@@ -40,12 +44,9 @@ import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import {
   type RequestContext,
-  type Route,
-  defineRoute,
   GITHUB_USER_OR_SERVICE_ROUTE,
   SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE,
   error,
-  extractRepoParams,
   json,
   parseJsonBody,
   NO_AUTHORIZATION,
@@ -176,7 +177,6 @@ function parseCallbackBody<Schema extends z.ZodType>(
 async function handleBuildComplete(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await readCallbackBody(request);
@@ -212,7 +212,6 @@ async function handleBuildComplete(
 async function handleBuildFailed(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await readCallbackBody(request);
@@ -273,13 +272,13 @@ async function triggerBuildForScope(
 async function handleTriggerEnvironmentBuild(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const environmentId = match.groups?.id;
+  const environmentId = params.id;
   if (!environmentId) return error("Environment ID required", 400);
 
   return triggerBuildForScope(env, { kind: "environment", id: environmentId }, ctx);
@@ -292,16 +291,16 @@ async function handleTriggerEnvironmentBuild(
 async function handleTriggerRepoBuild(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
 
-  return triggerBuildForScope(env, repoImageBuildScope(params.owner, params.name), ctx);
+  return triggerBuildForScope(env, repoImageBuildScope(repository.owner, repository.name), ctx);
 }
 
 /**
@@ -314,15 +313,15 @@ async function handleTriggerRepoBuild(
 async function handleToggleRepoImageBuilds(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   const rawBody = await parseJsonBody<unknown>(request);
   if (rawBody instanceof Response) return rawBody;
@@ -406,12 +405,7 @@ async function readStatusRows(
  * `ImageBuildRecordView`, so no storage encoding, callback token, or provider
  * id reaches a client.
  */
-async function handleGetStatus(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleGetStatus(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
@@ -439,7 +433,6 @@ async function handleGetStatus(
 async function handleGetEnabledUnits(
   _request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
@@ -473,7 +466,6 @@ async function handleGetEnabledUnits(
 async function handleGetEnabledRepos(
   _request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
@@ -491,53 +483,47 @@ async function handleGetEnabledRepos(
   }
 }
 
-export const imageBuildRoutes: Route[] = [
-  defineRoute(SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, {
-    method: "POST",
-    path: "/image-builds/build-complete",
-    authorization: NO_AUTHORIZATION,
-    handler: handleBuildComplete,
-  }),
-  defineRoute(SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, {
-    method: "POST",
-    path: "/image-builds/build-failed",
-    authorization: NO_AUTHORIZATION,
-    handler: handleBuildFailed,
-  }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "POST",
-    path: "/image-builds/trigger/environment/:id",
+const BUILD_CALLBACK = admit({
+  ...SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE,
+  authorization: NO_AUTHORIZATION,
+});
+const REPO_IMAGES_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("repositories.images.manage"),
+});
+const IMAGE_BUILDS_READ = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("image_builds.read"),
+});
+
+export const imageBuildRoutes = new Hono<ControlPlaneHonoEnv>();
+
+imageBuildRoutes.post("/image-builds/build-complete", BUILD_CALLBACK, (c) =>
+  handleBuildComplete(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+imageBuildRoutes.post("/image-builds/build-failed", BUILD_CALLBACK, (c) =>
+  handleBuildFailed(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+imageBuildRoutes.post(
+  "/image-builds/trigger/environment/:id",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("environments.images.manage"),
-    handler: handleTriggerEnvironmentBuild,
   }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "POST",
-    path: "/image-builds/trigger/repo/:owner/:name",
-    authorization: requirePermission("repositories.images.manage"),
-    handler: handleTriggerRepoBuild,
-  }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "PUT",
-    path: "/image-builds/toggle/repo/:owner/:name",
-    authorization: requirePermission("repositories.images.manage"),
-    handler: handleToggleRepoImageBuilds,
-  }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "GET",
-    path: "/image-builds/status",
-    authorization: requirePermission("image_builds.read"),
-    handler: handleGetStatus,
-  }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "GET",
-    path: "/image-builds/enabled",
-    authorization: requirePermission("image_builds.read"),
-    handler: handleGetEnabledUnits,
-  }),
-  defineRoute(GITHUB_USER_OR_SERVICE_ROUTE, {
-    method: "GET",
-    path: "/image-builds/enabled-repos",
-    authorization: requirePermission("image_builds.read"),
-    handler: handleGetEnabledRepos,
-  }),
-];
+  (c) => dispatch(c, handleTriggerEnvironmentBuild)
+);
+imageBuildRoutes.post("/image-builds/trigger/repo/:owner/:name", REPO_IMAGES_MANAGE, (c) =>
+  dispatch(c, handleTriggerRepoBuild)
+);
+imageBuildRoutes.put("/image-builds/toggle/repo/:owner/:name", REPO_IMAGES_MANAGE, (c) =>
+  dispatch(c, handleToggleRepoImageBuilds)
+);
+imageBuildRoutes.get("/image-builds/status", IMAGE_BUILDS_READ, (c) =>
+  handleGetStatus(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+imageBuildRoutes.get("/image-builds/enabled", IMAGE_BUILDS_READ, (c) =>
+  handleGetEnabledUnits(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+imageBuildRoutes.get("/image-builds/enabled-repos", IMAGE_BUILDS_READ, (c) =>
+  handleGetEnabledRepos(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as AuthenticateModule from "../auth/authenticate";
 import { createTestBackgroundTasks } from "../background-tasks.test-support";
-import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import { reposRoutes } from "./repos";
 import type * as SharedRoutes from "./shared";
-import type { RequestContext } from "./shared";
-import { matchRoute, TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
+import {
+  createTestRequestHandler,
+  ownerAuthorizationDatabase,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "../router.test-support";
 
 const {
   mockCacheDelete,
@@ -30,6 +34,13 @@ const {
   mockUpsert: vi.fn(),
 }));
 
+const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
+
 vi.mock("../db/repo-metadata", () => ({
   RepoMetadataStore: vi.fn().mockImplementation(function () {
     return { upsert: mockUpsert, getBatch: mockGetBatch };
@@ -48,22 +59,6 @@ vi.mock("../logger", () => ({
   createLogger: vi.fn(() => mockLogger),
 }));
 
-function createContext(): RequestContext {
-  return {
-    trace_id: "trace-1",
-    request_id: "request-1",
-    principal: { kind: "user", userId: "user-1" },
-    db: {} as SqlDatabase,
-    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
-    metrics: {
-      d1Queries: [],
-      spans: {},
-      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
-      summarize: () => ({}),
-    },
-  };
-}
-
 vi.mock("./shared", async () => {
   const actual = await vi.importActual<typeof SharedRoutes>("./shared");
   return {
@@ -74,21 +69,40 @@ vi.mock("./shared", async () => {
   };
 });
 
-function getListHandler() {
-  const matched = matchRoute(reposRoutes, "GET", "/repos");
-  if (!matched) throw new Error("No repository list route found");
-  return { handler: matched.route.handler, match: matched.match };
+const handleRequest = createTestRequestHandler([reposRoutes]);
+
+function createEnv(): Env {
+  return {
+    ...TEST_SERVICE_SECRETS,
+    SCM_PROVIDER: "github",
+    DB: ownerAuthorizationDatabase(),
+    REPOS_CACHE: {} as KVNamespace,
+  } as unknown as Env;
 }
 
-function getUpdateHandler(path: string) {
-  const matched = matchRoute(reposRoutes, "PUT", path);
-  if (!matched) throw new Error(`Update route did not match ${path}`);
-  return { handler: matched.route.handler, match: matched.match };
+/** Requests carry the trace id the handlers log under. */
+function request(path: string, init?: RequestInit): Request {
+  return new Request(`https://test.local${path}`, {
+    ...init,
+    headers: { "x-trace-id": "trace-1", ...(init?.headers ?? {}) },
+  });
+}
+
+function updateMetadata(path: string, body: string): Promise<Response> {
+  return handleRequest(
+    request(path, { method: "PUT", body }),
+    createEnv(),
+    TEST_BACKGROUND_TASK_CONTEXT
+  );
 }
 
 describe("repository list route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.authenticate.mockImplementation(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    }));
     mockCacheGet.mockResolvedValue(null);
     mockCachePut.mockResolvedValue(undefined);
     mockGetBatch.mockResolvedValue(new Map());
@@ -112,18 +126,8 @@ describe("repository list route", () => {
     // refresh is registered with waitUntil, the KV write never lands and every
     // later request repeats the same slow path against an empty cache.
     const backgroundTasks = createTestBackgroundTasks();
-    const { handler, match } = getListHandler();
-    const ctx = createContext();
 
-    const response = await handler(
-      new Request("https://test.local/repos"),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      {
-        ...ctx,
-        executionCtx: backgroundTasks,
-      }
-    );
+    const response = await handleRequest(request("/repos"), createEnv(), backgroundTasks);
 
     expect(response.status).toBe(200);
     expect(mockCachePut).toHaveBeenCalledTimes(1);
@@ -136,6 +140,10 @@ describe("repository list route", () => {
 describe("repository metadata routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.authenticate.mockImplementation(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    }));
     mockUpsert.mockResolvedValue(undefined);
     mockCacheDelete.mockResolvedValue(undefined);
   });
@@ -150,17 +158,9 @@ describe("repository metadata routes", () => {
     );
     const cacheError = new Error("KV unavailable");
     mockCacheDelete.mockRejectedValue(cacheError);
-    const path = "/repos/Acme/Widget/metadata";
-    const { handler, match } = getUpdateHandler(path);
-
-    const responsePromise = handler(
-      new Request(`https://test.local${path}`, {
-        method: "PUT",
-        body: JSON.stringify({ description: "Updated description" }),
-      }),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      createContext()
+    const responsePromise = updateMetadata(
+      "/repos/Acme/Widget/metadata",
+      JSON.stringify({ description: "Updated description" })
     );
 
     await vi.waitFor(() => expect(mockUpsert).toHaveBeenCalledOnce());
@@ -190,17 +190,9 @@ describe("repository metadata routes", () => {
   it("returns an error and skips cache invalidation when the metadata update fails", async () => {
     const updateError = new Error("D1 unavailable");
     mockUpsert.mockRejectedValue(updateError);
-    const path = "/repos/acme/widget/metadata";
-    const { handler, match } = getUpdateHandler(path);
-
-    const response = await handler(
-      new Request(`https://test.local${path}`, {
-        method: "PUT",
-        body: JSON.stringify({ description: "Updated description" }),
-      }),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      createContext()
+    const response = await updateMetadata(
+      "/repos/acme/widget/metadata",
+      JSON.stringify({ description: "Updated description" })
     );
 
     expect(response.status).toBe(500);
@@ -213,17 +205,9 @@ describe("repository metadata routes", () => {
   });
 
   it("rejects malformed metadata before persistence", async () => {
-    const path = "/repos/acme/widget/metadata";
-    const { handler, match } = getUpdateHandler(path);
-
-    const response = await handler(
-      new Request(`https://test.local${path}`, {
-        method: "PUT",
-        body: JSON.stringify({ aliases: ["api", 42] }),
-      }),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      createContext()
+    const response = await updateMetadata(
+      "/repos/acme/widget/metadata",
+      JSON.stringify({ aliases: ["api", 42] })
     );
 
     expect(response.status).toBe(400);
@@ -233,15 +217,7 @@ describe("repository metadata routes", () => {
   });
 
   it("rejects malformed JSON with the same 400 as an invalid object", async () => {
-    const path = "/repos/acme/widget/metadata";
-    const { handler, match } = getUpdateHandler(path);
-
-    const response = await handler(
-      new Request(`https://test.local${path}`, { method: "PUT", body: "{" }),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      createContext()
-    );
+    const response = await updateMetadata("/repos/acme/widget/metadata", "{");
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Invalid repository metadata" });
@@ -250,21 +226,13 @@ describe("repository metadata routes", () => {
   });
 
   it("persists only schema fields and drops unknown keys", async () => {
-    const path = "/repos/acme/widget/metadata";
-    const { handler, match } = getUpdateHandler(path);
-
-    const response = await handler(
-      new Request(`https://test.local${path}`, {
-        method: "PUT",
-        body: JSON.stringify({
-          description: "Updated description",
-          keywords: ["billing"],
-          notAField: "dropped",
-        }),
-      }),
-      { REPOS_CACHE: {} as KVNamespace } as Env,
-      match,
-      createContext()
+    const response = await updateMetadata(
+      "/repos/acme/widget/metadata",
+      JSON.stringify({
+        description: "Updated description",
+        keywords: ["billing"],
+        notAField: "dropped",
+      })
     );
 
     expect(response.status).toBe(200);

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -2,6 +2,10 @@
  * Repository listing and metadata routes and handlers.
  */
 
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { repositoryParams } from "./repository-params";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
@@ -15,13 +19,10 @@ import {
 import { SourceControlProviderError } from "../source-control";
 import { createLogger } from "../logger";
 import {
-  type Route,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   type RequestContext,
   json,
   error,
-  extractRepoParams,
   createRouteSourceControlProvider,
   requirePermission,
 } from "./shared";
@@ -137,12 +138,7 @@ async function refreshReposCache(
  * This prevents slow API pagination from blocking the Worker
  * isolate and causing head-of-line blocking for other requests.
  */
-async function handleListRepos(
-  request: Request,
-  env: Env,
-  _match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
+async function handleListRepos(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
   const cacheStore = createKvCacheStore(env.REPOS_CACHE);
 
   // Read from KV cache
@@ -215,12 +211,12 @@ async function handleListRepos(
 async function handleUpdateRepoMetadata(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   // Parse and validate at the trust boundary: malformed JSON and structurally
   // invalid metadata both take the same 400 path, before any persistence.
@@ -272,12 +268,12 @@ async function handleUpdateRepoMetadata(
 async function handleGetRepoMetadata(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   const normalizedRepo = `${owner.toLowerCase()}/${name.toLowerCase()}`;
   const metadataStore = new RepoMetadataStore(ctx.db);
@@ -301,12 +297,12 @@ async function handleGetRepoMetadata(
 async function handleListBranches(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   _ctx: RequestContext
 ): Promise<Response> {
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   try {
     const provider = createRouteSourceControlProvider(env);
@@ -325,33 +321,41 @@ async function handleListBranches(
   }
 }
 
-export const reposRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/repos",
+const REPOSITORIES_READ = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("repositories.read"),
+});
+
+export const reposRoutes = new Hono<ControlPlaneHonoEnv>();
+
+reposRoutes.get(
+  "/repos",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("repositories.read", {
       actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
     }),
-    handler: handleListRepos,
-  },
-  {
-    method: "PUT",
-    path: "/repos/:owner/:name/metadata",
+  }),
+  (c) => handleListRepos(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+reposRoutes.put(
+  "/repos/:owner/:name/metadata",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("repositories.settings.manage"),
-    handler: handleUpdateRepoMetadata,
-  },
-  {
-    method: "GET",
-    path: "/repos/:owner/:name/metadata",
+  }),
+  (c) => dispatch(c, handleUpdateRepoMetadata)
+);
+reposRoutes.get(
+  "/repos/:owner/:name/metadata",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("repositories.read", {
       actorlessGrants: [{ service: "github-bot" }],
     }),
-    handler: handleGetRepoMetadata,
-  },
-  {
-    method: "GET",
-    path: "/repos/:owner/:name/branches",
-    authorization: requirePermission("repositories.read"),
-    handler: handleListBranches,
-  },
-]);
+  }),
+  (c) => dispatch(c, handleGetRepoMetadata)
+);
+reposRoutes.get("/repos/:owner/:name/branches", REPOSITORIES_READ, (c) =>
+  dispatch(c, handleListBranches)
+);

--- a/packages/control-plane/src/routes/repository-params.ts
+++ b/packages/control-plane/src/routes/repository-params.ts
@@ -1,0 +1,23 @@
+import {
+  formatRepositoryFullName,
+  parseRepositoryFullName,
+} from "@open-inspect/shared/types/repositories";
+import { error } from "../http/responses";
+
+/**
+ * The repository a route's `:owner/:name` parameters name, or the 400 the
+ * route answers when they are not a valid pair. Hono decoded the segments
+ * once before admission; nothing here decodes them again.
+ */
+export function repositoryParams(params: {
+  owner: string;
+  name: string;
+}): { owner: string; name: string } | Response {
+  const repository = parseRepositoryFullName(
+    formatRepositoryFullName({ repoOwner: params.owner, repoName: params.name })
+  );
+  if (!repository || repository.repoOwner !== params.owner || repository.repoName !== params.name) {
+    return error("Owner and name must be valid repository path segments", 400);
+  }
+  return { owner: repository.repoOwner, name: repository.repoName };
+}

--- a/packages/control-plane/src/routes/repository-params.ts
+++ b/packages/control-plane/src/routes/repository-params.ts
@@ -1,22 +1,17 @@
-import {
-  formatRepositoryFullName,
-  parseRepositoryFullName,
-} from "@open-inspect/shared/types/repositories";
+import { validateRepositoryPathSegments } from "@open-inspect/shared/types/repositories";
 import { error } from "../http/responses";
 
 /**
  * The repository a route's `:owner/:name` parameters name, or the 400 the
- * route answers when they are not a valid pair. Hono decoded the segments
- * once before admission; nothing here decodes them again.
+ * route answers when they are not a canonical pair. Hono decoded the
+ * segments once before admission; the shared identity module owns the rule.
  */
 export function repositoryParams(params: {
   owner: string;
   name: string;
 }): { owner: string; name: string } | Response {
-  const repository = parseRepositoryFullName(
-    formatRepositoryFullName({ repoOwner: params.owner, repoName: params.name })
-  );
-  if (!repository || repository.repoOwner !== params.owner || repository.repoName !== params.name) {
+  const repository = validateRepositoryPathSegments(params.owner, params.name);
+  if (!repository) {
     return error("Owner and name must be valid repository path segments", 400);
   }
   return { owner: repository.repoOwner, name: repository.repoName };

--- a/packages/control-plane/src/routes/secrets.ts
+++ b/packages/control-plane/src/routes/secrets.ts
@@ -2,20 +2,21 @@
  * Repository and global secrets routes and handlers.
  */
 
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { repositoryParams } from "./repository-params";
 import { RepoSecretsStore } from "../db/repo-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { SecretsValidationError, normalizeKey, validateKey } from "../db/secrets-validation";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 import {
-  type Route,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   type RequestContext,
   json,
   error,
   parseJsonBody,
-  extractRepoParams,
   resolveRepoOrError,
   requirePermission,
 } from "./shared";
@@ -29,7 +30,7 @@ const logger = createLogger("router:secrets");
 async function handleSetRepoSecrets(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -39,9 +40,9 @@ async function handleSetRepoSecrets(
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
 
@@ -105,7 +106,7 @@ async function handleSetRepoSecrets(
 async function handleListRepoSecrets(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string },
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -115,9 +116,9 @@ async function handleListRepoSecrets(
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
 
@@ -170,7 +171,7 @@ async function handleListRepoSecrets(
 async function handleDeleteRepoSecret(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { owner: string; name: string; key: string },
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -180,11 +181,11 @@ async function handleDeleteRepoSecret(
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const params = extractRepoParams(match);
-  if (params instanceof Response) return params;
-  const { owner, name } = params;
+  const repository = repositoryParams(params);
+  if (repository instanceof Response) return repository;
+  const { owner, name } = repository;
 
-  const key = match.groups?.key;
+  const key = params.key;
   if (!key) {
     return error("Owner, name, and key are required");
   }
@@ -235,7 +236,6 @@ async function handleDeleteRepoSecret(
 async function handleSetGlobalSecrets(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -290,7 +290,6 @@ async function handleSetGlobalSecrets(
 async function handleListGlobalSecrets(
   _request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -326,7 +325,7 @@ async function handleListGlobalSecrets(
 async function handleDeleteGlobalSecret(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { key: string },
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -336,7 +335,7 @@ async function handleDeleteGlobalSecret(
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const key = match.groups?.key;
+  const key = params.key;
   if (!key) {
     return error("Key is required");
   }
@@ -376,41 +375,32 @@ async function handleDeleteGlobalSecret(
   }
 }
 
-export const secretsRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "PUT",
-    path: "/repos/:owner/:name/secrets",
-    authorization: requirePermission("repositories.secrets.manage"),
-    handler: handleSetRepoSecrets,
-  },
-  {
-    method: "GET",
-    path: "/repos/:owner/:name/secrets",
-    authorization: requirePermission("repositories.secrets.manage"),
-    handler: handleListRepoSecrets,
-  },
-  {
-    method: "DELETE",
-    path: "/repos/:owner/:name/secrets/:key",
-    authorization: requirePermission("repositories.secrets.manage"),
-    handler: handleDeleteRepoSecret,
-  },
-  {
-    method: "PUT",
-    path: "/secrets",
-    authorization: requirePermission("global_secrets.manage"),
-    handler: handleSetGlobalSecrets,
-  },
-  {
-    method: "GET",
-    path: "/secrets",
-    authorization: requirePermission("global_secrets.manage"),
-    handler: handleListGlobalSecrets,
-  },
-  {
-    method: "DELETE",
-    path: "/secrets/:key",
-    authorization: requirePermission("global_secrets.manage"),
-    handler: handleDeleteGlobalSecret,
-  },
-]);
+const REPO_SECRETS_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("repositories.secrets.manage"),
+});
+const GLOBAL_SECRETS_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("global_secrets.manage"),
+});
+
+export const secretsRoutes = new Hono<ControlPlaneHonoEnv>();
+
+secretsRoutes.put("/repos/:owner/:name/secrets", REPO_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleSetRepoSecrets)
+);
+secretsRoutes.get("/repos/:owner/:name/secrets", REPO_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleListRepoSecrets)
+);
+secretsRoutes.delete("/repos/:owner/:name/secrets/:key", REPO_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleDeleteRepoSecret)
+);
+secretsRoutes.put("/secrets", GLOBAL_SECRETS_MANAGE, (c) =>
+  handleSetGlobalSecrets(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+secretsRoutes.get("/secrets", GLOBAL_SECRETS_MANAGE, (c) =>
+  handleListGlobalSecrets(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+secretsRoutes.delete("/secrets/:key", GLOBAL_SECRETS_MANAGE, (c) =>
+  dispatch(c, handleDeleteGlobalSecret)
+);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -54,6 +54,7 @@ export {
   encodeRepositoryPathSegments,
   formatRepositoryFullName,
   parseRepositoryFullName,
+  validateRepositoryPathSegments,
   normalizeOptionalRepositoryPair,
 } from "./repositories";
 export type {

--- a/packages/shared/src/types/repositories.ts
+++ b/packages/shared/src/types/repositories.ts
@@ -186,19 +186,31 @@ export function parseRepositoryFullName(fullName: string): RepositoryPair | null
   return { repoOwner, repoName };
 }
 
+/**
+ * The repository named by two already-decoded path segments, or null when
+ * they are not a canonical pair: an owner may be a nested namespace, but a
+ * name may not contain a slash, and neither may be empty.
+ */
+export function validateRepositoryPathSegments(
+  repoOwner: string,
+  repoName: string
+): RepositoryPair | null {
+  const repository = parseRepositoryFullName(formatRepositoryFullName({ repoOwner, repoName }));
+  return repository?.repoOwner === repoOwner && repository.repoName === repoName
+    ? repository
+    : null;
+}
+
 /** Decode and validate the two path segments used by repository APIs. */
 export function decodeRepositoryPathSegments(
   encodedOwner: string,
   encodedName: string
 ): RepositoryPair | null {
   try {
-    const repoOwner = decodeURIComponent(encodedOwner);
-    const repoName = decodeURIComponent(encodedName);
-    const repository = parseRepositoryFullName(formatRepositoryFullName({ repoOwner, repoName }));
-
-    return repository?.repoOwner === repoOwner && repository.repoName === repoName
-      ? repository
-      : null;
+    return validateRepositoryPathSegments(
+      decodeURIComponent(encodedOwner),
+      decodeURIComponent(encodedName)
+    );
   } catch {
     return null;
   }

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -10,6 +10,7 @@ import {
   serverMessageSchema,
   sessionRepositoriesInputSchema,
   toRepositoryRef,
+  validateRepositoryPathSegments,
 } from "./index";
 import { sandboxEventSchema } from "./sandbox-events";
 import { createSessionRequestSchema } from "./session-api";
@@ -40,6 +41,28 @@ describe("repository full names", () => {
     ["group%ZZsubgroup", "web"],
   ])("rejects a non-canonical repository API path (%s/%s)", (owner, name) => {
     expect(decodeRepositoryPathSegments(owner, name)).toBeNull();
+  });
+
+  it("validates already-decoded segments with the same rules the decoder applies", () => {
+    expect(validateRepositoryPathSegments("group/subgroup", "web app")).toEqual({
+      repoOwner: "group/subgroup",
+      repoName: "web app",
+    });
+    // A once-decoded escape is data, not a separator.
+    expect(validateRepositoryPathSegments("acme", "web%2Fapp")).toEqual({
+      repoOwner: "acme",
+      repoName: "web%2Fapp",
+    });
+  });
+
+  it.each([
+    ["group", "web/api"],
+    ["group//subgroup", "web"],
+    ["", "web"],
+    ["group", ""],
+    ["/group", "web"],
+  ])("rejects a non-canonical decoded pair (%j/%j)", (owner, name) => {
+    expect(validateRepositoryPathSegments(owner, name)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Rebased onto `main` after #1724 merged; the diff is this PR alone.

PR 4 of the Hono follow-up series (plan: `docs/internal/2026-09-02-control-plane-hono-follow-ups.md` in prod). Converts the repository family to Hono sub-apps; 81 of 171 routes are now native.

## What changed

| Module | Routes |
|---|---|
| `repos` | 4 |
| `secrets` | 6 |
| `environments` | 5 |
| `environment-secrets` | 4 |
| `image-builds` | 8 |

- Each module is a `Hono` sub-app mounted at the catalog position its spread held, so precedence is unchanged.
- Handlers take the parameters Hono decoded, typed from the path literal, through the `dispatch(c, handler)` adapter from #1724. Parameterless handlers keep their three-argument form.
- Policies are byte-for-byte what `defineRoute(s)` declared; repeated ones are hoisted into `admit()` constants.

## Decode once (D-B)

The owner/name handlers stop decoding. `repositoryParams()` (new, `routes/repository-params.ts`) validates the pair Hono already decoded and answers the same `Owner and name must be valid repository path segments` 400 as before. No handler in this family calls `decodeURIComponent`; a segment that does not decode is refused by admission (#1724). The matrix's repo cases (`group%2Fsubgroup`, `web%2Fapp`, `web%252Fapp`) hold without edits.

`extractRepoParams` stays in `routes/shared.ts` for the modules PR 6 converts; PR 8 deletes it.

## Tests

`repos.test.ts`, `environment-secrets.test.ts`, and `image-builds.trigger.test.ts` now dispatch requests through the production sub-apps (`createTestRequestHandler([module])`, mocked `authenticate`, owner authorization database) instead of calling handlers with hand-built match arrays, so a route bound to the wrong handler fails a test. One fixture change: the environment-secrets `batch` mock returns `[]` (D1's shape) because the request path goes through the instrumented database, which reads the batch result.

## Verification

| Check | Result |
|---|---|
| Unit | 234 files, 3,495 passed |
| Integration (workerd, real D1) | 96 files, 1,129 passed |
| Matrix and conformance snapshots | byte-identical |
| Typecheck (`tsconfig.json` + `tsconfig.test.json`), ESLint, Prettier | clean |

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency and reliability across repository, secret, environment, and image-build request handling.
  - Preserved existing authentication, authorization, validation, and create, read, update, and delete behavior.
  - Improved route validation for repository-related requests, providing clearer handling of invalid repository paths.

- **Tests**
  - Updated automated coverage and test infrastructure to better reflect current request-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->