### PR TITLE
refactor: convert automations, autofix, and webhooks to Hono sub-apps

### DIFF
--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -73,6 +73,9 @@ export function contractFor(method: string, path: string): RouteContract | undef
   );
 }
 
+/** The user every authorization fixture answers for unless a test names another. */
+export const TEST_USER_ID = "user-1";
+
 /** How admission's authorization lookups are answered, and where every other statement goes. */
 export interface AuthorizationDatabaseOptions {
   userId?: string;
@@ -101,7 +104,7 @@ export function emptyStatement(): SqlStatement {
  * grants) are recognized here so no suite has to know their shape.
  */
 export function authorizationDatabase(options: AuthorizationDatabaseOptions = {}): SqlDatabase {
-  const { userId = "user-1", permissions, statement = emptyStatement, batch } = options;
+  const { userId = TEST_USER_ID, permissions, statement = emptyStatement, batch } = options;
   const role = permissions
     ? { role_id: "role-1", role_key: null, role_name: "Custom" }
     : { role_id: BUILT_IN_ROLE_REGISTRY.owner.id, role_key: "owner", role_name: "Owner" };
@@ -128,12 +131,15 @@ export function authorizationDatabase(options: AuthorizationDatabaseOptions = {}
       }
       return statement(sql);
     },
-    batch: batch ?? (async () => []),
+    batch:
+      batch ??
+      (async <T>(statements: SqlStatement[]) =>
+        statements.map(() => ({ results: [] as T[], meta: { changes: 0 } }))),
   };
 }
 
 /** An owner's database: every permission, data access mocked at the store. */
-export function ownerAuthorizationDatabase(userId = "user-1"): SqlDatabase {
+export function ownerAuthorizationDatabase(userId = TEST_USER_ID): SqlDatabase {
   return authorizationDatabase({ userId });
 }
 

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -10,7 +10,7 @@ import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/
 import type { BackgroundTasks } from "./platform-ports";
 import { createTestBackgroundTasks } from "./background-tasks.test-support";
 import { Hono } from "hono";
-import { BUILT_IN_ROLE_REGISTRY } from "@open-inspect/shared/rbac";
+import { BUILT_IN_ROLE_REGISTRY, type PermissionId } from "@open-inspect/shared/rbac";
 import type { SqlDatabase, SqlStatement } from "./db/sql-database";
 import { cloudflareHost, createControlPlaneApp, type RouteCatalogEntry } from "./routing/hono-app";
 import { listRouteContracts, type RouteContract } from "./routing/route-contracts";
@@ -73,33 +73,68 @@ export function contractFor(method: string, path: string): RouteContract | undef
   );
 }
 
+/** How admission's authorization lookups are answered, and where every other statement goes. */
+export interface AuthorizationDatabaseOptions {
+  userId?: string;
+  /** Grants of a custom role; omitted, the user is a workspace owner. */
+  permissions?: readonly PermissionId[];
+  /** Answers statements that are not admission's; omitted, they answer null and no rows. */
+  statement?: (sql: string) => SqlStatement;
+  batch?: SqlDatabase["batch"];
+}
+
+/** A statement that answers null and no rows, for data access mocked at the store. */
+export function emptyStatement(): SqlStatement {
+  const statement: SqlStatement = {
+    bind: () => statement,
+    first: async <T>() => null as T | null,
+    all: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+    run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+  };
+  return statement;
+}
+
 /**
- * A database whose effective-authorization lookup answers with an active
- * workspace owner, for request-level unit tests of admitted handlers whose
- * data access is mocked at the store.
+ * A database whose effective-authorization lookup answers for one active
+ * user, for request-level unit tests of admitted handlers. The two
+ * statements admission issues (the user's role, then a custom role's
+ * grants) are recognized here so no suite has to know their shape.
  */
-export function ownerAuthorizationDatabase(userId = "user-1"): SqlDatabase {
+export function authorizationDatabase(options: AuthorizationDatabaseOptions = {}): SqlDatabase {
+  const { userId = "user-1", permissions, statement = emptyStatement, batch } = options;
+  const role = permissions
+    ? { role_id: "role-1", role_key: null, role_name: "Custom" }
+    : { role_id: BUILT_IN_ROLE_REGISTRY.owner.id, role_key: "owner", role_name: "Owner" };
   return {
     prepare(sql: string) {
-      const statement: SqlStatement = {
-        bind: () => statement,
-        first: async <T>() =>
-          (sql.includes("FROM users u")
-            ? {
-                user_id: userId,
-                suspended_at: null,
-                role_id: BUILT_IN_ROLE_REGISTRY.owner.id,
-                role_key: "owner",
-                role_name: "Owner",
-              }
-            : null) as T | null,
-        all: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
-        run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
-      };
-      return statement;
+      if (sql.includes("FROM users u")) {
+        const lookup: SqlStatement = {
+          ...emptyStatement(),
+          bind: () => lookup,
+          first: async <T>() => ({ user_id: userId, suspended_at: null, ...role }) as T | null,
+        };
+        return lookup;
+      }
+      if (sql.includes("FROM role_permissions")) {
+        const grants: SqlStatement = {
+          ...emptyStatement(),
+          bind: () => grants,
+          all: async <T>() => ({
+            results: (permissions ?? []).map((permission_id) => ({ permission_id })) as T[],
+            meta: { changes: 0 },
+          }),
+        };
+        return grants;
+      }
+      return statement(sql);
     },
-    batch: async () => [],
+    batch: batch ?? (async () => []),
   };
+}
+
+/** An owner's database: every permission, data access mocked at the store. */
+export function ownerAuthorizationDatabase(userId = "user-1"): SqlDatabase {
+  return authorizationDatabase({ userId });
 }
 
 /** Compile a catalog path into the legacy raw-path matcher, for handler-level fixtures. */

--- a/packages/control-plane/src/routes/autofix.ts
+++ b/packages/control-plane/src/routes/autofix.ts
@@ -1,14 +1,16 @@
+import { Hono } from "hono";
 import { PrAutofixFeedbackStore } from "../db/pr-autofix-feedback-store";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
-  defineRoutes,
   error,
   json,
   NO_AUTHORIZATION,
   SCM_AGNOSTIC_WEB_SERVICE_ROUTE,
-  type Route,
+  type RequestContext,
 } from "./shared";
 
-const handleActivity: Route["handler"] = async (request, _env, _match, ctx) => {
+async function handleActivity(request: Request, ctx: RequestContext): Promise<Response> {
   const url = new URL(request.url);
   const rawLimit = url.searchParams.get("limit") ?? "50";
   const limit = Number(rawLimit);
@@ -29,13 +31,12 @@ const handleActivity: Route["handler"] = async (request, _env, _match, ctx) => {
     }
     throw caught;
   }
-};
+}
 
-export const autofixRoutes: Route[] = defineRoutes(SCM_AGNOSTIC_WEB_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/autofix/activity",
-    authorization: NO_AUTHORIZATION,
-    handler: handleActivity,
-  },
-]);
+export const autofixRoutes = new Hono<ControlPlaneHonoEnv>();
+
+autofixRoutes.get(
+  "/autofix/activity",
+  admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION }),
+  (c) => handleActivity(c.var.admitted.request, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -317,6 +317,9 @@ describe("automation route handlers", () => {
     vi.clearAllMocks();
     // Defaults every test can override; re-set here so per-test overrides
     // (mockClear keeps implementations) cannot leak across tests.
+    // Admission resolves the automation for every manage route, so the
+    // lookup must not depend on what an earlier test left behind.
+    mockStore.getById.mockResolvedValue(sampleRow);
     mockStore.getRepositoriesForAutomation.mockResolvedValue([]);
     mockStore.getRepositoriesForAutomationIds.mockResolvedValue(new Map());
     mockStore.getEnvironmentsForAutomation.mockResolvedValue([]);

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -1,23 +1,40 @@
 /**
- * Unit tests for automation CRUD route handlers.
+ * Unit tests for automation CRUD routes.
  *
  * Tests run in Node (not workerd) with mocked AutomationStore and source
- * control. Handler functions are extracted from the exported automationRoutes
- * array and invoked directly, bypassing the auth middleware.
+ * control. Requests dispatch through the production `automationRoutes`
+ * module, so admission (including the automation ownership requirement)
+ * runs; authentication is mocked to supply the principal.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as AuthenticateModule from "../auth/authenticate";
 import { automationRoutes } from "./automations";
-import { HttpError, resolveRepoOrError, type RequestContext } from "./shared";
+import { HttpError, resolveRepoOrError } from "./shared";
 import type { Principal } from "../auth/principal";
-import type { SqlDatabase } from "../db/sql-database";
+import type { SqlDatabase, SqlStatement } from "../db/sql-database";
 import type { Env } from "../types";
-import { routePathPattern, TEST_BACKGROUND_TASK_CONTEXT } from "../router.test-support";
+import {
+  createTestRequestHandler,
+  TEST_BACKGROUND_TASK_CONTEXT,
+  TEST_SERVICE_SECRETS,
+} from "../router.test-support";
 import {
   AutomationExecutionUnauthorizedError,
   AutomationTriggerBlockedError,
 } from "../scheduler/scheduler";
-import { PERMISSION_IDS, type PermissionId } from "@open-inspect/shared/rbac";
+import {
+  BUILT_IN_ROLE_REGISTRY,
+  PERMISSION_IDS,
+  type PermissionId,
+} from "@open-inspect/shared/rbac";
+
+const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
+
+vi.mock("../auth/authenticate", async (importOriginal) => ({
+  ...(await importOriginal<typeof AuthenticateModule>()),
+  authenticate: mocks.authenticate,
+}));
 
 const mockProviderAdapterGet = vi.hoisted(() => vi.fn());
 const mockResolveGitHubCredentialAuthority = vi.hoisted(() => vi.fn());
@@ -40,6 +57,7 @@ vi.mock("../session/identity", () => ({
 const mockStore = {
   list: vi.fn(),
   getById: vi.fn(),
+  resolveCanonicalOwner: vi.fn(async (automation: unknown) => automation),
   update: vi.fn(),
   softDelete: vi.fn(),
   pause: vi.fn(),
@@ -169,13 +187,55 @@ vi.mock("./shared", async (importOriginal) => {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function createEnv(): Env {
+/**
+ * The workspace database as admission and the handlers see it: admission's
+ * role lookups are answered here, every other statement goes to a statement
+ * spy, and `batch` is the shared spy.
+ */
+function createDatabase(permissions: readonly PermissionId[]): SqlDatabase {
+  const custom = permissions.length !== PERMISSION_IDS.length;
+  const role = custom
+    ? { role_id: "role-1", role_key: null, role_name: "Custom" }
+    : { role_id: BUILT_IN_ROLE_REGISTRY.owner.id, role_key: "owner", role_name: "Owner" };
+  const statement = {
+    bind: vi.fn(() => statement),
+    first: vi.fn(async () => ({ satisfied: 1 })),
+    all: vi.fn(async () => ({ results: [] })),
+  };
   return {
-    DB: { batch: mockBatch } as unknown as D1Database,
+    prepare(sql: string) {
+      if (sql.includes("FROM users u") || sql.includes("FROM role_permissions")) {
+        const admission: SqlStatement = {
+          bind: () => admission,
+          first: async <T>() =>
+            (sql.includes("FROM users u")
+              ? { user_id: "user-1", suspended_at: null, ...role }
+              : null) as T | null,
+          all: async <T>() => ({
+            results: (sql.includes("FROM role_permissions")
+              ? permissions.map((permission_id) => ({ permission_id }))
+              : []) as T[],
+            meta: { changes: 0 },
+          }),
+          run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+        };
+        return admission;
+      }
+      return statement as unknown as SqlStatement;
+    },
+    batch: mockBatch,
+  } as unknown as SqlDatabase;
+}
+
+function createEnv(permissions: readonly PermissionId[] = PERMISSION_IDS): Env {
+  return {
+    ...TEST_SERVICE_SECRETS,
+    SCM_PROVIDER: "github",
+    DB: createDatabase(permissions),
     SESSION: {} as DurableObjectNamespace,
     DEPLOYMENT_NAME: "test",
     TOKEN_ENCRYPTION_KEY: "test-key",
-  } as Env;
+  } as unknown as Env;
 }
 
 const USER_PRINCIPAL: Principal = {
@@ -194,39 +254,7 @@ const SLACK_BOT_PRINCIPAL: Principal = {
   },
 };
 
-function createCtx(
-  principal: Principal = USER_PRINCIPAL,
-  permissions: readonly PermissionId[] = PERMISSION_IDS
-): RequestContext {
-  const statement = {
-    bind: vi.fn(() => statement),
-    first: vi.fn(async () => ({ satisfied: 1 })),
-    all: vi.fn(async () => ({ results: [] })),
-  };
-  return {
-    trace_id: "trace-1",
-    request_id: "req-1",
-    principal,
-    ...(principal.kind === "user"
-      ? {
-          authorization: {
-            userId: principal.userId,
-            suspendedAt: null,
-            role: { id: "role_builtin_owner", key: "owner" as const, name: "Owner" },
-            permissions: [...permissions],
-          },
-        }
-      : {}),
-    db: { batch: mockBatch, prepare: vi.fn(() => statement) } as unknown as SqlDatabase,
-    executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
-    metrics: {
-      d1Queries: [],
-      spans: {},
-      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
-      summarize: () => ({}),
-    },
-  };
-}
+const handleRequest = createTestRequestHandler([automationRoutes]);
 
 async function callRoute(
   method: string,
@@ -238,11 +266,6 @@ async function callRoute(
     permissions?: readonly PermissionId[];
   }
 ): Promise<Response> {
-  const route = automationRoutes.find(
-    (candidate) => candidate.method === method && routePathPattern(candidate.path).test(path)
-  );
-  if (!route) throw new Error(`No route found for ${method} ${path}`);
-  const match = path.match(routePathPattern(route.path))!;
   const url = new URL(`https://test.local${path}`);
   if (options?.query) {
     for (const [k, v] of Object.entries(options.query)) {
@@ -256,20 +279,13 @@ async function callRoute(
     init.headers = { "Content-Type": "application/json" };
     init.body = JSON.stringify(options.body);
   }
-  const ctx = createCtx(options?.principal, options?.permissions);
-  const automationRequirement =
-    route.authorization.kind === "active-user"
-      ? route.authorization.allOf.find((requirement) => requirement.kind === "automation")
-      : undefined;
-  if (automationRequirement) {
-    const automation = await mockStore.getById(
-      match.groups?.[automationRequirement.automationIdParam]
-    );
-    if (!automation)
-      return new Response(JSON.stringify({ error: "Automation not found" }), { status: 404 });
-    ctx.automationAdmission = { automation };
-  }
-  return route.handler(new Request(url, init), createEnv(), match, ctx);
+  const principal = options?.principal ?? USER_PRINCIPAL;
+  mocks.authenticate.mockImplementation(async (request: Request) => ({ principal, request }));
+  return handleRequest(
+    new Request(url, init),
+    createEnv(options?.permissions),
+    TEST_BACKGROUND_TASK_CONTEXT
+  );
 }
 
 // ─── Sample data ────────────────────────────────────────────────────────────
@@ -587,19 +603,19 @@ describe("automation route handlers", () => {
         };
       });
 
-      await expect(
-        callRoute("POST", "/automations", {
-          body: {
-            ...validBody,
-            repositories: [
-              { repoOwner: "acme", repoName: "web-app" },
-              { repoOwner: "acme", repoName: "api" },
-            ],
-          },
-        })
-      ).rejects.toMatchObject({
-        status: 404,
-        message: "Repository is not installed for the GitHub App",
+      const res = await callRoute("POST", "/automations", {
+        body: {
+          ...validBody,
+          repositories: [
+            { repoOwner: "acme", repoName: "web-app" },
+            { repoOwner: "acme", repoName: "api" },
+          ],
+        },
+      });
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({
+        error: "Repository is not installed for the GitHub App",
       });
       expect(mockStore.bindAutomationInsert).not.toHaveBeenCalled();
       expect(mockStore.bindRepositoryInserts).not.toHaveBeenCalled();
@@ -615,17 +631,18 @@ describe("automation route handlers", () => {
           })
       );
 
-      await expect(
-        callRoute("POST", "/automations", {
-          body: {
-            ...validBody,
-            repositories: [
-              { repoOwner: "acme", repoName: "first" },
-              { repoOwner: "acme", repoName: "second" },
-            ],
-          },
-        })
-      ).rejects.toMatchObject({ message: "failed first" });
+      const res = await callRoute("POST", "/automations", {
+        body: {
+          ...validBody,
+          repositories: [
+            { repoOwner: "acme", repoName: "first" },
+            { repoOwner: "acme", repoName: "second" },
+          ],
+        },
+      });
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "failed first" });
       expect(mockBatch).not.toHaveBeenCalled();
     });
 
@@ -931,7 +948,7 @@ describe("automation route handlers", () => {
       );
     });
 
-    it("fails closed when a bot actor bypasses admission", async () => {
+    it("refuses a bot actor at admission before any identity is resolved", async () => {
       mockStore.getById.mockResolvedValue(sampleRow);
 
       const res = await callRoute("POST", "/automations", {
@@ -944,8 +961,11 @@ describe("automation route handlers", () => {
         principal: SLACK_BOT_PRINCIPAL,
       });
 
-      expect(res.status).toBe(500);
-      await expect(res.json()).resolves.toEqual({ error: "Failed to resolve session identity" });
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toEqual({
+        error: "Forbidden",
+        code: "service_capability_required",
+      });
       expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
       expect(mockStore.bindAutomationInsert).not.toHaveBeenCalled();
     });

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -15,6 +15,7 @@ import type { Principal } from "../auth/principal";
 import type { SqlDatabase, SqlStatement } from "../db/sql-database";
 import type { Env } from "../types";
 import {
+  authorizationDatabase,
   createTestRequestHandler,
   TEST_BACKGROUND_TASK_CONTEXT,
   TEST_SERVICE_SECRETS,
@@ -23,11 +24,7 @@ import {
   AutomationExecutionUnauthorizedError,
   AutomationTriggerBlockedError,
 } from "../scheduler/scheduler";
-import {
-  BUILT_IN_ROLE_REGISTRY,
-  PERMISSION_IDS,
-  type PermissionId,
-} from "@open-inspect/shared/rbac";
+import { PERMISSION_IDS, type PermissionId } from "@open-inspect/shared/rbac";
 
 const mocks = vi.hoisted(() => ({ authenticate: vi.fn() }));
 
@@ -189,42 +186,20 @@ vi.mock("./shared", async (importOriginal) => {
 
 /**
  * The workspace database as admission and the handlers see it: admission's
- * role lookups are answered here, every other statement goes to a statement
- * spy, and `batch` is the shared spy.
+ * lookups are answered by test support, every other statement goes to a
+ * statement spy, and `batch` is the shared spy.
  */
 function createDatabase(permissions: readonly PermissionId[]): SqlDatabase {
-  const custom = permissions.length !== PERMISSION_IDS.length;
-  const role = custom
-    ? { role_id: "role-1", role_key: null, role_name: "Custom" }
-    : { role_id: BUILT_IN_ROLE_REGISTRY.owner.id, role_key: "owner", role_name: "Owner" };
   const statement = {
     bind: vi.fn(() => statement),
     first: vi.fn(async () => ({ satisfied: 1 })),
     all: vi.fn(async () => ({ results: [] })),
   };
-  return {
-    prepare(sql: string) {
-      if (sql.includes("FROM users u") || sql.includes("FROM role_permissions")) {
-        const admission: SqlStatement = {
-          bind: () => admission,
-          first: async <T>() =>
-            (sql.includes("FROM users u")
-              ? { user_id: "user-1", suspended_at: null, ...role }
-              : null) as T | null,
-          all: async <T>() => ({
-            results: (sql.includes("FROM role_permissions")
-              ? permissions.map((permission_id) => ({ permission_id }))
-              : []) as T[],
-            meta: { changes: 0 },
-          }),
-          run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
-        };
-        return admission;
-      }
-      return statement as unknown as SqlStatement;
-    },
+  return authorizationDatabase({
+    permissions: permissions.length === PERMISSION_IDS.length ? undefined : permissions,
+    statement: () => statement as unknown as SqlStatement,
     batch: mockBatch,
-  } as unknown as SqlDatabase;
+  });
 }
 
 function createEnv(permissions: readonly PermissionId[] = PERMISSION_IDS): Env {

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -59,11 +59,12 @@ import {
 } from "../scheduler/scheduler";
 import { hydrateAutomation } from "../automation/hydrate";
 import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared/types/automations";
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
-  type Route,
   type RequestContext,
   GITHUB_USER_OR_SERVICE_ROUTE,
-  defineRoutes,
   json,
   error,
   parseJsonBody,
@@ -496,7 +497,6 @@ function parseAutomationListParams(request: Request): ParseAutomationListParamsR
 async function handleListAutomations(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const parsed = parseAutomationListParams(request);
@@ -537,7 +537,6 @@ async function handleListAutomations(
 async function handleCreateAutomation(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const rawBody = await parseJsonBody<unknown>(request);
@@ -791,11 +790,10 @@ async function handleCreateAutomation(
 async function handleGetAutomation(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const store = new AutomationStore(ctx.db);
   const row = await store.getById(id);
@@ -807,11 +805,10 @@ async function handleGetAutomation(
 async function handleUpdateAutomation(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const db: SqlDatabase = ctx.db;
   const store = new AutomationStore(db);
@@ -1108,11 +1105,10 @@ async function handleUpdateAutomation(
 async function handleDeleteAutomation(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const store = new AutomationStore(ctx.db);
   admittedAutomation(ctx);
@@ -1133,11 +1129,10 @@ async function handleDeleteAutomation(
 async function handlePauseAutomation(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const store = new AutomationStore(ctx.db);
   admittedAutomation(ctx);
@@ -1161,11 +1156,10 @@ async function handlePauseAutomation(
 async function handleResumeAutomation(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const store = new AutomationStore(ctx.db);
   const { automation: existing } = admittedAutomation(ctx);
@@ -1203,11 +1197,10 @@ async function handleResumeAutomation(
 async function handleTriggerAutomation(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   admittedAutomation(ctx);
   const requesterUserId = ctx.authorization?.userId;
@@ -1278,11 +1271,10 @@ function parseRunListParams(request: Request): { limit: number; offset: number }
 async function handleListInvocations(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const automationId = match.groups?.id;
-  if (!automationId) return error("Automation ID required", 400);
+  const automationId = params.id;
 
   const store = new AutomationStore(ctx.db);
   const automation = await store.getById(automationId);
@@ -1300,12 +1292,10 @@ async function handleListInvocations(
 async function handleGetRun(
   _request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string; runId: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const automationId = match.groups?.id;
-  const runId = match.groups?.runId;
-  if (!automationId || !runId) return error("Automation ID and Run ID required", 400);
+  const { id: automationId, runId } = params;
 
   const store = new AutomationStore(ctx.db);
   const run = await store.getRunById(automationId, runId);
@@ -1317,11 +1307,10 @@ async function handleGetRun(
 async function handleRegenerateKey(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const id = match.groups?.id;
-  if (!id) return error("Automation ID required", 400);
+  const id = params.id;
 
   const store = new AutomationStore(ctx.db);
   const { automation } = admittedAutomation(ctx);
@@ -1405,7 +1394,6 @@ async function handleRegenerateKey(
 async function handleGetWatchedSlackChannels(
   _request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   const channels = await new SlackChannelStore(ctx.db).getWatchedSlackChannels();
@@ -1427,7 +1415,6 @@ async function handleGetWatchedSlackChannels(
 async function handleGetSlackChannels(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   _ctx: RequestContext
 ): Promise<Response> {
   if (!env.SLACK_BOT_TOKEN) {
@@ -1443,85 +1430,65 @@ async function handleGetSlackChannels(
 
 // ─── Route exports ───────────────────────────────────────────────────────────
 
-export const automationRoutes: Route[] = defineRoutes(GITHUB_USER_OR_SERVICE_ROUTE, [
-  {
-    method: "GET",
-    path: "/integration-settings/slack/watched-channels",
+const AUTOMATIONS_READ = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requirePermission("automations.read"),
+});
+const AUTOMATION_MANAGE = admit({
+  ...GITHUB_USER_OR_SERVICE_ROUTE,
+  authorization: requireAutomation("manage"),
+});
+
+export const automationRoutes = new Hono<ControlPlaneHonoEnv>();
+
+automationRoutes.get(
+  "/integration-settings/slack/watched-channels",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("automations.read", {
       actorlessGrants: [{ service: "slack-bot" }],
     }),
-    handler: handleGetWatchedSlackChannels,
-  },
-  {
-    method: "GET",
-    path: "/integration-settings/slack/channels",
-    authorization: requirePermission("automations.read"),
-    handler: handleGetSlackChannels,
-  },
-  {
-    method: "GET",
-    path: "/automations",
-    authorization: requirePermission("automations.read"),
-    handler: handleListAutomations,
-  },
-  {
-    method: "POST",
-    path: "/automations",
+  }),
+  (c) => handleGetWatchedSlackChannels(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+automationRoutes.get("/integration-settings/slack/channels", AUTOMATIONS_READ, (c) =>
+  handleGetSlackChannels(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+automationRoutes.get("/automations", AUTOMATIONS_READ, (c) =>
+  handleListAutomations(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+automationRoutes.post(
+  "/automations",
+  admit({
+    ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("automations.create"),
-    handler: handleCreateAutomation,
-  },
-  {
-    method: "GET",
-    path: "/automations/:id",
-    authorization: requirePermission("automations.read"),
-    handler: handleGetAutomation,
-  },
-  {
-    method: "PUT",
-    path: "/automations/:id",
-    authorization: requireAutomation("manage"),
-    handler: handleUpdateAutomation,
-  },
-  {
-    method: "DELETE",
-    path: "/automations/:id",
-    authorization: requireAutomation("manage"),
-    handler: handleDeleteAutomation,
-  },
-  {
-    method: "POST",
-    path: "/automations/:id/pause",
-    authorization: requireAutomation("manage"),
-    handler: handlePauseAutomation,
-  },
-  {
-    method: "POST",
-    path: "/automations/:id/resume",
-    authorization: requireAutomation("manage"),
-    handler: handleResumeAutomation,
-  },
-  {
-    method: "POST",
-    path: "/automations/:id/trigger",
-    authorization: requireAutomation("trigger"),
-    handler: handleTriggerAutomation,
-  },
-  {
-    method: "GET",
-    path: "/automations/:id/invocations",
-    authorization: requirePermission("automations.read"),
-    handler: handleListInvocations,
-  },
-  {
-    method: "GET",
-    path: "/automations/:id/runs/:runId",
-    authorization: requirePermission("automations.read"),
-    handler: handleGetRun,
-  },
-  {
-    method: "POST",
-    path: "/automations/:id/regenerate-key",
-    authorization: requireAutomation("manage"),
-    handler: handleRegenerateKey,
-  },
-]);
+  }),
+  (c) => handleCreateAutomation(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);
+automationRoutes.get("/automations/:id", AUTOMATIONS_READ, (c) => dispatch(c, handleGetAutomation));
+automationRoutes.put("/automations/:id", AUTOMATION_MANAGE, (c) =>
+  dispatch(c, handleUpdateAutomation)
+);
+automationRoutes.delete("/automations/:id", AUTOMATION_MANAGE, (c) =>
+  dispatch(c, handleDeleteAutomation)
+);
+automationRoutes.post("/automations/:id/pause", AUTOMATION_MANAGE, (c) =>
+  dispatch(c, handlePauseAutomation)
+);
+automationRoutes.post("/automations/:id/resume", AUTOMATION_MANAGE, (c) =>
+  dispatch(c, handleResumeAutomation)
+);
+automationRoutes.post(
+  "/automations/:id/trigger",
+  admit({ ...GITHUB_USER_OR_SERVICE_ROUTE, authorization: requireAutomation("trigger") }),
+  (c) => dispatch(c, handleTriggerAutomation)
+);
+automationRoutes.get("/automations/:id/invocations", AUTOMATIONS_READ, (c) =>
+  dispatch(c, handleListInvocations)
+);
+automationRoutes.get("/automations/:id/runs/:runId", AUTOMATIONS_READ, (c) =>
+  dispatch(c, handleGetRun)
+);
+automationRoutes.post("/automations/:id/regenerate-key", AUTOMATION_MANAGE, (c) =>
+  dispatch(c, handleRegenerateKey)
+);

--- a/packages/control-plane/src/routes/catalog.ts
+++ b/packages/control-plane/src/routes/catalog.ts
@@ -74,7 +74,7 @@ export const catalog: RouteCatalogEntry[] = [
   ...scmSettingsRoutes,
 
   // Automations
-  ...automationRoutes,
+  automationRoutes,
 
   // MCP servers
   ...mcpServerRoutes,
@@ -86,7 +86,7 @@ export const catalog: RouteCatalogEntry[] = [
   auditEventRoutes,
 
   // Pull request feedback Autofix activity
-  ...autofixRoutes,
+  autofixRoutes,
 
   // Installation-wide managed skills and personal profiles
   ...skillRoutes,
@@ -98,5 +98,5 @@ export const catalog: RouteCatalogEntry[] = [
   ...rbacRoutes,
 
   // Webhooks (public routes — auth handled per-route)
-  ...webhookRoutes,
+  webhookRoutes,
 ];

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -3,10 +3,8 @@
  * (e.g. `/internal/github-event`, `/internal/slack-event`). Each bot
  * pre-normalizes its source's events and POSTs them here; this layer
  * authenticates, validates the event envelope, and invokes the scheduler for
- * matching and dispatch. Sources with no extra behavior use
- * `createAutomationEventRoutes`; sources that piggyback additional processing
- * (github's PR lifecycle tracking) compose the exported steps in their own
- * named handler.
+ * matching and dispatch. Each source registers its own route with its own
+ * service policy and composes the exported steps in its handler.
  */
 
 import {
@@ -14,12 +12,9 @@ import {
   type AutomationEvent,
   type AutomationEventSource,
 } from "@open-inspect/shared/triggers";
-import { Hono } from "hono";
 import { createLogger } from "../logger";
-import { admit } from "../routing/admit";
-import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import type { RequestContext } from "../routes/shared";
-import { error, GITHUB_SERVICE_ROUTE, json, serviceAuthorized } from "../routes/shared";
+import { error, json } from "../routes/shared";
 import type { Env } from "../types";
 import { Scheduler } from "../scheduler/scheduler";
 
@@ -118,36 +113,4 @@ export async function forwardAutomationEventToScheduler(
   }
 
   return json({ ok: true, ...result });
-}
-
-/** Create the authenticated route module for a normalized automation event source. */
-export function createAutomationEventRoutes(opts: {
-  path: string;
-  source: AutomationEventSource;
-}): Hono<ControlPlaneHonoEnv> {
-  async function handler(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      logAutomationEventRejection(undefined, opts.source, ["body"], ctx);
-      return error("Invalid JSON", 400);
-    }
-
-    const validated = validateAutomationEventEnvelope(body, opts.source);
-    if (validated.response) {
-      logAutomationEventRejection(body, opts.source, validated.issuePaths, ctx);
-      return validated.response;
-    }
-
-    return forwardAutomationEventToScheduler(env, validated.event, ctx);
-  }
-
-  const routes = new Hono<ControlPlaneHonoEnv>();
-  routes.post(
-    opts.path,
-    admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("slack-bot") }),
-    (c) => handler(c.var.admitted.request, c.env, c.var.admitted.ctx)
-  );
-  return routes;
 }

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -4,7 +4,7 @@
  * pre-normalizes its source's events and POSTs them here; this layer
  * authenticates, validates the event envelope, and invokes the scheduler for
  * matching and dispatch. Sources with no extra behavior use
- * `createAutomationEventRoute`; sources that piggyback additional processing
+ * `createAutomationEventRoutes`; sources that piggyback additional processing
  * (github's PR lifecycle tracking) compose the exported steps in their own
  * named handler.
  */
@@ -14,15 +14,12 @@ import {
   type AutomationEvent,
   type AutomationEventSource,
 } from "@open-inspect/shared/triggers";
+import { Hono } from "hono";
 import { createLogger } from "../logger";
-import type { Route, RequestContext } from "../routes/shared";
-import {
-  defineRoute,
-  error,
-  GITHUB_SERVICE_ROUTE,
-  json,
-  serviceAuthorized,
-} from "../routes/shared";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { RequestContext } from "../routes/shared";
+import { error, GITHUB_SERVICE_ROUTE, json, serviceAuthorized } from "../routes/shared";
 import type { Env } from "../types";
 import { Scheduler } from "../scheduler/scheduler";
 
@@ -123,17 +120,12 @@ export async function forwardAutomationEventToScheduler(
   return json({ ok: true, ...result });
 }
 
-/** Create an authenticated route for a normalized automation event source. */
-export function createAutomationEventRoute(opts: {
+/** Create the authenticated route module for a normalized automation event source. */
+export function createAutomationEventRoutes(opts: {
   path: string;
   source: AutomationEventSource;
-}): Route {
-  async function handler(
-    request: Request,
-    env: Env,
-    _match: RegExpMatchArray,
-    ctx: RequestContext
-  ): Promise<Response> {
+}): Hono<ControlPlaneHonoEnv> {
+  async function handler(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
     let body: unknown;
     try {
       body = await request.json();
@@ -151,10 +143,11 @@ export function createAutomationEventRoute(opts: {
     return forwardAutomationEventToScheduler(env, validated.event, ctx);
   }
 
-  return defineRoute(GITHUB_SERVICE_ROUTE, {
-    method: "POST",
-    path: opts.path,
-    authorization: serviceAuthorized("slack-bot"),
-    handler,
-  });
+  const routes = new Hono<ControlPlaneHonoEnv>();
+  routes.post(
+    opts.path,
+    admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("slack-bot") }),
+    (c) => handler(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  );
+  return routes;
 }

--- a/packages/control-plane/src/webhooks/automation-webhook.ts
+++ b/packages/control-plane/src/webhooks/automation-webhook.ts
@@ -5,9 +5,11 @@
 import { normalizeWebhookEvent } from "@open-inspect/shared/triggers";
 import { AutomationStore } from "../db/automation-store";
 import { verifyWebhookApiKey } from "../auth/webhook-key";
-import type { Route, RequestContext } from "../routes/shared";
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { RequestContext } from "../routes/shared";
 import {
-  defineRoute,
   error,
   json,
   NO_AUTHORIZATION,
@@ -30,11 +32,10 @@ export function parseWebhookIdempotencyKey(body: unknown): string | undefined {
 async function handleAutomationWebhook(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const automationId = match.groups?.id;
-  if (!automationId) return error("Automation ID required", 400);
+  const automationId = params.id;
 
   // 1. Validate content type
   const contentType = request.headers.get("content-type");
@@ -87,9 +88,10 @@ async function handleAutomationWebhook(
   return json({ ok: true, ...result });
 }
 
-export const automationWebhookRoute: Route = defineRoute(SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, {
-  method: "POST",
-  path: "/webhooks/automation/:id",
-  authorization: NO_AUTHORIZATION,
-  handler: handleAutomationWebhook,
-});
+export const automationWebhookRoutes = new Hono<ControlPlaneHonoEnv>();
+
+automationWebhookRoutes.post(
+  "/webhooks/automation/:id",
+  admit({ ...SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, authorization: NO_AUTHORIZATION }),
+  (c) => dispatch(c, handleAutomationWebhook)
+);

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -13,8 +13,11 @@ import { createLogger, parseLogLevel } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
 import { createSessionRuntimeClient } from "../session/runtime-client";
 import type { Env } from "../types";
-import type { RequestContext, Route } from "../routes/shared";
-import { defineRoute, error, GITHUB_SERVICE_ROUTE, serviceAuthorized } from "../routes/shared";
+import { Hono } from "hono";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { RequestContext } from "../routes/shared";
+import { error, GITHUB_SERVICE_ROUTE, serviceAuthorized } from "../routes/shared";
 import {
   forwardAutomationEventToScheduler,
   logAutomationEventRejection,
@@ -96,7 +99,6 @@ async function trackPullRequestLifecycle(
 async function handleGitHubAutomationEvent(
   request: Request,
   env: Env,
-  _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
   let body: unknown;
@@ -120,9 +122,10 @@ async function handleGitHubAutomationEvent(
   return forwardAutomationEventToScheduler(env, validated.event, ctx);
 }
 
-export const githubAutomationEventRoute: Route = defineRoute(GITHUB_SERVICE_ROUTE, {
-  method: "POST",
-  path: "/internal/github-event",
-  authorization: serviceAuthorized("github-bot"),
-  handler: handleGitHubAutomationEvent,
-});
+export const githubAutomationEventRoutes = new Hono<ControlPlaneHonoEnv>();
+
+githubAutomationEventRoutes.post(
+  "/internal/github-event",
+  admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("github-bot") }),
+  (c) => handleGitHubAutomationEvent(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/webhooks/index.ts
+++ b/packages/control-plane/src/webhooks/index.ts
@@ -1,16 +1,20 @@
 /**
- * Webhook route exports.
+ * Webhook route modules, mounted in precedence order.
  */
 
-import type { Route } from "../routes/shared";
-import { sentryWebhookRoute } from "./sentry";
-import { automationWebhookRoute } from "./automation-webhook";
-import { githubAutomationEventRoute } from "./github";
-import { slackAutomationEventRoute } from "./slack";
+import { Hono } from "hono";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { sentryWebhookRoutes } from "./sentry";
+import { automationWebhookRoutes } from "./automation-webhook";
+import { githubAutomationEventRoutes } from "./github";
+import { slackAutomationEventRoutes } from "./slack";
 
-export const webhookRoutes: Route[] = [
-  sentryWebhookRoute,
-  automationWebhookRoute,
-  githubAutomationEventRoute,
-  slackAutomationEventRoute,
-];
+export const webhookRoutes = new Hono<ControlPlaneHonoEnv>();
+for (const module of [
+  sentryWebhookRoutes,
+  automationWebhookRoutes,
+  githubAutomationEventRoutes,
+  slackAutomationEventRoutes,
+]) {
+  webhookRoutes.route("/", module);
+}

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -7,9 +7,11 @@ import { verifySentrySignature, normalizeSentryEvent } from "@open-inspect/share
 import { AutomationStore } from "../db/automation-store";
 import { decryptSentrySecret } from "../auth/webhook-key";
 import { createLogger } from "../logger";
-import type { Route, RequestContext } from "../routes/shared";
+import { Hono } from "hono";
+import { admit, dispatch } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { RequestContext } from "../routes/shared";
 import {
-  defineRoute,
   error,
   json,
   NO_AUTHORIZATION,
@@ -34,11 +36,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 async function handleSentryWebhook(
   request: Request,
   env: Env,
-  match: RegExpMatchArray,
+  params: { id: string },
   ctx: RequestContext
 ): Promise<Response> {
-  const automationId = match.groups?.id;
-  if (!automationId) return error("Automation ID required", 400);
+  const automationId = params.id;
 
   // 1. Look up the automation
   const store = new AutomationStore(ctx.db);
@@ -119,9 +120,10 @@ async function handleSentryWebhook(
   return json({ ok: true, ...result });
 }
 
-export const sentryWebhookRoute: Route = defineRoute(SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, {
-  method: "POST",
-  path: "/webhooks/sentry/:id",
-  authorization: NO_AUTHORIZATION,
-  handler: handleSentryWebhook,
-});
+export const sentryWebhookRoutes = new Hono<ControlPlaneHonoEnv>();
+
+sentryWebhookRoutes.post(
+  "/webhooks/sentry/:id",
+  admit({ ...SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE, authorization: NO_AUTHORIZATION }),
+  (c) => dispatch(c, handleSentryWebhook)
+);

--- a/packages/control-plane/src/webhooks/slack.ts
+++ b/packages/control-plane/src/webhooks/slack.ts
@@ -9,9 +9,44 @@
  * selection, condition evaluation, and dedup all happen in the scheduler.
  */
 
-import { createAutomationEventRoutes } from "./automation-event";
+import { Hono } from "hono";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { RequestContext } from "../routes/shared";
+import { error, GITHUB_SERVICE_ROUTE, serviceAuthorized } from "../routes/shared";
+import type { Env } from "../types";
+import {
+  forwardAutomationEventToScheduler,
+  logAutomationEventRejection,
+  validateAutomationEventEnvelope,
+} from "./automation-event";
 
-export const slackAutomationEventRoutes = createAutomationEventRoutes({
-  path: "/internal/slack-event",
-  source: "slack",
-});
+async function handleSlackAutomationEvent(
+  request: Request,
+  env: Env,
+  ctx: RequestContext
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    logAutomationEventRejection(undefined, "slack", ["body"], ctx);
+    return error("Invalid JSON", 400);
+  }
+
+  const validated = validateAutomationEventEnvelope(body, "slack");
+  if (validated.response) {
+    logAutomationEventRejection(body, "slack", validated.issuePaths, ctx);
+    return validated.response;
+  }
+
+  return forwardAutomationEventToScheduler(env, validated.event, ctx);
+}
+
+export const slackAutomationEventRoutes = new Hono<ControlPlaneHonoEnv>();
+
+slackAutomationEventRoutes.post(
+  "/internal/slack-event",
+  admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("slack-bot") }),
+  (c) => handleSlackAutomationEvent(c.var.admitted.request, c.env, c.var.admitted.ctx)
+);

--- a/packages/control-plane/src/webhooks/slack.ts
+++ b/packages/control-plane/src/webhooks/slack.ts
@@ -9,9 +9,9 @@
  * selection, condition evaluation, and dedup all happen in the scheduler.
  */
 
-import { createAutomationEventRoute } from "./automation-event";
+import { createAutomationEventRoutes } from "./automation-event";
 
-export const slackAutomationEventRoute = createAutomationEventRoute({
+export const slackAutomationEventRoutes = createAutomationEventRoutes({
   path: "/internal/slack-event",
   source: "slack",
 });


### PR DESCRIPTION
Rebased onto `main` after #1724 merged; the diff is this PR alone.

PR 5 of the Hono follow-up series (plan: `docs/internal/2026-09-02-control-plane-hono-follow-ups.md`). Converts the automation, Autofix, and webhook groups to Hono sub-apps; 19 more routes leave the legacy adapter.

## What changed

- **`automations`** (13 routes): one sub-app; shared `admit()` consts for the `automations.read` and `requireAutomation("manage")` policies. Handlers take `params: { id }` / `{ id, runId }` typed from the path; the "ID required" guards for an absent match group are gone with the match array.
- **`autofix`** (1 route) and the **webhooks** (Sentry, automation webhook, GitHub event, Slack event): each file exports a sub-app; `src/webhooks/index.ts` nests them under one `webhookRoutes` sub-app in the previous order. `createAutomationEventRoute` is now `createAutomationEventRoutes` and returns the module.
- **`catalog.ts`**: the three spreads become module entries at the same positions, so precedence is unchanged.
- No handler decodes a path segment; Hono decodes once and admission refuses a segment it could not decode.

## Tests

`automations.test.ts` (113 tests) now dispatches every request through the production `automationRoutes` module with the mocked-`authenticate` + admission-aware database recipe from the sessions PR. Consequences recorded in the tests:

- the automation ownership requirement is enforced by `admitRoute` (the hand-simulated `automationAdmission` is gone);
- `HttpError` thrown during repository resolution surfaces as the 404 JSON envelope the lifecycle produces, rather than a rejected promise;
- a Slack bot actor posting to `/automations` is refused at admission with `service_capability_required`, so the handler's fail-closed identity branch is unreachable through the app and its test now asserts the admission response.

## Verification

| Check | Result |
|---|---|
| Unit | 234 files, 3,495 passed |
| Integration (workerd, real D1) | 96 files, 1,129 passed |
| Matrix and conformance snapshots | byte-identical |
| Typecheck (`tsconfig.json`, `tsconfig.test.json`), ESLint, Prettier | clean |

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Migrated automation, autofix, and webhook request handling to a unified routing system.
  - Preserved existing endpoints, HTTP methods, authorization rules, and webhook behavior.
  - Improved route parameter handling for automation and webhook requests.

- **Tests**
  - Updated route tests to exercise production routing and authorization flows.
  - Added coverage for permission checks and admission failures.
  - Standardized expected error responses for missing resources and unauthorized bot actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->