### PR TITLE
refactor: parse JSON bodies through one helper

### DIFF
--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -647,6 +647,38 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     expect(SessionIndexStore).not.toHaveBeenCalled();
   });
 
+  it("returns 400 for a child spawn body that is not JSON", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+
+    const env = {
+      ...TEST_SERVICE_SECRETS,
+      SCM_PROVIDER: "github",
+      DB: authorizedDb(),
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: vi.fn(),
+      },
+    };
+
+    const response = await handleRequest(
+      await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
+        method: "POST",
+        service: "linear-bot",
+        actor: "linear:U1",
+        body: "{",
+      }),
+      env as never,
+      TEST_BACKGROUND_TASK_CONTEXT
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(SessionIndexStore).not.toHaveBeenCalled();
+  });
+
   it("returns 500 for a malformed parent spawn context", async () => {
     const store = makeStore();
     vi.mocked(SessionIndexStore).mockImplementation(function () {

--- a/packages/control-plane/src/routes/automation-crud.ts
+++ b/packages/control-plane/src/routes/automation-crud.ts
@@ -35,9 +35,9 @@ import {
   GITHUB_USER_OR_SERVICE_ROUTE,
   json,
   error,
-  parseJsonBody,
   requirePermission,
 } from "./shared";
+import { parseJsonBody } from "./body";
 import type { Env } from "../types";
 import type { SqlDatabase, SqlStatement } from "../db/sql-database";
 import { ProviderAccountSelectionPolicyError } from "../model-provider-accounts/selection-policy";

--- a/packages/control-plane/src/routes/automation-keys.ts
+++ b/packages/control-plane/src/routes/automation-keys.ts
@@ -8,7 +8,8 @@ import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
-import { type RequestContext, json, error, parseJsonBody } from "./shared";
+import { type RequestContext, json, error } from "./shared";
+import { parseBody } from "./body";
 import type { Env } from "../types";
 import { z } from "zod";
 import { createLogger } from "../logger";
@@ -35,17 +36,17 @@ async function handleRegenerateKey(
 
   if (automation.trigger_type === "sentry") {
     // Sentry: user provides a new client secret
-    const rawBody = await parseJsonBody<unknown>(request);
-    if (rawBody instanceof Response) return rawBody;
-    const parsedBody = regenerateSentrySecretBodySchema.safeParse(rawBody);
-    if (!parsedBody.success) {
-      return error("sentryClientSecret is required", 400);
-    }
+    const body = await parseBody(
+      request,
+      regenerateSentrySecretBodySchema,
+      "sentryClientSecret is required"
+    );
+    if (body instanceof Response) return body;
     if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
       return error("Encryption key not configured", 503);
     }
     const encrypted = await encryptSentrySecret(
-      parsedBody.data.sentryClientSecret,
+      body.sentryClientSecret,
       env.REPO_SECRETS_ENCRYPTION_KEY
     );
     const statement = store.bindAutomationUpdate(id, {

--- a/packages/control-plane/src/routes/body.test.ts
+++ b/packages/control-plane/src/routes/body.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { bodyIssue, parseBody } from "./body";
+import { bodyIssue, parseBody, parseJsonBody } from "./body";
 
 const schema = z.object({
   name: z.string().min(1, { error: "must not be empty" }),
@@ -21,7 +21,33 @@ async function rejection(result: unknown): Promise<{ status: number; body: unkno
   return { status: response.status, body: await response.json() };
 }
 
+describe("parseJsonBody", () => {
+  it("returns the raw value", async () => {
+    await expect(parseJsonBody<unknown>(request('{"a":1}'))).resolves.toEqual({ a: 1 });
+  });
+
+  it("answers 400 when the body is not JSON", async () => {
+    await expect(rejection(await parseJsonBody<unknown>(request("nope")))).resolves.toEqual({
+      status: 400,
+      body: { error: "Invalid JSON body" },
+    });
+  });
+});
+
 describe("parseBody", () => {
+  it("runs async refinements instead of escaping as a 500", async () => {
+    const asyncSchema = z.object({
+      name: z.string().refine(async (name) => name !== "taken", { error: "name is taken" }),
+    });
+
+    await expect(parseBody(request('{"name":"free"}'), asyncSchema)).resolves.toEqual({
+      name: "free",
+    });
+    await expect(
+      rejection(await parseBody(request('{"name":"taken"}'), asyncSchema))
+    ).resolves.toEqual({ status: 400, body: { error: "name: name is taken" } });
+  });
+
   it("returns the parsed body", async () => {
     await expect(parseBody(request('{"name":"x","extra":1}'), schema)).resolves.toEqual({
       name: "x",

--- a/packages/control-plane/src/routes/body.test.ts
+++ b/packages/control-plane/src/routes/body.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { bodyIssue, parseBody } from "./body";
+
+const schema = z.object({
+  name: z.string().min(1, { error: "must not be empty" }),
+  settings: z.object({ enabled: z.boolean() }).optional(),
+});
+
+function request(body: string): Request {
+  return new Request("https://test.local/things", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+async function rejection(result: unknown): Promise<{ status: number; body: unknown }> {
+  expect(result).toBeInstanceOf(Response);
+  const response = result as Response;
+  return { status: response.status, body: await response.json() };
+}
+
+describe("parseBody", () => {
+  it("returns the parsed body", async () => {
+    await expect(parseBody(request('{"name":"x","extra":1}'), schema)).resolves.toEqual({
+      name: "x",
+    });
+  });
+
+  it("answers 400 when the body is not JSON", async () => {
+    await expect(rejection(await parseBody(request("{"), schema))).resolves.toEqual({
+      status: 400,
+      body: { error: "Invalid JSON body" },
+    });
+  });
+
+  it("names the failing field when the route gives no wording", async () => {
+    await expect(
+      rejection(await parseBody(request('{"name":"x","settings":{"enabled":"yes"}}'), schema))
+    ).resolves.toEqual({
+      status: 400,
+      body: { error: "settings.enabled: Invalid input: expected boolean, received string" },
+    });
+  });
+
+  it("answers the route's own wording for a schema failure", async () => {
+    await expect(
+      rejection(await parseBody(request('{"name":""}'), schema, "Invalid thing"))
+    ).resolves.toEqual({ status: 400, body: { error: "Invalid thing" } });
+  });
+
+  it("keeps the route's wording out of the not-JSON answer", async () => {
+    await expect(
+      rejection(await parseBody(request("nope"), schema, "Invalid thing"))
+    ).resolves.toEqual({ status: 400, body: { error: "Invalid JSON body" } });
+  });
+});
+
+describe("bodyIssue", () => {
+  it("omits the path prefix for a top-level issue", () => {
+    const failure = z.string().safeParse(1);
+    expect(failure.success).toBe(false);
+    if (!failure.success)
+      expect(bodyIssue(failure.error)).toBe("Invalid input: expected string, received number");
+  });
+
+  it("joins a nested path with dots", () => {
+    const failure = z.object({ a: z.array(z.number()) }).safeParse({ a: [1, "b"] });
+    expect(failure.success).toBe(false);
+    if (!failure.success)
+      expect(bodyIssue(failure.error)).toBe("a.1: Invalid input: expected number, received string");
+  });
+});

--- a/packages/control-plane/src/routes/body.ts
+++ b/packages/control-plane/src/routes/body.ts
@@ -10,6 +10,20 @@ export function bodyIssue(failure: z.ZodError): string {
 }
 
 /**
+ * Read the request body as JSON, or answer the route's 400.
+ *
+ * For routes that validate the raw value themselves; `parseBody` is the
+ * schema-backed form.
+ */
+export async function parseJsonBody<T>(request: Request): Promise<T | Response> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+}
+
+/**
  * Parse a request's JSON body with `schema`, or answer the route's 400.
  *
  * A body that is not JSON answers `Invalid JSON body`. A schema failure
@@ -21,13 +35,9 @@ export async function parseBody<Schema extends z.ZodType>(
   schema: Schema,
   message?: string
 ): Promise<z.output<Schema> | Response> {
-  let raw: unknown;
-  try {
-    raw = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
-  const result = schema.safeParse(raw);
+  const raw = await parseJsonBody<unknown>(request);
+  if (raw instanceof Response) return raw;
+  const result = await schema.safeParseAsync(raw);
   if (!result.success) return error(message ?? bodyIssue(result.error), 400);
   return result.data;
 }

--- a/packages/control-plane/src/routes/body.ts
+++ b/packages/control-plane/src/routes/body.ts
@@ -1,0 +1,33 @@
+import type { z } from "zod";
+import { error } from "../http/responses";
+
+/** The first issue of a body schema failure, prefixed with its field path when it has one. */
+export function bodyIssue(failure: z.ZodError): string {
+  const issue = failure.issues[0];
+  if (!issue) return "Invalid request body";
+  const path = issue.path.map(String).join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+/**
+ * Parse a request's JSON body with `schema`, or answer the route's 400.
+ *
+ * A body that is not JSON answers `Invalid JSON body`. A schema failure
+ * answers `message` when the route names its own wording, otherwise the
+ * first issue prefixed with the field it concerns.
+ */
+export async function parseBody<Schema extends z.ZodType>(
+  request: Request,
+  schema: Schema,
+  message?: string
+): Promise<z.output<Schema> | Response> {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+  const result = schema.safeParse(raw);
+  if (!result.success) return error(message ?? bodyIssue(result.error), 400);
+  return result.data;
+}

--- a/packages/control-plane/src/routes/commit-signing.ts
+++ b/packages/control-plane/src/routes/commit-signing.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { commitSigningWriteRequestSchema } from "@open-inspect/shared/types/commit-signing";
 import { Hono } from "hono";
 
@@ -15,7 +16,6 @@ import type { Env } from "../types";
 import {
   error,
   json,
-  parseJsonBody,
   type RequestContext,
   GITHUB_USER_OR_SERVICE_ROUTE,
   SCM_AGNOSTIC_SANDBOX_ROUTE,
@@ -94,17 +94,17 @@ async function handlePutCommitSigning(
   const store = createStore(env, ctx.db);
   if (store instanceof Response) return store;
 
-  const unparsedBody = await parseJsonBody<unknown>(request);
-  if (unparsedBody instanceof Response) return noStore(unparsedBody);
-  const parsedBody = commitSigningWriteRequestSchema.safeParse(unparsedBody);
-  if (!parsedBody.success) {
-    return noStore(error("Invalid commit signing configuration", 400));
-  }
+  const body = await parseBody(
+    request,
+    commitSigningWriteRequestSchema,
+    "Invalid commit signing configuration"
+  );
+  if (body instanceof Response) return noStore(body);
 
   try {
-    const validatedKey = await validateOpenSshEd25519PrivateKey(parsedBody.data.privateKey);
+    const validatedKey = await validateOpenSshEd25519PrivateKey(body.privateKey);
     const metadata = await store.save({
-      ...parsedBody.data,
+      ...body,
       ...validatedKey,
     });
     return noStore(json({ enabled: true, ...metadata }));

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -4,7 +4,7 @@
  * Split from ./environments so each routes file stays focused.
  */
 
-import { parseBody } from "./body";
+import { parseBody, parseJsonBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -22,7 +22,6 @@ import {
   GITHUB_USER_OR_SERVICE_ROUTE,
   json,
   error,
-  parseJsonBody,
   resolveRepoOrError,
   requirePermission,
 } from "./shared";

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -4,6 +4,7 @@
  * Split from ./environments so each routes file stays focused.
  */
 
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -130,13 +131,12 @@ async function handleSetEnvironmentSecrets(
   const environment = await store.getById(id);
   if (!environment) return error("Environment not found", 404);
 
-  const rawBody = await parseJsonBody<unknown>(request);
-  if (rawBody instanceof Response) return rawBody;
-  const parsedBody = secretsRequestBodySchema.safeParse(rawBody);
-  if (!parsedBody.success) {
-    return error("Request body must include secrets object", 400);
-  }
-  const body = parsedBody.data;
+  const body = await parseBody(
+    request,
+    secretsRequestBodySchema,
+    "Request body must include secrets object"
+  );
+  if (body instanceof Response) return body;
 
   const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
   try {

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -6,6 +6,7 @@
  * live in ./environment-secrets.
  */
 
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -29,21 +30,11 @@ import {
   type RequestContext,
   json,
   error,
-  parseJsonBody,
   requirePermission,
 } from "./shared";
 import type { Env } from "../types";
 
 const logger = createLogger("router:environments");
-
-/** Turn a zod validation failure into a 400 naming the first offending field. */
-function validationError(err: {
-  issues: { path: (string | number | symbol)[]; message: string }[];
-}): Response {
-  const issue = err.issues[0];
-  const prefix = issue && issue.path.length ? `${issue.path.map(String).join(".")}: ` : "";
-  return error(`${prefix}${issue?.message ?? "invalid request"}`, 400);
-}
 
 /** Empty/whitespace description collapses to null (the column is nullable). */
 function normalizeDescription(description: string | null | undefined): string | null {
@@ -104,12 +95,9 @@ async function handleCreateEnvironment(
   _params: object,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parseJsonBody<unknown>(request);
-  if (body instanceof Response) return body;
-
-  const parsed = createEnvironmentInputSchema.safeParse(body);
-  if (!parsed.success) return validationError(parsed.error);
-  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed.data;
+  const parsed = await parseBody(request, createEnvironmentInputSchema);
+  if (parsed instanceof Response) return parsed;
+  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed;
 
   const store = new EnvironmentStore(ctx.db);
   if (await store.getByName(name)) {
@@ -178,12 +166,9 @@ async function handleUpdateEnvironment(
   const existing = await store.getById(id);
   if (!existing) return error("Environment not found", 404);
 
-  const body = await parseJsonBody<unknown>(request);
-  if (body instanceof Response) return body;
-
-  const parsed = updateEnvironmentInputSchema.safeParse(body);
-  if (!parsed.success) return validationError(parsed.error);
-  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed.data;
+  const parsed = await parseBody(request, updateEnvironmentInputSchema);
+  if (parsed instanceof Response) return parsed;
+  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed;
 
   if (name !== undefined) {
     const other = await store.getByName(name);

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -8,6 +8,7 @@
  * - Enabled-scope and status queries
  */
 
+import { bodyIssue, parseBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -48,7 +49,6 @@ import {
   SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE,
   error,
   json,
-  parseJsonBody,
   NO_AUTHORIZATION,
   requirePermission,
 } from "./shared";
@@ -164,11 +164,7 @@ function parseCallbackBody<Schema extends z.ZodType>(
   body: unknown
 ): z.infer<Schema> | Response {
   const parsed = schema.safeParse(body);
-  if (parsed.success) return parsed.data;
-
-  const issue = parsed.error.issues[0];
-  const path = issue.path.join(".");
-  return error(path ? `${path}: ${issue.message}` : issue.message, 400);
+  return parsed.success ? parsed.data : error(bodyIssue(parsed.error), 400);
 }
 
 /**
@@ -325,13 +321,12 @@ async function handleToggleRepoImageBuilds(
   if (repository instanceof Response) return repository;
   const { owner, name } = repository;
 
-  const rawBody = await parseJsonBody<unknown>(request);
-  if (rawBody instanceof Response) return rawBody;
-  const parsedBody = toggleRepoImageBuildsBodySchema.safeParse(rawBody);
-  if (!parsedBody.success) {
-    return error("enabled must be a boolean", 400);
-  }
-  const body = parsedBody.data;
+  const body = await parseBody(
+    request,
+    toggleRepoImageBuildsBodySchema,
+    "enabled must be a boolean"
+  );
+  if (body instanceof Response) return body;
 
   const scope = repoImageBuildScope(owner, name);
 

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -33,9 +33,9 @@ import {
   GITHUB_USER_OR_SERVICE_ROUTE,
   json,
   error,
-  parseJsonBody,
   requirePermission,
 } from "./shared";
+import { parseJsonBody } from "./body";
 
 const logger = createLogger("router:integration-settings");
 

--- a/packages/control-plane/src/routes/keyboard-shortcuts.ts
+++ b/packages/control-plane/src/routes/keyboard-shortcuts.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { keyboardShortcutPreferencesPayloadSchema } from "@open-inspect/shared/types/keyboard-shortcuts";
 import { KeyboardShortcutPreferencesStore } from "../db/keyboard-shortcut-preferences";
@@ -6,7 +7,6 @@ import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   ACTIVE_SELF,
   activeSelf,
-  error,
   json,
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
   type UserRouteContext,
@@ -29,17 +29,15 @@ async function handleSetKeyboardShortcuts(
   _params: object,
   ctx: UserRouteContext
 ): Promise<Response> {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
-  const parsed = keyboardShortcutPreferencesPayloadSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid keyboard shortcuts", 400);
+  const parsed = await parseBody(
+    request,
+    keyboardShortcutPreferencesPayloadSchema,
+    "Invalid keyboard shortcuts"
+  );
+  if (parsed instanceof Response) return parsed;
   const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).set(
     ctx.principal.userId,
-    parsed.data.shortcuts
+    parsed.shortcuts
   );
   return json({ shortcuts });
 }

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import {
   createMcpServerInputSchema,
   updateMcpServerInputSchema,
@@ -18,7 +19,6 @@ import {
   type RequestContext,
   json,
   error,
-  parseJsonBody,
   requirePermission,
 } from "./shared";
 
@@ -75,15 +75,17 @@ async function handleCreateMcpServer(
 ): Promise<Response> {
   if (!ctx.db) return error("Database not configured", 503);
 
-  const body = await parseJsonBody<unknown>(request);
-  if (body instanceof Response) return body;
-  const parsed = createMcpServerInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid MCP server configuration", 400);
+  const parsed = await parseBody(
+    request,
+    createMcpServerInputSchema,
+    "Invalid MCP server configuration"
+  );
+  if (parsed instanceof Response) return parsed;
 
   const encryptionKey = requireRepoSecretsEncryptionKey(env);
   try {
     const store = new McpServerStore(ctx.db, encryptionKey);
-    const server = await store.create(parsed.data);
+    const server = await store.create(parsed);
     logger.info("MCP server created", {
       event: "mcp_server.created",
       request_id: ctx.request_id,
@@ -109,15 +111,17 @@ async function handleUpdateMcpServer(
   const { id } = params;
   if (!ctx.db) return error("Database not configured", 503);
 
-  const body = await parseJsonBody<unknown>(request);
-  if (body instanceof Response) return body;
-  const parsed = updateMcpServerInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid MCP server configuration", 400);
+  const parsed = await parseBody(
+    request,
+    updateMcpServerInputSchema,
+    "Invalid MCP server configuration"
+  );
+  if (parsed instanceof Response) return parsed;
 
   const encryptionKey = requireRepoSecretsEncryptionKey(env);
   try {
     const store = new McpServerStore(ctx.db, encryptionKey);
-    const { revision, ...patch } = parsed.data;
+    const { revision, ...patch } = parsed;
     const updated = await store.update(id, patch, revision);
     if (!updated) return error("MCP server not found", 404);
 

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -14,10 +14,10 @@ import {
   type RequestContext,
   json,
   error,
-  parseJsonBody,
   activeGlobal,
   requirePermission,
 } from "./shared";
+import { parseJsonBody } from "./body";
 
 const logger = createLogger("router:model-preferences");
 

--- a/packages/control-plane/src/routes/model-provider-accounts.ts
+++ b/packages/control-plane/src/routes/model-provider-accounts.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import {
   MODEL_PROVIDER_ACCOUNT_ID_PATTERN,
   PROVIDER_DEVICE_AUTHORIZATION_ID_PATTERN,
@@ -50,7 +51,6 @@ import { createSessionRuntimeClient } from "../session/runtime-client";
 import {
   error,
   json,
-  parseJsonBody,
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
   SCM_AGNOSTIC_SANDBOX_ROUTE,
   type RequestContext,
@@ -229,13 +229,15 @@ modelProviderAccountRoutes.get("/model-provider-accounts", ACCOUNTS_READ, (c) =>
 );
 modelProviderAccountRoutes.post("/model-provider-accounts", ACCOUNTS_MANAGE, (c) =>
   dispatch(c, async (request, env, _params, ctx) => {
-    const body = await parseJsonBody<unknown>(request);
+    const body = await parseBody(
+      request,
+      connectModelProviderAccountRequestSchema,
+      "Invalid provider account"
+    );
     if (body instanceof Response) return body;
-    const parsed = connectModelProviderAccountRequestSchema.safeParse(body);
-    if (!parsed.success) return error("Invalid provider account", 400);
     const accounts = service(env, ctx);
     return accountOperation(ctx, async () => {
-      const result = await accounts.create(parsed.data, ctx.principal.userId);
+      const result = await accounts.create(body, ctx.principal.userId);
       return json(result, result.reconnectedExisting ? 200 : 201);
     });
   })
@@ -247,17 +249,15 @@ modelProviderAccountRoutes.post(
     dispatch(c, async (request, env, params, ctx) => {
       const parsedProvider = provider(params.provider);
       if (parsedProvider instanceof Response) return parsedProvider;
-      const body = await parseJsonBody<unknown>(request);
+      const body = await parseBody(
+        request,
+        startProviderDeviceAuthorizationRequestSchema,
+        "Invalid device authorization request"
+      );
       if (body instanceof Response) return body;
-      const parsed = startProviderDeviceAuthorizationRequestSchema.safeParse(body);
-      if (!parsed.success) return error("Invalid device authorization request", 400);
       return authorizationOperation(ctx, async () =>
         json(
-          await authorizationService(env, ctx).start(
-            ctx.principal.userId,
-            parsedProvider,
-            parsed.data
-          ),
+          await authorizationService(env, ctx).start(ctx.principal.userId, parsedProvider, body),
           201
         )
       );
@@ -304,13 +304,11 @@ modelProviderAccountRoutes.patch("/model-provider-accounts/:id", ACCOUNTS_MANAGE
   dispatch(c, async (request, env, params, ctx) => {
     const id = accountId(params.id);
     if (id instanceof Response) return id;
-    const body = await parseJsonBody<unknown>(request);
+    const body = await parseBody(request, renameSchema, "Invalid provider account name");
     if (body instanceof Response) return body;
-    const parsed = renameSchema.safeParse(body);
-    if (!parsed.success) return error("Invalid provider account name", 400);
     const accounts = service(env, ctx);
     return accountOperation(ctx, async () =>
-      json({ account: await accounts.rename(id, parsed.data.displayName, ctx.principal.userId) })
+      json({ account: await accounts.rename(id, body.displayName, ctx.principal.userId) })
     );
   })
 );
@@ -338,13 +336,15 @@ modelProviderAccountRoutes.post("/model-provider-accounts/:id/reconnect", ACCOUN
   dispatch(c, async (request, env, params, ctx) => {
     const id = accountId(params.id);
     if (id instanceof Response) return id;
-    const body = await parseJsonBody<unknown>(request);
+    const body = await parseBody(
+      request,
+      reconnectModelProviderAccountRequestSchema,
+      "Invalid provider account reconnect request"
+    );
     if (body instanceof Response) return body;
-    const parsed = reconnectModelProviderAccountRequestSchema.safeParse(body);
-    if (!parsed.success) return error("Invalid provider account reconnect request", 400);
     const accounts = service(env, ctx);
     return accountOperation(ctx, async () =>
-      json({ account: await accounts.reconnect(id, parsed.data, ctx.principal.userId) })
+      json({ account: await accounts.reconnect(id, body, ctx.principal.userId) })
     );
   })
 );
@@ -368,20 +368,22 @@ modelProviderAccountRoutes.put("/model-provider-account-defaults/:provider", ACC
   dispatch(c, async (request, _env, params, ctx) => {
     const parsedProvider = provider(params.provider);
     if (parsedProvider instanceof Response) return parsedProvider;
-    const body = await parseJsonBody<unknown>(request);
+    const body = await parseBody(
+      request,
+      modelProviderAccountDefaultRequestSchema,
+      "Invalid provider default"
+    );
     if (body instanceof Response) return body;
-    const parsed = modelProviderAccountDefaultRequestSchema.safeParse(body);
-    if (!parsed.success) return error("Invalid provider default", 400);
     const defaults = new ProviderDefaultStore(ctx.db);
     try {
       await new ProviderAccountSelectionPolicy(
         new ModelProviderAccountStore(ctx.db),
         modelProviderAccountAdapterRegistry
-      ).validateDefault(parsedProvider, parsed.data.providerAccountId);
+      ).validateDefault(parsedProvider, body.providerAccountId);
       await defaults.set(
         parsedProvider,
-        parsed.data.providerAccountId,
-        parsed.data.unattendedMode,
+        body.providerAccountId,
+        body.unattendedMode,
         ctx.principal.userId
       );
       return json({ default: await defaults.get(parsedProvider) });

--- a/packages/control-plane/src/routes/rbac.ts
+++ b/packages/control-plane/src/routes/rbac.ts
@@ -1,10 +1,10 @@
+import { parseBody } from "./body";
 import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import {
   replaceMemberRoleInputSchema,
   replaceMemberStatusInputSchema,
 } from "@open-inspect/shared/rbac";
 import { Hono } from "hono";
-import { ZodError } from "zod";
 import {
   AuthorizationError,
   AuthorizationService,
@@ -18,7 +18,6 @@ import {
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
   error,
   json,
-  parseJsonBody,
   requirePermission,
   type UserRouteContext,
 } from "./shared";
@@ -37,7 +36,6 @@ function rbacErrorResponse(cause: unknown): Response {
   if (cause instanceof RbacConflictError) {
     return json({ error: cause.message, code: "rbac_conflict" }, 409);
   }
-  if (cause instanceof ZodError) return error("Invalid request body", 400);
   return json({ error: "Authorization unavailable", code: "authorization_unavailable" }, 503);
 }
 
@@ -106,14 +104,13 @@ async function handleReplaceMemberRole(
 ): Promise<Response> {
   const targetUserId = params.id;
   if (!isCanonicalUserId(targetUserId)) return error("Invalid user ID", 400);
-  const body = await parseJsonBody<unknown>(request);
+  const body = await parseBody(request, replaceMemberRoleInputSchema, "Invalid request body");
   if (body instanceof Response) return body;
   const service = new AuthorizationService(ctx.db);
   try {
-    const parsed = replaceMemberRoleInputSchema.parse(body);
     await service.replaceMemberRole({
       targetUserId,
-      roleId: parsed.roleId,
+      roleId: body.roleId,
       actorUserId: ctx.principal.userId,
       requestId: ctx.request_id,
     });
@@ -131,14 +128,13 @@ async function handleReplaceMemberStatus(
 ): Promise<Response> {
   const targetUserId = params.id;
   if (!isCanonicalUserId(targetUserId)) return error("Invalid user ID", 400);
-  const body = await parseJsonBody<unknown>(request);
+  const body = await parseBody(request, replaceMemberStatusInputSchema, "Invalid request body");
   if (body instanceof Response) return body;
   const service = new AuthorizationService(ctx.db);
   try {
-    const parsed = replaceMemberStatusInputSchema.parse(body);
     await service.replaceMemberStatus({
       targetUserId,
-      suspended: parsed.suspended,
+      suspended: body.suspended,
       actorUserId: ctx.principal.userId,
       requestId: ctx.request_id,
     });

--- a/packages/control-plane/src/routes/scm-settings.ts
+++ b/packages/control-plane/src/routes/scm-settings.ts
@@ -24,9 +24,9 @@ import {
   SCM_AGNOSTIC_USER_OR_SERVICE_ROUTE,
   json,
   error,
-  parseJsonBody,
   requirePermission,
 } from "./shared";
+import { parseJsonBody } from "./body";
 
 const logger = createLogger("router:scm-settings");
 

--- a/packages/control-plane/src/routes/secrets.ts
+++ b/packages/control-plane/src/routes/secrets.ts
@@ -2,6 +2,7 @@
  * Repository and global secrets routes and handlers.
  */
 
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -16,7 +17,6 @@ import {
   type RequestContext,
   json,
   error,
-  parseJsonBody,
   resolveRepoOrError,
   requirePermission,
 } from "./shared";
@@ -46,14 +46,12 @@ async function handleSetRepoSecrets(
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
 
-  const rawBody = await parseJsonBody<unknown>(request);
-  if (rawBody instanceof Response) return rawBody;
-
-  const parsedBody = secretsRequestBodySchema.safeParse(rawBody);
-  if (!parsedBody.success) {
-    return error("Request body must include secrets object", 400);
-  }
-  const body = parsedBody.data;
+  const body = await parseBody(
+    request,
+    secretsRequestBodySchema,
+    "Request body must include secrets object"
+  );
+  if (body instanceof Response) return body;
 
   const store = new RepoSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
@@ -246,14 +244,12 @@ async function handleSetGlobalSecrets(
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const rawBody = await parseJsonBody<unknown>(request);
-  if (rawBody instanceof Response) return rawBody;
-
-  const parsedBody = secretsRequestBodySchema.safeParse(rawBody);
-  if (!parsedBody.success) {
-    return error("Request body must include secrets object", 400);
-  }
-  const body = parsedBody.data;
+  const body = await parseBody(
+    request,
+    secretsRequestBodySchema,
+    "Request body must include secrets object"
+  );
+  if (body instanceof Response) return body;
 
   const store = new GlobalSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { admit } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -56,11 +57,12 @@ export async function handleSpawnChild(
 ): Promise<Response> {
   const parentId = params.id;
 
-  const parsedBody = spawnChildSessionRequestSchema.safeParse(await request.json());
-  if (!parsedBody.success) {
-    return error("title and prompt are required");
-  }
-  const body = parsedBody.data;
+  const body = await parseBody(
+    request,
+    spawnChildSessionRequestSchema,
+    "title and prompt are required"
+  );
+  if (body instanceof Response) return body;
 
   if (!body.title || !body.prompt) {
     return error("title and prompt are required");

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
@@ -76,14 +77,8 @@ export async function handlePromptChild(
   const childId = params.childId;
   if (!parentId || !childId) return error("Parent and child session IDs required");
 
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return error("Invalid prompt body", 400);
-  }
-  const parsed = childFollowUpPromptRequestSchema.safeParse(rawBody);
-  if (!parsed.success) return error("Invalid prompt body", 400);
+  const parsed = await parseBody(request, childFollowUpPromptRequestSchema, "Invalid prompt body");
+  if (parsed instanceof Response) return parsed;
 
   const sessionStore = new SessionIndexStore(ctx.db);
   const childSession = await sessionStore.get(childId);
@@ -128,7 +123,7 @@ export async function handlePromptChild(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       parentSessionId: parentId,
-      content: parsed.data.content,
+      content: parsed.content,
       author: author.data,
     }),
   });

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import { z } from "zod";
 import { admit, dispatch } from "../routing/admit";
@@ -19,7 +20,6 @@ import {
   error,
   GITHUB_USER_OR_SERVICE_ROUTE,
   json,
-  parseJsonBody,
   SCM_AGNOSTIC_HUMAN_USER_ROUTE,
   requirePermission,
   type RequestContext,
@@ -211,11 +211,8 @@ export async function handlePatchReadState(
 ): Promise<Response> {
   const sessionId = params.id;
 
-  const unparsedBody = await parseJsonBody<unknown>(request);
-  if (unparsedBody instanceof Response) return unparsedBody;
-  const parsedBody = sessionReadActionSchema.safeParse(unparsedBody);
-  if (!parsedBody.success) return error("Invalid session read action", 400);
-  const body = parsedBody.data;
+  const body = await parseBody(request, sessionReadActionSchema, "Invalid session read action");
+  if (body instanceof Response) return body;
 
   const store = new SessionIndexStore(ctx.db);
   const result = await store.updateReadState(ctx.principal.userId, sessionId, body);

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -27,7 +27,7 @@ import {
   type GitHubEnrichment,
 } from "../session/identity";
 import type { Env } from "../types";
-import { error, GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
+import { error, GITHUB_USER_OR_SERVICE_ROUTE, parseJsonBody, requirePermission } from "./shared";
 import { type SessionRouteContext, dispatchSession } from "./session-route";
 
 const logger = createLogger("router:session-prompt");
@@ -55,12 +55,8 @@ export async function handleSessionPrompt(
 ): Promise<Response> {
   const sessionId = params.id;
 
-  let rawBody: unknown;
-  try {
-    rawBody = await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
+  const rawBody = await parseJsonBody<unknown>(request);
+  if (rawBody instanceof Response) return rawBody;
 
   const enforcement = applyIdentityEnforcement(ctx, "prompt", rawBody);
   if (enforcement.rejection) return enforcement.rejection;

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -27,7 +27,8 @@ import {
   type GitHubEnrichment,
 } from "../session/identity";
 import type { Env } from "../types";
-import { error, GITHUB_USER_OR_SERVICE_ROUTE, parseJsonBody, requirePermission } from "./shared";
+import { error, GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
+import { parseJsonBody } from "./body";
 import { type SessionRouteContext, dispatchSession } from "./session-route";
 
 const logger = createLogger("router:session-prompt");

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -21,7 +21,6 @@ import {
   GITHUB_SANDBOX_FALLBACK_ROUTE,
   GITHUB_USER_OR_SERVICE_ROUTE,
   NO_AUTHORIZATION,
-  parseJsonBody,
   requirePermission,
   SCM_AGNOSTIC_SANDBOX_FALLBACK_ROUTE,
   SCM_AGNOSTIC_HANDLER_AUTHENTICATED_ROUTE,
@@ -30,6 +29,7 @@ import {
   SCM_AGNOSTIC_USER_OR_SERVICE_ROUTE,
   SCM_CREDENTIALS_ROUTE,
 } from "./shared";
+import { parseJsonBody } from "./body";
 import { type SessionRouteContext, dispatchSession } from "./session-route";
 
 const participantsResponseSchema = z.object({

--- a/packages/control-plane/src/routes/session-ws-token.ts
+++ b/packages/control-plane/src/routes/session-ws-token.ts
@@ -5,7 +5,8 @@ import { applyIdentityEnforcement } from "../routing/identity-enforcement";
 import { SESSION_WEBSOCKET_CONNECT_PERMISSION } from "@open-inspect/shared/rbac";
 import { SessionInternalPaths, sessionScmDisplayFieldsSchema } from "../session/contracts";
 import type { Env } from "../types";
-import { error, GITHUB_USER_OR_SERVICE_ROUTE, parseJsonBody, requirePermission } from "./shared";
+import { error, GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
+import { parseJsonBody } from "./body";
 import { dispatchSession, type SessionRouteContext } from "./session-route";
 
 export async function handleSessionWsToken(

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -4,7 +4,7 @@
 
 import type { Principal } from "../auth/principal";
 import type { RequestContext } from "../http/request-context";
-import { error, HttpError } from "../http/responses";
+import { HttpError } from "../http/responses";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import type { PermissionId, ScopedPermissionStem } from "@open-inspect/shared/rbac";
@@ -350,23 +350,6 @@ export async function resolveInstalledRepo(
 ): Promise<RepositoryAccessResult | null> {
   const result = await provider.checkRepositoryAccess({ owner: repoOwner, name: repoName });
   return result;
-}
-
-/**
- * Parse the request body as JSON, returning the typed result or an error Response.
- *
- * Usage:
- * ```ts
- * const body = await parseJsonBody<{ secrets: Record<string, string> }>(request);
- * if (body instanceof Response) return body;
- * ```
- */
-export async function parseJsonBody<T>(request: Request): Promise<T | Response> {
-  try {
-    return (await request.json()) as T;
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
 }
 
 /**

--- a/packages/control-plane/src/routes/skills.ts
+++ b/packages/control-plane/src/routes/skills.ts
@@ -1,3 +1,4 @@
+import { parseBody } from "./body";
 import { Hono } from "hono";
 import {
   createSkillInputSchema,
@@ -87,14 +88,6 @@ function canonicalUserId(ctx: RequestContext): string | null {
   return null;
 }
 
-async function parsedBody(request: Request): Promise<unknown | Response> {
-  try {
-    return await request.json();
-  } catch {
-    return error("Invalid JSON body", 400);
-  }
-}
-
 const skillListQuerySchema = z.object({
   limit: z
     .string()
@@ -146,12 +139,10 @@ async function handleCreateSkill(
 ): Promise<Response> {
   const userId = canonicalUserId(ctx);
   if (!userId) return error("Canonical user required", 403);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = createSkillInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill", 400);
+  const parsed = await parseBody(request, createSkillInputSchema, "Invalid skill");
+  if (parsed instanceof Response) return parsed;
   try {
-    const skill = await new SkillStore(ctx.db).create(parsed.data, userId);
+    const skill = await new SkillStore(ctx.db).create(parsed, userId);
     audit(ctx, {
       action: "skill.created",
       skill_id: skill.id,
@@ -169,12 +160,14 @@ async function handlePreviewSkill(
   _params: object,
   _ctx: RequestContext
 ): Promise<Response> {
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = createSkillInputSchema.pick({ name: true, content: true }).safeParse(body);
-  if (!parsed.success) return error("Invalid skill", 400);
+  const parsed = await parseBody(
+    request,
+    createSkillInputSchema.pick({ name: true, content: true }),
+    "Invalid skill"
+  );
+  if (parsed instanceof Response) return parsed;
   try {
-    const revision = await buildValidatedSkillRevision(parsed.data.name, parsed.data.content);
+    const revision = await buildValidatedSkillRevision(parsed.name, parsed.content);
     return json({
       skillMarkdown: revision.files.find((file) => file.path === "SKILL.md")?.content,
       revisionSha256: revision.revisionSha256,
@@ -248,15 +241,17 @@ async function handlePreviewSkillImport(
   _params: object,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = skillImportPreviewInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill import source", 400);
+  const parsed = await parseBody(
+    request,
+    skillImportPreviewInputSchema,
+    "Invalid skill import source"
+  );
+  if (parsed instanceof Response) return parsed;
   try {
     const result = await fetchSkillImport(
       createRouteSourceControlProvider(env),
-      parsed.data.source,
-      parsed.data.name
+      parsed.source,
+      parsed.name
     );
     return json(await importPreviewResponse(ctx, result));
   } catch (e) {
@@ -272,20 +267,18 @@ async function handleImportSkill(
 ): Promise<Response> {
   const userId = canonicalUserId(ctx);
   if (!userId) return error("Canonical user required", 403);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = importSkillInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill import", 400);
+  const parsed = await parseBody(request, importSkillInputSchema, "Invalid skill import");
+  if (parsed instanceof Response) return parsed;
   try {
     const result = await fetchSkillImport(
       createRouteSourceControlProvider(env),
-      parsed.data.source,
-      parsed.data.name
+      parsed.source,
+      parsed.name
     );
-    const stale = confirmedImport(result, parsed.data);
+    const stale = confirmedImport(result, parsed);
     if (stale) return stale;
     const skill = await new SkillStore(ctx.db).create(
-      { name: result.name, content: result.content, assignments: parsed.data.assignments },
+      { name: result.name, content: result.content, assignments: parsed.assignments },
       userId,
       result.source
     );
@@ -337,15 +330,17 @@ async function handlePreviewSkillReimport(
   ctx: RequestContext
 ): Promise<Response> {
   const { id } = params;
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = reimportSkillPreviewInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill re-import", 400);
+  const parsed = await parseBody(
+    request,
+    reimportSkillPreviewInputSchema,
+    "Invalid skill re-import"
+  );
+  if (parsed instanceof Response) return parsed;
   const skill = await new SkillStore(ctx.db).get(id);
   if (!skill) return error("Skill not found", 404);
   try {
     const provider = createRouteSourceControlProvider(env);
-    const source = recordedImportSource(skill.source, parsed.data.ref, provider.name);
+    const source = recordedImportSource(skill.source, parsed.ref, provider.name);
     if (source instanceof Response) return source;
     const result = await fetchSkillImport(provider, source, skill.name);
     return json(await importPreviewResponse(ctx, result, skill.name));
@@ -365,10 +360,8 @@ async function handleReimportSkill(
   if (!userId) return error("Canonical user required", 403);
   const ifMatch = request.headers.get("If-Match")?.replace(/^"|"$/g, "");
   if (!ifMatch) return error("If-Match revision is required", 428);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = reimportSkillInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill re-import", 400);
+  const parsed = await parseBody(request, reimportSkillInputSchema, "Invalid skill re-import");
+  if (parsed instanceof Response) return parsed;
   const store = new SkillStore(ctx.db);
   const skill = await store.get(id);
   if (!skill) return error("Skill not found", 404);
@@ -377,10 +370,10 @@ async function handleReimportSkill(
   }
   try {
     const provider = createRouteSourceControlProvider(env);
-    const source = recordedImportSource(skill.source, parsed.data.ref, provider.name);
+    const source = recordedImportSource(skill.source, parsed.ref, provider.name);
     if (source instanceof Response) return source;
     const result = await fetchSkillImport(provider, source, skill.name);
-    const stale = confirmedImport(result, parsed.data);
+    const stale = confirmedImport(result, parsed);
     if (stale) return stale;
     const applied = await store.applyImportedRevision(
       id,
@@ -423,12 +416,10 @@ async function handleSetSkillEnabled(
   const { id } = params;
   const userId = canonicalUserId(ctx);
   if (!userId) return error("Canonical user required", 403);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = setSkillEnabledInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill update", 400);
+  const parsed = await parseBody(request, setSkillEnabledInputSchema, "Invalid skill update");
+  if (parsed instanceof Response) return parsed;
   try {
-    const skill = await new SkillStore(ctx.db).setEnabled(id, parsed.data, userId);
+    const skill = await new SkillStore(ctx.db).setEnabled(id, parsed, userId);
     if (skill) audit(ctx, { action: "skill.enabled_updated", skill_id: id });
     return skill ? json({ skill }) : error("Skill not found", 404);
   } catch (e) {
@@ -447,14 +438,16 @@ async function handleReplaceSkillContentAndAssignments(
   if (!userId) return error("Canonical user required", 403);
   const ifMatch = request.headers.get("If-Match")?.replace(/^"|"$/g, "");
   if (!ifMatch) return error("If-Match revision is required", 428);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = replaceSkillContentAndAssignmentsInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill edit", 400);
+  const parsed = await parseBody(
+    request,
+    replaceSkillContentAndAssignmentsInputSchema,
+    "Invalid skill edit"
+  );
+  if (parsed instanceof Response) return parsed;
   try {
     const skill = await new SkillStore(ctx.db).replaceContentAndAssignments(
       id,
-      parsed.data,
+      parsed,
       userId,
       ifMatch
     );
@@ -503,15 +496,13 @@ async function handleCreateProfile(
 ): Promise<Response> {
   const userId = canonicalUserId(ctx);
   if (!userId) return error("Canonical user required", 403);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = createSkillProfileInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill profile", 400);
+  const parsed = await parseBody(request, createSkillProfileInputSchema, "Invalid skill profile");
+  if (parsed instanceof Response) return parsed;
   try {
     const profile = await new SkillProfileStore(ctx.db).create(
       userId,
-      parsed.data.name,
-      parsed.data.skillIds
+      parsed.name,
+      parsed.skillIds
     );
     const response = json({ profile }, 201);
     audit(ctx, { action: "profile.created", profile_id: profile.id });
@@ -530,12 +521,10 @@ async function handleUpdateProfile(
   const { id } = params;
   const userId = canonicalUserId(ctx);
   if (!userId) return error("Canonical user required", 403);
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = updateSkillProfileInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill profile", 400);
+  const parsed = await parseBody(request, updateSkillProfileInputSchema, "Invalid skill profile");
+  if (parsed instanceof Response) return parsed;
   try {
-    const profile = await new SkillProfileStore(ctx.db).update(id, userId, parsed.data);
+    const profile = await new SkillProfileStore(ctx.db).update(id, userId, parsed);
     if (profile) audit(ctx, { action: "profile.updated", profile_id: id });
     return profile ? json({ profile }) : error("Skill profile not found", 404);
   } catch (e) {
@@ -563,32 +552,34 @@ async function handleResolvePreview(
   _params: object,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parsedBody(request);
-  if (body instanceof Response) return body;
-  const parsed = skillResolutionPreviewInputSchema.safeParse(body);
-  if (!parsed.success) return error("Invalid skill resolution target", 400);
+  const parsed = await parseBody(
+    request,
+    skillResolutionPreviewInputSchema,
+    "Invalid skill resolution target"
+  );
+  if (parsed instanceof Response) return parsed;
   let repositories =
-    parsed.data.repositories ??
-    (parsed.data.repoOwner && parsed.data.repoName
-      ? [{ repoOwner: parsed.data.repoOwner, repoName: parsed.data.repoName }]
+    parsed.repositories ??
+    (parsed.repoOwner && parsed.repoName
+      ? [{ repoOwner: parsed.repoOwner, repoName: parsed.repoName }]
       : []);
-  if (parsed.data.environmentId) {
+  if (parsed.environmentId) {
     const environments = new EnvironmentStore(ctx.db);
-    if (!(await environments.getById(parsed.data.environmentId))) {
+    if (!(await environments.getById(parsed.environmentId))) {
       return error("Environment not found", 404);
     }
-    repositories = (
-      await environments.getRepositoriesForEnvironment(parsed.data.environmentId)
-    ).map((repository) => ({
-      repoOwner: repository.repo_owner,
-      repoName: repository.repo_name,
-    }));
+    repositories = (await environments.getRepositoriesForEnvironment(parsed.environmentId)).map(
+      (repository) => ({
+        repoOwner: repository.repo_owner,
+        repoName: repository.repo_name,
+      })
+    );
   }
   try {
     const manifest = await resolveManagedSkills(
       ctx.db,
-      { repositories, environmentId: parsed.data.environmentId ?? null },
-      parsed.data.selection,
+      { repositories, environmentId: parsed.environmentId ?? null },
+      parsed.selection,
       canonicalUserId(ctx)
     );
     return json({


### PR DESCRIPTION
Finding #2 of the Hono cleanup review: JSON body parsing standardization, plus the spawn-child defect it uncovered.

## The helper

`src/routes/body.ts`, beside `parseQuery`:

- `parseBody(request, schema, message?)`: a body that is not JSON answers `400 Invalid JSON body`; a schema failure answers `message` when the route names its own wording, otherwise the first issue prefixed with its field path.
- `bodyIssue(zodError)`: that formatter, previously hand-written twice (`environments.ts` `validationError`, `image-builds.ts` `parseCallbackBody`). Both duplicates are gone.

Rule applied throughout: **every existing schema-failure message is preserved** by passing it as `message`. The only wording that changes is the "not JSON" answer at the two sites that previously used route-specific text for it (see table).

## Sites converted

| File | Sites | Before | Schema-failure wording |
| --- | --- | --- | --- |
| `model-provider-accounts.ts` | 5 | `parseJsonBody` + `safeParse` | preserved |
| `mcp-servers.ts` | 2 | same | preserved |
| `secrets.ts` | 2 | same | preserved |
| `environments.ts` | 2 | same + local formatter | now `bodyIssue` (same output) |
| `rbac.ts` | 2 | `parseJsonBody` + `.parse` → `ZodError` branch | preserved (`Invalid request body`); dead `ZodError` branch removed |
| `commit-signing.ts` | 1 | `parseJsonBody` + `safeParse` (under `noStore`) | preserved |
| `automation-keys.ts` | 1 | same | preserved |
| `environment-secrets.ts` | 1 of 2 | same | preserved (import site keeps its custom mapping) |
| `image-builds.ts` | 1 + formatter | same | preserved; callback parser now uses `bodyIssue` |
| `session-index.ts` | 1 | same | preserved |
| `skills.ts` | 11 | private `parsedBody` copy + `safeParse` | preserved; private copy deleted |
| `keyboard-shortcuts.ts` | 1 | bare `try { request.json() }` | preserved |
| `session-children.ts` | 1 | bare try/catch | preserved; not-JSON was `Invalid prompt body`, now standard |
| `session-child-spawn.ts` | 1 | **unguarded** `request.json()` | preserved; not-JSON was a **500**, now 400 |
| `session-prompt.ts` | 1 | bare try/catch before identity enforcement | now `parseJsonBody` (raw reader; needs the raw body first) |

33 sites, 16 files, +232 / −241 including the new helper and its tests (handler code alone is about −110).

## The defect

`POST /sessions/:id/children` did `schema.safeParse(await request.json())`. A body that was not JSON threw `SyntaxError`, which `onError` turned into `500 Internal server error`. New test in `router.spawn-child.test.ts` sends `{` and expects `400 { error: "Invalid JSON body" }`; it fails on the old code with `expected 500 to be 400`.

## Left alone, on purpose

- `parseJsonBody` stays exported for the raw-first routes: `session-prompt`, `session-ws-token`, `automation-crud` (identity enforcement reads the raw body before the schema; `automation-crud` also maps issues itself), `environment-secrets` import, `scm-settings` (two-step envelope with its own wording), `session-runtime-proxy` (hand-written `typeof` checks, a separate item).
- `repos.ts` metadata: its test pins the not-JSON answer to `Invalid repository metadata` by design.
- Size-bounded readers (`session-diffs.ts`, `image-builds.ts` callbacks), `session-children.ts` cancel (tolerates an empty body), `create-session-input.ts` (returns a result type and needs the raw keys), and the webhooks (verify signatures over the raw text).
- DO-side handlers under `src/session/http/handlers` are not route handlers and were out of scope.

## Verification

- `tsc -p tsconfig.json`, `-p tsconfig.test.json`, `-p test/integration`
- eslint + prettier on touched files
- unit: 242 files / 3572 tests; integration: 96 files / 1129 tests; both integration snapshots byte-identical

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized request parsing and validation across control-plane endpoints, including environments, secrets, sessions, skills, model accounts, MCP servers, and access controls.
  - Malformed JSON now consistently returns a clear `400` response.
  - Validation errors provide route-specific messages and identify affected fields when available.
  - Invalid child-session spawn requests are rejected before session resources are created.

- **Tests**
  - Added coverage for malformed JSON, asynchronous schema validation, nested field errors, and child-session spawn failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->