### PR TITLE
refactor: dispatch every route handler and drop unreachable path guards

### DIFF
--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -634,6 +634,7 @@ describe("handleCreateSession D1 ordering", () => {
         }),
       }),
       testEnv as never,
+      {},
       {
         request_id: "test-request",
         trace_id: "test-trace",

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -11,8 +11,9 @@ import {
 } from "../db/pull-request-analytics-store";
 import { Hono } from "hono";
 import { z } from "zod";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import type { Env } from "../types";
 import { parseQuery } from "./query";
 import {
   type RequestContext,
@@ -56,7 +57,12 @@ function getPullRequestFilters(days: AnalyticsDays): PullRequestAnalyticsFilters
   return { startAt: now - days * 24 * 60 * 60 * 1000, endAt: now, now };
 }
 
-async function handleDashboard(request: Request, ctx: RequestContext): Promise<Response> {
+async function handleDashboard(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, daysQuery);
   if (query instanceof Response) return query;
   const { days } = query;
@@ -72,7 +78,12 @@ async function handleDashboard(request: Request, ctx: RequestContext): Promise<R
   );
 }
 
-async function handleSummary(request: Request, ctx: RequestContext): Promise<Response> {
+async function handleSummary(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, daysQuery);
   if (query instanceof Response) return query;
   const { days } = query;
@@ -81,7 +92,12 @@ async function handleSummary(request: Request, ctx: RequestContext): Promise<Res
   return json(await store.getSummary(getFilters(days)));
 }
 
-async function handleTimeseries(request: Request, ctx: RequestContext): Promise<Response> {
+async function handleTimeseries(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, daysQuery);
   if (query instanceof Response) return query;
   const { days } = query;
@@ -90,7 +106,12 @@ async function handleTimeseries(request: Request, ctx: RequestContext): Promise<
   return json(await store.getTimeseries(getFilters(days)));
 }
 
-async function handleBreakdown(request: Request, ctx: RequestContext): Promise<Response> {
+async function handleBreakdown(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, breakdownQuery);
   if (query instanceof Response) return query;
   const { days, by } = query;
@@ -99,7 +120,12 @@ async function handleBreakdown(request: Request, ctx: RequestContext): Promise<R
   return json(await store.getBreakdown(getFilters(days), by));
 }
 
-async function handlePullRequests(request: Request, ctx: RequestContext): Promise<Response> {
+async function handlePullRequests(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, daysQuery);
   if (query instanceof Response) return query;
   const { days } = query;
@@ -115,18 +141,10 @@ const ANALYTICS_READ = admit({
 
 export const analyticsRoutes = new Hono<ControlPlaneHonoEnv>();
 
-analyticsRoutes.get("/analytics/dashboard", ANALYTICS_READ, (c) =>
-  handleDashboard(c.var.admitted.request, c.var.admitted.ctx)
-);
-analyticsRoutes.get("/analytics/summary", ANALYTICS_READ, (c) =>
-  handleSummary(c.var.admitted.request, c.var.admitted.ctx)
-);
-analyticsRoutes.get("/analytics/timeseries", ANALYTICS_READ, (c) =>
-  handleTimeseries(c.var.admitted.request, c.var.admitted.ctx)
-);
-analyticsRoutes.get("/analytics/breakdown", ANALYTICS_READ, (c) =>
-  handleBreakdown(c.var.admitted.request, c.var.admitted.ctx)
-);
+analyticsRoutes.get("/analytics/dashboard", ANALYTICS_READ, (c) => dispatch(c, handleDashboard));
+analyticsRoutes.get("/analytics/summary", ANALYTICS_READ, (c) => dispatch(c, handleSummary));
+analyticsRoutes.get("/analytics/timeseries", ANALYTICS_READ, (c) => dispatch(c, handleTimeseries));
+analyticsRoutes.get("/analytics/breakdown", ANALYTICS_READ, (c) => dispatch(c, handleBreakdown));
 analyticsRoutes.get("/analytics/pull-requests", ANALYTICS_READ, (c) =>
-  handlePullRequests(c.var.admitted.request, c.var.admitted.ctx)
+  dispatch(c, handlePullRequests)
 );

--- a/packages/control-plane/src/routes/audit-events.ts
+++ b/packages/control-plane/src/routes/audit-events.ts
@@ -2,10 +2,16 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { encodeAuditEventCursor, parseAuditEventCursor } from "../db/audit-event-cursor";
 import { AuditEventStore, toAuditEvent } from "../db/audit-event-store";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import { parseQuery } from "./query";
-import { json, requirePermission, SCM_AGNOSTIC_HUMAN_USER_ROUTE } from "./shared";
+import {
+  json,
+  type RequestContext,
+  requirePermission,
+  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
+} from "./shared";
+import type { Env } from "../types";
 
 export const DEFAULT_AUDIT_EVENT_LIMIT = 25;
 const MAX_AUDIT_EVENT_LIMIT = 100;
@@ -32,6 +38,23 @@ const auditEventQuery = z.object({
     }),
 });
 
+async function handleListAuditEvents(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
+  const query = parseQuery(request, auditEventQuery);
+  if (query instanceof Response) return query;
+
+  const result = await new AuditEventStore(ctx.db).list(query);
+  return json({
+    events: result.rows.map(toAuditEvent),
+    hasMore: result.hasMore,
+    nextCursor: result.nextCursor ? encodeAuditEventCursor(result.nextCursor) : null,
+  });
+}
+
 export const auditEventRoutes = new Hono<ControlPlaneHonoEnv>();
 
 auditEventRoutes.get(
@@ -41,16 +64,5 @@ auditEventRoutes.get(
     authorization: requirePermission("workspace.audit.read", { service: "deny" }),
     cacheControl: "private, no-store",
   }),
-  async (c) => {
-    const { request, ctx } = c.var.admitted;
-    const query = parseQuery(request, auditEventQuery);
-    if (query instanceof Response) return query;
-
-    const result = await new AuditEventStore(ctx.db).list(query);
-    return json({
-      events: result.rows.map(toAuditEvent),
-      hasMore: result.hasMore,
-      nextCursor: result.nextCursor ? encodeAuditEventCursor(result.nextCursor) : null,
-    });
-  }
+  (c) => dispatch(c, handleListAuditEvents)
 );

--- a/packages/control-plane/src/routes/autofix.ts
+++ b/packages/control-plane/src/routes/autofix.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
+import type { Env } from "../types";
 import { PrAutofixFeedbackStore } from "../db/pr-autofix-feedback-store";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   error,
@@ -26,7 +27,12 @@ const activityQuerySchema = z.object({
   cursor: z.string().optional(),
 });
 
-async function handleActivity(request: Request, ctx: RequestContext): Promise<Response> {
+async function handleActivity(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const query = parseQuery(request, activityQuerySchema);
   if (query instanceof Response) return query;
 
@@ -50,5 +56,5 @@ export const autofixRoutes = new Hono<ControlPlaneHonoEnv>();
 autofixRoutes.get(
   "/autofix/activity",
   admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION }),
-  (c) => handleActivity(c.var.admitted.request, c.var.admitted.ctx)
+  (c) => dispatch(c, handleActivity)
 );

--- a/packages/control-plane/src/routes/automation-crud.ts
+++ b/packages/control-plane/src/routes/automation-crud.ts
@@ -72,6 +72,7 @@ const logger = createLogger("router:automations");
 async function handleCreateAutomation(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const rawBody = await parseJsonBody<unknown>(request);
@@ -646,7 +647,6 @@ async function handleDeleteAutomation(
   const id = params.id;
 
   const store = new AutomationStore(ctx.db);
-  admittedAutomation(ctx);
   const result = await ctx.db.batch([store.bindSoftDelete(id)]);
   const deleted = result[0]?.meta.changes === 1;
   if (!deleted) return error("Automation not found", 404);
@@ -669,7 +669,7 @@ automationCrudRoutes.post(
     ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("automations.create"),
   }),
-  (c) => handleCreateAutomation(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleCreateAutomation)
 );
 automationCrudRoutes.get("/automations/:id", AUTOMATIONS_READ, (c) =>
   dispatch(c, handleGetAutomation)

--- a/packages/control-plane/src/routes/automation-lifecycle.ts
+++ b/packages/control-plane/src/routes/automation-lifecycle.ts
@@ -38,7 +38,6 @@ async function handlePauseAutomation(
   const id = params.id;
 
   const store = new AutomationStore(ctx.db);
-  admittedAutomation(ctx);
   const result = await ctx.db.batch([store.bindPause(id)]);
   const paused = result[0]?.meta.changes === 1;
   if (!paused) return error("Automation not found", 404);
@@ -105,7 +104,6 @@ async function handleTriggerAutomation(
 ): Promise<Response> {
   const id = params.id;
 
-  admittedAutomation(ctx);
   const requesterUserId = ctx.authorization?.userId;
   if (!requesterUserId) return error("Authorization unavailable", 503);
 

--- a/packages/control-plane/src/routes/automation-list.ts
+++ b/packages/control-plane/src/routes/automation-list.ts
@@ -3,6 +3,7 @@
  */
 
 import { AutomationStore, toAutomation } from "../db/automation-store";
+import { dispatch } from "../routing/admit";
 import {
   encodeAutomationListCursor,
   parseAutomationListCursor,
@@ -54,6 +55,7 @@ const automationListQuerySchema = z.object({
 async function handleListAutomations(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const query = parseQuery(request, automationListQuerySchema);
@@ -100,5 +102,5 @@ async function handleListAutomations(
 export const automationListRoutes = new Hono<ControlPlaneHonoEnv>();
 
 automationListRoutes.get("/automations", AUTOMATIONS_READ, (c) =>
-  handleListAutomations(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleListAutomations)
 );

--- a/packages/control-plane/src/routes/automation-slack-settings.ts
+++ b/packages/control-plane/src/routes/automation-slack-settings.ts
@@ -5,7 +5,7 @@
 import { listChannels } from "@open-inspect/shared/slack";
 import { SlackChannelStore } from "../db/slack-channel-store";
 import { Hono } from "hono";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   type RequestContext,
@@ -34,6 +34,7 @@ const logger = createLogger("router:automations");
 async function handleGetWatchedSlackChannels(
   _request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const channels = await new SlackChannelStore(ctx.db).getWatchedSlackChannels();
@@ -55,6 +56,7 @@ async function handleGetWatchedSlackChannels(
 async function handleGetSlackChannels(
   request: Request,
   env: Env,
+  _params: object,
   _ctx: RequestContext
 ): Promise<Response> {
   if (!env.SLACK_BOT_TOKEN) {
@@ -78,8 +80,8 @@ automationSlackSettingsRoutes.get(
       actorlessGrants: [{ service: "slack-bot" }],
     }),
   }),
-  (c) => handleGetWatchedSlackChannels(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleGetWatchedSlackChannels)
 );
 automationSlackSettingsRoutes.get("/integration-settings/slack/channels", AUTOMATIONS_READ, (c) =>
-  handleGetSlackChannels(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleGetSlackChannels)
 );

--- a/packages/control-plane/src/routes/browser-auth.ts
+++ b/packages/control-plane/src/routes/browser-auth.ts
@@ -55,7 +55,7 @@ export async function forwardBrowserAuthRequest(
 async function handleBrowserAuth(
   request: Request,
   _env: Env,
-  _params: Record<string, never>,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   try {

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -86,7 +86,6 @@ async function handleListEnvironmentSecrets(
   if (config instanceof Response) return config;
 
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   if (!(await store.getById(id))) return error("Environment not found", 404);
@@ -126,7 +125,6 @@ async function handleSetEnvironmentSecrets(
   if (config instanceof Response) return config;
 
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   const environment = await store.getById(id);
@@ -234,7 +232,6 @@ async function handleImportEnvironmentSecrets(
   if (config instanceof Response) return config;
 
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   const environment = await store.getById(id);

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -83,6 +83,7 @@ export async function resolveEnvironmentRepositories(
 async function handleListEnvironments(
   _request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const store = new EnvironmentStore(ctx.db);
@@ -100,6 +101,7 @@ async function handleListEnvironments(
 async function handleCreateEnvironment(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await parseJsonBody<unknown>(request);
@@ -156,7 +158,6 @@ async function handleGetEnvironment(
   ctx: RequestContext
 ): Promise<Response> {
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   const row = await store.getById(id);
@@ -172,7 +173,6 @@ async function handleUpdateEnvironment(
   ctx: RequestContext
 ): Promise<Response> {
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   const existing = await store.getById(id);
@@ -233,7 +233,6 @@ async function handleDeleteEnvironment(
   ctx: RequestContext
 ): Promise<Response> {
   const id = params.id;
-  if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(ctx.db);
   const deleted = await store.delete(id);
@@ -264,10 +263,10 @@ environmentRoutes.get(
       actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
     }),
   }),
-  (c) => handleListEnvironments(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleListEnvironments)
 );
 environmentRoutes.post("/environments", ENVIRONMENTS_MANAGE, (c) =>
-  handleCreateEnvironment(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleCreateEnvironment)
 );
 environmentRoutes.get(
   "/environments/:id",

--- a/packages/control-plane/src/routes/health.ts
+++ b/packages/control-plane/src/routes/health.ts
@@ -1,7 +1,17 @@
 import { Hono } from "hono";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
-import { json, NO_AUTHORIZATION } from "./shared";
+import { json, NO_AUTHORIZATION, type RequestContext } from "./shared";
+import type { Env } from "../types";
+
+async function handleHealth(
+  _request: Request,
+  _env: Env,
+  _params: object,
+  _ctx: RequestContext
+): Promise<Response> {
+  return json({ status: "healthy", service: "open-inspect-control-plane" });
+}
 
 export const healthRoutes = new Hono<ControlPlaneHonoEnv>();
 
@@ -12,5 +22,5 @@ healthRoutes.get(
     supportedScmProviders: "all",
     authorization: NO_AUTHORIZATION,
   }),
-  () => json({ status: "healthy", service: "open-inspect-control-plane" })
+  (c) => dispatch(c, handleHealth)
 );

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -178,6 +178,7 @@ function parseCallbackBody<Schema extends z.ZodType>(
 async function handleBuildComplete(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await readCallbackBody(request);
@@ -213,6 +214,7 @@ async function handleBuildComplete(
 async function handleBuildFailed(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const body = await readCallbackBody(request);
@@ -280,7 +282,6 @@ async function handleTriggerEnvironmentBuild(
   if (providerError) return providerError;
 
   const environmentId = params.id;
-  if (!environmentId) return error("Environment ID required", 400);
 
   return triggerBuildForScope(env, { kind: "environment", id: environmentId }, ctx);
 }
@@ -416,7 +417,12 @@ async function readStatusRows(
  * `ImageBuildRecordView`, so no storage encoding, callback token, or provider
  * id reaches a client.
  */
-async function handleGetStatus(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
+async function handleGetStatus(
+  request: Request,
+  env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
@@ -444,6 +450,7 @@ async function handleGetStatus(request: Request, env: Env, ctx: RequestContext):
 async function handleGetEnabledUnits(
   _request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
@@ -477,6 +484,7 @@ async function handleGetEnabledUnits(
 async function handleGetEnabledRepos(
   _request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
@@ -510,10 +518,10 @@ const IMAGE_BUILDS_READ = admit({
 export const imageBuildRoutes = new Hono<ControlPlaneHonoEnv>();
 
 imageBuildRoutes.post("/image-builds/build-complete", BUILD_CALLBACK, (c) =>
-  handleBuildComplete(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleBuildComplete)
 );
 imageBuildRoutes.post("/image-builds/build-failed", BUILD_CALLBACK, (c) =>
-  handleBuildFailed(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleBuildFailed)
 );
 imageBuildRoutes.post(
   "/image-builds/trigger/environment/:id",
@@ -530,11 +538,11 @@ imageBuildRoutes.put("/image-builds/toggle/repo/:owner/:name", REPO_IMAGES_MANAG
   dispatch(c, handleToggleRepoImageBuilds)
 );
 imageBuildRoutes.get("/image-builds/status", IMAGE_BUILDS_READ, (c) =>
-  handleGetStatus(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleGetStatus)
 );
 imageBuildRoutes.get("/image-builds/enabled", IMAGE_BUILDS_READ, (c) =>
-  handleGetEnabledUnits(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleGetEnabledUnits)
 );
 imageBuildRoutes.get("/image-builds/enabled-repos", IMAGE_BUILDS_READ, (c) =>
-  handleGetEnabledRepos(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  dispatch(c, handleGetEnabledRepos)
 );

--- a/packages/control-plane/src/routes/keyboard-shortcuts.ts
+++ b/packages/control-plane/src/routes/keyboard-shortcuts.ts
@@ -1,9 +1,48 @@
 import { Hono } from "hono";
 import { keyboardShortcutPreferencesPayloadSchema } from "@open-inspect/shared/types/keyboard-shortcuts";
 import { KeyboardShortcutPreferencesStore } from "../db/keyboard-shortcut-preferences";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
-import { ACTIVE_SELF, activeSelf, error, json, SCM_AGNOSTIC_HUMAN_USER_ROUTE } from "./shared";
+import {
+  ACTIVE_SELF,
+  activeSelf,
+  error,
+  json,
+  SCM_AGNOSTIC_HUMAN_USER_ROUTE,
+  type UserRouteContext,
+} from "./shared";
+import type { Env } from "../types";
+
+async function handleGetKeyboardShortcuts(
+  _request: Request,
+  _env: Env,
+  _params: object,
+  ctx: UserRouteContext
+): Promise<Response> {
+  const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).get(ctx.principal.userId);
+  return json({ shortcuts });
+}
+
+async function handleSetKeyboardShortcuts(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: UserRouteContext
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+  const parsed = keyboardShortcutPreferencesPayloadSchema.safeParse(body);
+  if (!parsed.success) return error("Invalid keyboard shortcuts", 400);
+  const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).set(
+    ctx.principal.userId,
+    parsed.data.shortcuts
+  );
+  return json({ shortcuts });
+}
 
 export const keyboardShortcutRoutes = new Hono<ControlPlaneHonoEnv>();
 
@@ -14,30 +53,11 @@ keyboardShortcutRoutes.get(
     authorization: ACTIVE_SELF,
     cacheControl: "private, no-store",
   }),
-  async (c) => {
-    const { ctx } = c.var.admitted;
-    const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).get(ctx.principal.userId);
-    return json({ shortcuts });
-  }
+  (c) => dispatch(c, handleGetKeyboardShortcuts)
 );
 
 keyboardShortcutRoutes.put(
   "/keyboard-shortcuts",
   admit({ ...SCM_AGNOSTIC_HUMAN_USER_ROUTE, authorization: activeSelf({ auditAllowed: true }) }),
-  async (c) => {
-    const { request, ctx } = c.var.admitted;
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return error("Invalid JSON body", 400);
-    }
-    const parsed = keyboardShortcutPreferencesPayloadSchema.safeParse(body);
-    if (!parsed.success) return error("Invalid keyboard shortcuts", 400);
-    const shortcuts = await new KeyboardShortcutPreferencesStore(ctx.db).set(
-      ctx.principal.userId,
-      parsed.data.shortcuts
-    );
-    return json({ shortcuts });
-  }
+  (c) => dispatch(c, handleSetKeyboardShortcuts)
 );

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -3,10 +3,11 @@
  */
 
 import { Hono } from "hono";
+import type { Env } from "../types";
 import { DEFAULT_ENABLED_MODELS, normalizeValidModels } from "@open-inspect/shared/models";
 import { ModelPreferencesStore, ModelPreferencesValidationError } from "../db/model-preferences";
 import { createLogger } from "../logger";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import {
   GITHUB_USER_OR_SERVICE_ROUTE,
@@ -20,7 +21,12 @@ import {
 
 const logger = createLogger("router:model-preferences");
 
-async function getModelPreferences(ctx: RequestContext): Promise<Response> {
+async function getModelPreferences(
+  _request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   if (!ctx.db) {
     return json({ enabledModels: DEFAULT_ENABLED_MODELS });
   }
@@ -55,7 +61,12 @@ async function getModelPreferences(ctx: RequestContext): Promise<Response> {
   }
 }
 
-async function setModelPreferences(request: Request, ctx: RequestContext): Promise<Response> {
+async function setModelPreferences(
+  request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   if (!ctx.db) {
     return error("Model preferences storage is not configured", 503);
   }
@@ -105,7 +116,7 @@ modelPreferencesRoutes.get(
     authorization: activeGlobal({ actorlessGrants: [{ service: "slack-bot" }] }),
     cacheControl: "private, no-store",
   }),
-  (c) => getModelPreferences(c.var.admitted.ctx)
+  (c) => dispatch(c, getModelPreferences)
 );
 
 modelPreferencesRoutes.put(
@@ -114,5 +125,5 @@ modelPreferencesRoutes.put(
     ...GITHUB_USER_OR_SERVICE_ROUTE,
     authorization: requirePermission("models.preferences.manage"),
   }),
-  (c) => setModelPreferences(c.var.admitted.request, c.var.admitted.ctx)
+  (c) => dispatch(c, setModelPreferences)
 );

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -138,7 +138,12 @@ async function refreshReposCache(
  * This prevents slow API pagination from blocking the Worker
  * isolate and causing head-of-line blocking for other requests.
  */
-async function handleListRepos(request: Request, env: Env, ctx: RequestContext): Promise<Response> {
+async function handleListRepos(
+  request: Request,
+  env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
   const cacheStore = createKvCacheStore(env.REPOS_CACHE);
 
   // Read from KV cache
@@ -336,7 +341,7 @@ reposRoutes.get(
       actorlessGrants: [{ service: "slack-bot" }, { service: "linear-bot" }],
     }),
   }),
-  (c) => handleListRepos(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleListRepos)
 );
 reposRoutes.put(
   "/repos/:owner/:name/metadata",

--- a/packages/control-plane/src/routes/secrets.ts
+++ b/packages/control-plane/src/routes/secrets.ts
@@ -236,6 +236,7 @@ async function handleDeleteRepoSecret(
 async function handleSetGlobalSecrets(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -290,6 +291,7 @@ async function handleSetGlobalSecrets(
 async function handleListGlobalSecrets(
   _request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   if (!ctx.db) {
@@ -395,12 +397,8 @@ secretsRoutes.get("/repos/:owner/:name/secrets", REPO_SECRETS_MANAGE, (c) =>
 secretsRoutes.delete("/repos/:owner/:name/secrets/:key", REPO_SECRETS_MANAGE, (c) =>
   dispatch(c, handleDeleteRepoSecret)
 );
-secretsRoutes.put("/secrets", GLOBAL_SECRETS_MANAGE, (c) =>
-  handleSetGlobalSecrets(c.var.admitted.request, c.env, c.var.admitted.ctx)
-);
-secretsRoutes.get("/secrets", GLOBAL_SECRETS_MANAGE, (c) =>
-  handleListGlobalSecrets(c.var.admitted.request, c.env, c.var.admitted.ctx)
-);
+secretsRoutes.put("/secrets", GLOBAL_SECRETS_MANAGE, (c) => dispatch(c, handleSetGlobalSecrets));
+secretsRoutes.get("/secrets", GLOBAL_SECRETS_MANAGE, (c) => dispatch(c, handleListGlobalSecrets));
 secretsRoutes.delete("/secrets/:key", GLOBAL_SECRETS_MANAGE, (c) =>
   dispatch(c, handleDeleteGlobalSecret)
 );

--- a/packages/control-plane/src/routes/session-attachments.ts
+++ b/packages/control-plane/src/routes/session-attachments.ts
@@ -84,7 +84,6 @@ export async function handleAttachmentPost(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
   if (sessionAttachmentRequestExceedsLimit(request)) {
     return error("Attachment request is too large", 413);
   }

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -55,7 +55,6 @@ export async function handleSpawnChild(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const parentId = params.id;
-  if (!parentId) return error("Parent session ID required");
 
   const parsedBody = spawnChildSessionRequestSchema.safeParse(await request.json());
   if (!parsedBody.success) {

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -34,7 +34,6 @@ export async function handleListChildren(
   ctx: RequestContext
 ): Promise<Response> {
   const parentId = params.id;
-  if (!parentId) return error("Parent session ID required");
 
   const sessionStore = new SessionIndexStore(ctx.db);
   const children = await sessionStore.listByParent(parentId);

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import type { RepositoryRef, RepositoryPair } from "@open-inspect/shared/types/repositories";
 import { getValidModelOrDefault, isValidReasoningEffort } from "@open-inspect/shared/models";
@@ -69,6 +69,7 @@ async function extractSessionActorProfileClaims(
 export async function handleCreateSession(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const parsed = await parseCreateSessionInput(request);
@@ -301,5 +302,5 @@ sessionCreateRoutes.post(
     authorization: requirePermission("sessions.create"),
     serviceActorClaims: extractSessionActorProfileClaims,
   }),
-  (c) => handleCreateSession(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleCreateSession)
 );

--- a/packages/control-plane/src/routes/session-diffs.ts
+++ b/packages/control-plane/src/routes/session-diffs.ts
@@ -85,7 +85,6 @@ export async function handleDiffState(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required", 400);
   const response = await ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.diffState);
   if (!response.ok) {
     return response.status === 404
@@ -105,7 +104,6 @@ export async function handleDiffUpload(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required", 400);
   const body = await readBoundedJson(
     request,
     SESSION_DIFF_UPLOAD_BODY_MAX_BYTES,
@@ -125,7 +123,6 @@ export async function handleDiffFailure(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required", 400);
   const body = await readBoundedJson(
     request,
     SESSION_DIFF_FAILURE_BODY_MAX_BYTES,
@@ -171,7 +168,6 @@ export async function handleDiffRetry(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required", 400);
   const response = await ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.diffRetry, {
     method: "POST",
   });

--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -67,6 +67,7 @@ async function listSessions(query = "", principal?: Principal): Promise<Response
   return handleListSessions(
     new Request(`https://test.local/sessions${query}`),
     createEnv(),
+    {},
     createCtx(principal)
   );
 }
@@ -77,22 +78,19 @@ async function listInbox(query = ""): Promise<Response> {
   return handleListSessionInbox(
     new Request(`https://test.local/sessions/inbox${query}`),
     createEnv(),
+    {},
     createCtx(USER_PRINCIPAL) as UserRouteContext
   );
 }
 
-async function patchReadState(
-  body: string,
-  principal?: Principal,
-  paramsOverride?: { id: string }
-): Promise<Response> {
+async function patchReadState(body: string, principal?: Principal): Promise<Response> {
   return handlePatchReadState(
     new Request("https://test.local/sessions/session-1/read-state", {
       method: "PATCH",
       body,
     }),
     createEnv(),
-    paramsOverride ?? { id: "session-1" },
+    { id: "session-1" },
     createCtx(principal) as UserRouteContext
   );
 }
@@ -304,18 +302,6 @@ describe("session index routes", () => {
     expect(mockSessionIndexStore.listInbox).not.toHaveBeenCalled();
     expect(mockSessionIndexStore.listInboxSnapshot).not.toHaveBeenCalled();
   });
-
-  it("requires a session ID for read-state mutations", async () => {
-    const response = await patchReadState(
-      JSON.stringify({ action: "mark_latest_message_read" }),
-      { kind: "user", userId: "user-1" },
-      { id: "" }
-    );
-
-    expect(response.status).toBe(400);
-    expect(mockSessionIndexStore.updateReadState).not.toHaveBeenCalled();
-  });
-
   it.each([
     ["invalid JSON", "{"],
     ["an invalid action", JSON.stringify({ action: "mark_latest_message_read", userId: "user-2" })],

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -76,6 +76,7 @@ function parseCreatedByFilters(
 export async function handleListSessions(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
@@ -130,6 +131,7 @@ export async function handleListSessions(
 export async function handleListSessionInbox(
   request: Request,
   _env: Env,
+  _params: object,
   ctx: UserRouteContext
 ): Promise<Response> {
   const query = parseQuery(request, sessionInboxQuerySchema);
@@ -208,7 +210,6 @@ export async function handlePatchReadState(
   ctx: UserRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
 
   const unparsedBody = await parseJsonBody<unknown>(request);
   if (unparsedBody instanceof Response) return unparsedBody;
@@ -241,7 +242,6 @@ export async function handleDeleteSession(
   ctx: RequestContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
 
   const sessionStore = new SessionIndexStore(ctx.db);
   await sessionStore.delete(sessionId);
@@ -254,7 +254,7 @@ export const sessionIndexRoutes = new Hono<ControlPlaneHonoEnv>();
 sessionIndexRoutes.get(
   "/sessions",
   admit({ ...GITHUB_USER_OR_SERVICE_ROUTE, authorization: requirePermission("sessions.read") }),
-  (c) => handleListSessions(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleListSessions)
 );
 sessionIndexRoutes.get(
   "/sessions/inbox",
@@ -262,7 +262,7 @@ sessionIndexRoutes.get(
     ...SCM_AGNOSTIC_HUMAN_USER_ROUTE,
     authorization: requirePermission("sessions.read", { service: "deny" }),
   }),
-  (c) => handleListSessionInbox(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleListSessionInbox)
 );
 sessionIndexRoutes.patch(
   "/sessions/:id/read-state",

--- a/packages/control-plane/src/routes/session-media-upload.ts
+++ b/packages/control-plane/src/routes/session-media-upload.ts
@@ -48,7 +48,6 @@ export async function handleMediaUpload(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
   const storage = createMediaObjectStorage(env);
 
   let formData: FormData;

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -54,7 +54,6 @@ export async function handleSessionPrompt(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
 
   let rawBody: unknown;
   try {

--- a/packages/control-plane/src/routes/session-pull-requests.ts
+++ b/packages/control-plane/src/routes/session-pull-requests.ts
@@ -3,7 +3,7 @@ import { admit } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import { SessionInternalPaths } from "../session/contracts";
 import type { Env } from "../types";
-import { error, GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
+import { GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
 import { type SessionRouteContext, dispatchSession } from "./session-route";
 
 /**
@@ -19,7 +19,6 @@ export async function handleRefreshPullRequests(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
 
   return ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.pullRequestsRefresh, {
     method: "POST",

--- a/packages/control-plane/src/routes/session-ws-token.ts
+++ b/packages/control-plane/src/routes/session-ws-token.ts
@@ -15,7 +15,6 @@ export async function handleSessionWsToken(
   ctx: SessionRouteContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required");
 
   const rawBody = await parseJsonBody<unknown>(request);
   if (rawBody instanceof Response) return rawBody;

--- a/packages/control-plane/src/routes/sign-in-providers.ts
+++ b/packages/control-plane/src/routes/sign-in-providers.ts
@@ -1,37 +1,50 @@
 import { Hono } from "hono";
 import { UserAuthConfigurationError } from "../auth/user/runtime";
 import { createLogger } from "../logger";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
-import { error, json, NO_AUTHORIZATION, SCM_AGNOSTIC_WEB_SERVICE_ROUTE } from "./shared";
+import {
+  error,
+  json,
+  NO_AUTHORIZATION,
+  type RequestContext,
+  SCM_AGNOSTIC_WEB_SERVICE_ROUTE,
+} from "./shared";
+import type { Env } from "../types";
 
 const logger = createLogger("sign-in-providers");
+
+async function handleListSignInProviders(
+  _request: Request,
+  _env: Env,
+  _params: object,
+  ctx: RequestContext
+): Promise<Response> {
+  try {
+    if (!ctx.getUserAuthRuntime) {
+      throw new UserAuthConfigurationError("User authentication runtime is unavailable");
+    }
+    const response = json({ providers: ctx.getUserAuthRuntime().enabledProviders });
+    response.headers.set("Cache-Control", "no-store");
+    return response;
+  } catch (cause) {
+    if (cause instanceof UserAuthConfigurationError) {
+      logger.error("Sign-in provider configuration is unavailable", {
+        event: "auth.providers.misconfigured",
+        error: cause,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return error("Sign-in providers are not configured", 503);
+    }
+    throw cause;
+  }
+}
 
 export const signInProviderRoutes = new Hono<ControlPlaneHonoEnv>();
 
 signInProviderRoutes.get(
   "/internal/auth/sign-in-providers",
   admit({ ...SCM_AGNOSTIC_WEB_SERVICE_ROUTE, authorization: NO_AUTHORIZATION }),
-  (c) => {
-    const { ctx } = c.var.admitted;
-    try {
-      if (!ctx.getUserAuthRuntime) {
-        throw new UserAuthConfigurationError("User authentication runtime is unavailable");
-      }
-      const response = json({ providers: ctx.getUserAuthRuntime().enabledProviders });
-      response.headers.set("Cache-Control", "no-store");
-      return response;
-    } catch (cause) {
-      if (cause instanceof UserAuthConfigurationError) {
-        logger.error("Sign-in provider configuration is unavailable", {
-          event: "auth.providers.misconfigured",
-          error: cause,
-          request_id: ctx.request_id,
-          trace_id: ctx.trace_id,
-        });
-        return error("Sign-in providers are not configured", 503);
-      }
-      throw cause;
-    }
-  }
+  (c) => dispatch(c, handleListSignInProviders)
 );

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -21,7 +21,6 @@ import { SessionIndexStore } from "../db/session-index";
 import { createLogger } from "../logger";
 import type { Env } from "../types";
 import {
-  error,
   GITHUB_SANDBOX_FALLBACK_ROUTE,
   json,
   requirePermission,
@@ -63,7 +62,6 @@ export async function handleSlackNotify(
   ctx: RequestContext
 ): Promise<Response> {
   const sessionId = params.id;
-  if (!sessionId) return error("Session ID required", 400);
 
   const parsed = await parseBody(request);
   if (parsed instanceof Response) return parsed;

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -14,7 +14,7 @@ import { SessionInternalPaths } from "../session/contracts";
 import { createSessionRuntimeClient } from "../session/runtime-client";
 import type { Env } from "../types";
 import { Hono } from "hono";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import type { RequestContext } from "../routes/shared";
 import { error, GITHUB_SERVICE_ROUTE, serviceAuthorized } from "../routes/shared";
@@ -99,6 +99,7 @@ async function trackPullRequestLifecycle(
 async function handleGitHubAutomationEvent(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   let body: unknown;
@@ -127,5 +128,5 @@ export const githubAutomationEventRoutes = new Hono<ControlPlaneHonoEnv>();
 githubAutomationEventRoutes.post(
   "/internal/github-event",
   admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("github-bot") }),
-  (c) => handleGitHubAutomationEvent(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleGitHubAutomationEvent)
 );

--- a/packages/control-plane/src/webhooks/slack.ts
+++ b/packages/control-plane/src/webhooks/slack.ts
@@ -10,7 +10,7 @@
  */
 
 import { Hono } from "hono";
-import { admit } from "../routing/admit";
+import { admit, dispatch } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import type { RequestContext } from "../routes/shared";
 import { error, GITHUB_SERVICE_ROUTE, serviceAuthorized } from "../routes/shared";
@@ -24,6 +24,7 @@ import {
 async function handleSlackAutomationEvent(
   request: Request,
   env: Env,
+  _params: object,
   ctx: RequestContext
 ): Promise<Response> {
   let body: unknown;
@@ -48,5 +49,5 @@ export const slackAutomationEventRoutes = new Hono<ControlPlaneHonoEnv>();
 slackAutomationEventRoutes.post(
   "/internal/slack-event",
   admit({ ...GITHUB_SERVICE_ROUTE, authorization: serviceAuthorized("slack-bot") }),
-  (c) => handleSlackAutomationEvent(c.var.admitted.request, c.env, c.var.admitted.ctx)
+  (c) => dispatch(c, handleSlackAutomationEvent)
 );


### PR DESCRIPTION
Finding #4 from the control-plane Hono cleanup review: handler wiring uniformity and dead code inside handlers. Pure refactor, no behavior change; both integration snapshots are byte-identical.

## One way to wire a route

Every registration now goes through `dispatch(c, handler)` or `dispatchSession(c, handler)`, so a Hono context is unpacked in exactly one place (`routing/admit.ts`). Converted:

- 17 inline closures of the form `(c) => handleX(c.var.admitted.request, c.env, c.var.admitted.ctx)` across `automation-crud`, `automation-list`, `automation-slack-settings`, `analytics`, `autofix`, `environments`, `image-builds`, `model-preferences`, `repos`, `secrets`, `session-create`, `session-index`, and `webhooks/{github,slack}`.
- 5 inline handler bodies in `audit-events`, `keyboard-shortcuts` (2), `sign-in-providers`, and `health`, each now a named handler.

Handlers take the standard `(request, env, params, ctx)` shape, with `_params: object` where the path has no parameters (the spelling `browser-auth.ts` already used; its one `Record<string, never>` is normalized too). This also retires the two-argument shape in `analytics`/`autofix`/`model-preferences` and the one-argument `getModelPreferences`.

```
$ grep -rn "c\.var\.admitted" src --include='*.ts' | grep -v '\.test\.'
src/routing/admit.ts:73:  return handler(c.var.admitted.request, c.env, c.req.param(), c.var.admitted.ctx);
```

## Unreachable path-parameter guards deleted (21)

`if (!id) return error("... ID required")` on a value that comes from a `:param` segment can never fire: Hono does not match `:param` to an empty segment, and `dispatch` types the parameter `string`.

| file | guards |
| --- | --- |
| `session-diffs.ts` | 4 |
| `environments.ts` | 3 |
| `environment-secrets.ts` | 3 |
| `session-index.ts` | 2 |
| `image-builds.ts`, `session-attachments.ts`, `session-child-spawn.ts`, `session-children.ts`, `session-media-upload.ts`, `session-prompt.ts`, `session-pull-requests.ts`, `session-ws-token.ts`, `slack-notify.ts` | 1 each |

The `integration-settings.ts` guards that look similar are kept: their `id` is the result of `integrationId(params.id)`, which is null for an unknown integration.

One unit test exercised a deleted guard by calling `handlePatchReadState` directly with `{ id: "" }`; it is removed along with the helper parameter that existed only for it.

## No-op admission assertions deleted (3)

`admittedAutomation(ctx);` with the result discarded in `automation-crud.ts` (delete) and `automation-lifecycle.ts` (pause, resume). The route policy already guarantees admission resolved the automation.

## Not in this PR

Body and query parsing (findings #2 and #3) are separate PRs; the eslint `args` setting (finding #5) is untouched.

## Verification

- `tsc -p tsconfig.json`, `-p tsconfig.test.json`, `-p test/integration`
- eslint + prettier on all 32 touched files
- control-plane unit: 241 files / 3563 tests (one unreachable test removed); integration: 96 files / 1129 tests
- `git diff --stat -- test/integration/__snapshots__` empty

https://claude.ai/code/session_01KdDpTgGEjXpBA9SaGQVUH1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when handling route-based requests across analytics, sessions, automations, environments, secrets, webhooks, and related endpoints.
  - Requests with valid route parameters now proceed without redundant missing-identifier errors.
  - Preserved existing response formats, authentication behavior, validation, and health-check results.

- **Refactor**
  - Standardized request handling across control-plane endpoints, improving reliability and maintainability without changing supported routes or core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->