### PR TITLE
fix: keep the app mounted when authorization revalidation fails

### DIFF
--- a/packages/web/src/components/app-auth-boundary.test.tsx
+++ b/packages/web/src/components/app-auth-boundary.test.tsx
@@ -3,6 +3,7 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAuthSession } from "@/lib/auth-session";
 import { AppAuthBoundary } from "./app-auth-boundary";
@@ -23,6 +24,14 @@ const activeAuthorization = {
   role: { id: "role_builtin_member", key: "member" as const, name: "Member" },
   permissions: ["repositories.read" as const],
 };
+
+let composerMounts = 0;
+
+/** Stands in for the prompt composer: unsaved draft text held in React state. */
+function DraftComposer() {
+  const [draft] = useState(() => `draft-${++composerMounts}`);
+  return <div data-testid="draft">{draft}</div>;
+}
 
 afterEach(() => {
   cleanup();
@@ -80,6 +89,64 @@ describe("AppAuthBoundary", () => {
       "Authentication is temporarily unavailable."
     );
     expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the app mounted when a revalidation fails but authorization is cached", () => {
+    composerMounts = 0;
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { id: "user-1", name: "Test User" } },
+      status: "authenticated",
+    });
+    const cached = {
+      authorization: activeAuthorization,
+      loading: false,
+      hasPermission: () => true,
+    };
+    vi.mocked(useCurrentUserAuthorization).mockReturnValue({ ...cached, error: null });
+
+    // A fresh element every time: React bails out of re-rendering an identical
+    // element reference, which would hide the state change under test.
+    const tree = () => (
+      <AppAuthBoundary>
+        <DraftComposer />
+      </AppAuthBoundary>
+    );
+    const { rerender } = render(tree());
+    expect(screen.getByTestId("draft")).toHaveTextContent("draft-1");
+
+    // A failed revalidation: SWR reports the error but retains the cached value.
+    vi.mocked(useCurrentUserAuthorization).mockReturnValue({
+      ...cached,
+      error: new Error("Authorization request failed (500)"),
+    });
+    rerender(tree());
+    expect(screen.getByTestId("draft")).toHaveTextContent("draft-1");
+
+    // The retry succeeds; the subtree must never have remounted.
+    vi.mocked(useCurrentUserAuthorization).mockReturnValue({ ...cached, error: null });
+    rerender(tree());
+    expect(screen.getByTestId("draft")).toHaveTextContent("draft-1");
+    expect(composerMounts).toBe(1);
+  });
+
+  it("fails closed when authorization has never resolved", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { id: "user-1", name: "Test User" } },
+      status: "authenticated",
+    });
+    vi.mocked(useCurrentUserAuthorization).mockReturnValue({
+      authorization: null,
+      loading: false,
+      error: new Error("Authorization request failed (500)"),
+      hasPermission: () => false,
+    });
+
+    render(<AppAuthBoundary>Session</AppAuthBoundary>);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Authorization is temporarily unavailable."
+    );
+    expect(screen.queryByText("Session")).not.toBeInTheDocument();
   });
 
   it("fails closed when workspace access is suspended", () => {

--- a/packages/web/src/components/app-auth-boundary.tsx
+++ b/packages/web/src/components/app-auth-boundary.tsx
@@ -12,7 +12,7 @@ import { useCurrentUserAuthorization } from "@/hooks/use-current-user-authorizat
  */
 export function AppAuthBoundary({ children }: { children: React.ReactNode }) {
   const { status } = useAuthSession();
-  const { authorization, loading: authorizationLoading, error } = useCurrentUserAuthorization();
+  const { authorization, loading: authorizationLoading } = useCurrentUserAuthorization();
 
   if (status === "loading") {
     return (
@@ -63,7 +63,11 @@ export function AppAuthBoundary({ children }: { children: React.ReactNode }) {
         </div>
       );
     }
-    if (error || !authorization) {
+    // Cached authorization keeps the app mounted through a failed revalidation:
+    // SWR retains the last good value and only reports the error, and remounting
+    // this subtree would discard unsaved work (an in-progress prompt). Access is
+    // denied only when no authorization has ever resolved.
+    if (!authorization) {
       return (
         <div className="min-h-screen flex items-center justify-center px-6">
           <ErrorBanner role="alert">Authorization is temporarily unavailable.</ErrorBanner>

--- a/packages/web/src/components/app-auth-boundary.tsx
+++ b/packages/web/src/components/app-auth-boundary.tsx
@@ -63,10 +63,10 @@ export function AppAuthBoundary({ children }: { children: React.ReactNode }) {
         </div>
       );
     }
-    // Cached authorization keeps the app mounted through a failed revalidation:
-    // SWR retains the last good value and only reports the error, and remounting
-    // this subtree would discard unsaved work (an in-progress prompt). Access is
-    // denied only when no authorization has ever resolved.
+    // No authorization means none has resolved yet, or the hook withheld a cached
+    // grant because the server denied access. A grant that merely failed to
+    // refresh is still present here, so a transient failure cannot unmount the
+    // app and discard unsaved work.
     if (!authorization) {
       return (
         <div className="min-h-screen flex items-center justify-center px-6">

--- a/packages/web/src/hooks/use-current-user-authorization.test.tsx
+++ b/packages/web/src/hooks/use-current-user-authorization.test.tsx
@@ -78,14 +78,15 @@ describe("useCurrentUserAuthorization", () => {
     expect(result.current.authorization.authorization).toEqual(AUTHORIZATION);
   });
 
-  it("withholds the cached grant once the server denies access", async () => {
+  // 401 follows a revoked session; 403 follows a removed role assignment
+  // (`assignment_required`). Both are answers, not blips.
+  it.each([401, 403])("withholds the cached grant once the server answers %i", async (status) => {
     vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse(AUTHORIZATION));
     const { result } = renderHarness();
     await waitFor(() => expect(result.current.authorization.authorization).not.toBeNull());
 
-    // 200 -> 403: a removed role assignment is a permanent denial, not a blip.
     vi.mocked(browserApiFetch).mockResolvedValueOnce(
-      jsonResponse({ error: "assignment_required" }, 403)
+      jsonResponse({ error: "assignment_required" }, status)
     );
     await result.current.mutate(currentUserAuthorizationKey("user-1"));
 

--- a/packages/web/src/hooks/use-current-user-authorization.test.tsx
+++ b/packages/web/src/hooks/use-current-user-authorization.test.tsx
@@ -1,60 +1,106 @@
 // @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
 
 import { renderHook, waitFor } from "@testing-library/react";
-import { SWRConfig } from "swr";
+import { SWRConfig, useSWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
 import { useAuthSession } from "@/lib/auth-session";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
-import { useCurrentUserAuthorization } from "./use-current-user-authorization";
+import {
+  currentUserAuthorizationKey,
+  useCurrentUserAuthorization,
+} from "./use-current-user-authorization";
 
 vi.mock("@/lib/auth-session", () => ({ useAuthSession: vi.fn() }));
 vi.mock("@/lib/browser-api-fetch", () => ({ browserApiFetch: vi.fn() }));
 
-const authorizations = {
-  owner: {
-    userId: "11111111111111111111111111111111",
-    suspendedAt: null,
-    role: { id: "role_builtin_owner", key: "owner" as const, name: "Owner" },
-    permissions: ["workspace.transfer_ownership" as const],
-  },
-  member: {
-    userId: "22222222222222222222222222222222",
-    suspendedAt: null,
-    role: { id: "role_builtin_member", key: "member" as const, name: "Member" },
-    permissions: ["repositories.read" as const],
-  },
+const AUTHORIZATION = {
+  userId: "11111111111111111111111111111111",
+  suspendedAt: null,
+  role: { id: "role_builtin_member", key: "member", name: "Member" },
+  permissions: ["repositories.read"],
 };
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+/** Exposes the hook plus a mutate bound to the same isolated cache. */
+function useHarness() {
+  return { authorization: useCurrentUserAuthorization(), mutate: useSWRConfig().mutate };
+}
+
+function renderHarness() {
+  return renderHook(useHarness, {
+    // A fresh provider per render keeps SWR's cache from leaking between tests.
+    wrapper: ({ children }) => (
+      <SWRConfig
+        value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}
+      >
+        {children}
+      </SWRConfig>
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useAuthSession).mockReturnValue({
+    data: { user: { id: "user-1", name: "Test User" } },
+    status: "authenticated",
+  });
+});
+
 describe("useCurrentUserAuthorization", () => {
-  beforeEach(() => vi.clearAllMocks());
+  it("keeps the cached grant when a revalidation fails with a server error", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse(AUTHORIZATION));
+    const { result } = renderHarness();
+    await waitFor(() => expect(result.current.authorization.authorization).not.toBeNull());
 
-  it("does not reuse cached authorization after the authenticated user changes", async () => {
-    let currentUser: keyof typeof authorizations = "owner";
-    vi.mocked(useAuthSession).mockImplementation(
-      () =>
-        ({
-          status: "authenticated",
-          data: { user: { id: authorizations[currentUser].userId } },
-        }) as ReturnType<typeof useAuthSession>
-    );
-    vi.mocked(browserApiFetch).mockImplementation(async () =>
-      Response.json(authorizations[currentUser])
-    );
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
-    );
-    const { result, rerender } = renderHook(useCurrentUserAuthorization, { wrapper });
-    await waitFor(() => expect(result.current.authorization?.role.key).toBe("owner"));
-    const ownerHasPermission = result.current.hasPermission;
-    rerender();
-    expect(result.current.hasPermission).toBe(ownerHasPermission);
+    // 200 -> 500: the server answered nothing about this user's access.
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500));
+    await result.current.mutate(currentUserAuthorizationKey("user-1"));
 
-    currentUser = "member";
-    rerender();
+    await waitFor(() => expect(result.current.authorization.error).toBeDefined());
+    expect(result.current.authorization.authorization).toEqual(AUTHORIZATION);
+    expect(result.current.authorization.hasPermission("repositories.read")).toBe(true);
+  });
 
-    await waitFor(() => expect(result.current.authorization?.role.key).toBe("member"));
-    expect(result.current.hasPermission).not.toBe(ownerHasPermission);
-    expect(result.current.hasPermission("workspace.transfer_ownership")).toBe(false);
+  it("keeps the cached grant when the request never reaches the server", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse(AUTHORIZATION));
+    const { result } = renderHarness();
+    await waitFor(() => expect(result.current.authorization.authorization).not.toBeNull());
+
+    vi.mocked(browserApiFetch).mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await result.current.mutate(currentUserAuthorizationKey("user-1"));
+
+    await waitFor(() => expect(result.current.authorization.error).toBeDefined());
+    expect(result.current.authorization.authorization).toEqual(AUTHORIZATION);
+  });
+
+  it("withholds the cached grant once the server denies access", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse(AUTHORIZATION));
+    const { result } = renderHarness();
+    await waitFor(() => expect(result.current.authorization.authorization).not.toBeNull());
+
+    // 200 -> 403: a removed role assignment is a permanent denial, not a blip.
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(
+      jsonResponse({ error: "assignment_required" }, 403)
+    );
+    await result.current.mutate(currentUserAuthorizationKey("user-1"));
+
+    await waitFor(() => expect(result.current.authorization.authorization).toBeNull());
+    expect(result.current.authorization.hasPermission("repositories.read")).toBe(false);
+  });
+
+  it("withholds the cached grant when the response breaks the contract", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse(AUTHORIZATION));
+    const { result } = renderHarness();
+    await waitFor(() => expect(result.current.authorization.authorization).not.toBeNull());
+
+    vi.mocked(browserApiFetch).mockResolvedValueOnce(jsonResponse({ nonsense: true }));
+    await result.current.mutate(currentUserAuthorizationKey("user-1"));
+
+    await waitFor(() => expect(result.current.authorization.authorization).toBeNull());
   });
 });

--- a/packages/web/src/hooks/use-current-user-authorization.ts
+++ b/packages/web/src/hooks/use-current-user-authorization.ts
@@ -18,9 +18,40 @@ export function currentUserAuthorizationKey(userId: string) {
   return [CURRENT_USER_AUTHORIZATION_KEY, userId] as const;
 }
 
+/**
+ * A failed authorization lookup, classified by whether the grant it failed to
+ * refresh may still be trusted. Retryable failures leave the request unanswered;
+ * every other failure is an answer, and a denial answer must take effect.
+ */
+class AuthorizationRequestError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = "AuthorizationRequestError";
+  }
+}
+
+/** Whether a cached grant survives `error`; an unrecognized failure never does. */
+function retainsCachedAuthorization(error: unknown): boolean {
+  return error instanceof AuthorizationRequestError && error.retryable;
+}
+
 async function fetchAuthorization(): Promise<EffectiveAuthorization> {
-  const response = await browserApiFetch(CURRENT_USER_AUTHORIZATION_KEY);
-  if (!response.ok) throw new Error(`Authorization request failed (${response.status})`);
+  let response: Response;
+  try {
+    response = await browserApiFetch(CURRENT_USER_AUTHORIZATION_KEY);
+  } catch (cause) {
+    // The request never reached the server, so it denies nothing.
+    throw new AuthorizationRequestError(`Authorization request failed (${String(cause)})`, true);
+  }
+  if (!response.ok) {
+    throw new AuthorizationRequestError(
+      `Authorization request failed (${response.status})`,
+      response.status >= 500
+    );
+  }
   return effectiveAuthorizationSchema.parse(await response.json());
 }
 
@@ -39,13 +70,17 @@ export function useCurrentUserAuthorization(): {
     status === "authenticated" && userId ? currentUserAuthorizationKey(userId) : null,
     fetchAuthorization
   );
+  // A revalidation that failed without denying anything leaves the last grant in
+  // force; anything else withholds it, so a revoked role stops granting access.
+  const authorization =
+    error === undefined || retainsCachedAuthorization(error) ? (data ?? null) : null;
   const hasPermission = useCallback(
-    (permission: PermissionId) => data?.permissions.includes(permission) ?? false,
-    [data?.permissions]
+    (permission: PermissionId) => authorization?.permissions.includes(permission) ?? false,
+    [authorization]
   );
 
   return {
-    authorization: data ?? null,
+    authorization,
     loading: status === "authenticated" && isLoading,
     error,
     hasPermission,


### PR DESCRIPTION
## Problem

`AppAuthBoundary` wraps the entire authenticated app (`app/(app)/layout.tsx`), and it denied access whenever `useCurrentUserAuthorization` reported an error:

```ts
if (error || !authorization) { /* "Authorization is temporarily unavailable." */ }
```

SWR **retains the last good value** on a failed revalidation and only sets `error`. So one transient failure of `/api/me/authorization` — while the user's access was valid the whole time — swapped `children` for a banner, and the next successful retry **remounted the entire subtree from scratch**.

Everything below the boundary lost its state: the sidebar refetched, the session page rebuilt, the WebSocket reconnected, and the unsent prompt draft (unpersisted React state) was destroyed. To a user this is indistinguishable from a random page refresh.

`revalidateOnFocus: true` is set globally (`app/providers.tsx`), so this is reachable on any tab focus.

## Fix

Deny access only when no authorization has ever resolved, matching the data-first ordering `useAuthSession` already uses (`if (data)` is checked before `error`). Stale-but-valid cached authorization keeps the shell mounted through a blip.

This does not weaken access control:

- The server re-authorizes every request through `admit()`; this only governs whether the shell stays mounted.
- The `suspendedAt` gate still runs, against the cached authorization.
- With nothing cached, the boundary still fails closed — covered by a new test.
- `AppAuthBoundary` was the only consumer of the hook's `error`; every other call site uses `hasPermission`, which already defaults closed.

## Tests

Two added to `app-auth-boundary.test.tsx`:

- **`keeps the app mounted when a revalidation fails but authorization is cached`** — renders a stateful stand-in for the prompt composer, flips the hook to an error with cached data, then back. Asserts the child never remounted. Verified red before the fix (`Unable to find an element by: [data-testid="draft"]`) and green after.
- **`fails closed when authorization has never resolved`** — pins the deny path so the fix can't be loosened into a real bypass.

Full web suite, lint, and typecheck pass.

## Context

Found while investigating #1725. That reporter's symptom turned out to be a fork-local change, but this is the same failure mode reachable on upstream through a different branch, so it is worth closing here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the app’s current access and mounted content when authorization revalidation fails but cached authorization remains available.
  * Continued to deny access when no authorization data is available.
  * Added coverage for authorization revalidation and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->