### PR TITLE
fix: cap browser auth request bodies

### DIFF
--- a/packages/control-plane/src/auth/authenticate.ts
+++ b/packages/control-plane/src/auth/authenticate.ts
@@ -21,7 +21,7 @@ import type { Env } from "../types";
 const logger = createLogger("auth");
 
 export { isAuthError, type AuthResult } from "./result";
-export { SERVICE_REQUEST_MAX_BODY_BYTES } from "./service/request-authenticator";
+export { SERVICE_REQUEST_MAX_BODY_BYTES } from "@open-inspect/shared/service-auth";
 
 export interface AuthenticationRequirement {
   /**

--- a/packages/control-plane/src/auth/service/request-authenticator.ts
+++ b/packages/control-plane/src/auth/service/request-authenticator.ts
@@ -1,6 +1,7 @@
 import {
   ACTOR_HEADER,
   SERVICE_HEADER,
+  SERVICE_REQUEST_MAX_BODY_BYTES,
   isServiceName,
   parseServiceSignatureHeader,
   sha256Hex,
@@ -18,13 +19,6 @@ import type { AuthResult } from "../result";
 import { serviceAuthSecret } from "./config";
 
 const logger = createLogger("auth");
-
-/**
- * Hard cap on a service-signed request body. The signature covers the body
- * hash, so the body must be buffered and hashed before verification can
- * finish. The largest legitimate signed body is a session attachment upload.
- */
-export const SERVICE_REQUEST_MAX_BODY_BYTES = 16 * 1024 * 1024;
 
 /** Parse `<namespace>:<id>` into a typed actor reference; null when malformed. */
 function parseActor(actor: string): { provider: ActorNamespace; providerUserId: string } | null {

--- a/packages/shared/src/http-body.ts
+++ b/packages/shared/src/http-body.ts
@@ -7,7 +7,7 @@
 export async function readBodyCapped(
   body: ReadableStream<Uint8Array> | null,
   maxBytes: number
-): Promise<Uint8Array | null> {
+): Promise<Uint8Array<ArrayBuffer> | null> {
   if (body === null) return new Uint8Array();
 
   const reader = body.getReader();

--- a/packages/shared/src/service-auth.ts
+++ b/packages/shared/src/service-auth.ts
@@ -18,6 +18,13 @@ export const SERVICE_SIGNATURE_HEADER = "X-OpenInspect-Service-Signature";
 export const ACTOR_HEADER = "X-OpenInspect-Actor";
 export const SIG1_PREFIX = "sig1";
 
+/**
+ * Hard cap on a service-signed request body. The signature covers the body
+ * hash, so every signing and verification edge must buffer no more than this.
+ * The largest legitimate signed body is a session attachment upload.
+ */
+export const SERVICE_REQUEST_MAX_BODY_BYTES = 16 * 1024 * 1024;
+
 export const SERVICE_NAMES = ["web", "slack-bot", "github-bot", "linear-bot"] as const;
 export type ServiceName = (typeof SERVICE_NAMES)[number];
 

--- a/packages/web/src/lib/browser-auth-proxy.test.ts
+++ b/packages/web/src/lib/browser-auth-proxy.test.ts
@@ -1,4 +1,8 @@
-import { sha256Hex, verifyServiceSignature } from "@open-inspect/shared/service-auth";
+import {
+  SERVICE_REQUEST_MAX_BODY_BYTES,
+  sha256Hex,
+  verifyServiceSignature,
+} from "@open-inspect/shared/service-auth";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -25,6 +29,42 @@ describe("proxyBrowserAuthRequest", () => {
 
   afterEach(() => {
     process.env = originalEnv;
+  });
+
+  it("rejects an oversized browser-auth body before dispatching it", async () => {
+    const request = new Request("https://web.example/api/auth/sign-in/social", {
+      method: "POST",
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(SERVICE_REQUEST_MAX_BODY_BYTES + 1));
+          controller.close();
+        },
+      }),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const response = await proxyBrowserAuthRequest(request);
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body is too large" });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+    expect(mocks.dispatchControlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized declared body without reading its stream", async () => {
+    const request = new Request("https://web.example/api/auth/sign-in/social", {
+      method: "POST",
+      headers: { "Content-Length": String(SERVICE_REQUEST_MAX_BODY_BYTES + 1) },
+      body: new ReadableStream<Uint8Array>(),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const response = await proxyBrowserAuthRequest(request);
+
+    expect(response.status).toBe(413);
+    expect(request.bodyUsed).toBe(false);
+    expect(mocks.dispatchControlPlaneFetch).not.toHaveBeenCalled();
   });
 
   it("forwards the auth request transparently with a fresh web signature", async () => {

--- a/packages/web/src/lib/browser-auth-proxy.ts
+++ b/packages/web/src/lib/browser-auth-proxy.ts
@@ -2,6 +2,8 @@ import {
   BROWSER_AUTH_CLIENT_IP_HEADER,
   isBrowserAuthProxyRoute,
 } from "@open-inspect/shared/browser-auth-routes";
+import { readBodyCapped } from "@open-inspect/shared/http-body";
+import { SERVICE_REQUEST_MAX_BODY_BYTES } from "@open-inspect/shared/service-auth";
 import { dispatchWebServiceRequest } from "./control-plane-service";
 
 const REQUEST_HEADERS = [
@@ -25,6 +27,13 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
 ]);
 
 const DECODED_BODY_RESPONSE_HEADERS = new Set(["content-encoding", "content-length"]);
+
+function requestBodyTooLarge(): Response {
+  return Response.json(
+    { error: "Request body is too large" },
+    { status: 413, headers: { "Cache-Control": "no-store", Pragma: "no-cache" } }
+  );
+}
 
 /**
  * A logical browser-auth request for server code that has no incoming URL.
@@ -130,8 +139,18 @@ export async function proxyBrowserAuthRequest(request: Request): Promise<Respons
     return Response.json({ error: "Not found" }, { status: 404 });
   }
 
-  const body =
-    method === "GET" || method === "HEAD" ? undefined : new Uint8Array(await request.arrayBuffer());
+  let body: Uint8Array<ArrayBuffer> | undefined;
+  if (method !== "GET" && method !== "HEAD") {
+    const contentLength = Number(request.headers.get("Content-Length"));
+    if (Number.isFinite(contentLength) && contentLength > SERVICE_REQUEST_MAX_BODY_BYTES) {
+      return requestBodyTooLarge();
+    }
+    const buffered = await readBodyCapped(request.body, SERVICE_REQUEST_MAX_BODY_BYTES);
+    if (buffered === null) {
+      return requestBodyTooLarge();
+    }
+    body = buffered;
+  }
   return dispatchAllowedBrowserAuthRequest({
     method,
     pathname: incomingUrl.pathname,


### PR DESCRIPTION
## Summary

- cap browser-auth request buffering at the existing 16 MiB signed-service limit
- reject oversized declared bodies before reading their streams
- share the signing and verification limit across the web and control-plane edges

## Security impact

Prevents unauthenticated browser-auth requests from making the web BFF buffer bodies up to the hosting platform limit before the control plane can apply its downstream cap.

## Testing

- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/web`
- `npm test -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/web`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`

The local Next.js production build was environment-blocked because Turbopack could not bind a local port; GitHub CI remains the authoritative web-build check.
