### PR TITLE
chore: upgrade Hono to 4.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10544,9 +10544,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -17783,7 +17783,7 @@
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
         "better-auth": "1.6.25",
-        "hono": "^4.13.0",
+        "hono": "^4.13.5",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -17802,7 +17802,7 @@
       "dependencies": {
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.13.0",
+        "hono": "^4.13.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -17818,7 +17818,7 @@
       "dependencies": {
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.13.0",
+        "hono": "^4.13.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -17858,7 +17858,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.13.0",
+        "hono": "^4.13.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -17,7 +17,7 @@
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
     "better-auth": "1.6.25",
-    "hono": "^4.13.0",
+    "hono": "^4.13.5",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/packages/github-bot/package.json
+++ b/packages/github-bot/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.13.0",
+    "hono": "^4.13.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/linear-bot/package.json
+++ b/packages/linear-bot/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.13.0",
+    "hono": "^4.13.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/slack-bot/package.json
+++ b/packages/slack-bot/package.json
@@ -16,7 +16,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.13.0",
+    "hono": "^4.13.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- raise the direct Hono dependency floor from 4.13.0 to 4.13.5
- update the single hoisted lockfile entry used by the control plane and bot workers
- pick up fixes for the recently published query-parser and body-parser advisories

## Testing

- clean `npm ci --ignore-scripts`; all four workspaces resolve Hono 4.13.5
- control-plane unit: 3,588 tests passed
- github-bot unit: 146 tests passed
- linear-bot unit: 233 tests passed
- slack-bot unit: 432 tests passed
- control-plane integration: 1,129 tests passed
- typecheck, lint, and builds passed for all four Hono consumers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hono framework version across control-plane and bot services.
  * Incorporates the latest available fixes and improvements from the updated framework version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->