### PR TITLE
Decide WebSocket upgrades in the session, complete them in the host (COL-84)

### DIFF
--- a/packages/control-plane/src/cloudflare/websocket-upgrade.ts
+++ b/packages/control-plane/src/cloudflare/websocket-upgrade.ts
@@ -1,0 +1,28 @@
+import type { Logger } from "../logger";
+import type { SessionUpgradeAdmission } from "../session/connection-authenticator";
+
+/**
+ * Complete a WebSocket upgrade the way Workers do it: the session decides,
+ * then the server half of a `WebSocketPair` is attached to the runtime and
+ * the client half rides back on a 101 response.
+ */
+export async function upgradeWebSocket(
+  upgrades: SessionUpgradeAdmission,
+  request: Request,
+  log: Logger
+): Promise<Response> {
+  const decision = await upgrades.authorize(request, log);
+  if (decision.kind === "reject") return decision.response;
+
+  const pair = new WebSocketPair();
+  const [client, server] = Object.values(pair);
+  try {
+    await upgrades.attach(server, decision, log);
+  } catch (error) {
+    log.error("WebSocket upgrade failed", {
+      error: error instanceof Error ? error : String(error),
+    });
+    return new Response("WebSocket upgrade failed", { status: 500 });
+  }
+  return new Response(null, { status: 101, webSocket: client });
+}

--- a/packages/control-plane/src/cloudflare/websocket-upgrade.ts
+++ b/packages/control-plane/src/cloudflare/websocket-upgrade.ts
@@ -4,24 +4,34 @@ import type { SessionUpgradeAdmission } from "../session/connection-authenticato
 /**
  * Complete a WebSocket upgrade the way Workers do it: the session decides,
  * then the server half of a `WebSocketPair` is attached to the runtime and
- * the client half rides back on a 101 response.
+ * the client half rides back on a 101 response. `log` is the session logger;
+ * the decision carries its own request-scoped one.
  */
 export async function upgradeWebSocket(
   upgrades: SessionUpgradeAdmission,
   request: Request,
   log: Logger
 ): Promise<Response> {
-  const decision = await upgrades.authorize(request, log);
+  const decision = await upgrades.authorize(request);
   if (decision.kind === "reject") return decision.response;
 
   const pair = new WebSocketPair();
   const [client, server] = Object.values(pair);
   try {
-    await upgrades.attach(server, decision, log);
+    await decision.attach(server);
   } catch (error) {
     log.error("WebSocket upgrade failed", {
+      ws_type: decision.role,
       error: error instanceof Error ? error : String(error),
     });
+    // Attachment commits nothing before its one await, so the server half is
+    // either unaccepted or fully attached; closing covers both without
+    // leaving the runtime a socket the client never received.
+    try {
+      server.close(1011, "WebSocket upgrade failed");
+    } catch {
+      // Never accepted: there is nothing to close.
+    }
     return new Response("WebSocket upgrade failed", { status: 500 });
   }
   return new Response(null, { status: 101, webSocket: client });

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -113,7 +113,6 @@ import {
 } from "./alarm/scheduler";
 import { createSessionInternalRoutes } from "./http/routes";
 import { SessionServer } from "./server";
-import { requestLogger } from "./request-logger";
 import { SessionHttpDispatcher } from "./http/dispatcher";
 import { SessionMessageRouter } from "./message-router";
 import { SessionDisconnectHandler } from "./disconnect-handler";
@@ -151,10 +150,8 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
 export interface SessionRuntime {
   readonly log: Logger;
   readonly server: SessionServer<WebSocket, ClientInfo>;
-  /** Admission of WebSocket upgrades; the host completes the handshake between its two calls. */
+  /** Admission of WebSocket upgrades; the host completes the handshake and attaches its socket. */
   readonly upgrades: SessionUpgradeAdmission;
-  /** The request-scoped logger for entry points the host serves outside `server`. */
-  requestLogger(request: Request): Logger;
   readonly alarms: {
     /** Expire stale authorization leases and re-arm persisted deadlines after a cold start. */
     rehydrate(): void;
@@ -846,7 +843,6 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     log,
     server,
     upgrades: connectionAuthenticator,
-    requestLogger: (request) => requestLogger(log, request),
     alarms: {
       rehydrate: () =>
         backgroundTasks.submit(

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -113,11 +113,15 @@ import {
 } from "./alarm/scheduler";
 import { createSessionInternalRoutes } from "./http/routes";
 import { SessionServer } from "./server";
+import { requestLogger } from "./request-logger";
 import { SessionHttpDispatcher } from "./http/dispatcher";
 import { SessionMessageRouter } from "./message-router";
 import { SessionDisconnectHandler } from "./disconnect-handler";
 import type { Clock, SandboxDisconnectMonitor, SessionBroadcaster, SocketRegistry } from "./ports";
-import { SessionConnectionAuthenticator } from "./connection-authenticator";
+import {
+  SessionConnectionAuthenticator,
+  type SessionUpgradeAdmission,
+} from "./connection-authenticator";
 import { SessionSnapshotReader } from "./snapshot-reader";
 import { SessionAccessReader } from "./sandbox-access-reader";
 import { createSessionScopedLogger } from "./session-logger";
@@ -147,6 +151,10 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
 export interface SessionRuntime {
   readonly log: Logger;
   readonly server: SessionServer<WebSocket, ClientInfo>;
+  /** Admission of WebSocket upgrades; the host completes the handshake between its two calls. */
+  readonly upgrades: SessionUpgradeAdmission;
+  /** The request-scoped logger for entry points the host serves outside `server`. */
+  requestLogger(request: Request): Logger;
   readonly alarms: {
     /** Expire stale authorization leases and re-arm persisted deadlines after a cold start. */
     rehydrate(): void;
@@ -790,13 +798,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   };
 
   const server = new SessionServer<WebSocket, ClientInfo>({
-    http: new SessionHttpDispatcher({
-      log,
-      routes,
-      handleWebSocketUpgrade: (request, url, requestLog) =>
-        connectionAuthenticator.handleWebSocketUpgrade(request, url, requestLog),
-      clock,
-    }),
+    http: new SessionHttpDispatcher({ log, routes, clock }),
     messages: new SessionMessageRouter({
       log,
       sockets,
@@ -843,6 +845,8 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
   return {
     log,
     server,
+    upgrades: connectionAuthenticator,
+    requestLogger: (request) => requestLogger(log, request),
     alarms: {
       rehydrate: () =>
         backgroundTasks.submit(

--- a/packages/control-plane/src/session/connection-authenticator.test.ts
+++ b/packages/control-plane/src/session/connection-authenticator.test.ts
@@ -150,10 +150,9 @@ describe("SessionConnectionAuthenticator.authorize", () => {
   it("accepts a client upgrade with a fresh ws id and no guards", async () => {
     const h = createHarness({ sandbox: null });
 
-    const decision = await h.authenticator.authorize(upgradeRequest({}), h.log);
+    const decision = await h.authenticator.authorize(upgradeRequest({}));
 
     expect(decision).toMatchObject({ kind: "accept", role: "client" });
-    expect((decision as { wsId: string }).wsId).toMatch(/^ws-\d+-[a-z0-9]+$/);
     expect(h.sandboxRepository.getSandbox).not.toHaveBeenCalled();
   });
 
@@ -161,19 +160,17 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     const h = createHarness({ sandbox: await sandboxRow() });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID })
     );
 
-    expect(decision).toEqual({ kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID });
+    expect(decision).toMatchObject({ kind: "accept", role: "sandbox" });
   });
 
   it("rejects a wrong sandbox id with 403 before checking the token", async () => {
     const h = createHarness({ sandbox: await sandboxRow() });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: "not-even-checked", sandboxId: "stale" }),
-      h.log
+      upgradeRequest({ sandbox: true, token: "not-even-checked", sandboxId: "stale" })
     );
 
     expect(await rejection(decision)).toEqual({ status: 403, body: "Forbidden: Wrong sandbox ID" });
@@ -187,8 +184,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     const h = createHarness({ sandbox: await sandboxRow() });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID })
     );
 
     expect(await rejection(decision)).toEqual({
@@ -201,8 +197,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     const h = createHarness({ sandbox: await sandboxRow({ status: "stopped" }) });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID })
     );
 
     expect((await rejection(decision)).status).toBe(401);
@@ -212,8 +207,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     const h = createHarness({ sandbox: await sandboxRow(), session: sessionRow("cancelled") });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID })
     );
 
     expect(await rejection(decision)).toEqual({ status: 410, body: "Session is terminal" });
@@ -227,8 +221,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID })
     );
 
     expect(await rejection(decision)).toEqual({ status: 410, body: "Sandbox is stopped" });
@@ -242,8 +235,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID })
     );
 
     expect(await rejection(decision)).toEqual({
@@ -260,8 +252,7 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID })
     );
 
     expect((await rejection(decision)).status).toBe(403);
@@ -271,36 +262,41 @@ describe("SessionConnectionAuthenticator.authorize", () => {
     const h = createHarness({ sandbox: await sandboxRow({ modal_sandbox_id: null }) });
 
     const decision = await h.authenticator.authorize(
-      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: "anything" }),
-      h.log
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: "anything" })
     );
 
-    expect(decision).toEqual({ kind: "accept", role: "sandbox", sandboxId: "anything" });
+    expect(decision).toMatchObject({ kind: "accept", role: "sandbox" });
   });
 });
 
-describe("SessionConnectionAuthenticator.attach", () => {
+async function accepted(h: Harness, request: Request) {
+  const decision = await h.authenticator.authorize(request);
+  if (decision.kind !== "accept") throw new Error("expected an acceptance");
+  return decision;
+}
+
+const sandboxUpgrade = () => upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID });
+
+describe("UpgradeDecision.attach", () => {
   const socket = {} as WebSocket;
 
-  it("registers a client socket and arms the authentication timeout", async () => {
+  it("registers a client socket under its ws id and arms the authentication timeout", async () => {
     const h = createHarness({ sandbox: null });
 
-    await h.authenticator.attach(socket, { kind: "accept", role: "client", wsId: "ws-1" }, h.log);
+    await (await accepted(h, upgradeRequest({}))).attach(socket);
 
-    expect(h.wsManager.acceptClientSocket).toHaveBeenCalledWith(socket, "ws-1");
+    expect(h.wsManager.acceptClientSocket).toHaveBeenCalledOnce();
+    const [, wsId] = h.wsManager.acceptClientSocket.mock.calls[0] as [WebSocket, string];
+    expect(wsId).toMatch(/^ws-\d+-[a-z0-9]+$/);
     expect(h.submitted).toEqual(["websocket.enforce_auth_timeout"]);
-    expect(h.wsManager.enforceAuthTimeout).toHaveBeenCalledWith(socket, "ws-1");
+    expect(h.wsManager.enforceAuthTimeout).toHaveBeenCalledWith(socket, wsId);
     expect(h.broadcast).not.toHaveBeenCalled();
   });
 
   it("marks the sandbox ready, publishes access, arms the inactivity check, and drains the queue", async () => {
     const h = createHarness({ sandbox: await sandboxRow() });
 
-    await h.authenticator.attach(
-      socket,
-      { kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID },
-      h.log
-    );
+    await (await accepted(h, sandboxUpgrade())).attach(socket);
 
     expect(h.wsManager.acceptAndSetSandboxSocket).toHaveBeenCalledWith(socket, SANDBOX_ID);
     expect(h.lifecycleManager.onSandboxConnected).toHaveBeenCalledOnce();
@@ -318,28 +314,63 @@ describe("SessionConnectionAuthenticator.attach", () => {
     );
   });
 
+  it("arms the inactivity check before adopting the socket", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+    const order: string[] = [];
+    h.lifecycleManager.scheduleInactivityCheck.mockImplementation(async () => {
+      order.push("schedule");
+    });
+    h.wsManager.acceptAndSetSandboxSocket.mockImplementation(() => {
+      order.push("accept");
+      return { replaced: false };
+    });
+
+    await (await accepted(h, sandboxUpgrade())).attach(socket);
+
+    expect(order).toEqual(["schedule", "accept"]);
+  });
+
+  it("commits nothing when the inactivity check cannot be armed", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+    h.lifecycleManager.scheduleInactivityCheck.mockRejectedValue(new Error("alarm unavailable"));
+
+    await expect((await accepted(h, sandboxUpgrade())).attach(socket)).rejects.toThrow(
+      "alarm unavailable"
+    );
+
+    expect(h.wsManager.acceptAndSetSandboxSocket).not.toHaveBeenCalled();
+    expect(h.lifecycleManager.onSandboxConnected).not.toHaveBeenCalled();
+    expect(h.sandboxRepository.updateSandboxStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+    expect(h.submitted).toEqual([]);
+  });
+
   it("withholds the access broadcast while provider startup is still persisting", async () => {
     const h = createHarness({ sandbox: await sandboxRow() });
     h.lifecycleManager.isProviderStartupPending.mockReturnValue(true);
 
-    await h.authenticator.attach(
-      socket,
-      { kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID },
-      h.log
-    );
+    await (await accepted(h, sandboxUpgrade())).attach(socket);
 
     expect(h.broadcast.mock.calls.map(([message]) => message.type)).toEqual(["sandbox_status"]);
   });
 
-  it("passes an absent sandbox id through as undefined", async () => {
-    const h = createHarness({ sandbox: await sandboxRow() });
+  it("passes the presented sandbox id through, or undefined when the bridge sent none", async () => {
+    const h = createHarness({ sandbox: await sandboxRow({ modal_sandbox_id: null }) });
 
-    await h.authenticator.attach(
-      socket,
-      { kind: "accept", role: "sandbox", sandboxId: null },
-      h.log
-    );
+    await (
+      await accepted(h, upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: null }))
+    ).attach(socket);
 
     expect(h.wsManager.acceptAndSetSandboxSocket).toHaveBeenCalledWith(socket, undefined);
+  });
+
+  it("attaches exactly once", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+    const decision = await accepted(h, sandboxUpgrade());
+
+    await decision.attach(socket);
+
+    await expect(decision.attach({} as WebSocket)).rejects.toThrow("already attached");
+    expect(h.wsManager.acceptAndSetSandboxSocket).toHaveBeenCalledOnce();
   });
 });

--- a/packages/control-plane/src/session/connection-authenticator.test.ts
+++ b/packages/control-plane/src/session/connection-authenticator.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for the WebSocket upgrade decision: every guard is driven through
+ * `authorize` with fake collaborators, and `attach` is checked for the side
+ * effects each accepted role runs on the host's socket.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { hashToken } from "../auth/crypto";
+import type { Logger } from "../logger";
+import type { BackgroundTasks } from "../platform-ports";
+import {
+  SessionConnectionAuthenticator,
+  type SessionConnectionAuthenticatorDeps,
+} from "./connection-authenticator";
+import type { SandboxRow, SessionRow } from "./types";
+
+const TOKEN = "sandbox-token";
+const SANDBOX_ID = "sb-1";
+
+function createLogger(): Logger {
+  const log: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => log),
+  };
+  return log;
+}
+
+async function sandboxRow(overrides: Partial<SandboxRow> = {}): Promise<SandboxRow> {
+  return {
+    id: "row",
+    modal_sandbox_id: SANDBOX_ID,
+    auth_token: null,
+    auth_token_hash: await hashToken(TOKEN),
+    status: "ready",
+    ...overrides,
+  } as SandboxRow;
+}
+
+function sessionRow(status: SessionRow["status"]): SessionRow {
+  return { id: "session", status } as SessionRow;
+}
+
+function upgradeRequest(opts: {
+  sandbox?: boolean;
+  token?: string | null;
+  sandboxId?: string | null;
+  traceId?: string;
+}): Request {
+  const headers: Record<string, string> = { Upgrade: "websocket" };
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+  if (opts.sandboxId) headers["X-Sandbox-ID"] = opts.sandboxId;
+  const query = opts.sandbox ? "?type=sandbox" : "";
+  return new Request(`https://session.local/sessions/s/ws${query}`, { headers });
+}
+
+interface Harness {
+  authenticator: SessionConnectionAuthenticator;
+  log: Logger;
+  sandboxRepository: {
+    getSandbox: ReturnType<typeof vi.fn>;
+    updateSandboxStatus: ReturnType<typeof vi.fn>;
+    updateSandboxHeartbeat: ReturnType<typeof vi.fn>;
+  };
+  wsManager: {
+    acceptClientSocket: ReturnType<typeof vi.fn>;
+    acceptAndSetSandboxSocket: ReturnType<typeof vi.fn>;
+    enforceAuthTimeout: ReturnType<typeof vi.fn>;
+  };
+  lifecycleManager: {
+    isProviderStartupPending: ReturnType<typeof vi.fn>;
+    onSandboxConnected: ReturnType<typeof vi.fn>;
+    updateLastActivity: ReturnType<typeof vi.fn>;
+    scheduleInactivityCheck: ReturnType<typeof vi.fn>;
+  };
+  broadcast: ReturnType<typeof vi.fn>;
+  submitted: string[];
+  processMessageQueue: ReturnType<typeof vi.fn>;
+}
+
+function createHarness(opts: {
+  sandbox: SandboxRow | null;
+  session?: SessionRow | null;
+  /** Called on the second sandbox read, standing in for a write landing mid-await. */
+  duringTokenHash?: () => SandboxRow | null;
+}): Harness {
+  const log = createLogger();
+  let reads = 0;
+  const sandboxRepository = {
+    getSandbox: vi.fn(() => {
+      reads += 1;
+      if (reads > 1 && opts.duringTokenHash) return opts.duringTokenHash();
+      return opts.sandbox;
+    }),
+    updateSandboxStatus: vi.fn(),
+    updateSandboxHeartbeat: vi.fn(),
+  };
+  const wsManager = {
+    acceptClientSocket: vi.fn(),
+    acceptAndSetSandboxSocket: vi.fn(() => ({ replaced: false })),
+    enforceAuthTimeout: vi.fn(async () => undefined),
+  };
+  const lifecycleManager = {
+    isProviderStartupPending: vi.fn(() => false),
+    onSandboxConnected: vi.fn(),
+    updateLastActivity: vi.fn(),
+    scheduleInactivityCheck: vi.fn(async () => undefined),
+  };
+  const broadcast = vi.fn();
+  const submitted: string[] = [];
+  const backgroundTasks: BackgroundTasks = {
+    submit: (task, metadata) => {
+      submitted.push(metadata.name);
+      void task();
+    },
+  };
+  const processMessageQueue = vi.fn(async () => undefined);
+  const deps = {
+    wsManager,
+    sessionCoreRepository: { getSession: () => opts.session ?? sessionRow("active") },
+    sandboxRepository,
+    lifecycleManager,
+    messenger: { broadcast },
+    backgroundTasks,
+    messageQueue: { processMessageQueue },
+    log,
+  } as unknown as SessionConnectionAuthenticatorDeps;
+  return {
+    authenticator: new SessionConnectionAuthenticator(deps),
+    log,
+    sandboxRepository,
+    wsManager,
+    lifecycleManager,
+    broadcast,
+    submitted,
+    processMessageQueue,
+  };
+}
+
+async function rejection(
+  decision: Awaited<ReturnType<SessionConnectionAuthenticator["authorize"]>>
+) {
+  if (decision.kind !== "reject") throw new Error(`expected a rejection, got ${decision.role}`);
+  return { status: decision.response.status, body: await decision.response.text() };
+}
+
+describe("SessionConnectionAuthenticator.authorize", () => {
+  it("accepts a client upgrade with a fresh ws id and no guards", async () => {
+    const h = createHarness({ sandbox: null });
+
+    const decision = await h.authenticator.authorize(upgradeRequest({}), h.log);
+
+    expect(decision).toMatchObject({ kind: "accept", role: "client" });
+    expect((decision as { wsId: string }).wsId).toMatch(/^ws-\d+-[a-z0-9]+$/);
+    expect(h.sandboxRepository.getSandbox).not.toHaveBeenCalled();
+  });
+
+  it("accepts a sandbox upgrade carrying the presented sandbox id", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect(decision).toEqual({ kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID });
+  });
+
+  it("rejects a wrong sandbox id with 403 before checking the token", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: "not-even-checked", sandboxId: "stale" }),
+      h.log
+    );
+
+    expect(await rejection(decision)).toEqual({ status: 403, body: "Forbidden: Wrong sandbox ID" });
+    expect(h.log.warn).toHaveBeenCalledWith(
+      "ws.connect",
+      expect.objectContaining({ reject_reason: "sandbox_id_mismatch" })
+    );
+  });
+
+  it("rejects an invalid token with 401", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect(await rejection(decision)).toEqual({
+      status: 401,
+      body: "Unauthorized: Invalid auth token",
+    });
+  });
+
+  it("rejects a stopped sandbox with 401, not 410, when the token is invalid", async () => {
+    const h = createHarness({ sandbox: await sandboxRow({ status: "stopped" }) });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: "wrong", sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect((await rejection(decision)).status).toBe(401);
+  });
+
+  it("rejects a terminal session with 410 on a read taken after authentication", async () => {
+    const h = createHarness({ sandbox: await sandboxRow(), session: sessionRow("cancelled") });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect(await rejection(decision)).toEqual({ status: 410, body: "Session is terminal" });
+  });
+
+  it("rejects a sandbox that stopped during the token hash with 410", async () => {
+    const row = await sandboxRow();
+    const h = createHarness({
+      sandbox: row,
+      duringTokenHash: () => ({ ...row, status: "stopped" }),
+    });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect(await rejection(decision)).toEqual({ status: 410, body: "Sandbox is stopped" });
+  });
+
+  it("rejects credentials rotated during the token hash with 403", async () => {
+    const row = await sandboxRow();
+    const h = createHarness({
+      sandbox: row,
+      duringTokenHash: () => ({ ...row, auth_token_hash: "rotated" }),
+    });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect(await rejection(decision)).toEqual({
+      status: 403,
+      body: "Forbidden: Sandbox credentials changed",
+    });
+  });
+
+  it("rejects a sandbox replaced during the token hash with 403", async () => {
+    const row = await sandboxRow();
+    const h = createHarness({
+      sandbox: row,
+      duringTokenHash: () => ({ ...row, modal_sandbox_id: "sb-2" }),
+    });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: SANDBOX_ID }),
+      h.log
+    );
+
+    expect((await rejection(decision)).status).toBe(403);
+  });
+
+  it("accepts a bridge for a sandbox row that has no id yet", async () => {
+    const h = createHarness({ sandbox: await sandboxRow({ modal_sandbox_id: null }) });
+
+    const decision = await h.authenticator.authorize(
+      upgradeRequest({ sandbox: true, token: TOKEN, sandboxId: "anything" }),
+      h.log
+    );
+
+    expect(decision).toEqual({ kind: "accept", role: "sandbox", sandboxId: "anything" });
+  });
+});
+
+describe("SessionConnectionAuthenticator.attach", () => {
+  const socket = {} as WebSocket;
+
+  it("registers a client socket and arms the authentication timeout", async () => {
+    const h = createHarness({ sandbox: null });
+
+    await h.authenticator.attach(socket, { kind: "accept", role: "client", wsId: "ws-1" }, h.log);
+
+    expect(h.wsManager.acceptClientSocket).toHaveBeenCalledWith(socket, "ws-1");
+    expect(h.submitted).toEqual(["websocket.enforce_auth_timeout"]);
+    expect(h.wsManager.enforceAuthTimeout).toHaveBeenCalledWith(socket, "ws-1");
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("marks the sandbox ready, publishes access, arms the inactivity check, and drains the queue", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+
+    await h.authenticator.attach(
+      socket,
+      { kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID },
+      h.log
+    );
+
+    expect(h.wsManager.acceptAndSetSandboxSocket).toHaveBeenCalledWith(socket, SANDBOX_ID);
+    expect(h.lifecycleManager.onSandboxConnected).toHaveBeenCalledOnce();
+    expect(h.sandboxRepository.updateSandboxStatus).toHaveBeenCalledWith("ready");
+    expect(h.broadcast.mock.calls.map(([message]) => message.type)).toEqual([
+      "sandbox_status",
+      "sandbox_access_changed",
+    ]);
+    expect(h.lifecycleManager.scheduleInactivityCheck).toHaveBeenCalledOnce();
+    expect(h.submitted).toEqual(["message_queue.process"]);
+    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    expect(h.log.info).toHaveBeenCalledWith(
+      "ws.connect",
+      expect.objectContaining({ outcome: "success", sandbox_id: SANDBOX_ID })
+    );
+  });
+
+  it("withholds the access broadcast while provider startup is still persisting", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+    h.lifecycleManager.isProviderStartupPending.mockReturnValue(true);
+
+    await h.authenticator.attach(
+      socket,
+      { kind: "accept", role: "sandbox", sandboxId: SANDBOX_ID },
+      h.log
+    );
+
+    expect(h.broadcast.mock.calls.map(([message]) => message.type)).toEqual(["sandbox_status"]);
+  });
+
+  it("passes an absent sandbox id through as undefined", async () => {
+    const h = createHarness({ sandbox: await sandboxRow() });
+
+    await h.authenticator.attach(
+      socket,
+      { kind: "accept", role: "sandbox", sandboxId: null },
+      h.log
+    );
+
+    expect(h.wsManager.acceptAndSetSandboxSocket).toHaveBeenCalledWith(socket, undefined);
+  });
+});

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -17,6 +17,7 @@ import type { SourceControlProviderName } from "../source-control";
 import type { BackgroundTasks } from "../platform-ports";
 import type { ClientInfo } from "../types";
 import { isValidSandboxToken } from "./sandbox-access";
+import { requestLogger } from "./request-logger";
 import { resolveParticipantName } from "./participant-name";
 import { getAvatarUrl, type ParticipantService } from "./participant-service";
 import type { PresenceService } from "./presence-service";
@@ -61,28 +62,25 @@ type AuthorizationResolution =
 
 export type ClientCommandAuthorization = "allowed" | "denied" | "unavailable";
 
-/** An upgrade the session admits; the host completes it and hands back the socket. */
-export type AcceptedUpgrade =
-  | { kind: "accept"; role: "sandbox"; sandboxId: string | null }
-  | { kind: "accept"; role: "client"; wsId: string };
-
 /**
  * The outcome of authenticating a WebSocket upgrade. The session decides;
- * the host completes the handshake because only it can produce a socket, and
- * then attaches the result.
+ * the host completes the handshake because only it can produce a socket,
+ * then hands the server-side socket to `attach`. An accepted decision is the
+ * only way to attach, and it attaches exactly once: the guards were evaluated
+ * against the state at decision time, so attach directly after authorizing.
  */
-export type UpgradeDecision = AcceptedUpgrade | { kind: "reject"; response: Response };
+export type UpgradeDecision =
+  | {
+      kind: "accept";
+      role: "sandbox" | "client";
+      /** Adopt the host's socket for this upgrade and run the connection's side effects. */
+      attach(ws: WebSocket): Promise<void>;
+    }
+  | { kind: "reject"; response: Response };
 
-/**
- * Admission of WebSocket upgrades, as the host drives it: `authorize` runs
- * every guard and decides; on accept the host completes the handshake its
- * own way and passes the server-side socket to `attach`, which adopts it and
- * runs the connection's side effects. Attach directly after authorizing —
- * the guards were evaluated against the state at decision time.
- */
+/** Admission of WebSocket upgrades, as the host drives it. */
 export interface SessionUpgradeAdmission {
-  authorize(request: Request, log: Logger): Promise<UpgradeDecision>;
-  attach(ws: WebSocket, accepted: AcceptedUpgrade, log: Logger): Promise<void>;
+  authorize(request: Request): Promise<UpgradeDecision>;
 }
 
 /**
@@ -95,17 +93,18 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
   constructor(private readonly deps: SessionConnectionAuthenticatorDeps) {}
 
   /**
-   * Decide a WebSocket upgrade. `log` is the request-scoped logger. Every
-   * guard runs here; a rejection carries the response the host returns.
+   * Decide a WebSocket upgrade. Every guard runs here; a rejection carries
+   * the response the host returns, an acceptance carries the attachment.
    */
-  async authorize(request: Request, log: Logger): Promise<UpgradeDecision> {
+  async authorize(request: Request): Promise<UpgradeDecision> {
     const { sessionCoreRepository, sandboxRepository } = this.deps;
+    const log = requestLogger(this.deps.log, request);
     log.debug("WebSocket upgrade requested");
     const url = new URL(request.url);
     const isSandbox = url.searchParams.get("type") === "sandbox";
     if (!isSandbox) {
       const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-      return { kind: "accept", role: "client", wsId };
+      return accept("client", (ws) => this.attachClient(ws, wsId));
     }
 
     const wsStartTime = Date.now();
@@ -190,11 +189,25 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
     }
 
     // The success ws.connect event is emitted once the socket is attached.
-    return { kind: "accept", role: "sandbox", sandboxId };
+    return accept("sandbox", (ws) => this.attachSandbox(ws, sandboxId, log));
   }
 
-  /** Adopt the host's server-side socket for an accepted upgrade and run its side effects. */
-  async attach(ws: WebSocket, accepted: AcceptedUpgrade, log: Logger): Promise<void> {
+  private attachClient(ws: WebSocket, wsId: string): void {
+    const { wsManager, backgroundTasks } = this.deps;
+    wsManager.acceptClientSocket(ws, wsId);
+    backgroundTasks.submit(() => wsManager.enforceAuthTimeout(ws, wsId), {
+      name: "websocket.enforce_auth_timeout",
+      context: { ws_id: wsId },
+    });
+  }
+
+  /**
+   * Prepare, then commit. The inactivity alarm is the one fallible step, so
+   * it runs first: a failure leaves the previous bridge in place and nothing
+   * published. Everything after the await is synchronous, so the new socket,
+   * the ready status, and the broadcasts land together.
+   */
+  private async attachSandbox(ws: WebSocket, sandboxId: string | null, log: Logger): Promise<void> {
     const {
       wsManager,
       sandboxRepository,
@@ -204,17 +217,11 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
       messageQueue,
     } = this.deps;
 
-    if (accepted.role === "client") {
-      const { wsId } = accepted;
-      wsManager.acceptClientSocket(ws, wsId);
-      backgroundTasks.submit(() => wsManager.enforceAuthTimeout(ws, wsId), {
-        name: "websocket.enforce_auth_timeout",
-        context: { ws_id: wsId },
-      });
-      return;
-    }
+    const now = Date.now();
+    lifecycleManager.updateLastActivity(now);
+    sandboxRepository.updateSandboxHeartbeat(now);
+    await lifecycleManager.scheduleInactivityCheck();
 
-    const { sandboxId } = accepted;
     // The lifecycle manager publishes access after any pending provider
     // startup has persisted its URLs and credentials.
     const accessIsPersisted = !lifecycleManager.isProviderStartupPending();
@@ -226,13 +233,6 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
     if (accessIsPersisted) {
       messenger.broadcast({ type: "sandbox_access_changed" });
     }
-
-    // Set initial activity timestamp and schedule inactivity check
-    // IMPORTANT: Must await to ensure alarm is scheduled before returning
-    const now = Date.now();
-    lifecycleManager.updateLastActivity(now);
-    sandboxRepository.updateSandboxHeartbeat(now);
-    await lifecycleManager.scheduleInactivityCheck();
 
     log.info("ws.connect", {
       event: "ws.connect",
@@ -474,4 +474,21 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
 
 function reject(body: string, status: number): UpgradeDecision {
   return { kind: "reject", response: new Response(body, { status }) };
+}
+
+/** An accepted decision whose attachment can run once. */
+function accept(
+  role: "sandbox" | "client",
+  attach: (ws: WebSocket) => void | Promise<void>
+): UpgradeDecision {
+  let attached = false;
+  return {
+    kind: "accept",
+    role,
+    attach: async (ws) => {
+      if (attached) throw new Error("WebSocket upgrade already attached");
+      attached = true;
+      await attach(ws);
+    },
+  };
 }

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -61,172 +61,192 @@ type AuthorizationResolution =
 
 export type ClientCommandAuthorization = "allowed" | "denied" | "unavailable";
 
+/** An upgrade the session admits; the host completes it and hands back the socket. */
+export type AcceptedUpgrade =
+  | { kind: "accept"; role: "sandbox"; sandboxId: string | null }
+  | { kind: "accept"; role: "client"; wsId: string };
+
+/**
+ * The outcome of authenticating a WebSocket upgrade. The session decides;
+ * the host completes the handshake because only it can produce a socket, and
+ * then attaches the result.
+ */
+export type UpgradeDecision = AcceptedUpgrade | { kind: "reject"; response: Response };
+
+/**
+ * Admission of WebSocket upgrades, as the host drives it: `authorize` runs
+ * every guard and decides; on accept the host completes the handshake its
+ * own way and passes the server-side socket to `attach`, which adopts it and
+ * runs the connection's side effects. Attach directly after authorizing —
+ * the guards were evaluated against the state at decision time.
+ */
+export interface SessionUpgradeAdmission {
+  authorize(request: Request, log: Logger): Promise<UpgradeDecision>;
+  attach(ws: WebSocket, accepted: AcceptedUpgrade, log: Logger): Promise<void>;
+}
+
 /**
  * Admits connections to the session: sandbox WebSocket upgrades (token +
  * lifecycle-state guards, re-checked after the non-storage token-hash await),
  * client subscriptions (token TTL, permission checks, authorization leases,
  * snapshot handoff), and post-hibernation client identity recovery.
  */
-export class SessionConnectionAuthenticator {
+export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
   constructor(private readonly deps: SessionConnectionAuthenticatorDeps) {}
 
   /**
-   * Handle WebSocket upgrade request. `log` is the request-scoped logger.
+   * Decide a WebSocket upgrade. `log` is the request-scoped logger. Every
+   * guard runs here; a rejection carries the response the host returns.
    */
-  async handleWebSocketUpgrade(request: Request, url: URL, log: Logger): Promise<Response> {
+  async authorize(request: Request, log: Logger): Promise<UpgradeDecision> {
+    const { sessionCoreRepository, sandboxRepository } = this.deps;
+    log.debug("WebSocket upgrade requested");
+    const url = new URL(request.url);
+    const isSandbox = url.searchParams.get("type") === "sandbox";
+    if (!isSandbox) {
+      const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      return { kind: "accept", role: "client", wsId };
+    }
+
+    const wsStartTime = Date.now();
+    const authHeader = request.headers.get("Authorization");
+    const sandboxId = request.headers.get("X-Sandbox-ID");
+    const providedToken = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length)
+      : null;
+
+    // Get expected values from DB
+    const sandbox = sandboxRepository.getSandbox();
+    const expectedSandboxId = sandbox?.modal_sandbox_id;
+
+    // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
+    if (expectedSandboxId && sandboxId !== expectedSandboxId) {
+      log.warn("ws.connect", {
+        event: "ws.connect",
+        ws_type: "sandbox",
+        outcome: "auth_failed",
+        reject_reason: "sandbox_id_mismatch",
+        expected_sandbox_id: expectedSandboxId,
+        sandbox_id: sandboxId,
+        duration_ms: Date.now() - wsStartTime,
+      });
+      return reject("Forbidden: Wrong sandbox ID", 403);
+    }
+
+    // Validate auth token
+    const tokenMatches = await isValidSandboxToken(providedToken, sandbox);
+    if (!tokenMatches) {
+      log.warn("ws.connect", {
+        event: "ws.connect",
+        ws_type: "sandbox",
+        outcome: "auth_failed",
+        reject_reason: "token_mismatch",
+        duration_ms: Date.now() - wsStartTime,
+      });
+      return reject("Unauthorized: Invalid auth token", 401);
+    }
+
+    // Reject connection if the session itself is closed for good. Narrower
+    // than "not active": `completed` and `failed` sessions are idle, not
+    // over — warm-on-typing spawns a sandbox for one before the follow-up
+    // prompt arrives, and rejecting its bridge stranded that prompt.
+    //
+    // Read after authentication, not before: token hashing is a non-storage
+    // await, so the input gate lets a cancel or archive land while this
+    // request is suspended. Admission needs a fresh, synchronous read.
+    const currentSession = sessionCoreRepository.getSession();
+    if (currentSession && !isSessionPromptable(currentSession.status)) {
+      log.warn("ws.connect", {
+        event: "ws.connect",
+        ws_type: "sandbox",
+        outcome: "rejected",
+        reject_reason: "session_terminal",
+        session_status: currentSession.status,
+        duration_ms: Date.now() - wsStartTime,
+      });
+      return reject("Session is terminal", 410);
+    }
+
+    const currentSandbox = sandboxRepository.getSandbox();
+    // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
+    // still connect after a slow boot and self-heal by becoming ready.
+    if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
+      log.warn("ws.connect", {
+        event: "ws.connect",
+        ws_type: "sandbox",
+        outcome: "rejected",
+        reject_reason: "sandbox_stopped",
+        sandbox_status: currentSandbox.status,
+        duration_ms: Date.now() - wsStartTime,
+      });
+      return reject("Sandbox is stopped", 410);
+    }
+    if (
+      currentSandbox?.modal_sandbox_id !== expectedSandboxId ||
+      currentSandbox?.auth_token_hash !== sandbox?.auth_token_hash ||
+      currentSandbox?.auth_token !== sandbox?.auth_token
+    ) {
+      return reject("Forbidden: Sandbox credentials changed", 403);
+    }
+
+    // The success ws.connect event is emitted once the socket is attached.
+    return { kind: "accept", role: "sandbox", sandboxId };
+  }
+
+  /** Adopt the host's server-side socket for an accepted upgrade and run its side effects. */
+  async attach(ws: WebSocket, accepted: AcceptedUpgrade, log: Logger): Promise<void> {
     const {
       wsManager,
-      sessionCoreRepository,
       sandboxRepository,
       lifecycleManager,
       messenger,
       backgroundTasks,
       messageQueue,
     } = this.deps;
-    log.debug("WebSocket upgrade requested");
-    const isSandbox = url.searchParams.get("type") === "sandbox";
 
-    // Validate sandbox authentication
-    if (isSandbox) {
-      const wsStartTime = Date.now();
-      const authHeader = request.headers.get("Authorization");
-      const sandboxId = request.headers.get("X-Sandbox-ID");
-      const providedToken = authHeader?.startsWith("Bearer ")
-        ? authHeader.slice("Bearer ".length)
-        : null;
-
-      // Get expected values from DB
-      const sandbox = sandboxRepository.getSandbox();
-      const expectedSandboxId = sandbox?.modal_sandbox_id;
-
-      // Validate sandbox ID first (catches stale sandboxes reconnecting after restore)
-      if (expectedSandboxId && sandboxId !== expectedSandboxId) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "auth_failed",
-          reject_reason: "sandbox_id_mismatch",
-          expected_sandbox_id: expectedSandboxId,
-          sandbox_id: sandboxId,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Forbidden: Wrong sandbox ID", { status: 403 });
-      }
-
-      // Validate auth token
-      const tokenMatches = await isValidSandboxToken(providedToken, sandbox);
-      if (!tokenMatches) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "auth_failed",
-          reject_reason: "token_mismatch",
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Unauthorized: Invalid auth token", { status: 401 });
-      }
-
-      // Reject connection if the session itself is closed for good. Narrower
-      // than "not active": `completed` and `failed` sessions are idle, not
-      // over — warm-on-typing spawns a sandbox for one before the follow-up
-      // prompt arrives, and rejecting its bridge stranded that prompt.
-      //
-      // Read after authentication, not before: token hashing is a non-storage
-      // await, so the input gate lets a cancel or archive land while this
-      // request is suspended. Admission needs a fresh, synchronous read.
-      const currentSession = sessionCoreRepository.getSession();
-      if (currentSession && !isSessionPromptable(currentSession.status)) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "rejected",
-          reject_reason: "session_terminal",
-          session_status: currentSession.status,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Session is terminal", { status: 410 });
-      }
-
-      const currentSandbox = sandboxRepository.getSandbox();
-      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
-      // still connect after a slow boot and self-heal by becoming ready.
-      if (currentSandbox && isSandboxReconnectBlockedStatus(currentSandbox.status)) {
-        log.warn("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "rejected",
-          reject_reason: "sandbox_stopped",
-          sandbox_status: currentSandbox.status,
-          duration_ms: Date.now() - wsStartTime,
-        });
-        return new Response("Sandbox is stopped", { status: 410 });
-      }
-      if (
-        currentSandbox?.modal_sandbox_id !== expectedSandboxId ||
-        currentSandbox?.auth_token_hash !== sandbox?.auth_token_hash ||
-        currentSandbox?.auth_token !== sandbox?.auth_token
-      ) {
-        return new Response("Forbidden: Sandbox credentials changed", { status: 403 });
-      }
-
-      // Auth passed — continue to WebSocket accept below
-      // The success ws.connect event is emitted after the WebSocket is accepted
-    }
-
-    try {
-      const { client, server } = wsManager.createUpgradeSockets();
-
-      const sandboxId = request.headers.get("X-Sandbox-ID");
-
-      if (isSandbox) {
-        // The lifecycle manager publishes access after any pending provider
-        // startup has persisted its URLs and credentials.
-        const accessIsPersisted = !lifecycleManager.isProviderStartupPending();
-        const { replaced } = wsManager.acceptAndSetSandboxSocket(server, sandboxId ?? undefined);
-        // Notify manager that sandbox connected so it can reset the spawning flag
-        lifecycleManager.onSandboxConnected();
-        sandboxRepository.updateSandboxStatus("ready");
-        messenger.broadcast({ type: "sandbox_status", status: "ready" });
-        if (accessIsPersisted) {
-          messenger.broadcast({ type: "sandbox_access_changed" });
-        }
-
-        // Set initial activity timestamp and schedule inactivity check
-        // IMPORTANT: Must await to ensure alarm is scheduled before returning
-        const now = Date.now();
-        lifecycleManager.updateLastActivity(now);
-        sandboxRepository.updateSandboxHeartbeat(now);
-        await lifecycleManager.scheduleInactivityCheck();
-
-        log.info("ws.connect", {
-          event: "ws.connect",
-          ws_type: "sandbox",
-          outcome: "success",
-          sandbox_id: sandboxId,
-          replaced_existing: replaced,
-          duration_ms: Date.now() - now,
-        });
-
-        // Process any pending messages now that sandbox is connected
-        backgroundTasks.submit(() => messageQueue.processMessageQueue(), {
-          name: "message_queue.process",
-        });
-      } else {
-        const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-        wsManager.acceptClientSocket(server, wsId);
-        backgroundTasks.submit(() => wsManager.enforceAuthTimeout(server, wsId), {
-          name: "websocket.enforce_auth_timeout",
-          context: { ws_id: wsId },
-        });
-      }
-
-      return new Response(null, { status: 101, webSocket: client });
-    } catch (error) {
-      log.error("WebSocket upgrade failed", {
-        error: error instanceof Error ? error : String(error),
+    if (accepted.role === "client") {
+      const { wsId } = accepted;
+      wsManager.acceptClientSocket(ws, wsId);
+      backgroundTasks.submit(() => wsManager.enforceAuthTimeout(ws, wsId), {
+        name: "websocket.enforce_auth_timeout",
+        context: { ws_id: wsId },
       });
-      return new Response("WebSocket upgrade failed", { status: 500 });
+      return;
     }
+
+    const { sandboxId } = accepted;
+    // The lifecycle manager publishes access after any pending provider
+    // startup has persisted its URLs and credentials.
+    const accessIsPersisted = !lifecycleManager.isProviderStartupPending();
+    const { replaced } = wsManager.acceptAndSetSandboxSocket(ws, sandboxId ?? undefined);
+    // Notify manager that sandbox connected so it can reset the spawning flag
+    lifecycleManager.onSandboxConnected();
+    sandboxRepository.updateSandboxStatus("ready");
+    messenger.broadcast({ type: "sandbox_status", status: "ready" });
+    if (accessIsPersisted) {
+      messenger.broadcast({ type: "sandbox_access_changed" });
+    }
+
+    // Set initial activity timestamp and schedule inactivity check
+    // IMPORTANT: Must await to ensure alarm is scheduled before returning
+    const now = Date.now();
+    lifecycleManager.updateLastActivity(now);
+    sandboxRepository.updateSandboxHeartbeat(now);
+    await lifecycleManager.scheduleInactivityCheck();
+
+    log.info("ws.connect", {
+      event: "ws.connect",
+      ws_type: "sandbox",
+      outcome: "success",
+      sandbox_id: sandboxId,
+      replaced_existing: replaced,
+      duration_ms: Date.now() - now,
+    });
+
+    // Process any pending messages now that sandbox is connected
+    backgroundTasks.submit(() => messageQueue.processMessageQueue(), {
+      name: "message_queue.process",
+    });
   }
 
   /** Validate the client token and current permission before granting an authorization lease. */
@@ -450,4 +470,8 @@ export class SessionConnectionAuthenticator {
     wsManager.setClient(ws, clientInfo);
     return clientInfo;
   }
+}
+
+function reject(body: string, status: number): UpgradeDecision {
+  return { kind: "reject", response: new Response(body, { status }) };
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -74,7 +74,7 @@ export class SessionDO extends DurableObject<Env> {
   async fetch(request: Request): Promise<Response> {
     const runtime = this.runtime;
     if (request.headers.get("Upgrade") === "websocket") {
-      return upgradeWebSocket(runtime.upgrades, request, runtime.requestLogger(request));
+      return upgradeWebSocket(runtime.upgrades, request, runtime.log);
     }
     return runtime.server.onRequest(request);
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -11,6 +11,7 @@ import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import type { Env } from "../types";
 import { createDurableObjectSessionPlatform } from "../cloudflare/session-platform";
+import { upgradeWebSocket } from "../cloudflare/websocket-upgrade";
 import type { SessionPlatform } from "./platform";
 import { createSessionRuntime, type SessionRuntime } from "./components";
 
@@ -66,10 +67,16 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Handle incoming HTTP requests.
+   * Handle incoming HTTP requests. WebSocket upgrades are completed here,
+   * on the Cloudflare side of the session, because only the host can turn
+   * an admitted upgrade into a socket.
    */
   async fetch(request: Request): Promise<Response> {
-    return this.runtime.server.onRequest(request);
+    const runtime = this.runtime;
+    if (request.headers.get("Upgrade") === "websocket") {
+      return upgradeWebSocket(runtime.upgrades, request, runtime.requestLogger(request));
+    }
+    return runtime.server.onRequest(request);
   }
 
   /**

--- a/packages/control-plane/src/session/http/dispatcher.ts
+++ b/packages/control-plane/src/session/http/dispatcher.ts
@@ -1,11 +1,11 @@
 import type { Logger } from "../../logger";
 import type { Clock } from "../ports";
+import { requestLogger } from "../request-logger";
 import type { SessionInternalRoute } from "./routes";
 
 export interface SessionHttpDispatcherDeps {
   log: Logger;
   routes: readonly SessionInternalRoute[];
-  handleWebSocketUpgrade: (request: Request, url: URL, log: Logger) => Promise<Response>;
   clock: Clock;
 }
 
@@ -15,15 +15,12 @@ export class SessionHttpDispatcher {
 
   async dispatch(request: Request): Promise<Response> {
     const fetchStart = this.deps.clock.monotonicNowMs();
-    const log = this.requestLogger(request);
+    const log = requestLogger(this.deps.log, request);
     const url = new URL(request.url);
     const path = url.pathname;
 
-    // Preserve the existing contract: upgrades and unmatched routes are not route metrics.
-    if (request.headers.get("Upgrade") === "websocket") {
-      return this.deps.handleWebSocketUpgrade(request, url, log);
-    }
-
+    // Unmatched routes are not route metrics. WebSocket upgrades never reach
+    // this dispatcher: the host completes them against `SessionUpgradeAdmission`.
     const route = this.deps.routes.find(
       (candidate) => candidate.path === path && candidate.method === request.method
     );
@@ -54,18 +51,5 @@ export class SessionHttpDispatcher {
         outcome,
       });
     }
-  }
-
-  private requestLogger(request: Request): Logger {
-    // Never mutate the session logger with request correlation shared by later callbacks.
-    const sessionLog = this.deps.log;
-    const traceId = request.headers.get("x-trace-id");
-    const requestId = request.headers.get("x-request-id");
-    if (!traceId && !requestId) return sessionLog;
-
-    const correlationContext: Record<string, unknown> = {};
-    if (traceId) correlationContext.trace_id = traceId;
-    if (requestId) correlationContext.request_id = requestId;
-    return sessionLog.child(correlationContext);
   }
 }

--- a/packages/control-plane/src/session/request-logger.ts
+++ b/packages/control-plane/src/session/request-logger.ts
@@ -1,0 +1,18 @@
+import type { Logger } from "../logger";
+
+/**
+ * A child of the session logger carrying the request's trace and request
+ * ids. Returns the session logger itself when the request carries neither,
+ * and never mutates it: request correlation must not leak into the callbacks
+ * the session logger serves later.
+ */
+export function requestLogger(sessionLog: Logger, request: Request): Logger {
+  const traceId = request.headers.get("x-trace-id");
+  const requestId = request.headers.get("x-request-id");
+  if (!traceId && !requestId) return sessionLog;
+
+  const correlationContext: Record<string, unknown> = {};
+  if (traceId) correlationContext.trace_id = traceId;
+  if (requestId) correlationContext.request_id = requestId;
+  return sessionLog.child(correlationContext);
+}

--- a/packages/control-plane/src/session/server.test.ts
+++ b/packages/control-plane/src/session/server.test.ts
@@ -76,7 +76,6 @@ function createHarness() {
         handler: vi.fn(async () => new Response("state", { status: 200 })),
       },
     ],
-    handleWebSocketUpgrade: vi.fn(async () => new Response(null, { status: 200 })),
     clock,
   };
   const messageDeps: SessionMessageRouterDeps<string, TestClient> = {

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -319,6 +319,19 @@ describe("SessionWebSocketManagerImpl", () => {
       expect(oldWs.close).toHaveBeenCalledWith(1000, "New sandbox connecting");
     });
 
+    it("closes an attached sandbox socket after the in-memory pointer is lost", () => {
+      const { manager } = createManager();
+      const oldWs = createFakeWebSocket();
+      const newWs = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(oldWs, "sb-1");
+      manager.clearSandboxSocket();
+
+      const result = manager.acceptAndSetSandboxSocket(newWs, "sb-1");
+
+      expect(result.replaced).toBe(true);
+      expect(oldWs.close).toHaveBeenCalledWith(1000, "New sandbox connecting");
+    });
+
     it("does not try to close an already-closed sandbox socket", () => {
       const { manager } = createManager();
       const oldWs = createFakeWebSocket(WebSocket.CLOSED);
@@ -387,6 +400,16 @@ describe("SessionWebSocketManagerImpl", () => {
 
       expect(manager.getSandboxSocket()).toBeNull();
       expect(untaggedWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
+    });
+
+    it("rejects a cached socket when the persisted sandbox ID changes", () => {
+      const { manager, mockRepo } = createManager();
+      const oldWs = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(oldWs, "old-id");
+      mockRepo.setSandbox(createSandboxRow("new-id"));
+
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(oldWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
     });
 
     it("returns null when cached socket is closed", () => {

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -143,12 +143,16 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     this.host.accept(ws, tags);
 
     let replaced = false;
-    if (this.sandboxWs && this.sandboxWs !== ws) {
+    // Close every other live sandbox socket, not only the cached one: after
+    // hibernation the pointer is gone but the old bridge's socket is still
+    // attached under its tags.
+    const existingSockets = new Set(this.host.sockets("sandbox"));
+    if (this.sandboxWs) existingSockets.add(this.sandboxWs);
+    for (const existing of existingSockets) {
+      if (existing === ws || existing.readyState !== WebSocket.OPEN) continue;
       try {
-        if (this.sandboxWs.readyState === WebSocket.OPEN) {
-          this.sandboxWs.close(1000, "New sandbox connecting");
-          replaced = true;
-        }
+        existing.close(1000, "New sandbox connecting");
+        replaced = true;
       } catch {
         // Ignore errors closing old WebSocket
       }
@@ -198,7 +202,15 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     }
 
     if (this.sandboxWs?.readyState === WebSocket.OPEN) {
-      return this.sandboxWs;
+      const cached = this.classify(this.sandboxWs);
+      if (
+        !expectedSandboxId ||
+        (cached.kind === "sandbox" && cached.sandboxId === expectedSandboxId)
+      ) {
+        return this.sandboxWs;
+      }
+      this.close(this.sandboxWs, 1000, "Sandbox identity changed");
+      this.sandboxWs = null;
     }
 
     // Hibernation recovery: scan all WebSockets, validate sandbox identity

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -33,9 +33,6 @@ export interface WebSocketManagerConfig {
 
 /** Manages session sockets, client identity, and expiring authorization leases. */
 export interface SessionWebSocketManager {
-  /** Create the client/server WebSocket pair for an upgrade response. */
-  createUpgradeSockets(): { client: WebSocket; server: WebSocket };
-
   /** Accept a client WebSocket with a wsId tag for hibernation recovery. */
   acceptClientSocket(ws: WebSocket, wsId: string): void;
 
@@ -127,12 +124,6 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // -------------------------------------------------------------------------
   // Accept
   // -------------------------------------------------------------------------
-
-  createUpgradeSockets(): { client: WebSocket; server: WebSocket } {
-    const pair = new WebSocketPair();
-    const [client, server] = Object.values(pair);
-    return { client, server };
-  }
 
   acceptClientSocket(ws: WebSocket, wsId: string): void {
     this.host.accept(ws, [`wsid:${wsId}`]);


### PR DESCRIPTION
## Summary

Roadmap **P-2 / COL-84** (Control plane on AWS, epic E1). Follows #1715 (P-1).

`SessionConnectionAuthenticator.handleWebSocketUpgrade` performed the whole upgrade for both legs: it created a `WebSocketPair`, accepted the server half, and returned the 101 with `webSocket: client`. Both the pair and `Response.webSocket` exist only on Workers; on Node the HTTP server completes the handshake (`ws.handleUpgrade`) after the same authentication and guards. So the session now **decides** and the host **accepts**.

### What changed

- **`UpgradeDecision`** (`session/connection-authenticator.ts`): `authorize(request)` runs every guard and returns either `{ kind: "reject", response }` or `{ kind: "accept", role, attach(ws) }`. Guard order is unchanged and still entirely after token validation: 403 wrong sandbox id → 401 invalid token → 410 session terminal → 410 sandbox stopped → 403 credentials changed. `attach` is a **one-shot capability** closed over the admitted identity and the request-scoped logger, so authorize → host handshake → attach is the only successful path by construction. Sandbox attachment is **prepare-then-commit**: arming the inactivity alarm is the one fallible await and runs first; adopting the socket, the ready status, and the broadcasts follow synchronously, so a failed handshake leaves the previous bridge in place and publishes nothing. The authenticator implements the narrow `SessionUpgradeAdmission` interface hosts program against.
- **Cloudflare adapter** `src/cloudflare/websocket-upgrade.ts`: authorize → `WebSocketPair` → attach the server half → 101 with the client half; on attach failure it closes the server half and returns 500. `SessionDO.fetch` routes `Upgrade: websocket` requests to it; everything else still goes through `server.onRequest`.
- The HTTP dispatcher no longer has an upgrade branch or dep, and `createUpgradeSockets()` is gone from the manager. `SessionRuntime` gains `upgrades`; the request-correlation child logger moved to `session/request-logger.ts`, shared by the dispatcher and the authenticator.
- **Prod → public reconciliation** (first commit): the two manager hunks production has carried since #1586 land on the `SocketHost` port. Accepting a bridge now closes every other live sandbox socket (not only the cached pointer, which hibernation drops), and the cached socket is validated against the persisted sandbox id before the fast-path return. Two tests ported with them.

### Deviations from the issue text

- The accepted decision carries the attachment rather than the identity fields (`sandboxId` / `wsId`); the identity is closed over. `ClientInfo` is built at `subscribe`, not at upgrade, so there was nothing else to carry.
- `sockets.accept(server, tags)` stays inside the manager (`acceptClientSocket` / `acceptAndSetSandboxSocket`) rather than moving to the adapter: the tags are manager-owned identity and the manager already reaches the host through the `SocketHost` port, so a Node host gets the same tagging for free.

### Done when

- [x] No `WebSocketPair` or `webSocket:` outside `src/cloudflare/` (`index.ts:141` is the Worker-level forward, untouched per the issue).
- [x] `websocket-sandbox.test.ts`, `websocket-client.test.ts`, the #1577 410 race tests and the credentials-changed 403 test pass unchanged.
- [x] `connection-authenticator.test.ts` drives `authorize` with fake collaborators and asserts the decision for each guard, including the mid-hash mutations, and `attach` for both roles, the prepare-then-commit ordering, the nothing-committed failure path, and one-shot attachment.
- [x] `index.ts handleWebSocket` untouched.

### Verification

- `npm run typecheck -w @open-inspect/control-plane`: clean
- Unit: 245 files, 3,619 tests pass
- Workerd integration: 96 files, 1,129 tests pass (the two "force eviction" uncaught-exception lines are the eviction test's deliberate abort)

### Follow-up filed, not in this PR

The deep review noted that closing replaced sandbox sockets is cleanup, not a dispatch fence: the message router processes frames from any `sandbox`-tagged socket without checking it against the active one. That predates this PR (and the prod hunk it reconciles) and needs its own design for stale-bridge trailing events and hibernation recovery, so it is filed as COL-128 (P-9), blocking N-8.

Closes COL-84. PR #1513 closed as superseded.

https://claude.ai/code/session_01E3k9fw7GE4HMYHh86vKxXp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-managed WebSocket upgrades for session connections.
  * Added request correlation using trace and request IDs in logs.

* **Bug Fixes**
  * Improved validation for sandbox WebSocket connections, including stale credentials and changed sandbox identities.
  * Replaced all active sandbox sockets when a sandbox reconnects, including sockets retained during hibernation.
  * Improved handling of upgrade authorization failures and attachment errors.

* **Tests**
  * Added coverage for connection authorization, lifecycle events, socket replacement, and stale connection recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->