### PR TITLE
feat: Node host alarm clock and deadline index for session runtimes (COL-94)

### DIFF
--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -10,11 +10,20 @@ import {
   PersistedAlarmDeadlineStore,
 } from "../session/alarm/scheduler";
 import { initSchema } from "../session/schema";
-import { HostAlarmClock } from "./host-alarm-clock";
+import { HostAlarmClock, MAX_RETRIES, RETRY_BASE_DELAY_MS } from "./host-alarm-clock";
 import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
 import { createNodeSqlStorage } from "./sqlite-storage";
 
 const log = createLogger("host-alarm-clock-test");
+
+/** The delay before retry number `n` (1-based). */
+const retryDelay = (n: number): number => RETRY_BASE_DELAY_MS * 2 ** (n - 1);
+/** Time for retries `from` through `to` inclusive to elapse. */
+const retriesElapsed = (from: number, to: number): number => {
+  let total = 0;
+  for (let n = from; n <= to; n += 1) total += retryDelay(n);
+  return total;
+};
 
 describe("HostAlarmClock", () => {
   let dataDir: string;
@@ -159,31 +168,31 @@ describe("HostAlarmClock", () => {
     await clock.storeFor("s1").setAlarm(Date.now() + 100);
     await vi.advanceTimersByTimeAsync(100);
     expect(deliver).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(retryDelay(1));
     expect(deliver).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(retryDelay(2));
     expect(deliver).toHaveBeenCalledTimes(3);
-    // 8s, 16s, 32s, 64s complete the six retries; nothing follows.
-    await vi.advanceTimersByTimeAsync(8_000 + 16_000 + 32_000 + 64_000);
-    expect(deliver).toHaveBeenCalledTimes(7);
+    // The remaining retries complete the budget; nothing follows.
+    await vi.advanceTimersByTimeAsync(retriesElapsed(3, MAX_RETRIES));
+    expect(deliver).toHaveBeenCalledTimes(1 + MAX_RETRIES);
     await vi.advanceTimersByTimeAsync(10_000_000);
-    expect(deliver).toHaveBeenCalledTimes(7);
+    expect(deliver).toHaveBeenCalledTimes(1 + MAX_RETRIES);
     expect(index.earliest()).toBeNull();
   });
 
   it("keeps the retry count across a restart", async () => {
     deliver.mockRejectedValue(new Error("handler failed"));
     await clock.storeFor("s1").setAlarm(Date.now() + 100);
-    await vi.advanceTimersByTimeAsync(100 + 2_000 + 4_000);
+    await vi.advanceTimersByTimeAsync(100 + retriesElapsed(1, 2));
     expect(deliver).toHaveBeenCalledTimes(3);
     clock.stop();
 
     const restarted = new HostAlarmClock({ index, deliver, log });
     restarted.start();
-    await vi.advanceTimersByTimeAsync(8_000 + 16_000 + 32_000 + 64_000);
-    expect(deliver).toHaveBeenCalledTimes(7);
+    await vi.advanceTimersByTimeAsync(retriesElapsed(3, MAX_RETRIES));
+    expect(deliver).toHaveBeenCalledTimes(1 + MAX_RETRIES);
     await vi.advanceTimersByTimeAsync(10_000_000);
-    expect(deliver).toHaveBeenCalledTimes(7);
+    expect(deliver).toHaveBeenCalledTimes(1 + MAX_RETRIES);
     restarted.stop();
   });
 
@@ -222,14 +231,14 @@ describe("HostAlarmClock", () => {
     deliver.mockRejectedValue(new Error("handler failed"));
     const store = clock.storeFor("s1");
     await store.setAlarm(Date.now() + 100);
-    await vi.advanceTimersByTimeAsync(100 + 2_000 + 4_000);
+    await vi.advanceTimersByTimeAsync(100 + retriesElapsed(1, 2));
     expect(deliver).toHaveBeenCalledTimes(3);
     // The session arms a new deadline: the three failures belonged to the old one.
     await store.setAlarm(Date.now() + 100);
-    await vi.advanceTimersByTimeAsync(100 + 2_000 * (1 + 2 + 4 + 8 + 16 + 32));
-    expect(deliver).toHaveBeenCalledTimes(3 + 7);
+    await vi.advanceTimersByTimeAsync(100 + retriesElapsed(1, MAX_RETRIES));
+    expect(deliver).toHaveBeenCalledTimes(3 + 1 + MAX_RETRIES);
     await vi.advanceTimersByTimeAsync(10_000_000);
-    expect(deliver).toHaveBeenCalledTimes(10);
+    expect(deliver).toHaveBeenCalledTimes(3 + 1 + MAX_RETRIES);
   });
 
   it("resumes deadlines recorded before a restart", async () => {
@@ -340,9 +349,9 @@ describe("HostAlarmClock", () => {
       await scheduler.schedule(Date.now() + 1_000);
       await vi.advanceTimersByTimeAsync(1_000);
       expect(attempts).toBe(1);
-      expect(await clock.storeFor("s1").getAlarm()).toBe(Date.now() + 2_000);
+      expect(await clock.storeFor("s1").getAlarm()).toBe(Date.now() + retryDelay(1));
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(retryDelay(1));
       expect(attempts).toBe(2);
       // The retry acknowledged the failed deadline and re-armed its replacement.
       expect(deadlines.pending()).toBe(replacement);
@@ -363,8 +372,8 @@ describe("HostAlarmClock", () => {
         )
       );
       await scheduler.schedule(Date.now() + 100);
-      await vi.advanceTimersByTimeAsync(100 + 2_000 * (1 + 2 + 4 + 8 + 16 + 32));
-      expect(deliver).toHaveBeenCalledTimes(7);
+      await vi.advanceTimersByTimeAsync(100 + retriesElapsed(1, MAX_RETRIES));
+      expect(deliver).toHaveBeenCalledTimes(1 + MAX_RETRIES);
       expect(index.earliest()).toBeNull();
       // The session file still holds the deadline in flight.
       expect(deadlines.earliest()).toBe(1_000_100);

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -98,7 +98,7 @@ describe("HostAlarmClock", () => {
     expect(delivered).toEqual(["first", "s1"]);
   });
 
-  it("never overlaps two deliveries to one session", async () => {
+  it("never overlaps two deliveries to one session, and waits without spinning", async () => {
     const store = clock.storeFor("s1");
     let release!: () => void;
     deliver.mockImplementationOnce(async () => {
@@ -109,16 +109,52 @@ describe("HostAlarmClock", () => {
         release = resolve;
       });
     });
+    const due = vi.spyOn(index, "due");
     await store.setAlarm(Date.now() + 100);
     await vi.advanceTimersByTimeAsync(100);
+    const ticksBefore = due.mock.calls.length;
     await vi.advanceTimersByTimeAsync(5_000);
     expect(delivered).toEqual(["slow"]);
+    // Nothing else is armed, so nothing wakes the clock while it waits.
+    expect(due.mock.calls.length).toBe(ticksBefore);
     release();
     await vi.advanceTimersByTimeAsync(0);
     expect(delivered).toEqual(["slow", "s1"]);
   });
 
-  it("retries a failed delivery with backoff and drops it after the last attempt", async () => {
+  it("fires other sessions while one delivery is still running", async () => {
+    let release!: () => void;
+    deliver.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    await clock.storeFor("slow").setAlarm(Date.now() + 100);
+    await clock.storeFor("other").setAlarm(Date.now() + 200);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(deliver).toHaveBeenCalledWith("slow");
+    expect(deliver).toHaveBeenCalledWith("other");
+    release();
+  });
+
+  it("delivers again after a restart when the previous process died mid-delivery", async () => {
+    deliver.mockImplementationOnce(() => new Promise<void>(() => {}));
+    await clock.storeFor("s1").setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(deliver).toHaveBeenCalledTimes(1);
+    // The process dies here: the clock is abandoned with the claim on disk.
+    clock.stop();
+
+    const restarted = new HostAlarmClock({ index, deliver, log });
+    restarted.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(delivered).toEqual(["s1"]);
+    restarted.stop();
+  });
+
+  it("retries a failed delivery with backoff and stops after the last attempt", async () => {
     deliver.mockRejectedValue(new Error("handler failed"));
     await clock.storeFor("s1").setAlarm(Date.now() + 100);
     await vi.advanceTimersByTimeAsync(100);
@@ -133,6 +169,20 @@ describe("HostAlarmClock", () => {
     await vi.advanceTimersByTimeAsync(10_000_000);
     expect(deliver).toHaveBeenCalledTimes(6);
     expect(index.earliest()).toBeNull();
+  });
+
+  it("gives a newly armed deadline its full retry budget", async () => {
+    deliver.mockRejectedValue(new Error("handler failed"));
+    const store = clock.storeFor("s1");
+    await store.setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100 + 30_000 + 60_000);
+    expect(deliver).toHaveBeenCalledTimes(3);
+    // The session arms a new deadline: the three failures belonged to the old one.
+    await store.setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100 + 30_000 * (1 + 2 + 4 + 8 + 16));
+    expect(deliver).toHaveBeenCalledTimes(3 + 6);
+    await vi.advanceTimersByTimeAsync(10_000_000);
+    expect(deliver).toHaveBeenCalledTimes(9);
   });
 
   it("resumes deadlines recorded before a restart", async () => {
@@ -221,6 +271,63 @@ describe("HostAlarmClock", () => {
       await scheduler.rehydrate();
       await vi.advanceTimersByTimeAsync(500);
       expect(delivered).toEqual(["s1"]);
+    });
+
+    it("retries a failed delivery sooner than the replacement its handler armed, then restores the replacement", async () => {
+      const scheduler = createEarliestAlarmScheduler(clock.storeFor("s1"), deadlines);
+      const replacement = Date.now() + 3_600_000;
+      let attempts = 0;
+      deliver.mockImplementation(() =>
+        handleAlarmDelivery(
+          deadlines,
+          async () => {
+            attempts += 1;
+            if (attempts === 1) {
+              await scheduler.schedule(replacement);
+              throw new Error("first attempt failed");
+            }
+          },
+          () => scheduler.rearmPending()
+        )
+      );
+      await scheduler.schedule(Date.now() + 1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(attempts).toBe(1);
+      expect(await clock.storeFor("s1").getAlarm()).toBe(Date.now() + 30_000);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(attempts).toBe(2);
+      // The retry acknowledged the failed deadline and re-armed its replacement.
+      expect(deadlines.pending()).toBe(replacement);
+      expect(await clock.storeFor("s1").getAlarm()).toBe(replacement);
+      await vi.advanceTimersByTimeAsync(replacement - Date.now());
+      expect(attempts).toBe(3);
+    });
+
+    it("after the host stops retrying, the session's next rehydrate re-arms the deadline", async () => {
+      const scheduler = createEarliestAlarmScheduler(clock.storeFor("s1"), deadlines);
+      deliver.mockImplementation(() =>
+        handleAlarmDelivery(
+          deadlines,
+          async () => {
+            throw new Error("always fails");
+          },
+          () => scheduler.rearmPending()
+        )
+      );
+      await scheduler.schedule(Date.now() + 100);
+      await vi.advanceTimersByTimeAsync(100 + 30_000 * (1 + 2 + 4 + 8 + 16));
+      expect(deliver).toHaveBeenCalledTimes(6);
+      expect(index.earliest()).toBeNull();
+      // The session file still holds the deadline in flight.
+      expect(deadlines.earliest()).toBe(1_000_100);
+
+      deliver.mockImplementation(async () => {
+        delivered.push("recovered");
+      });
+      await scheduler.rehydrate();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(delivered).toEqual(["recovered"]);
     });
 
     it("rearmPending re-arms a pending deadline the host has lost", async () => {

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -154,35 +154,82 @@ describe("HostAlarmClock", () => {
     restarted.stop();
   });
 
-  it("retries a failed delivery with backoff and stops after the last attempt", async () => {
+  it("retries a failed delivery on the platform's backoff and stops after six retries", async () => {
     deliver.mockRejectedValue(new Error("handler failed"));
     await clock.storeFor("s1").setAlarm(Date.now() + 100);
     await vi.advanceTimersByTimeAsync(100);
     expect(deliver).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     expect(deliver).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(4_000);
     expect(deliver).toHaveBeenCalledTimes(3);
-    // 120s, 240s, 480s complete the six attempts; nothing follows.
-    await vi.advanceTimersByTimeAsync(120_000 + 240_000 + 480_000);
-    expect(deliver).toHaveBeenCalledTimes(6);
+    // 8s, 16s, 32s, 64s complete the six retries; nothing follows.
+    await vi.advanceTimersByTimeAsync(8_000 + 16_000 + 32_000 + 64_000);
+    expect(deliver).toHaveBeenCalledTimes(7);
     await vi.advanceTimersByTimeAsync(10_000_000);
-    expect(deliver).toHaveBeenCalledTimes(6);
+    expect(deliver).toHaveBeenCalledTimes(7);
     expect(index.earliest()).toBeNull();
+  });
+
+  it("keeps the retry count across a restart", async () => {
+    deliver.mockRejectedValue(new Error("handler failed"));
+    await clock.storeFor("s1").setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100 + 2_000 + 4_000);
+    expect(deliver).toHaveBeenCalledTimes(3);
+    clock.stop();
+
+    const restarted = new HostAlarmClock({ index, deliver, log });
+    restarted.start();
+    await vi.advanceTimersByTimeAsync(8_000 + 16_000 + 32_000 + 64_000);
+    expect(deliver).toHaveBeenCalledTimes(7);
+    await vi.advanceTimersByTimeAsync(10_000_000);
+    expect(deliver).toHaveBeenCalledTimes(7);
+    restarted.stop();
+  });
+
+  it("delivers to overdue sessions a bounded number at a time after downtime", async () => {
+    const releases = new Map<string, () => void>();
+    deliver.mockImplementation(
+      (sessionId) =>
+        new Promise<void>((resolve) => {
+          releases.set(sessionId, resolve);
+        })
+    );
+    for (let i = 0; i < 10; i += 1) {
+      index.set(`s${i}`, Date.now() - 1_000);
+    }
+    const bounded = new HostAlarmClock({ index, deliver, log, maxConcurrentDeliveries: 3 });
+    bounded.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deliver).toHaveBeenCalledTimes(3);
+
+    // Each settled delivery lets the next overdue session start.
+    let settled = 0;
+    while (releases.size > 0) {
+      const [sessionId, release] = [...releases.entries()][0]!;
+      releases.delete(sessionId);
+      release();
+      settled += 1;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(deliver).toHaveBeenCalledTimes(Math.min(10, 3 + settled));
+    }
+    expect(deliver).toHaveBeenCalledTimes(10);
+    expect(index.earliest()).toBeNull();
+    bounded.stop();
   });
 
   it("gives a newly armed deadline its full retry budget", async () => {
     deliver.mockRejectedValue(new Error("handler failed"));
     const store = clock.storeFor("s1");
     await store.setAlarm(Date.now() + 100);
-    await vi.advanceTimersByTimeAsync(100 + 30_000 + 60_000);
+    await vi.advanceTimersByTimeAsync(100 + 2_000 + 4_000);
     expect(deliver).toHaveBeenCalledTimes(3);
     // The session arms a new deadline: the three failures belonged to the old one.
     await store.setAlarm(Date.now() + 100);
-    await vi.advanceTimersByTimeAsync(100 + 30_000 * (1 + 2 + 4 + 8 + 16));
-    expect(deliver).toHaveBeenCalledTimes(3 + 6);
+    await vi.advanceTimersByTimeAsync(100 + 2_000 * (1 + 2 + 4 + 8 + 16 + 32));
+    expect(deliver).toHaveBeenCalledTimes(3 + 7);
     await vi.advanceTimersByTimeAsync(10_000_000);
-    expect(deliver).toHaveBeenCalledTimes(9);
+    expect(deliver).toHaveBeenCalledTimes(10);
   });
 
   it("resumes deadlines recorded before a restart", async () => {
@@ -293,9 +340,9 @@ describe("HostAlarmClock", () => {
       await scheduler.schedule(Date.now() + 1_000);
       await vi.advanceTimersByTimeAsync(1_000);
       expect(attempts).toBe(1);
-      expect(await clock.storeFor("s1").getAlarm()).toBe(Date.now() + 30_000);
+      expect(await clock.storeFor("s1").getAlarm()).toBe(Date.now() + 2_000);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(2_000);
       expect(attempts).toBe(2);
       // The retry acknowledged the failed deadline and re-armed its replacement.
       expect(deadlines.pending()).toBe(replacement);
@@ -316,8 +363,8 @@ describe("HostAlarmClock", () => {
         )
       );
       await scheduler.schedule(Date.now() + 100);
-      await vi.advanceTimersByTimeAsync(100 + 30_000 * (1 + 2 + 4 + 8 + 16));
-      expect(deliver).toHaveBeenCalledTimes(6);
+      await vi.advanceTimersByTimeAsync(100 + 2_000 * (1 + 2 + 4 + 8 + 16 + 32));
+      expect(deliver).toHaveBeenCalledTimes(7);
       expect(index.earliest()).toBeNull();
       // The session file still holds the deadline in flight.
       expect(deadlines.earliest()).toBe(1_000_100);

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -1,0 +1,235 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "../logger";
+import {
+  createEarliestAlarmScheduler,
+  handleAlarmDelivery,
+  PersistedAlarmDeadlineStore,
+} from "../session/alarm/scheduler";
+import { initSchema } from "../session/schema";
+import { HostAlarmClock } from "./host-alarm-clock";
+import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
+import { createNodeSqlStorage } from "./sqlite-storage";
+
+const log = createLogger("host-alarm-clock-test");
+
+describe("HostAlarmClock", () => {
+  let dataDir: string;
+  let index: HostAlarmIndex;
+  let delivered: string[];
+  let deliver: ReturnType<typeof vi.fn<(sessionId: string) => Promise<void>>>;
+  let clock: HostAlarmClock;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    dataDir = mkdtempSync(join(tmpdir(), "host-alarm-clock-"));
+    index = openHostAlarmIndex(dataDir);
+    delivered = [];
+    deliver = vi.fn(async (sessionId: string) => {
+      delivered.push(sessionId);
+    });
+    clock = new HostAlarmClock({ index, deliver, log });
+    clock.start();
+  });
+
+  afterEach(() => {
+    clock.stop();
+    index.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it("fires a session at its deadline and consumes the record before the handler runs", async () => {
+    const store = clock.storeFor("s1");
+    let armedDuringDelivery: number | null = 1;
+    deliver.mockImplementationOnce(async () => {
+      armedDuringDelivery = await store.getAlarm();
+    });
+    await store.setAlarm(Date.now() + 5_000);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(deliver).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(deliver).toHaveBeenCalledWith("s1");
+    expect(armedDuringDelivery).toBeNull();
+    expect(await store.getAlarm()).toBeNull();
+  });
+
+  it("fires in deadline order across sessions and follows an earlier replacement", async () => {
+    await clock.storeFor("late").setAlarm(Date.now() + 10_000);
+    await clock.storeFor("soon").setAlarm(Date.now() + 2_000);
+    await clock.storeFor("late").setAlarm(Date.now() + 3_000);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(delivered).toEqual(["soon"]);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(delivered).toEqual(["soon", "late"]);
+  });
+
+  it("does not fire a deleted deadline", async () => {
+    const store = clock.storeFor("s1");
+    await store.setAlarm(Date.now() + 1_000);
+    await store.deleteAlarm();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("reaches a deadline farther away than one timer can hold", async () => {
+    const far = Date.now() + 2 ** 31 + 60_000;
+    await clock.storeFor("s1").setAlarm(far);
+    await vi.advanceTimersByTimeAsync(2 ** 31);
+    expect(deliver).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(delivered).toEqual(["s1"]);
+  });
+
+  it("fires again for a deadline the handler arms while it runs", async () => {
+    const store = clock.storeFor("s1");
+    deliver.mockImplementationOnce(async () => {
+      delivered.push("first");
+      await store.setAlarm(Date.now() + 1_000);
+    });
+    await store.setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(delivered).toEqual(["first"]);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(delivered).toEqual(["first", "s1"]);
+  });
+
+  it("never overlaps two deliveries to one session", async () => {
+    const store = clock.storeFor("s1");
+    let release!: () => void;
+    deliver.mockImplementationOnce(async () => {
+      delivered.push("slow");
+      // Re-arm for right now while still running: the clock must wait.
+      await store.setAlarm(Date.now());
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+    await store.setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(delivered).toEqual(["slow"]);
+    release();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(delivered).toEqual(["slow", "s1"]);
+  });
+
+  it("retries a failed delivery with backoff and drops it after the last attempt", async () => {
+    deliver.mockRejectedValue(new Error("handler failed"));
+    await clock.storeFor("s1").setAlarm(Date.now() + 100);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(deliver).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(deliver).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(deliver).toHaveBeenCalledTimes(3);
+    // 120s, 240s, 480s complete the six attempts; nothing follows.
+    await vi.advanceTimersByTimeAsync(120_000 + 240_000 + 480_000);
+    expect(deliver).toHaveBeenCalledTimes(6);
+    await vi.advanceTimersByTimeAsync(10_000_000);
+    expect(deliver).toHaveBeenCalledTimes(6);
+    expect(index.earliest()).toBeNull();
+  });
+
+  it("resumes deadlines recorded before a restart", async () => {
+    await clock.storeFor("evicted").setAlarm(Date.now() + 2_000);
+    clock.stop();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(deliver).not.toHaveBeenCalled();
+
+    const restarted = new HostAlarmClock({ index, deliver, log });
+    restarted.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(delivered).toEqual(["evicted"]);
+    restarted.stop();
+  });
+
+  it("drain waits for running deliveries", async () => {
+    let release!: () => void;
+    deliver.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    await clock.storeFor("s1").setAlarm(Date.now());
+    await vi.advanceTimersByTimeAsync(0);
+    let drained = false;
+    const drain = clock.drain().then(() => {
+      drained = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(drained).toBe(false);
+    release();
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  describe("as the session core's alarm store", () => {
+    let db: DatabaseSync;
+    let deadlines: PersistedAlarmDeadlineStore;
+
+    beforeEach(() => {
+      db = new DatabaseSync(":memory:");
+      const { sql } = createNodeSqlStorage(db);
+      initSchema(sql);
+      deadlines = new PersistedAlarmDeadlineStore(sql);
+    });
+
+    afterEach(() => {
+      db.close();
+    });
+
+    it("schedules the earliest deadline, delivers it once, and re-arms the replacement", async () => {
+      const scheduler = createEarliestAlarmScheduler(clock.storeFor("s1"), deadlines);
+      const handled: number[] = [];
+      deliver.mockImplementation(() =>
+        handleAlarmDelivery(
+          deadlines,
+          async () => {
+            handled.push(Date.now());
+          },
+          () => scheduler.rearmPending()
+        )
+      );
+      await scheduler.schedule(Date.now() + 5_000);
+      await scheduler.schedule(Date.now() + 1_000);
+      await scheduler.schedule(Date.now() + 3_000);
+      expect(await scheduler.current()).toBe(1_001_000);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(handled).toEqual([1_001_000]);
+      // The handler consumed the deadline and nothing was pending behind it.
+      expect(await clock.storeFor("s1").getAlarm()).toBeNull();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(handled).toEqual([1_001_000]);
+    });
+
+    it("does not deliver after cancel, and rehydrates work scheduled behind the cancellation", async () => {
+      const scheduler = createEarliestAlarmScheduler(clock.storeFor("s1"), deadlines);
+      await scheduler.schedule(Date.now() + 1_000);
+      await scheduler.cancel();
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(deliver).not.toHaveBeenCalled();
+
+      // Work persisted while cancelled is armed again by rehydrate, as after a restart.
+      deadlines.setPending(Date.now() + 500);
+      await scheduler.rehydrate();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(delivered).toEqual(["s1"]);
+    });
+
+    it("rearmPending re-arms a pending deadline the host has lost", async () => {
+      const scheduler = createEarliestAlarmScheduler(clock.storeFor("s1"), deadlines);
+      await scheduler.schedule(Date.now() + 1_000);
+      index.delete("s1");
+      await scheduler.rearmPending();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(delivered).toEqual(["s1"]);
+    });
+  });
+});

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -7,10 +7,18 @@
  * `storeFor(sessionId)` is the per-session `AlarmScheduleStore` the session
  * runtime is built over: what a Durable Object's `ctx.storage` alarm methods
  * provide. Setting a deadline records it in the index and re-arms the
- * timer; firing consumes the record before the handler runs, as the
- * platform clears a Durable Object's alarm when it fires, so a handler that
- * arms a new deadline replaces nothing. Delivery failures are retried with
- * backoff a bounded number of times, matching the platform.
+ * timer. Firing *claims* the record: the session reads as disarmed while
+ * its handler runs, as the platform clears a Durable Object's alarm when it
+ * fires, so a handler that arms a new deadline replaces nothing; the claim
+ * itself stays on disk until the delivery settles, so a process that dies
+ * mid-delivery fires it again at the next start.
+ *
+ * A failed delivery is retried with doubling backoff, sooner if the session
+ * armed something sooner, a bounded number of times. After the last attempt
+ * the host stops retrying on its own; the session file still holds the
+ * deadline, and the session's next activation re-arms it through
+ * `rehydrate()`, which is also what happens on Cloudflare once the platform
+ * gives up on an alarm.
  */
 
 import type { Logger } from "../logger";
@@ -21,7 +29,7 @@ import type { HostAlarmIndex } from "./host-alarm-index";
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 /** First retry delay after a failed delivery; doubles per attempt. */
 const RETRY_BASE_DELAY_MS = 30_000;
-/** Retries before a deadline is dropped, as the platform does. */
+/** Attempts before the host stops retrying on its own, as the platform does. */
 const MAX_DELIVERY_ATTEMPTS = 6;
 
 export interface HostAlarmClockOptions {
@@ -56,20 +64,34 @@ export class HostAlarmClock {
   storeFor(sessionId: string): AlarmScheduleStore {
     return {
       getAlarm: async () => this.index.get(sessionId),
+      // Arming or disarming starts a new alarm: earlier failures were the
+      // previous one's, so it gets the full retry budget.
       setAlarm: async (timestamp) => {
+        this.failures.delete(sessionId);
         this.index.set(sessionId, timestamp);
         this.arm();
       },
       deleteAlarm: async () => {
+        this.failures.delete(sessionId);
         this.index.delete(sessionId);
         this.arm();
       },
     };
   }
 
-  /** Arm for whatever the index holds; a restart resumes from the file. */
+  /**
+   * Arm for whatever the index holds. Claims a previous process left in
+   * flight are delivered again: their handlers may not have run.
+   */
   start(): void {
     this.running = true;
+    const recovered = this.index.recoverClaims();
+    if (recovered.length > 0) {
+      this.log.warn("Re-arming deadlines a previous process left in flight", {
+        event: "alarm.claims_recovered",
+        session_ids: recovered,
+      });
+    }
     this.arm();
   }
 
@@ -93,7 +115,9 @@ export class HostAlarmClock {
       this.timer = null;
     }
     if (!this.running) return;
-    const next = this.index.earliest();
+    // A session being delivered to is left out: its next deadline is picked
+    // up when that delivery settles and re-arms the clock.
+    const next = this.index.earliest(this.inFlight.keys());
     if (next === null) return;
     const delay = Math.min(Math.max(0, next.deadline - this.now()), MAX_TIMER_DELAY_MS);
     this.timer = setTimeout(() => this.tick(), delay);
@@ -101,15 +125,17 @@ export class HostAlarmClock {
 
   private tick(): void {
     this.timer = null;
-    for (const { sessionId, deadline } of this.index.due(this.now())) {
-      // A session already being delivered keeps its new record until the
-      // running delivery settles and the clock re-arms.
-      if (this.inFlight.has(sessionId)) continue;
-      this.index.delete(sessionId);
-      const delivery = this.deliverTo(sessionId, deadline).finally(() => {
-        this.inFlight.delete(sessionId);
-        this.arm();
-      });
+    for (const { sessionId } of this.index.due(this.now(), this.inFlight.keys())) {
+      const deadline = this.index.claim(sessionId);
+      if (deadline === null) continue;
+      // Registered before the handler starts, so a deadline it arms at once
+      // is excluded from the next wake-up until this delivery settles.
+      const delivery = Promise.resolve()
+        .then(() => this.deliverTo(sessionId, deadline))
+        .finally(() => {
+          this.inFlight.delete(sessionId);
+          this.arm();
+        });
       this.inFlight.set(sessionId, delivery);
     }
     this.arm();
@@ -119,6 +145,7 @@ export class HostAlarmClock {
     try {
       await this.deliver(sessionId);
       this.failures.delete(sessionId);
+      this.index.complete(sessionId);
     } catch (error) {
       const attempt = (this.failures.get(sessionId) ?? 0) + 1;
       const retry = attempt < MAX_DELIVERY_ATTEMPTS;
@@ -131,14 +158,14 @@ export class HostAlarmClock {
         error_message: error instanceof Error ? error.message : String(error),
       });
       if (!retry) {
+        // The session file keeps the deadline; its next activation re-arms it.
         this.failures.delete(sessionId);
+        this.index.complete(sessionId);
         return;
       }
       this.failures.set(sessionId, attempt);
-      // The handler may have armed a new deadline; a retry never delays it.
-      if (this.index.get(sessionId) === null) {
-        this.index.set(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
-      }
+      // Sooner than a replacement the handler armed, never later than it.
+      this.index.retry(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
     }
   }
 }

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -13,24 +13,31 @@
  * itself stays on disk until the delivery settles, so a process that dies
  * mid-delivery fires it again at the next start.
  *
- * A failed delivery is retried with doubling backoff, sooner if the session
- * armed something sooner, a bounded number of times. After the last attempt
- * the host stops retrying on its own; the session file still holds the
- * deadline, and the session's next activation re-arms it through
- * `rehydrate()`, which is also what happens on Cloudflare once the platform
- * gives up on an alarm.
+ * A failed delivery is retried on the platform's policy (doubling backoff
+ * from two seconds, six retries), sooner if the session armed something
+ * sooner; the count lives in the index, so a restart does not renew it.
+ * After the last attempt the host stops retrying on its own; the session
+ * file still holds the deadline, and the session's next activation re-arms
+ * it through `rehydrate()`, which is also what happens on Cloudflare once
+ * the platform gives up on an alarm.
+ *
+ * Deliveries run concurrently across sessions up to a bound, so a host that
+ * comes back after downtime opens overdue sessions a few at a time rather
+ * than all at once; the next ones start as soon as one settles.
  */
 
 import type { Logger } from "../logger";
 import type { AlarmScheduleStore } from "../session/alarm/scheduler";
-import type { HostAlarmIndex } from "./host-alarm-index";
+import type { ClaimedDeadline, HostAlarmIndex } from "./host-alarm-index";
 
 /** The longest delay a single timer can hold; farther deadlines re-arm. */
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
-/** First retry delay after a failed delivery; doubles per attempt. */
-const RETRY_BASE_DELAY_MS = 30_000;
-/** Attempts before the host stops retrying on its own, as the platform does. */
-const MAX_DELIVERY_ATTEMPTS = 6;
+/** First retry delay after a failed delivery; doubles per retry, as on the platform. */
+const RETRY_BASE_DELAY_MS = 2_000;
+/** Retries before the host stops retrying on its own, as on the platform. */
+const MAX_RETRIES = 6;
+/** Sessions delivered to at the same time, unless the host says otherwise. */
+const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
 
 export interface HostAlarmClockOptions {
   index: HostAlarmIndex;
@@ -41,6 +48,8 @@ export interface HostAlarmClockOptions {
   deliver: (sessionId: string) => Promise<void>;
   log: Logger;
   now?: () => number;
+  /** How many sessions may be delivered to at once. */
+  maxConcurrentDeliveries?: number;
 }
 
 export class HostAlarmClock {
@@ -48,31 +57,29 @@ export class HostAlarmClock {
   private readonly deliver: (sessionId: string) => Promise<void>;
   private readonly log: Logger;
   private readonly now: () => number;
+  private readonly maxConcurrentDeliveries: number;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private readonly inFlight = new Map<string, Promise<void>>();
-  private readonly failures = new Map<string, number>();
 
   constructor(options: HostAlarmClockOptions) {
     this.index = options.index;
     this.deliver = options.deliver;
     this.log = options.log;
     this.now = options.now ?? Date.now;
+    this.maxConcurrentDeliveries =
+      options.maxConcurrentDeliveries ?? DEFAULT_MAX_CONCURRENT_DELIVERIES;
   }
 
   /** The alarm port for one session runtime. */
   storeFor(sessionId: string): AlarmScheduleStore {
     return {
       getAlarm: async () => this.index.get(sessionId),
-      // Arming or disarming starts a new alarm: earlier failures were the
-      // previous one's, so it gets the full retry budget.
       setAlarm: async (timestamp) => {
-        this.failures.delete(sessionId);
         this.index.set(sessionId, timestamp);
         this.arm();
       },
       deleteAlarm: async () => {
-        this.failures.delete(sessionId);
         this.index.delete(sessionId);
         this.arm();
       },
@@ -115,8 +122,9 @@ export class HostAlarmClock {
       this.timer = null;
     }
     if (!this.running) return;
-    // A session being delivered to is left out: its next deadline is picked
-    // up when that delivery settles and re-arms the clock.
+    // At capacity, the settling delivery re-arms the clock. A session being
+    // delivered to is left out: its next deadline is picked up the same way.
+    if (this.inFlight.size >= this.maxConcurrentDeliveries) return;
     const next = this.index.earliest(this.inFlight.keys());
     if (next === null) return;
     const delay = Math.min(Math.max(0, next.deadline - this.now()), MAX_TIMER_DELAY_MS);
@@ -125,13 +133,15 @@ export class HostAlarmClock {
 
   private tick(): void {
     this.timer = null;
-    for (const { sessionId } of this.index.due(this.now(), this.inFlight.keys())) {
-      const deadline = this.index.claim(sessionId);
-      if (deadline === null) continue;
+    const capacity = this.maxConcurrentDeliveries - this.inFlight.size;
+    if (capacity <= 0) return;
+    for (const { sessionId } of this.index.due(this.now(), this.inFlight.keys(), capacity)) {
+      const claimed = this.index.claim(sessionId);
+      if (claimed === null) continue;
       // Registered before the handler starts, so a deadline it arms at once
       // is excluded from the next wake-up until this delivery settles.
       const delivery = Promise.resolve()
-        .then(() => this.deliverTo(sessionId, deadline))
+        .then(() => this.deliverTo(sessionId, claimed))
         .finally(() => {
           this.inFlight.delete(sessionId);
           this.arm();
@@ -141,31 +151,27 @@ export class HostAlarmClock {
     this.arm();
   }
 
-  private async deliverTo(sessionId: string, deadline: number): Promise<void> {
+  private async deliverTo(sessionId: string, claimed: ClaimedDeadline): Promise<void> {
     try {
       await this.deliver(sessionId);
-      this.failures.delete(sessionId);
       this.index.complete(sessionId);
     } catch (error) {
-      const attempt = (this.failures.get(sessionId) ?? 0) + 1;
-      const retry = attempt < MAX_DELIVERY_ATTEMPTS;
+      const retry = claimed.failures < MAX_RETRIES;
       this.log.error("Scheduled deadline delivery failed", {
         event: "alarm.delivery_failed",
         session_id: sessionId,
-        deadline,
-        attempt,
+        deadline: claimed.deadline,
+        attempt: claimed.failures + 1,
         will_retry: retry,
         error_message: error instanceof Error ? error.message : String(error),
       });
       if (!retry) {
         // The session file keeps the deadline; its next activation re-arms it.
-        this.failures.delete(sessionId);
         this.index.complete(sessionId);
         return;
       }
-      this.failures.set(sessionId, attempt);
       // Sooner than a replacement the handler armed, never later than it.
-      this.index.retry(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+      this.index.retry(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** claimed.failures);
     }
   }
 }

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -1,0 +1,144 @@
+/**
+ * The Node host's alarm: one timer for the whole process, armed for the
+ * soonest deadline in the host alarm index, delivering to each session
+ * through the host's `deliver` callback (which opens the session if it was
+ * evicted and runs its scheduled-deadline handler).
+ *
+ * `storeFor(sessionId)` is the per-session `AlarmScheduleStore` the session
+ * runtime is built over: what a Durable Object's `ctx.storage` alarm methods
+ * provide. Setting a deadline records it in the index and re-arms the
+ * timer; firing consumes the record before the handler runs, as the
+ * platform clears a Durable Object's alarm when it fires, so a handler that
+ * arms a new deadline replaces nothing. Delivery failures are retried with
+ * backoff a bounded number of times, matching the platform.
+ */
+
+import type { Logger } from "../logger";
+import type { AlarmScheduleStore } from "../session/alarm/scheduler";
+import type { HostAlarmIndex } from "./host-alarm-index";
+
+/** The longest delay a single timer can hold; farther deadlines re-arm. */
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+/** First retry delay after a failed delivery; doubles per attempt. */
+const RETRY_BASE_DELAY_MS = 30_000;
+/** Retries before a deadline is dropped, as the platform does. */
+const MAX_DELIVERY_ATTEMPTS = 6;
+
+export interface HostAlarmClockOptions {
+  index: HostAlarmIndex;
+  /**
+   * Run the session's scheduled-deadline handler, opening the session
+   * first if the host had evicted it.
+   */
+  deliver: (sessionId: string) => Promise<void>;
+  log: Logger;
+  now?: () => number;
+}
+
+export class HostAlarmClock {
+  private readonly index: HostAlarmIndex;
+  private readonly deliver: (sessionId: string) => Promise<void>;
+  private readonly log: Logger;
+  private readonly now: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly inFlight = new Map<string, Promise<void>>();
+  private readonly failures = new Map<string, number>();
+
+  constructor(options: HostAlarmClockOptions) {
+    this.index = options.index;
+    this.deliver = options.deliver;
+    this.log = options.log;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** The alarm port for one session runtime. */
+  storeFor(sessionId: string): AlarmScheduleStore {
+    return {
+      getAlarm: async () => this.index.get(sessionId),
+      setAlarm: async (timestamp) => {
+        this.index.set(sessionId, timestamp);
+        this.arm();
+      },
+      deleteAlarm: async () => {
+        this.index.delete(sessionId);
+        this.arm();
+      },
+    };
+  }
+
+  /** Arm for whatever the index holds; a restart resumes from the file. */
+  start(): void {
+    this.running = true;
+    this.arm();
+  }
+
+  /** Stop firing. Deliveries already running are not interrupted. */
+  stop(): void {
+    this.running = false;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Resolves once every delivery that was running has settled. */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.inFlight.values()]);
+  }
+
+  private arm(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (!this.running) return;
+    const next = this.index.earliest();
+    if (next === null) return;
+    const delay = Math.min(Math.max(0, next.deadline - this.now()), MAX_TIMER_DELAY_MS);
+    this.timer = setTimeout(() => this.tick(), delay);
+  }
+
+  private tick(): void {
+    this.timer = null;
+    for (const { sessionId, deadline } of this.index.due(this.now())) {
+      // A session already being delivered keeps its new record until the
+      // running delivery settles and the clock re-arms.
+      if (this.inFlight.has(sessionId)) continue;
+      this.index.delete(sessionId);
+      const delivery = this.deliverTo(sessionId, deadline).finally(() => {
+        this.inFlight.delete(sessionId);
+        this.arm();
+      });
+      this.inFlight.set(sessionId, delivery);
+    }
+    this.arm();
+  }
+
+  private async deliverTo(sessionId: string, deadline: number): Promise<void> {
+    try {
+      await this.deliver(sessionId);
+      this.failures.delete(sessionId);
+    } catch (error) {
+      const attempt = (this.failures.get(sessionId) ?? 0) + 1;
+      const retry = attempt < MAX_DELIVERY_ATTEMPTS;
+      this.log.error("Scheduled deadline delivery failed", {
+        event: "alarm.delivery_failed",
+        session_id: sessionId,
+        deadline,
+        attempt,
+        will_retry: retry,
+        error_message: error instanceof Error ? error.message : String(error),
+      });
+      if (!retry) {
+        this.failures.delete(sessionId);
+        return;
+      }
+      this.failures.set(sessionId, attempt);
+      // The handler may have armed a new deadline; a retry never delays it.
+      if (this.index.get(sessionId) === null) {
+        this.index.set(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+      }
+    }
+  }
+}

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -33,9 +33,9 @@ import type { ClaimedDeadline, HostAlarmIndex } from "./host-alarm-index";
 /** The longest delay a single timer can hold; farther deadlines re-arm. */
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 /** First retry delay after a failed delivery; doubles per retry, as on the platform. */
-const RETRY_BASE_DELAY_MS = 2_000;
+export const RETRY_BASE_DELAY_MS = 2_000;
 /** Retries before the host stops retrying on its own, as on the platform. */
-const MAX_RETRIES = 6;
+export const MAX_RETRIES = 6;
 /** Sessions delivered to at the same time, unless the host says otherwise. */
 const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
 /** The clock source, unless a test supplies one; read per call so fake timers apply. */

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -38,6 +38,8 @@ const RETRY_BASE_DELAY_MS = 2_000;
 const MAX_RETRIES = 6;
 /** Sessions delivered to at the same time, unless the host says otherwise. */
 const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
+/** The clock source, unless a test supplies one; read per call so fake timers apply. */
+const DEFAULT_NOW = (): number => Date.now();
 
 export interface HostAlarmClockOptions {
   index: HostAlarmIndex;
@@ -66,7 +68,7 @@ export class HostAlarmClock {
     this.index = options.index;
     this.deliver = options.deliver;
     this.log = options.log;
-    this.now = options.now ?? Date.now;
+    this.now = options.now ?? DEFAULT_NOW;
     this.maxConcurrentDeliveries =
       options.maxConcurrentDeliveries ?? DEFAULT_MAX_CONCURRENT_DELIVERIES;
   }

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -53,6 +53,66 @@ describe("openHostAlarmIndex", () => {
     expect(index.due(99)).toEqual([]);
   });
 
+  it("claims a deadline for delivery, hides it while in flight, and completes it", () => {
+    const index = open();
+    index.set("s1", 100);
+    expect(index.claim("s1")).toBe(100);
+    expect(index.get("s1")).toBeNull();
+    expect(index.earliest()).toBeNull();
+    expect(index.claim("s1")).toBeNull();
+    // A deadline armed during delivery is visible and survives completion.
+    index.set("s1", 900);
+    index.complete("s1");
+    expect(index.get("s1")).toBe(900);
+    index.delete("s1");
+    expect(index.earliest()).toBeNull();
+  });
+
+  it("re-arms a failed claim at the retry time, or sooner if the session armed sooner", () => {
+    const index = open();
+    index.set("later", 100);
+    index.claim("later");
+    index.set("later", 5_000);
+    index.retry("later", 1_000);
+    expect(index.get("later")).toBe(1_000);
+
+    index.set("sooner", 100);
+    index.claim("sooner");
+    index.set("sooner", 200);
+    index.retry("sooner", 1_000);
+    expect(index.get("sooner")).toBe(200);
+  });
+
+  it("recovers claims left in flight at their original deadline, or sooner", () => {
+    const first = open();
+    first.set("crashed", 100);
+    first.claim("crashed");
+    first.set("rearmed", 100);
+    first.claim("rearmed");
+    first.set("rearmed", 50);
+    first.set("idle", 700);
+    first.close();
+
+    const second = open();
+    // Before recovery only armed deadlines count: the crashed claim is invisible.
+    expect(second.earliest(["rearmed"])).toEqual({ sessionId: "idle", deadline: 700 });
+    expect(second.recoverClaims().sort()).toEqual(["crashed", "rearmed"]);
+    expect(second.due(100)).toEqual([
+      { sessionId: "rearmed", deadline: 50 },
+      { sessionId: "crashed", deadline: 100 },
+    ]);
+    expect(second.recoverClaims()).toEqual([]);
+  });
+
+  it("leaves excluded sessions out of earliest and due", () => {
+    const index = open();
+    index.set("a", 100);
+    index.set("b", 200);
+    expect(index.earliest(["a"])).toEqual({ sessionId: "b", deadline: 200 });
+    expect(index.due(300, ["a", "b"])).toEqual([]);
+    expect(index.due(300, new Set(["b"]))).toEqual([{ sessionId: "a", deadline: 100 }]);
+  });
+
   it("survives close and reopen in a private file", () => {
     const first = open();
     first.set("s1", 700);

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -46,17 +46,18 @@ describe("openHostAlarmIndex", () => {
     index.set("soon", 100);
     index.set("mid", 500);
     expect(index.earliest()).toEqual({ sessionId: "soon", deadline: 100 });
-    expect(index.due(500)).toEqual([
+    expect(index.due(500, [], 10)).toEqual([
       { sessionId: "soon", deadline: 100 },
       { sessionId: "mid", deadline: 500 },
     ]);
-    expect(index.due(99)).toEqual([]);
+    expect(index.due(500, [], 1)).toEqual([{ sessionId: "soon", deadline: 100 }]);
+    expect(index.due(99, [], 10)).toEqual([]);
   });
 
   it("claims a deadline for delivery, hides it while in flight, and completes it", () => {
     const index = open();
     index.set("s1", 100);
-    expect(index.claim("s1")).toBe(100);
+    expect(index.claim("s1")).toEqual({ deadline: 100, failures: 0 });
     expect(index.get("s1")).toBeNull();
     expect(index.earliest()).toBeNull();
     expect(index.claim("s1")).toBeNull();
@@ -75,6 +76,17 @@ describe("openHostAlarmIndex", () => {
     index.set("later", 5_000);
     index.retry("later", 1_000);
     expect(index.get("later")).toBe(1_000);
+    // The failure is counted for the next claim of the same alarm.
+    expect(index.claim("later")).toEqual({ deadline: 1_000, failures: 1 });
+    index.retry("later", 2_000);
+    expect(index.claim("later")).toEqual({ deadline: 2_000, failures: 2 });
+    // Arming anew, or completing, starts the count over.
+    index.set("later", 3_000);
+    expect(index.claim("later")).toEqual({ deadline: 3_000, failures: 0 });
+    index.retry("later", 4_000);
+    index.complete("later");
+    index.set("later", 5_000);
+    expect(index.claim("later")).toEqual({ deadline: 5_000, failures: 0 });
 
     index.set("sooner", 100);
     index.claim("sooner");
@@ -97,7 +109,7 @@ describe("openHostAlarmIndex", () => {
     // Before recovery only armed deadlines count: the crashed claim is invisible.
     expect(second.earliest(["rearmed"])).toEqual({ sessionId: "idle", deadline: 700 });
     expect(second.recoverClaims().sort()).toEqual(["crashed", "rearmed"]);
-    expect(second.due(100)).toEqual([
+    expect(second.due(100, [], 10)).toEqual([
       { sessionId: "rearmed", deadline: 50 },
       { sessionId: "crashed", deadline: 100 },
     ]);
@@ -109,8 +121,8 @@ describe("openHostAlarmIndex", () => {
     index.set("a", 100);
     index.set("b", 200);
     expect(index.earliest(["a"])).toEqual({ sessionId: "b", deadline: 200 });
-    expect(index.due(300, ["a", "b"])).toEqual([]);
-    expect(index.due(300, new Set(["b"]))).toEqual([{ sessionId: "a", deadline: 100 }]);
+    expect(index.due(300, ["a", "b"], 10)).toEqual([]);
+    expect(index.due(300, new Set(["b"]), 10)).toEqual([{ sessionId: "a", deadline: 100 }]);
   });
 
   it("survives close and reopen in a private file", () => {

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
+
+describe("openHostAlarmIndex", () => {
+  let dataDir: string;
+  const opened: HostAlarmIndex[] = [];
+  const open = (): HostAlarmIndex => {
+    const index = openHostAlarmIndex(dataDir);
+    opened.push(index);
+    return index;
+  };
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "host-alarms-"));
+  });
+
+  afterEach(() => {
+    for (const index of opened.splice(0)) {
+      try {
+        index.close();
+      } catch {
+        // already closed by the test
+      }
+    }
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("records, replaces, reads and forgets a session's deadline", () => {
+    const index = open();
+    expect(index.get("s1")).toBeNull();
+    index.set("s1", 500);
+    expect(index.get("s1")).toBe(500);
+    index.set("s1", 300);
+    expect(index.get("s1")).toBe(300);
+    index.delete("s1");
+    expect(index.get("s1")).toBeNull();
+    expect(index.earliest()).toBeNull();
+  });
+
+  it("orders the earliest and the due deadlines soonest first", () => {
+    const index = open();
+    index.set("late", 900);
+    index.set("soon", 100);
+    index.set("mid", 500);
+    expect(index.earliest()).toEqual({ sessionId: "soon", deadline: 100 });
+    expect(index.due(500)).toEqual([
+      { sessionId: "soon", deadline: 100 },
+      { sessionId: "mid", deadline: 500 },
+    ]);
+    expect(index.due(99)).toEqual([]);
+  });
+
+  it("survives close and reopen in a private file", () => {
+    const first = open();
+    first.set("s1", 700);
+    first.close();
+    expect(statSync(join(dataDir, "host-alarms.db")).mode & 0o777).toBe(0o600);
+    expect(open().earliest()).toEqual({ sessionId: "s1", deadline: 700 });
+    expect(existsSync(join(dataDir, "host-alarms.db"))).toBe(true);
+  });
+});

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -12,7 +12,8 @@
  * clock waits for. `in_flight` holds a deadline from the moment the clock
  * claims it for delivery until the delivery settles, so a process that dies
  * mid-delivery finds the claim at the next start and fires it again instead
- * of stranding an evicted session.
+ * of stranding an evicted session. `failures` counts failed deliveries of
+ * the current alarm, on disk so a restart does not renew the retry budget.
  */
 
 import { join } from "node:path";
@@ -24,6 +25,12 @@ interface SessionDeadline {
   deadline: number;
 }
 
+export interface ClaimedDeadline {
+  deadline: number;
+  /** Failed deliveries of this alarm so far; arming a new deadline resets it. */
+  failures: number;
+}
+
 export interface HostAlarmIndex {
   /** The session's armed deadline, or null when none is armed. */
   get(sessionId: string): number | null;
@@ -33,17 +40,24 @@ export interface HostAlarmIndex {
   delete(sessionId: string): void;
   /** The soonest armed deadline, ignoring the sessions in `excluding`. */
   earliest(excluding?: Iterable<string>): SessionDeadline | null;
-  /** Sessions armed at or before `now`, soonest first, ignoring `excluding`. */
-  due(now: number, excluding?: Iterable<string>): SessionDeadline[];
   /**
-   * Take the session's armed deadline for delivery. Returns it, or null when
+   * Up to `limit` sessions armed at or before `now`, soonest first, ignoring
+   * `excluding`.
+   */
+  due(now: number, excluding: Iterable<string>, limit: number): SessionDeadline[];
+  /**
+   * Take the session's armed deadline for delivery, with the number of
+   * deliveries of this alarm that have already failed. Returns null when
    * nothing was armed. Until `complete` or `retry`, the session reads as
    * disarmed, so a handler that arms a new deadline replaces nothing.
    */
-  claim(sessionId: string): number | null;
+  claim(sessionId: string): ClaimedDeadline | null;
   /** The claimed delivery succeeded. */
   complete(sessionId: string): void;
-  /** The claimed delivery failed: arm again at `at`, or sooner if already armed. */
+  /**
+   * The claimed delivery failed: count the failure and arm again at `at`, or
+   * sooner if already armed.
+   */
   retry(sessionId: string, at: number): void;
   /**
    * Re-arm every claim a previous process left in flight, at its original
@@ -58,6 +72,7 @@ const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
   session_id TEXT PRIMARY KEY,
   deadline INTEGER,
   in_flight INTEGER,
+  failures INTEGER NOT NULL DEFAULT 0,
   CHECK (deadline IS NOT NULL OR in_flight IS NOT NULL)
 );
 CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);`;
@@ -77,7 +92,7 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   const read = db.prepare("SELECT deadline FROM session_deadlines WHERE session_id = ?");
   const arm = db.prepare(
     `INSERT INTO session_deadlines (session_id, deadline) VALUES (?, ?)
-     ON CONFLICT(session_id) DO UPDATE SET deadline = excluded.deadline`
+     ON CONFLICT(session_id) DO UPDATE SET deadline = excluded.deadline, failures = 0`
   );
   // Disarming or settling removes the row once neither slot is used, and
   // otherwise clears just the one slot; the order keeps the row's CHECK true.
@@ -90,11 +105,14 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   );
   const claimRow = db.prepare(
     `UPDATE session_deadlines SET in_flight = deadline, deadline = NULL
-     WHERE session_id = ? AND deadline IS NOT NULL RETURNING in_flight`
+     WHERE session_id = ? AND deadline IS NOT NULL RETURNING in_flight, failures`
   );
-  const settle = db.prepare("UPDATE session_deadlines SET in_flight = NULL WHERE session_id = ?");
+  const settle = db.prepare(
+    "UPDATE session_deadlines SET in_flight = NULL, failures = 0 WHERE session_id = ?"
+  );
   const armSooner = db.prepare(
-    `UPDATE session_deadlines SET deadline = MIN(COALESCE(deadline, ?), ?), in_flight = NULL
+    `UPDATE session_deadlines
+     SET deadline = MIN(COALESCE(deadline, ?), ?), in_flight = NULL, failures = failures + 1
      WHERE session_id = ?`
   );
   const recover = db.prepare(
@@ -108,7 +126,12 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   // Armed rows only, soonest first, minus the sessions the caller is already
   // delivering to. The exclusion is a handful of ids at most, so it is
   // inlined as placeholders rather than kept in a table.
-  const armedRows = (condition: string, params: unknown[], excluding: Iterable<string>) => {
+  const armedRows = (
+    condition: string,
+    params: number[],
+    excluding: Iterable<string>,
+    limit: number
+  ) => {
     const excluded = [...excluding];
     const exclusion =
       excluded.length > 0 ? ` AND session_id NOT IN (${excluded.map(() => "?").join(", ")})` : "";
@@ -116,9 +139,9 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
       .prepare(
         `SELECT session_id, deadline FROM session_deadlines
          WHERE deadline IS NOT NULL${condition}${exclusion}
-         ORDER BY deadline, session_id`
+         ORDER BY deadline, session_id LIMIT ?`
       )
-      .all(...(params as string[]), ...excluded)
+      .all(...params, ...excluded, limit)
       .map(toDeadline);
   };
   return {
@@ -133,11 +156,11 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
       dropUnclaimed.run(sessionId);
       disarm.run(sessionId);
     },
-    earliest: (excluding = []) => armedRows("", [], excluding)[0] ?? null,
-    due: (now, excluding = []) => armedRows(" AND deadline <= ?", [now], excluding),
+    earliest: (excluding = []) => armedRows("", [], excluding, 1)[0] ?? null,
+    due: (now, excluding, limit) => armedRows(" AND deadline <= ?", [now], excluding, limit),
     claim: (sessionId) => {
-      const row = claimRow.get(sessionId) as { in_flight: number } | undefined;
-      return row?.in_flight ?? null;
+      const row = claimRow.get(sessionId) as { in_flight: number; failures: number } | undefined;
+      return row === undefined ? null : { deadline: row.in_flight, failures: row.failures };
     },
     complete: (sessionId) => {
       dropDisarmed.run(sessionId);

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -7,6 +7,12 @@
  * and this index is what makes the deadline *fire*: it is the one place the
  * host clock (host-alarm-clock.ts) reads, for resident and evicted sessions
  * alike, and it survives a restart on the data volume.
+ *
+ * A row carries two slots. `deadline` is what the session armed and the
+ * clock waits for. `in_flight` holds a deadline from the moment the clock
+ * claims it for delivery until the delivery settles, so a process that dies
+ * mid-delivery finds the claim at the next start and fires it again instead
+ * of stranding an evicted session.
  */
 
 import { join } from "node:path";
@@ -19,22 +25,40 @@ interface SessionDeadline {
 }
 
 export interface HostAlarmIndex {
-  /** The session's recorded deadline, or null when none is armed. */
+  /** The session's armed deadline, or null when none is armed. */
   get(sessionId: string): number | null;
-  /** Record (replacing any earlier record) the session's next deadline. */
+  /** Arm (replacing any earlier armed deadline) the session's next deadline. */
   set(sessionId: string, deadline: number): void;
-  /** Forget the session's deadline. */
+  /** Disarm the session. A claim in flight is unaffected. */
   delete(sessionId: string): void;
-  /** The soonest recorded deadline across all sessions. */
-  earliest(): SessionDeadline | null;
-  /** Every session whose deadline is at or before `now`, soonest first. */
-  due(now: number): SessionDeadline[];
+  /** The soonest armed deadline, ignoring the sessions in `excluding`. */
+  earliest(excluding?: Iterable<string>): SessionDeadline | null;
+  /** Sessions armed at or before `now`, soonest first, ignoring `excluding`. */
+  due(now: number, excluding?: Iterable<string>): SessionDeadline[];
+  /**
+   * Take the session's armed deadline for delivery. Returns it, or null when
+   * nothing was armed. Until `complete` or `retry`, the session reads as
+   * disarmed, so a handler that arms a new deadline replaces nothing.
+   */
+  claim(sessionId: string): number | null;
+  /** The claimed delivery succeeded. */
+  complete(sessionId: string): void;
+  /** The claimed delivery failed: arm again at `at`, or sooner if already armed. */
+  retry(sessionId: string, at: number): void;
+  /**
+   * Re-arm every claim a previous process left in flight, at its original
+   * deadline (or sooner if the session armed one meanwhile). Returns the
+   * session ids recovered.
+   */
+  recoverClaims(): string[];
   close(): void;
 }
 
 const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
   session_id TEXT PRIMARY KEY,
-  deadline INTEGER NOT NULL
+  deadline INTEGER,
+  in_flight INTEGER,
+  CHECK (deadline IS NOT NULL OR in_flight IS NOT NULL)
 );
 CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);`;
 
@@ -51,37 +75,79 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
     throw error;
   }
   const read = db.prepare("SELECT deadline FROM session_deadlines WHERE session_id = ?");
-  const write = db.prepare(
+  const arm = db.prepare(
     `INSERT INTO session_deadlines (session_id, deadline) VALUES (?, ?)
      ON CONFLICT(session_id) DO UPDATE SET deadline = excluded.deadline`
   );
-  const remove = db.prepare("DELETE FROM session_deadlines WHERE session_id = ?");
-  const first = db.prepare(
-    "SELECT session_id, deadline FROM session_deadlines ORDER BY deadline, session_id LIMIT 1"
+  // Disarming or settling removes the row once neither slot is used, and
+  // otherwise clears just the one slot; the order keeps the row's CHECK true.
+  const dropUnclaimed = db.prepare(
+    "DELETE FROM session_deadlines WHERE session_id = ? AND in_flight IS NULL"
   );
-  const dueBy = db.prepare(
-    "SELECT session_id, deadline FROM session_deadlines WHERE deadline <= ? ORDER BY deadline, session_id"
+  const disarm = db.prepare("UPDATE session_deadlines SET deadline = NULL WHERE session_id = ?");
+  const dropDisarmed = db.prepare(
+    "DELETE FROM session_deadlines WHERE session_id = ? AND deadline IS NULL"
+  );
+  const claimRow = db.prepare(
+    `UPDATE session_deadlines SET in_flight = deadline, deadline = NULL
+     WHERE session_id = ? AND deadline IS NOT NULL RETURNING in_flight`
+  );
+  const settle = db.prepare("UPDATE session_deadlines SET in_flight = NULL WHERE session_id = ?");
+  const armSooner = db.prepare(
+    `UPDATE session_deadlines SET deadline = MIN(COALESCE(deadline, ?), ?), in_flight = NULL
+     WHERE session_id = ?`
+  );
+  const recover = db.prepare(
+    `UPDATE session_deadlines SET deadline = MIN(COALESCE(deadline, in_flight), in_flight), in_flight = NULL
+     WHERE in_flight IS NOT NULL RETURNING session_id`
   );
   const toDeadline = (row: unknown): SessionDeadline => {
     const { session_id, deadline } = row as { session_id: string; deadline: number };
     return { sessionId: session_id, deadline };
   };
+  // Armed rows only, soonest first, minus the sessions the caller is already
+  // delivering to. The exclusion is a handful of ids at most, so it is
+  // inlined as placeholders rather than kept in a table.
+  const armedRows = (condition: string, params: unknown[], excluding: Iterable<string>) => {
+    const excluded = [...excluding];
+    const exclusion =
+      excluded.length > 0 ? ` AND session_id NOT IN (${excluded.map(() => "?").join(", ")})` : "";
+    return db
+      .prepare(
+        `SELECT session_id, deadline FROM session_deadlines
+         WHERE deadline IS NOT NULL${condition}${exclusion}
+         ORDER BY deadline, session_id`
+      )
+      .all(...(params as string[]), ...excluded)
+      .map(toDeadline);
+  };
   return {
     get: (sessionId) => {
-      const row = read.get(sessionId) as { deadline: number } | undefined;
+      const row = read.get(sessionId) as { deadline: number | null } | undefined;
       return row?.deadline ?? null;
     },
     set: (sessionId, deadline) => {
-      write.run(sessionId, deadline);
+      arm.run(sessionId, deadline);
     },
     delete: (sessionId) => {
-      remove.run(sessionId);
+      dropUnclaimed.run(sessionId);
+      disarm.run(sessionId);
     },
-    earliest: () => {
-      const row = first.get();
-      return row === undefined ? null : toDeadline(row);
+    earliest: (excluding = []) => armedRows("", [], excluding)[0] ?? null,
+    due: (now, excluding = []) => armedRows(" AND deadline <= ?", [now], excluding),
+    claim: (sessionId) => {
+      const row = claimRow.get(sessionId) as { in_flight: number } | undefined;
+      return row?.in_flight ?? null;
     },
-    due: (now) => dueBy.all(now).map(toDeadline),
+    complete: (sessionId) => {
+      dropDisarmed.run(sessionId);
+      settle.run(sessionId);
+    },
+    retry: (sessionId, at) => {
+      armSooner.run(at, at, sessionId);
+    },
+    recoverClaims: () =>
+      (recover.all() as Array<{ session_id: string }>).map((row) => row.session_id),
     close: () => db.close(),
   };
 }

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -1,0 +1,87 @@
+/**
+ * The host's index of every session's next deadline: `<dataDir>/host-alarms.db`.
+ *
+ * A Durable Object's alarm lives with the object and the platform wakes a
+ * hibernated object when it fires. On a Node host the session's own file
+ * (`session_alarm_state`) stays the source of truth for *what* is pending,
+ * and this index is what makes the deadline *fire*: it is the one place the
+ * host clock (host-alarm-clock.ts) reads, for resident and evicted sessions
+ * alike, and it survives a restart on the data volume.
+ */
+
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { ensurePrivateDirectory, makeFilePrivate } from "./private-paths";
+
+interface SessionDeadline {
+  sessionId: string;
+  deadline: number;
+}
+
+export interface HostAlarmIndex {
+  /** The session's recorded deadline, or null when none is armed. */
+  get(sessionId: string): number | null;
+  /** Record (replacing any earlier record) the session's next deadline. */
+  set(sessionId: string, deadline: number): void;
+  /** Forget the session's deadline. */
+  delete(sessionId: string): void;
+  /** The soonest recorded deadline across all sessions. */
+  earliest(): SessionDeadline | null;
+  /** Every session whose deadline is at or before `now`, soonest first. */
+  due(now: number): SessionDeadline[];
+  close(): void;
+}
+
+const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
+  session_id TEXT PRIMARY KEY,
+  deadline INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);`;
+
+/** Open (creating if needed) the host's deadline index. */
+export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
+  ensurePrivateDirectory(dataDir);
+  const path = join(dataDir, "host-alarms.db");
+  const db = new DatabaseSync(path);
+  try {
+    makeFilePrivate(path);
+    db.exec(SCHEMA_SQL);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+  const read = db.prepare("SELECT deadline FROM session_deadlines WHERE session_id = ?");
+  const write = db.prepare(
+    `INSERT INTO session_deadlines (session_id, deadline) VALUES (?, ?)
+     ON CONFLICT(session_id) DO UPDATE SET deadline = excluded.deadline`
+  );
+  const remove = db.prepare("DELETE FROM session_deadlines WHERE session_id = ?");
+  const first = db.prepare(
+    "SELECT session_id, deadline FROM session_deadlines ORDER BY deadline, session_id LIMIT 1"
+  );
+  const dueBy = db.prepare(
+    "SELECT session_id, deadline FROM session_deadlines WHERE deadline <= ? ORDER BY deadline, session_id"
+  );
+  const toDeadline = (row: unknown): SessionDeadline => {
+    const { session_id, deadline } = row as { session_id: string; deadline: number };
+    return { sessionId: session_id, deadline };
+  };
+  return {
+    get: (sessionId) => {
+      const row = read.get(sessionId) as { deadline: number } | undefined;
+      return row?.deadline ?? null;
+    },
+    set: (sessionId, deadline) => {
+      write.run(sessionId, deadline);
+    },
+    delete: (sessionId) => {
+      remove.run(sessionId);
+    },
+    earliest: () => {
+      const row = first.get();
+      return row === undefined ? null : toDeadline(row);
+    },
+    due: (now) => dueBy.all(now).map(toDeadline),
+    close: () => db.close(),
+  };
+}

--- a/packages/control-plane/src/node/private-paths.ts
+++ b/packages/control-plane/src/node/private-paths.ts
@@ -1,0 +1,22 @@
+/**
+ * Files under the host's data directory hold session state, tokens and
+ * sandbox credentials, so they are private to the host user. chmod runs
+ * after creation so a pre-existing path or a permissive umask cannot widen
+ * them.
+ */
+
+import { chmodSync, mkdirSync } from "node:fs";
+
+const PRIVATE_DIRECTORY = 0o700;
+const PRIVATE_FILE = 0o600;
+
+/** Create `directory` if needed and make it private to the host user. */
+export function ensurePrivateDirectory(directory: string): void {
+  mkdirSync(directory, { recursive: true, mode: PRIVATE_DIRECTORY });
+  chmodSync(directory, PRIVATE_DIRECTORY);
+}
+
+/** Make an existing file private to the host user. */
+export function makeFilePrivate(path: string): void {
+  chmodSync(path, PRIVATE_FILE);
+}

--- a/packages/control-plane/src/node/session-store.ts
+++ b/packages/control-plane/src/node/session-store.ts
@@ -5,11 +5,11 @@
  * live on the host's persistent volume, so there is no snapshot cycle.
  */
 
-import { chmodSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { SessionStorage } from "../session/platform";
 import { initSchema } from "../session/schema";
+import { ensurePrivateDirectory, makeFilePrivate } from "./private-paths";
 import { createNodeSqlStorage } from "./sqlite-storage";
 
 /** How long a writer waits on another connection's lock before failing. */
@@ -18,9 +18,6 @@ const BUSY_TIMEOUT_MS = 5_000;
 /** How often the WAL switch is retried while another connection holds the file. */
 const BUSY_RETRY_MS = 10;
 const SQLITE_BUSY = 5;
-
-const PRIVATE_DIRECTORY = 0o700;
-const PRIVATE_FILE = 0o600;
 
 /** A session id must be a single path segment: it names the file directly. */
 const SESSION_FILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
@@ -69,17 +66,13 @@ export function openSessionStore(options: OpenSessionStoreOptions): NodeSessionS
   if (!SESSION_FILE_ID.test(sessionId)) {
     throw new Error(`Session id ${JSON.stringify(sessionId)} cannot name a session file`);
   }
-  // Session files hold tokens and sandbox credentials: the directory and
-  // every file in it are private to the host user. chmod runs after the
-  // fact so an existing directory or file, and a permissive umask, cannot
-  // widen them; SQLite gives the -wal and -shm files the main file's mode.
+  // SQLite gives the -wal and -shm files the main file's mode.
   const directory = join(dataDir, "sessions");
-  mkdirSync(directory, { recursive: true, mode: PRIVATE_DIRECTORY });
-  chmodSync(directory, PRIVATE_DIRECTORY);
+  ensurePrivateDirectory(directory);
   const path = join(directory, `${sessionId}.db`);
   const db = new DatabaseSync(path);
   try {
-    chmodSync(path, PRIVATE_FILE);
+    makeFilePrivate(path);
     db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
     enableWriteAheadLog(db);
     const storage = createNodeSqlStorage(db);


### PR DESCRIPTION
Roadmap N-7 (COL-94). The Node host's half of Durable Object alarms: the per-session `AlarmScheduleStore` the runtime is built over, plus the wake-up of sessions the host has evicted. Unused on Cloudflare; the worker bundle is unchanged.

## What lands

- `src/node/host-alarm-index.ts` — `openHostAlarmIndex(dataDir)`: a private SQLite file `<dataDir>/host-alarms.db` holding `(session_id, deadline)` for every armed session, with `earliest()` and `due(now)`.
- `src/node/host-alarm-clock.ts` — `HostAlarmClock`: one timer for the process, armed for the index's soonest deadline (chunked past the 2^31 ms `setTimeout` limit). `storeFor(sessionId)` returns the `AlarmScheduleStore` for one runtime: `setAlarm` records and re-arms, `deleteAlarm` forgets, `getAlarm` reads the index. When a deadline is due the clock **consumes the record, then** calls the host's `deliver(sessionId)` callback (H-2 will make that "open the session if evicted, run `server.onScheduledDeadline()`"), so a handler that arms a new deadline replaces nothing, the way the platform clears a Durable Object's alarm on fire. A failed delivery is retried with doubling backoff up to six attempts, then dropped and logged; a retry never delays a newer deadline the handler armed. One session is never delivered twice concurrently. `start()` arms from the file, `stop()` stops firing, `drain()` awaits running deliveries.
- `src/node/private-paths.ts` — the 0700/0600 handling shared by the session store and the index.

## One deviation from the issue text

COL-94 describes per-session `setTimeout`s plus a separate index used only for evicted sessions, maintained at eviction time. This lands **one clock driven by one durable index** for resident and evicted sessions alike. Reasons: there is no resident/evicted distinction to get wrong at eviction or wake-up time; a crash loses nothing, because the index is written on every `setAlarm` rather than only when the registry evicts; and H-2 needs no alarm-specific eviction step. The per-alarm cost is one upsert into a small local SQLite file.

`createEarliestAlarmScheduler` and `PersistedAlarmDeadlineStore` are untouched; the session file remains the source of truth for what is pending, and the index is what makes it fire.

## Tests

- Index: record/replace/forget, ordering of `earliest` and `due`, survives close and reopen in a private file.
- Clock (fake timers): fires at the deadline with the record consumed before the handler runs; deadline order across sessions and an earlier replacement; deleted deadlines do not fire; a deadline beyond one timer's reach; a deadline armed by the running handler fires again; no overlapping delivery to one session; retry with backoff then drop after the sixth attempt; a fresh clock over the same index resumes a deadline recorded before a restart; `drain` waits.
- Through the session core: `createEarliestAlarmScheduler(clock.storeFor(id), PersistedAlarmDeadlineStore)` with `handleAlarmDelivery` covers earliest-wins delivery exactly once, cancel, rehydrate after cancel, and `rearmPending`, which is the "Done when" list from the issue.

Verification: four typecheck programs, lint, prettier clean; unit suite 251 files / 3691 tests green; knip unchanged from main.

https://claude.ai/code/session_01E3k9fw7GE4HMYHh86vKxXp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent host-level alarm scheduling for session deadlines, including restart recovery.
  * Added exponential retry handling with preserved retry counts across restarts.
  * Added cancellation, rearming, draining, ordered delivery, and bounded concurrent processing without overlapping deliveries within a session.
  * Added configurable limits for concurrent alarm deliveries.

* **Security**
  * Session and alarm data is stored with private filesystem permissions.

* **Tests**
  * Expanded coverage for scheduling, persistence, retries, concurrency, cancellation, rearming, draining, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->