### PR TITLE
Require the active sandbox socket identity at message dispatch (COL-128)

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -121,6 +121,7 @@ function createMockSandbox(
     tunnel_urls: null,
     ttyd_url: null,
     ttyd_token: null,
+    active_socket_id: null,
     created_at: Date.now() - 60000,
     spawn_failure_count: 0,
     last_spawn_failure: 0,

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -775,6 +775,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     send: (ws, message) => wsManager.send(ws, message),
     getClient: (ws) => connectionAuthenticator.getClientInfo(ws),
     close: (ws, code, reason) => wsManager.close(ws, code, reason),
+    isActiveSandbox: (ws) => wsManager.isActiveSandboxSocket(ws),
     clearSandboxIfMatch: (ws) => wsManager.clearSandboxSocketIfMatch(ws),
     removeClient: (ws) => wsManager.removeClient(ws),
     hasParticipant: (participantId) =>

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -169,6 +169,7 @@ export interface SessionRuntime {
  */
 export interface SessionComponents {
   sandboxRepository: SandboxRepository;
+  wsManager: SessionWebSocketManager;
   /**
    * Assignable — the setter swaps the underlying cell for tests. Substitution
    * swaps operations only: the provider NAME was captured at construction and
@@ -826,6 +827,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
 
   const components: SessionComponents = {
     sandboxRepository,
+    wsManager,
     // Accessor pair over the local cell: production reads never go through
     // this property; the setter is the live-DO integration seam.
     get sourceControlProvider() {

--- a/packages/control-plane/src/session/http/handlers/child-summary.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-summary.handler.test.ts
@@ -67,6 +67,7 @@ function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
     tunnel_urls: null,
     ttyd_url: null,
     ttyd_token: null,
+    active_socket_id: null,
     created_at: 1,
     ...overrides,
   };

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -62,6 +62,7 @@ function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
     tunnel_urls: null,
     ttyd_url: null,
     ttyd_token: null,
+    active_socket_id: null,
     created_at: 1,
     ...overrides,
   };

--- a/packages/control-plane/src/session/message-router.ts
+++ b/packages/control-plane/src/session/message-router.ts
@@ -56,11 +56,23 @@ export class SessionMessageRouter<Connection, Client extends ConnectedClient> {
     // The wire protocol is JSON text; binary frames have always been ignored.
     if (typeof message !== "string") return;
 
-    if (this.deps.sockets.classify(connection).kind === "sandbox") {
-      await this.handleSandboxMessage(message);
-    } else {
+    const classified = this.deps.sockets.classify(connection);
+    if (classified.kind !== "sandbox") {
       await this.handleClientMessage(connection, message);
+      return;
     }
+    if (!this.deps.sockets.isActiveSandbox(connection)) {
+      // A replaced bridge keeps its tags until its close completes. A frame
+      // from it proves it is still open, so close it again instead of
+      // letting it mutate the session.
+      this.deps.log.debug("Ignoring frame from a replaced sandbox socket", {
+        sandbox_id: classified.sandboxId,
+        socket_id: classified.socketId,
+      });
+      this.deps.sockets.close(connection, 1000, "Sandbox socket replaced");
+      return;
+    }
+    await this.handleSandboxMessage(message);
   }
 
   private async handleSandboxMessage(message: string): Promise<void> {

--- a/packages/control-plane/src/session/ports.ts
+++ b/packages/control-plane/src/session/ports.ts
@@ -16,9 +16,14 @@ export interface ConnectedClient {
   lastFetchHistoryAtMs?: number;
 }
 
-/** Result of classifying an opaque runtime connection. */
+/**
+ * Result of classifying an opaque runtime connection. A sandbox socket
+ * carries the sandbox it authenticated as and its own accept-time identity;
+ * only the socket whose identity the session persisted as active is
+ * authoritative (see `SocketRegistry.isActiveSandbox`).
+ */
 export type ConnectionClassification =
-  | { kind: "sandbox"; sandboxId?: string }
+  | { kind: "sandbox"; sandboxId?: string; socketId?: string }
   | { kind: "client"; wsId?: string };
 
 /** Wall and monotonic time sources used by session application code. */
@@ -33,6 +38,12 @@ export interface SocketRegistry<Connection, Client extends ConnectedClient> {
   send(connection: Connection, message: ServerMessage): boolean;
   getClient(connection: Connection): Client | null;
   close(connection: Connection, code: number, reason: string): void;
+  /**
+   * Whether `connection` is the sandbox socket the session currently
+   * dispatches to. A replaced bridge keeps its tags until its close
+   * completes; its frames carry no authority.
+   */
+  isActiveSandbox(connection: Connection): boolean;
   clearSandboxIfMatch(connection: Connection): boolean;
   removeClient(connection: Connection): Client | null;
   hasParticipant(participantId: string): boolean;

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -131,6 +131,8 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].query).toContain("vnc_password = NULL");
       // A replacement sandbox must not inherit the predecessor's runtime.
       expect(mock.calls[0].query).toContain("runtime_version = NULL");
+      // ...nor its bridge: the predecessor's socket loses dispatch authority here.
+      expect(mock.calls[0].query).toContain("active_socket_id = NULL");
       expect(mock.calls[0].params).toEqual(["spawning", 1000, "modal-sb-1"]);
     });
 
@@ -143,6 +145,32 @@ describe("SandboxRepository", () => {
       });
 
       expect(mock.calls[0].query).toContain("modal_object_id = modal_object_id");
+    });
+  });
+
+  describe("active socket id", () => {
+    const query = `SELECT active_socket_id FROM sandbox LIMIT 1`;
+
+    it("reads null before any bridge has connected", () => {
+      mock.setData(query, [{ active_socket_id: null }]);
+      expect(repository.getActiveSocketId()).toBeNull();
+    });
+
+    it("reads null without a sandbox row", () => {
+      expect(repository.getActiveSocketId()).toBeNull();
+    });
+
+    it("reads the persisted identity", () => {
+      mock.setData(query, [{ active_socket_id: "sbws-1" }]);
+      expect(repository.getActiveSocketId()).toBe("sbws-1");
+    });
+
+    it("writes the identity to the session's one sandbox row", () => {
+      repository.setActiveSocketId("sbws-2");
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toContain("UPDATE sandbox SET active_socket_id = ?");
+      expect(mock.calls[0].params).toEqual(["sbws-2"]);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -131,8 +131,9 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].query).toContain("vnc_password = NULL");
       // A replacement sandbox must not inherit the predecessor's runtime.
       expect(mock.calls[0].query).toContain("runtime_version = NULL");
-      // ...nor its bridge: the predecessor's socket loses dispatch authority here.
-      expect(mock.calls[0].query).toContain("active_socket_id = NULL");
+      // ...nor its bridge: the predecessor's socket loses dispatch authority
+      // here. Revoked is '' — NULL is reserved for rows that predate identities.
+      expect(mock.calls[0].query).toContain("active_socket_id = ''");
       expect(mock.calls[0].params).toEqual(["spawning", 1000, "modal-sb-1"]);
     });
 
@@ -149,28 +150,20 @@ describe("SandboxRepository", () => {
   });
 
   describe("active socket id", () => {
-    const query = `SELECT active_socket_id FROM sandbox LIMIT 1`;
-
-    it("reads null before any bridge has connected", () => {
-      mock.setData(query, [{ active_socket_id: null }]);
-      expect(repository.getActiveSocketId()).toBeNull();
-    });
-
-    it("reads null without a sandbox row", () => {
-      expect(repository.getActiveSocketId()).toBeNull();
-    });
-
-    it("reads the persisted identity", () => {
-      mock.setData(query, [{ active_socket_id: "sbws-1" }]);
-      expect(repository.getActiveSocketId()).toBe("sbws-1");
-    });
-
     it("writes the identity to the session's one sandbox row", () => {
       repository.setActiveSocketId("sbws-2");
 
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toContain("UPDATE sandbox SET active_socket_id = ?");
       expect(mock.calls[0].params).toEqual(["sbws-2"]);
+    });
+
+    it("revokes with the empty sentinel rather than NULL", () => {
+      repository.revokeActiveSocketId();
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toContain("UPDATE sandbox SET active_socket_id = ''");
+      expect(mock.calls[0].params).toEqual([]);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -138,7 +138,7 @@ export class SandboxRepository {
          ttyd_url = NULL,
          ttyd_token = NULL,
          runtime_version = NULL,
-         active_socket_id = NULL
+         active_socket_id = ''
        WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       data.status,
       data.createdAt,
@@ -147,20 +147,23 @@ export class SandboxRepository {
   }
 
   /**
-   * The bridge socket the session dispatches to, by its `socket:<id>` tag.
-   * Null once a spawn reserves a new identity or before any bridge connects.
+   * Make `socketId` the socket the session dispatches to; every earlier
+   * socket loses authority. `active_socket_id` is three-valued: a tag id,
+   * `''` for revoked (no socket matches, see `revokeActiveSocketId` and the
+   * spawn reservation above), and NULL only on rows that predate persisted
+   * identities.
    */
-  getActiveSocketId(): string | null {
-    const result = this.sql.exec(`SELECT active_socket_id FROM sandbox LIMIT 1`);
-    const rows = this.rows<{ active_socket_id: string | null }>(result);
-    return rows[0]?.active_socket_id ?? null;
-  }
-
-  /** Make `socketId` the socket the session dispatches to; every earlier socket loses authority. */
   setActiveSocketId(socketId: string): void {
     this.sql.exec(
       `UPDATE sandbox SET active_socket_id = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       socketId
+    );
+  }
+
+  /** Leave the session with no authoritative bridge socket until the next accept. */
+  revokeActiveSocketId(): void {
+    this.sql.exec(
+      `UPDATE sandbox SET active_socket_id = '' WHERE id = (SELECT id FROM sandbox LIMIT 1)`
     );
   }
 

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -137,11 +137,30 @@ export class SandboxRepository {
          tunnel_urls = NULL,
          ttyd_url = NULL,
          ttyd_token = NULL,
-         runtime_version = NULL
+         runtime_version = NULL,
+         active_socket_id = NULL
        WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       data.status,
       data.createdAt,
       data.modalSandboxId
+    );
+  }
+
+  /**
+   * The bridge socket the session dispatches to, by its `socket:<id>` tag.
+   * Null once a spawn reserves a new identity or before any bridge connects.
+   */
+  getActiveSocketId(): string | null {
+    const result = this.sql.exec(`SELECT active_socket_id FROM sandbox LIMIT 1`);
+    const rows = this.rows<{ active_socket_id: string | null }>(result);
+    return rows[0]?.active_socket_id ?? null;
+  }
+
+  /** Make `socketId` the socket the session dispatches to; every earlier socket loses authority. */
+  setActiveSocketId(socketId: string): void {
+    this.sql.exec(
+      `UPDATE sandbox SET active_socket_id = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      socketId
     );
   }
 

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -273,6 +273,13 @@ describe("applyMigrations", () => {
     ]);
   });
 
+  it("adds sandbox.active_socket_id for fresh and migrated DOs", () => {
+    expect(SCHEMA_SQL).toContain("active_socket_id TEXT");
+
+    const migration = MIGRATIONS.find((entry) => entry.id === 48);
+    expect(migration?.run).toBe("ALTER TABLE sandbox ADD COLUMN active_socket_id TEXT");
+  });
+
   it("keeps repository context consistent at the session table boundary", () => {
     expect(SCHEMA_SQL).toContain("(repo_owner IS NULL) = (repo_name IS NULL)");
     expect(SCHEMA_SQL).toContain("repo_owner IS NOT NULL");

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -189,6 +189,7 @@ CREATE TABLE IF NOT EXISTS sandbox (
   tunnel_urls TEXT,                                 -- JSON mapping of port -> tunnel URL for extra ports
   ttyd_url TEXT,                                    -- ttyd proxy tunnel URL
   ttyd_token TEXT,                                  -- Encrypted JWT token for ttyd auth
+  active_socket_id TEXT,                            -- Bridge socket the session dispatches to (socket:<id> tag)
   created_at INTEGER NOT NULL
 );
 
@@ -647,6 +648,11 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 47,
     description: "Persist terminal message projections awaiting retry",
     run: TERMINAL_MESSAGE_PROJECTION_TABLE_SQL,
+  },
+  {
+    id: 48,
+    description: "Add active_socket_id to sandbox",
+    run: `ALTER TABLE sandbox ADD COLUMN active_socket_id TEXT`,
   },
 ];
 

--- a/packages/control-plane/src/session/server.test.ts
+++ b/packages/control-plane/src/session/server.test.ts
@@ -44,6 +44,7 @@ function createHarness() {
     send: vi.fn(() => true),
     getClient: vi.fn(() => currentClient),
     close: vi.fn(),
+    isActiveSandbox: vi.fn(() => true),
     clearSandboxIfMatch: vi.fn(() => true),
     removeClient: vi.fn(() => client),
     hasParticipant: vi.fn(() => false),
@@ -318,6 +319,29 @@ describe("SessionServer", () => {
       timestamp: 1000,
       status: "ready",
     });
+  });
+
+  it("refuses frames from a replaced sandbox socket and closes it again", async () => {
+    const { server, messageDeps, sockets, log, setConnectionKind } = createHarness();
+    setConnectionKind("sandbox");
+    vi.mocked(sockets.isActiveSandbox).mockReturnValue(false);
+
+    await server.onMessage(
+      "sandbox",
+      JSON.stringify({
+        type: "heartbeat",
+        sandboxId: "sandbox-1",
+        timestamp: 1000,
+        status: "ready",
+      })
+    );
+
+    expect(messageDeps.processSandboxEvent).not.toHaveBeenCalled();
+    expect(sockets.close).toHaveBeenCalledWith("sandbox", 1000, "Sandbox socket replaced");
+    expect(log.debug).toHaveBeenCalledWith(
+      "Ignoring frame from a replaced sandbox socket",
+      expect.objectContaining({ sandbox_id: "sandbox-1" })
+    );
   });
 
   it("schedules sandbox reconnect checks and always reciprocates close", async () => {

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -170,6 +170,8 @@ export interface SandboxRow {
   tunnel_urls: string | null; // JSON mapping of port -> tunnel URL
   ttyd_url: string | null;
   ttyd_token: string | null;
+  /** The `socket:<id>` tag of the bridge socket the session dispatches to. */
+  active_socket_id: string | null;
   created_at: number;
 }
 

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -170,7 +170,10 @@ export interface SandboxRow {
   tunnel_urls: string | null; // JSON mapping of port -> tunnel URL
   ttyd_url: string | null;
   ttyd_token: string | null;
-  /** The `socket:<id>` tag of the bridge socket the session dispatches to. */
+  /**
+   * The `socket:<id>` tag of the bridge socket the session dispatches to;
+   * `''` once revoked, NULL only on rows that predate persisted identities.
+   */
   active_socket_id: string | null;
   created_at: number;
 }

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -108,6 +108,11 @@ function createMockRepository() {
 
   const repo = {
     getSandbox: () => sandboxRow,
+    getActiveSocketId: () => sandboxRow?.active_socket_id ?? null,
+    setActiveSocketId: (socketId: string) => {
+      // Like the UPDATE it stands in for: nothing to write without a row.
+      if (sandboxRow) sandboxRow.active_socket_id = socketId;
+    },
     getWsClientMapping: (wsId: string) => mappings.get(wsId) ?? null,
     hasWsClientMapping: (wsId: string) => mappings.has(wsId),
     upsertWsClientMapping: (data: {
@@ -195,6 +200,7 @@ function createSandboxRow(modalSandboxId: string): SandboxRow {
     tunnel_urls: null,
     ttyd_url: null,
     ttyd_token: null,
+    active_socket_id: null,
     created_at: Date.now(),
   };
 }
@@ -304,7 +310,34 @@ describe("SessionWebSocketManagerImpl", () => {
 
       manager.acceptAndSetSandboxSocket(ws);
 
-      expect(sockets.get(ws)).toEqual(["sandbox"]);
+      expect(sockets.get(ws)).toEqual(["sandbox", expect.stringMatching(/^socket:sbws-/)]);
+    });
+
+    it("persists the new socket's identity before closing the socket it replaces", () => {
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
+      const order: string[] = [];
+      const oldWs = createFakeWebSocket();
+      vi.mocked(oldWs.close).mockImplementation(() => {
+        order.push(`close:${mockRepo.repo.getActiveSocketId()}`);
+      });
+      const newWs = createFakeWebSocket();
+
+      manager.acceptAndSetSandboxSocket(oldWs, "sb-1");
+      const oldId = mockRepo.repo.getActiveSocketId();
+      manager.acceptAndSetSandboxSocket(newWs, "sb-1");
+      const newId = mockRepo.repo.getActiveSocketId();
+
+      expect(oldId).toMatch(/^sbws-/);
+      expect(newId).toMatch(/^sbws-/);
+      expect(newId).not.toBe(oldId);
+      // The row already named the replacement when the old socket was closed.
+      expect(order).toEqual([`close:${newId}`]);
+      expect(manager.classify(newWs)).toEqual({
+        kind: "sandbox",
+        sandboxId: "sb-1",
+        socketId: newId,
+      });
     });
 
     it("closes existing sandbox socket and returns replaced=true", () => {
@@ -345,7 +378,8 @@ describe("SessionWebSocketManagerImpl", () => {
     });
 
     it("sets new socket as active sandbox", () => {
-      const { manager } = createManager();
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
       const ws = createFakeWebSocket();
 
       manager.acceptAndSetSandboxSocket(ws, "sb-1");
@@ -354,14 +388,96 @@ describe("SessionWebSocketManagerImpl", () => {
     });
   });
 
+  describe("isActiveSandboxSocket", () => {
+    it("is true only for the most recently accepted sandbox socket", () => {
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
+      const oldWs = createFakeWebSocket();
+      const newWs = createFakeWebSocket();
+
+      manager.acceptAndSetSandboxSocket(oldWs, "sb-1");
+      expect(manager.isActiveSandboxSocket(oldWs)).toBe(true);
+
+      // Same sandbox reconnecting: the replaced socket is still OPEN while
+      // its close completes, and still tagged, but no longer authoritative.
+      manager.acceptAndSetSandboxSocket(newWs, "sb-1");
+      expect(manager.isActiveSandboxSocket(oldWs)).toBe(false);
+      expect(manager.isActiveSandboxSocket(newWs)).toBe(true);
+    });
+
+    it("is false for client sockets", () => {
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
+      const ws = createFakeWebSocket();
+      manager.acceptClientSocket(ws, "ws-1");
+
+      expect(manager.isActiveSandboxSocket(ws)).toBe(false);
+    });
+
+    it("is false once a spawn reservation has cleared the persisted identity", () => {
+      const { manager, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
+      const ws = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(ws, "sb-1");
+
+      row.active_socket_id = null;
+      row.modal_sandbox_id = "sb-2";
+
+      expect(manager.isActiveSandboxSocket(ws)).toBe(false);
+    });
+
+    it("keeps a socket accepted before identities were persisted authoritative", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
+      const legacyWs = createFakeWebSocket();
+      sockets.set(legacyWs, ["sandbox", "sid:sb-1"]);
+
+      expect(manager.isActiveSandboxSocket(legacyWs)).toBe(true);
+
+      const newWs = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(newWs, "sb-1");
+      expect(manager.isActiveSandboxSocket(legacyWs)).toBe(false);
+    });
+  });
+
   describe("getSandboxSocket", () => {
     it("returns cached socket if open", () => {
-      const { manager } = createManager();
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
       const ws = createFakeWebSocket();
 
       manager.acceptAndSetSandboxSocket(ws, "sb-1");
 
       expect(manager.getSandboxSocket()).toBe(ws);
+    });
+
+    it("recovers the socket whose identity the row names, not the first open one", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      row.active_socket_id = "sbws-active";
+      mockRepo.setSandbox(row);
+      const replacedWs = createFakeWebSocket();
+      const activeWs = createFakeWebSocket();
+
+      // Both sockets belong to the same sandbox and both still look OPEN
+      // after a restart; the replaced one is enumerated first.
+      sockets.set(replacedWs, ["sandbox", "sid:sb-1", "socket:sbws-replaced"]);
+      sockets.set(activeWs, ["sandbox", "sid:sb-1", "socket:sbws-active"]);
+
+      expect(manager.getSandboxSocket()).toBe(activeWs);
+      expect(replacedWs.close).not.toHaveBeenCalled();
+    });
+
+    it("returns null when only replaced sockets survive a restart", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      row.active_socket_id = "sbws-active";
+      mockRepo.setSandbox(row);
+      const replacedWs = createFakeWebSocket();
+      sockets.set(replacedWs, ["sandbox", "sid:sb-1", "socket:sbws-replaced"]);
+
+      expect(manager.getSandboxSocket()).toBeNull();
     });
 
     it("returns null when no sandbox socket exists", () => {
@@ -508,7 +624,8 @@ describe("SessionWebSocketManagerImpl", () => {
 
   describe("clearSandboxSocketIfMatch", () => {
     it("clears and returns true when ws matches", () => {
-      const { manager } = createManager();
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
       const ws = createFakeWebSocket();
 
       manager.acceptAndSetSandboxSocket(ws, "sb-1");
@@ -521,12 +638,13 @@ describe("SessionWebSocketManagerImpl", () => {
     });
 
     it("returns false and does not clear when ws does not match", () => {
-      const { manager } = createManager();
+      const { manager, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-1"));
       const oldWs = createFakeWebSocket();
       const newWs = createFakeWebSocket();
 
       manager.acceptAndSetSandboxSocket(oldWs, "sb-1");
-      manager.acceptAndSetSandboxSocket(newWs, "sb-2");
+      manager.acceptAndSetSandboxSocket(newWs, "sb-1");
 
       // Try to clear with old socket — should not affect new socket
       const result = manager.clearSandboxSocketIfMatch(oldWs);
@@ -535,13 +653,33 @@ describe("SessionWebSocketManagerImpl", () => {
       expect(manager.getSandboxSocket()).toBe(newWs);
     });
 
-    it("returns true when no sandbox socket is set (post-hibernation)", () => {
-      const { manager } = createManager();
-      const ws = createFakeWebSocket();
+    it("recognizes the active socket after a restart by its persisted identity", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      row.active_socket_id = "sbws-active";
+      mockRepo.setSandbox(row);
+      const activeWs = createFakeWebSocket();
+      const replacedWs = createFakeWebSocket();
+      sockets.set(activeWs, ["sandbox", "sid:sb-1", "socket:sbws-active"]);
+      sockets.set(replacedWs, ["sandbox", "sid:sb-1", "socket:sbws-replaced"]);
 
-      // When sandboxWs is null (e.g., post-hibernation), the closing socket
-      // is treated as active since there's no replacement to compare against.
-      expect(manager.clearSandboxSocketIfMatch(ws)).toBe(true);
+      expect(manager.clearSandboxSocketIfMatch(replacedWs)).toBe(false);
+      expect(manager.clearSandboxSocketIfMatch(activeWs)).toBe(true);
+    });
+
+    it("treats the close of a socket a spawn reservation displaced as a replacement", () => {
+      const { manager, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
+      const ws = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(ws, "sb-1");
+      row.active_socket_id = null;
+      row.modal_sandbox_id = "sb-2";
+
+      expect(manager.clearSandboxSocketIfMatch(ws)).toBe(false);
+      // The pointer is still dropped: nothing may keep sending into it.
+      Object.defineProperty(ws, "readyState", { value: WebSocket.CLOSED });
+      expect(manager.getSandboxSocket()).toBeNull();
     });
   });
 

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -108,10 +108,12 @@ function createMockRepository() {
 
   const repo = {
     getSandbox: () => sandboxRow,
-    getActiveSocketId: () => sandboxRow?.active_socket_id ?? null,
     setActiveSocketId: (socketId: string) => {
       // Like the UPDATE it stands in for: nothing to write without a row.
       if (sandboxRow) sandboxRow.active_socket_id = socketId;
+    },
+    revokeActiveSocketId: () => {
+      if (sandboxRow) sandboxRow.active_socket_id = "";
     },
     getWsClientMapping: (wsId: string) => mappings.get(wsId) ?? null,
     hasWsClientMapping: (wsId: string) => mappings.has(wsId),
@@ -315,18 +317,19 @@ describe("SessionWebSocketManagerImpl", () => {
 
     it("persists the new socket's identity before closing the socket it replaces", () => {
       const { manager, mockRepo } = createManager();
-      mockRepo.setSandbox(createSandboxRow("sb-1"));
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
       const order: string[] = [];
       const oldWs = createFakeWebSocket();
       vi.mocked(oldWs.close).mockImplementation(() => {
-        order.push(`close:${mockRepo.repo.getActiveSocketId()}`);
+        order.push(`close:${row.active_socket_id}`);
       });
       const newWs = createFakeWebSocket();
 
       manager.acceptAndSetSandboxSocket(oldWs, "sb-1");
-      const oldId = mockRepo.repo.getActiveSocketId();
+      const oldId = row.active_socket_id;
       manager.acceptAndSetSandboxSocket(newWs, "sb-1");
-      const newId = mockRepo.repo.getActiveSocketId();
+      const newId = row.active_socket_id;
 
       expect(oldId).toMatch(/^sbws-/);
       expect(newId).toMatch(/^sbws-/);
@@ -414,17 +417,54 @@ describe("SessionWebSocketManagerImpl", () => {
       expect(manager.isActiveSandboxSocket(ws)).toBe(false);
     });
 
-    it("is false once a spawn reservation has cleared the persisted identity", () => {
+    it("is false once a spawn reservation has revoked the persisted identity", () => {
       const { manager, mockRepo } = createManager();
       const row = createSandboxRow("sb-1");
       mockRepo.setSandbox(row);
       const ws = createFakeWebSocket();
       manager.acceptAndSetSandboxSocket(ws, "sb-1");
 
-      row.active_socket_id = null;
+      // What updateSandboxForSpawn writes.
+      row.active_socket_id = "";
       row.modal_sandbox_id = "sb-2";
 
       expect(manager.isActiveSandboxSocket(ws)).toBe(false);
+    });
+
+    it("is false for every socket once detach has revoked authority", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
+      const ws = createFakeWebSocket();
+      manager.acceptAndSetSandboxSocket(ws, "sb-1");
+
+      manager.detachSandboxSocket(1000, "Heartbeat stale");
+
+      expect(row.active_socket_id).toBe("");
+      expect(ws.close).toHaveBeenCalledWith(1000, "Heartbeat stale");
+      // The close is cleanup; the row is the fence, so a trailing frame from
+      // the still-tagged socket is refused whether or not the close landed.
+      expect(manager.isActiveSandboxSocket(ws)).toBe(false);
+      expect(manager.clearSandboxSocketIfMatch(ws)).toBe(false);
+      // Nor does a restart re-adopt it, even after an in-place resume.
+      row.status = "connecting";
+      expect(sockets.get(ws)).toBeDefined();
+      expect(manager.getSandboxSocket()).toBeNull();
+    });
+
+    it("revokes authority before closing on detach", () => {
+      const { manager, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
+      const ws = createFakeWebSocket();
+      vi.mocked(ws.close).mockImplementation(() => {
+        expect(row.active_socket_id).toBe("");
+      });
+      manager.acceptAndSetSandboxSocket(ws, "sb-1");
+
+      manager.detachSandboxSocket(1011, "Fatal sandbox runtime error");
+
+      expect(ws.close).toHaveBeenCalledOnce();
     });
 
     it("keeps a socket accepted before identities were persisted authoritative", () => {
@@ -438,6 +478,34 @@ describe("SessionWebSocketManagerImpl", () => {
       const newWs = createFakeWebSocket();
       manager.acceptAndSetSandboxSocket(newWs, "sb-1");
       expect(manager.isActiveSandboxSocket(legacyWs)).toBe(false);
+    });
+
+    it("requires a pre-identity socket to belong to the row's sandbox", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      mockRepo.setSandbox(createSandboxRow("sb-2"));
+      const staleWs = createFakeWebSocket();
+      sockets.set(staleWs, ["sandbox", "sid:sb-1"]);
+
+      expect(manager.isActiveSandboxSocket(staleWs)).toBe(false);
+    });
+
+    it("refuses a pre-identity socket once a spawn reservation has revoked authority", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const row = createSandboxRow("sb-1");
+      mockRepo.setSandbox(row);
+      const legacyWs = createFakeWebSocket();
+      sockets.set(legacyWs, ["sandbox", "sid:sb-1"]);
+      expect(manager.isActiveSandboxSocket(legacyWs)).toBe(true);
+
+      // The reservation revokes rather than clears, so the migration
+      // compatibility branch never reopens for a displaced sandbox.
+      row.active_socket_id = "";
+      row.modal_sandbox_id = "sb-2";
+
+      expect(manager.isActiveSandboxSocket(legacyWs)).toBe(false);
+      expect(manager.clearSandboxSocketIfMatch(legacyWs)).toBe(false);
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(legacyWs.close).toHaveBeenCalledWith(1000, "Sandbox identity changed");
     });
   });
 
@@ -673,7 +741,7 @@ describe("SessionWebSocketManagerImpl", () => {
       mockRepo.setSandbox(row);
       const ws = createFakeWebSocket();
       manager.acceptAndSetSandboxSocket(ws, "sb-1");
-      row.active_socket_id = null;
+      row.active_socket_id = "";
       row.modal_sandbox_id = "sb-2";
 
       expect(manager.clearSandboxSocketIfMatch(ws)).toBe(false);

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -5,6 +5,12 @@
  * The manager owns socket identity, persistence, and authorization leases.
  * The connection authenticator builds ClientInfo and stores it here after
  * snapshot synchronization.
+ *
+ * Exactly one sandbox socket is authoritative at a time. Accepting a bridge
+ * tags its socket with a fresh `socket:<id>` and persists that id on the
+ * sandbox row before the socket is published; dispatch, recovery after a
+ * restart, and close handling all compare a socket's tag against the row.
+ * Closing a replaced socket is cleanup — the persisted identity is the fence.
  */
 
 import type { Logger } from "../logger";
@@ -37,10 +43,13 @@ export interface SessionWebSocketManager {
   acceptClientSocket(ws: WebSocket, wsId: string): void;
 
   /**
-   * Accept a sandbox WebSocket, close any existing sandbox socket, and set
-   * as the active sandbox connection.
+   * Accept a sandbox WebSocket as the session's active bridge: persist its
+   * identity, then close every other sandbox socket.
    */
   acceptAndSetSandboxSocket(ws: WebSocket, sandboxId?: string): { replaced: boolean };
+
+  /** Whether `ws` is the sandbox socket the session currently dispatches to. */
+  isActiveSandboxSocket(ws: WebSocket): boolean;
 
   /** Parse a WebSocket's tags to determine its kind and identity. */
   classify(ws: WebSocket): ConnectionClassification;
@@ -57,7 +66,11 @@ export interface SessionWebSocketManager {
   /** Clear and close all active sandbox sockets without consulting persisted dispatch status. */
   detachSandboxSocket(code: number, reason: string): void;
 
-  /** Clear sandbox socket only if ws matches current reference. Returns true if it was the active socket. */
+  /**
+   * Drop the in-memory pointer for a closing sandbox socket. Returns whether
+   * it was the active socket — whether its close is the loss of the session's
+   * bridge rather than the tail of a replacement.
+   */
   clearSandboxSocketIfMatch(ws: WebSocket): boolean;
 
   setClient(ws: WebSocket, info: ClientInfo): void;
@@ -130,8 +143,14 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   }
 
   acceptAndSetSandboxSocket(ws: WebSocket, sandboxId?: string): { replaced: boolean } {
-    const tags = ["sandbox", ...(sandboxId ? [`sid:${sandboxId}`] : [])];
+    const socketId = `sbws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const tags = ["sandbox", ...(sandboxId ? [`sid:${sandboxId}`] : []), `socket:${socketId}`];
     this.host.accept(ws, tags);
+    // Advance the persisted identity before anything else observes the new
+    // socket: from here on every earlier bridge socket is refused at dispatch
+    // whether or not its close below completes, and recovery after a restart
+    // re-selects this socket by its tag.
+    this.sandboxRepository.setActiveSocketId(socketId);
 
     let replaced = false;
     // Close every other live sandbox socket, not only the cached one: after
@@ -161,7 +180,8 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     const tags = this.host.tags(ws);
     if (tags.includes("sandbox")) {
       const sidTag = tags.find((t) => t.startsWith("sid:"));
-      return { kind: "sandbox", sandboxId: sidTag?.slice(4) };
+      const socketTag = tags.find((t) => t.startsWith("socket:"));
+      return { kind: "sandbox", sandboxId: sidTag?.slice(4), socketId: socketTag?.slice(7) };
     }
     const wsIdTag = tags.find((t) => t.startsWith("wsid:"));
     return { kind: "client", wsId: wsIdTag?.slice(5) };
@@ -171,9 +191,18 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Sandbox socket
   // -------------------------------------------------------------------------
 
+  isActiveSandboxSocket(ws: WebSocket): boolean {
+    const parsed = this.classify(ws);
+    if (parsed.kind !== "sandbox") return false;
+    // A socket accepted before identities were persisted (no tag, no row
+    // value) stays authoritative until the next bridge connects.
+    return (parsed.socketId ?? null) === this.sandboxRepository.getActiveSocketId();
+  }
+
   getSandboxSocket(): WebSocket | null {
     const sandbox = this.sandboxRepository.getSandbox();
     const expectedSandboxId = sandbox?.modal_sandbox_id;
+    const activeSocketId = sandbox?.active_socket_id ?? null;
 
     // If the sandbox is in a terminal state, don't re-adopt stale WebSockets.
     // After inactivity timeout or heartbeat stale, the DO closes the WS and sets
@@ -195,8 +224,9 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     if (this.sandboxWs?.readyState === WebSocket.OPEN) {
       const cached = this.classify(this.sandboxWs);
       if (
-        !expectedSandboxId ||
-        (cached.kind === "sandbox" && cached.sandboxId === expectedSandboxId)
+        cached.kind === "sandbox" &&
+        (!expectedSandboxId || cached.sandboxId === expectedSandboxId) &&
+        (cached.socketId ?? null) === activeSocketId
       ) {
         return this.sandboxWs;
       }
@@ -204,8 +234,10 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
       this.sandboxWs = null;
     }
 
-    // Hibernation recovery: scan all WebSockets, validate sandbox identity
-
+    // Recovery after a restart: the pointer is gone but the accepted sockets
+    // and their tags survive. Only the socket carrying the persisted active
+    // identity is re-adopted — a same-sandbox socket it replaced may still be
+    // open while its close completes, and must not win for coming first.
     for (const ws of this.host.sockets()) {
       const parsed = this.classify(ws);
       if (parsed.kind !== "sandbox" || ws.readyState !== WebSocket.OPEN) continue;
@@ -218,6 +250,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
         this.close(ws, 1000, "Sandbox identity changed");
         continue;
       }
+      if ((parsed.socketId ?? null) !== activeSocketId) continue;
 
       this.log.info("Recovered sandbox WebSocket from hibernation");
       this.sandboxWs = ws;
@@ -242,13 +275,9 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   }
 
   clearSandboxSocketIfMatch(ws: WebSocket): boolean {
-    if (this.sandboxWs === ws) {
-      this.sandboxWs = null;
-      return true;
-    }
-    // sandboxWs is null (post-hibernation or already cleared) — treat as active.
-    // The only definitive "replaced" signal is sandboxWs pointing to a different socket.
-    return this.sandboxWs === null;
+    const active = this.isActiveSandboxSocket(ws);
+    if (active || this.sandboxWs === ws) this.sandboxWs = null;
+    return active;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -19,6 +19,7 @@ import type { ClientInfo } from "../types";
 import type { SocketHost } from "./platform";
 import type { ConnectionClassification } from "./ports";
 import type { SandboxRepository } from "./sandbox-repository";
+import type { SandboxRow } from "./types";
 import type {
   WsClientMappingRepository,
   WsClientMappingResult,
@@ -63,7 +64,11 @@ export interface SessionWebSocketManager {
   /** Clear the in-memory sandbox socket reference. */
   clearSandboxSocket(): void;
 
-  /** Clear and close all active sandbox sockets without consulting persisted dispatch status. */
+  /**
+   * Revoke the persisted dispatch authority, then close every sandbox socket
+   * without consulting the sandbox status. Nothing dispatches from, or is
+   * recovered as, the bridge until the next accept.
+   */
   detachSandboxSocket(code: number, reason: string): void;
 
   /**
@@ -192,17 +197,30 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // -------------------------------------------------------------------------
 
   isActiveSandboxSocket(ws: WebSocket): boolean {
-    const parsed = this.classify(ws);
-    if (parsed.kind !== "sandbox") return false;
-    // A socket accepted before identities were persisted (no tag, no row
-    // value) stays authoritative until the next bridge connects.
-    return (parsed.socketId ?? null) === this.sandboxRepository.getActiveSocketId();
+    return this.isAuthoritative(this.classify(ws), this.sandboxRepository.getSandbox());
+  }
+
+  /**
+   * Whether a sandbox socket is the one the row names. The row's
+   * `active_socket_id` is three-valued: a tag id matches exactly that socket;
+   * `''` (revoked by detach or a spawn reservation) matches nothing; NULL
+   * means the row predates persisted identities, and then an untagged socket
+   * for the row's sandbox stays authoritative until the next accept.
+   */
+  private isAuthoritative(parsed: ConnectionClassification, sandbox: SandboxRow | null): boolean {
+    if (parsed.kind !== "sandbox" || !sandbox) return false;
+    if (sandbox.active_socket_id === null) {
+      return (
+        parsed.socketId === undefined &&
+        (!sandbox.modal_sandbox_id || parsed.sandboxId === sandbox.modal_sandbox_id)
+      );
+    }
+    return parsed.socketId !== undefined && parsed.socketId === sandbox.active_socket_id;
   }
 
   getSandboxSocket(): WebSocket | null {
     const sandbox = this.sandboxRepository.getSandbox();
     const expectedSandboxId = sandbox?.modal_sandbox_id;
-    const activeSocketId = sandbox?.active_socket_id ?? null;
 
     // If the sandbox is in a terminal state, don't re-adopt stale WebSockets.
     // After inactivity timeout or heartbeat stale, the DO closes the WS and sets
@@ -222,12 +240,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     }
 
     if (this.sandboxWs?.readyState === WebSocket.OPEN) {
-      const cached = this.classify(this.sandboxWs);
-      if (
-        cached.kind === "sandbox" &&
-        (!expectedSandboxId || cached.sandboxId === expectedSandboxId) &&
-        (cached.socketId ?? null) === activeSocketId
-      ) {
+      if (this.isAuthoritative(this.classify(this.sandboxWs), sandbox)) {
         return this.sandboxWs;
       }
       this.close(this.sandboxWs, 1000, "Sandbox identity changed");
@@ -250,7 +263,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
         this.close(ws, 1000, "Sandbox identity changed");
         continue;
       }
-      if ((parsed.socketId ?? null) !== activeSocketId) continue;
+      if (!this.isAuthoritative(parsed, sandbox)) continue;
 
       this.log.info("Recovered sandbox WebSocket from hibernation");
       this.sandboxWs = ws;
@@ -270,6 +283,9 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     for (const ws of this.host.sockets()) {
       if (this.classify(ws).kind === "sandbox") sockets.add(ws);
     }
+    // Revoke before closing: a trailing frame from a detached socket, or a
+    // restart that still finds it open, must not find the row naming it.
+    this.sandboxRepository.revokeActiveSocketId();
     this.sandboxWs = null;
     for (const ws of sockets) this.close(ws, code, reason);
   }

--- a/packages/control-plane/test/integration/durable-object-eviction.test.ts
+++ b/packages/control-plane/test/integration/durable-object-eviction.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { env, runDurableObjectAlarm } from "cloudflare:test";
+import type { SandboxStatus } from "@open-inspect/shared/types/sessions";
 import { runInSessionDO } from "./session-do-access";
 import type { SessionDO } from "../../src/session/durable-object";
 import { cleanD1Tables } from "./cleanup";
@@ -7,8 +8,10 @@ import {
   INTEGRATION_WEBSOCKET_TIMEOUT_MS,
   initNamedSession,
   openClientWs,
+  openSandboxWs,
   queryDO,
   seedMessage,
+  seedSandboxAuth,
   waitForSandboxStatus,
 } from "./helpers";
 
@@ -16,10 +19,17 @@ const INSTANCE_MARKER = "pre-eviction-instance";
 
 type MarkedSessionDO = SessionDO & { __evictionMarker?: string };
 
-/** Tear down the running instance and return a stub bound to its replacement. */
-async function evictSessionDO(sessionName: string): Promise<DurableObjectStub> {
+/**
+ * Tear down the running instance and return a stub bound to its replacement.
+ * Waits for the sandbox to settle in `settledStatus` first so no in-flight
+ * status write from the (always-failing) test spawn lands on the replacement.
+ */
+async function evictSessionDO(
+  sessionName: string,
+  settledStatus: SandboxStatus = "failed"
+): Promise<DurableObjectStub> {
   const stub = env.SESSION.get(env.SESSION.idFromName(sessionName));
-  await waitForSandboxStatus(stub, "failed");
+  await waitForSandboxStatus(stub, settledStatus);
   await expect(
     runInSessionDO(stub, (instance: MarkedSessionDO) => {
       instance.__evictionMarker = INSTANCE_MARKER;
@@ -154,6 +164,58 @@ describe("SessionDO eviction and hibernation restore", () => {
     );
     expect(messages).toEqual([
       { status: "failed", error_message: "Execution timed out (stuck processing)" },
+    ]);
+  });
+
+  it("dispatches sandbox frames by the persisted socket identity after a restore", async () => {
+    const sessionName = `do-evict-sandbox-${Date.now()}`;
+    const sandboxId = "sb-evict";
+    const { stub } = await initNamedSession(sessionName);
+    await seedSandboxAuth(stub, { authToken: "sandbox-token-evict", sandboxId });
+    const { ws } = await openSandboxWs(sessionName, {
+      authToken: "sandbox-token-evict",
+      sandboxId,
+    });
+    expect(ws).not.toBeNull();
+    ws!.accept();
+    await waitForSandboxStatus(stub, "ready");
+    const [{ active_socket_id: activeSocketId }] = await queryDO<{
+      active_socket_id: string | null;
+    }>(stub, "SELECT active_socket_id FROM sandbox");
+    expect(activeSocketId).toMatch(/^sbws-/);
+
+    const restored = await evictSessionDO(sessionName, "ready");
+    const toolCall = (callId: string) =>
+      JSON.stringify({
+        type: "tool_call",
+        tool: "read_file",
+        args: { path: "/src/main.ts" },
+        callId,
+        messageId: "msg-evict",
+        sandboxId,
+        timestamp: Date.now() / 1000,
+      });
+    // Two same-sandbox sockets survive only as their tags: the one the row
+    // names is dispatched from, the one it replaced is not.
+    await runInSessionDO(restored, async (instance: SessionDO, state) => {
+      const replaced = new WebSocketPair();
+      state.acceptWebSocket(replaced[1], ["sandbox", `sid:${sandboxId}`, "socket:sbws-replaced"]);
+      replaced[0].accept();
+      const active = new WebSocketPair();
+      state.acceptWebSocket(active[1], ["sandbox", `sid:${sandboxId}`, `socket:${activeSocketId}`]);
+      active[0].accept();
+
+      await instance.webSocketMessage(replaced[1], toolCall("call-replaced"));
+      await instance.webSocketMessage(active[1], toolCall("call-active"));
+    });
+
+    const events = await queryDO<{ data: string }>(
+      restored,
+      "SELECT data FROM events WHERE type = ?",
+      "tool_call"
+    );
+    expect(events.map((event) => (JSON.parse(event.data) as { callId: string }).callId)).toEqual([
+      "call-active",
     ]);
   });
 

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -377,6 +377,64 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     activeWs!.close();
   });
 
+  it("revokes dispatch authority on detach before the close completes", async () => {
+    const name = `ws-sandbox-detach-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws } = await openSandboxWs(name, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+    expect(ws).not.toBeNull();
+    ws!.accept();
+    const [{ active_socket_id: activeSocketId }] = await queryDO<{
+      active_socket_id: string | null;
+    }>(stub, "SELECT active_socket_id FROM sandbox");
+    expect(activeSocketId).toMatch(/^sbws-/);
+
+    const toolCall = (callId: string) =>
+      JSON.stringify({
+        type: "tool_call",
+        tool: "read_file",
+        args: { path: "/src/main.ts" },
+        callId,
+        messageId: "msg-detach",
+        sandboxId: SANDBOX_ID,
+        timestamp: Date.now() / 1000,
+      });
+
+    await runInSessionDO(stub, async (instance: SessionDO, state) => {
+      const [serverWs] = openSandboxSockets(state);
+      expect(serverWs).toBeDefined();
+      const { wsManager } = componentsOf(instance);
+
+      wsManager.detachSandboxSocket(1000, "Heartbeat stale");
+
+      // The row was revoked, so a frame that was already in flight from the
+      // detached socket is refused even though the socket is still tagged.
+      await instance.webSocketMessage(serverWs, toolCall("call-detached"));
+      expect(wsManager.getSandboxSocket()).toBeNull();
+
+      // A restart that still finds the detached socket open, tagged with the
+      // identity the row named before, must not re-adopt it.
+      const pair = new WebSocketPair();
+      state.acceptWebSocket(pair[1], ["sandbox", `sid:${SANDBOX_ID}`, `socket:${activeSocketId}`]);
+      pair[0].accept();
+      expect(wsManager.getSandboxSocket()).toBeNull();
+      await instance.webSocketMessage(pair[1], toolCall("call-restored-detached"));
+    });
+
+    const [{ active_socket_id: revoked }] = await queryDO<{ active_socket_id: string | null }>(
+      stub,
+      "SELECT active_socket_id FROM sandbox"
+    );
+    expect(revoked).toBe("");
+    const events = await queryDO<{ data: string }>(
+      stub,
+      "SELECT data FROM events WHERE type = ?",
+      "tool_call"
+    );
+    expect(events).toHaveLength(0);
+  });
+
   it("sandbox connect sets status to ready", async () => {
     const name = `ws-sandbox-ready-${Date.now()}`;
     const { stub } = await initNamedSession(name);

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -317,6 +317,66 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     replacementWs!.close();
   });
 
+  it("dispatches only from the sandbox socket whose identity the session persisted", async () => {
+    const name = `ws-sandbox-authority-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws: activeWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(activeWs).not.toBeNull();
+    activeWs!.accept();
+
+    const [{ active_socket_id: activeSocketId }] = await queryDO<{
+      active_socket_id: string | null;
+    }>(stub, "SELECT active_socket_id FROM sandbox");
+    expect(activeSocketId).toMatch(/^sbws-/);
+
+    const toolCall = (callId: string) =>
+      JSON.stringify({
+        type: "tool_call",
+        tool: "read_file",
+        args: { path: "/src/main.ts" },
+        callId,
+        messageId: "msg-authority",
+        sandboxId: SANDBOX_ID,
+        timestamp: Date.now() / 1000,
+      });
+
+    // A bridge the active one replaced, in the shape a restart leaves it:
+    // still accepted at the platform level under the same sandbox id, still
+    // open, carrying an identity the row no longer names.
+    await runInSessionDO(stub, async (instance: SessionDO, state) => {
+      const pair = new WebSocketPair();
+      state.acceptWebSocket(pair[1], ["sandbox", `sid:${SANDBOX_ID}`, "socket:sbws-replaced"]);
+      pair[0].accept();
+      expect(openSandboxSockets(state)).toHaveLength(2);
+
+      await instance.webSocketMessage(pair[1], toolCall("call-replaced"));
+
+      // Refused, and closed again rather than left open.
+      const live = openSandboxSockets(state);
+      expect(live).toHaveLength(1);
+      expect(state.getTags(live[0])).toContain(`socket:${activeSocketId}`);
+    });
+
+    activeWs!.send(toolCall("call-active"));
+    await new Promise((r) => setTimeout(r, 200));
+
+    const events = await queryDO<{ data: string }>(
+      stub,
+      "SELECT data FROM events WHERE type = ?",
+      "tool_call"
+    );
+    const callIds = events.map((event) => (JSON.parse(event.data) as { callId: string }).callId);
+    expect(callIds).toContain("call-active");
+    expect(callIds).not.toContain("call-replaced");
+
+    activeWs!.close();
+  });
+
   it("sandbox connect sets status to ready", async () => {
     const name = `ws-sandbox-ready-${Date.now()}`;
     const { stub } = await initNamedSession(name);


### PR DESCRIPTION
## Why

`SessionMessageRouter.route` treated any socket tagged `sandbox` as authoritative. Replacing a bridge closed the previous sockets, but `close()` is cleanup, not a fence: a replaced socket keeps its tags until its close handshake completes, and a frame already queued on it (or delivered to a restored instance) still mutated session state after the new bridge was selected. Recovery after hibernation had the mirror problem: `getSandboxSocket()` re-adopted the first OPEN sandbox socket, which could be the one that was closing. Surfaced by the deep review on #1745; tracked as P-9 / COL-128, which blocks N-8.

## What

- Every accepted bridge socket gets a fresh `socket:<id>` tag, and `acceptAndSetSandboxSocket` persists that id as `sandbox.active_socket_id` (migration 48) **before** closing the sockets it replaces. The row, not the in-memory pointer, is the authority.
- `SocketRegistry.isActiveSandbox` / `SessionWebSocketManager.isActiveSandboxSocket` compare a socket's tag against the row. The router refuses sandbox frames from any other socket (debug log) and closes that socket again, since a frame from it proves the first close did not complete.
- `getSandboxSocket()` recovery re-adopts only the socket carrying the persisted id; a same-sandbox socket that was replaced is skipped even when it is enumerated first.
- `clearSandboxSocketIfMatch` answers by identity instead of the old "pointer is null, assume active" heuristic, so a replaced socket's close never schedules a disconnect check after a restart.
- `updateSandboxForSpawn` clears `active_socket_id` along with the credentials: a spawn reservation displaces the previous bridge's authority the same way it invalidates its token.

## Decisions

- **Authority is the socket, not the sandbox id.** Two sockets from the same sandbox (a bridge reconnect) are distinguishable only by accept-time identity, and the closing one must be neither adopted for sends nor trusted for frames.
- **A replaced bridge's trailing frames are dropped**, including `execution_complete` / `step_finish`. Critical events are covered by the bridge's re-flush on the new socket (the `host.socket-ack-redelivery` contract); non-critical trailing frames are lost exactly as a network drop would lose them.
- **Sockets accepted before this change** (no `socket:` tag, NULL column) stay authoritative until the next bridge connects, so hibernated sessions are not stranded by the deploy.
- **Migration id 48** is the next sequential id on `main`. #1672 and #1683 also claim 48 on their branches; whichever merges later renumbers.

## Tests

- Unit: manager (identity persisted before the replaced close; `isActiveSandboxSocket`; recovery picks the persisted id over enumeration order; spawn reset; pre-change sockets), router (replaced frame refused and closed), repository, schema.
- Workerd: a still-open replaced socket in hibernation shape is refused and closed while the active one dispatches; after a real eviction, dispatch follows the persisted id between two same-sandbox sockets.
- `websocket-sandbox`, `websocket-client`, and `durable-object-eviction` pass; the conformance host contracts are unchanged.

No Cloudflare behavior changes beyond the fence itself. The Node socket host (N-8) inherits the same semantics through `SocketHost.tags`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured only the currently active sandbox connection can process messages.
  - Replaced, detached, or stale connections are safely closed and prevented from affecting session activity.
  - Preserved connection authority across restarts, reconnections, and Durable Object recovery.
  - Prevented replacement sandbox reservations from inheriting a previous connection’s identity.
  - Revoked sandbox connection authority before socket closure.

- **Database**
  - Added migration support for tracking active sandbox connection state and revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->