### PR TITLE
Add the Node socket host over ws and type the core's sockets structurally (COL-95)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -90,7 +90,7 @@
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -107,7 +107,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -121,7 +121,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -131,7 +131,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ast-grep/napi": {
@@ -1349,7 +1349,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1359,7 +1359,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1369,7 +1369,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -1395,7 +1395,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -1409,7 +1409,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1446,7 +1446,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -1618,7 +1618,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1638,7 +1638,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
       "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1662,7 +1662,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
       "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1690,7 +1690,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1713,7 +1713,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
       "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1738,7 +1738,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1834,6 +1834,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1855,6 +1856,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1868,6 +1870,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1884,6 +1887,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1900,6 +1904,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1916,6 +1921,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,6 +1938,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1948,6 +1955,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1964,6 +1972,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1980,6 +1989,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1996,6 +2006,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2012,6 +2023,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2028,6 +2040,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2044,6 +2057,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,6 +2074,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,6 +2091,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2092,6 +2108,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2108,6 +2125,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2124,6 +2142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,6 +2159,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2156,6 +2176,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2172,6 +2193,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,6 +2210,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,6 +2227,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,6 +2244,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2236,6 +2261,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2252,6 +2278,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2268,6 +2295,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,7 +2466,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -3159,7 +3187,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3170,7 +3198,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3198,6 +3226,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
       "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3382,7 +3411,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -5267,6 +5296,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5283,6 +5313,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5299,6 +5330,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5315,6 +5347,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5331,6 +5364,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5347,6 +5381,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5363,6 +5398,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5379,6 +5415,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5395,6 +5432,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5411,6 +5449,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5427,6 +5466,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5443,6 +5483,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5459,6 +5500,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5474,6 +5516,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5487,6 +5530,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5503,6 +5547,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6335,6 +6380,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6534,6 +6580,16 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.1",
@@ -6801,7 +6857,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
@@ -6971,7 +7027,7 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6994,7 +7050,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7322,7 +7378,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
       "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -7334,7 +7390,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7345,7 +7401,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -7736,7 +7792,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -7870,7 +7926,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -8408,7 +8464,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -8441,7 +8497,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
       "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
@@ -8584,7 +8640,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -8669,7 +8725,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -8954,7 +9010,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -9201,7 +9257,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10307,7 +10363,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10510,7 +10566,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -10523,7 +10579,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {
@@ -10571,7 +10627,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -10585,7 +10641,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11098,7 +11154,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -11284,7 +11340,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -11294,7 +11350,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -11309,7 +11365,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -11396,7 +11452,7 @@
       "version": "28.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
@@ -11612,6 +11668,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11632,6 +11689,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11652,6 +11710,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11672,6 +11731,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11692,6 +11752,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11712,6 +11773,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11732,6 +11794,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11752,6 +11815,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11772,6 +11836,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11792,6 +11857,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11812,6 +11878,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12006,7 +12073,7 @@
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
       "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -12046,7 +12113,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -12058,7 +12125,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -12074,7 +12141,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12388,7 +12455,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -14280,7 +14347,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -14723,7 +14790,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15208,7 +15275,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15455,7 +15522,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -15848,7 +15915,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15867,7 +15934,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -16206,7 +16273,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16244,7 +16311,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -16350,7 +16417,7 @@
       "version": "5.16.9",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
       "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -16369,7 +16436,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -16446,7 +16513,7 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
       "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.4.3"
@@ -16459,7 +16526,7 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
       "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -16488,7 +16555,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -16501,7 +16568,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -16757,7 +16824,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -17228,7 +17295,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -17260,7 +17327,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -17270,7 +17337,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -17280,7 +17347,7 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -17562,7 +17629,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -17588,7 +17655,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/y18n": {
@@ -17727,16 +17794,39 @@
         "@open-inspect/shared": "file:../shared",
         "better-auth": "1.6.25",
         "hono": "^4.13.5",
+        "ws": "^8.21.3",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.16.18",
+        "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.0",
         "esbuild": "^0.28.1",
         "typescript": "^5.7.2",
         "vitest": "^4.1.0",
         "wrangler": "^4.103.0"
+      }
+    },
+    "packages/control-plane/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/github-bot": {

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -18,11 +18,13 @@
     "@open-inspect/shared": "file:../shared",
     "better-auth": "1.6.25",
     "hono": "^4.13.5",
+    "ws": "^8.21.3",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.16.18",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.0",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2",

--- a/packages/control-plane/src/cloudflare/session-platform.test.ts
+++ b/packages/control-plane/src/cloudflare/session-platform.test.ts
@@ -55,7 +55,7 @@ describe("createDurableObjectSessionPlatform", () => {
 
   it("delegates socket acceptance, tags, and enumeration, passing the tag filter through", () => {
     const { state, calls, db } = createFakeState();
-    const ws = {} as WebSocket;
+    const ws = Object.create(WebSocket.prototype) as WebSocket;
 
     const { sockets: host } = createDurableObjectSessionPlatform(state, db);
     host.accept(ws, ["sandbox", "sid:sb-1"]);
@@ -66,6 +66,14 @@ describe("createDurableObjectSessionPlatform", () => {
     expect(host.tags(ws)).toEqual(["sandbox", "sid:sb-1"]);
     expect(calls.getTags).toHaveBeenCalledWith(ws);
     expect(calls.getWebSockets.mock.calls).toEqual([[undefined], ["sandbox"]]);
+  });
+
+  it("refuses a socket the object did not upgrade", () => {
+    const { state, calls, db } = createFakeState();
+    const { sockets: host } = createDurableObjectSessionPlatform(state, db);
+
+    expect(() => host.accept({ readyState: 1, send() {}, close() {} }, [])).toThrow(TypeError);
+    expect(calls.acceptWebSocket).not.toHaveBeenCalled();
   });
 
   it("installs the auto-response as a request/response pair", () => {

--- a/packages/control-plane/src/cloudflare/session-platform.test.ts
+++ b/packages/control-plane/src/cloudflare/session-platform.test.ts
@@ -58,7 +58,7 @@ describe("createDurableObjectSessionPlatform", () => {
     const ws = Object.create(WebSocket.prototype) as WebSocket;
 
     const { sockets: host } = createDurableObjectSessionPlatform(state, db);
-    host.accept(ws, ["sandbox", "sid:sb-1"]);
+    host.adopt(ws, ["sandbox", "sid:sb-1"]);
     host.sockets();
     host.sockets("sandbox");
 
@@ -72,7 +72,7 @@ describe("createDurableObjectSessionPlatform", () => {
     const { state, calls, db } = createFakeState();
     const { sockets: host } = createDurableObjectSessionPlatform(state, db);
 
-    expect(() => host.accept({ readyState: 1, send() {}, close() {} }, [])).toThrow(TypeError);
+    expect(() => host.adopt({ readyState: 1, send() {}, close() {} }, [])).toThrow(TypeError);
     expect(calls.acceptWebSocket).not.toHaveBeenCalled();
   });
 

--- a/packages/control-plane/src/cloudflare/session-platform.ts
+++ b/packages/control-plane/src/cloudflare/session-platform.ts
@@ -1,5 +1,5 @@
 import type { SqlDatabase } from "../db/sql-database";
-import type { SessionSocket } from "../platform-ports";
+import type { SessionWebSocket } from "../platform-ports";
 import type { SessionPlatform } from "../session/platform";
 import { createCloudflareBackgroundTasks } from "./background-tasks";
 
@@ -8,7 +8,7 @@ import { createCloudflareBackgroundTasks } from "./background-tasks";
  * hibernatable sockets ever reach its host, so anything else is a wiring
  * error rather than a socket to adopt.
  */
-function platformSocket(ws: SessionSocket): WebSocket {
+function requireCloudflareWebSocket(ws: SessionWebSocket): WebSocket {
   if (!(ws instanceof WebSocket)) {
     throw new TypeError("Durable Object socket host received a socket it did not upgrade");
   }
@@ -29,8 +29,8 @@ export function createDurableObjectSessionPlatform(
     db,
     alarmStore: ctx.storage,
     sockets: {
-      accept: (ws, tags) => ctx.acceptWebSocket(platformSocket(ws), tags),
-      tags: (ws) => ctx.getTags(platformSocket(ws)),
+      adopt: (ws, tags) => ctx.acceptWebSocket(requireCloudflareWebSocket(ws), tags),
+      tags: (ws) => ctx.getTags(requireCloudflareWebSocket(ws)),
       sockets: (tag) => ctx.getWebSockets(tag),
       // Hibernation-level auto-response: matched by the runtime without
       // waking the object.

--- a/packages/control-plane/src/cloudflare/session-platform.ts
+++ b/packages/control-plane/src/cloudflare/session-platform.ts
@@ -1,6 +1,19 @@
 import type { SqlDatabase } from "../db/sql-database";
+import type { SessionSocket } from "../platform-ports";
 import type { SessionPlatform } from "../session/platform";
 import { createCloudflareBackgroundTasks } from "./background-tasks";
+
+/**
+ * The core types its sockets structurally; only this object's own
+ * hibernatable sockets ever reach its host, so anything else is a wiring
+ * error rather than a socket to adopt.
+ */
+function platformSocket(ws: SessionSocket): WebSocket {
+  if (!(ws instanceof WebSocket)) {
+    throw new TypeError("Durable Object socket host received a socket it did not upgrade");
+  }
+  return ws;
+}
 
 /**
  * A Durable Object's storage, hibernatable sockets, alarm, and event lifetime
@@ -16,8 +29,8 @@ export function createDurableObjectSessionPlatform(
     db,
     alarmStore: ctx.storage,
     sockets: {
-      accept: (ws, tags) => ctx.acceptWebSocket(ws, tags),
-      tags: (ws) => ctx.getTags(ws),
+      accept: (ws, tags) => ctx.acceptWebSocket(platformSocket(ws), tags),
+      tags: (ws) => ctx.getTags(platformSocket(ws)),
       sockets: (tag) => ctx.getWebSockets(tag),
       // Hibernation-level auto-response: matched by the runtime without
       // waking the object.

--- a/packages/control-plane/src/node/socket-host.test.ts
+++ b/packages/control-plane/src/node/socket-host.test.ts
@@ -3,8 +3,13 @@ import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
 import type { Logger } from "../logger";
-import type { SessionSocket } from "../platform-ports";
-import { NodeSocketHost, type SocketEvents } from "./socket-host";
+import { isSocketOpen, type SessionSocket } from "../platform-ports";
+import {
+  BACKLOG_EXCEEDED_CLOSE_CODE,
+  NodeSocketHost,
+  type NodeSocketHostOptions,
+  type SocketEvents,
+} from "./socket-host";
 
 function createLogger(): Logger {
   const log = {
@@ -28,13 +33,13 @@ function createEvents() {
 }
 
 /** A real `ws` server on an ephemeral port whose connections the test accepts into `host`. */
-async function createHarness() {
+async function createHarness(options: NodeSocketHostOptions = {}) {
   const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
   await once(server, "listening");
   const { port } = server.address() as AddressInfo;
   const log = createLogger();
   const events = createEvents();
-  const host = new NodeSocketHost(log);
+  const host = new NodeSocketHost(log, options);
   host.bind(events);
   const clients: NodeWebSocket[] = [];
 
@@ -231,13 +236,94 @@ describe("NodeSocketHost", () => {
     await vi.waitFor(() => expect(harness!.events.onError).toHaveBeenCalledWith(socket, failure));
   });
 
-  it("keeps ready-state semantics the core relies on", async () => {
+  it("reports an incomplete closing handshake as unclean even with a normal code", async () => {
     harness = await createHarness();
     const { socket } = await harness.connect(["wsid:ws-1"]);
 
-    // The manager compares against the global WebSocket constants.
-    expect(socket.readyState).toBe(WebSocket.OPEN);
+    // `ws` derives wasClean from both close-frame flags; the peer's frame
+    // arrived but ours never went out. Emitting the close with those flags
+    // set is how that state is observable without racing a real handshake.
+    const internals = socket as unknown as {
+      _closeFrameReceived: boolean;
+      _closeFrameSent: boolean;
+    };
+    internals._closeFrameReceived = true;
+    internals._closeFrameSent = false;
+    socket.emit("close", 1000, Buffer.from("half"));
+
+    await vi.waitFor(() =>
+      expect(harness!.events.onClose).toHaveBeenCalledWith(socket, 1000, "half", false)
+    );
+  });
+
+  it("pauses a flooding peer while a delivery is in flight and loses nothing", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["sandbox", "sid:sb-1"]);
+    let release!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      harness!.events.onMessage.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((done) => {
+          release = done;
+        });
+      });
+    });
+    const delivered: string[] = [];
+    harness.events.onMessage.mockImplementation(async (_ws, message) => {
+      delivered.push(String(message));
+    });
+
+    client.send("0");
+    await firstStarted;
+    // Frames large enough that the flood spans several socket reads, so
+    // pausing has reads left to hold back.
+    const flood = Array.from({ length: 1_000 }, (_, i) => `frame-${i + 1}`.padEnd(256, "."));
+    for (const frame of flood) client.send(frame);
+
+    // Backpressure, not heap growth: the socket stops reading while the
+    // runtime is busy, so the flood waits in the kernel.
+    await vi.waitFor(() => expect(socket.isPaused).toBe(true));
+    expect(delivered).toEqual([]);
+
+    release();
+    await vi.waitFor(() => expect(delivered).toHaveLength(flood.length), { timeout: 5_000 });
+    expect(delivered).toEqual(flood);
+    expect(socket.isPaused).toBe(false);
+    expect(harness.log.warn).not.toHaveBeenCalled();
+  }, 15_000);
+
+  it("closes a peer whose parsed backlog exceeds the bound instead of retaining it", async () => {
+    harness = await createHarness({ maxPendingDeliveries: 3 });
+    const { client, socket } = await harness.connect(["wsid:ws-1"]);
+    harness.events.onMessage.mockImplementationOnce(
+      () => new Promise<void>(() => {}) // never settles
+    );
+
+    // Frames `ws` already decoded reach the host regardless of pause; emit
+    // them directly to model that burst deterministically.
+    socket.emit("message", Buffer.from("blocking"), false);
+    for (let i = 0; i < 4; i += 1) socket.emit("message", Buffer.from(`queued-${i}`), false);
+
+    const [code, reason] = await once(client, "close");
+    expect(code).toBe(BACKLOG_EXCEEDED_CLOSE_CODE);
+    expect(String(reason)).toBe("Message backlog exceeded");
+    expect(harness.log.warn).toHaveBeenCalledWith(
+      "socket.backlog_exceeded",
+      expect.objectContaining({ tags: ["wsid:ws-1"], pending: 3 })
+    );
+    expect(harness.host.sockets()).toEqual([]);
+    // The blocked handler still holds this socket's queue, close included:
+    // bounding handler time is the executor's job, not the host's.
+    expect(harness.events.onMessage).toHaveBeenCalledOnce();
+    expect(harness.events.onClose).not.toHaveBeenCalled();
+  });
+
+  it("satisfies the core's open check without the ambient WebSocket global", async () => {
+    harness = await createHarness();
+    const { socket } = await harness.connect(["wsid:ws-1"]);
+
+    expect(isSocketOpen(socket)).toBe(true);
     socket.close();
-    expect(socket.readyState).not.toBe(WebSocket.OPEN);
+    expect(isSocketOpen(socket)).toBe(false);
   });
 });

--- a/packages/control-plane/src/node/socket-host.test.ts
+++ b/packages/control-plane/src/node/socket-host.test.ts
@@ -3,12 +3,12 @@ import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
 import type { Logger } from "../logger";
-import { isSocketOpen, type SessionSocket } from "../platform-ports";
+import { isSocketOpen, type SessionWebSocket } from "../platform-ports";
 import {
   BACKLOG_EXCEEDED_CLOSE_CODE,
-  NodeSocketHost,
+  NodeWebSocketHost,
   type NodeSocketHostOptions,
-  type SocketEvents,
+  type SessionWebSocketEventSink,
 } from "./socket-host";
 
 function createLogger(): Logger {
@@ -24,12 +24,12 @@ function createLogger(): Logger {
 
 function createEvents() {
   return {
-    onMessage: vi.fn(async (_ws: SessionSocket, _message: string | ArrayBuffer) => {}),
+    onMessage: vi.fn(async (_ws: SessionWebSocket, _message: string | ArrayBuffer) => {}),
     onClose: vi.fn(
-      async (_ws: SessionSocket, _code: number, _reason: string, _wasClean: boolean) => {}
+      async (_ws: SessionWebSocket, _code: number, _reason: string, _wasClean: boolean) => {}
     ),
-    onError: vi.fn((_ws: SessionSocket, _error: Error) => {}),
-  } satisfies SocketEvents;
+    onError: vi.fn((_ws: SessionWebSocket, _error: Error) => {}),
+  } satisfies SessionWebSocketEventSink;
 }
 
 /** A real `ws` server on an ephemeral port whose connections the test accepts into `host`. */
@@ -39,8 +39,8 @@ async function createHarness(options: NodeSocketHostOptions = {}) {
   const { port } = server.address() as AddressInfo;
   const log = createLogger();
   const events = createEvents();
-  const host = new NodeSocketHost(log, options);
-  host.bind(events);
+  const host = new NodeWebSocketHost(log, options);
+  host.bindEventSink(events);
   const clients: NodeWebSocket[] = [];
 
   /** Open one connection; resolves once the server side is accepted under `tags`. */
@@ -49,7 +49,7 @@ async function createHarness(options: NodeSocketHostOptions = {}) {
   ): Promise<{ client: NodeWebSocket; socket: NodeWebSocket }> {
     const accepted = new Promise<NodeWebSocket>((resolve) => {
       server.once("connection", (socket) => {
-        host.accept(socket, tags);
+        host.adopt(socket, tags);
         resolve(socket);
       });
     });
@@ -76,7 +76,7 @@ async function createHarness(options: NodeSocketHostOptions = {}) {
 
 type Harness = Awaited<ReturnType<typeof createHarness>>;
 
-describe("NodeSocketHost", () => {
+describe("NodeWebSocketHost", () => {
   let harness: Harness | null = null;
   afterEach(async () => {
     await harness?.close();
@@ -101,16 +101,18 @@ describe("NodeSocketHost", () => {
     expect(harness.host.tags({ readyState: 1, send() {}, close() {} })).toEqual([]);
   });
 
-  it("refuses sockets it did not upgrade, double accepts, and accepts before bind", async () => {
+  it("refuses sockets it did not upgrade, double adoptions, and adoptions before bindEventSink", async () => {
     harness = await createHarness();
     const { socket } = await harness.connect(["wsid:ws-1"]);
 
-    expect(() => harness!.host.accept({ readyState: 1, send() {}, close() {} }, [])).toThrow(
+    expect(() => harness!.host.adopt({ readyState: 1, send() {}, close() {} }, [])).toThrow(
       TypeError
     );
-    expect(() => harness!.host.accept(socket, ["wsid:again"])).toThrow(/already accepted/);
-    expect(() => new NodeSocketHost(createLogger()).accept(socket, [])).toThrow(/before bind/);
-    expect(() => harness!.host.bind(harness!.events)).toThrow(/already bound/);
+    expect(() => harness!.host.adopt(socket, ["wsid:again"])).toThrow(/already adopted/);
+    expect(() => new NodeWebSocketHost(createLogger()).adopt(socket, [])).toThrow(
+      /before bindEventSink/
+    );
+    expect(() => harness!.host.bindEventSink(harness!.events)).toThrow(/already bound/);
   });
 
   it("forwards text frames as strings and binary frames as ArrayBuffers", async () => {
@@ -275,6 +277,9 @@ describe("NodeSocketHost", () => {
 
     client.send("0");
     await firstStarted;
+    // Paused before the first delivery starts, not once a second frame shows
+    // up: otherwise the next message is assembled on the heap meanwhile.
+    expect(socket.isPaused).toBe(true);
     // Frames large enough that the flood spans several socket reads, so
     // pausing has reads left to hold back.
     const flood = Array.from({ length: 1_000 }, (_, i) => `frame-${i + 1}`.padEnd(256, "."));
@@ -311,7 +316,8 @@ describe("NodeSocketHost", () => {
       "socket.backlog_exceeded",
       expect.objectContaining({ tags: ["wsid:ws-1"], pending: 3 })
     );
-    expect(harness.host.sockets()).toEqual([]);
+    // The peer observing the close does not order the server-side listener.
+    await vi.waitFor(() => expect(harness!.host.sockets()).toEqual([]));
     // The blocked handler still holds this socket's queue, close included:
     // bounding handler time is the executor's job, not the host's.
     expect(harness.events.onMessage).toHaveBeenCalledOnce();

--- a/packages/control-plane/src/node/socket-host.test.ts
+++ b/packages/control-plane/src/node/socket-host.test.ts
@@ -1,0 +1,243 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
+import type { Logger } from "../logger";
+import type { SessionSocket } from "../platform-ports";
+import { NodeSocketHost, type SocketEvents } from "./socket-host";
+
+function createLogger(): Logger {
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => log),
+  };
+  return log as unknown as Logger;
+}
+
+function createEvents() {
+  return {
+    onMessage: vi.fn(async (_ws: SessionSocket, _message: string | ArrayBuffer) => {}),
+    onClose: vi.fn(
+      async (_ws: SessionSocket, _code: number, _reason: string, _wasClean: boolean) => {}
+    ),
+    onError: vi.fn((_ws: SessionSocket, _error: Error) => {}),
+  } satisfies SocketEvents;
+}
+
+/** A real `ws` server on an ephemeral port whose connections the test accepts into `host`. */
+async function createHarness() {
+  const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const log = createLogger();
+  const events = createEvents();
+  const host = new NodeSocketHost(log);
+  host.bind(events);
+  const clients: NodeWebSocket[] = [];
+
+  /** Open one connection; resolves once the server side is accepted under `tags`. */
+  async function connect(
+    tags: string[]
+  ): Promise<{ client: NodeWebSocket; socket: NodeWebSocket }> {
+    const accepted = new Promise<NodeWebSocket>((resolve) => {
+      server.once("connection", (socket) => {
+        host.accept(socket, tags);
+        resolve(socket);
+      });
+    });
+    const client = new NodeWebSocket(`ws://127.0.0.1:${port}`);
+    clients.push(client);
+    await once(client, "open");
+    return { client, socket: await accepted };
+  }
+
+  return {
+    host,
+    events,
+    log,
+    server,
+    connect,
+    /** A server-side socket the host never upgraded, for wiring-error tests. */
+    port,
+    async close() {
+      for (const client of clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+type Harness = Awaited<ReturnType<typeof createHarness>>;
+
+describe("NodeSocketHost", () => {
+  let harness: Harness | null = null;
+  afterEach(async () => {
+    await harness?.close();
+    harness = null;
+  });
+
+  it("adopts sockets under their tags and enumerates them by tag", async () => {
+    harness = await createHarness();
+    const client1 = await harness.connect(["wsid:ws-1"]);
+    const sandbox = await harness.connect(["sandbox", "sid:sb-1", "socket:sbws-1"]);
+
+    expect(harness.host.tags(client1.socket)).toEqual(["wsid:ws-1"]);
+    expect(harness.host.tags(sandbox.socket)).toEqual(["sandbox", "sid:sb-1", "socket:sbws-1"]);
+    expect(harness.host.sockets()).toEqual([client1.socket, sandbox.socket]);
+    expect(harness.host.sockets("sandbox")).toEqual([sandbox.socket]);
+    expect(harness.host.sockets("wsid:ws-1")).toEqual([client1.socket]);
+    expect(harness.host.sockets("missing")).toEqual([]);
+  });
+
+  it("returns no tags for a socket it never accepted", async () => {
+    harness = await createHarness();
+    expect(harness.host.tags({ readyState: 1, send() {}, close() {} })).toEqual([]);
+  });
+
+  it("refuses sockets it did not upgrade, double accepts, and accepts before bind", async () => {
+    harness = await createHarness();
+    const { socket } = await harness.connect(["wsid:ws-1"]);
+
+    expect(() => harness!.host.accept({ readyState: 1, send() {}, close() {} }, [])).toThrow(
+      TypeError
+    );
+    expect(() => harness!.host.accept(socket, ["wsid:again"])).toThrow(/already accepted/);
+    expect(() => new NodeSocketHost(createLogger()).accept(socket, [])).toThrow(/before bind/);
+    expect(() => harness!.host.bind(harness!.events)).toThrow(/already bound/);
+  });
+
+  it("forwards text frames as strings and binary frames as ArrayBuffers", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["wsid:ws-1"]);
+
+    client.send('{"type":"typing"}');
+    client.send(new Uint8Array([1, 2, 3]));
+    await vi.waitFor(() => expect(harness!.events.onMessage).toHaveBeenCalledTimes(2));
+
+    const [first, second] = harness.events.onMessage.mock.calls;
+    expect(first).toEqual([socket, '{"type":"typing"}']);
+    expect(second[0]).toBe(socket);
+    expect(second[1]).toBeInstanceOf(ArrayBuffer);
+    expect([...new Uint8Array(second[1] as ArrayBuffer)]).toEqual([1, 2, 3]);
+  });
+
+  it("answers the exact keepalive request without delivering it", async () => {
+    harness = await createHarness();
+    harness.host.setAutoResponse('{"type":"ping"}', '{"type":"pong","timestamp":1}');
+    const { client } = await harness.connect(["wsid:ws-1"]);
+
+    client.send('{"type":"ping"}');
+    const [reply] = await once(client, "message");
+    expect(String(reply)).toBe('{"type":"pong","timestamp":1}');
+    expect(harness.events.onMessage).not.toHaveBeenCalled();
+
+    // Only the exact payload is platform-level; anything else reaches the runtime.
+    client.send('{"type":"ping","extra":true}');
+    await vi.waitFor(() => expect(harness!.events.onMessage).toHaveBeenCalledOnce());
+  });
+
+  it("delivers a runtime-initiated close to the peer and to the runtime, then drops the socket", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["wsid:ws-1"]);
+
+    socket.close(4008, "Authentication timeout");
+    const [code, reason] = await once(client, "close");
+    expect(code).toBe(4008);
+    expect(String(reason)).toBe("Authentication timeout");
+
+    await vi.waitFor(() =>
+      expect(harness!.events.onClose).toHaveBeenCalledWith(
+        socket,
+        4008,
+        "Authentication timeout",
+        true
+      )
+    );
+    expect(harness.host.sockets()).toEqual([]);
+    // Classification survives the close: the disconnect handler still needs the tags.
+    expect(harness.host.tags(socket)).toEqual(["wsid:ws-1"]);
+  });
+
+  it("reports a lost connection as an unclean 1006 close", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["sandbox", "sid:sb-1"]);
+
+    client.terminate();
+
+    await vi.waitFor(() =>
+      expect(harness!.events.onClose).toHaveBeenCalledWith(socket, 1006, "", false)
+    );
+    expect(harness.host.sockets("sandbox")).toEqual([]);
+  });
+
+  it("delivers one socket's events in order, one at a time, close last", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["wsid:ws-1"]);
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      harness!.events.onMessage.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseFirst = release;
+        });
+      });
+    });
+    const order: string[] = [];
+    harness.events.onMessage.mockImplementation(async (_ws, message) => {
+      order.push(`message:${String(message)}`);
+    });
+    harness.events.onClose.mockImplementation(async () => {
+      order.push("close");
+    });
+
+    client.send("one");
+    await firstStarted;
+    client.send("two");
+    client.close(1000, "done");
+    // Nothing behind the blocked handler is delivered until it settles.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(order).toEqual([]);
+
+    releaseFirst();
+    await vi.waitFor(() => expect(order).toEqual(["message:two", "close"]));
+    expect(harness.events.onClose).toHaveBeenCalledWith(socket, 1000, "done", true);
+  });
+
+  it("logs a failed delivery and keeps delivering", async () => {
+    harness = await createHarness();
+    const { client, socket } = await harness.connect(["wsid:ws-1"]);
+    harness.events.onMessage.mockRejectedValueOnce(new Error("handler exploded"));
+
+    client.send("first");
+    client.send("second");
+
+    await vi.waitFor(() => expect(harness!.events.onMessage).toHaveBeenCalledTimes(2));
+    expect(harness.events.onMessage).toHaveBeenLastCalledWith(socket, "second");
+    expect(harness.log.error).toHaveBeenCalledWith(
+      "socket.delivery_failed",
+      expect.objectContaining({ tags: ["wsid:ws-1"], error: expect.any(Error) })
+    );
+  });
+
+  it("forwards socket errors to the runtime", async () => {
+    harness = await createHarness();
+    const { socket } = await harness.connect(["wsid:ws-1"]);
+    const failure = new Error("boom");
+
+    socket.emit("error", failure);
+
+    await vi.waitFor(() => expect(harness!.events.onError).toHaveBeenCalledWith(socket, failure));
+  });
+
+  it("keeps ready-state semantics the core relies on", async () => {
+    harness = await createHarness();
+    const { socket } = await harness.connect(["wsid:ws-1"]);
+
+    // The manager compares against the global WebSocket constants.
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+    socket.close();
+    expect(socket.readyState).not.toBe(WebSocket.OPEN);
+  });
+});

--- a/packages/control-plane/src/node/socket-host.ts
+++ b/packages/control-plane/src/node/socket-host.ts
@@ -1,5 +1,5 @@
 /**
- * NodeSocketHost — the session's `SocketHost` over `ws` sockets.
+ * NodeWebSocketHost — the session's `SessionWebSocketHost` over `ws` sockets.
  *
  * The HTTP host upgrades a connection and hands the runtime the `ws` socket;
  * this host adopts it under the runtime's tags, enumerates it, answers the
@@ -8,25 +8,30 @@
  * Durable Object adapter uses.
  *
  * Unlike the Durable Object runtime, this host owns inbound flow control.
- * Events from one socket are delivered one at a time in arrival order; while
- * a delivery is in flight the socket is paused so the peer's bytes wait in
- * the kernel rather than on the heap, and the frames `ws` had already parsed
- * queue behind it up to `maxPendingDeliveries`. A peer that exceeds that
- * bound is closed with 1013. A handler that never settles holds only its own
- * socket; bounding handler time is the session executor's concern, which is
- * whatever `bind` receives.
+ * Events from one socket are delivered one at a time in arrival order. The
+ * socket is paused before each delivery starts and resumed when its queue
+ * empties, so the peer's bytes wait in the kernel rather than on the heap;
+ * only the frames `ws` had already decoded from the read in progress queue
+ * behind an in-flight delivery, up to `maxPendingDeliveries`. A peer that
+ * exceeds that bound is closed with 1013. A handler that never settles holds
+ * only its own socket; bounding handler time is the session executor's
+ * concern, which is whatever `bindEventSink` receives.
+ *
+ * A host and the runtime it is bound to share one lifetime: the registry
+ * builds them together and retires them together, and a runtime with open
+ * sockets is never retired underneath them. There is no re-binding.
  */
 
 import { WebSocket as NodeWebSocket, type RawData } from "ws";
 import type { Logger } from "../logger";
-import type { SessionSocket } from "../platform-ports";
-import type { SocketHost } from "../session/platform";
+import type { SessionWebSocket } from "../platform-ports";
+import type { SessionWebSocketHost } from "../session/platform";
 
 /** The session server's socket entry points, as the host delivers them. */
-export interface SocketEvents {
-  onMessage(ws: SessionSocket, message: string | ArrayBuffer): Promise<void>;
-  onClose(ws: SessionSocket, code: number, reason: string, wasClean: boolean): Promise<void>;
-  onError(ws: SessionSocket, error: Error): void;
+export interface SessionWebSocketEventSink {
+  onMessage(ws: SessionWebSocket, message: string | ArrayBuffer): Promise<void>;
+  onClose(ws: SessionWebSocket, code: number, reason: string, wasClean: boolean): Promise<void>;
+  onError(ws: SessionWebSocket, error: Error): void;
 }
 
 export interface NodeSocketHostOptions {
@@ -53,14 +58,14 @@ interface Deliveries {
   draining: boolean;
 }
 
-export class NodeSocketHost implements SocketHost {
+export class NodeWebSocketHost implements SessionWebSocketHost {
   /** Tags outlive the socket's presence in `sockets()`: a closing socket still classifies. */
-  private readonly tagsOf = new WeakMap<SessionSocket, readonly string[]>();
+  private readonly tagsOf = new WeakMap<SessionWebSocket, readonly string[]>();
   private readonly open = new Set<NodeWebSocket>();
   private readonly deliveries = new WeakMap<NodeWebSocket, Deliveries>();
   private readonly maxPendingDeliveries: number;
   private autoResponse: { request: string; response: string } | null = null;
-  private events: SocketEvents | null = null;
+  private events: SessionWebSocketEventSink | null = null;
 
   constructor(
     private readonly log: Logger,
@@ -70,22 +75,22 @@ export class NodeSocketHost implements SocketHost {
   }
 
   /**
-   * Route every accepted socket's events to `events`. Binding precedes the
-   * first accept by construction: sockets are accepted through the runtime,
-   * and the runtime is what gets bound.
+   * Route every adopted socket's events to `sink`, once. Binding precedes
+   * the first adoption by construction: sockets are adopted through the
+   * runtime, and the runtime is what gets bound.
    */
-  bind(events: SocketEvents): void {
-    if (this.events) throw new Error("NodeSocketHost is already bound");
-    this.events = events;
+  bindEventSink(sink: SessionWebSocketEventSink): void {
+    if (this.events) throw new Error("NodeWebSocketHost is already bound");
+    this.events = sink;
   }
 
-  accept(ws: SessionSocket, tags: string[]): void {
+  adopt(ws: SessionWebSocket, tags: string[]): void {
     const events = this.events;
-    if (!events) throw new Error("NodeSocketHost.accept called before bind");
-    const socket = upgradedSocket(ws);
-    if (this.tagsOf.has(socket)) throw new Error("Socket was already accepted");
+    if (!events) throw new Error("NodeWebSocketHost.adopt called before bindEventSink");
+    const socket = requireNodeWebSocket(ws);
+    if (this.tagsOf.has(socket)) throw new Error("Socket was already adopted");
     if (socket.readyState !== NodeWebSocket.OPEN) {
-      throw new Error("Cannot accept a socket that is not open");
+      throw new Error("Cannot adopt a socket that is not open");
     }
     this.tagsOf.set(socket, [...tags]);
     this.open.add(socket);
@@ -118,11 +123,11 @@ export class NodeSocketHost implements SocketHost {
     });
   }
 
-  tags(ws: SessionSocket): string[] {
+  tags(ws: SessionWebSocket): string[] {
     return [...(this.tagsOf.get(ws) ?? [])];
   }
 
-  sockets(tag?: string): SessionSocket[] {
+  sockets(tag?: string): SessionWebSocket[] {
     const accepted = [...this.open];
     if (tag === undefined) return accepted;
     return accepted.filter((socket) => this.tagsOf.get(socket)?.includes(tag));
@@ -132,7 +137,7 @@ export class NodeSocketHost implements SocketHost {
     this.autoResponse = { request, response };
   }
 
-  /** Queue `handle` behind this socket's earlier events, pausing the socket while any are in flight. */
+  /** Queue `handle` behind this socket's earlier events; the socket stays paused until the queue empties. */
   private deliver(socket: NodeWebSocket, handle: () => Promise<void>): void {
     let deliveries = this.deliveries.get(socket);
     if (!deliveries) {
@@ -153,15 +158,16 @@ export class NodeSocketHost implements SocketHost {
       return;
     }
     deliveries.queue.push(handle);
-    if (deliveries.draining) {
-      socket.pause();
-      return;
-    }
+    if (deliveries.draining) return;
     void this.drain(socket, deliveries);
   }
 
   private async drain(socket: NodeWebSocket, deliveries: Deliveries): Promise<void> {
     deliveries.draining = true;
+    // Pause before the first delivery, not the second: otherwise `ws` keeps
+    // reading and assembles the next message (up to maxPayload) on the heap
+    // while the runtime is busy.
+    socket.pause();
     try {
       let handle = deliveries.queue.shift();
       while (handle) {
@@ -188,9 +194,9 @@ export class NodeSocketHost implements SocketHost {
  * upgraded ever reach it, so anything else is a wiring error rather than a
  * socket to adopt.
  */
-function upgradedSocket(ws: SessionSocket): NodeWebSocket {
+function requireNodeWebSocket(ws: SessionWebSocket): NodeWebSocket {
   if (!(ws instanceof NodeWebSocket)) {
-    throw new TypeError("NodeSocketHost received a socket it did not upgrade");
+    throw new TypeError("NodeWebSocketHost received a socket it did not upgrade");
   }
   return ws;
 }

--- a/packages/control-plane/src/node/socket-host.ts
+++ b/packages/control-plane/src/node/socket-host.ts
@@ -5,9 +5,16 @@
  * this host adopts it under the runtime's tags, enumerates it, answers the
  * platform-level keepalive without waking the runtime, and forwards message,
  * close, and error events to the session server with the signatures the
- * Durable Object adapter uses. Events from one socket are delivered one at a
- * time in arrival order. Ordering across sockets, requests, and alarms is the
- * session executor's concern; it is whatever `bind` receives.
+ * Durable Object adapter uses.
+ *
+ * Unlike the Durable Object runtime, this host owns inbound flow control.
+ * Events from one socket are delivered one at a time in arrival order; while
+ * a delivery is in flight the socket is paused so the peer's bytes wait in
+ * the kernel rather than on the heap, and the frames `ws` had already parsed
+ * queue behind it up to `maxPendingDeliveries`. A peer that exceeds that
+ * bound is closed with 1013. A handler that never settles holds only its own
+ * socket; bounding handler time is the session executor's concern, which is
+ * whatever `bind` receives.
  */
 
 import { WebSocket as NodeWebSocket, type RawData } from "ws";
@@ -22,18 +29,45 @@ export interface SocketEvents {
   onError(ws: SessionSocket, error: Error): void;
 }
 
-/** RFC 6455 close code for a connection lost without a close frame. */
-const ABNORMAL_CLOSURE = 1006;
+export interface NodeSocketHostOptions {
+  /**
+   * Frames a socket may hold parsed but undelivered while an earlier
+   * delivery is in flight. Pausing stops the next read, so this backlog is
+   * whatever `ws` decodes from one read that was already in progress: its
+   * bytes are bounded by that read, and its count by how small the peer
+   * makes its frames. The default is well above what realistically sized
+   * frames fit in one read; a peer that fills a read with thousands of
+   * near-empty frames is closed. Payload size per frame is the upgrade
+   * server's `maxPayload`, not this host's concern.
+   */
+  maxPendingDeliveries?: number;
+}
+
+const DEFAULT_MAX_PENDING_DELIVERIES = 4096;
+
+/** RFC 6455 "try again later": the server cannot keep up with this peer. */
+export const BACKLOG_EXCEEDED_CLOSE_CODE = 1013;
+
+interface Deliveries {
+  queue: Array<() => Promise<void>>;
+  draining: boolean;
+}
 
 export class NodeSocketHost implements SocketHost {
   /** Tags outlive the socket's presence in `sockets()`: a closing socket still classifies. */
   private readonly tagsOf = new WeakMap<SessionSocket, readonly string[]>();
   private readonly open = new Set<NodeWebSocket>();
-  private readonly deliveries = new WeakMap<SessionSocket, Promise<void>>();
+  private readonly deliveries = new WeakMap<NodeWebSocket, Deliveries>();
+  private readonly maxPendingDeliveries: number;
   private autoResponse: { request: string; response: string } | null = null;
   private events: SocketEvents | null = null;
 
-  constructor(private readonly log: Logger) {}
+  constructor(
+    private readonly log: Logger,
+    options: NodeSocketHostOptions = {}
+  ) {
+    this.maxPendingDeliveries = options.maxPendingDeliveries ?? DEFAULT_MAX_PENDING_DELIVERIES;
+  }
 
   /**
    * Route every accepted socket's events to `events`. Binding precedes the
@@ -57,6 +91,10 @@ export class NodeSocketHost implements SocketHost {
     this.open.add(socket);
 
     socket.on("message", (data, isBinary) => {
+      // Frames still arriving after this side began closing are dropped: the
+      // Durable Object runtime delivers nothing after close() either, and a
+      // peer closed for backlog must not refill the queue.
+      if (socket.readyState !== NodeWebSocket.OPEN) return;
       if (isBinary) {
         this.deliver(socket, () => events.onMessage(socket, toArrayBuffer(data)));
         return;
@@ -72,11 +110,11 @@ export class NodeSocketHost implements SocketHost {
     socket.on("error", (error) => {
       this.deliver(socket, async () => events.onError(socket, error));
     });
-    socket.on("close", (code, reason) => {
+    // The standards-style event carries `wasClean` as `ws` computes it (a
+    // close frame both received and sent); the emitter-style event does not.
+    socket.addEventListener("close", (event) => {
       this.open.delete(socket);
-      this.deliver(socket, () =>
-        events.onClose(socket, code, reason.toString(), code !== ABNORMAL_CLOSURE)
-      );
+      this.deliver(socket, () => events.onClose(socket, event.code, event.reason, event.wasClean));
     });
   }
 
@@ -94,17 +132,54 @@ export class NodeSocketHost implements SocketHost {
     this.autoResponse = { request, response };
   }
 
-  /** Run `handle` after this socket's earlier events settle; a failure is logged and never stalls the socket. */
+  /** Queue `handle` behind this socket's earlier events, pausing the socket while any are in flight. */
   private deliver(socket: NodeWebSocket, handle: () => Promise<void>): void {
-    const previous = this.deliveries.get(socket) ?? Promise.resolve();
-    const next = previous.then(handle).catch((error: unknown) => {
-      this.log.error("socket.delivery_failed", {
-        event: "socket.delivery_failed",
+    let deliveries = this.deliveries.get(socket);
+    if (!deliveries) {
+      deliveries = { queue: [], draining: false };
+      this.deliveries.set(socket, deliveries);
+    }
+    if (deliveries.queue.length >= this.maxPendingDeliveries) {
+      this.log.warn("socket.backlog_exceeded", {
+        event: "socket.backlog_exceeded",
         tags: this.tags(socket),
-        error: error instanceof Error ? error : String(error),
+        pending: deliveries.queue.length,
       });
-    });
-    this.deliveries.set(socket, next);
+      deliveries.queue.length = 0;
+      socket.close(BACKLOG_EXCEEDED_CLOSE_CODE, "Message backlog exceeded");
+      // The socket was paused for the in-flight delivery, which may never
+      // settle; the closing handshake still has to read the peer's frame.
+      socket.resume();
+      return;
+    }
+    deliveries.queue.push(handle);
+    if (deliveries.draining) {
+      socket.pause();
+      return;
+    }
+    void this.drain(socket, deliveries);
+  }
+
+  private async drain(socket: NodeWebSocket, deliveries: Deliveries): Promise<void> {
+    deliveries.draining = true;
+    try {
+      let handle = deliveries.queue.shift();
+      while (handle) {
+        try {
+          await handle();
+        } catch (error: unknown) {
+          this.log.error("socket.delivery_failed", {
+            event: "socket.delivery_failed",
+            tags: this.tags(socket),
+            error: error instanceof Error ? error : String(error),
+          });
+        }
+        handle = deliveries.queue.shift();
+      }
+    } finally {
+      deliveries.draining = false;
+      socket.resume();
+    }
   }
 }
 

--- a/packages/control-plane/src/node/socket-host.ts
+++ b/packages/control-plane/src/node/socket-host.ts
@@ -1,0 +1,139 @@
+/**
+ * NodeSocketHost — the session's `SocketHost` over `ws` sockets.
+ *
+ * The HTTP host upgrades a connection and hands the runtime the `ws` socket;
+ * this host adopts it under the runtime's tags, enumerates it, answers the
+ * platform-level keepalive without waking the runtime, and forwards message,
+ * close, and error events to the session server with the signatures the
+ * Durable Object adapter uses. Events from one socket are delivered one at a
+ * time in arrival order. Ordering across sockets, requests, and alarms is the
+ * session executor's concern; it is whatever `bind` receives.
+ */
+
+import { WebSocket as NodeWebSocket, type RawData } from "ws";
+import type { Logger } from "../logger";
+import type { SessionSocket } from "../platform-ports";
+import type { SocketHost } from "../session/platform";
+
+/** The session server's socket entry points, as the host delivers them. */
+export interface SocketEvents {
+  onMessage(ws: SessionSocket, message: string | ArrayBuffer): Promise<void>;
+  onClose(ws: SessionSocket, code: number, reason: string, wasClean: boolean): Promise<void>;
+  onError(ws: SessionSocket, error: Error): void;
+}
+
+/** RFC 6455 close code for a connection lost without a close frame. */
+const ABNORMAL_CLOSURE = 1006;
+
+export class NodeSocketHost implements SocketHost {
+  /** Tags outlive the socket's presence in `sockets()`: a closing socket still classifies. */
+  private readonly tagsOf = new WeakMap<SessionSocket, readonly string[]>();
+  private readonly open = new Set<NodeWebSocket>();
+  private readonly deliveries = new WeakMap<SessionSocket, Promise<void>>();
+  private autoResponse: { request: string; response: string } | null = null;
+  private events: SocketEvents | null = null;
+
+  constructor(private readonly log: Logger) {}
+
+  /**
+   * Route every accepted socket's events to `events`. Binding precedes the
+   * first accept by construction: sockets are accepted through the runtime,
+   * and the runtime is what gets bound.
+   */
+  bind(events: SocketEvents): void {
+    if (this.events) throw new Error("NodeSocketHost is already bound");
+    this.events = events;
+  }
+
+  accept(ws: SessionSocket, tags: string[]): void {
+    const events = this.events;
+    if (!events) throw new Error("NodeSocketHost.accept called before bind");
+    const socket = upgradedSocket(ws);
+    if (this.tagsOf.has(socket)) throw new Error("Socket was already accepted");
+    if (socket.readyState !== NodeWebSocket.OPEN) {
+      throw new Error("Cannot accept a socket that is not open");
+    }
+    this.tagsOf.set(socket, [...tags]);
+    this.open.add(socket);
+
+    socket.on("message", (data, isBinary) => {
+      if (isBinary) {
+        this.deliver(socket, () => events.onMessage(socket, toArrayBuffer(data)));
+        return;
+      }
+      const text = toText(data);
+      const auto = this.autoResponse;
+      if (auto && text === auto.request) {
+        socket.send(auto.response);
+        return;
+      }
+      this.deliver(socket, () => events.onMessage(socket, text));
+    });
+    socket.on("error", (error) => {
+      this.deliver(socket, async () => events.onError(socket, error));
+    });
+    socket.on("close", (code, reason) => {
+      this.open.delete(socket);
+      this.deliver(socket, () =>
+        events.onClose(socket, code, reason.toString(), code !== ABNORMAL_CLOSURE)
+      );
+    });
+  }
+
+  tags(ws: SessionSocket): string[] {
+    return [...(this.tagsOf.get(ws) ?? [])];
+  }
+
+  sockets(tag?: string): SessionSocket[] {
+    const accepted = [...this.open];
+    if (tag === undefined) return accepted;
+    return accepted.filter((socket) => this.tagsOf.get(socket)?.includes(tag));
+  }
+
+  setAutoResponse(request: string, response: string): void {
+    this.autoResponse = { request, response };
+  }
+
+  /** Run `handle` after this socket's earlier events settle; a failure is logged and never stalls the socket. */
+  private deliver(socket: NodeWebSocket, handle: () => Promise<void>): void {
+    const previous = this.deliveries.get(socket) ?? Promise.resolve();
+    const next = previous.then(handle).catch((error: unknown) => {
+      this.log.error("socket.delivery_failed", {
+        event: "socket.delivery_failed",
+        tags: this.tags(socket),
+        error: error instanceof Error ? error : String(error),
+      });
+    });
+    this.deliveries.set(socket, next);
+  }
+}
+
+/**
+ * The core types its sockets structurally; only sockets this host's server
+ * upgraded ever reach it, so anything else is a wiring error rather than a
+ * socket to adopt.
+ */
+function upgradedSocket(ws: SessionSocket): NodeWebSocket {
+  if (!(ws instanceof NodeWebSocket)) {
+    throw new TypeError("NodeSocketHost received a socket it did not upgrade");
+  }
+  return ws;
+}
+
+function toBuffer(data: RawData): Buffer {
+  if (Array.isArray(data)) return Buffer.concat(data);
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  return data;
+}
+
+function toText(data: RawData): string {
+  return toBuffer(data).toString("utf8");
+}
+
+/** The frame's bytes as a standalone ArrayBuffer, the shape the Workers runtime delivers. */
+function toArrayBuffer(data: RawData): ArrayBuffer {
+  const buffer = toBuffer(data);
+  const copy = new ArrayBuffer(buffer.byteLength);
+  new Uint8Array(copy).set(buffer);
+  return copy;
+}

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -16,6 +16,19 @@ export interface BackgroundTasks {
   ): void;
 }
 
+/**
+ * The socket surface the session core uses. Structural on purpose: the
+ * Cloudflare host hands the runtime hibernatable `WebSocket`s and the Node
+ * host hands it `ws` sockets, and the core compiles against both without
+ * naming a member only one platform has. `readyState` uses the standard
+ * CONNECTING/OPEN/CLOSING/CLOSED values on both.
+ */
+export interface SessionSocket {
+  readonly readyState: number;
+  send(message: string | ArrayBuffer | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+}
+
 /** Access the runtime's single scheduled wake-up. */
 export interface AlarmScheduler {
   schedule(at: number): Promise<void>;

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -29,6 +29,14 @@ export interface SessionSocket {
   close(code?: number, reason?: string): void;
 }
 
+/** The RFC 6455 OPEN ready state; every platform's socket reports this value. */
+const SOCKET_OPEN = 1;
+
+/** Whether `socket` can currently send and receive. */
+export function isSocketOpen(socket: SessionSocket): boolean {
+  return socket.readyState === SOCKET_OPEN;
+}
+
 /** Access the runtime's single scheduled wake-up. */
 export interface AlarmScheduler {
   schedule(at: number): Promise<void>;

--- a/packages/control-plane/src/platform-ports.ts
+++ b/packages/control-plane/src/platform-ports.ts
@@ -23,7 +23,7 @@ export interface BackgroundTasks {
  * naming a member only one platform has. `readyState` uses the standard
  * CONNECTING/OPEN/CLOSING/CLOSED values on both.
  */
-export interface SessionSocket {
+export interface SessionWebSocket {
   readonly readyState: number;
   send(message: string | ArrayBuffer | ArrayBufferView): void;
   close(code?: number, reason?: string): void;
@@ -33,7 +33,7 @@ export interface SessionSocket {
 const SOCKET_OPEN = 1;
 
 /** Whether `socket` can currently send and receive. */
-export function isSocketOpen(socket: SessionSocket): boolean {
+export function isSocketOpen(socket: SessionWebSocket): boolean {
   return socket.readyState === SOCKET_OPEN;
 }
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -56,7 +56,7 @@ import {
   type ImageBuildLookup,
   type SelectedImageBuild,
 } from "./image-selection";
-import type { AlarmScheduler, SessionSocket } from "../../platform-ports";
+import type { AlarmScheduler, SessionWebSocket } from "../../platform-ports";
 import { DEFAULT_SANDBOX_STATUS } from "../sandbox-status";
 
 export type { ImageBuildLookup } from "./image-selection";
@@ -184,7 +184,7 @@ export interface SandboxBroadcaster {
  */
 export interface WebSocketManager {
   /** Get the sandbox WebSocket (with hibernation recovery) */
-  getSandboxWebSocket(): SessionSocket | null;
+  getSandboxWebSocket(): SessionWebSocket | null;
   /** Detach the active sandbox dispatch boundary and close its WebSocket. */
   detachSandboxWebSocket(code: number, reason: string): void;
   /** Send a message to the sandbox */

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -56,7 +56,7 @@ import {
   type ImageBuildLookup,
   type SelectedImageBuild,
 } from "./image-selection";
-import type { AlarmScheduler } from "../../platform-ports";
+import type { AlarmScheduler, SessionSocket } from "../../platform-ports";
 import { DEFAULT_SANDBOX_STATUS } from "../sandbox-status";
 
 export type { ImageBuildLookup } from "./image-selection";
@@ -184,7 +184,7 @@ export interface SandboxBroadcaster {
  */
 export interface WebSocketManager {
   /** Get the sandbox WebSocket (with hibernation recovery) */
-  getSandboxWebSocket(): WebSocket | null;
+  getSandboxWebSocket(): SessionSocket | null;
   /** Detach the active sandbox dispatch boundary and close its WebSocket. */
   detachSandboxWebSocket(code: number, reason: string): void;
   /** Send a message to the sandbox */

--- a/packages/control-plane/src/session/client-command-facade.ts
+++ b/packages/control-plane/src/session/client-command-facade.ts
@@ -21,10 +21,10 @@ import type { SessionConnectionAuthenticator } from "./connection-authenticator"
 import type { SessionMessageQueue } from "./message-queue";
 import type { PresenceService } from "./presence-service";
 import type { PermissionId } from "@open-inspect/shared/rbac";
-import type { SessionSocket } from "../platform-ports";
+import type { SessionWebSocket } from "../platform-ports";
 
 export class SessionClientCommandFacade implements SessionClientCommands<
-  SessionSocket,
+  SessionWebSocket,
   ClientInfo
 > {
   constructor(
@@ -34,19 +34,19 @@ export class SessionClientCommandFacade implements SessionClientCommands<
     private readonly events: SessionEventStream
   ) {}
 
-  subscribe(connection: SessionSocket, message: ClientSubscribe): Promise<void> {
+  subscribe(connection: SessionWebSocket, message: ClientSubscribe): Promise<void> {
     return this.authenticator.handleSubscribe(connection, message);
   }
 
   submitPrompt(
-    connection: SessionSocket,
+    connection: SessionWebSocket,
     client: ClientInfo,
     message: ClientPrompt
   ): Promise<void> {
     return this.prompts.handlePromptMessage(connection, client, message);
   }
 
-  cancelPrompt(connection: SessionSocket, message: ClientCancelPrompt): Promise<void> {
+  cancelPrompt(connection: SessionWebSocket, message: ClientCancelPrompt): Promise<void> {
     return this.prompts.cancelQueuedPrompt(connection, message);
   }
 

--- a/packages/control-plane/src/session/client-command-facade.ts
+++ b/packages/control-plane/src/session/client-command-facade.ts
@@ -21,8 +21,12 @@ import type { SessionConnectionAuthenticator } from "./connection-authenticator"
 import type { SessionMessageQueue } from "./message-queue";
 import type { PresenceService } from "./presence-service";
 import type { PermissionId } from "@open-inspect/shared/rbac";
+import type { SessionSocket } from "../platform-ports";
 
-export class SessionClientCommandFacade implements SessionClientCommands<WebSocket, ClientInfo> {
+export class SessionClientCommandFacade implements SessionClientCommands<
+  SessionSocket,
+  ClientInfo
+> {
   constructor(
     private readonly authenticator: SessionConnectionAuthenticator,
     private readonly prompts: SessionMessageQueue,
@@ -30,15 +34,19 @@ export class SessionClientCommandFacade implements SessionClientCommands<WebSock
     private readonly events: SessionEventStream
   ) {}
 
-  subscribe(connection: WebSocket, message: ClientSubscribe): Promise<void> {
+  subscribe(connection: SessionSocket, message: ClientSubscribe): Promise<void> {
     return this.authenticator.handleSubscribe(connection, message);
   }
 
-  submitPrompt(connection: WebSocket, client: ClientInfo, message: ClientPrompt): Promise<void> {
+  submitPrompt(
+    connection: SessionSocket,
+    client: ClientInfo,
+    message: ClientPrompt
+  ): Promise<void> {
     return this.prompts.handlePromptMessage(connection, client, message);
   }
 
-  cancelPrompt(connection: WebSocket, message: ClientCancelPrompt): Promise<void> {
+  cancelPrompt(connection: SessionSocket, message: ClientCancelPrompt): Promise<void> {
     return this.prompts.cancelQueuedPrompt(connection, message);
   }
 

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -133,7 +133,7 @@ import { createSessionRuntimeClientForTrace } from "./runtime-client";
 import { SessionTitleService } from "./title-service";
 import { parseArtifactMetadata } from "./artifact-metadata";
 import { AuthorizationError, AuthorizationService } from "../authorization/service";
-import type { SessionSocket } from "../platform-ports";
+import type { SessionWebSocket } from "../platform-ports";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -151,7 +151,7 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
  */
 export interface SessionRuntime {
   readonly log: Logger;
-  readonly server: SessionServer<SessionSocket, ClientInfo>;
+  readonly server: SessionServer<SessionWebSocket, ClientInfo>;
   /** Admission of WebSocket upgrades; the host completes the handshake and attaches its socket. */
   readonly upgrades: SessionUpgradeAdmission;
   readonly alarms: {
@@ -772,7 +772,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     nowMs: () => Date.now(),
     monotonicNowMs: () => performance.now(),
   };
-  const sockets: SocketRegistry<SessionSocket, ClientInfo> = {
+  const sockets: SocketRegistry<SessionWebSocket, ClientInfo> = {
     classify: (ws) => wsManager.classify(ws),
     send: (ws, message) => wsManager.send(ws, message),
     getClient: (ws) => connectionAuthenticator.getClientInfo(ws),
@@ -800,7 +800,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     broadcast: (message) => messenger.broadcast(message),
   };
 
-  const server = new SessionServer<SessionSocket, ClientInfo>({
+  const server = new SessionServer<SessionWebSocket, ClientInfo>({
     http: new SessionHttpDispatcher({ log, routes, clock }),
     messages: new SessionMessageRouter({
       log,

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -133,6 +133,7 @@ import { createSessionRuntimeClientForTrace } from "./runtime-client";
 import { SessionTitleService } from "./title-service";
 import { parseArtifactMetadata } from "./artifact-metadata";
 import { AuthorizationError, AuthorizationService } from "../authorization/service";
+import type { SessionSocket } from "../platform-ports";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -150,7 +151,7 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
  */
 export interface SessionRuntime {
   readonly log: Logger;
-  readonly server: SessionServer<WebSocket, ClientInfo>;
+  readonly server: SessionServer<SessionSocket, ClientInfo>;
   /** Admission of WebSocket upgrades; the host completes the handshake and attaches its socket. */
   readonly upgrades: SessionUpgradeAdmission;
   readonly alarms: {
@@ -771,7 +772,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     nowMs: () => Date.now(),
     monotonicNowMs: () => performance.now(),
   };
-  const sockets: SocketRegistry<WebSocket, ClientInfo> = {
+  const sockets: SocketRegistry<SessionSocket, ClientInfo> = {
     classify: (ws) => wsManager.classify(ws),
     send: (ws, message) => wsManager.send(ws, message),
     getClient: (ws) => connectionAuthenticator.getClientInfo(ws),
@@ -799,7 +800,7 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     broadcast: (message) => messenger.broadcast(message),
   };
 
-  const server = new SessionServer<WebSocket, ClientInfo>({
+  const server = new SessionServer<SessionSocket, ClientInfo>({
     http: new SessionHttpDispatcher({ log, routes, clock }),
     messages: new SessionMessageRouter({
       log,

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -356,7 +356,6 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
         lastSeen: Date.now(),
         clientId: data.clientId,
         authorizationExpiresAt,
-        ws,
       };
 
       try {
@@ -468,7 +467,6 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
       lastSeen: Date.now(),
       clientId: mapping.client_id || `client-${Date.now()}`,
       authorizationExpiresAt: mapping.authorization_expires_at,
-      ws,
     };
 
     wsManager.setClient(ws, clientInfo);

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -14,7 +14,7 @@ import type { Logger } from "../logger";
 import { isSandboxReconnectBlockedStatus } from "../sandbox/lifecycle/decisions";
 import type { SandboxLifecycleManager } from "../sandbox/lifecycle/manager";
 import type { SourceControlProviderName } from "../source-control";
-import type { BackgroundTasks } from "../platform-ports";
+import type { BackgroundTasks, SessionSocket } from "../platform-ports";
 import type { ClientInfo } from "../types";
 import { isValidSandboxToken } from "./sandbox-access";
 import { requestLogger } from "./request-logger";
@@ -74,7 +74,7 @@ export type UpgradeDecision =
       kind: "accept";
       role: "sandbox" | "client";
       /** Adopt the host's socket for this upgrade and run the connection's side effects. */
-      attach(ws: WebSocket): Promise<void>;
+      attach(ws: SessionSocket): Promise<void>;
     }
   | { kind: "reject"; response: Response };
 
@@ -192,7 +192,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
     return accept("sandbox", (ws) => this.attachSandbox(ws, sandboxId, log));
   }
 
-  private attachClient(ws: WebSocket, wsId: string): void {
+  private attachClient(ws: SessionSocket, wsId: string): void {
     const { wsManager, backgroundTasks } = this.deps;
     wsManager.acceptClientSocket(ws, wsId);
     backgroundTasks.submit(() => wsManager.enforceAuthTimeout(ws, wsId), {
@@ -207,7 +207,11 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
    * published. Everything after the await is synchronous, so the new socket,
    * the ready status, and the broadcasts land together.
    */
-  private async attachSandbox(ws: WebSocket, sandboxId: string | null, log: Logger): Promise<void> {
+  private async attachSandbox(
+    ws: SessionSocket,
+    sandboxId: string | null,
+    log: Logger
+  ): Promise<void> {
     const {
       wsManager,
       sandboxRepository,
@@ -251,7 +255,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
 
   /** Validate the client token and current permission before granting an authorization lease. */
   async handleSubscribe(
-    ws: WebSocket,
+    ws: SessionSocket,
     data: {
       token: string;
       clientId: string;
@@ -399,7 +403,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
    * structural rather than a convention inside the async authentication flow.
    */
   private completeClientSubscription(
-    ws: WebSocket,
+    ws: SessionSocket,
     client: ClientInfo,
     enrichment: Parameters<SessionSnapshotReader["readSessionSnapshot"]>[0],
     canAccessSandbox: boolean
@@ -443,7 +447,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
   }
 
   /** Return authorized client state, recovering an unexpired lease after hibernation. */
-  getClientInfo(ws: WebSocket): ClientInfo | null {
+  getClientInfo(ws: SessionSocket): ClientInfo | null {
     const { wsManager, log } = this.deps;
     const lookup = wsManager.lookupClient(ws);
     if (lookup.kind === "cached") return lookup.client;
@@ -479,7 +483,7 @@ function reject(body: string, status: number): UpgradeDecision {
 /** An accepted decision whose attachment can run once. */
 function accept(
   role: "sandbox" | "client",
-  attach: (ws: WebSocket) => void | Promise<void>
+  attach: (ws: SessionSocket) => void | Promise<void>
 ): UpgradeDecision {
   let attached = false;
   return {

--- a/packages/control-plane/src/session/connection-authenticator.ts
+++ b/packages/control-plane/src/session/connection-authenticator.ts
@@ -14,7 +14,7 @@ import type { Logger } from "../logger";
 import { isSandboxReconnectBlockedStatus } from "../sandbox/lifecycle/decisions";
 import type { SandboxLifecycleManager } from "../sandbox/lifecycle/manager";
 import type { SourceControlProviderName } from "../source-control";
-import type { BackgroundTasks, SessionSocket } from "../platform-ports";
+import type { BackgroundTasks, SessionWebSocket } from "../platform-ports";
 import type { ClientInfo } from "../types";
 import { isValidSandboxToken } from "./sandbox-access";
 import { requestLogger } from "./request-logger";
@@ -74,7 +74,7 @@ export type UpgradeDecision =
       kind: "accept";
       role: "sandbox" | "client";
       /** Adopt the host's socket for this upgrade and run the connection's side effects. */
-      attach(ws: SessionSocket): Promise<void>;
+      attach(ws: SessionWebSocket): Promise<void>;
     }
   | { kind: "reject"; response: Response };
 
@@ -192,7 +192,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
     return accept("sandbox", (ws) => this.attachSandbox(ws, sandboxId, log));
   }
 
-  private attachClient(ws: SessionSocket, wsId: string): void {
+  private attachClient(ws: SessionWebSocket, wsId: string): void {
     const { wsManager, backgroundTasks } = this.deps;
     wsManager.acceptClientSocket(ws, wsId);
     backgroundTasks.submit(() => wsManager.enforceAuthTimeout(ws, wsId), {
@@ -208,7 +208,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
    * the ready status, and the broadcasts land together.
    */
   private async attachSandbox(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     sandboxId: string | null,
     log: Logger
   ): Promise<void> {
@@ -255,7 +255,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
 
   /** Validate the client token and current permission before granting an authorization lease. */
   async handleSubscribe(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     data: {
       token: string;
       clientId: string;
@@ -402,7 +402,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
    * structural rather than a convention inside the async authentication flow.
    */
   private completeClientSubscription(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     client: ClientInfo,
     enrichment: Parameters<SessionSnapshotReader["readSessionSnapshot"]>[0],
     canAccessSandbox: boolean
@@ -446,7 +446,7 @@ export class SessionConnectionAuthenticator implements SessionUpgradeAdmission {
   }
 
   /** Return authorized client state, recovering an unexpired lease after hibernation. */
-  getClientInfo(ws: SessionSocket): ClientInfo | null {
+  getClientInfo(ws: SessionWebSocket): ClientInfo | null {
     const { wsManager, log } = this.deps;
     const lookup = wsManager.lookupClient(ws);
     if (lookup.kind === "cached") return lookup.client;
@@ -481,7 +481,7 @@ function reject(body: string, status: number): UpgradeDecision {
 /** An accepted decision whose attachment can run once. */
 function accept(
   role: "sandbox" | "client",
-  attach: (ws: SessionSocket) => void | Promise<void>
+  attach: (ws: SessionWebSocket) => void | Promise<void>
 ): UpgradeDecision {
   let attached = false;
   return {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -104,7 +104,6 @@ function createClientInfo(overrides: Partial<ClientInfo> = {}): ClientInfo {
     lastSeen: 1000,
     clientId: "client-1",
     authorizationExpiresAt: Date.now() + 300_000,
-    ws: {} as WebSocket,
     ...overrides,
   };
 }

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -39,7 +39,7 @@ import type { SessionStatusService } from "./session-status-service";
 import type { EnqueuePromptRequest } from "./enqueue-prompt-contract";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
-import type { AlarmScheduler, BackgroundTasks } from "../platform-ports";
+import type { AlarmScheduler, BackgroundTasks, SessionSocket } from "../platform-ports";
 import { resolveGitAuthorIdentity } from "./identity";
 import { validateReasoningEffort } from "./reasoning-effort";
 import {
@@ -239,7 +239,7 @@ export class SessionMessageQueue {
   }
 
   async handlePromptMessage(
-    ws: WebSocket,
+    ws: SessionSocket,
     client: ClientInfo,
     data: PromptMessageData
   ): Promise<void> {
@@ -325,7 +325,7 @@ export class SessionMessageQueue {
   }
 
   async cancelQueuedPrompt(
-    ws: WebSocket,
+    ws: SessionSocket,
     data: { messageId: string; clientRequestId: string }
   ): Promise<void> {
     if (!this.messageRepository.cancelPendingMessage(data.messageId)) {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -39,7 +39,7 @@ import type { SessionStatusService } from "./session-status-service";
 import type { EnqueuePromptRequest } from "./enqueue-prompt-contract";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
-import type { AlarmScheduler, BackgroundTasks, SessionSocket } from "../platform-ports";
+import type { AlarmScheduler, BackgroundTasks, SessionWebSocket } from "../platform-ports";
 import { resolveGitAuthorIdentity } from "./identity";
 import { validateReasoningEffort } from "./reasoning-effort";
 import {
@@ -239,7 +239,7 @@ export class SessionMessageQueue {
   }
 
   async handlePromptMessage(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     client: ClientInfo,
     data: PromptMessageData
   ): Promise<void> {
@@ -325,7 +325,7 @@ export class SessionMessageQueue {
   }
 
   async cancelQueuedPrompt(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     data: { messageId: string; clientRequestId: string }
   ): Promise<void> {
     if (!this.messageRepository.cancelPendingMessage(data.messageId)) {

--- a/packages/control-plane/src/session/platform.ts
+++ b/packages/control-plane/src/session/platform.ts
@@ -7,19 +7,25 @@
  */
 
 import type { Logger } from "../logger";
-import type { BackgroundTasks, SessionSocket } from "../platform-ports";
+import type { BackgroundTasks, SessionWebSocket } from "../platform-ports";
 import type { SqlDatabase } from "../db/sql-database";
 import type { AlarmScheduleStore } from "./alarm/scheduler";
 import type { SqlStorage, TransactionSync } from "./sql-storage";
 
-/** The host that owns the session's accepted sockets. */
-export interface SocketHost {
-  /** Adopt `ws` into the runtime, tagged so its identity survives a restart. */
-  accept(ws: SessionSocket, tags: string[]): void;
-  /** The tags `ws` was accepted with. */
-  tags(ws: SessionSocket): string[];
-  /** Every accepted socket, or only those carrying `tag`. */
-  sockets(tag?: string): SessionSocket[];
+/** The host that owns the session's adopted WebSockets. */
+export interface SessionWebSocketHost {
+  /**
+   * Adopt `ws` into the runtime under `tags`. The tags are the socket's
+   * identity for the whole life of the connection; a host that rehydrates
+   * a runtime under live connections (the Durable Object) preserves them
+   * across that too, while a host that cannot (a Node process restart)
+   * loses the connection and the peer reconnects.
+   */
+  adopt(ws: SessionWebSocket, tags: string[]): void;
+  /** The tags `ws` was adopted with. */
+  tags(ws: SessionWebSocket): string[];
+  /** Every adopted socket, or only those carrying `tag`. */
+  sockets(tag?: string): SessionWebSocket[];
   /**
    * Answer `request` frames with `response` at the platform level, without
    * waking the runtime.
@@ -47,7 +53,7 @@ export interface SessionPlatform {
   db: SqlDatabase;
   /** The runtime's single scheduled wake-up. */
   alarmStore: AlarmScheduleStore;
-  sockets: SocketHost;
+  sockets: SessionWebSocketHost;
   /**
    * Build the deferred-work port for this runtime. Takes the session-scoped
    * logger so failures of background work are attributed to the session.

--- a/packages/control-plane/src/session/platform.ts
+++ b/packages/control-plane/src/session/platform.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Logger } from "../logger";
-import type { BackgroundTasks } from "../platform-ports";
+import type { BackgroundTasks, SessionSocket } from "../platform-ports";
 import type { SqlDatabase } from "../db/sql-database";
 import type { AlarmScheduleStore } from "./alarm/scheduler";
 import type { SqlStorage, TransactionSync } from "./sql-storage";
@@ -15,11 +15,11 @@ import type { SqlStorage, TransactionSync } from "./sql-storage";
 /** The host that owns the session's accepted sockets. */
 export interface SocketHost {
   /** Adopt `ws` into the runtime, tagged so its identity survives a restart. */
-  accept(ws: WebSocket, tags: string[]): void;
+  accept(ws: SessionSocket, tags: string[]): void;
   /** The tags `ws` was accepted with. */
-  tags(ws: WebSocket): string[];
+  tags(ws: SessionSocket): string[];
   /** Every accepted socket, or only those carrying `tag`. */
-  sockets(tag?: string): WebSocket[];
+  sockets(tag?: string): SessionSocket[];
   /**
    * Answer `request` frames with `response` at the platform level, without
    * waking the runtime.

--- a/packages/control-plane/src/session/presence-service.test.ts
+++ b/packages/control-plane/src/session/presence-service.test.ts
@@ -25,7 +25,6 @@ function createMockClient(overrides?: Partial<ClientInfo>): ClientInfo {
     lastSeen: 1000,
     clientId: "client-1",
     authorizationExpiresAt: Date.now() + 300_000,
-    ws: {} as WebSocket,
     ...overrides,
   };
 }

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -15,6 +15,7 @@ import type {
 } from "@open-inspect/shared/types/server-messages";
 import type { ClientInfo } from "../types";
 import type { SessionMessenger } from "./messenger";
+import type { SessionSocket } from "../platform-ports";
 
 /** Project one participant per identity from one or more client connections. */
 function projectConnectedParticipants(connections: Iterable<ClientInfo>): ParticipantPresence[] {
@@ -45,8 +46,8 @@ function projectConnectedParticipants(connections: Iterable<ClientInfo>): Partic
 export interface PresenceServiceDeps {
   getAuthenticatedClients: () => IterableIterator<ClientInfo>;
   messenger: SessionMessenger;
-  send: (ws: WebSocket, message: ServerMessage) => boolean;
-  getSandboxSocket: () => WebSocket | null;
+  send: (ws: SessionSocket, message: ServerMessage) => boolean;
+  getSandboxSocket: () => SessionSocket | null;
   isSpawning: () => boolean;
   spawnSandbox: () => Promise<void>;
   log: Logger;
@@ -73,7 +74,7 @@ export class PresenceService {
   /**
    * Send presence info to a specific client.
    */
-  sendPresence(ws: WebSocket): void {
+  sendPresence(ws: SessionSocket): void {
     const participants = this.getPresenceList();
     this.deps.send(ws, { type: "presence_sync", participants });
   }

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -15,7 +15,7 @@ import type {
 } from "@open-inspect/shared/types/server-messages";
 import type { ClientInfo } from "../types";
 import type { SessionMessenger } from "./messenger";
-import type { SessionSocket } from "../platform-ports";
+import type { SessionWebSocket } from "../platform-ports";
 
 /** Project one participant per identity from one or more client connections. */
 function projectConnectedParticipants(connections: Iterable<ClientInfo>): ParticipantPresence[] {
@@ -46,8 +46,8 @@ function projectConnectedParticipants(connections: Iterable<ClientInfo>): Partic
 export interface PresenceServiceDeps {
   getAuthenticatedClients: () => IterableIterator<ClientInfo>;
   messenger: SessionMessenger;
-  send: (ws: SessionSocket, message: ServerMessage) => boolean;
-  getSandboxSocket: () => SessionSocket | null;
+  send: (ws: SessionWebSocket, message: ServerMessage) => boolean;
+  getSandboxSocket: () => SessionWebSocket | null;
   isSpawning: () => boolean;
   spawnSandbox: () => Promise<void>;
   log: Logger;
@@ -74,7 +74,7 @@ export class PresenceService {
   /**
    * Send presence info to a specific client.
    */
-  sendPresence(ws: SessionSocket): void {
+  sendPresence(ws: SessionWebSocket): void {
     const participants = this.getPresenceList();
     this.deps.send(ws, { type: "presence_sync", participants });
   }

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -15,7 +15,7 @@ import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionRow } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
-import type { SessionSocket } from "../platform-ports";
+import type { SessionWebSocket } from "../platform-ports";
 
 /** The session-context reads owned by the session repositories and resolver. */
 export class LifecycleSessionContext implements SessionContextReader {
@@ -56,7 +56,7 @@ type LifecycleSockets = Pick<
 export class LifecycleSocketAdapter implements WebSocketManager {
   constructor(private readonly sockets: LifecycleSockets) {}
 
-  getSandboxWebSocket(): SessionSocket | null {
+  getSandboxWebSocket(): SessionWebSocket | null {
     return this.sockets.getSandboxSocket();
   }
 

--- a/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
+++ b/packages/control-plane/src/session/sandbox-lifecycle-adapters.ts
@@ -15,6 +15,7 @@ import type { UserEnvResolver } from "./user-env-resolver";
 import type { SessionRow } from "./types";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import { DEFAULT_BASE_BRANCH } from "../repos/default-branch";
+import type { SessionSocket } from "../platform-ports";
 
 /** The session-context reads owned by the session repositories and resolver. */
 export class LifecycleSessionContext implements SessionContextReader {
@@ -55,7 +56,7 @@ type LifecycleSockets = Pick<
 export class LifecycleSocketAdapter implements WebSocketManager {
   constructor(private readonly sockets: LifecycleSockets) {}
 
-  getSandboxWebSocket(): WebSocket | null {
+  getSandboxWebSocket(): SessionSocket | null {
     return this.sockets.getSandboxSocket();
   }
 

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -173,7 +173,6 @@ function createClientInfo(overrides: Partial<ClientInfo> = {}): ClientInfo {
     lastSeen: Date.now(),
     clientId: "client-1",
     authorizationExpiresAt: Date.now() + 300_000,
-    ws: createFakeWebSocket(),
     ...overrides,
   };
 }
@@ -756,7 +755,7 @@ describe("SessionWebSocketManagerImpl", () => {
     it("returns a cached live client", () => {
       const { manager } = createManager();
       const ws = createFakeWebSocket();
-      const info = createClientInfo({ ws });
+      const info = createClientInfo();
 
       manager.setClient(ws, info);
 
@@ -774,7 +773,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager, sockets } = createManager();
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-expired"]);
-      manager.setClient(ws, createClientInfo({ ws, authorizationExpiresAt: Date.now() - 1 }));
+      manager.setClient(ws, createClientInfo({ authorizationExpiresAt: Date.now() - 1 }));
 
       expect(manager.lookupClient(ws)).toEqual({ kind: "authorization_rejected" });
       expect(ws.close).toHaveBeenCalledWith(4010, "Authorization expired or changed");
@@ -783,7 +782,7 @@ describe("SessionWebSocketManagerImpl", () => {
     it("removeClient returns the client and removes every identity representation", () => {
       const { manager, sockets, mockRepo } = createManager();
       const ws = createFakeWebSocket();
-      const info = createClientInfo({ ws });
+      const info = createClientInfo();
       sockets.set(ws, ["wsid:ws-1"]);
       mockRepo.addMapping("ws-1", {
         participant_id: info.participantId,
@@ -880,7 +879,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager, sockets } = createManager();
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-expired"]);
-      manager.setClient(ws, createClientInfo({ ws, authorizationExpiresAt: Date.now() - 1 }));
+      manager.setClient(ws, createClientInfo({ authorizationExpiresAt: Date.now() - 1 }));
 
       expect(manager.lookupClient(ws)).toEqual({ kind: "authorization_rejected" });
       expect(ws.close).toHaveBeenCalledTimes(1);
@@ -893,7 +892,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager, alarmScheduler, mockRepo, sockets } = createManager();
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-1"]);
-      const info = createClientInfo({ ws, authorizationExpiresAt: 301_000 });
+      const info = createClientInfo({ authorizationExpiresAt: 301_000 });
 
       const synchronize = vi.fn(() => true);
       await expect(manager.activateClient(ws, info, synchronize)).resolves.toBe(true);
@@ -917,9 +916,9 @@ describe("SessionWebSocketManagerImpl", () => {
       alarmScheduler.schedule.mockRejectedValueOnce(new Error("alarm unavailable"));
 
       const synchronize = vi.fn(() => true);
-      await expect(
-        manager.activateClient(ws, createClientInfo({ ws }), synchronize)
-      ).rejects.toThrow("alarm unavailable");
+      await expect(manager.activateClient(ws, createClientInfo(), synchronize)).rejects.toThrow(
+        "alarm unavailable"
+      );
       expect(synchronize).not.toHaveBeenCalled();
       expect(mockRepo.upsertCalls).toHaveLength(0);
       expect(manager.lookupClient(ws)).toEqual({ kind: "missing" });
@@ -930,7 +929,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-1"]);
 
-      await expect(manager.activateClient(ws, createClientInfo({ ws }), () => false)).resolves.toBe(
+      await expect(manager.activateClient(ws, createClientInfo(), () => false)).resolves.toBe(
         false
       );
       expect(mockRepo.upsertCalls).toHaveLength(0);
@@ -1048,7 +1047,7 @@ describe("SessionWebSocketManagerImpl", () => {
       sockets.set(authedWs, ["wsid:ws-1"]);
       sockets.set(unauthedWs, ["wsid:ws-2"]);
 
-      manager.setClient(authedWs, createClientInfo({ ws: authedWs }));
+      manager.setClient(authedWs, createClientInfo());
 
       const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
@@ -1095,7 +1094,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager, sockets } = createManager();
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-expired"]);
-      manager.setClient(ws, createClientInfo({ ws, authorizationExpiresAt: Date.now() - 1 }));
+      manager.setClient(ws, createClientInfo({ authorizationExpiresAt: Date.now() - 1 }));
 
       const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (client) => called.push(client));
@@ -1130,7 +1129,7 @@ describe("SessionWebSocketManagerImpl", () => {
       // Authenticated client (in-memory)
       const authedWs = createFakeWebSocket();
       sockets.set(authedWs, ["wsid:ws-authed"]);
-      manager.setClient(authedWs, createClientInfo({ ws: authedWs }));
+      manager.setClient(authedWs, createClientInfo());
 
       // Post-hibernation client (persisted mapping only, no in-memory ClientInfo)
       const hibernatedWs = createFakeWebSocket();
@@ -1215,7 +1214,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-1"]);
 
-      manager.setClient(ws, createClientInfo({ ws }));
+      manager.setClient(ws, createClientInfo());
 
       await manager.enforceAuthTimeout(ws, "ws-1");
 
@@ -1267,8 +1266,8 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager } = createManager();
       const ws1 = createFakeWebSocket();
       const ws2 = createFakeWebSocket();
-      const info1 = createClientInfo({ ws: ws1, userId: "user-1" });
-      const info2 = createClientInfo({ ws: ws2, userId: "user-2" });
+      const info1 = createClientInfo({ userId: "user-1" });
+      const info2 = createClientInfo({ userId: "user-2" });
 
       manager.setClient(ws1, info1);
       manager.setClient(ws2, info2);
@@ -1289,7 +1288,7 @@ describe("SessionWebSocketManagerImpl", () => {
       const { manager, sockets, mockRepo } = createManager();
       const ws = createFakeWebSocket();
       sockets.set(ws, ["wsid:ws-expired"]);
-      manager.setClient(ws, createClientInfo({ ws, authorizationExpiresAt: Date.now() - 1 }));
+      manager.setClient(ws, createClientInfo({ authorizationExpiresAt: Date.now() - 1 }));
       mockRepo.addMapping("ws-expired", {
         participant_id: "part-1",
         client_id: "client-1",

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for SessionWebSocketManagerImpl.
  *
- * Uses a fake SocketHost and mock repositories to test
+ * Uses a fake SessionWebSocketHost and mock repositories to test
  * all WebSocket mechanics in isolation from the host.
  */
 
@@ -9,8 +9,8 @@ import { describe, it, expect, vi } from "vitest";
 import { SessionWebSocketManagerImpl } from "./websocket-manager";
 import type { WebSocketManagerConfig } from "./websocket-manager";
 import type { Logger } from "../logger";
-import type { SessionSocket } from "../platform-ports";
-import type { SocketHost } from "./platform";
+import type { SessionWebSocket } from "../platform-ports";
+import type { SessionWebSocketHost } from "./platform";
 import type { ClientInfo } from "../types";
 import type { SandboxRepository } from "./sandbox-repository";
 import type {
@@ -55,18 +55,18 @@ function createFakeWebSocket(readyState = WebSocket.OPEN): WebSocket {
 
 /** Type for the fake DurableObjectState with test helpers. */
 interface FakeSocketHost {
-  sockets: Map<SessionSocket, string[]>;
-  host: SocketHost;
+  sockets: Map<SessionWebSocket, string[]>;
+  host: SessionWebSocketHost;
 }
 
 /**
- * Fake SocketHost that tracks accepted WebSockets and their tags.
+ * Fake SessionWebSocketHost that tracks accepted WebSockets and their tags.
  */
 function createFakeSocketHost(): FakeSocketHost {
-  const sockets = new Map<SessionSocket, string[]>();
+  const sockets = new Map<SessionWebSocket, string[]>();
 
-  const host: SocketHost = {
-    accept(ws, tags) {
+  const host: SessionWebSocketHost = {
+    adopt(ws, tags) {
       sockets.set(ws, tags);
     },
     tags(ws) {
@@ -1030,7 +1030,7 @@ describe("SessionWebSocketManagerImpl", () => {
       sockets.set(clientWs2, ["wsid:ws-2"]);
       sockets.set(sandboxWs, ["sandbox"]);
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("all_clients", (ws) => called.push(ws));
 
       expect(called).toHaveLength(2);
@@ -1049,7 +1049,7 @@ describe("SessionWebSocketManagerImpl", () => {
 
       manager.setClient(authedWs, createClientInfo());
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toEqual([authedWs]);
@@ -1072,7 +1072,7 @@ describe("SessionWebSocketManagerImpl", () => {
         authorization_expires_at: Date.now() + 300_000,
       });
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toEqual([ws]);
@@ -1084,7 +1084,7 @@ describe("SessionWebSocketManagerImpl", () => {
 
       sockets.set(ws, ["wsid:ws-unknown"]);
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toHaveLength(0);
@@ -1096,7 +1096,7 @@ describe("SessionWebSocketManagerImpl", () => {
       sockets.set(ws, ["wsid:ws-expired"]);
       manager.setClient(ws, createClientInfo({ authorizationExpiresAt: Date.now() - 1 }));
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (client) => called.push(client));
 
       expect(called).toEqual([]);
@@ -1116,7 +1116,7 @@ describe("SessionWebSocketManagerImpl", () => {
         authorization_expires_at: Date.now() - 1,
       });
 
-      const called: SessionSocket[] = [];
+      const called: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (client) => called.push(client));
 
       expect(called).toEqual([]);
@@ -1170,11 +1170,11 @@ describe("SessionWebSocketManagerImpl", () => {
 
       sockets.set(sandboxWs, ["sandbox"]);
 
-      const allClientsCalled: SessionSocket[] = [];
+      const allClientsCalled: SessionWebSocket[] = [];
       manager.forEachClientSocket("all_clients", (ws) => allClientsCalled.push(ws));
       expect(allClientsCalled).toHaveLength(0);
 
-      const authOnlyCalled: SessionSocket[] = [];
+      const authOnlyCalled: SessionWebSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => authOnlyCalled.push(ws));
       expect(authOnlyCalled).toHaveLength(0);
     });

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from "vitest";
 import { SessionWebSocketManagerImpl } from "./websocket-manager";
 import type { WebSocketManagerConfig } from "./websocket-manager";
 import type { Logger } from "../logger";
+import type { SessionSocket } from "../platform-ports";
 import type { SocketHost } from "./platform";
 import type { ClientInfo } from "../types";
 import type { SandboxRepository } from "./sandbox-repository";
@@ -54,7 +55,7 @@ function createFakeWebSocket(readyState = WebSocket.OPEN): WebSocket {
 
 /** Type for the fake DurableObjectState with test helpers. */
 interface FakeSocketHost {
-  sockets: Map<WebSocket, string[]>;
+  sockets: Map<SessionSocket, string[]>;
   host: SocketHost;
 }
 
@@ -62,7 +63,7 @@ interface FakeSocketHost {
  * Fake SocketHost that tracks accepted WebSockets and their tags.
  */
 function createFakeSocketHost(): FakeSocketHost {
-  const sockets = new Map<WebSocket, string[]>();
+  const sockets = new Map<SessionSocket, string[]>();
 
   const host: SocketHost = {
     accept(ws, tags) {
@@ -1030,7 +1031,7 @@ describe("SessionWebSocketManagerImpl", () => {
       sockets.set(clientWs2, ["wsid:ws-2"]);
       sockets.set(sandboxWs, ["sandbox"]);
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("all_clients", (ws) => called.push(ws));
 
       expect(called).toHaveLength(2);
@@ -1049,7 +1050,7 @@ describe("SessionWebSocketManagerImpl", () => {
 
       manager.setClient(authedWs, createClientInfo({ ws: authedWs }));
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toEqual([authedWs]);
@@ -1072,7 +1073,7 @@ describe("SessionWebSocketManagerImpl", () => {
         authorization_expires_at: Date.now() + 300_000,
       });
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toEqual([ws]);
@@ -1084,7 +1085,7 @@ describe("SessionWebSocketManagerImpl", () => {
 
       sockets.set(ws, ["wsid:ws-unknown"]);
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => called.push(ws));
 
       expect(called).toHaveLength(0);
@@ -1096,7 +1097,7 @@ describe("SessionWebSocketManagerImpl", () => {
       sockets.set(ws, ["wsid:ws-expired"]);
       manager.setClient(ws, createClientInfo({ ws, authorizationExpiresAt: Date.now() - 1 }));
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (client) => called.push(client));
 
       expect(called).toEqual([]);
@@ -1116,7 +1117,7 @@ describe("SessionWebSocketManagerImpl", () => {
         authorization_expires_at: Date.now() - 1,
       });
 
-      const called: WebSocket[] = [];
+      const called: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (client) => called.push(client));
 
       expect(called).toEqual([]);
@@ -1170,11 +1171,11 @@ describe("SessionWebSocketManagerImpl", () => {
 
       sockets.set(sandboxWs, ["sandbox"]);
 
-      const allClientsCalled: WebSocket[] = [];
+      const allClientsCalled: SessionSocket[] = [];
       manager.forEachClientSocket("all_clients", (ws) => allClientsCalled.push(ws));
       expect(allClientsCalled).toHaveLength(0);
 
-      const authOnlyCalled: WebSocket[] = [];
+      const authOnlyCalled: SessionSocket[] = [];
       manager.forEachClientSocket("authenticated_only", (ws) => authOnlyCalled.push(ws));
       expect(authOnlyCalled).toHaveLength(0);
     });

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -1,6 +1,6 @@
 /**
  * SessionWebSocketManager — the session's socket registry over its
- * `SocketHost`.
+ * `SessionWebSocketHost`.
  *
  * The manager owns socket identity, persistence, and authorization leases.
  * The connection authenticator builds ClientInfo and stores it here after
@@ -14,9 +14,9 @@
  */
 
 import type { Logger } from "../logger";
-import { isSocketOpen, type AlarmScheduler, type SessionSocket } from "../platform-ports";
+import { isSocketOpen, type AlarmScheduler, type SessionWebSocket } from "../platform-ports";
 import type { ClientInfo } from "../types";
-import type { SocketHost } from "./platform";
+import type { SessionWebSocketHost } from "./platform";
 import type { ConnectionClassification } from "./ports";
 import type { SandboxRepository } from "./sandbox-repository";
 import type { SandboxRow } from "./types";
@@ -41,25 +41,25 @@ export interface WebSocketManagerConfig {
 /** Manages session sockets, client identity, and expiring authorization leases. */
 export interface SessionWebSocketManager {
   /** Accept a client WebSocket with a wsId tag for hibernation recovery. */
-  acceptClientSocket(ws: SessionSocket, wsId: string): void;
+  acceptClientSocket(ws: SessionWebSocket, wsId: string): void;
 
   /**
    * Accept a sandbox WebSocket as the session's active bridge: persist its
    * identity, then close every other sandbox socket.
    */
-  acceptAndSetSandboxSocket(ws: SessionSocket, sandboxId?: string): { replaced: boolean };
+  acceptAndSetSandboxSocket(ws: SessionWebSocket, sandboxId?: string): { replaced: boolean };
 
   /** Whether `ws` is the sandbox socket the session currently dispatches to. */
-  isActiveSandboxSocket(ws: SessionSocket): boolean;
+  isActiveSandboxSocket(ws: SessionWebSocket): boolean;
 
   /** Parse a WebSocket's tags to determine its kind and identity. */
-  classify(ws: SessionSocket): ConnectionClassification;
+  classify(ws: SessionWebSocket): ConnectionClassification;
 
   /**
    * Get the active sandbox socket, recovering from hibernation if needed.
    * Validates sandbox ID against the repository during hibernation recovery.
    */
-  getSandboxSocket(): SessionSocket | null;
+  getSandboxSocket(): SessionWebSocket | null;
 
   /** Clear the in-memory sandbox socket reference. */
   clearSandboxSocket(): void;
@@ -76,38 +76,42 @@ export interface SessionWebSocketManager {
    * it was the active socket — whether its close is the loss of the session's
    * bridge rather than the tail of a replacement.
    */
-  clearSandboxSocketIfMatch(ws: SessionSocket): boolean;
+  clearSandboxSocketIfMatch(ws: SessionWebSocket): boolean;
 
-  setClient(ws: SessionSocket, info: ClientInfo): void;
-  removeClient(ws: SessionSocket): ClientInfo | null;
+  setClient(ws: SessionWebSocket, info: ClientInfo): void;
+  removeClient(ws: SessionWebSocket): ClientInfo | null;
 
   /** Schedule, synchronize, and atomically publish a client authorization lease. */
-  activateClient(ws: SessionSocket, info: ClientInfo, synchronize: () => boolean): Promise<boolean>;
+  activateClient(
+    ws: SessionWebSocket,
+    info: ClientInfo,
+    synchronize: () => boolean
+  ): Promise<boolean>;
 
   /** Return a live client or its persisted hibernation mapping, rejecting expired leases. */
-  lookupClient(ws: SessionSocket): ClientLookup;
+  lookupClient(ws: SessionWebSocket): ClientLookup;
 
   /** Close expired sockets, delete expired mappings, and schedule the next lease deadline. */
   expireAuthorizationLeases(now: number): Promise<void>;
 
-  setClientSynchronizing(ws: SessionSocket, synchronizing: boolean): void;
-  isClientSynchronizing(ws: SessionSocket): boolean;
+  setClientSynchronizing(ws: SessionWebSocket, synchronizing: boolean): void;
+  isClientSynchronizing(ws: SessionWebSocket): boolean;
   /** Return whether the client has an unexpired authorization lease. */
-  isClientAuthenticated(ws: SessionSocket): boolean;
+  isClientAuthenticated(ws: SessionWebSocket): boolean;
 
   /** Check if a wsId has a persisted mapping (used by auth timeout). */
   hasPersistedMapping(wsId: string): boolean;
 
-  send(ws: SessionSocket, message: string | object): boolean;
-  close(ws: SessionSocket, code: number, reason: string): void;
+  send(ws: SessionWebSocket, message: string | object): boolean;
+  close(ws: SessionWebSocket, code: number, reason: string): void;
 
   /** Visit client sockets, optionally limiting the visit to unexpired authorization leases. */
   forEachClientSocket(
     mode: "all_clients" | "authenticated_only",
-    fn: (ws: SessionSocket) => void
+    fn: (ws: SessionWebSocket) => void
   ): void;
 
-  enforceAuthTimeout(ws: SessionSocket, wsId: string): Promise<void>;
+  enforceAuthTimeout(ws: SessionWebSocket, wsId: string): Promise<void>;
   getAuthenticatedClients(): IterableIterator<ClientInfo>;
   getConnectedClientCount(): number;
 }
@@ -125,13 +129,13 @@ export type ClientLookup =
 
 /** Session WebSocket manager with persisted authorization leases. */
 export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
-  private clients = new Map<SessionSocket, ClientInfo>();
-  private synchronizingClients = new Set<SessionSocket>();
-  private sandboxWs: SessionSocket | null = null;
+  private clients = new Map<SessionWebSocket, ClientInfo>();
+  private synchronizingClients = new Set<SessionWebSocket>();
+  private sandboxWs: SessionWebSocket | null = null;
 
   /** Create a WebSocket manager over the host's sockets and persisted client mappings. */
   constructor(
-    private readonly host: SocketHost,
+    private readonly host: SessionWebSocketHost,
     private readonly sandboxRepository: SandboxRepository,
     private readonly wsClientMappingRepository: WsClientMappingRepository,
     private readonly alarmScheduler: AlarmScheduler,
@@ -143,14 +147,14 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Accept
   // -------------------------------------------------------------------------
 
-  acceptClientSocket(ws: SessionSocket, wsId: string): void {
-    this.host.accept(ws, [`wsid:${wsId}`]);
+  acceptClientSocket(ws: SessionWebSocket, wsId: string): void {
+    this.host.adopt(ws, [`wsid:${wsId}`]);
   }
 
-  acceptAndSetSandboxSocket(ws: SessionSocket, sandboxId?: string): { replaced: boolean } {
+  acceptAndSetSandboxSocket(ws: SessionWebSocket, sandboxId?: string): { replaced: boolean } {
     const socketId = `sbws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     const tags = ["sandbox", ...(sandboxId ? [`sid:${sandboxId}`] : []), `socket:${socketId}`];
-    this.host.accept(ws, tags);
+    this.host.adopt(ws, tags);
     // Advance the persisted identity before anything else observes the new
     // socket: from here on every earlier bridge socket is refused at dispatch
     // whether or not its close below completes, and recovery after a restart
@@ -181,7 +185,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Classification
   // -------------------------------------------------------------------------
 
-  classify(ws: SessionSocket): ConnectionClassification {
+  classify(ws: SessionWebSocket): ConnectionClassification {
     const tags = this.host.tags(ws);
     if (tags.includes("sandbox")) {
       const sidTag = tags.find((t) => t.startsWith("sid:"));
@@ -196,7 +200,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Sandbox socket
   // -------------------------------------------------------------------------
 
-  isActiveSandboxSocket(ws: SessionSocket): boolean {
+  isActiveSandboxSocket(ws: SessionWebSocket): boolean {
     return this.isAuthoritative(this.classify(ws), this.sandboxRepository.getSandbox());
   }
 
@@ -218,7 +222,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return parsed.socketId !== undefined && parsed.socketId === sandbox.active_socket_id;
   }
 
-  getSandboxSocket(): SessionSocket | null {
+  getSandboxSocket(): SessionWebSocket | null {
     const sandbox = this.sandboxRepository.getSandbox();
     const expectedSandboxId = sandbox?.modal_sandbox_id;
 
@@ -278,7 +282,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   }
 
   detachSandboxSocket(code: number, reason: string): void {
-    const sockets = new Set<SessionSocket>();
+    const sockets = new Set<SessionWebSocket>();
     if (this.sandboxWs) sockets.add(this.sandboxWs);
     for (const ws of this.host.sockets()) {
       if (this.classify(ws).kind === "sandbox") sockets.add(ws);
@@ -290,7 +294,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     for (const ws of sockets) this.close(ws, code, reason);
   }
 
-  clearSandboxSocketIfMatch(ws: SessionSocket): boolean {
+  clearSandboxSocketIfMatch(ws: SessionWebSocket): boolean {
     const active = this.isActiveSandboxSocket(ws);
     if (active || this.sandboxWs === ws) this.sandboxWs = null;
     return active;
@@ -300,11 +304,11 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Client identity registry
   // -------------------------------------------------------------------------
 
-  setClient(ws: SessionSocket, info: ClientInfo): void {
+  setClient(ws: SessionWebSocket, info: ClientInfo): void {
     this.clients.set(ws, info);
   }
 
-  removeClient(ws: SessionSocket): ClientInfo | null {
+  removeClient(ws: SessionWebSocket): ClientInfo | null {
     return this.teardownClient(ws, this.classify(ws));
   }
 
@@ -313,7 +317,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // -------------------------------------------------------------------------
 
   /** Return cached or persisted client state, closing the socket if its lease expired. */
-  lookupClient(ws: SessionSocket): ClientLookup {
+  lookupClient(ws: SessionWebSocket): ClientLookup {
     const client = this.clients.get(ws);
     if (client) {
       if (client.authorizationExpiresAt <= Date.now()) {
@@ -336,7 +340,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
 
   /** Schedule and synchronize before publishing persistent and in-memory identity together. */
   async activateClient(
-    ws: SessionSocket,
+    ws: SessionWebSocket,
     info: ClientInfo,
     synchronize: () => boolean
   ): Promise<boolean> {
@@ -382,17 +386,17 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     if (nextExpiry !== null) await this.alarmScheduler.schedule(nextExpiry);
   }
 
-  setClientSynchronizing(ws: SessionSocket, synchronizing: boolean): void {
+  setClientSynchronizing(ws: SessionWebSocket, synchronizing: boolean): void {
     if (synchronizing) this.synchronizingClients.add(ws);
     else this.synchronizingClients.delete(ws);
   }
 
-  isClientSynchronizing(ws: SessionSocket): boolean {
+  isClientSynchronizing(ws: SessionWebSocket): boolean {
     return this.synchronizingClients.has(ws);
   }
 
   /** Return whether the client has an unexpired authorization lease. */
-  isClientAuthenticated(ws: SessionSocket): boolean {
+  isClientAuthenticated(ws: SessionWebSocket): boolean {
     return this.isAuthenticated(ws, this.classify(ws));
   }
 
@@ -404,7 +408,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Send / close
   // -------------------------------------------------------------------------
 
-  send(ws: SessionSocket, message: string | object): boolean {
+  send(ws: SessionWebSocket, message: string | object): boolean {
     try {
       if (!isSocketOpen(ws)) {
         this.log.debug("Cannot send: WebSocket not open", { ready_state: ws.readyState });
@@ -419,7 +423,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     }
   }
 
-  close(ws: SessionSocket, code: number, reason: string): void {
+  close(ws: SessionWebSocket, code: number, reason: string): void {
     try {
       ws.close(code, reason);
     } catch {
@@ -434,7 +438,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   /** Visit client sockets, optionally limiting the visit to unexpired authorization leases. */
   forEachClientSocket(
     mode: "all_clients" | "authenticated_only",
-    fn: (ws: SessionSocket) => void
+    fn: (ws: SessionWebSocket) => void
   ): void {
     for (const ws of this.host.sockets()) {
       const parsed = this.classify(ws);
@@ -452,7 +456,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
    * Check whether a client socket has authentication evidence,
    * either in-memory or via persisted DB mapping (post-hibernation).
    */
-  private isAuthenticated(ws: SessionSocket, parsed: ConnectionClassification): boolean {
+  private isAuthenticated(ws: SessionWebSocket, parsed: ConnectionClassification): boolean {
     const expiresAt = this.authorizationExpiry(ws, parsed);
     if (expiresAt === null) return false;
     if (expiresAt > Date.now()) return true;
@@ -460,7 +464,10 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return false;
   }
 
-  private authorizationExpiry(ws: SessionSocket, parsed: ConnectionClassification): number | null {
+  private authorizationExpiry(
+    ws: SessionWebSocket,
+    parsed: ConnectionClassification
+  ): number | null {
     const client = this.clients.get(ws);
     if (client) return client.authorizationExpiresAt;
     if (parsed.kind !== "client" || !parsed.wsId) return null;
@@ -468,13 +475,16 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return mapping?.authorization_expires_at ?? null;
   }
 
-  private rejectExpiredAuthorization(ws: SessionSocket, parsed: ConnectionClassification): void {
+  private rejectExpiredAuthorization(ws: SessionWebSocket, parsed: ConnectionClassification): void {
     this.teardownClient(ws, parsed);
     this.close(ws, WS_CLOSE_AUTHORIZATION_REVOKED, WS_AUTHORIZATION_REVOKED_REASON);
   }
 
   /** Remove every representation of a client before callers notify or close it. */
-  private teardownClient(ws: SessionSocket, parsed: ConnectionClassification): ClientInfo | null {
+  private teardownClient(
+    ws: SessionWebSocket,
+    parsed: ConnectionClassification
+  ): ClientInfo | null {
     const client = this.clients.get(ws) ?? null;
     this.clients.delete(ws);
     this.synchronizingClients.delete(ws);
@@ -488,7 +498,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Auth timeout enforcement
   // -------------------------------------------------------------------------
 
-  async enforceAuthTimeout(ws: SessionSocket, wsId: string): Promise<void> {
+  async enforceAuthTimeout(ws: SessionWebSocket, wsId: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, this.config.authTimeoutMs));
 
     if (!isSocketOpen(ws)) return;

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Logger } from "../logger";
-import type { AlarmScheduler } from "../platform-ports";
+import type { AlarmScheduler, SessionSocket } from "../platform-ports";
 import type { ClientInfo } from "../types";
 import type { SocketHost } from "./platform";
 import type { ConnectionClassification } from "./ports";
@@ -41,25 +41,25 @@ export interface WebSocketManagerConfig {
 /** Manages session sockets, client identity, and expiring authorization leases. */
 export interface SessionWebSocketManager {
   /** Accept a client WebSocket with a wsId tag for hibernation recovery. */
-  acceptClientSocket(ws: WebSocket, wsId: string): void;
+  acceptClientSocket(ws: SessionSocket, wsId: string): void;
 
   /**
    * Accept a sandbox WebSocket as the session's active bridge: persist its
    * identity, then close every other sandbox socket.
    */
-  acceptAndSetSandboxSocket(ws: WebSocket, sandboxId?: string): { replaced: boolean };
+  acceptAndSetSandboxSocket(ws: SessionSocket, sandboxId?: string): { replaced: boolean };
 
   /** Whether `ws` is the sandbox socket the session currently dispatches to. */
-  isActiveSandboxSocket(ws: WebSocket): boolean;
+  isActiveSandboxSocket(ws: SessionSocket): boolean;
 
   /** Parse a WebSocket's tags to determine its kind and identity. */
-  classify(ws: WebSocket): ConnectionClassification;
+  classify(ws: SessionSocket): ConnectionClassification;
 
   /**
    * Get the active sandbox socket, recovering from hibernation if needed.
    * Validates sandbox ID against the repository during hibernation recovery.
    */
-  getSandboxSocket(): WebSocket | null;
+  getSandboxSocket(): SessionSocket | null;
 
   /** Clear the in-memory sandbox socket reference. */
   clearSandboxSocket(): void;
@@ -76,38 +76,38 @@ export interface SessionWebSocketManager {
    * it was the active socket — whether its close is the loss of the session's
    * bridge rather than the tail of a replacement.
    */
-  clearSandboxSocketIfMatch(ws: WebSocket): boolean;
+  clearSandboxSocketIfMatch(ws: SessionSocket): boolean;
 
-  setClient(ws: WebSocket, info: ClientInfo): void;
-  removeClient(ws: WebSocket): ClientInfo | null;
+  setClient(ws: SessionSocket, info: ClientInfo): void;
+  removeClient(ws: SessionSocket): ClientInfo | null;
 
   /** Schedule, synchronize, and atomically publish a client authorization lease. */
-  activateClient(ws: WebSocket, info: ClientInfo, synchronize: () => boolean): Promise<boolean>;
+  activateClient(ws: SessionSocket, info: ClientInfo, synchronize: () => boolean): Promise<boolean>;
 
   /** Return a live client or its persisted hibernation mapping, rejecting expired leases. */
-  lookupClient(ws: WebSocket): ClientLookup;
+  lookupClient(ws: SessionSocket): ClientLookup;
 
   /** Close expired sockets, delete expired mappings, and schedule the next lease deadline. */
   expireAuthorizationLeases(now: number): Promise<void>;
 
-  setClientSynchronizing(ws: WebSocket, synchronizing: boolean): void;
-  isClientSynchronizing(ws: WebSocket): boolean;
+  setClientSynchronizing(ws: SessionSocket, synchronizing: boolean): void;
+  isClientSynchronizing(ws: SessionSocket): boolean;
   /** Return whether the client has an unexpired authorization lease. */
-  isClientAuthenticated(ws: WebSocket): boolean;
+  isClientAuthenticated(ws: SessionSocket): boolean;
 
   /** Check if a wsId has a persisted mapping (used by auth timeout). */
   hasPersistedMapping(wsId: string): boolean;
 
-  send(ws: WebSocket, message: string | object): boolean;
-  close(ws: WebSocket, code: number, reason: string): void;
+  send(ws: SessionSocket, message: string | object): boolean;
+  close(ws: SessionSocket, code: number, reason: string): void;
 
   /** Visit client sockets, optionally limiting the visit to unexpired authorization leases. */
   forEachClientSocket(
     mode: "all_clients" | "authenticated_only",
-    fn: (ws: WebSocket) => void
+    fn: (ws: SessionSocket) => void
   ): void;
 
-  enforceAuthTimeout(ws: WebSocket, wsId: string): Promise<void>;
+  enforceAuthTimeout(ws: SessionSocket, wsId: string): Promise<void>;
   getAuthenticatedClients(): IterableIterator<ClientInfo>;
   getConnectedClientCount(): number;
 }
@@ -125,9 +125,9 @@ export type ClientLookup =
 
 /** Session WebSocket manager with persisted authorization leases. */
 export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
-  private clients = new Map<WebSocket, ClientInfo>();
-  private synchronizingClients = new Set<WebSocket>();
-  private sandboxWs: WebSocket | null = null;
+  private clients = new Map<SessionSocket, ClientInfo>();
+  private synchronizingClients = new Set<SessionSocket>();
+  private sandboxWs: SessionSocket | null = null;
 
   /** Create a WebSocket manager over the host's sockets and persisted client mappings. */
   constructor(
@@ -143,11 +143,11 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Accept
   // -------------------------------------------------------------------------
 
-  acceptClientSocket(ws: WebSocket, wsId: string): void {
+  acceptClientSocket(ws: SessionSocket, wsId: string): void {
     this.host.accept(ws, [`wsid:${wsId}`]);
   }
 
-  acceptAndSetSandboxSocket(ws: WebSocket, sandboxId?: string): { replaced: boolean } {
+  acceptAndSetSandboxSocket(ws: SessionSocket, sandboxId?: string): { replaced: boolean } {
     const socketId = `sbws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     const tags = ["sandbox", ...(sandboxId ? [`sid:${sandboxId}`] : []), `socket:${socketId}`];
     this.host.accept(ws, tags);
@@ -181,7 +181,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Classification
   // -------------------------------------------------------------------------
 
-  classify(ws: WebSocket): ConnectionClassification {
+  classify(ws: SessionSocket): ConnectionClassification {
     const tags = this.host.tags(ws);
     if (tags.includes("sandbox")) {
       const sidTag = tags.find((t) => t.startsWith("sid:"));
@@ -196,7 +196,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Sandbox socket
   // -------------------------------------------------------------------------
 
-  isActiveSandboxSocket(ws: WebSocket): boolean {
+  isActiveSandboxSocket(ws: SessionSocket): boolean {
     return this.isAuthoritative(this.classify(ws), this.sandboxRepository.getSandbox());
   }
 
@@ -218,7 +218,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return parsed.socketId !== undefined && parsed.socketId === sandbox.active_socket_id;
   }
 
-  getSandboxSocket(): WebSocket | null {
+  getSandboxSocket(): SessionSocket | null {
     const sandbox = this.sandboxRepository.getSandbox();
     const expectedSandboxId = sandbox?.modal_sandbox_id;
 
@@ -278,7 +278,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   }
 
   detachSandboxSocket(code: number, reason: string): void {
-    const sockets = new Set<WebSocket>();
+    const sockets = new Set<SessionSocket>();
     if (this.sandboxWs) sockets.add(this.sandboxWs);
     for (const ws of this.host.sockets()) {
       if (this.classify(ws).kind === "sandbox") sockets.add(ws);
@@ -290,7 +290,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     for (const ws of sockets) this.close(ws, code, reason);
   }
 
-  clearSandboxSocketIfMatch(ws: WebSocket): boolean {
+  clearSandboxSocketIfMatch(ws: SessionSocket): boolean {
     const active = this.isActiveSandboxSocket(ws);
     if (active || this.sandboxWs === ws) this.sandboxWs = null;
     return active;
@@ -300,11 +300,11 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Client identity registry
   // -------------------------------------------------------------------------
 
-  setClient(ws: WebSocket, info: ClientInfo): void {
+  setClient(ws: SessionSocket, info: ClientInfo): void {
     this.clients.set(ws, info);
   }
 
-  removeClient(ws: WebSocket): ClientInfo | null {
+  removeClient(ws: SessionSocket): ClientInfo | null {
     return this.teardownClient(ws, this.classify(ws));
   }
 
@@ -313,7 +313,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // -------------------------------------------------------------------------
 
   /** Return cached or persisted client state, closing the socket if its lease expired. */
-  lookupClient(ws: WebSocket): ClientLookup {
+  lookupClient(ws: SessionSocket): ClientLookup {
     const client = this.clients.get(ws);
     if (client) {
       if (client.authorizationExpiresAt <= Date.now()) {
@@ -336,7 +336,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
 
   /** Schedule and synchronize before publishing persistent and in-memory identity together. */
   async activateClient(
-    ws: WebSocket,
+    ws: SessionSocket,
     info: ClientInfo,
     synchronize: () => boolean
   ): Promise<boolean> {
@@ -382,17 +382,17 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     if (nextExpiry !== null) await this.alarmScheduler.schedule(nextExpiry);
   }
 
-  setClientSynchronizing(ws: WebSocket, synchronizing: boolean): void {
+  setClientSynchronizing(ws: SessionSocket, synchronizing: boolean): void {
     if (synchronizing) this.synchronizingClients.add(ws);
     else this.synchronizingClients.delete(ws);
   }
 
-  isClientSynchronizing(ws: WebSocket): boolean {
+  isClientSynchronizing(ws: SessionSocket): boolean {
     return this.synchronizingClients.has(ws);
   }
 
   /** Return whether the client has an unexpired authorization lease. */
-  isClientAuthenticated(ws: WebSocket): boolean {
+  isClientAuthenticated(ws: SessionSocket): boolean {
     return this.isAuthenticated(ws, this.classify(ws));
   }
 
@@ -404,7 +404,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Send / close
   // -------------------------------------------------------------------------
 
-  send(ws: WebSocket, message: string | object): boolean {
+  send(ws: SessionSocket, message: string | object): boolean {
     try {
       if (ws.readyState !== WebSocket.OPEN) {
         this.log.debug("Cannot send: WebSocket not open", { ready_state: ws.readyState });
@@ -419,7 +419,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     }
   }
 
-  close(ws: WebSocket, code: number, reason: string): void {
+  close(ws: SessionSocket, code: number, reason: string): void {
     try {
       ws.close(code, reason);
     } catch {
@@ -434,7 +434,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   /** Visit client sockets, optionally limiting the visit to unexpired authorization leases. */
   forEachClientSocket(
     mode: "all_clients" | "authenticated_only",
-    fn: (ws: WebSocket) => void
+    fn: (ws: SessionSocket) => void
   ): void {
     for (const ws of this.host.sockets()) {
       const parsed = this.classify(ws);
@@ -452,7 +452,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
    * Check whether a client socket has authentication evidence,
    * either in-memory or via persisted DB mapping (post-hibernation).
    */
-  private isAuthenticated(ws: WebSocket, parsed: ConnectionClassification): boolean {
+  private isAuthenticated(ws: SessionSocket, parsed: ConnectionClassification): boolean {
     const expiresAt = this.authorizationExpiry(ws, parsed);
     if (expiresAt === null) return false;
     if (expiresAt > Date.now()) return true;
@@ -460,7 +460,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return false;
   }
 
-  private authorizationExpiry(ws: WebSocket, parsed: ConnectionClassification): number | null {
+  private authorizationExpiry(ws: SessionSocket, parsed: ConnectionClassification): number | null {
     const client = this.clients.get(ws);
     if (client) return client.authorizationExpiresAt;
     if (parsed.kind !== "client" || !parsed.wsId) return null;
@@ -468,13 +468,13 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     return mapping?.authorization_expires_at ?? null;
   }
 
-  private rejectExpiredAuthorization(ws: WebSocket, parsed: ConnectionClassification): void {
+  private rejectExpiredAuthorization(ws: SessionSocket, parsed: ConnectionClassification): void {
     this.teardownClient(ws, parsed);
     this.close(ws, WS_CLOSE_AUTHORIZATION_REVOKED, WS_AUTHORIZATION_REVOKED_REASON);
   }
 
   /** Remove every representation of a client before callers notify or close it. */
-  private teardownClient(ws: WebSocket, parsed: ConnectionClassification): ClientInfo | null {
+  private teardownClient(ws: SessionSocket, parsed: ConnectionClassification): ClientInfo | null {
     const client = this.clients.get(ws) ?? null;
     this.clients.delete(ws);
     this.synchronizingClients.delete(ws);
@@ -488,7 +488,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   // Auth timeout enforcement
   // -------------------------------------------------------------------------
 
-  async enforceAuthTimeout(ws: WebSocket, wsId: string): Promise<void> {
+  async enforceAuthTimeout(ws: SessionSocket, wsId: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, this.config.authTimeoutMs));
 
     if (ws.readyState !== WebSocket.OPEN) return;

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Logger } from "../logger";
-import type { AlarmScheduler, SessionSocket } from "../platform-ports";
+import { isSocketOpen, type AlarmScheduler, type SessionSocket } from "../platform-ports";
 import type { ClientInfo } from "../types";
 import type { SocketHost } from "./platform";
 import type { ConnectionClassification } from "./ports";
@@ -164,7 +164,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     const existingSockets = new Set(this.host.sockets("sandbox"));
     if (this.sandboxWs) existingSockets.add(this.sandboxWs);
     for (const existing of existingSockets) {
-      if (existing === ws || existing.readyState !== WebSocket.OPEN) continue;
+      if (existing === ws || !isSocketOpen(existing)) continue;
       try {
         existing.close(1000, "New sandbox connecting");
         replaced = true;
@@ -239,7 +239,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
       return null;
     }
 
-    if (this.sandboxWs?.readyState === WebSocket.OPEN) {
+    if (this.sandboxWs && isSocketOpen(this.sandboxWs)) {
       if (this.isAuthoritative(this.classify(this.sandboxWs), sandbox)) {
         return this.sandboxWs;
       }
@@ -253,7 +253,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     // open while its close completes, and must not win for coming first.
     for (const ws of this.host.sockets()) {
       const parsed = this.classify(ws);
-      if (parsed.kind !== "sandbox" || ws.readyState !== WebSocket.OPEN) continue;
+      if (parsed.kind !== "sandbox" || !isSocketOpen(ws)) continue;
 
       if (expectedSandboxId && parsed.sandboxId !== expectedSandboxId) {
         this.log.debug("Skipping WS with wrong sandbox ID", {
@@ -345,7 +345,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
       throw new Error("Cannot activate a client without a WebSocket ID");
     }
     await this.alarmScheduler.schedule(info.authorizationExpiresAt);
-    if (ws.readyState !== WebSocket.OPEN || info.authorizationExpiresAt <= Date.now()) {
+    if (!isSocketOpen(ws) || info.authorizationExpiresAt <= Date.now()) {
       throw new Error("Cannot activate a closed client or an expired authorization lease");
     }
     // No await is allowed from snapshot send through both identity writes: a
@@ -406,7 +406,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
 
   send(ws: SessionSocket, message: string | object): boolean {
     try {
-      if (ws.readyState !== WebSocket.OPEN) {
+      if (!isSocketOpen(ws)) {
         this.log.debug("Cannot send: WebSocket not open", { ready_state: ws.readyState });
         return false;
       }
@@ -491,7 +491,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   async enforceAuthTimeout(ws: SessionSocket, wsId: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, this.config.authTimeoutMs));
 
-    if (ws.readyState !== WebSocket.OPEN) return;
+    if (!isSocketOpen(ws)) return;
     if (this.clients.has(ws)) return;
     if (this.synchronizingClients.has(ws)) return;
     if (this.hasPersistedMapping(wsId)) return;
@@ -520,7 +520,7 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     let count = 0;
     for (const ws of this.host.sockets()) {
       const parsed = this.classify(ws);
-      if (parsed.kind !== "sandbox" && ws.readyState === WebSocket.OPEN) {
+      if (parsed.kind !== "sandbox" && isSocketOpen(ws)) {
         count++;
       }
     }

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
-import type { SessionSocket } from "./platform-ports";
 
 // Environment bindings
 export interface Env {
@@ -123,6 +122,5 @@ export interface ClientInfo {
   clientId: string;
   /** Wall-clock time when this connection's authorization lease expires. */
   authorizationExpiresAt: number;
-  ws: SessionSocket;
   lastFetchHistoryAtMs?: number;
 }

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
+import type { SessionSocket } from "./platform-ports";
 
 // Environment bindings
 export interface Env {
@@ -122,6 +123,6 @@ export interface ClientInfo {
   clientId: string;
   /** Wall-clock time when this connection's authorization lease expires. */
   authorizationExpiresAt: number;
-  ws: WebSocket;
+  ws: SessionSocket;
   lastFetchHistoryAtMs?: number;
 }

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -111,7 +111,7 @@ export interface Env {
   LOG_LEVEL?: string; // "debug" | "info" | "warn" | "error" (default: "info")
 }
 
-/** Authenticated client state stored in Durable Object memory. */
+/** Authenticated client state stored in session-runtime memory. */
 export interface ClientInfo {
   participantId: string;
   userId: string;


### PR DESCRIPTION
## Why

N-8 on the multi-cloud roadmap: the session runtime identifies sockets by tag, enumerates them for broadcast and recovery, and answers the client keepalive without waking; a Node host needs its own implementation of that `SocketHost` port so the WebSocket manager and the rest of the core run unchanged on a container. Two commits, both required by COL-95.

## Commit 1: type the session core's sockets structurally

The core named the Workers `WebSocket` type wherever it held a socket, but only ever reads `readyState` and calls `send` and `close`. A `ws` socket is not assignable to that type, so shared code could not compile against both platforms. `SessionWebSocket` in `platform-ports.ts` is that three-member surface, and the core's annotations now use it (66 annotation sites, no logic change). The core's open checks go through `isSocketOpen` from the same module, so the neutral code no longer reads the ambient `WebSocket` global. `ClientInfo.ws`, which nothing read, is gone; the manager's map is the only socket-to-client association. The Durable Object adapter narrows back to its own socket type with an `instanceof` check, since only sockets it upgraded ever reach it; the workerd socket suites confirm the check holds on real hibernatable sockets.

## Commits 2 to 4: `NodeWebSocketHost` over `ws`

`src/node/socket-host.ts`, per session:

- `adopt(ws, tags)` adopts the `ws` socket the HTTP host (H-1) upgraded, refusing anything it did not upgrade (`instanceof`), double adoptions, and sockets that are not open.
- `tags` / `sockets(tag?)` back the manager's classification and enumeration. Tags outlive the socket's presence in the enumeration, so a closing socket still classifies for the disconnect handler.
- `setAutoResponse` answers the exact keepalive payload at the host level; any other text reaches the runtime.
- Message, close, and error events go to the bound `SessionWebSocketEventSink` (the session server's three entry points) with the Durable Object adapter's signatures: text as string, binary as a standalone `ArrayBuffer`, close with code, reason, and `wasClean` as `ws` computes it from both close-frame flags.
- The host owns inbound flow control: the socket is paused before each delivery and resumed when its queue empties, so a busy runtime leaves the peer's bytes in the kernel. Only the frames `ws` already decoded from the read in progress queue behind an in-flight delivery, bounded by `maxPendingDeliveries` (default 4096, sized against one socket read); a peer exceeding it is closed with 1013. One socket's events are delivered one at a time in arrival order, close last; a failing handler is logged (`socket.delivery_failed`) and never stalls the socket.
- `bindEventSink(sink)` is the one-shot seam for the session executor (H-2): ordering across sockets, requests, and alarms is its concern, not the host's. A host and its runtime share one lifetime; there is no re-binding.

`ws` 8.21.3 becomes a dependency of the control-plane package (`@types/ws` dev). It is Node-only: `src/node/**` is excluded from the worker bundle, and `worker-build.test.ts` plus the esbuild metafile confirm `ws` is not in it.

## Tests

- `src/node/socket-host.test.ts`: fourteen cases against a real `ws` server on an ephemeral port: tags and enumeration, wiring-error refusals, text and binary forwarding, keepalive auto-response with no runtime call, runtime-initiated close reaching the peer and the runtime, 1006 on `terminate()`, an incomplete closing handshake reported unclean, per-socket ordering with a blocked handler, a flooding peer paused with nothing lost, backlog overflow closed at the bound, failure logging, error forwarding, and the core's open check without the ambient global.
- Cloudflare adapter test gains the refusal case; the manager and platform suites are green; full unit suite 3733 passing; `websocket-sandbox`, `websocket-client`, `durable-object-eviction` workerd suites pass unchanged.
- Typecheck (including the Node program), lint, prettier, and knip clean.

No behavior change on Cloudflare. The conformance host contracts run on this host once H-1/H-2 give it an upgrade path and a registry (V-2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Node.js WebSocket session hosting with socket adoption, tagging, message forwarding, keepalive responses, connection lifecycle handling, and flow-control protection.
  * Added support for text and binary messages, connection errors, clean and unclean closes, and overloaded connection handling.

* **Bug Fixes**
  * WebSocket acceptance now rejects sockets that were not properly upgraded.
  * Socket handling no longer depends on a globally available WebSocket implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->