### PR TITLE
feat: NodeSqlDatabase over node:sqlite, migration runner, and SqlDatabase conformance (COL-89)

### DIFF
--- a/packages/control-plane/src/db/errors.test.ts
+++ b/packages/control-plane/src/db/errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isUniqueConstraintError } from "./errors";
+
+describe("isUniqueConstraintError", () => {
+  it("recognizes D1's message text", () => {
+    expect(isUniqueConstraintError(new Error("D1_ERROR: UNIQUE constraint failed: t.k"))).toBe(
+      true
+    );
+    expect(isUniqueConstraintError(new Error("no such table: t"))).toBe(false);
+  });
+
+  it("recognizes the SQLite result codes node:sqlite carries, whatever the message", () => {
+    const withCode = (errcode: number): Error =>
+      Object.assign(new Error("constraint failed"), { errcode });
+    expect(isUniqueConstraintError(withCode(2067))).toBe(true);
+    expect(isUniqueConstraintError(withCode(1555))).toBe(true);
+    expect(isUniqueConstraintError(withCode(787))).toBe(false);
+    expect(isUniqueConstraintError(null)).toBe(false);
+  });
+});

--- a/packages/control-plane/src/db/errors.ts
+++ b/packages/control-plane/src/db/errors.ts
@@ -1,9 +1,16 @@
 /**
  * Single point where engine-specific database error text is interpreted.
- * Today this matches SQLite/D1's message; a future engine adapter extends the
- * match here (e.g. Postgres SQLSTATE 23505) instead of per-store string checks.
+ * D1 surfaces constraint failures as message text; `node:sqlite` also
+ * carries the SQLite result code. A future engine adapter extends the match
+ * here (e.g. Postgres SQLSTATE 23505) instead of per-store string checks.
  */
+
+const SQLITE_CONSTRAINT_UNIQUE = 2067;
+const SQLITE_CONSTRAINT_PRIMARYKEY = 1555;
+
 export function isUniqueConstraintError(err: unknown): boolean {
+  const code = (err as { errcode?: unknown } | null)?.errcode;
+  if (code === SQLITE_CONSTRAINT_UNIQUE || code === SQLITE_CONSTRAINT_PRIMARYKEY) return true;
   const msg = err instanceof Error ? err.message : String(err);
   return msg.toLowerCase().includes("unique constraint failed");
 }

--- a/packages/control-plane/src/node/migrate.test.ts
+++ b/packages/control-plane/src/node/migrate.test.ts
@@ -1,8 +1,10 @@
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
+import { buildSync } from "esbuild";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { applyMigrations, containsTransactionControl, listMigrations } from "./migrate";
 
@@ -155,4 +157,58 @@ describe("applyMigrations", () => {
       true
     );
   });
+
+  it("lets several processes open and migrate one fresh file at once, applying each migration once", async () => {
+    const migrations = join(dir, "migrations");
+    mkdirMigrations(migrations, {
+      "0001_first.sql": "CREATE TABLE first (id INTEGER);",
+      "0002_second.sql": "CREATE TABLE second (id INTEGER);",
+    });
+    // The opener is bundled once so plain `node` can run it in each process.
+    const entry = join(dir, "open.ts");
+    const adapter = resolve(dirname(fileURLToPath(import.meta.url)), "sqlite-database.ts");
+    writeFileSync(
+      entry,
+      `import { openNodeSqlDatabase } from ${JSON.stringify(adapter)};
+       openNodeSqlDatabase(process.argv[2], { migrationsDir: process.argv[3] }).close();`
+    );
+    const script = join(dir, "open.mjs");
+    buildSync({
+      entryPoints: [entry],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      target: "node22",
+      outfile: script,
+      logLevel: "silent",
+    });
+    const path = join(dir, "global.db");
+
+    const children = Array.from(
+      { length: 4 },
+      () =>
+        new Promise<{ code: number | null; stderr: string }>((done) => {
+          const child = spawn(process.execPath, ["--no-warnings", script, path, migrations], {
+            stdio: ["ignore", "ignore", "pipe"],
+          });
+          let stderr = "";
+          child.stderr.on("data", (chunk) => (stderr += String(chunk)));
+          child.on("exit", (code) => done({ code, stderr }));
+        })
+    );
+    const results = await Promise.all(children);
+
+    expect(results.map((r) => [r.code, r.stderr])).toEqual(results.map(() => [0, ""]));
+    const file = new DatabaseSync(path);
+    try {
+      expect(ledger(file).map((row) => row.name)).toEqual(["0001_first.sql", "0002_second.sql"]);
+    } finally {
+      file.close();
+    }
+  });
 });
+
+function mkdirMigrations(directory: string, files: Record<string, string>): void {
+  mkdirSync(directory);
+  for (const [name, sql] of Object.entries(files)) writeFileSync(join(directory, name), sql);
+}

--- a/packages/control-plane/src/node/migrate.test.ts
+++ b/packages/control-plane/src/node/migrate.test.ts
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyMigrations, listMigrations } from "./migrate";
+import { applyMigrations, containsTransactionControl, listMigrations } from "./migrate";
 
 const MIGRATIONS_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -72,14 +72,22 @@ describe("applyMigrations", () => {
     );
   });
 
-  it("rejects files without a numeric prefix and duplicate prefixes before applying anything", () => {
+  it("rejects misnamed files and duplicate versions before applying anything", () => {
     writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
     writeFileSync(join(dir, "notes.sql"), "CREATE TABLE notes (id INTEGER);");
-    expect(() => applyMigrations(db, dir)).toThrow("without a leading numeric prefix: notes.sql");
+    expect(() => applyMigrations(db, dir)).toThrow("notes.sql is not named NNNN_description.sql");
     rmSync(join(dir, "notes.sql"));
 
+    // An unpadded version would sort differently from the deploy script's
+    // filename order, so the width is part of the name.
+    writeFileSync(join(dir, "10_tenth.sql"), "CREATE TABLE tenth (id INTEGER);");
+    expect(() => applyMigrations(db, dir)).toThrow(
+      "10_tenth.sql is not named NNNN_description.sql"
+    );
+    rmSync(join(dir, "10_tenth.sql"));
+
     writeFileSync(join(dir, "0001_again.sql"), "CREATE TABLE again (id INTEGER);");
-    expect(() => applyMigrations(db, dir)).toThrow("Duplicate migration version prefix 0001");
+    expect(() => applyMigrations(db, dir)).toThrow("Duplicate migration version 0001");
     expect(
       db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE name = 'first'").get()
     ).toEqual({
@@ -103,5 +111,48 @@ describe("applyMigrations", () => {
     // The next run retries the failed migration once it is fixed.
     writeFileSync(join(dir, "0002_broken.sql"), "CREATE TABLE partial (id INTEGER);");
     expect(applyMigrations(db, dir)).toEqual(["0002_broken.sql"]);
+  });
+
+  it("rejects a migration that controls transactions itself, before applying it", () => {
+    writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+    writeFileSync(
+      join(dir, "0002_commits.sql"),
+      "-- a COMMIT in a comment is fine\nCREATE TABLE t (v TEXT DEFAULT 'BEGIN');\nCOMMIT;\nCREATE TABLE u (id INTEGER);"
+    );
+
+    expect(() => applyMigrations(db, dir)).toThrow(
+      "Migration 0002_commits.sql controls transactions itself"
+    );
+    expect(ledger(db).map((row) => row.name)).toEqual(["0001_first.sql"]);
+  });
+
+  it("finds a migration another connection applied meanwhile recorded, not pending", () => {
+    const path = join(dir, "global.db");
+    const first = new DatabaseSync(path);
+    const second = new DatabaseSync(path);
+    try {
+      writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+      expect(applyMigrations(first, dir)).toEqual(["0001_first.sql"]);
+      // The second connection checks the ledger under the write lock and
+      // sees the row the first committed.
+      expect(applyMigrations(second, dir)).toEqual([]);
+      expect(ledger(second)).toEqual([{ version: "0001", name: "0001_first.sql" }]);
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
+  it("tells transaction control apart from trigger bodies, comments, and strings", () => {
+    expect(
+      containsTransactionControl(
+        "CREATE TRIGGER t_ai AFTER INSERT ON t\nBEGIN\n  UPDATE t SET n = n + 1;\nEND;\nCREATE TABLE u (v TEXT DEFAULT 'COMMIT'); -- COMMIT here is a comment"
+      )
+    ).toBe(false);
+    expect(containsTransactionControl("CREATE TABLE u (id INTEGER);\nCOMMIT;")).toBe(true);
+    expect(containsTransactionControl("begin transaction; CREATE TABLE u (id INTEGER)")).toBe(true);
+    expect(containsTransactionControl("SAVEPOINT s; CREATE TABLE u (id INTEGER); RELEASE s")).toBe(
+      true
+    );
   });
 });

--- a/packages/control-plane/src/node/migrate.test.ts
+++ b/packages/control-plane/src/node/migrate.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, listMigrations } from "./migrate";
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../terraform/d1/migrations"
+);
+
+const ledger = (db: DatabaseSync): Array<{ version: string; name: string }> =>
+  db.prepare("SELECT version, name FROM _schema_migrations ORDER BY version").all() as Array<{
+    version: string;
+    name: string;
+  }>;
+
+describe("applyMigrations", () => {
+  let dir: string;
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "migrate-"));
+    db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("applies every repository migration from zero and records each in the ledger", () => {
+    const files = readdirSync(MIGRATIONS_DIR).filter((name) => name.endsWith(".sql"));
+
+    const applied = applyMigrations(db, MIGRATIONS_DIR);
+
+    expect(applied).toEqual(listMigrations(MIGRATIONS_DIR).map((file) => file.name));
+    expect(applied).toHaveLength(files.length);
+    expect(ledger(db).map((row) => row.name)).toEqual(applied);
+    expect(
+      db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type = 'table'").get()
+    ).toMatchObject({ n: expect.any(Number) });
+    // A second run finds everything recorded and applies nothing.
+    expect(applyMigrations(db, MIGRATIONS_DIR)).toEqual([]);
+  });
+
+  it("applies files in version order and skips the ones already recorded", () => {
+    writeFileSync(join(dir, "0002_second.sql"), "CREATE TABLE second (id INTEGER);");
+    writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+    expect(applyMigrations(db, dir)).toEqual(["0001_first.sql", "0002_second.sql"]);
+
+    writeFileSync(join(dir, "0003_third.sql"), "CREATE TABLE third (id INTEGER);");
+    expect(applyMigrations(db, dir)).toEqual(["0003_third.sql"]);
+    expect(ledger(db)).toEqual([
+      { version: "0001", name: "0001_first.sql" },
+      { version: "0002", name: "0002_second.sql" },
+      { version: "0003", name: "0003_third.sql" },
+    ]);
+  });
+
+  it("refuses a version already recorded under a different name", () => {
+    writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+    applyMigrations(db, dir);
+    rmSync(join(dir, "0001_first.sql"));
+    writeFileSync(join(dir, "0001_other.sql"), "CREATE TABLE other (id INTEGER);");
+
+    expect(() => applyMigrations(db, dir)).toThrow(
+      "version 0001 is already recorded as 0001_first.sql"
+    );
+  });
+
+  it("rejects files without a numeric prefix and duplicate prefixes before applying anything", () => {
+    writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+    writeFileSync(join(dir, "notes.sql"), "CREATE TABLE notes (id INTEGER);");
+    expect(() => applyMigrations(db, dir)).toThrow("without a leading numeric prefix: notes.sql");
+    rmSync(join(dir, "notes.sql"));
+
+    writeFileSync(join(dir, "0001_again.sql"), "CREATE TABLE again (id INTEGER);");
+    expect(() => applyMigrations(db, dir)).toThrow("Duplicate migration version prefix 0001");
+    expect(
+      db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE name = 'first'").get()
+    ).toEqual({
+      n: 0,
+    });
+  });
+
+  it("commits a migration together with its ledger row, or neither", () => {
+    writeFileSync(join(dir, "0001_first.sql"), "CREATE TABLE first (id INTEGER);");
+    writeFileSync(
+      join(dir, "0002_broken.sql"),
+      "CREATE TABLE partial (id INTEGER);\nINSERT INTO no_such_table VALUES (1);"
+    );
+
+    expect(() => applyMigrations(db, dir)).toThrow("Migration 0002_broken.sql failed: ");
+
+    expect(ledger(db).map((row) => row.name)).toEqual(["0001_first.sql"]);
+    expect(
+      db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE name = 'partial'").get()
+    ).toEqual({ n: 0 });
+    // The next run retries the failed migration once it is fixed.
+    writeFileSync(join(dir, "0002_broken.sql"), "CREATE TABLE partial (id INTEGER);");
+    expect(applyMigrations(db, dir)).toEqual(["0002_broken.sql"]);
+  });
+});

--- a/packages/control-plane/src/node/migrate.ts
+++ b/packages/control-plane/src/node/migrate.ts
@@ -1,0 +1,113 @@
+/**
+ * Apply the global store's migrations to a Node host's SQLite file, the way
+ * `scripts/d1-migrate.sh` applies them to D1.
+ *
+ * The migration files are the same `terraform/d1/migrations/*.sql`; the
+ * ledger is the same `_schema_migrations` table with the same columns, so a
+ * D1 export of a production database imports here with its history intact
+ * and a file exported back is one D1 recognizes. The rules mirror the
+ * script: every file needs a numeric prefix, no two files may share one,
+ * files apply in prefix order, a version already recorded under a different
+ * name is a hard error (downstream installations may have used the number),
+ * and each migration commits together with its ledger row, so a failed
+ * migration leaves neither.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+
+const LEDGER_SQL = `CREATE TABLE IF NOT EXISTS _schema_migrations (
+  version TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+)`;
+
+export interface MigrationFile {
+  version: string;
+  name: string;
+  path: string;
+}
+
+/**
+ * The migration files in `directory`, in version order, validated as the
+ * deploy script validates them.
+ */
+export function listMigrations(directory: string): MigrationFile[] {
+  const names = readdirSync(directory)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  const invalid = names.filter((name) => !/^[0-9]+/.test(name));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Migration files without a leading numeric prefix: ${invalid.join(", ")}. ` +
+        "Rename them as NNNN_description.sql so they can be tracked."
+    );
+  }
+  const files = names.map((name) => ({
+    version: /^[0-9]+/.exec(name)![0],
+    name,
+    path: join(directory, name),
+  }));
+  const seen = new Map<string, string>();
+  for (const file of files) {
+    const earlier = seen.get(file.version);
+    if (earlier !== undefined) {
+      throw new Error(
+        `Duplicate migration version prefix ${file.version}: ${earlier} and ${file.name}. ` +
+          "Renumber the colliding files so each prefix is unique."
+      );
+    }
+    seen.set(file.version, file.name);
+  }
+  return files.sort((a, b) => Number(a.version) - Number(b.version) || (a.name < b.name ? -1 : 1));
+}
+
+/**
+ * Apply every migration in `directory` not yet recorded in the ledger.
+ * Returns the names applied, in order.
+ */
+export function applyMigrations(db: DatabaseSync, directory: string): string[] {
+  const files = listMigrations(directory);
+  db.exec(LEDGER_SQL);
+  const recorded = new Map(
+    (
+      db.prepare("SELECT version, name FROM _schema_migrations").all() as Array<{
+        version: string;
+        name: string;
+      }>
+    ).map((row) => [row.version, row.name])
+  );
+  const record = db.prepare("INSERT INTO _schema_migrations (version, name) VALUES (?, ?)");
+  const applied: string[] = [];
+  for (const file of files) {
+    const recordedName = recorded.get(file.version);
+    if (recordedName !== undefined) {
+      if (recordedName !== file.name) {
+        throw new Error(
+          `Migration version ${file.version} is already recorded as ${recordedName}; ` +
+            `renumber ${file.name} before applying it to this installation.`
+        );
+      }
+      continue;
+    }
+    const sql = readFileSync(file.path, "utf8");
+    // The migration and its ledger row commit together, as D1 executes the
+    // deploy script's combined file atomically.
+    db.exec("BEGIN");
+    try {
+      db.exec(sql);
+      record.run(file.version, file.name);
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw new Error(`Migration ${file.name} failed: ${errorMessage(error)}`, { cause: error });
+    }
+    applied.push(file.name);
+  }
+  return applied;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/control-plane/src/node/migrate.ts
+++ b/packages/control-plane/src/node/migrate.ts
@@ -6,11 +6,19 @@
  * ledger is the same `_schema_migrations` table with the same columns, so a
  * D1 export of a production database imports here with its history intact
  * and a file exported back is one D1 recognizes. The rules mirror the
- * script: every file needs a numeric prefix, no two files may share one,
- * files apply in prefix order, a version already recorded under a different
- * name is a hard error (downstream installations may have used the number),
- * and each migration commits together with its ledger row, so a failed
- * migration leaves neither.
+ * script: every file is named `NNNN_description.sql` (the script accepts
+ * any numeric prefix but orders by filename, so the width is what keeps
+ * its order and this runner's the same), no two files share a version,
+ * files apply in filename order, a version already recorded under a
+ * different name is a hard error (downstream installations may have used
+ * the number), and each migration commits together with its ledger row or
+ * not at all.
+ *
+ * Each migration is checked and applied under one write lock, so two
+ * processes opening the same file cannot both apply it: the second finds
+ * the ledger row once the first commits. A migration therefore must not
+ * control transactions itself; a `COMMIT` inside one would end the runner's
+ * transaction early and strand the ledger row.
  */
 
 import { readdirSync, readFileSync } from "node:fs";
@@ -23,6 +31,11 @@ const LEDGER_SQL = `CREATE TABLE IF NOT EXISTS _schema_migrations (
   applied_at TEXT NOT NULL DEFAULT (datetime('now'))
 )`;
 
+/** `NNNN_description.sql`: a four-digit version, an underscore, a description. */
+const MIGRATION_FILE = /^(\d{4})_.+\.sql$/;
+
+const TRANSACTION_CONTROL = /^(BEGIN|COMMIT|END|ROLLBACK|SAVEPOINT|RELEASE)\b/i;
+
 export interface MigrationFile {
   version: string;
   name: string;
@@ -30,37 +43,35 @@ export interface MigrationFile {
 }
 
 /**
- * The migration files in `directory`, in version order, validated as the
+ * The migration files in `directory`, in filename order, validated as the
  * deploy script validates them.
  */
 export function listMigrations(directory: string): MigrationFile[] {
   const names = readdirSync(directory)
     .filter((name) => name.endsWith(".sql"))
     .sort();
-  const invalid = names.filter((name) => !/^[0-9]+/.test(name));
-  if (invalid.length > 0) {
-    throw new Error(
-      `Migration files without a leading numeric prefix: ${invalid.join(", ")}. ` +
-        "Rename them as NNNN_description.sql so they can be tracked."
-    );
-  }
-  const files = names.map((name) => ({
-    version: /^[0-9]+/.exec(name)![0],
-    name,
-    path: join(directory, name),
-  }));
+  const files: MigrationFile[] = [];
   const seen = new Map<string, string>();
-  for (const file of files) {
-    const earlier = seen.get(file.version);
-    if (earlier !== undefined) {
+  for (const name of names) {
+    const match = MIGRATION_FILE.exec(name);
+    if (!match) {
       throw new Error(
-        `Duplicate migration version prefix ${file.version}: ${earlier} and ${file.name}. ` +
-          "Renumber the colliding files so each prefix is unique."
+        `Migration file ${name} is not named NNNN_description.sql; ` +
+          "rename it so it can be tracked and ordered."
       );
     }
-    seen.set(file.version, file.name);
+    const version = match[1]!;
+    const earlier = seen.get(version);
+    if (earlier !== undefined) {
+      throw new Error(
+        `Duplicate migration version ${version}: ${earlier} and ${name}. ` +
+          "Renumber the colliding files so each version is unique."
+      );
+    }
+    seen.set(version, name);
+    files.push({ version, name, path: join(directory, name) });
   }
-  return files.sort((a, b) => Number(a.version) - Number(b.version) || (a.name < b.name ? -1 : 1));
+  return files;
 }
 
 /**
@@ -70,42 +81,85 @@ export function listMigrations(directory: string): MigrationFile[] {
 export function applyMigrations(db: DatabaseSync, directory: string): string[] {
   const files = listMigrations(directory);
   db.exec(LEDGER_SQL);
-  const recorded = new Map(
-    (
-      db.prepare("SELECT version, name FROM _schema_migrations").all() as Array<{
-        version: string;
-        name: string;
-      }>
-    ).map((row) => [row.version, row.name])
-  );
+  const recordedName = db.prepare("SELECT name FROM _schema_migrations WHERE version = ?");
   const record = db.prepare("INSERT INTO _schema_migrations (version, name) VALUES (?, ?)");
   const applied: string[] = [];
   for (const file of files) {
-    const recordedName = recorded.get(file.version);
-    if (recordedName !== undefined) {
-      if (recordedName !== file.name) {
+    const sql = readFileSync(file.path, "utf8");
+    if (containsTransactionControl(sql)) {
+      throw new Error(
+        `Migration ${file.name} controls transactions itself; ` +
+          "the runner applies each migration as one transaction."
+      );
+    }
+    // The ledger is read under the write lock, so a migration another
+    // process applied meanwhile is found recorded rather than applied twice.
+    db.exec("BEGIN IMMEDIATE");
+    let recorded: { name: string } | undefined;
+    try {
+      recorded = recordedName.get(file.version) as { name: string } | undefined;
+    } catch (error) {
+      rollbackQuietly(db);
+      throw error;
+    }
+    if (recorded !== undefined) {
+      db.exec("ROLLBACK");
+      if (recorded.name !== file.name) {
         throw new Error(
-          `Migration version ${file.version} is already recorded as ${recordedName}; ` +
+          `Migration version ${file.version} is already recorded as ${recorded.name}; ` +
             `renumber ${file.name} before applying it to this installation.`
         );
       }
       continue;
     }
-    const sql = readFileSync(file.path, "utf8");
-    // The migration and its ledger row commit together, as D1 executes the
-    // deploy script's combined file atomically.
-    db.exec("BEGIN");
     try {
       db.exec(sql);
       record.run(file.version, file.name);
       db.exec("COMMIT");
     } catch (error) {
-      db.exec("ROLLBACK");
+      rollbackQuietly(db);
       throw new Error(`Migration ${file.name} failed: ${errorMessage(error)}`, { cause: error });
     }
     applied.push(file.name);
   }
   return applied;
+}
+
+/**
+ * Whether any statement in `sql` is transaction control. Comments and
+ * string literals are removed first, so a mention inside either does not
+ * count, and trigger bodies are skipped, since their `BEGIN … END` is not
+ * a transaction; a migration is otherwise plain DDL/DML, so statement
+ * starts are what matter.
+ */
+export function containsTransactionControl(sql: string): boolean {
+  const stripped = sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--[^\n]*/g, " ")
+    .replace(/'(?:[^']|'')*'/g, "''");
+  let inTrigger = false;
+  for (const segment of stripped.split(";")) {
+    const statement = segment.trim();
+    if (inTrigger) {
+      if (/^END\b/i.test(statement)) inTrigger = false;
+      continue;
+    }
+    if (/^CREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\b/i.test(statement)) {
+      inTrigger = true;
+      continue;
+    }
+    if (TRANSACTION_CONTROL.test(statement)) return true;
+  }
+  return false;
+}
+
+/** Roll back if a transaction is open; a failed COMMIT leaves one, a failed BEGIN does not. */
+function rollbackQuietly(db: DatabaseSync): void {
+  try {
+    db.exec("ROLLBACK");
+  } catch {
+    // No transaction to roll back.
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/control-plane/src/node/session-store.test.ts
+++ b/packages/control-plane/src/node/session-store.test.ts
@@ -8,6 +8,7 @@ import {
   openSessionStore,
   type NodeSessionStore,
 } from "./session-store";
+import { BUSY_TIMEOUT_MS } from "./sqlite-file";
 
 describe("openSessionStore", () => {
   let dataDir: string;
@@ -38,7 +39,9 @@ describe("openSessionStore", () => {
     expect(store.path).toBe(join(dataDir, "sessions", "session-1.db"));
     expect(existsSync(store.path)).toBe(true);
     expect(store.storage.sql.exec("PRAGMA journal_mode").one()).toEqual({ journal_mode: "wal" });
-    expect(store.storage.sql.exec("PRAGMA busy_timeout").one()).toEqual({ timeout: 5000 });
+    expect(store.storage.sql.exec("PRAGMA busy_timeout").one()).toEqual({
+      timeout: BUSY_TIMEOUT_MS,
+    });
     expect(store.storage.sql.exec("PRAGMA foreign_keys").one()).toEqual({ foreign_keys: 1 });
     expect(
       store.storage.sql.exec("SELECT count(*) AS n FROM sqlite_master WHERE name = 'session'").one()

--- a/packages/control-plane/src/node/session-store.ts
+++ b/packages/control-plane/src/node/session-store.ts
@@ -6,18 +6,11 @@
  */
 
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import type { SessionStorage } from "../session/platform";
 import { initSchema } from "../session/schema";
-import { ensurePrivateDirectory, makeFilePrivate } from "./private-paths";
+import { ensurePrivateDirectory } from "./private-paths";
+import { openPrivateSqliteFile } from "./sqlite-file";
 import { createNodeSqlStorage } from "./sqlite-storage";
-
-/** How long a writer waits on another connection's lock before failing. */
-const BUSY_TIMEOUT_MS = 5_000;
-
-/** How often the WAL switch is retried while another connection holds the file. */
-const BUSY_RETRY_MS = 10;
-const SQLITE_BUSY = 5;
 
 /** A session id must be a single path segment: it names the file directly. */
 const SESSION_FILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
@@ -55,45 +48,17 @@ export function createFileSessionStoreProvider(dataDir: string): SessionStorePro
   };
 }
 
-/**
- * Switch the file to WAL mode, waiting out another connection's write lock.
- * The busy timeout does not cover this switch: SQLite reports SQLITE_BUSY
- * from it at once rather than invoking the busy handler, so a connection
- * opening the same new file while another still holds it would fail. The
- * mode persists in the file, so later opens find it already set.
- */
-function enableWriteAheadLog(db: DatabaseSync): void {
-  const deadline = Date.now() + BUSY_TIMEOUT_MS;
-  for (;;) {
-    try {
-      db.exec("PRAGMA journal_mode = WAL");
-      return;
-    } catch (error) {
-      if (!isBusy(error) || Date.now() >= deadline) throw error;
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, BUSY_RETRY_MS);
-    }
-  }
-}
-
-function isBusy(error: unknown): boolean {
-  return (error as { errcode?: number }).errcode === SQLITE_BUSY;
-}
-
 /** Open (creating if needed) the session's database and apply the schema. */
 export function openSessionStore(options: OpenSessionStoreOptions): NodeSessionStore {
   const { dataDir, sessionId } = options;
   if (!SESSION_FILE_ID.test(sessionId)) {
     throw new Error(`Session id ${JSON.stringify(sessionId)} cannot name a session file`);
   }
-  // SQLite gives the -wal and -shm files the main file's mode.
   const directory = join(dataDir, "sessions");
   ensurePrivateDirectory(directory);
   const path = join(directory, `${sessionId}.db`);
-  const db = new DatabaseSync(path);
+  const db = openPrivateSqliteFile(path);
   try {
-    makeFilePrivate(path);
-    db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
-    enableWriteAheadLog(db);
     const storage = createNodeSqlStorage(db);
     initSchema(storage.sql);
     return { storage, path, close: () => db.close() };

--- a/packages/control-plane/src/node/sqlite-database.test.ts
+++ b/packages/control-plane/src/node/sqlite-database.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createNodeSqlDatabase,
+  openNodeSqlDatabase,
+  type NodeSqlDatabase,
+} from "./sqlite-database";
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../terraform/d1/migrations"
+);
+
+describe("createNodeSqlDatabase", () => {
+  let db: NodeSqlDatabase;
+
+  beforeEach(async () => {
+    db = createNodeSqlDatabase(new DatabaseSync(":memory:"));
+    await db.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT, b BLOB, n INTEGER)").run();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("takes exactly one statement per prepare(), as D1 does", async () => {
+    // Like D1, the text is compiled when the statement runs, not at prepare().
+    await expect(db.prepare("INSERT INTO t (a) VALUES ('x'); DELETE FROM t").run()).rejects.toThrow(
+      "exactly one SQL statement"
+    );
+    expect(await db.prepare("SELECT count(*) AS n FROM t").first()).toEqual({ n: 0 });
+    await expect(db.prepare("-- nothing here").all()).rejects.toThrow(
+      "did not contain a statement"
+    );
+    // Trailing whitespace and comments after the one statement are fine.
+    expect(await db.prepare("SELECT 1 AS one; -- done\n").first()).toEqual({ one: 1 });
+  });
+
+  it("binds bigints and buffers, converts booleans, and names what it cannot bind", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    await db
+      .prepare("INSERT INTO t (a, b, n) VALUES (?, ?, ?)")
+      .bind("big", bytes.buffer, 2n ** 40n)
+      .run();
+    await db.prepare("INSERT INTO t (a, b, n) VALUES (?, ?, ?)").bind("view", bytes, false).run();
+    const rows = await db.prepare("SELECT a, b, n FROM t ORDER BY id").all<{
+      a: string;
+      b: Uint8Array;
+      n: number;
+    }>();
+    expect(rows.results.map((r) => [r.a, [...r.b], r.n])).toEqual([
+      ["big", [1, 2, 3], 2 ** 40],
+      ["view", [1, 2, 3], 0],
+    ]);
+    expect(() => db.prepare("SELECT ?").bind(new Date())).toThrow(
+      "Cannot bind a value of type Date"
+    );
+    expect(() => db.prepare("SELECT ?").bind({})).toThrow("Cannot bind a value of type Object");
+  });
+
+  it("rolls a batch back and leaves the connection usable", async () => {
+    await expect(
+      db.batch([
+        db.prepare("INSERT INTO t (a) VALUES ('kept?')"),
+        db.prepare("INSERT INTO no_such_table (a) VALUES ('boom')"),
+      ])
+    ).rejects.toThrow("no such table");
+    expect(await db.prepare("SELECT count(*) AS n FROM t").first()).toEqual({ n: 0 });
+    await db.prepare("INSERT INTO t (a) VALUES ('after')").run();
+    expect(await db.prepare("SELECT count(*) AS n FROM t").first()).toEqual({ n: 1 });
+  });
+
+  it("returns RETURNING rows from run() with the write counted", async () => {
+    const result = await db.prepare("INSERT INTO t (a) VALUES ('x') RETURNING id, a").run();
+    expect(result.results).toEqual([{ id: 1, a: "x" }]);
+    expect(result.meta.changes).toBe(1);
+    expect(result.meta.rows_written).toBe(1);
+    expect(typeof result.meta.duration).toBe("number");
+  });
+});
+
+describe("openNodeSqlDatabase", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-sql-database-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("opens a private WAL-mode file with a busy timeout and foreign keys enforced", async () => {
+    const path = join(dataDir, "global.db");
+    const db = openNodeSqlDatabase(path);
+    try {
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(await db.prepare("PRAGMA journal_mode").first()).toEqual({ journal_mode: "wal" });
+      expect(await db.prepare("PRAGMA busy_timeout").first()).toEqual({ timeout: 5000 });
+      expect(await db.prepare("PRAGMA foreign_keys").first()).toEqual({ foreign_keys: 1 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("applies the repository's migrations when given the directory", async () => {
+    const db = openNodeSqlDatabase(join(dataDir, "global.db"), { migrationsDir: MIGRATIONS_DIR });
+    try {
+      const sessions = await db
+        .prepare("SELECT count(*) AS n FROM sqlite_master WHERE name = 'sessions'")
+        .first();
+      expect(sessions).toEqual({ n: 1 });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/control-plane/src/node/sqlite-database.test.ts
+++ b/packages/control-plane/src/node/sqlite-database.test.ts
@@ -9,6 +9,7 @@ import {
   openNodeSqlDatabase,
   type NodeSqlDatabase,
 } from "./sqlite-database";
+import { BUSY_TIMEOUT_MS } from "./sqlite-file";
 
 const MIGRATIONS_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -40,11 +41,11 @@ describe("createNodeSqlDatabase", () => {
     expect(await db.prepare("SELECT 1 AS one; -- done\n").first()).toEqual({ one: 1 });
   });
 
-  it("binds bigints and buffers, converts booleans, and names what it cannot bind", async () => {
+  it("binds buffers and views as blobs, converts booleans, and names what it cannot bind", async () => {
     const bytes = new Uint8Array([1, 2, 3]);
     await db
       .prepare("INSERT INTO t (a, b, n) VALUES (?, ?, ?)")
-      .bind("big", bytes.buffer, 2n ** 40n)
+      .bind("buffer", bytes.buffer, 1)
       .run();
     await db.prepare("INSERT INTO t (a, b, n) VALUES (?, ?, ?)").bind("view", bytes, false).run();
     const rows = await db.prepare("SELECT a, b, n FROM t ORDER BY id").all<{
@@ -53,13 +54,16 @@ describe("createNodeSqlDatabase", () => {
       n: number;
     }>();
     expect(rows.results.map((r) => [r.a, [...r.b], r.n])).toEqual([
-      ["big", [1, 2, 3], 2 ** 40],
+      ["buffer", [1, 2, 3], 1],
       ["view", [1, 2, 3], 0],
     ]);
     expect(() => db.prepare("SELECT ?").bind(new Date())).toThrow(
       "Cannot bind a value of type Date"
     );
     expect(() => db.prepare("SELECT ?").bind({})).toThrow("Cannot bind a value of type Object");
+    expect(() => db.prepare("SELECT ?").bind(2n ** 40n)).toThrow(
+      "Cannot bind a value of type bigint"
+    );
   });
 
   it("rolls a batch back and leaves the connection usable", async () => {
@@ -100,7 +104,7 @@ describe("openNodeSqlDatabase", () => {
     try {
       expect(statSync(path).mode & 0o777).toBe(0o600);
       expect(await db.prepare("PRAGMA journal_mode").first()).toEqual({ journal_mode: "wal" });
-      expect(await db.prepare("PRAGMA busy_timeout").first()).toEqual({ timeout: 5000 });
+      expect(await db.prepare("PRAGMA busy_timeout").first()).toEqual({ timeout: BUSY_TIMEOUT_MS });
       expect(await db.prepare("PRAGMA foreign_keys").first()).toEqual({ foreign_keys: 1 });
     } finally {
       db.close();

--- a/packages/control-plane/src/node/sqlite-database.ts
+++ b/packages/control-plane/src/node/sqlite-database.ts
@@ -29,7 +29,7 @@ import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import type { SqlDatabase, SqlResult, SqlStatement } from "../db/sql-database";
 import { applyMigrations } from "./migrate";
 import { openPrivateSqliteFile } from "./sqlite-file";
-import { isStatementlessSql } from "./sqlite-storage";
+import { isStatementlessSql } from "./sqlite-sql";
 
 export interface NodeSqlDatabase extends SqlDatabase {
   /** Close the connection. Every later statement throws. */
@@ -38,7 +38,6 @@ export interface NodeSqlDatabase extends SqlDatabase {
 
 /** The port over an open connection the caller owns. */
 export function createNodeSqlDatabase(db: DatabaseSync): NodeSqlDatabase {
-  const own = new WeakSet<SqlStatement>();
   const totalChanges = db.prepare("SELECT total_changes() AS n");
   const changesNow = (): number => Number((totalChanges.get() as { n: number | bigint }).n);
 
@@ -56,35 +55,42 @@ export function createNodeSqlDatabase(db: DatabaseSync): NodeSqlDatabase {
     };
   };
 
+  // Each statement's synchronous work, keyed by the statement it belongs
+  // to: the brand that admits it to batch(), and what batch() runs without
+  // yielding.
+  const executors = new WeakMap<SqlStatement, StatementExecutor>();
+
   const statementFor = (query: string, params: SQLInputValue[]): SqlStatement => {
+    const executor: StatementExecutor = {
+      all: <T>() => execute<T>(query, params),
+      first: <T>() => (prepareOne(db, query).get(...params) as T | undefined) ?? null,
+    };
     const statement: SqlStatement = {
       bind: (...values) => statementFor(query, values.map(toBoundValue)),
-      first: async <T>() => {
-        const row = prepareOne(db, query).get(...params) as T | undefined;
-        return row ?? null;
-      },
-      run: async <T>() => execute<T>(query, params),
-      all: async <T>() => execute<T>(query, params),
+      first: async <T>() => executor.first<T>(),
+      run: async <T>() => executor.all<T>(),
+      all: async <T>() => executor.all<T>(),
     };
-    own.add(statement);
+    executors.set(statement, executor);
     return statement;
   };
 
   return {
     prepare: (query) => statementFor(query, []),
     async batch<T>(statements: SqlStatement[]): Promise<SqlResult<T>[]> {
-      for (const statement of statements) {
-        if (!own.has(statement)) {
+      const work = statements.map((statement) => {
+        const executor = executors.get(statement);
+        if (!executor) {
           throw new TypeError("batch() accepts only statements prepared by this database");
         }
-      }
+        return executor;
+      });
+      // Nothing yields between BEGIN and COMMIT: the transaction opens and
+      // closes within this call, so no other caller's statement can land
+      // inside it.
       db.exec("BEGIN IMMEDIATE");
       try {
-        const results: SqlResult<T>[] = [];
-        for (const statement of statements) {
-          // Resolves in this turn: the statement's work is synchronous.
-          results.push(await statement.all<T>());
-        }
+        const results = work.map((executor) => executor.all<T>());
         db.exec("COMMIT");
         return results;
       } catch (error) {
@@ -94,6 +100,11 @@ export function createNodeSqlDatabase(db: DatabaseSync): NodeSqlDatabase {
     },
     close: () => db.close(),
   };
+}
+
+interface StatementExecutor {
+  all<T>(): SqlResult<T>;
+  first<T>(): T | null;
 }
 
 export interface OpenNodeSqlDatabaseOptions {
@@ -148,7 +159,9 @@ function toBoundValue(value: unknown): SQLInputValue {
     default:
       break;
   }
-  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  // Copied at bind time, as D1 snapshots binary values: a later mutation of
+  // the caller's buffer does not change what runs.
+  if (value instanceof ArrayBuffer) return new Uint8Array(value).slice();
   if (ArrayBuffer.isView(value)) {
     return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
   }

--- a/packages/control-plane/src/node/sqlite-database.ts
+++ b/packages/control-plane/src/node/sqlite-database.ts
@@ -11,7 +11,7 @@
  *   SQL is rejected here instead.
  * - `bind(...)` returns a new statement and validates the values the way
  *   D1 does: booleans become integers, buffers are bound as blobs, and
- *   `undefined` or any other object is a type error at bind time.
+ *   `undefined`, `bigint`, or any other object is a type error at bind time.
  * - `first()` is `null` when no row matches; `all()` and `run()` return the
  *   rows with `meta.changes` from SQLite's change counter, which the stores
  *   gate CAS and upsert correctness on.
@@ -146,12 +146,16 @@ function prepareOne(db: DatabaseSync, query: string) {
   return statement;
 }
 
-/** The value as SQLite binds it, with D1's conversions and rejections. */
+/**
+ * The value as SQLite binds it, with D1's conversions and rejections. The
+ * accepted set is what both engines take: `node:sqlite` would also bind a
+ * `bigint`, but D1 rejects one, so store code that bound it would pass on
+ * Node and fail on Workers.
+ */
 function toBoundValue(value: unknown): SQLInputValue {
   if (value === null) return null;
   switch (typeof value) {
     case "number":
-    case "bigint":
     case "string":
       return value;
     case "boolean":

--- a/packages/control-plane/src/node/sqlite-database.ts
+++ b/packages/control-plane/src/node/sqlite-database.ts
@@ -1,0 +1,162 @@
+/**
+ * The global store over `node:sqlite`: the `SqlDatabase` port the data layer
+ * is written against, backed by one SQLite file on the host. D1 is SQLite,
+ * so the stores' SQL and every migration run unchanged (decision D-1); this
+ * adapter reproduces the D1 client's contract rather than its wire protocol.
+ *
+ * What the stores rely on and this adapter guarantees:
+ *
+ * - `prepare(query)` takes exactly one statement, as D1 does. SQLite would
+ *   silently compile only the first statement of a longer text; trailing
+ *   SQL is rejected here instead.
+ * - `bind(...)` returns a new statement and validates the values the way
+ *   D1 does: booleans become integers, buffers are bound as blobs, and
+ *   `undefined` or any other object is a type error at bind time.
+ * - `first()` is `null` when no row matches; `all()` and `run()` return the
+ *   rows with `meta.changes` from SQLite's change counter, which the stores
+ *   gate CAS and upsert correctness on.
+ * - `batch(statements)` runs every statement inside one `BEGIN IMMEDIATE`
+ *   transaction, rolls back on any throw, and returns results positionally.
+ *   Only statements from this database's `prepare()` are accepted, so a
+ *   statement from another engine or an unwrapped instrumented wrapper is a
+ *   wiring error rather than a silent no-op.
+ *
+ * The connection is synchronous underneath: every method resolves in the
+ * same turn it was called, which is what makes a batch a single snapshot.
+ */
+
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import type { SqlDatabase, SqlResult, SqlStatement } from "../db/sql-database";
+import { applyMigrations } from "./migrate";
+import { openPrivateSqliteFile } from "./sqlite-file";
+import { isStatementlessSql } from "./sqlite-storage";
+
+export interface NodeSqlDatabase extends SqlDatabase {
+  /** Close the connection. Every later statement throws. */
+  close(): void;
+}
+
+/** The port over an open connection the caller owns. */
+export function createNodeSqlDatabase(db: DatabaseSync): NodeSqlDatabase {
+  const own = new WeakSet<SqlStatement>();
+  const totalChanges = db.prepare("SELECT total_changes() AS n");
+  const changesNow = (): number => Number((totalChanges.get() as { n: number | bigint }).n);
+
+  const execute = <T>(query: string, params: SQLInputValue[]): SqlResult<T> => {
+    const statement = prepareOne(db, query);
+    const started = performance.now();
+    const before = changesNow();
+    // Stepping to completion returns the rows of a read or a RETURNING
+    // clause and an empty list for any other write.
+    const results = statement.all(...params) as T[];
+    const changes = changesNow() - before;
+    return {
+      results,
+      meta: { changes, duration: performance.now() - started, rows_written: changes },
+    };
+  };
+
+  const statementFor = (query: string, params: SQLInputValue[]): SqlStatement => {
+    const statement: SqlStatement = {
+      bind: (...values) => statementFor(query, values.map(toBoundValue)),
+      first: async <T>() => {
+        const row = prepareOne(db, query).get(...params) as T | undefined;
+        return row ?? null;
+      },
+      run: async <T>() => execute<T>(query, params),
+      all: async <T>() => execute<T>(query, params),
+    };
+    own.add(statement);
+    return statement;
+  };
+
+  return {
+    prepare: (query) => statementFor(query, []),
+    async batch<T>(statements: SqlStatement[]): Promise<SqlResult<T>[]> {
+      for (const statement of statements) {
+        if (!own.has(statement)) {
+          throw new TypeError("batch() accepts only statements prepared by this database");
+        }
+      }
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const results: SqlResult<T>[] = [];
+        for (const statement of statements) {
+          // Resolves in this turn: the statement's work is synchronous.
+          results.push(await statement.all<T>());
+        }
+        db.exec("COMMIT");
+        return results;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+    close: () => db.close(),
+  };
+}
+
+export interface OpenNodeSqlDatabaseOptions {
+  /** Apply the migrations in this directory before returning (see migrate.ts). */
+  migrationsDir?: string;
+}
+
+/**
+ * Open (creating if needed) the global store at `path`: private to the host
+ * user, WAL mode, busy timeout, and foreign keys enforced as D1 enforces
+ * them, with the schema migrated when a directory is given. The parent
+ * directory must already exist.
+ */
+export function openNodeSqlDatabase(
+  path: string,
+  options: OpenNodeSqlDatabaseOptions = {}
+): NodeSqlDatabase {
+  const db = openPrivateSqliteFile(path);
+  try {
+    db.exec("PRAGMA foreign_keys = ON");
+    if (options.migrationsDir !== undefined) applyMigrations(db, options.migrationsDir);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+  return createNodeSqlDatabase(db);
+}
+
+/** Prepare `query`, which must hold exactly one statement, as D1 requires. */
+function prepareOne(db: DatabaseSync, query: string) {
+  if (isStatementlessSql(query)) {
+    throw new Error("SQL code did not contain a statement.");
+  }
+  const statement = db.prepare(query);
+  const rest = query.slice(statement.sourceSQL.length);
+  if (!isStatementlessSql(rest)) {
+    throw new Error("prepare() takes exactly one SQL statement.");
+  }
+  return statement;
+}
+
+/** The value as SQLite binds it, with D1's conversions and rejections. */
+function toBoundValue(value: unknown): SQLInputValue {
+  if (value === null) return null;
+  switch (typeof value) {
+    case "number":
+    case "bigint":
+    case "string":
+      return value;
+    case "boolean":
+      return value ? 1 : 0;
+    default:
+      break;
+  }
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
+  }
+  throw new TypeError(`Cannot bind a value of type ${describeType(value)}`);
+}
+
+function describeType(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (typeof value !== "object") return typeof value;
+  return (value as object).constructor?.name ?? "object";
+}

--- a/packages/control-plane/src/node/sqlite-file.ts
+++ b/packages/control-plane/src/node/sqlite-file.ts
@@ -1,0 +1,59 @@
+/**
+ * How the Node host opens a SQLite file it owns: private to the host user,
+ * in WAL mode, with a busy timeout so concurrent connections wait for a
+ * writer instead of failing. Shared by the per-session stores and the
+ * global store.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { makeFilePrivate } from "./private-paths";
+
+/** How long a writer waits on another connection's lock before failing. */
+const BUSY_TIMEOUT_MS = 5_000;
+
+/** How often the WAL switch is retried while another connection holds the file. */
+const BUSY_RETRY_MS = 10;
+const SQLITE_BUSY = 5;
+
+/**
+ * Open (creating if needed) `path` as a private WAL-mode database with the
+ * busy timeout set. The directory must already exist. Closes the connection
+ * and rethrows if any step fails.
+ */
+export function openPrivateSqliteFile(path: string): DatabaseSync {
+  const db = new DatabaseSync(path);
+  try {
+    // SQLite gives the -wal and -shm files the main file's mode.
+    makeFilePrivate(path);
+    db.exec(`PRAGMA busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    enableWriteAheadLog(db);
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}
+
+/**
+ * Switch the file to WAL mode, waiting out another connection's write lock.
+ * The busy timeout does not cover this switch: SQLite reports SQLITE_BUSY
+ * from it at once rather than invoking the busy handler, so a connection
+ * opening the same new file while another still holds it would fail. The
+ * mode persists in the file, so later opens find it already set.
+ */
+function enableWriteAheadLog(db: DatabaseSync): void {
+  const deadline = Date.now() + BUSY_TIMEOUT_MS;
+  for (;;) {
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+      return;
+    } catch (error) {
+      if (!isBusy(error) || Date.now() >= deadline) throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, BUSY_RETRY_MS);
+    }
+  }
+}
+
+function isBusy(error: unknown): boolean {
+  return (error as { errcode?: number }).errcode === SQLITE_BUSY;
+}

--- a/packages/control-plane/src/node/sqlite-file.ts
+++ b/packages/control-plane/src/node/sqlite-file.ts
@@ -9,7 +9,7 @@ import { DatabaseSync } from "node:sqlite";
 import { makeFilePrivate } from "./private-paths";
 
 /** How long a writer waits on another connection's lock before failing. */
-const BUSY_TIMEOUT_MS = 5_000;
+export const BUSY_TIMEOUT_MS = 5_000;
 
 /** How often the WAL switch is retried while another connection holds the file. */
 const BUSY_RETRY_MS = 10;

--- a/packages/control-plane/src/node/sqlite-sql.ts
+++ b/packages/control-plane/src/node/sqlite-sql.ts
@@ -1,0 +1,47 @@
+/**
+ * SQL text handling shared by the Node host's SQLite adapters: what both
+ * the per-session storage and the global store must recognize before
+ * handing text to `node:sqlite`.
+ */
+
+/**
+ * Whether SQLite would consume this input without producing a statement.
+ *
+ * SQLite reports success with a null statement pointer for whitespace, a BOM,
+ * comments, empty statements, and input terminated by NUL. Node versions
+ * before 26.8 wrap and track that pointer, then leave a dangling registry entry
+ * when the wrapper is collected. Never pass that input to
+ * DatabaseSync.prepare().
+ */
+export function isStatementlessSql(sql: string): boolean {
+  let index = 0;
+  while (index < sql.length) {
+    const char = sql[index];
+    const code = sql.charCodeAt(index);
+    if (code === 0x00) return true;
+    if (
+      char === ";" ||
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0c ||
+      code === 0x0d ||
+      code === 0x20 ||
+      code === 0xfeff
+    ) {
+      index += 1;
+      continue;
+    }
+    if (char === "-" && sql[index + 1] === "-") {
+      const newline = sql.indexOf("\n", index + 2);
+      index = newline === -1 ? sql.length : newline + 1;
+      continue;
+    }
+    if (char === "/" && sql[index + 1] === "*") {
+      const end = sql.indexOf("*/", index + 2);
+      index = end === -1 ? sql.length : end + 2;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}

--- a/packages/control-plane/src/node/sqlite-storage.ts
+++ b/packages/control-plane/src/node/sqlite-storage.ts
@@ -21,6 +21,7 @@
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import type { SessionStorage } from "../session/platform";
 import type { SqlResult, SqlStorage, TransactionSync } from "../session/sql-storage";
+import { isStatementlessSql } from "./sqlite-sql";
 
 export function createNodeSqlStorage(db: DatabaseSync): SessionStorage {
   const totalChanges = db.prepare("SELECT total_changes() AS n");
@@ -102,48 +103,6 @@ function prepareAll(db: DatabaseSync, query: string): StatementSync[] {
     throw new Error("SQL code did not contain a statement.");
   }
   return statements;
-}
-
-/**
- * Whether SQLite would consume this input without producing a statement.
- *
- * SQLite reports success with a null statement pointer for whitespace, a BOM,
- * comments, empty statements, and input terminated by NUL. Node versions
- * before 26.8 wrap and track that pointer, then leave a dangling registry entry
- * when the wrapper is collected. Never pass that input to
- * DatabaseSync.prepare().
- */
-export function isStatementlessSql(sql: string): boolean {
-  let index = 0;
-  while (index < sql.length) {
-    const char = sql[index];
-    const code = sql.charCodeAt(index);
-    if (code === 0x00) return true;
-    if (
-      char === ";" ||
-      code === 0x09 ||
-      code === 0x0a ||
-      code === 0x0c ||
-      code === 0x0d ||
-      code === 0x20 ||
-      code === 0xfeff
-    ) {
-      index += 1;
-      continue;
-    }
-    if (char === "-" && sql[index + 1] === "-") {
-      const newline = sql.indexOf("\n", index + 2);
-      index = newline === -1 ? sql.length : newline + 1;
-      continue;
-    }
-    if (char === "/" && sql[index + 1] === "*") {
-      const end = sql.indexOf("*/", index + 2);
-      index = end === -1 ? sql.length : end + 2;
-      continue;
-    }
-    return false;
-  }
-  return true;
 }
 
 /** Durable Object cursors throw from `one()` unless the result is a single row. */

--- a/packages/control-plane/src/node/sqlite-storage.ts
+++ b/packages/control-plane/src/node/sqlite-storage.ts
@@ -113,7 +113,7 @@ function prepareAll(db: DatabaseSync, query: string): StatementSync[] {
  * when the wrapper is collected. Never pass that input to
  * DatabaseSync.prepare().
  */
-function isStatementlessSql(sql: string): boolean {
+export function isStatementlessSql(sql: string): boolean {
   let index = 0;
   while (index < sql.length) {
     const char = sql[index];

--- a/packages/control-plane/test/conformance/sql-database-conformance.node.test.ts
+++ b/packages/control-plane/test/conformance/sql-database-conformance.node.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The `SqlDatabase` conformance suite on the Node host's global store, both
+ * in memory and as the WAL-mode file `openNodeSqlDatabase` manages. The same
+ * suite runs on D1 from test/integration/sql-database-conformance.test.ts.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe } from "vitest";
+import { createNodeSqlDatabase, openNodeSqlDatabase } from "../../src/node/sqlite-database";
+import {
+  registerSqlDatabaseConformanceSuite,
+  type SqlDatabaseFactory,
+} from "./sql-database-conformance";
+
+const inMemoryFactory: SqlDatabaseFactory = async (run) => {
+  const db = createNodeSqlDatabase(new DatabaseSync(":memory:"));
+  try {
+    return await run(db);
+  } finally {
+    db.close();
+  }
+};
+
+const fileFactory: SqlDatabaseFactory = async (run) => {
+  const dataDir = mkdtempSync(join(tmpdir(), "sql-conformance-"));
+  const db = openNodeSqlDatabase(join(dataDir, "global.db"));
+  try {
+    return await run(db);
+  } finally {
+    db.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+};
+
+describe("node:sqlite in memory", () => {
+  registerSqlDatabaseConformanceSuite(inMemoryFactory);
+});
+
+describe("node:sqlite global store file", () => {
+  registerSqlDatabaseConformanceSuite(fileFactory);
+});

--- a/packages/control-plane/test/conformance/sql-database-conformance.ts
+++ b/packages/control-plane/test/conformance/sql-database-conformance.ts
@@ -100,6 +100,22 @@ export function registerSqlDatabaseConformanceSuite(factory: SqlDatabaseFactory)
       });
     });
 
+    it("refuses a bigint, which not every engine can bind", async () => {
+      await withTable(async (db) => {
+        // Refused at bind or at execution, whichever the engine does; the
+        // portable rule is that it never runs.
+        await expect(
+          Promise.resolve().then(() =>
+            db
+              .prepare(`INSERT INTO ${TABLE} (k, v) VALUES (?, ?)`)
+              .bind("big", 2n ** 40n)
+              .run()
+          )
+        ).rejects.toThrow();
+        expect(await count(db)).toBe(0);
+      });
+    });
+
     it("snapshots a bound binary value at bind time", async () => {
       await withTable(async (db) => {
         const bytes = new Uint8Array([1, 2, 3]);

--- a/packages/control-plane/test/conformance/sql-database-conformance.ts
+++ b/packages/control-plane/test/conformance/sql-database-conformance.ts
@@ -31,6 +31,16 @@ export function registerSqlDatabaseConformanceSuite(factory: SqlDatabaseFactory)
       }
     });
 
+  /** A stored binary value as bytes, however the engine returns it. */
+  const bytesOf = (value: unknown): number[] => {
+    if (Array.isArray(value)) return value as number[];
+    if (value instanceof ArrayBuffer) return [...new Uint8Array(value)];
+    if (ArrayBuffer.isView(value)) {
+      return [...new Uint8Array(value.buffer, value.byteOffset, value.byteLength)];
+    }
+    throw new Error(`Not a binary value: ${String(value)}`);
+  };
+
   const count = async (db: SqlDatabase): Promise<number> => {
     const row = await db.prepare(`SELECT count(*) AS n FROM ${TABLE}`).first<{ n: number }>();
     return row!.n;
@@ -90,6 +100,21 @@ export function registerSqlDatabaseConformanceSuite(factory: SqlDatabaseFactory)
       });
     });
 
+    it("snapshots a bound binary value at bind time", async () => {
+      await withTable(async (db) => {
+        const bytes = new Uint8Array([1, 2, 3]);
+        const insert = db
+          .prepare(`INSERT INTO ${TABLE} (k, v) VALUES (?, ?)`)
+          .bind("blob", bytes.buffer);
+        bytes[0] = 9;
+        await insert.run();
+        const row = await db
+          .prepare(`SELECT v FROM ${TABLE} WHERE k = 'blob'`)
+          .first<{ v: unknown }>();
+        expect(bytesOf(row!.v)).toEqual([1, 2, 3]);
+      });
+    });
+
     it("batch() applies every statement or none", async () => {
       await withTable(async (db) => {
         await expect(
@@ -101,6 +126,22 @@ export function registerSqlDatabaseConformanceSuite(factory: SqlDatabaseFactory)
           ])
         ).rejects.toThrow();
         expect(await count(db)).toBe(0);
+      });
+    });
+
+    it("keeps a write issued while a batch is in flight outside the batch", async () => {
+      await withTable(async (db) => {
+        // Not awaited before the unrelated write: the batch must not leave
+        // its transaction open across a turn for the write to land inside.
+        const failing = db.batch([
+          db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1)`),
+          db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 2)`),
+        ]);
+        const unrelated = db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('z', 26)`).run();
+        await expect(failing).rejects.toThrow();
+        await unrelated;
+        const rows = await db.prepare(`SELECT k FROM ${TABLE}`).all<{ k: string }>();
+        expect(rows.results).toEqual([{ k: "z" }]);
       });
     });
 

--- a/packages/control-plane/test/conformance/sql-database-conformance.ts
+++ b/packages/control-plane/test/conformance/sql-database-conformance.ts
@@ -1,0 +1,150 @@
+/**
+ * The `SqlDatabase` contract, run against every engine that implements the
+ * port: D1 in the workerd lane (test/integration/sql-database-conformance.test.ts)
+ * and `node:sqlite` in the Node lane (sql-database-conformance.node.test.ts).
+ * Each case pins a semantic the stores rely on; an engine that fails one
+ * would make a store misbehave silently.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isUniqueConstraintError } from "../../src/db/errors";
+import type { SqlDatabase, SqlStatement } from "../../src/db/sql-database";
+
+/** Runs one assertion against an engine; the callback owns the connection's lifetime. */
+export type SqlDatabaseFactory = <T>(run: (db: SqlDatabase) => Promise<T>) => Promise<T>;
+
+const TABLE = "sql_conformance_rows";
+
+export function registerSqlDatabaseConformanceSuite(factory: SqlDatabaseFactory): void {
+  const withTable = <T>(run: (db: SqlDatabase) => Promise<T>): Promise<T> =>
+    factory(async (db) => {
+      await db
+        .prepare(
+          `CREATE TABLE IF NOT EXISTS ${TABLE} (id INTEGER PRIMARY KEY, k TEXT UNIQUE, v INTEGER)`
+        )
+        .run();
+      await db.prepare(`DELETE FROM ${TABLE}`).run();
+      try {
+        return await run(db);
+      } finally {
+        await db.prepare(`DROP TABLE IF EXISTS ${TABLE}`).run();
+      }
+    });
+
+  const count = async (db: SqlDatabase): Promise<number> => {
+    const row = await db.prepare(`SELECT count(*) AS n FROM ${TABLE}`).first<{ n: number }>();
+    return row!.n;
+  };
+
+  describe("SqlDatabase conformance", () => {
+    it("first() is null when no row matches and the row otherwise", async () => {
+      await withTable(async (db) => {
+        expect(await db.prepare(`SELECT k FROM ${TABLE} WHERE k = ?`).bind("a").first()).toBeNull();
+        await db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES (?, ?)`).bind("a", 1).run();
+        expect(await db.prepare(`SELECT k, v FROM ${TABLE} WHERE k = ?`).bind("a").first()).toEqual(
+          { k: "a", v: 1 }
+        );
+      });
+    });
+
+    it("bind() returns an independent statement each time", async () => {
+      await withTable(async (db) => {
+        await db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1), ('b', 2)`).run();
+        const select = db.prepare(`SELECT v FROM ${TABLE} WHERE k = ?`);
+        const forA = select.bind("a");
+        const forB = select.bind("b");
+        expect(await forA.first()).toEqual({ v: 1 });
+        expect(await forB.first()).toEqual({ v: 2 });
+        expect(await forA.first()).toEqual({ v: 1 });
+      });
+    });
+
+    it("reports the rows a statement wrote in meta.changes, and zero for a read", async () => {
+      await withTable(async (db) => {
+        const inserted = await db
+          .prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1), ('b', 2), ('c', 3)`)
+          .run();
+        expect(inserted.meta.changes).toBe(3);
+        const updated = await db
+          .prepare(`UPDATE ${TABLE} SET v = v + 10 WHERE v > ?`)
+          .bind(1)
+          .run();
+        expect(updated.meta.changes).toBe(2);
+        const missed = await db.prepare(`UPDATE ${TABLE} SET v = 0 WHERE k = ?`).bind("zz").run();
+        expect(missed.meta.changes).toBe(0);
+        const read = await db.prepare(`SELECT k FROM ${TABLE} ORDER BY k`).all<{ k: string }>();
+        expect(read.meta.changes).toBe(0);
+        expect(read.results).toEqual([{ k: "a" }, { k: "b" }, { k: "c" }]);
+        const deleted = await db.prepare(`DELETE FROM ${TABLE}`).run();
+        expect(deleted.meta.changes).toBe(3);
+      });
+    });
+
+    it("binds booleans as integers and refuses undefined at bind time", async () => {
+      await withTable(async (db) => {
+        await db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES (?, ?)`).bind("flag", true).run();
+        expect(await db.prepare(`SELECT v FROM ${TABLE} WHERE k = 'flag'`).first()).toEqual({
+          v: 1,
+        });
+        expect(() => db.prepare(`SELECT ?`).bind(undefined)).toThrow();
+      });
+    });
+
+    it("batch() applies every statement or none", async () => {
+      await withTable(async (db) => {
+        await expect(
+          db.batch([
+            db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1)`),
+            db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('b', 2)`),
+            // Violates the unique key: the whole batch must roll back.
+            db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 3)`),
+          ])
+        ).rejects.toThrow();
+        expect(await count(db)).toBe(0);
+      });
+    });
+
+    it("batch() returns results positionally, each statement seeing the earlier ones", async () => {
+      await withTable(async (db) => {
+        const [inserted, seen, updated, after] = await db.batch<{ n?: number; v?: number }>([
+          db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1)`),
+          db.prepare(`SELECT count(*) AS n FROM ${TABLE}`),
+          db.prepare(`UPDATE ${TABLE} SET v = ? WHERE k = ?`).bind(5, "a"),
+          db.prepare(`SELECT v FROM ${TABLE} WHERE k = 'a'`),
+        ]);
+        expect(inserted!.meta.changes).toBe(1);
+        expect(seen!.results).toEqual([{ n: 1 }]);
+        expect(updated!.meta.changes).toBe(1);
+        expect(after!.results).toEqual([{ v: 5 }]);
+      });
+    });
+
+    it("batch() refuses a statement this database did not prepare", async () => {
+      await withTable(async (db) => {
+        const foreign: SqlStatement = {
+          bind: () => foreign,
+          first: async () => null,
+          run: async () => ({ results: [], meta: { changes: 0 } }),
+          all: async () => ({ results: [], meta: { changes: 0 } }),
+        };
+        await expect(
+          db.batch([db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1)`), foreign])
+        ).rejects.toThrow();
+        expect(await count(db)).toBe(0);
+      });
+    });
+
+    it("surfaces a unique violation as a unique constraint error", async () => {
+      await withTable(async (db) => {
+        const insert = db.prepare(`INSERT INTO ${TABLE} (k, v) VALUES ('a', 1)`);
+        await insert.run();
+        const failure = await insert.run().then(
+          () => null,
+          (error: unknown) => error
+        );
+        expect(failure).not.toBeNull();
+        expect(isUniqueConstraintError(failure)).toBe(true);
+      });
+    });
+  });
+}

--- a/packages/control-plane/test/integration/sql-database-conformance.test.ts
+++ b/packages/control-plane/test/integration/sql-database-conformance.test.ts
@@ -1,0 +1,15 @@
+/**
+ * The `SqlDatabase` conformance suite on the D1 binding, the engine the
+ * stores run against on Cloudflare. The same suite runs on the Node host's
+ * `node:sqlite` adapter from test/conformance/sql-database-conformance.node.test.ts.
+ */
+
+import { env } from "cloudflare:test";
+import {
+  registerSqlDatabaseConformanceSuite,
+  type SqlDatabaseFactory,
+} from "../conformance/sql-database-conformance";
+
+const d1Factory: SqlDatabaseFactory = (run) => run(env.DB);
+
+registerSqlDatabaseConformanceSuite(d1Factory);


### PR DESCRIPTION
Roadmap **N-2 · COL-89**: the global store on a Node host. Node host only; the worker bundle has no `src/node` input (`dist/meta.json` checked). One production-shared change: `db/errors.ts` gains a SQLite result-code branch.

## What

**`src/node/sqlite-database.ts`.** `createNodeSqlDatabase(db)` implements the `SqlDatabase` port over `node:sqlite` with the D1 client's contract, not its wire protocol:

- `prepare(query)` takes exactly one statement. SQLite would silently compile only the first statement of a longer text; the adapter rejects trailing SQL at execution, where D1 also reports it.
- `bind(...)` returns a new statement and converts values as D1 does: booleans to integers, `ArrayBuffer`/views to blobs; `undefined`, `bigint` (which D1 rejects), and other objects are a `TypeError` at bind time, so the accepted set is what both engines take.
- `first()` is `null` with no row. `all()`/`run()` return the rows (so `RETURNING` works) with `meta.changes` from SQLite's change counter, the field ~38 store call sites gate CAS and upsert correctness on. `duration` and `rows_written` are filled for `instrumentD1`.
- `batch()` runs inside one `BEGIN IMMEDIATE` **without yielding**: every branded statement carries a synchronous executor (a `WeakMap`), so the transaction opens and closes within the call and no other caller's statement can land inside it. It rolls back on any throw, returns results positionally, and refuses statements this database did not prepare.
- Binary values are copied at bind time, as D1 snapshots them.

`openNodeSqlDatabase(path, { migrationsDir? })` opens the file private to the host user, WAL mode, busy timeout, `foreign_keys = ON` as D1 enforces them, and migrates when given the directory. The file opener is now shared with the per-session stores (`sqlite-file.ts`; `session-store.ts` refactored onto it, behavior unchanged).

**`src/node/migrate.ts`.** `applyMigrations(db, dir)` mirrors `scripts/d1-migrate.sh`: files must be named `NNNN_description.sql` (the script orders by filename; the fixed width is what keeps both orders equal), versions unique (hard errors, checked before anything applies), files apply in filename order, a version already recorded under a different name is a hard error (downstream installations may have used the number). Each migration's ledger check and application run under one `BEGIN IMMEDIATE`, so two processes on the same file cannot apply a migration twice, and each commits together with its ledger row or not at all. A migration that controls transactions itself is refused before it runs (trigger bodies' `BEGIN … END` excepted); the scan blanks comments and quoted text in one pass, so neither can hide a statement boundary inside the other.

**`src/node/sqlite-sql.ts`.** The statement-trivia check both adapters need, out of the session-specific `sqlite-storage.ts` so the global adapter does not depend on it.

**`src/db/errors.ts`.** `isUniqueConstraintError` also matches SQLite result codes 2067 / 1555, which `node:sqlite` carries as `errcode`; the message branch stays for D1. Its own unit test exercises the code branch with a message the fallback would not match.

**Contract suite.** `test/conformance/sql-database-conformance.ts` is the `SqlDatabase` contract, run on D1 in the workerd lane (`test/integration/sql-database-conformance.test.ts`) and on `node:sqlite` in memory and as a file in the Node lane (`.node.test.ts`): `first`/`bind`/`all`/`run` shapes, `meta.changes` accuracy, boolean and `undefined` binding, atomic batch, positional results with each statement seeing the earlier ones, refusal of foreign statements, unique-violation recognition, binary snapshot at bind, `bigint` refused, and a write issued while a batch is in flight staying outside it. Eleven cases, green on both engines.

## Deviations from the issue text

- **Ledger table.** The issue says to record migrations in wrangler's `d1_migrations`; the repository's deploy script records them in `_schema_migrations (version, name, applied_at)` and that is what a production D1 export contains. The runner uses `_schema_migrations`, so an export imports with its history intact.
- **`instrumentD1` wiring** (item 4) is the composition root's job and lands with H-1; the adapter fills the meta fields it reads.
- **Import of a D1 export and app boot** (done-when item 2, second half) needs the Node entry point (H-1) and a dev export; the migrations-from-zero half is tested. Litestream replication is I-5's.

## Tests

- `src/node/sqlite-database.test.ts` (6): one statement per prepare with trailing comments allowed; bigint/buffer/boolean binding and the type error's message; batch rollback leaves the connection usable; `RETURNING` rows from `run()` with the write counted; file opened private/WAL/busy-timeout/foreign-keys; migrations applied at open.
- `src/node/migrate.test.ts` (10): all 73 repository migrations apply from zero and are recorded, a second run applies nothing; filename order and skipping recorded files; different-name refusal; misnamed (`notes.sql`, `10_tenth.sql`) and duplicate-version refusal before anything applies; a failing migration leaves neither DDL nor ledger row and retries once fixed; a migration with its own `COMMIT` refused; a second connection finds what the first applied recorded; the transaction-control scan versus trigger bodies, comments, and strings; comment markers inside literals and apostrophes inside comments not mis-pairing each other; and four processes racing through opening and migrating one fresh file (the opener bundled with esbuild), every process exiting cleanly with each migration recorded once.
- `src/db/errors.test.ts` (2): message branch and result-code branch.
- Conformance: 11 cases × 3 engines (D1 in workerd, `node:sqlite` memory, `node:sqlite` file).

Note: in the workerd lane the foreign-statement case makes miniflare log a `ZodError` from its D1 worker before rejecting; that is the expected failure being logged, not a test problem.

Control-plane unit suite 258 files / 3804 tests green; full workerd integration suite green; `npm run typecheck` (all four programs), eslint, prettier, knip clean.

## Follow-ups

- H-1 (COL-97): `openNodeSqlDatabase(DATA_DIR/global.db, { migrationsDir })` at boot, then the per-request instrumented wrapper as the Worker does, after renaming `instrumentD1` / `D1QueryRecord` / `d1_*` metrics to engine-neutral names so SQLite traffic does not report as D1 (recorded on COL-97).
- N-4 (COL-91) and N-5 (COL-92) build on this store.
- I-5 (COL-114): import a production D1 export and verify Litestream on the file.
