### PR TITLE
fix: scan migration SQL for transaction control in one pass (COL-89 follow-up)

### DIFF
--- a/packages/control-plane/src/node/migrate.test.ts
+++ b/packages/control-plane/src/node/migrate.test.ts
@@ -158,6 +158,30 @@ describe("applyMigrations", () => {
     );
   });
 
+  it("does not let a literal and a comment mis-pair each other's delimiters", () => {
+    // A comment marker inside a literal must not swallow the COMMIT after it.
+    expect(
+      containsTransactionControl(
+        "CREATE TABLE t (v TEXT DEFAULT '--'); COMMIT; CREATE TABLE u (id)"
+      )
+    ).toBe(true);
+    expect(
+      containsTransactionControl(
+        "CREATE TABLE t (v TEXT DEFAULT '/*'); COMMIT; CREATE TABLE u (id)"
+      )
+    ).toBe(true);
+    // An apostrophe inside a comment must not open a literal that swallows the COMMIT.
+    expect(containsTransactionControl("-- don't\nCOMMIT;\nINSERT INTO t (v) VALUES ('x')")).toBe(
+      true
+    );
+    // Nor may either invent a statement: quoted text may hold a semicolon and an escaped quote.
+    expect(
+      containsTransactionControl(
+        "INSERT INTO t (v) VALUES ('a; COMMIT; it''s fine');\nCREATE INDEX \"i; COMMIT\" ON t (v);\n/* don't ' COMMIT */\nCREATE TABLE [u; COMMIT] (id)"
+      )
+    ).toBe(false);
+  });
+
   it("lets several processes open and migrate one fresh file at once, applying each migration once", async () => {
     const migrations = join(dir, "migrations");
     mkdirMigrations(migrations, {

--- a/packages/control-plane/src/node/migrate.ts
+++ b/packages/control-plane/src/node/migrate.ts
@@ -127,18 +127,15 @@ export function applyMigrations(db: DatabaseSync, directory: string): string[] {
 
 /**
  * Whether any statement in `sql` is transaction control. Comments and
- * string literals are removed first, so a mention inside either does not
- * count, and trigger bodies are skipped, since their `BEGIN … END` is not
- * a transaction; a migration is otherwise plain DDL/DML, so statement
- * starts are what matter.
+ * quoted text are blanked in one left-to-right pass, so a comment marker
+ * inside a literal (`DEFAULT '--'`) or an apostrophe inside a comment
+ * (`-- don't`) does not hide or invent a statement boundary. Trigger
+ * bodies are skipped, since their `BEGIN … END` is not a transaction; a
+ * migration is otherwise plain DDL/DML, so statement starts are what matter.
  */
 export function containsTransactionControl(sql: string): boolean {
-  const stripped = sql
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/--[^\n]*/g, " ")
-    .replace(/'(?:[^']|'')*'/g, "''");
   let inTrigger = false;
-  for (const segment of stripped.split(";")) {
+  for (const segment of blankCommentsAndQuotes(sql).split(";")) {
     const statement = segment.trim();
     if (inTrigger) {
       if (/^END\b/i.test(statement)) inTrigger = false;
@@ -151,6 +148,56 @@ export function containsTransactionControl(sql: string): boolean {
     if (TRANSACTION_CONTROL.test(statement)) return true;
   }
   return false;
+}
+
+/**
+ * `sql` with each comment replaced by a space and each string literal or
+ * quoted identifier by an empty one. One scan decides which construct each
+ * character belongs to, so the two cannot mis-pair each other's delimiters.
+ * A doubled quote inside quoted text is an escaped quote; unterminated
+ * text runs to the end, as SQLite would read it.
+ */
+function blankCommentsAndQuotes(sql: string): string {
+  let out = "";
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql[i]!;
+    const next = sql[i + 1];
+    if (ch === "-" && next === "-") {
+      const end = sql.indexOf("\n", i);
+      i = end === -1 ? sql.length : end;
+      out += " ";
+    } else if (ch === "/" && next === "*") {
+      const end = sql.indexOf("*/", i + 2);
+      i = end === -1 ? sql.length : end + 2;
+      out += " ";
+    } else if (ch === "'" || ch === '"' || ch === "`") {
+      i = skipQuoted(sql, i, ch);
+      out += ch + ch;
+    } else if (ch === "[") {
+      const end = sql.indexOf("]", i + 1);
+      i = end === -1 ? sql.length : end + 1;
+      out += "[]";
+    } else {
+      out += ch;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+/** The index just past the quoted text opening at `start` with `quote`. */
+function skipQuoted(sql: string, start: number, quote: string): number {
+  let i = start + 1;
+  for (;;) {
+    const close = sql.indexOf(quote, i);
+    if (close === -1) return sql.length;
+    if (sql[close + 1] === quote) {
+      i = close + 2;
+      continue;
+    }
+    return close + 1;
+  }
 }
 
 /** Roll back if a transaction is open; a failed COMMIT leaves one, a failed BEGIN does not. */


### PR DESCRIPTION
Follow-up to #1755 (N-2 · COL-89), from CodeRabbit's finding on the merged head: `containsTransactionControl` stripped comments before string literals, so a literal holding a comment marker (`DEFAULT '--'`) swallowed the rest of its line and hid a `COMMIT` after it. A migration with a hidden `COMMIT` would end the runner's transaction early and leave the schema change committed without its ledger row.

## What

Reordering the two replacements, as suggested, moves the bug rather than removing it: with literals blanked first, an apostrophe inside a comment (`-- don't bloat the index`, migration 0012) opens a "literal" that runs to the next quote in the file and swallows whatever sits between. Twenty-one repository migrations have such comments; under the reordered scan eight of them lose whole statements (0041 and 0069 collapse to a column definition, 0057 loses seven statements).

`containsTransactionControl` now blanks comments, string literals, and quoted identifiers in one left-to-right pass (`blankCommentsAndQuotes`), deciding for each character which construct it belongs to, so neither can mis-pair the other's delimiters. Unterminated quoted text runs to the end, as SQLite would read it.

## Tests

`migrate.test.ts` gains one case: a comment marker inside a literal (`'--'`, `'/*'`) before a `COMMIT` is still caught; an apostrophe inside a comment before a `COMMIT` is still caught; quoted text holding a semicolon and an escaped quote, a bracketed identifier, and a block comment with an apostrophe do not invent a statement. The from-zero run over all repository migrations still applies every file.

Node host only; no worker bundle input. Typecheck (all four programs), eslint, prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of transaction-control statements in SQL containing comments, string literals, escaped quotes, or quoted identifiers.
  * Prevented comment markers and semicolons inside quoted or commented text from causing false positives or incorrect statement boundaries.

* **Tests**
  * Added coverage for SQL literals, comments, escaped quotes, semicolons, quoted identifiers, and genuine transaction-control statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->