### PR TITLE
refactor: scheduled jobs as one table both clocks can drive (COL-86)

### DIFF
--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -9,20 +9,13 @@ import { createLogger } from "./logger";
 import type { Env } from "./types";
 import type { GitHubAutofixEnvelope } from "@open-inspect/shared";
 import { handleAutofixQueue } from "./autofix/handler";
-import { checkAutofixQueueHealth } from "./autofix/queue-health";
 import { consumeImageBuildFinalizations } from "./image-builds/finalization-consumer";
-import { IMAGE_BUILD_SCHEDULER_CRON, runImageBuildScheduler } from "./image-builds/scheduler";
-import {
-  ABANDONED_DRAFT_SWEEP_CRON,
-  AbandonedDraftSweep,
-  SessionDraftExpiryClient,
-} from "./session/abandoned-draft-sweep";
 import { createSessionRuntimeClient } from "./session/runtime-client";
 import { createRequestMetrics, instrumentD1, type RequestMetrics } from "./db/instrumented-d1";
 import { SessionIndexStore } from "./db/session-index";
 import type { SqlDatabase } from "./db/sql-database";
 import { createCloudflareBackgroundTasks } from "./cloudflare/background-tasks";
-import { Scheduler } from "./scheduler/scheduler";
+import { findScheduledJob } from "./scheduled-jobs";
 import { isAutofixQueue } from "./queue-routing";
 
 const logger = createLogger("worker");
@@ -49,38 +42,28 @@ export default {
   },
 
   /**
-   * Cron trigger handler — processes overdue automations.
+   * Cron trigger handler: runs the job bound to the trigger's expression.
    */
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
-    if (event.cron === IMAGE_BUILD_SCHEDULER_CRON) {
-      const requestId = crypto.randomUUID();
-      // eslint-disable-next-line no-restricted-syntax -- scheduled composition root: the one cron env.DB read
-      await runImageBuildScheduler(env, env.DB, {
-        request_id: requestId,
-        trace_id: requestId,
-      });
-      return;
-    }
-    if (event.cron === ABANDONED_DRAFT_SWEEP_CRON) {
-      const sweepId = crypto.randomUUID();
-      const sweepContext = { trace_id: sweepId, request_id: sweepId };
-      await new AbandonedDraftSweep(
-        // eslint-disable-next-line no-restricted-syntax -- scheduled composition root: the one cron env.DB read
-        new SessionIndexStore(env.DB),
-        new SessionDraftExpiryClient(createSessionRuntimeClient(env, sweepContext)),
-        logger
-      ).run(Date.now());
-      return;
-    }
-    if (event.cron !== "* * * * *") {
+    const job = findScheduledJob(event.cron);
+    if (!job) {
       logger.warn("Unknown scheduled trigger", { cron: event.cron });
       return;
     }
-    ctx.waitUntil(checkAutofixQueueHealth(env, logger));
-    // The tick runs both the recovery sweep (orphaned/timed-out runs) and
-    // processes overdue automations.
-    // eslint-disable-next-line no-restricted-syntax -- scheduled composition root: construct the scheduler's database dependency
-    await new Scheduler(env.DB, env, createCloudflareBackgroundTasks(ctx)).tick();
+    const runId = crypto.randomUUID();
+    const correlation = { trace_id: runId, request_id: runId };
+    await job.run(
+      {
+        env,
+        // eslint-disable-next-line no-restricted-syntax -- scheduled composition root: the one cron env.DB read
+        db: env.DB,
+        sessions: createSessionRuntimeClient(env, correlation),
+        backgroundTasks: createCloudflareBackgroundTasks(ctx),
+        log: logger,
+        correlation,
+      },
+      Date.now()
+    );
   },
 
   async queue(batch: MessageBatch<unknown>, env: Env): Promise<void> {

--- a/packages/control-plane/src/scheduled-jobs.test.ts
+++ b/packages/control-plane/src/scheduled-jobs.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { checkAutofixQueueHealth } from "./autofix/queue-health";
+import { SessionIndexStore } from "./db/session-index";
+import type { SqlDatabase } from "./db/sql-database";
+import { runImageBuildScheduler } from "./image-builds/scheduler";
+import type { Logger } from "./logger";
+import type { BackgroundTasks } from "./platform-ports";
+import { Scheduler } from "./scheduler/scheduler";
+import { AbandonedDraftSweep, SessionDraftExpiryClient } from "./session/abandoned-draft-sweep";
+import type { SessionRuntimeClient } from "./session/runtime-client";
+import { SCHEDULED_JOBS, findScheduledJob, type ScheduledJobDeps } from "./scheduled-jobs";
+import type { Env } from "./types";
+
+vi.mock("./autofix/queue-health", () => ({ checkAutofixQueueHealth: vi.fn(async () => {}) }));
+vi.mock("./image-builds/scheduler", () => ({
+  IMAGE_BUILD_SCHEDULER_CRON: "7,37 * * * *",
+  runImageBuildScheduler: vi.fn(async () => ({})),
+}));
+vi.mock("./scheduler/scheduler", () => ({
+  Scheduler: vi.fn(function () {
+    return { tick: schedulerTick };
+  }),
+}));
+vi.mock("./session/abandoned-draft-sweep", () => ({
+  ABANDONED_DRAFT_SWEEP_CRON: "23 * * * *",
+  AbandonedDraftSweep: vi.fn(function () {
+    return { run: sweepRun };
+  }),
+  SessionDraftExpiryClient: vi.fn(),
+}));
+
+const { schedulerTick, sweepRun } = vi.hoisted(() => ({
+  schedulerTick: vi.fn(async () => ({})),
+  sweepRun: vi.fn(async () => ({})),
+}));
+
+const TERRAFORM_WORKER = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../terraform/environments/production/workers-control-plane.tf"
+);
+
+/** The `cron_triggers` Terraform declares for the control-plane Worker. */
+function terraformCronTriggers(): string[] {
+  const match = /cron_triggers\s*=\s*\[([^\]]*)\]/.exec(readFileSync(TERRAFORM_WORKER, "utf8"));
+  if (!match) throw new Error(`No cron_triggers in ${TERRAFORM_WORKER}`);
+  return [...match[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+}
+
+function fakeDeps(): ScheduledJobDeps & {
+  submitted: Array<{ name: string; task: () => Promise<unknown> }>;
+} {
+  const submitted: Array<{ name: string; task: () => Promise<unknown> }> = [];
+  const backgroundTasks: BackgroundTasks = {
+    submit(task, metadata) {
+      submitted.push({ name: metadata.name, task });
+    },
+  };
+  return {
+    env: { LOG_LEVEL: "error" } as unknown as Env,
+    db: {} as SqlDatabase,
+    sessions: {} as SessionRuntimeClient,
+    backgroundTasks,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger,
+    correlation: { trace_id: "trace-1", request_id: "request-1" },
+    submitted,
+  };
+}
+
+describe("SCHEDULED_JOBS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("binds each cron expression to exactly one job, and Terraform's triggers to exactly those", () => {
+    const crons = SCHEDULED_JOBS.map((job) => job.cron);
+    expect(new Set(crons).size).toBe(crons.length);
+    expect(new Set(SCHEDULED_JOBS.map((job) => job.name)).size).toBe(crons.length);
+    expect([...terraformCronTriggers()].sort()).toEqual([...crons].sort());
+    for (const job of SCHEDULED_JOBS) expect(findScheduledJob(job.cron)).toBe(job);
+    expect(findScheduledJob("0 0 * * *")).toBeUndefined();
+  });
+
+  it("runs the every-minute tick: queue health in the background, the scheduler tick awaited", async () => {
+    const deps = fakeDeps();
+
+    await findScheduledJob("* * * * *")!.run(deps, 1_000);
+
+    expect(Scheduler).toHaveBeenCalledWith(deps.db, deps.env, deps.backgroundTasks);
+    expect(schedulerTick).toHaveBeenCalledTimes(1);
+    expect(deps.submitted.map((entry) => entry.name)).toEqual(["autofix_queue_health"]);
+    expect(checkAutofixQueueHealth).not.toHaveBeenCalled();
+    await deps.submitted[0]!.task();
+    expect(checkAutofixQueueHealth).toHaveBeenCalledWith(deps.env, deps.log);
+  });
+
+  it("runs the image-build scheduler with the run's correlation", async () => {
+    const deps = fakeDeps();
+
+    await findScheduledJob("7,37 * * * *")!.run(deps, 1_000);
+
+    expect(runImageBuildScheduler).toHaveBeenCalledWith(deps.env, deps.db, deps.correlation);
+    expect(deps.submitted).toEqual([]);
+  });
+
+  it("runs the abandoned-draft sweep over the index store and the session client at the run's time", async () => {
+    const deps = fakeDeps();
+
+    await findScheduledJob("23 * * * *")!.run(deps, 1_234_567);
+
+    expect(SessionDraftExpiryClient).toHaveBeenCalledWith(deps.sessions);
+    const [index, client, log] = vi.mocked(AbandonedDraftSweep).mock.calls[0]!;
+    expect(index).toBeInstanceOf(SessionIndexStore);
+    expect(client).toBe(vi.mocked(SessionDraftExpiryClient).mock.instances[0]);
+    expect(log).toBe(deps.log);
+    expect(sweepRun).toHaveBeenCalledWith(1_234_567);
+  });
+});

--- a/packages/control-plane/src/scheduled-jobs.test.ts
+++ b/packages/control-plane/src/scheduled-jobs.test.ts
@@ -5,18 +5,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { checkAutofixQueueHealth } from "./autofix/queue-health";
 import { SessionIndexStore } from "./db/session-index";
 import type { SqlDatabase } from "./db/sql-database";
-import { runImageBuildScheduler } from "./image-builds/scheduler";
+import type * as ImageBuildScheduler from "./image-builds/scheduler";
+import { IMAGE_BUILD_SCHEDULER_CRON, runImageBuildScheduler } from "./image-builds/scheduler";
 import type { Logger } from "./logger";
 import type { BackgroundTasks } from "./platform-ports";
 import { Scheduler } from "./scheduler/scheduler";
-import { AbandonedDraftSweep, SessionDraftExpiryClient } from "./session/abandoned-draft-sweep";
+import type * as AbandonedDraftSweepModule from "./session/abandoned-draft-sweep";
+import {
+  ABANDONED_DRAFT_SWEEP_CRON,
+  AbandonedDraftSweep,
+  SessionDraftExpiryClient,
+} from "./session/abandoned-draft-sweep";
 import type { SessionRuntimeClient } from "./session/runtime-client";
-import { SCHEDULED_JOBS, findScheduledJob, type ScheduledJobDeps } from "./scheduled-jobs";
+import {
+  SCHEDULED_JOBS,
+  SCHEDULER_TICK_CRON,
+  findScheduledJob,
+  type ScheduledJobDeps,
+} from "./scheduled-jobs";
 import type { Env } from "./types";
 
+// The job bodies are mocked; the cron constants stay the production values so
+// the Terraform parity check below reads what the Worker really registers.
 vi.mock("./autofix/queue-health", () => ({ checkAutofixQueueHealth: vi.fn(async () => {}) }));
-vi.mock("./image-builds/scheduler", () => ({
-  IMAGE_BUILD_SCHEDULER_CRON: "7,37 * * * *",
+vi.mock("./image-builds/scheduler", async (importOriginal) => ({
+  ...(await importOriginal<typeof ImageBuildScheduler>()),
   runImageBuildScheduler: vi.fn(async () => ({})),
 }));
 vi.mock("./scheduler/scheduler", () => ({
@@ -24,8 +37,8 @@ vi.mock("./scheduler/scheduler", () => ({
     return { tick: schedulerTick };
   }),
 }));
-vi.mock("./session/abandoned-draft-sweep", () => ({
-  ABANDONED_DRAFT_SWEEP_CRON: "23 * * * *",
+vi.mock("./session/abandoned-draft-sweep", async (importOriginal) => ({
+  ...(await importOriginal<typeof AbandonedDraftSweepModule>()),
   AbandonedDraftSweep: vi.fn(function () {
     return { run: sweepRun };
   }),
@@ -78,6 +91,9 @@ describe("SCHEDULED_JOBS", () => {
     const crons = SCHEDULED_JOBS.map((job) => job.cron);
     expect(new Set(crons).size).toBe(crons.length);
     expect(new Set(SCHEDULED_JOBS.map((job) => job.name)).size).toBe(crons.length);
+    expect([...crons].sort()).toEqual(
+      [SCHEDULER_TICK_CRON, IMAGE_BUILD_SCHEDULER_CRON, ABANDONED_DRAFT_SWEEP_CRON].sort()
+    );
     expect([...terraformCronTriggers()].sort()).toEqual([...crons].sort());
     for (const job of SCHEDULED_JOBS) expect(findScheduledJob(job.cron)).toBe(job);
     expect(findScheduledJob("0 0 * * *")).toBeUndefined();
@@ -86,7 +102,7 @@ describe("SCHEDULED_JOBS", () => {
   it("runs the every-minute tick: queue health in the background, the scheduler tick awaited", async () => {
     const deps = fakeDeps();
 
-    await findScheduledJob("* * * * *")!.run(deps, 1_000);
+    await findScheduledJob(SCHEDULER_TICK_CRON)!.run(deps, 1_000);
 
     expect(Scheduler).toHaveBeenCalledWith(deps.db, deps.env, deps.backgroundTasks);
     expect(schedulerTick).toHaveBeenCalledTimes(1);
@@ -99,7 +115,7 @@ describe("SCHEDULED_JOBS", () => {
   it("runs the image-build scheduler with the run's correlation", async () => {
     const deps = fakeDeps();
 
-    await findScheduledJob("7,37 * * * *")!.run(deps, 1_000);
+    await findScheduledJob(IMAGE_BUILD_SCHEDULER_CRON)!.run(deps, 1_000);
 
     expect(runImageBuildScheduler).toHaveBeenCalledWith(deps.env, deps.db, deps.correlation);
     expect(deps.submitted).toEqual([]);
@@ -108,7 +124,7 @@ describe("SCHEDULED_JOBS", () => {
   it("runs the abandoned-draft sweep over the index store and the session client at the run's time", async () => {
     const deps = fakeDeps();
 
-    await findScheduledJob("23 * * * *")!.run(deps, 1_234_567);
+    await findScheduledJob(ABANDONED_DRAFT_SWEEP_CRON)!.run(deps, 1_234_567);
 
     expect(SessionDraftExpiryClient).toHaveBeenCalledWith(deps.sessions);
     const [index, client, log] = vi.mocked(AbandonedDraftSweep).mock.calls[0]!;

--- a/packages/control-plane/src/scheduled-jobs.ts
+++ b/packages/control-plane/src/scheduled-jobs.ts
@@ -4,14 +4,15 @@
  * Terraform declares (`cron_triggers` in
  * `terraform/environments/production/workers-control-plane.tf`), which must
  * list exactly the expressions below; a unit test checks the two agree. The
- * Node host runs an in-process loop over the same table with
- * `nextCronOccurrence` from `@open-inspect/shared`.
+ * Node host will drive the same table from an in-process loop over
+ * `nextCronOccurrence` from `@open-inspect/shared` (H-5); nothing on Node
+ * consumes it yet.
  *
  * A slot may fire twice (a retried trigger, two hosts during a cutover) and
  * that is harmless: the automation scheduler's tick claims its work with an
  * SQL compare-and-swap, and the sweeps are idempotent, so a double tick costs
- * extra reads and nothing else. The Node host is one process, so there is no
- * leader election and none is needed.
+ * extra reads and nothing else. The Node host is planned as one process, so
+ * it needs no leader election.
  */
 
 import { checkAutofixQueueHealth } from "./autofix/queue-health";

--- a/packages/control-plane/src/scheduled-jobs.ts
+++ b/packages/control-plane/src/scheduled-jobs.ts
@@ -1,0 +1,90 @@
+/**
+ * The control plane's scheduled jobs: one table that both clocks drive.
+ * Cloudflare fires `scheduled()` in `src/index.ts` from the cron triggers
+ * Terraform declares (`cron_triggers` in
+ * `terraform/environments/production/workers-control-plane.tf`), which must
+ * list exactly the expressions below; a unit test checks the two agree. The
+ * Node host runs an in-process loop over the same table with
+ * `nextCronOccurrence` from `@open-inspect/shared`.
+ *
+ * A slot may fire twice (a retried trigger, two hosts during a cutover) and
+ * that is harmless: the automation scheduler's tick claims its work with an
+ * SQL compare-and-swap, and the sweeps are idempotent, so a double tick costs
+ * extra reads and nothing else. The Node host is one process, so there is no
+ * leader election and none is needed.
+ */
+
+import { checkAutofixQueueHealth } from "./autofix/queue-health";
+import { SessionIndexStore } from "./db/session-index";
+import type { SqlDatabase } from "./db/sql-database";
+import { IMAGE_BUILD_SCHEDULER_CRON, runImageBuildScheduler } from "./image-builds/scheduler";
+import type { CorrelationContext, Logger } from "./logger";
+import type { BackgroundTasks } from "./platform-ports";
+import { Scheduler } from "./scheduler/scheduler";
+import {
+  ABANDONED_DRAFT_SWEEP_CRON,
+  AbandonedDraftSweep,
+  SessionDraftExpiryClient,
+} from "./session/abandoned-draft-sweep";
+import type { SessionRuntimeClient } from "./session/runtime-client";
+import type { Env } from "./types";
+
+/** Every minute: the automation scheduler's tick and the autofix queue health check. */
+export const SCHEDULER_TICK_CRON = "* * * * *";
+
+/** What one run of a scheduled job is given. The host builds it per run. */
+export interface ScheduledJobDeps {
+  env: Env;
+  db: SqlDatabase;
+  sessions: SessionRuntimeClient;
+  backgroundTasks: BackgroundTasks;
+  log: Logger;
+  /** Identifies this run in logs; the host mints one per run. */
+  correlation: CorrelationContext;
+}
+
+export interface ScheduledJob {
+  readonly name: string;
+  /** Five-field cron expression, evaluated in UTC. */
+  readonly cron: string;
+  /** Run the job once for the slot at `nowMs` (epoch milliseconds). */
+  run(deps: ScheduledJobDeps, nowMs: number): Promise<void>;
+}
+
+export const SCHEDULED_JOBS: readonly ScheduledJob[] = [
+  {
+    name: "scheduler_tick",
+    cron: SCHEDULER_TICK_CRON,
+    async run({ env, db, backgroundTasks, log }) {
+      backgroundTasks.submit(() => checkAutofixQueueHealth(env, log), {
+        name: "autofix_queue_health",
+      });
+      // The tick runs both the recovery sweep (orphaned/timed-out runs) and
+      // processes overdue automations.
+      await new Scheduler(db, env, backgroundTasks).tick();
+    },
+  },
+  {
+    name: "image_build_scheduler",
+    cron: IMAGE_BUILD_SCHEDULER_CRON,
+    async run({ env, db, correlation }) {
+      await runImageBuildScheduler(env, db, correlation);
+    },
+  },
+  {
+    name: "abandoned_draft_sweep",
+    cron: ABANDONED_DRAFT_SWEEP_CRON,
+    async run({ db, sessions, log }, nowMs) {
+      await new AbandonedDraftSweep(
+        new SessionIndexStore(db),
+        new SessionDraftExpiryClient(sessions),
+        log
+      ).run(nowMs);
+    },
+  },
+];
+
+/** The job bound to `cron`, or `undefined` when no job runs on that expression. */
+export function findScheduledJob(cron: string): ScheduledJob | undefined {
+  return SCHEDULED_JOBS.find((job) => job.cron === cron);
+}

--- a/packages/control-plane/test/integration/abandoned-draft-sweep.test.ts
+++ b/packages/control-plane/test/integration/abandoned-draft-sweep.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createExecutionContext, env } from "cloudflare:test";
 import worker from "../../src/index";
 import { SessionIndexStore } from "../../src/db/session-index";
+import { SCHEDULER_TICK_CRON } from "../../src/scheduled-jobs";
 import { ABANDONED_DRAFT_SWEEP_CRON } from "../../src/session/abandoned-draft-sweep";
 import type { Env } from "../../src/types";
 import { cleanD1Tables } from "./cleanup";
@@ -60,7 +61,7 @@ describe("abandoned draft sweep cron routing", () => {
     );
 
     await worker.scheduled(
-      { cron: "* * * * *" } as ScheduledEvent,
+      { cron: SCHEDULER_TICK_CRON } as ScheduledEvent,
       {
         DB: env.DB,
         SESSION: sessionNamespace,


### PR DESCRIPTION
Roadmap **P-7 · COL-86**: the `scheduled()` switch in `src/index.ts` becomes a job table both clocks can drive. No behavior change on Cloudflare; the Node host's cron loop (H-5) will iterate the same table.

## What

**`src/scheduled-jobs.ts`.** `SCHEDULED_JOBS: readonly ScheduledJob[]`, one entry per cron trigger: `scheduler_tick` (`* * * * *`: the autofix queue health check submitted to background tasks, then the automation scheduler's tick awaited), `image_build_scheduler` (`7,37 * * * *`), `abandoned_draft_sweep` (`23 * * * *`). Each job is `run(deps, nowMs)` over one explicitly typed `ScheduledJobDeps { env, db, sessions, backgroundTasks, log, correlation }` that the host builds per run; `findScheduledJob(cron)` is the lookup. The table imports no Cloudflare types, only the port types (`SqlDatabase`, `BackgroundTasks`, `SessionRuntimeClient`) and `Env`. Its doc comment records that a double-fired slot is harmless (the scheduler's tick claims work with an SQL compare-and-swap, the sweeps are idempotent) and that the Node host is one process, so there is no leader election and none is needed.

**`src/index.ts`.** `scheduled()` is now the lookup, the existing unknown-trigger warning, one `env.DB` read, and `job.run(deps, Date.now())`. Its diff is confined to that handler and its imports so P-5 (COL-74, in flight in parallel) can swap the deps for the platform record with a one-line change; whichever of the two lands second rebases.

The autofix queue health check moves from a raw `ctx.waitUntil(promise)` to `backgroundTasks.submit(...)`, which is `waitUntil` plus a rejection log (`background_task.failed`); the check catches its own errors, so this changes nothing observable.

## Deviations from the issue text

- **Where the cron constants live.** `IMAGE_BUILD_SCHEDULER_CRON` and `ABANDONED_DRAFT_SWEEP_CRON` stay exported from the modules that also log them (`image-builds/scheduler.ts` logs its cron on every run; `abandoned-draft-sweep.ts` documents its offset from the image-build schedule); moving them into the table would make those modules import the table that imports them. The table binds each constant to its job, the tick's `* * * * *` now lives in the table as `SCHEDULER_TICK_CRON`, and each expression appears once in code. A unit test reads Terraform's `cron_triggers` and asserts they are exactly the table's crons, so the two cannot drift.
- **Deps from the platform record** (item 2) waits for P-5; `scheduled()` builds the same fields from `env` and `ctx` today.

## Tests

- `src/scheduled-jobs.test.ts` (4): every cron and name bound once and Terraform's `cron_triggers` equal to the table's crons; the tick submits the health check to background tasks (not run inline) and awaits the scheduler's tick with `(db, env, backgroundTasks)`; the image-build job runs with the run's correlation and submits nothing; the draft sweep runs over the index store and the session client at the run's time. Job bodies are mocked, so each case is against fakes.
- `test/integration/abandoned-draft-sweep.test.ts` uses `SCHEDULER_TICK_CRON` instead of a literal; it and `image-build-scheduler.test.ts` still drive `worker.scheduled()` in workerd and prove the routing.

Control-plane unit suite green; full workerd integration suite green; typecheck (all four programs), eslint, prettier clean; knip output identical to main; worker bundle has no Node-only inputs.

## Follow-ups

- H-5 (COL-101): the Node cron loop iterates `SCHEDULED_JOBS` with `nextCronOccurrence(job.cron, "UTC", after)` and builds `ScheduledJobDeps` from the Node adapters.
- P-5 (COL-74): replace the deps built in `scheduled()` with the Cloudflare platform record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Scheduled background tasks now run through a consistent trigger-to-job mapping.
  - Unrecognized schedule triggers are safely ignored rather than causing unintended work.
  - Scheduled processing remains safe when a trigger is retried or runs concurrently, preventing duplicate effects.

- **Bug Fixes**
  - Improved separation between scheduled tasks so one task does not incorrectly invoke another.

- **Tests**
  - Added coverage confirming all configured schedules map to the correct tasks and execute as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->