### PR TITLE
feat: in-process SessionRuntimeClient for the Node host (COL-96)

### DIFF
--- a/packages/control-plane/src/node/runtime-client.test.ts
+++ b/packages/control-plane/src/node/runtime-client.test.ts
@@ -8,42 +8,48 @@ import type { AlarmScheduleStore } from "../session/alarm/scheduler";
 import { SessionInternalPaths } from "../session/contracts";
 import type { SessionPlatform } from "../session/platform";
 import {
-  createNodeSessionRuntimeClient,
-  createNodeSessionRuntimeClientForTrace,
-  type NodeSessionRuntimeClientOptions,
-  type RequestServingRuntime,
-} from "./runtime-client";
+  createSessionRuntimeClientForTraceOver,
+  createSessionRuntimeClientOver,
+} from "../session/runtime-client";
+import { createNodeSessionRuntimeDispatch, type RequestServingRuntime } from "./runtime-client";
 import { SessionRuntimeRegistry, type ManagedSessionRuntime } from "./session-runtime-registry";
 import { createFileSessionStoreProvider } from "./session-store";
 
 const ctx: CorrelationContext = { trace_id: "trace-1", request_id: "request-1" };
 
-/** A lookup over one runtime per id, counting how often each is used. */
+/** A lookup over one runtime shared by every present id, counting leases in flight. */
 function fakeRuntimes(handle: (request: Request) => Promise<Response>) {
-  const uses = new Map<string, number>();
-  const options: NodeSessionRuntimeClientOptions<RequestServingRuntime> = {
-    runtimes: {
-      withRuntime: async (sessionId, use) => {
-        uses.set(sessionId, (uses.get(sessionId) ?? 0) + 1);
-        return use({ server: { onRequest: handle } });
-      },
+  const present = new Set<string>();
+  const state = { inFlight: 0, released: 0 };
+  const runtimes = {
+    withRuntimeIfPresent: async <T>(
+      sessionId: string,
+      use: (runtime: RequestServingRuntime) => Promise<T>
+    ): Promise<T | undefined> => {
+      if (!present.has(sessionId)) return undefined;
+      state.inFlight += 1;
+      try {
+        return await use({ server: { onRequest: handle } });
+      } finally {
+        state.inFlight -= 1;
+        state.released += 1;
+      }
     },
-    sessionIndex: { exists: vi.fn(async () => false) },
-    storeProvider: { exists: vi.fn(async () => false) },
   };
-  return { options, uses };
+  return { runtimes, present, state };
 }
 
-describe("createNodeSessionRuntimeClient", () => {
-  it("dispatches a correlated internal request to the session's runtime", async () => {
+describe("createNodeSessionRuntimeDispatch", () => {
+  it("delivers the client's correlated internal request to the session's runtime", async () => {
     const requests: Request[] = [];
-    const { options, uses } = fakeRuntimes(async (request) => {
+    const { runtimes, present } = fakeRuntimes(async (request) => {
       requests.push(request);
       return Response.json({ ok: true });
     });
-    vi.mocked(options.storeProvider.exists).mockResolvedValue(true);
+    present.add("session-1");
+    const client = createSessionRuntimeClientOver(createNodeSessionRuntimeDispatch(runtimes), ctx);
 
-    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
+    const response = await client.fetch(
       "session-1",
       SessionInternalPaths.events,
       { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
@@ -51,7 +57,6 @@ describe("createNodeSessionRuntimeClient", () => {
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(uses.get("session-1")).toBe(1);
     const request = requests[0]!;
     expect(request.method).toBe("POST");
     expect(new URL(request.url).pathname).toBe(SessionInternalPaths.events);
@@ -62,64 +67,32 @@ describe("createNodeSessionRuntimeClient", () => {
     await expect(request.text()).resolves.toBe("{}");
   });
 
-  it("answers 404 for a session with no store and no index row without opening a runtime", async () => {
+  it("answers 404 for a session the registry finds nothing behind", async () => {
     const handle = vi.fn(async () => new Response(null, { status: 200 }));
-    const { options, uses } = fakeRuntimes(handle);
+    const { runtimes } = fakeRuntimes(handle);
+    const client = createSessionRuntimeClientOver(createNodeSessionRuntimeDispatch(runtimes), ctx);
 
-    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
-      "missing",
-      SessionInternalPaths.expireDraft,
-      { method: "POST" }
-    );
+    const response = await client.fetch("missing", SessionInternalPaths.expireDraft, {
+      method: "POST",
+    });
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Session not found" });
-    expect(uses.size).toBe(0);
     expect(handle).not.toHaveBeenCalled();
   });
 
-  it("opens a runtime for a session that has an index row but no store yet", async () => {
-    const { options, uses } = fakeRuntimes(async () => new Response(null, { status: 201 }));
-    vi.mocked(options.sessionIndex.exists).mockResolvedValue(true);
-
-    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
-      "session-new",
-      SessionInternalPaths.init,
-      { method: "POST" }
-    );
-
-    expect(response.status).toBe(201);
-    expect(uses.get("session-new")).toBe(1);
-  });
-
-  it("answers 404 rather than throwing for an id that cannot name a store", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "runtime-client-"));
-    try {
-      const { options } = fakeRuntimes(async () => new Response(null, { status: 200 }));
-      options.storeProvider = createFileSessionStoreProvider(dataDir);
-
-      const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
-        "../outside",
-        SessionInternalPaths.state
-      );
-
-      expect(response.status).toBe(404);
-    } finally {
-      rmSync(dataDir, { recursive: true, force: true });
-    }
-  });
-});
-
-describe("createNodeSessionRuntimeClientForTrace", () => {
-  it("keeps the trace and mints a fresh request id for every call", async () => {
+  it("mints a fresh request id per call for a trace-only caller", async () => {
     const requests: Request[] = [];
-    const { options } = fakeRuntimes(async (request) => {
+    const { runtimes, present } = fakeRuntimes(async (request) => {
       requests.push(request);
       return new Response(null, { status: 200 });
     });
-    vi.mocked(options.storeProvider.exists).mockResolvedValue(true);
+    present.add("parent-1");
+    const client = createSessionRuntimeClientForTraceOver(
+      createNodeSessionRuntimeDispatch(runtimes),
+      "child-session-id"
+    );
 
-    const client = createNodeSessionRuntimeClientForTrace(options, "child-session-id");
     await client.fetch("parent-1", SessionInternalPaths.childSessionUpdate, { method: "POST" });
     await client.fetch("parent-1", SessionInternalPaths.childSessionUpdate, { method: "POST" });
 
@@ -131,6 +104,78 @@ describe("createNodeSessionRuntimeClientForTrace", () => {
     expect(requestIds[0]).toMatch(/[0-9a-f-]{36}/);
     expect(requestIds[0]).not.toBe(requestIds[1]);
   });
+
+  describe("abort", () => {
+    it("rejects an already-aborted request without touching the registry", async () => {
+      const handle = vi.fn(async () => new Response(null, { status: 200 }));
+      const { runtimes, present, state } = fakeRuntimes(handle);
+      present.add("s1");
+      const client = createSessionRuntimeClientOver(
+        createNodeSessionRuntimeDispatch(runtimes),
+        ctx
+      );
+      const controller = new AbortController();
+      controller.abort(new Error("gone before dispatch"));
+
+      await expect(
+        client.fetch("s1", SessionInternalPaths.state, { signal: controller.signal })
+      ).rejects.toThrow("gone before dispatch");
+      expect(handle).not.toHaveBeenCalled();
+      expect(state.inFlight).toBe(0);
+    });
+
+    it("rejects promptly when the signal aborts mid-handler and releases the lease when the handler settles", async () => {
+      let finish!: () => void;
+      const handlerDone = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      const { runtimes, present, state } = fakeRuntimes(async () => {
+        await handlerDone;
+        return new Response(null, { status: 200 });
+      });
+      present.add("s1");
+      const client = createSessionRuntimeClientOver(
+        createNodeSessionRuntimeDispatch(runtimes),
+        ctx
+      );
+      const controller = new AbortController();
+
+      const pending = client.fetch("s1", SessionInternalPaths.expireDraft, {
+        method: "POST",
+        signal: controller.signal,
+      });
+      await new Promise((tick) => setImmediate(tick));
+      expect(state.inFlight).toBe(1);
+
+      controller.abort(new DOMException("The operation timed out.", "TimeoutError"));
+      await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+      // The handler is still running under its lease; only the caller has gone.
+      expect(state.inFlight).toBe(1);
+      expect(state.released).toBe(0);
+
+      finish();
+      await new Promise((tick) => setImmediate(tick));
+      expect(state.inFlight).toBe(0);
+      expect(state.released).toBe(1);
+    });
+
+    it("stops listening to a signal once the request has settled", async () => {
+      const { runtimes, present } = fakeRuntimes(async () => new Response(null, { status: 200 }));
+      present.add("s1");
+      const client = createSessionRuntimeClientOver(
+        createNodeSessionRuntimeDispatch(runtimes),
+        ctx
+      );
+      const controller = new AbortController();
+
+      const response = await client.fetch("s1", SessionInternalPaths.state, {
+        signal: controller.signal,
+      });
+      expect(response.status).toBe(200);
+      controller.abort();
+      await expect(response.text()).resolves.toBe("");
+    });
+  });
 });
 
 describe("with the session runtime registry", () => {
@@ -139,6 +184,7 @@ describe("with the session runtime registry", () => {
   let now: number;
   let registry: SessionRuntimeRegistry<Runtime>;
   let builds: number;
+  const indexed = new Set<string>();
 
   const alarmStoreFor = (): AlarmScheduleStore => ({
     getAlarm: async () => null,
@@ -164,11 +210,13 @@ describe("with the session runtime registry", () => {
     dataDir = mkdtempSync(join(tmpdir(), "runtime-client-registry-"));
     now = 1_000_000;
     builds = 0;
+    indexed.clear();
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() };
     log.child.mockReturnValue(log);
     registry = new SessionRuntimeRegistry<Runtime>({
       db: {} as SqlDatabase,
       storeProvider: createFileSessionStoreProvider(dataDir),
+      sessionIndex: { exists: async (id) => indexed.has(id) },
       alarmStoreFor,
       buildRuntime: buildRuntime as (platform: SessionPlatform) => Runtime,
       log: log as never,
@@ -182,30 +230,30 @@ describe("with the session runtime registry", () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
-  it("re-opens a session the registry evicted, from its store on disk", async () => {
-    const storeProvider = createFileSessionStoreProvider(dataDir);
-    // Creation: the index row exists before the store does.
-    const index = { exists: async () => true };
-    const client = createNodeSessionRuntimeClient(
-      { runtimes: registry, sessionIndex: index, storeProvider },
-      ctx
-    );
+  it("creates a session from its index row, and re-opens it from its store once evicted", async () => {
+    const stores = createFileSessionStoreProvider(dataDir);
+    const client = createSessionRuntimeClientOver(createNodeSessionRuntimeDispatch(registry), ctx);
 
+    // Unknown everywhere: nothing is built and no store appears.
+    const missing = await client.fetch("s1", SessionInternalPaths.state);
+    expect(missing.status).toBe(404);
+    expect(builds).toBe(0);
+    expect(await stores.exists("s1")).toBe(false);
+
+    // Creation: the index row exists before the store does.
+    indexed.add("s1");
     const created = await client.fetch("s1", SessionInternalPaths.init, { method: "POST" });
     await expect(created.json()).resolves.toEqual({ path: SessionInternalPaths.init });
     expect(builds).toBe(1);
-    expect(await storeProvider.exists("s1")).toBe(true);
+    expect(await stores.exists("s1")).toBe(true);
 
     now += 2_000;
     expect(await registry.sweep()).toEqual(["s1"]);
     expect(registry.residentSessionIds()).toEqual([]);
 
     // The index row is gone; the store alone brings the session back.
-    const evicted = createNodeSessionRuntimeClient(
-      { runtimes: registry, sessionIndex: { exists: async () => false }, storeProvider },
-      ctx
-    );
-    const reopened = await evicted.fetch("s1", SessionInternalPaths.state);
+    indexed.delete("s1");
+    const reopened = await client.fetch("s1", SessionInternalPaths.state);
     await expect(reopened.json()).resolves.toEqual({ path: SessionInternalPaths.state });
     expect(builds).toBe(2);
     expect(registry.residentSessionIds()).toEqual(["s1"]);

--- a/packages/control-plane/src/node/runtime-client.test.ts
+++ b/packages/control-plane/src/node/runtime-client.test.ts
@@ -1,0 +1,213 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SqlDatabase } from "../db/sql-database";
+import type { CorrelationContext } from "../logger";
+import type { AlarmScheduleStore } from "../session/alarm/scheduler";
+import { SessionInternalPaths } from "../session/contracts";
+import type { SessionPlatform } from "../session/platform";
+import {
+  createNodeSessionRuntimeClient,
+  createNodeSessionRuntimeClientForTrace,
+  type NodeSessionRuntimeClientOptions,
+  type RequestServingRuntime,
+} from "./runtime-client";
+import { SessionRuntimeRegistry, type ManagedSessionRuntime } from "./session-runtime-registry";
+import { createFileSessionStoreProvider } from "./session-store";
+
+const ctx: CorrelationContext = { trace_id: "trace-1", request_id: "request-1" };
+
+/** A lookup over one runtime per id, counting how often each is used. */
+function fakeRuntimes(handle: (request: Request) => Promise<Response>) {
+  const uses = new Map<string, number>();
+  const options: NodeSessionRuntimeClientOptions<RequestServingRuntime> = {
+    runtimes: {
+      withRuntime: async (sessionId, use) => {
+        uses.set(sessionId, (uses.get(sessionId) ?? 0) + 1);
+        return use({ server: { onRequest: handle } });
+      },
+    },
+    sessionIndex: { exists: vi.fn(async () => false) },
+    storeProvider: { exists: vi.fn(async () => false) },
+  };
+  return { options, uses };
+}
+
+describe("createNodeSessionRuntimeClient", () => {
+  it("dispatches a correlated internal request to the session's runtime", async () => {
+    const requests: Request[] = [];
+    const { options, uses } = fakeRuntimes(async (request) => {
+      requests.push(request);
+      return Response.json({ ok: true });
+    });
+    vi.mocked(options.storeProvider.exists).mockResolvedValue(true);
+
+    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
+      "session-1",
+      SessionInternalPaths.events,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+      "?limit=10"
+    );
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(uses.get("session-1")).toBe(1);
+    const request = requests[0]!;
+    expect(request.method).toBe("POST");
+    expect(new URL(request.url).pathname).toBe(SessionInternalPaths.events);
+    expect(new URL(request.url).search).toBe("?limit=10");
+    expect(request.headers.get("x-trace-id")).toBe("trace-1");
+    expect(request.headers.get("x-request-id")).toBe("request-1");
+    expect(request.headers.get("Content-Type")).toBe("application/json");
+    await expect(request.text()).resolves.toBe("{}");
+  });
+
+  it("answers 404 for a session with no store and no index row without opening a runtime", async () => {
+    const handle = vi.fn(async () => new Response(null, { status: 200 }));
+    const { options, uses } = fakeRuntimes(handle);
+
+    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
+      "missing",
+      SessionInternalPaths.expireDraft,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Session not found" });
+    expect(uses.size).toBe(0);
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it("opens a runtime for a session that has an index row but no store yet", async () => {
+    const { options, uses } = fakeRuntimes(async () => new Response(null, { status: 201 }));
+    vi.mocked(options.sessionIndex.exists).mockResolvedValue(true);
+
+    const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
+      "session-new",
+      SessionInternalPaths.init,
+      { method: "POST" }
+    );
+
+    expect(response.status).toBe(201);
+    expect(uses.get("session-new")).toBe(1);
+  });
+
+  it("answers 404 rather than throwing for an id that cannot name a store", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "runtime-client-"));
+    try {
+      const { options } = fakeRuntimes(async () => new Response(null, { status: 200 }));
+      options.storeProvider = createFileSessionStoreProvider(dataDir);
+
+      const response = await createNodeSessionRuntimeClient(options, ctx).fetch(
+        "../outside",
+        SessionInternalPaths.state
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("createNodeSessionRuntimeClientForTrace", () => {
+  it("keeps the trace and mints a fresh request id for every call", async () => {
+    const requests: Request[] = [];
+    const { options } = fakeRuntimes(async (request) => {
+      requests.push(request);
+      return new Response(null, { status: 200 });
+    });
+    vi.mocked(options.storeProvider.exists).mockResolvedValue(true);
+
+    const client = createNodeSessionRuntimeClientForTrace(options, "child-session-id");
+    await client.fetch("parent-1", SessionInternalPaths.childSessionUpdate, { method: "POST" });
+    await client.fetch("parent-1", SessionInternalPaths.childSessionUpdate, { method: "POST" });
+
+    expect(requests.map((request) => request.headers.get("x-trace-id"))).toEqual([
+      "child-session-id",
+      "child-session-id",
+    ]);
+    const requestIds = requests.map((request) => request.headers.get("x-request-id"));
+    expect(requestIds[0]).toMatch(/[0-9a-f-]{36}/);
+    expect(requestIds[0]).not.toBe(requestIds[1]);
+  });
+});
+
+describe("with the session runtime registry", () => {
+  type Runtime = ManagedSessionRuntime & RequestServingRuntime;
+  let dataDir: string;
+  let now: number;
+  let registry: SessionRuntimeRegistry<Runtime>;
+  let builds: number;
+
+  const alarmStoreFor = (): AlarmScheduleStore => ({
+    getAlarm: async () => null,
+    setAlarm: async () => {},
+    deleteAlarm: async () => {},
+  });
+
+  const buildRuntime = (): Runtime => {
+    builds += 1;
+    return {
+      server: {
+        onRequest: async (request) => Response.json({ path: new URL(request.url).pathname }),
+        onMessage: async () => {},
+        onClose: async () => {},
+        onError: () => {},
+        onScheduledDeadline: async () => {},
+      },
+      alarms: { rehydrate: () => {} },
+    };
+  };
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "runtime-client-registry-"));
+    now = 1_000_000;
+    builds = 0;
+    const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() };
+    log.child.mockReturnValue(log);
+    registry = new SessionRuntimeRegistry<Runtime>({
+      db: {} as SqlDatabase,
+      storeProvider: createFileSessionStoreProvider(dataDir),
+      alarmStoreFor,
+      buildRuntime: buildRuntime as (platform: SessionPlatform) => Runtime,
+      log: log as never,
+      nowMs: () => now,
+      idleAfterMs: 1_000,
+    });
+  });
+
+  afterEach(async () => {
+    await registry.shutdown({ timeoutMs: 1_000 });
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("re-opens a session the registry evicted, from its store on disk", async () => {
+    const storeProvider = createFileSessionStoreProvider(dataDir);
+    // Creation: the index row exists before the store does.
+    const index = { exists: async () => true };
+    const client = createNodeSessionRuntimeClient(
+      { runtimes: registry, sessionIndex: index, storeProvider },
+      ctx
+    );
+
+    const created = await client.fetch("s1", SessionInternalPaths.init, { method: "POST" });
+    await expect(created.json()).resolves.toEqual({ path: SessionInternalPaths.init });
+    expect(builds).toBe(1);
+    expect(await storeProvider.exists("s1")).toBe(true);
+
+    now += 2_000;
+    expect(await registry.sweep()).toEqual(["s1"]);
+    expect(registry.residentSessionIds()).toEqual([]);
+
+    // The index row is gone; the store alone brings the session back.
+    const evicted = createNodeSessionRuntimeClient(
+      { runtimes: registry, sessionIndex: { exists: async () => false }, storeProvider },
+      ctx
+    );
+    const reopened = await evicted.fetch("s1", SessionInternalPaths.state);
+    await expect(reopened.json()).resolves.toEqual({ path: SessionInternalPaths.state });
+    expect(builds).toBe(2);
+    expect(registry.residentSessionIds()).toEqual(["s1"]);
+  });
+});

--- a/packages/control-plane/src/node/runtime-client.ts
+++ b/packages/control-plane/src/node/runtime-client.ts
@@ -1,0 +1,105 @@
+/**
+ * The Node host's `SessionRuntimeClient`: a session's runtime lives in this
+ * process, inside the runtime registry, so a call is a leased method call
+ * on it rather than a Durable Object stub's RPC. The request carries the
+ * same internal URL and correlation headers the Cloudflare client sends, so
+ * the session's HTTP dispatcher sees one shape on both hosts.
+ *
+ * A session that has neither an index row nor a store on this host answers
+ * 404 without a runtime being opened: opening would create an empty store
+ * for a session that does not exist, and callers such as the draft sweep
+ * treat 404 as the definitive answer that nothing is behind the id. A
+ * session with an index row and no store yet is the one being created; its
+ * init request opens the store.
+ *
+ * Re-entrancy rule: a runtime never calls its own session through this
+ * client. On the Durable Object such a call would block on the input gate;
+ * here it re-enters the runtime synchronously under a second lease. No
+ * runtime does this today, and the concurrency model (H-3) records the rule.
+ *
+ * The lease covers the handler, not the response body: a body read after
+ * `fetch` resolves runs outside it, as a stub's response does on Cloudflare.
+ */
+
+import type { CorrelationContext } from "../logger";
+import { buildSessionInternalUrl, type SessionInternalPath } from "../session/contracts";
+import type { SessionRuntimeClient } from "../session/runtime-client";
+import type { SessionStoreProvider } from "./session-store";
+
+/** What the client needs of a runtime: the session's request entry point. */
+export interface RequestServingRuntime {
+  readonly server: { onRequest(request: Request): Promise<Response> };
+}
+
+/** Leased access to a session's runtime; `SessionRuntimeRegistry` satisfies it. */
+interface SessionRuntimeLookup<Runtime extends RequestServingRuntime> {
+  withRuntime<T>(sessionId: string, use: (runtime: Runtime) => Promise<T>): Promise<T>;
+}
+
+export interface NodeSessionRuntimeClientOptions<Runtime extends RequestServingRuntime> {
+  runtimes: SessionRuntimeLookup<Runtime>;
+  /** The deployment's session index; `SessionIndexStore` satisfies it. */
+  sessionIndex: { exists(sessionId: string): Promise<boolean> };
+  storeProvider: Pick<SessionStoreProvider, "exists">;
+}
+
+class NodeSessionRuntimeClient<
+  Runtime extends RequestServingRuntime,
+> implements SessionRuntimeClient {
+  constructor(
+    private readonly options: NodeSessionRuntimeClientOptions<Runtime>,
+    private readonly ctx: CorrelationContext
+  ) {}
+
+  async fetch(
+    sessionId: string,
+    path: SessionInternalPath,
+    init?: RequestInit,
+    search?: string
+  ): Promise<Response> {
+    if (!(await this.exists(sessionId))) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+    const request = this.internalRequest(buildSessionInternalUrl(path, search), init);
+    return this.options.runtimes.withRuntime(sessionId, (runtime) =>
+      runtime.server.onRequest(request)
+    );
+  }
+
+  private async exists(sessionId: string): Promise<boolean> {
+    const { sessionIndex, storeProvider } = this.options;
+    return (await storeProvider.exists(sessionId)) || (await sessionIndex.exists(sessionId));
+  }
+
+  private internalRequest(url: string, init?: RequestInit): Request {
+    const headers = new Headers(init?.headers);
+    headers.set("x-trace-id", this.ctx.trace_id);
+    headers.set("x-request-id", this.ctx.request_id);
+    return new Request(url, { ...init, headers });
+  }
+}
+
+export function createNodeSessionRuntimeClient<Runtime extends RequestServingRuntime>(
+  options: NodeSessionRuntimeClientOptions<Runtime>,
+  ctx: CorrelationContext
+): SessionRuntimeClient {
+  return new NodeSessionRuntimeClient(options, ctx);
+}
+
+/**
+ * A client for a caller that has no request of its own, such as a runtime
+ * notifying another runtime. Every call is one hop: it carries `traceId` and
+ * a fresh request id, so unrelated calls never share a request identity.
+ */
+export function createNodeSessionRuntimeClientForTrace<Runtime extends RequestServingRuntime>(
+  options: NodeSessionRuntimeClientOptions<Runtime>,
+  traceId: string
+): SessionRuntimeClient {
+  return {
+    fetch: (sessionId, path, init, search) =>
+      createNodeSessionRuntimeClient(options, {
+        trace_id: traceId,
+        request_id: crypto.randomUUID(),
+      }).fetch(sessionId, path, init, search),
+  };
+}

--- a/packages/control-plane/src/node/runtime-client.ts
+++ b/packages/control-plane/src/node/runtime-client.ts
@@ -1,105 +1,66 @@
 /**
- * The Node host's `SessionRuntimeClient`: a session's runtime lives in this
- * process, inside the runtime registry, so a call is a leased method call
- * on it rather than a Durable Object stub's RPC. The request carries the
- * same internal URL and correlation headers the Cloudflare client sends, so
- * the session's HTTP dispatcher sees one shape on both hosts.
+ * The Node host's `SessionRuntimeDispatch`: a session's runtime lives in
+ * this process, inside the runtime registry, so a request is a leased
+ * method call on it rather than a Durable Object stub's RPC. Request
+ * construction and correlation stay in `session/runtime-client.ts`; this
+ * module is only the delivery.
  *
- * A session that has neither an index row nor a store on this host answers
- * 404 without a runtime being opened: opening would create an empty store
- * for a session that does not exist, and callers such as the draft sweep
- * treat 404 as the definitive answer that nothing is behind the id. A
- * session with an index row and no store yet is the one being created; its
- * init request opens the store.
+ * A session the registry finds nothing behind (no store on this host, no
+ * index row) answers 404 without a runtime being opened; the draft sweep
+ * relies on 404 as the definitive answer that nothing is behind the id.
  *
- * Re-entrancy rule: a runtime never calls its own session through this
+ * The request's signal aborts the delivery as it aborts a fetch: the
+ * caller's promise rejects with the signal's reason at once, while the
+ * handler already running keeps its lease until it settles, so an aborted
+ * request cannot leave the registry holding a runtime open for a caller
+ * that has gone.
+ *
+ * Re-entrancy rule: a runtime never calls its own session through the
  * client. On the Durable Object such a call would block on the input gate;
- * here it re-enters the runtime synchronously under a second lease. No
- * runtime does this today, and the concurrency model (H-3) records the rule.
- *
- * The lease covers the handler, not the response body: a body read after
- * `fetch` resolves runs outside it, as a stub's response does on Cloudflare.
+ * here it re-enters the runtime under a second lease. No runtime does this
+ * today, and the concurrency model (H-3) records the rule.
  */
 
-import type { CorrelationContext } from "../logger";
-import { buildSessionInternalUrl, type SessionInternalPath } from "../session/contracts";
-import type { SessionRuntimeClient } from "../session/runtime-client";
-import type { SessionStoreProvider } from "./session-store";
+import type { SessionRuntimeDispatch } from "../session/runtime-client";
 
-/** What the client needs of a runtime: the session's request entry point. */
+/** What the dispatch needs of a runtime: the session's request entry point. */
 export interface RequestServingRuntime {
   readonly server: { onRequest(request: Request): Promise<Response> };
 }
 
-/** Leased access to a session's runtime; `SessionRuntimeRegistry` satisfies it. */
-interface SessionRuntimeLookup<Runtime extends RequestServingRuntime> {
-  withRuntime<T>(sessionId: string, use: (runtime: Runtime) => Promise<T>): Promise<T>;
-}
-
-export interface NodeSessionRuntimeClientOptions<Runtime extends RequestServingRuntime> {
-  runtimes: SessionRuntimeLookup<Runtime>;
-  /** The deployment's session index; `SessionIndexStore` satisfies it. */
-  sessionIndex: { exists(sessionId: string): Promise<boolean> };
-  storeProvider: Pick<SessionStoreProvider, "exists">;
-}
-
-class NodeSessionRuntimeClient<
-  Runtime extends RequestServingRuntime,
-> implements SessionRuntimeClient {
-  constructor(
-    private readonly options: NodeSessionRuntimeClientOptions<Runtime>,
-    private readonly ctx: CorrelationContext
-  ) {}
-
-  async fetch(
+/** Leased access to an existing session's runtime; `SessionRuntimeRegistry` satisfies it. */
+export interface SessionRuntimeLookup<Runtime extends RequestServingRuntime> {
+  withRuntimeIfPresent<T>(
     sessionId: string,
-    path: SessionInternalPath,
-    init?: RequestInit,
-    search?: string
-  ): Promise<Response> {
-    if (!(await this.exists(sessionId))) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-    const request = this.internalRequest(buildSessionInternalUrl(path, search), init);
-    return this.options.runtimes.withRuntime(sessionId, (runtime) =>
-      runtime.server.onRequest(request)
-    );
-  }
-
-  private async exists(sessionId: string): Promise<boolean> {
-    const { sessionIndex, storeProvider } = this.options;
-    return (await storeProvider.exists(sessionId)) || (await sessionIndex.exists(sessionId));
-  }
-
-  private internalRequest(url: string, init?: RequestInit): Request {
-    const headers = new Headers(init?.headers);
-    headers.set("x-trace-id", this.ctx.trace_id);
-    headers.set("x-request-id", this.ctx.request_id);
-    return new Request(url, { ...init, headers });
-  }
+    use: (runtime: Runtime) => Promise<T>
+  ): Promise<T | undefined>;
 }
 
-export function createNodeSessionRuntimeClient<Runtime extends RequestServingRuntime>(
-  options: NodeSessionRuntimeClientOptions<Runtime>,
-  ctx: CorrelationContext
-): SessionRuntimeClient {
-  return new NodeSessionRuntimeClient(options, ctx);
+export function createNodeSessionRuntimeDispatch<Runtime extends RequestServingRuntime>(
+  runtimes: SessionRuntimeLookup<Runtime>
+): SessionRuntimeDispatch {
+  return (sessionId, request) =>
+    untilAborted(request.signal, async () => {
+      const response = await runtimes.withRuntimeIfPresent(sessionId, (runtime) =>
+        runtime.server.onRequest(request)
+      );
+      return response ?? Response.json({ error: "Session not found" }, { status: 404 });
+    });
 }
 
 /**
- * A client for a caller that has no request of its own, such as a runtime
- * notifying another runtime. Every call is one hop: it carries `traceId` and
- * a fresh request id, so unrelated calls never share a request identity.
+ * `run`, rejected with the signal's reason as soon as it aborts. A signal
+ * already aborted rejects before `run` starts; otherwise `run` continues
+ * to its own end, and its outcome is dropped once the abort has won.
  */
-export function createNodeSessionRuntimeClientForTrace<Runtime extends RequestServingRuntime>(
-  options: NodeSessionRuntimeClientOptions<Runtime>,
-  traceId: string
-): SessionRuntimeClient {
-  return {
-    fetch: (sessionId, path, init, search) =>
-      createNodeSessionRuntimeClient(options, {
-        trace_id: traceId,
-        request_id: crypto.randomUUID(),
-      }).fetch(sessionId, path, init, search),
-  };
+function untilAborted<T>(signal: AbortSignal | undefined, run: () => Promise<T>): Promise<T> {
+  if (!signal) return run();
+  if (signal.aborted) return Promise.reject(signal.reason as Error);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason as Error);
+    signal.addEventListener("abort", onAbort, { once: true });
+    run()
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener("abort", onAbort));
+  });
 }

--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -88,6 +88,7 @@ function fakeStores() {
   const opened: Array<{ id: string; storage: SessionStorage; closes: number }> = [];
   const state = { gate: null as Deferred | null, failNext: null as Error | null };
   const provider: SessionStoreProvider = {
+    exists: async (id) => opened.some((record) => record.id === id),
     open: async (id) => {
       if (state.gate) await state.gate.promise;
       if (state.failNext) {

--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -134,6 +134,10 @@ describe("SessionRuntimeRegistry", () => {
   let now: number;
   const clock = { now: () => now, advance: (ms: number) => (now += ms) };
   let stores: ReturnType<typeof fakeStores>;
+  let index: {
+    known: Set<string>;
+    exists: ReturnType<typeof vi.fn<(id: string) => Promise<boolean>>>;
+  };
   let alarms: ReturnType<typeof fakeAlarms>;
   let log: ReturnType<typeof spyLogger>;
   let built: FakeRuntime[];
@@ -146,6 +150,7 @@ describe("SessionRuntimeRegistry", () => {
     const registry = new SessionRuntimeRegistry<FakeRuntime>({
       db: {} as SqlDatabase,
       storeProvider: stores.provider,
+      sessionIndex: index,
       alarmStoreFor: alarms.alarmStoreFor,
       buildRuntime,
       log: log as never,
@@ -161,6 +166,8 @@ describe("SessionRuntimeRegistry", () => {
   beforeEach(() => {
     now = 1_000_000;
     stores = fakeStores();
+    const known = new Set<string>();
+    index = { known, exists: vi.fn(async (id: string) => known.has(id)) };
     alarms = fakeAlarms();
     log = spyLogger();
     built = [];
@@ -208,6 +215,75 @@ describe("SessionRuntimeRegistry", () => {
     expect(await a).toBe(await b);
     expect(buildRuntime).toHaveBeenCalledTimes(1);
     expect(stores.opened).toHaveLength(1);
+  });
+
+  describe("withRuntimeIfPresent", () => {
+    it("opens nothing for an id with neither a store nor an index row", async () => {
+      const registry = makeRegistry();
+
+      const outcome = await registry.withRuntimeIfPresent("ghost", async () => "used");
+
+      expect(outcome).toBeUndefined();
+      expect(buildRuntime).not.toHaveBeenCalled();
+      expect(stores.opened).toEqual([]);
+      expect(registry.residentSessionIds()).toEqual([]);
+    });
+
+    it("opens a session known to the index but without a store yet: the one being created", async () => {
+      const registry = makeRegistry();
+      index.known.add("s1");
+
+      const outcome = await registry.withRuntimeIfPresent("s1", async (runtime) => runtime);
+
+      expect(outcome).toBeDefined();
+      expect(stores.opened.map((s) => s.id)).toEqual(["s1"]);
+      expect(registry.residentSessionIds()).toEqual(["s1"]);
+    });
+
+    it("opens a session whose store exists after its index row is gone, without asking the index", async () => {
+      const registry = makeRegistry();
+      await registry.withRuntime("s1", async () => {});
+      clock.advance(IDLE_AFTER_MS);
+      expect(await registry.sweep()).toEqual(["s1"]);
+      index.exists.mockClear();
+
+      const outcome = await registry.withRuntimeIfPresent("s1", async (runtime) => runtime);
+
+      expect(outcome).toBeDefined();
+      expect(index.exists).not.toHaveBeenCalled();
+      expect(buildRuntime).toHaveBeenCalledTimes(2);
+    });
+
+    it("shares one presence check and one build between concurrent conditional opens", async () => {
+      const registry = makeRegistry();
+      index.known.add("s1");
+      stores.state.gate = deferred();
+
+      const a = registry.withRuntimeIfPresent("s1", async (runtime) => runtime);
+      const b = registry.withRuntimeIfPresent("s1", async (runtime) => runtime);
+      await flush();
+      stores.state.gate.resolve();
+
+      expect(await a).toBe(await b);
+      expect(index.exists).toHaveBeenCalledTimes(1);
+      expect(buildRuntime).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets an unconditional open that joined an absent outcome build on its own turn", async () => {
+      const registry = makeRegistry();
+      const lookup = deferred<boolean>();
+      index.exists.mockImplementationOnce(() => lookup.promise);
+
+      const conditional = registry.withRuntimeIfPresent("s1", async (runtime) => runtime);
+      await flush();
+      const unconditional = registry.withRuntime("s1", async (runtime) => runtime);
+      lookup.resolve(false);
+
+      expect(await conditional).toBeUndefined();
+      expect(await unconditional).toBeDefined();
+      expect(buildRuntime).toHaveBeenCalledTimes(1);
+      expect(registry.residentSessionIds()).toEqual(["s1"]);
+    });
   });
 
   it("does not cache a failed build: the store is closed and the next event retries", async () => {
@@ -727,6 +803,7 @@ if (isGcChild) {
       const registry = new SessionRuntimeRegistry<FakeRuntime>({
         db: {} as SqlDatabase,
         storeProvider: createFileSessionStoreProvider(dataDir),
+        sessionIndex: { exists: async () => false },
         alarmStoreFor: alarms.alarmStoreFor,
         buildRuntime: (platform) => fakeRuntime(platform),
         log: spyLogger() as never,

--- a/packages/control-plane/src/node/session-runtime-registry.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.ts
@@ -72,6 +72,8 @@ export interface SessionRuntimeRegistryOptions<Runtime extends ManagedSessionRun
   /** The deployment's global store, shared by every runtime. */
   db: SqlDatabase;
   storeProvider: SessionStoreProvider;
+  /** The deployment's session index; `SessionIndexStore` satisfies it. */
+  sessionIndex: SessionIndex;
   /** The session's alarm port, from the host alarm clock. */
   alarmStoreFor: (sessionId: string) => AlarmScheduleStore;
   /** The composition root, with the deployment's configuration already bound. */
@@ -84,6 +86,11 @@ export interface SessionRuntimeRegistryOptions<Runtime extends ManagedSessionRun
   sweepIntervalMs?: number;
   maxResident?: number;
   socketHostOptions?: NodeSocketHostOptions;
+}
+
+/** Whether the deployment knows the session at all. */
+export interface SessionIndex {
+  exists(sessionId: string): Promise<boolean>;
 }
 
 export interface ShutdownOptions {
@@ -124,9 +131,9 @@ interface ActivationIntent {
   waiters: number;
 }
 
-/** A build in progress. */
+/** A build in progress; `null` when it found no session behind the id. */
 interface Opening<Runtime> {
-  promise: Promise<Acquired<Runtime>>;
+  promise: Promise<Acquired<Runtime> | null>;
   intent: ActivationIntent;
 }
 
@@ -141,6 +148,7 @@ type RetireReason = "idle" | "capacity" | "shutdown" | "activation_failed";
 export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
   private readonly db: SqlDatabase;
   private readonly storeProvider: SessionStoreProvider;
+  private readonly sessionIndex: SessionIndex;
   private readonly alarmStoreFor: (sessionId: string) => AlarmScheduleStore;
   private readonly buildRuntime: (platform: SessionPlatform) => Runtime;
   private readonly log: Logger;
@@ -159,6 +167,7 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
   constructor(options: SessionRuntimeRegistryOptions<Runtime>) {
     this.db = options.db;
     this.storeProvider = options.storeProvider;
+    this.sessionIndex = options.sessionIndex;
     this.alarmStoreFor = options.alarmStoreFor;
     this.buildRuntime = options.buildRuntime;
     this.log = options.log;
@@ -175,7 +184,23 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
    * resident. The runtime is leased for as long as `use` runs.
    */
   async withRuntime<T>(sessionId: string, use: (runtime: Runtime) => Promise<T>): Promise<T> {
-    const session = await this.acquireLease(sessionId, true);
+    const session = await this.acquireLease(sessionId, true, false);
+    return this.runUnderLease(session, () => use(session.runtime));
+  }
+
+  /**
+   * `withRuntime` for a session that must already exist: one with a store
+   * on this host or a row in the session index (the row is written before
+   * the session's init request, so a session being created counts). The
+   * check runs inside the single-flight open, so nothing is built for an
+   * unknown id, and `undefined` reports that nothing is behind it.
+   */
+  async withRuntimeIfPresent<T>(
+    sessionId: string,
+    use: (runtime: Runtime) => Promise<T>
+  ): Promise<T | undefined> {
+    const session = await this.acquireLease(sessionId, true, true);
+    if (!session) return undefined;
     return this.runUnderLease(session, () => use(session.runtime));
   }
 
@@ -185,7 +210,7 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
    * rehydrate the alarm: this delivery is the alarm, as on the Durable Object.
    */
   async deliverScheduledDeadline(sessionId: string): Promise<void> {
-    const session = await this.acquireLease(sessionId, false);
+    const session = await this.acquireLease(sessionId, false, false);
     await this.runUnderLease(session, () => session.runtime.server.onScheduledDeadline());
   }
 
@@ -298,13 +323,32 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
    * lease was pre-taken when the runtime published, or it is taken in the
    * same continuation that saw the runtime resident, so nothing can retire
    * it between the check and the lease. Refused once a shutdown has begun.
+   * With `ifPresent`, `undefined` when no session exists behind the id.
    */
+  private acquireLease(
+    sessionId: string,
+    rehydrate: boolean,
+    ifPresent: false
+  ): Promise<ResidentSession<Runtime>>;
+  private acquireLease(
+    sessionId: string,
+    rehydrate: boolean,
+    ifPresent: true
+  ): Promise<ResidentSession<Runtime> | undefined>;
   private async acquireLease(
     sessionId: string,
-    rehydrate: boolean
-  ): Promise<ResidentSession<Runtime>> {
+    rehydrate: boolean,
+    ifPresent: boolean
+  ): Promise<ResidentSession<Runtime> | undefined> {
     for (;;) {
-      const { session, leased } = await this.open(sessionId, rehydrate);
+      const acquired = await this.open(sessionId, rehydrate, ifPresent);
+      if (!acquired) {
+        // A conditional open found nothing; an unconditional caller that
+        // joined it builds on its own turn.
+        if (ifPresent) return undefined;
+        continue;
+      }
+      const { session, leased } = acquired;
       if (this.shuttingDown || session.state === "quiescing") {
         if (leased) this.release(session);
         throw new Error("SessionRuntimeRegistry is shutting down");
@@ -339,7 +383,11 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
   }
 
   /** Single-flight per id: events that find a build in progress join it. */
-  private open(sessionId: string, rehydrate: boolean): Promise<Acquired<Runtime>> {
+  private open(
+    sessionId: string,
+    rehydrate: boolean,
+    ifPresent: boolean
+  ): Promise<Acquired<Runtime> | null> {
     const resident = this.resident.get(sessionId);
     if (resident) return Promise.resolve({ session: resident, leased: false });
     const opening = this.opening.get(sessionId);
@@ -352,13 +400,29 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
       return Promise.reject(new Error("SessionRuntimeRegistry is shutting down"));
     }
     const intent: ActivationIntent = { rehydrate, waiters: 1 };
-    const promise = this.build(sessionId, intent)
-      .then((session) => ({ session, leased: true }))
+    const promise = this.buildIf(sessionId, intent, ifPresent)
+      .then((session) => (session ? { session, leased: true } : null))
       .finally(() => {
         this.opening.delete(sessionId);
       });
     this.opening.set(sessionId, { promise, intent });
     return promise;
+  }
+
+  /** `build`, unless `ifPresent` and nothing on this host or in the index knows the id. */
+  private async buildIf(
+    sessionId: string,
+    intent: ActivationIntent,
+    ifPresent: boolean
+  ): Promise<ResidentSession<Runtime> | null> {
+    if (ifPresent && !(await this.isPresent(sessionId))) return null;
+    return this.build(sessionId, intent);
+  }
+
+  private async isPresent(sessionId: string): Promise<boolean> {
+    return (
+      (await this.storeProvider.exists(sessionId)) || (await this.sessionIndex.exists(sessionId))
+    );
   }
 
   private async build(

--- a/packages/control-plane/src/node/session-store.ts
+++ b/packages/control-plane/src/node/session-store.ts
@@ -5,7 +5,7 @@
  * live on the host's persistent volume, so there is no snapshot cycle.
  */
 
-import { existsSync } from "node:fs";
+import { access } from "node:fs/promises";
 import { join } from "node:path";
 import type { SessionStorage } from "../session/platform";
 import { initSchema } from "../session/schema";
@@ -48,9 +48,22 @@ export interface SessionStoreProvider {
 export function createFileSessionStoreProvider(dataDir: string): SessionStoreProvider {
   return {
     open: async (sessionId) => openSessionStore({ dataDir, sessionId }),
-    exists: async (sessionId) =>
-      SESSION_FILE_ID.test(sessionId) && existsSync(join(dataDir, "sessions", `${sessionId}.db`)),
+    exists: (sessionId) =>
+      SESSION_FILE_ID.test(sessionId)
+        ? fileExists(join(dataDir, "sessions", `${sessionId}.db`))
+        : Promise.resolve(false),
   };
+}
+
+/** Whether `path` exists, asked without blocking the event loop. */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 /** Open (creating if needed) the session's database and apply the schema. */

--- a/packages/control-plane/src/node/session-store.ts
+++ b/packages/control-plane/src/node/session-store.ts
@@ -5,6 +5,7 @@
  * live on the host's persistent volume, so there is no snapshot cycle.
  */
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { SessionStorage } from "../session/platform";
 import { initSchema } from "../session/schema";
@@ -39,12 +40,16 @@ export type OwnedSessionStore = Pick<NodeSessionStore, "storage" | "close">;
  */
 export interface SessionStoreProvider {
   open(sessionId: string): Promise<OwnedSessionStore>;
+  /** Whether the session already has a store, without creating one. */
+  exists(sessionId: string): Promise<boolean>;
 }
 
 /** The provider over `<dataDir>/sessions/<id>.db` files. */
 export function createFileSessionStoreProvider(dataDir: string): SessionStoreProvider {
   return {
     open: async (sessionId) => openSessionStore({ dataDir, sessionId }),
+    exists: async (sessionId) =>
+      SESSION_FILE_ID.test(sessionId) && existsSync(join(dataDir, "sessions", `${sessionId}.db`)),
   };
 }
 

--- a/packages/control-plane/src/session/runtime-client.ts
+++ b/packages/control-plane/src/session/runtime-client.ts
@@ -11,9 +11,16 @@ export interface SessionRuntimeClient {
   ): Promise<Response>;
 }
 
-class CloudflareSessionRuntimeClient implements SessionRuntimeClient {
+/**
+ * Delivers one internal request to the session's runtime, however the host
+ * reaches it: a Durable Object stub on Cloudflare, the runtime registry on
+ * Node. The request's signal aborts the delivery as it aborts a fetch.
+ */
+export type SessionRuntimeDispatch = (sessionId: string, request: Request) => Promise<Response>;
+
+class DispatchingSessionRuntimeClient implements SessionRuntimeClient {
   constructor(
-    private readonly env: Env,
+    private readonly dispatch: SessionRuntimeDispatch,
     private readonly ctx: CorrelationContext
   ) {}
 
@@ -23,9 +30,10 @@ class CloudflareSessionRuntimeClient implements SessionRuntimeClient {
     init?: RequestInit,
     search?: string
   ): Promise<Response> {
-    const doId = this.env.SESSION.idFromName(sessionId);
-    const stub = this.env.SESSION.get(doId);
-    return stub.fetch(this.internalRequest(buildSessionInternalUrl(path, search), init));
+    return this.dispatch(
+      sessionId,
+      this.internalRequest(buildSessionInternalUrl(path, search), init)
+    );
   }
 
   private internalRequest(url: string, init?: RequestInit): Request {
@@ -36,11 +44,12 @@ class CloudflareSessionRuntimeClient implements SessionRuntimeClient {
   }
 }
 
-export function createSessionRuntimeClient(
-  env: Env,
+/** A client for the caller's own request, correlated with `ctx`, over `dispatch`. */
+export function createSessionRuntimeClientOver(
+  dispatch: SessionRuntimeDispatch,
   ctx: CorrelationContext
 ): SessionRuntimeClient {
-  return new CloudflareSessionRuntimeClient(env, ctx);
+  return new DispatchingSessionRuntimeClient(dispatch, ctx);
 }
 
 /**
@@ -48,15 +57,34 @@ export function createSessionRuntimeClient(
  * notifying another runtime. Every call is one hop: it carries `traceId` and
  * a fresh request id, so unrelated calls never share a request identity.
  */
-export function createSessionRuntimeClientForTrace(
-  env: Env,
+export function createSessionRuntimeClientForTraceOver(
+  dispatch: SessionRuntimeDispatch,
   traceId: string
 ): SessionRuntimeClient {
   return {
     fetch: (sessionId, path, init, search) =>
-      createSessionRuntimeClient(env, {
+      createSessionRuntimeClientOver(dispatch, {
         trace_id: traceId,
         request_id: crypto.randomUUID(),
       }).fetch(sessionId, path, init, search),
   };
+}
+
+/** The Cloudflare dispatch: the session's Durable Object stub. */
+function durableObjectDispatch(env: Env): SessionRuntimeDispatch {
+  return (sessionId, request) => env.SESSION.get(env.SESSION.idFromName(sessionId)).fetch(request);
+}
+
+export function createSessionRuntimeClient(
+  env: Env,
+  ctx: CorrelationContext
+): SessionRuntimeClient {
+  return createSessionRuntimeClientOver(durableObjectDispatch(env), ctx);
+}
+
+export function createSessionRuntimeClientForTrace(
+  env: Env,
+  traceId: string
+): SessionRuntimeClient {
+  return createSessionRuntimeClientForTraceOver(durableObjectDispatch(env), traceId);
 }


### PR DESCRIPTION
Roadmap **N-9 · COL-96**: the Node host's `SessionRuntimeClient`. The worker bundle has no `src/node` input (`dist/meta.json` checked). One shared change: `session/runtime-client.ts` is inverted around a host dispatch function; the Cloudflare factories keep their names and behavior, and the nine call sites are untouched.

## What

**`src/session/runtime-client.ts`.** One `SessionRuntimeClient` implementation over a `SessionRuntimeDispatch = (sessionId, request) => Promise<Response>`: request construction (`buildSessionInternalUrl`), the `x-trace-id` / `x-request-id` headers, and the for-trace decorator that mints a fresh request id per call live here once. `createSessionRuntimeClientOver(dispatch, ctx)` and `createSessionRuntimeClientForTraceOver(dispatch, traceId)` are the host-neutral factories; `createSessionRuntimeClient(env, ctx)` and `createSessionRuntimeClientForTrace(env, traceId)` are those over the Durable Object stub dispatch, so Cloudflare behavior is unchanged and the existing tests pass as they were.

**`src/node/runtime-client.ts`.** Only the dispatch difference: `createNodeSessionRuntimeDispatch(registry)` delivers the request to `runtime.server.onRequest` (the entry point `SessionDO.fetch` uses) under the registry's lease, and answers `404 { error: "Session not found" }` when the registry reports nothing behind the id. The request's signal aborts the delivery as it aborts a fetch: the caller's promise rejects with the signal's reason at once (an already-aborted signal rejects before anything is opened), while the handler already running keeps its lease until it settles. `SessionDraftExpiryClient` relies on `AbortSignal.timeout` for exactly this, so one stalled runtime cannot hold the whole sweep. The module doc records the re-entrancy rule (a runtime never calls its own session through the client).

**`src/node/session-runtime-registry.ts`.** The registry owns session admission: `withRuntimeIfPresent(sessionId, use)` is `withRuntime` for a session that must already exist, meaning a store on this host or a row in the session index (the row is written before the session's init request, so a session being created counts). The check runs inside the single-flight open, so nothing is built and no empty store appears for an unknown id, concurrent conditional opens share one check and one build, and an unconditional open that joined an absent outcome builds on its own turn. The registry takes a `sessionIndex` (`SessionIndexStore` satisfies it through `exists`).

**`src/node/session-store.ts`.** `SessionStoreProvider` gains `exists(sessionId)`, asked without blocking the event loop (`fs/promises.access`); the registry's presence check is its consumer.

## Deviations from the issue text

- The issue describes `registry.get(sessionId)`; the registry from H-2 leases instead, so the request runs under the lease and the runtime cannot be retired mid-request.
- The existence rule lives in the registry rather than the client, so the transport knows nothing about files or the index. H-1's WebSocket upgrade path should use `withRuntimeIfPresent` for the same reason.
- The client is not wired at the `createSessionRuntimeClient(env, ctx)` call sites: P-4 made that factory the swap point, and how the Node host reaches it (`createSessionRuntimeClientOver(createNodeSessionRuntimeDispatch(registry), ctx)`) is P-5 / H-1's platform record.

## Tests

- `src/node/runtime-client.test.ts` (7): method, path, search, body, and both correlation headers reach the runtime; 404 with the handler untouched for an absent session; the for-trace client keeps the trace id and mints a fresh request id per call; an already-aborted signal rejects without touching the registry; an abort mid-handler rejects promptly with the signal's reason while the lease is held and is released when the handler settles; the abort listener is dropped once the request settles; and, against the real `SessionRuntimeRegistry` with file-backed stores, an unknown id opens nothing, a session known to the index is created, swept once idle, and rebuilt from its store after its index row is gone.
- `src/node/session-runtime-registry.test.ts` (+5): `withRuntimeIfPresent` opens nothing for an unknown id; opens a session known only to the index; opens one whose store exists without asking the index; shares one presence check and one build between concurrent conditional opens; an unconditional open that joined an absent outcome builds on its own turn.
- `src/session/runtime-client.test.ts` unchanged and green: the Cloudflare factories behave as before.

Control-plane unit suite 259 files / 3819 tests green; full workerd integration suite green; `npm run typecheck` (all four programs), eslint, prettier clean; knip reports nothing new.

## Follow-ups

- H-1 (COL-97): build the client from the Node dispatch in the platform record; use `withRuntimeIfPresent` on the upgrade path.
- H-3 (COL-99): records the re-entrancy rule in the concurrency document.
- V-2 (COL-116): child-session spawn/notify, the draft sweep, and scheduler prompt enqueue through this client.
