### PR TITLE
fix: re-check promptability after the prompt fingerprint await (COL-99)

### DIFF
--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -530,6 +530,28 @@ describe("SessionMessageQueue", () => {
     expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
   });
 
+  it("rejects a prompt whose session closed while its fingerprint was being hashed", async () => {
+    const h = buildQueue();
+    const session = createSession();
+    h.repository.getSession.mockImplementation(() => session);
+    const ws = {} as WebSocket;
+
+    // The fingerprint hash is the first await; the cancel lands there.
+    const handled = h.queue.handlePromptMessage(ws, createClientInfo(), {
+      content: "hello",
+      clientRequestId: "req-1",
+    });
+    session.status = "cancelled";
+    await handled;
+
+    expect(h.repository.createMessageWithAttachments).not.toHaveBeenCalled();
+    expect(h.sessionStatus.transition).not.toHaveBeenCalled();
+    expect(h.wsManager.send).toHaveBeenCalledWith(
+      ws,
+      expect.objectContaining({ type: "error", code: "SESSION_NOT_PROMPTABLE" })
+    );
+  });
+
   it("marks session active when a prompt is enqueued", async () => {
     const h = buildQueue();
 

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -758,14 +758,17 @@ export class SessionMessageQueue {
   }
 
   private async enqueuePromptCore(data: EnqueuePromptCoreData): Promise<EnqueuedPrompt> {
-    this.assertPromptableSession();
     let requestFingerprint: string | undefined;
     if (data.clientRequestId) {
       requestFingerprint = await fingerprintWebPrompt(data.participant.id, data);
     }
 
-    // Keep the idempotency lookup, capacity check, and insert in one synchronous
-    // turn so concurrent WebSocket requests cannot race between them.
+    // Keep the promptability check, idempotency lookup, capacity check, and
+    // insert in one synchronous turn so concurrent requests cannot race between
+    // them. The fingerprint hash above is a non-storage await: a cancel or
+    // archive can land while this request is suspended, so the session is
+    // read after it, not before.
+    this.assertPromptableSession();
     const queueDepthBefore = this.messageRepository.getPendingOrProcessingCount();
     if (data.clientRequestId) {
       const existing = this.messageRepository.getMessageByClientRequestId(data.clientRequestId);


### PR DESCRIPTION
Roadmap **H-3 · COL-99**, fix 1 of 3 from the concurrency audit (#1760, table row `enqueuePromptCore`). Behavior-preserving on Cloudflare outside the interleaving it closes.

## What

`SessionMessageQueue.enqueuePromptCore` checked that the session was promptable, then awaited the request fingerprint (`fingerprintWebPrompt`, a `crypto.subtle` hash), then ran the idempotency lookup, capacity check, and insert in one synchronous turn, then transitioned the session to `active`. The hash is a non-storage await, so the Durable Object's input gate opens across it and a cancel or archive can land while the request is suspended: the closed session then accepted the message and `transition("active")` moved it back to `active` (`transition` writes whatever it is given; every caller is responsible for reading the status in the same turn).

The check now runs after the await, in the same synchronous turn as the insert, which is the shape `connection-authenticator.ts` already uses for the sandbox handshake ("read after authentication, not before"). The two callers keep their own early checks, so the non-racy path is unchanged: a closed session is still rejected before any participant write.

## Tests

`message-queue.test.ts` +1: a web prompt whose session becomes `cancelled` while its fingerprint is hashed is rejected with `SESSION_NOT_PROMPTABLE`; no message is inserted and no status transition is made. Fails on `main` (the message is inserted).

Control-plane unit suite green; full workerd integration suite green; typecheck (all four programs), eslint, prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where prompts could be accepted after their session was cancelled during request processing.
  * Cancelled sessions now correctly reject prompts with a `SESSION_NOT_PROMPTABLE` error, without creating a message or activating the session.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->