### PR TITLE
fix: reconcile leaves a cancelled or archived session as it is (COL-99)

### DIFF
--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -294,9 +294,38 @@ describe("SessionStatusService.reconcileAfterExecution", () => {
 
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "failed" });
   });
+
+  it("leaves a session archived while its terminal projection was in flight", async () => {
+    // Archive is admissible once the completion is recorded (no unfinished
+    // message remains), and the reconcile runs after the D1 projection await.
+    const h = harness({ session: createSession({ status: "archived" }) });
+
+    await h.service.reconcileAfterExecution(true);
+
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("leaves a session cancelled while its terminal projection was in flight", async () => {
+    const h = harness({ session: createSession({ status: "cancelled" }) });
+
+    await h.service.reconcileAfterExecution(false);
+
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
 });
 
 describe("SessionStatusService.reconcileAfterQueueRemoval", () => {
+  it("leaves a cancelled session cancelled", async () => {
+    const h = harness({ session: createSession({ status: "cancelled" }) });
+
+    await h.service.reconcileAfterQueueRemoval();
+
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
+
   it("preserves the latest failed execution outcome", async () => {
     const h = harness({ session: createSession({ status: "active" }) });
     h.repository.getLatestTerminalMessage.mockReturnValue({ status: "failed" } as MessageRow);

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -19,7 +19,7 @@ import type { MessageRepository } from "./message-repository";
 import type { ArtifactRepository } from "./artifact-repository";
 import type { SessionMessenger } from "./messenger";
 import type { BackgroundTasks } from "../platform-ports";
-import { isTurnSettled } from "@open-inspect/shared/types/session-activity";
+import { isSessionPromptable, isTurnSettled } from "@open-inspect/shared/types/session-activity";
 
 export class SessionStatusService {
   constructor(
@@ -138,18 +138,35 @@ export class SessionStatusService {
   /**
    * After an execution finishes, settle the session status: back to active
    * when more prompts are queued, otherwise completed/failed by outcome.
+   * Leaves a session that was cancelled or archived meanwhile as it is.
    */
   async reconcileAfterExecution(success: boolean): Promise<void> {
+    if (this.isSessionClosed()) return;
     const pendingOrProcessing = this.messageRepository.getPendingOrProcessingCount();
     const nextStatus: SessionStatus =
       pendingOrProcessing > 0 ? "active" : success ? "completed" : "failed";
     await this.transition(nextStatus);
   }
 
+  /** Leaves a session that was cancelled or archived meanwhile as it is. */
   async reconcileAfterQueueRemoval(): Promise<void> {
+    if (this.isSessionClosed()) return;
     if (this.messageRepository.getPendingOrProcessingCount() > 0) return;
     const nextStatus = this.getIdleStatusFromTerminalMessages();
     await this.transition(nextStatus);
+  }
+
+  /**
+   * Whether the session has been cancelled or archived. A reconcile derives
+   * the next status from message state, and message state says nothing about
+   * a status the user chose; a reconcile that runs after an await (the
+   * terminal projection, the stop alarm) must not move such a session, and
+   * `transition` writes whatever it is given. Read in the same turn as the
+   * transition it guards.
+   */
+  private isSessionClosed(): boolean {
+    const session = this.repository.getSession();
+    return session !== null && !isSessionPromptable(session.status);
   }
 
   async settleFromMessageState(): Promise<SessionStatus> {


### PR DESCRIPTION
Roadmap **H-3 · COL-99**, fix 2 of 3 from the concurrency audit (#1760, table rows `handleExecutionComplete after completion` and `reconcileAfterExecution / reconcileAfterQueueRemoval`). Behavior-preserving on Cloudflare outside the interleaving it closes.

## What

`handleExecutionComplete` records the message completion synchronously, awaits the terminal projection to D1, then calls `SessionStatusService.reconcileAfterExecution`, which reads the unfinished-message count and transitions to `completed`, `failed`, or `active`. The projection is a non-storage await, so the input gate is open across it. Two requests are admissible there: an archive (the completion is recorded, so no unfinished message remains and the archive handler's guard passes) and a cancel. Both landed, wrote their status, and were then overwritten: the reconcile's decision came from message state alone, and `transition` writes whatever it is given. The session came back as `completed`/`failed` in the list, with a later `updated_at`, so the D1 fence accepted it too. `stopExecution` reaches the same reconcile after its alarm await.

`reconcileAfterExecution` and `reconcileAfterQueueRemoval` now return without transitioning when the session is cancelled or archived (the not-promptable statuses, read in the same turn as the transition they guard). `settleFromMessageState` is deliberately unchanged: it is the unarchive path and must leave `archived`.

## Tests

`session-status-service.test.ts` +3: `reconcileAfterExecution` leaves an archived session archived and a cancelled session cancelled (no local write, no broadcast); `reconcileAfterQueueRemoval` leaves a cancelled session cancelled. All three fail on `main`.

Control-plane unit suite green; full workerd integration suite green; typecheck (all four programs), eslint, prettier clean.
