### PR TITLE
feat: S3ObjectStorage for the Node host (COL-90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -312,7 +312,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -327,7 +326,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
       "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -339,7 +337,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
       "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -354,7 +351,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -368,7 +364,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -384,7 +379,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -398,7 +392,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -413,7 +406,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -423,7 +415,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -435,7 +426,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -449,7 +439,6 @@
       "version": "3.1000.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.7.tgz",
       "integrity": "sha512-qh0fG/RtrFztst4+vn1HZehAvAhr5Jlq/WMP7e5KvvfF16oNVBc9CDNVdxdm19vzOY2x0qiDMFCRjhxQAusGWQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -632,7 +621,6 @@
       "version": "3.984.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.984.0.tgz",
       "integrity": "sha512-7ny2Slr93Y+QniuluvcfWwyDi32zWQfznynL56Tk0vVh7bWrvS/odm8WP2nInKicRVNipcJHY2YInur6Q/9V0A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -752,7 +740,6 @@
       "version": "3.974.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
       "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.13",
@@ -772,7 +759,6 @@
       "version": "3.972.48",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
       "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -789,7 +775,6 @@
       "version": "3.972.50",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
       "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -808,7 +793,6 @@
       "version": "3.972.55",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
       "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -833,7 +817,6 @@
       "version": "3.972.54",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
       "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -851,7 +834,6 @@
       "version": "3.972.57",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
       "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.48",
@@ -874,7 +856,6 @@
       "version": "3.972.48",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
       "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -891,7 +872,6 @@
       "version": "3.972.54",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
       "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -910,7 +890,6 @@
       "version": "3.972.54",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
       "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -958,7 +937,6 @@
       "version": "3.972.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.26.tgz",
       "integrity": "sha512-DSIJDe1WTc7V9JPfpGfRatZFlzWYX4/fd0K7mOoyRijXFqo6YrPBptebOi1K+fJIkKL7zzsocL4pbMsMtuX/oA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.53",
@@ -989,7 +967,6 @@
       "version": "3.972.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.22.tgz",
       "integrity": "sha512-LmEmLhxrxh7uEQrWEpfqlhj8tkfClrLiOF5sDR/k18pbNaVSleSAwcwEMrlz1MOFnXB5ibS7boY1r8tYZKkvxQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.53",
@@ -1003,7 +980,6 @@
       "version": "3.974.32",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.32.tgz",
       "integrity": "sha512-KhuzFMzUbb3oEj43CdPDbEJ/RG/RkErkmXk3J/LE8OPFNvkCn8PYPMpjOLgzAzvxBacsSyytdWf+R50q0alJ4w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.7",
@@ -1017,7 +993,6 @@
       "version": "3.972.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.23.tgz",
       "integrity": "sha512-sWeojvaTI86wGRIt5HQb9o50V6AExi+NV3VrH2AwBlzV47a+m4JAejaC8CObaLXGVqSRqGt1B9AGYONp+NcTXg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1031,7 +1006,6 @@
       "version": "3.972.19",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.19.tgz",
       "integrity": "sha512-Ka3boCBtsOj7LC7w0z5dBF2SmxSUJEkvxb5Qd+MnFAwJyBc22FmR2LpB/3dQqsiRLtS81WEBfnpUkj4Sx3u/qA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.53",
@@ -1045,7 +1019,6 @@
       "version": "3.972.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.22.tgz",
       "integrity": "sha512-opYE2yUoQKJJz5QrGylnZeaBRmUaRzUSxlW40cX4LnmwO5XI61IWC3k/LDbJwF15AvmlNbome+glhIlFJzCWJw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1059,7 +1032,6 @@
       "version": "3.972.24",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.24.tgz",
       "integrity": "sha512-M0gO9RgAppZx7yDvFRB1pdnyzd34Gnt/JjpT9HoMZxxDYnAkYNa3eabbjsf2A6ffxDFAvZKFdkjthrQxlQgcRg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1073,7 +1045,6 @@
       "version": "3.972.53",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.53.tgz",
       "integrity": "sha512-keWp6Z5cEIJzPwoCf/WRm0ceAeephPDDivhRsK/xXs2ZYXyypJ2/DL9G1IR0bz/s+iZC0EgzmFV4r7rlvLlxQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1091,7 +1062,6 @@
       "version": "3.996.35",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
       "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.13",
@@ -1123,7 +1093,6 @@
       "version": "3.972.19",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.19.tgz",
       "integrity": "sha512-x0FepbRqAXRwfCw+bZN78rcVw3ZInXFXd8FjNQl2GBRTIZ/t7aj/p70qeG3ZnrpN4e5SeDi0y39gs1J/jUP4FQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.53",
@@ -1137,7 +1106,6 @@
       "version": "3.972.52",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.52.tgz",
       "integrity": "sha512-p4ltuhV74lYk4sKYj1iWo7UQuzHPYHfbcBKbKaZb/tKy92lqDMt/gaI+w4ShmEUOXV9k/uV/nRpoH0tHqpwXeA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1151,7 +1119,6 @@
       "version": "3.997.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
       "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1173,7 +1140,6 @@
       "version": "3.996.35",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
       "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.13",
@@ -1189,7 +1155,6 @@
       "version": "3.972.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.26.tgz",
       "integrity": "sha512-wDR6i4YBvJTGGElCQlXQd42f6AraatbU9ckvrjsKu1wFBwH0vTUBxFo6kqRWfuleKhDkMqSkQujCL1eWbFFLtw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1203,7 +1168,6 @@
       "version": "3.984.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.984.0.tgz",
       "integrity": "sha512-TaWbfYCwnuOSvDSrgs7QgoaoXse49E7LzUkVOUhoezwB7bkmhp+iojADm7UepCEu4021SquD7NG1xA+WCvmldA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.6",
@@ -1221,7 +1185,6 @@
       "version": "3.1071.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
       "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1239,7 +1202,6 @@
       "version": "3.973.13",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -1253,7 +1215,6 @@
       "version": "3.984.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.984.0.tgz",
       "integrity": "sha512-9ebjLA0hMKHeVvXEtTDCCOBtwjb0bOXiuUV06HNeVdgAjH6gj4x4Zwt4IBti83TiyTGOCl5YfZqGx4ehVsasbQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
@@ -1270,7 +1231,6 @@
       "version": "3.965.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
       "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1283,7 +1243,6 @@
       "version": "3.972.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.23.tgz",
       "integrity": "sha512-5jF9hUGr6vplVanji97KRmbbTUlStXOp/WSz7xArD9fIWxId7tZoq0fPVRNJC5xOuaGzkwO3jHZn8BicrwfwSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1294,7 +1253,6 @@
       "version": "3.973.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.38.tgz",
       "integrity": "sha512-s8V8B0m09mDVFJn7iBDWTZTAFXPHXqjGDhoQ0WK3JKac/Ckm0VkwF7Y/b2RS7/4VMijzaGzdkVwx1jfEHNQLAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
@@ -1308,7 +1266,6 @@
       "version": "3.972.30",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
       "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -1323,7 +1280,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -3424,7 +3380,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5694,7 +5649,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.6.1.tgz",
       "integrity": "sha512-VgMsljDnHwHjJQAvLmkaOc1d3On5/2Zh1/21++9FFhYS9YKMnGgolJF73EU3QfFPSzK5jTTFlGk3em0hiRKtwg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5708,7 +5662,6 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
       "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -5723,7 +5676,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
       "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5738,7 +5690,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.4.1.tgz",
       "integrity": "sha512-u1wI6ilZtur9uBmfndaccTMOvzdszEhmnG9CmnB7ws0omdYxkpRvO112UZdDxo7Ab8TIbrRKtITMua5ntBCJ9g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5752,7 +5703,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.5.1.tgz",
       "integrity": "sha512-tnPdkY8zM98wboQFRoog1XV/Yjv7Zz61cDJxciHqyHwuCLo/jhkRCUwnicpmUJ6EzGys0FkwveHZNkIO7lcOpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5766,7 +5716,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.4.1.tgz",
       "integrity": "sha512-h/4/rKk5d2w+vRBTbVzOvu4kxq+zNmtuGIlcI8hpE/yhsR2Ky+4YZRVU1JLx/sp+Ee9eoG8/hRjvAErcQOCQoQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5780,7 +5729,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
       "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5795,7 +5743,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.4.1.tgz",
       "integrity": "sha512-5pDuFvbCim3Er0SDLJWiR9P9r73ranu/FK3ZV/i3/mIVYi+P10h/rcaS51Kgh+1TKQbZSCnsGJkbJJnM27T9bg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5809,7 +5756,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.4.1.tgz",
       "integrity": "sha512-hFez+gkhSHuBoo3t/xTNp+rKx8Hd5VaJPBexBtVkyA/XqMgOUm1eNY00nIEtUDMTjdRbfJASIWXbY2bGpjRYcA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5823,7 +5769,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.4.1.tgz",
       "integrity": "sha512-5mIF0Qnpkokf8qN1LH2+cI09TQOvFedvNNK/eRhfhbC5E9zxtyTPSprWQFI4Kb6tRp+iBsllO/aaxeDjgASREQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5837,7 +5782,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.4.1.tgz",
       "integrity": "sha512-eMmXNUign1HaUU5KGcnOWMeTt21oeuvamPaP5ZwM6VeyuHeoBKOSGOW3DVnJbBX79Xd4/yeLcbZKrIS3HpCDMg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5851,7 +5795,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5864,7 +5807,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.4.1.tgz",
       "integrity": "sha512-6xEY7LhQYgj0mEKUa4TNNkPaF/EwY4Z7OM6lmOwOqaykK3BRMqabHVf0wk+C1e1JYTmx6rYVxz+8JWxbLErytA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5878,7 +5820,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.4.1.tgz",
       "integrity": "sha512-3WPxBy1eRXsVnXh7twWJWCkoV7cEjPwBbYaJ0RuIVFP/LjcKkAbLuWOtpv2j770yPgA+Jyf6y7z3QMEICVfxrQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5892,7 +5833,6 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.6.1.tgz",
       "integrity": "sha512-TgyNn9dd8oC87+9M5Iarpf0Nr8UTtlJW0FwEMtZHc6CbhD2NZDv9kYapnnLPmhdIOvX/XDatn26Cl9UhdZJsNQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5906,7 +5846,6 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.7.1.tgz",
       "integrity": "sha512-PYBrqSyaoW0f5aU7tFzJhrm0F0t3zIrEhwF69cIHSkDRlcP90ueF/Atm0npgRk2xSvcTYzfbs1kCT8Fw/SS+3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5920,7 +5859,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.4.1.tgz",
       "integrity": "sha512-WoibOTvoqWrHuahqyHx677qPKDqB/Xp4pW2793kAHgh/WD1fAdLp6DrNfvXViUKxJWb/W5QNAv3R9nYcrQnbuw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5934,7 +5872,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.4.1.tgz",
       "integrity": "sha512-QKi4auCXmRAKOlu9YRF39Ni4JynmwoHvIwWXZS+trP/Zm8r7Z5KmaiW7R3CJERfMcrSzqMHjadzGugUuzUnZKQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5948,7 +5885,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.5.1.tgz",
       "integrity": "sha512-0eZmif/bZe3dbrazG24BmormVJ7E0yoK9IN4wcNopYLM0MNElhgd3QfPyLeuLWWi0HR+MYu3JBy0LMzAZ8u2aQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5962,7 +5898,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
       "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5977,7 +5912,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.1.tgz",
       "integrity": "sha512-GRQofBqr/pPNjR04mU0JjdjsbV8F33KCxSHMFXBb2mWJXxyEalNe814Y4cFd4Efd5tNucaOc31L3/8wXlymjfg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -5991,7 +5925,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
       "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6006,7 +5939,6 @@
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.14.1.tgz",
       "integrity": "sha512-/GsNFh1enYQB4w3x1+ZHR3IFtEya3UlcyF/8+0GUX6qObxPsm8uA4EHzopmcO5Z6DjxLwjAOco+1wwCr9mis0A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6021,7 +5953,6 @@
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
       "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6034,7 +5965,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.4.1.tgz",
       "integrity": "sha512-nuY/KEW0mHOS1ZA3NN4xjSOR5TxIwnUSbvSh39KUhBGQ3xKkaf89ftnvw0yI+Ekr3GGobzO4Elj9t+4POP8iDg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6048,7 +5978,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.5.1.tgz",
       "integrity": "sha512-B4bqm9OpfcKda2sppILh7MFXNBS6IkcCYJAiFzgUWbC75luhBvgfHd5eMvEFpTfhDtpUQAPQrcCX0twMNeExmw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6062,7 +5991,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.4.1.tgz",
       "integrity": "sha512-eOowAQTjfrhd0Uci2vPppHx4SMdWD8wouzniFd8AOU0HCp6bmEsRZd3pEDJHhXWZ2jh7erz4+qpY+tVJabRHKA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6076,7 +6004,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.4.1.tgz",
       "integrity": "sha512-eEDHEciyZ3qXYY2rNBWFApS3iaTq5etqkUju4p5CO1ofF7cGFeH36yM3YlC7o1PHwMN4qvq5jiU+UkG4kzaHGw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6090,7 +6017,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -6104,7 +6030,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.5.1.tgz",
       "integrity": "sha512-Q19s6CWcliyjkGesjKikzDuUUu8/a6ijKM8x9S84WfUgVFimcX2WM9gfZIXbdrD93YD7AFklX4ZsPa/H0DKSNw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6118,7 +6043,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.4.1.tgz",
       "integrity": "sha512-I6LP1stNp6TkSjHWw3s5hXDDYUOxML5hBWAP6jshMYcsufZiLErpD5rc0657IWTMbYocs2OjRAjQJ8KMt4OpiQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6132,7 +6056,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.6.1.tgz",
       "integrity": "sha512-7/p7K1wgOrwA+NJDk7ca+eGWs9G2xQqhcZhFa0T7inEOav31ZmGTWgPIR382ydh5TsBE8K/kR0sAss1+PlBqrA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6146,7 +6069,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.4.1.tgz",
       "integrity": "sha512-UGV7Kg5WwiJaUoYQcS6VPe/qa/BRYnTLx5drtkCExohCxnJ0IKCtXe/HZUig8NswFjXf4xmsg4lAVRQHppB3fA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6160,7 +6082,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.5.1.tgz",
       "integrity": "sha512-SQJhb5j3Btnqvh4lYdWbVH5uuoJN1kdn+UI/ehsEwhV7kHMOp4DwTBxFpUiMIgviiZsIrOk0YyI9R42yBZw90A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6174,7 +6095,6 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.7.1.tgz",
       "integrity": "sha512-PxEh26CfAkeY9et6ak8gvu+23QdXyBwvf8bnkltD2cei9bMPT9rx5wSBWv1+mTuFtZzdpcksvQfdT0JA8IFcXQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6188,7 +6108,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
       "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -6202,7 +6121,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.5.1.tgz",
       "integrity": "sha512-pqI0LUxwqkjMYCyIm8A5MrTYpfS3WTD9210QL5MW8m1KQ83MWFR+rjuy1eBnttpZwFqQ9DWnEwr8TZsq9wVTbw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.25.1",
@@ -7175,7 +7093,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
       "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7860,7 +7777,6 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -9770,7 +9686,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9787,7 +9702,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14380,7 +14294,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
       "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16185,7 +16098,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
       "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17639,7 +17551,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17790,6 +17701,7 @@
       "name": "@open-inspect/control-plane",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.984.0",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
         "better-auth": "1.6.25",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint src/ --fix"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.984.0",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
     "better-auth": "1.6.25",

--- a/packages/control-plane/src/node/s3-object-storage.test.ts
+++ b/packages/control-plane/src/node/s3-object-storage.test.ts
@@ -20,7 +20,12 @@ interface StoredObject {
  */
 class FakeS3 {
   readonly objects = new Map<string, StoredObject>();
-  readonly requests: Array<{ method: string; path: string; range: string | undefined }> = [];
+  readonly requests: Array<{
+    method: string;
+    path: string;
+    range: string | undefined;
+    securityToken: string | undefined;
+  }> = [];
   /** A provider that answers without ETags, which the S3 API always carries. */
   omitEtag = false;
   private server: Server | null = null;
@@ -43,6 +48,7 @@ class FakeS3 {
       method: request.method!,
       path: url.pathname,
       range: request.headers.range,
+      securityToken: request.headers["x-amz-security-token"] as string | undefined,
     });
     if (!url.pathname.startsWith(`/${BUCKET}/`)) {
       // A missing bucket: S3 names it in the body, except on HEAD, which has none.
@@ -139,6 +145,7 @@ describe("createS3ObjectStorage", () => {
       bucket: BUCKET,
       region: "us-east-1",
       endpoint: s3.endpoint,
+      allowHttpEndpoint: true,
       forcePathStyle: true,
       credentials: { accessKeyId: "test", secretAccessKey: "test" },
     });
@@ -238,6 +245,7 @@ describe("createS3ObjectStorage", () => {
       bucket: "no-such-bucket",
       region: "us-east-1",
       endpoint: s3.endpoint,
+      allowHttpEndpoint: true,
       forcePathStyle: true,
       credentials: { accessKeyId: "test", secretAccessKey: "test" },
     });
@@ -257,6 +265,62 @@ describe("createS3ObjectStorage", () => {
     await expect(storage.head("k/doc")).rejects.toThrow(
       "S3 HeadObject/GetObject for k/doc answered without ETag"
     );
+  });
+
+  it("sends a temporary credential's session token with every request", async () => {
+    const temporary = createS3ObjectStorage({
+      bucket: BUCKET,
+      region: "us-east-1",
+      endpoint: s3.endpoint,
+      allowHttpEndpoint: true,
+      forcePathStyle: true,
+      credentials: { accessKeyId: "ASIA", secretAccessKey: "secret", sessionToken: "sts-token" },
+    });
+
+    await temporary.put("k/doc", "x");
+    expect(await temporary.head("k/doc")).not.toBeNull();
+
+    expect(s3.requests.map((request) => request.securityToken)).toEqual(["sts-token", "sts-token"]);
+  });
+
+  it("refuses a plaintext endpoint unless a local stack opts in", () => {
+    expect(() =>
+      createS3ObjectStorage({ bucket: BUCKET, region: "us-east-1", endpoint: s3.endpoint })
+    ).toThrow("plaintext http");
+    expect(() =>
+      createS3ObjectStorage({ bucket: BUCKET, region: "us-east-1", endpoint: "https://s3.example" })
+    ).not.toThrow();
+  });
+
+  it("refuses an object past the size limit, cancelling a stream as soon as it is exceeded", async () => {
+    const bounded = createS3ObjectStorage({
+      bucket: BUCKET,
+      region: "us-east-1",
+      endpoint: s3.endpoint,
+      allowHttpEndpoint: true,
+      forcePathStyle: true,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      maxObjectBytes: 8,
+    });
+    let pulls = 0;
+    let cancelled = false;
+    // Never closes: without the limit, put would buffer it forever.
+    const endless = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(4));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    await expect(bounded.put("k/endless", endless)).rejects.toThrow(RangeError);
+    expect(cancelled).toBe(true);
+    expect(pulls).toBeLessThan(8);
+    await expect(bounded.put("k/big", new Uint8Array(9))).rejects.toThrow("exceeds 8 bytes");
+    await expect(bounded.put("k/fits", new Uint8Array(8))).resolves.toBeUndefined();
+    expect(s3.requests.map((request) => request.path)).toEqual([`/${BUCKET}/k/fits`]);
   });
 
   it("deletes a key, and deleting an absent key is not an error", async () => {
@@ -280,11 +344,22 @@ describe("readS3ObjectStorageConfig", () => {
       bucket: "media",
       region: "us-east-1",
       endpoint: "http://minio:9000",
+      allowHttpEndpoint: false,
       forcePathStyle: true,
     });
     expect(
-      readS3ObjectStorageConfig({ OBJECT_STORE_BUCKET: "media", OBJECT_STORE_REGION: "eu-west-1" })
-    ).toEqual({ bucket: "media", region: "eu-west-1", endpoint: undefined, forcePathStyle: false });
+      readS3ObjectStorageConfig({
+        OBJECT_STORE_BUCKET: "media",
+        OBJECT_STORE_REGION: "eu-west-1",
+        OBJECT_STORE_ALLOW_HTTP: "true",
+      })
+    ).toEqual({
+      bucket: "media",
+      region: "eu-west-1",
+      endpoint: undefined,
+      allowHttpEndpoint: true,
+      forcePathStyle: false,
+    });
   });
 
   it("requires the bucket", () => {

--- a/packages/control-plane/src/node/s3-object-storage.test.ts
+++ b/packages/control-plane/src/node/s3-object-storage.test.ts
@@ -21,6 +21,8 @@ interface StoredObject {
 class FakeS3 {
   readonly objects = new Map<string, StoredObject>();
   readonly requests: Array<{ method: string; path: string; range: string | undefined }> = [];
+  /** A provider that answers without ETags, which the S3 API always carries. */
+  omitEtag = false;
   private server: Server | null = null;
   endpoint = "";
 
@@ -43,7 +45,14 @@ class FakeS3 {
       range: request.headers.range,
     });
     if (!url.pathname.startsWith(`/${BUCKET}/`)) {
-      response.writeHead(404).end();
+      // A missing bucket: S3 names it in the body, except on HEAD, which has none.
+      if (request.method === "HEAD") {
+        response.writeHead(404).end();
+      } else {
+        response
+          .writeHead(404, { "Content-Type": "application/xml" })
+          .end(`<?xml version="1.0"?><Error><Code>NoSuchBucket</Code></Error>`);
+      }
       return;
     }
     switch (request.method) {
@@ -68,7 +77,7 @@ class FakeS3 {
           response.writeHead(404).end();
           return;
         }
-        response.writeHead(200, headersOf(object)).end();
+        response.writeHead(200, headersOf(object, this.omitEtag)).end();
         return;
       }
       case "GET": {
@@ -106,12 +115,12 @@ function etagOf(bytes: Buffer): string {
   return `"${createHash("md5").update(bytes).digest("hex")}"`;
 }
 
-function headersOf(object: StoredObject): Record<string, string> {
+function headersOf(object: StoredObject, omitEtag = false): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Length": String(object.bytes.length),
-    ETag: etagOf(object.bytes),
     "Last-Modified": new Date(0).toUTCString(),
   };
+  if (!omitEtag) headers.ETag = etagOf(object.bytes);
   if (object.contentType) headers["Content-Type"] = object.contentType;
   return headers;
 }
@@ -142,6 +151,7 @@ describe("createS3ObjectStorage", () => {
   beforeEach(() => {
     s3.objects.clear();
     s3.requests.length = 0;
+    s3.omitEtag = false;
   });
 
   it("puts bytes with their content type, path-style, and reads them back whole", async () => {
@@ -221,6 +231,32 @@ describe("createS3ObjectStorage", () => {
     expect(s3.requests.at(-1)).toMatchObject({ method: "GET", range: "bytes=4-9" });
     expect((await readAll(part!.body)).toString()).toBe("456789");
     expect(part!.size).toBe(16);
+  });
+
+  it("reports a missing bucket as an error, not as a missing key", async () => {
+    const elsewhere = createS3ObjectStorage({
+      bucket: "no-such-bucket",
+      region: "us-east-1",
+      endpoint: s3.endpoint,
+      forcePathStyle: true,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    });
+
+    await expect(elsewhere.get("k/doc")).rejects.toMatchObject({ name: "NoSuchBucket" });
+    await expect(elsewhere.put("k/doc", "x")).rejects.toMatchObject({ name: "NoSuchBucket" });
+    await expect(elsewhere.delete("k/doc")).rejects.toMatchObject({ name: "NoSuchBucket" });
+    // HEAD carries no body, so S3 cannot say which is missing; the port's
+    // answer for an unreachable object is null, the same as R2's.
+    expect(await elsewhere.head("k/doc")).toBeNull();
+  });
+
+  it("reports a provider answering without the fields the port promises", async () => {
+    await storage.put("k/doc", new Uint8Array(3));
+    s3.omitEtag = true;
+
+    await expect(storage.head("k/doc")).rejects.toThrow(
+      "S3 HeadObject/GetObject for k/doc answered without ETag"
+    );
   });
 
   it("deletes a key, and deleting an absent key is not an error", async () => {

--- a/packages/control-plane/src/node/s3-object-storage.test.ts
+++ b/packages/control-plane/src/node/s3-object-storage.test.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { ObjectStorage } from "../storage/object-storage";
+import { createS3ObjectStorage, readS3ObjectStorageConfig } from "./s3-object-storage";
+
+const BUCKET = "media-bucket";
+
+interface StoredObject {
+  bytes: Buffer;
+  contentType: string | undefined;
+}
+
+/**
+ * The slice of the S3 REST API the four port methods use, path-style, with
+ * S3's answers: quoted MD5 ETags, `NoSuchKey` XML on a missing GET, a bare
+ * 404 on a missing HEAD, 206 with `Content-Range` for a ranged GET, 204 on
+ * DELETE whether or not the key existed.
+ */
+class FakeS3 {
+  readonly objects = new Map<string, StoredObject>();
+  readonly requests: Array<{ method: string; path: string; range: string | undefined }> = [];
+  private server: Server | null = null;
+  endpoint = "";
+
+  async start(): Promise<void> {
+    this.server = createServer((request, response) => this.handle(request, response));
+    await new Promise<void>((resolve) => this.server!.listen(0, "127.0.0.1", resolve));
+    this.endpoint = `http://127.0.0.1:${(this.server.address() as AddressInfo).port}`;
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server?.close(() => resolve()));
+  }
+
+  private handle(request: IncomingMessage, response: ServerResponse): void {
+    const url = new URL(request.url!, this.endpoint);
+    const key = decodeURIComponent(url.pathname.replace(`/${BUCKET}/`, ""));
+    this.requests.push({
+      method: request.method!,
+      path: url.pathname,
+      range: request.headers.range,
+    });
+    if (!url.pathname.startsWith(`/${BUCKET}/`)) {
+      response.writeHead(404).end();
+      return;
+    }
+    switch (request.method) {
+      case "PUT": {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => {
+          const bytes = Buffer.concat(chunks);
+          this.objects.set(key, { bytes, contentType: request.headers["content-type"] });
+          response.writeHead(200, { ETag: etagOf(bytes) }).end();
+        });
+        return;
+      }
+      case "DELETE": {
+        this.objects.delete(key);
+        response.writeHead(204).end();
+        return;
+      }
+      case "HEAD": {
+        const object = this.objects.get(key);
+        if (!object) {
+          response.writeHead(404).end();
+          return;
+        }
+        response.writeHead(200, headersOf(object)).end();
+        return;
+      }
+      case "GET": {
+        const object = this.objects.get(key);
+        if (!object) {
+          response
+            .writeHead(404, { "Content-Type": "application/xml" })
+            .end(`<?xml version="1.0"?><Error><Code>NoSuchKey</Code><Key>${key}</Key></Error>`);
+          return;
+        }
+        const range = /^bytes=(\d+)-(\d+)$/.exec(request.headers.range ?? "");
+        if (range) {
+          const start = Number(range[1]);
+          const end = Math.min(Number(range[2]), object.bytes.length - 1);
+          const part = object.bytes.subarray(start, end + 1);
+          response
+            .writeHead(206, {
+              ...headersOf(object),
+              "Content-Length": String(part.length),
+              "Content-Range": `bytes ${start}-${end}/${object.bytes.length}`,
+            })
+            .end(part);
+          return;
+        }
+        response.writeHead(200, headersOf(object)).end(object.bytes);
+        return;
+      }
+      default:
+        response.writeHead(405).end();
+    }
+  }
+}
+
+function etagOf(bytes: Buffer): string {
+  return `"${createHash("md5").update(bytes).digest("hex")}"`;
+}
+
+function headersOf(object: StoredObject): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Length": String(object.bytes.length),
+    ETag: etagOf(object.bytes),
+    "Last-Modified": new Date(0).toUTCString(),
+  };
+  if (object.contentType) headers["Content-Type"] = object.contentType;
+  return headers;
+}
+
+async function readAll(stream: ReadableStream): Promise<Buffer> {
+  return Buffer.from(await new Response(stream).arrayBuffer());
+}
+
+describe("createS3ObjectStorage", () => {
+  const s3 = new FakeS3();
+  let storage: ObjectStorage;
+
+  beforeAll(async () => {
+    await s3.start();
+    storage = createS3ObjectStorage({
+      bucket: BUCKET,
+      region: "us-east-1",
+      endpoint: s3.endpoint,
+      forcePathStyle: true,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    });
+  });
+
+  afterAll(async () => {
+    await s3.stop();
+  });
+
+  beforeEach(() => {
+    s3.objects.clear();
+    s3.requests.length = 0;
+  });
+
+  it("puts bytes with their content type, path-style, and reads them back whole", async () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    await storage.put("sessions/s1/shot.png", bytes, { contentType: "image/png" });
+
+    expect(s3.requests[0]).toMatchObject({
+      method: "PUT",
+      path: `/${BUCKET}/sessions/s1/shot.png`,
+    });
+    expect(s3.objects.get("sessions/s1/shot.png")).toEqual({
+      bytes: Buffer.from(bytes),
+      contentType: "image/png",
+    });
+
+    const object = await storage.get("sessions/s1/shot.png");
+    expect(object).not.toBeNull();
+    expect(object!.size).toBe(4);
+    expect(object!.httpEtag).toBe(etagOf(Buffer.from(bytes)));
+    expect(await readAll(object!.body)).toEqual(Buffer.from(bytes));
+    const headers = new Headers();
+    object!.writeHttpMetadata(headers);
+    expect(headers.get("Content-Type")).toBe("image/png");
+    expect(headers.get("ETag")).toBeNull();
+    expect(headers.get("Content-Length")).toBeNull();
+  });
+
+  it("puts a string, an ArrayBuffer, a view, and a stream as their bytes", async () => {
+    const text = new TextEncoder().encode("hello");
+    const buffer = new ArrayBuffer(text.length);
+    new Uint8Array(buffer).set(text);
+    await storage.put("k/string", "hello");
+    await storage.put("k/buffer", buffer);
+    await storage.put("k/view", new Uint8Array(buffer, 1, 3));
+    await storage.put(
+      "k/stream",
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(text.subarray(0, 2));
+          controller.enqueue(text.subarray(2));
+          controller.close();
+        },
+      })
+    );
+
+    expect(s3.objects.get("k/string")!.bytes.toString()).toBe("hello");
+    expect(s3.objects.get("k/buffer")!.bytes.toString()).toBe("hello");
+    expect(s3.objects.get("k/view")!.bytes.toString()).toBe("ell");
+    expect(s3.objects.get("k/stream")!.bytes.toString()).toBe("hello");
+  });
+
+  it("maps HEAD to the metadata shape, writing only the stored HTTP metadata", async () => {
+    await storage.put("k/doc", new Uint8Array(10), { contentType: "video/mp4" });
+
+    const head = await storage.head("k/doc");
+    expect(head).not.toBeNull();
+    expect(head!.size).toBe(10);
+    expect(head!.httpEtag).toBe(etagOf(Buffer.alloc(10)));
+    const headers = new Headers();
+    head!.writeHttpMetadata(headers);
+    expect([...headers.keys()]).toEqual(["content-type"]);
+    expect(headers.get("Content-Type")).toBe("video/mp4");
+  });
+
+  it("answers null, not an error, for a missing key on head and get", async () => {
+    expect(await storage.head("k/absent")).toBeNull();
+    expect(await storage.get("k/absent")).toBeNull();
+    expect(await storage.get("k/absent", { range: { offset: 0, length: 1 } })).toBeNull();
+  });
+
+  it("reads a byte range, reporting the whole object's size as R2 does", async () => {
+    const bytes = Buffer.from("0123456789abcdef");
+    await storage.put("k/ranged", bytes);
+
+    const part = await storage.get("k/ranged", { range: { offset: 4, length: 6 } });
+    expect(part).not.toBeNull();
+    expect(s3.requests.at(-1)).toMatchObject({ method: "GET", range: "bytes=4-9" });
+    expect((await readAll(part!.body)).toString()).toBe("456789");
+    expect(part!.size).toBe(16);
+  });
+
+  it("deletes a key, and deleting an absent key is not an error", async () => {
+    await storage.put("k/gone", new Uint8Array([1]));
+    await storage.delete("k/gone");
+    expect(s3.objects.has("k/gone")).toBe(false);
+    expect(await storage.head("k/gone")).toBeNull();
+    await expect(storage.delete("k/gone")).resolves.toBeUndefined();
+  });
+});
+
+describe("readS3ObjectStorageConfig", () => {
+  it("reads the OBJECT_STORE_* variables, defaulting the region", () => {
+    expect(
+      readS3ObjectStorageConfig({
+        OBJECT_STORE_BUCKET: "media",
+        OBJECT_STORE_ENDPOINT: "http://minio:9000",
+        OBJECT_STORE_FORCE_PATH_STYLE: "true",
+      })
+    ).toEqual({
+      bucket: "media",
+      region: "us-east-1",
+      endpoint: "http://minio:9000",
+      forcePathStyle: true,
+    });
+    expect(
+      readS3ObjectStorageConfig({ OBJECT_STORE_BUCKET: "media", OBJECT_STORE_REGION: "eu-west-1" })
+    ).toEqual({ bucket: "media", region: "eu-west-1", endpoint: undefined, forcePathStyle: false });
+  });
+
+  it("requires the bucket", () => {
+    expect(() => readS3ObjectStorageConfig({})).toThrow("OBJECT_STORE_BUCKET is required");
+  });
+});

--- a/packages/control-plane/src/node/s3-object-storage.ts
+++ b/packages/control-plane/src/node/s3-object-storage.ts
@@ -23,6 +23,7 @@ import {
   type GetObjectCommandOutput,
   type HeadObjectCommandOutput,
 } from "@aws-sdk/client-s3";
+import { VIDEO_MAX_BYTES } from "../media";
 import type { ObjectStorage, ObjectStorageMetadata } from "../storage/object-storage";
 
 export interface S3ObjectStorageConfig {
@@ -30,16 +31,31 @@ export interface S3ObjectStorageConfig {
   region: string;
   /** Set for MinIO or another non-AWS endpoint; AWS S3 when omitted. */
   endpoint?: string;
+  /**
+   * Whether a plaintext `http:` endpoint is accepted. Signed requests and
+   * object data would cross the network in the clear, so only a local
+   * compose stack should set it; an `http:` endpoint is otherwise refused.
+   */
+  allowHttpEndpoint?: boolean;
   /** `https://host/bucket/key` rather than `https://bucket.host/key`; MinIO needs it. */
   forcePathStyle?: boolean;
-  /** Static credentials; the SDK's default provider chain (instance role, env) when omitted. */
-  credentials?: { accessKeyId: string; secretAccessKey: string };
+  /**
+   * Static credentials, with the session token of temporary (STS) ones;
+   * the SDK's default provider chain (instance role, env) when omitted.
+   */
+  credentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+  /**
+   * The largest object `put` accepts, so a stream cannot be buffered
+   * without bound. Defaults to the largest media object a route stores.
+   */
+  maxObjectBytes?: number;
 }
 
 /**
  * The configuration from the `OBJECT_STORE_*` variables. `OBJECT_STORE_BUCKET`
  * is required; `OBJECT_STORE_REGION` defaults to `us-east-1`, the region
- * MinIO and most S3-compatible services answer to.
+ * MinIO and most S3-compatible services answer to; `OBJECT_STORE_ALLOW_HTTP`
+ * is the opt-in for a plaintext endpoint.
  */
 export function readS3ObjectStorageConfig(
   env: Record<string, string | undefined>
@@ -52,6 +68,7 @@ export function readS3ObjectStorageConfig(
     bucket,
     region: env.OBJECT_STORE_REGION || "us-east-1",
     endpoint: env.OBJECT_STORE_ENDPOINT || undefined,
+    allowHttpEndpoint: env.OBJECT_STORE_ALLOW_HTTP === "true",
     forcePathStyle: env.OBJECT_STORE_FORCE_PATH_STYLE === "true",
   };
 }
@@ -64,9 +81,22 @@ type StoredObject = NonNullable<Awaited<ReturnType<ObjectStorage["get"]>>>;
 class S3ObjectStorage implements ObjectStorage {
   private readonly client: S3Client;
   private readonly bucket: string;
+  private readonly maxObjectBytes: number;
 
   constructor(config: S3ObjectStorageConfig) {
+    if (
+      config.endpoint &&
+      new URL(config.endpoint).protocol === "http:" &&
+      !config.allowHttpEndpoint
+    ) {
+      throw new Error(
+        `S3 endpoint ${config.endpoint} is plaintext http; signed requests and object data ` +
+          "would cross the network in the clear. Use https, or set OBJECT_STORE_ALLOW_HTTP=true " +
+          "for a local compose stack only."
+      );
+    }
     this.bucket = config.bucket;
+    this.maxObjectBytes = config.maxObjectBytes ?? VIDEO_MAX_BYTES;
     this.client = new S3Client({
       region: config.region,
       endpoint: config.endpoint,
@@ -80,7 +110,7 @@ class S3ObjectStorage implements ObjectStorage {
       new PutObjectCommand({
         Bucket: this.bucket,
         Key: key,
-        Body: await bodyBytes(value),
+        Body: await bodyBytes(value, this.maxObjectBytes),
         ContentType: options?.contentType,
       })
     );
@@ -190,14 +220,42 @@ function required<T>(value: T | undefined, field: string, operation: string, key
 }
 
 /**
- * The value as bytes. A stream is read to the end first: S3 needs the
- * content length up front, and every caller today hands over bytes.
+ * The value as bytes, refused past `maxBytes`. A stream is read to the end
+ * first, since S3 needs the content length up front, and is cancelled the
+ * moment it exceeds the limit, so no caller can have the host buffer
+ * without bound.
  */
-async function bodyBytes(value: PutValue): Promise<Uint8Array | string> {
-  if (typeof value === "string") return value;
-  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+async function bodyBytes(value: PutValue, maxBytes: number): Promise<Uint8Array | string> {
+  if (typeof value === "string") return withinLimit(new TextEncoder().encode(value), maxBytes);
+  if (value instanceof ArrayBuffer) return withinLimit(new Uint8Array(value), maxBytes);
   if (ArrayBuffer.isView(value)) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return withinLimit(new Uint8Array(value.buffer, value.byteOffset, value.byteLength), maxBytes);
   }
-  return new Uint8Array(await new Response(value).arrayBuffer());
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = value.getReader();
+  for (;;) {
+    const { done, value: chunk } = await reader.read();
+    if (done) break;
+    total += chunk.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new RangeError(`S3 put refused: the object exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(chunk);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function withinLimit(bytes: Uint8Array, maxBytes: number): Uint8Array {
+  if (bytes.byteLength > maxBytes) {
+    throw new RangeError(`S3 put refused: the object exceeds ${maxBytes} bytes`);
+  }
+  return bytes;
 }

--- a/packages/control-plane/src/node/s3-object-storage.ts
+++ b/packages/control-plane/src/node/s3-object-storage.ts
@@ -1,0 +1,184 @@
+/**
+ * The `ObjectStorage` port on S3-compatible storage: AWS S3, MinIO in the
+ * compose stack, or any service speaking the S3 API. The Node host's media
+ * artifacts (screenshots, uploads, session media) go through it, as they go
+ * through R2 on Cloudflare.
+ *
+ * This is the one module that imports `@aws-sdk/*`. The contract mirrors
+ * `R2ObjectStorage`: a missing key is `null` from `head` and `get`, never an
+ * error; `size` is the whole object's size even for a ranged read; and
+ * `writeHttpMetadata` writes the HTTP metadata stored with the object
+ * (content type, language, disposition, encoding, cache control, expiry),
+ * not the entity headers the response builder sets itself.
+ */
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  type GetObjectCommandOutput,
+  type HeadObjectCommandOutput,
+} from "@aws-sdk/client-s3";
+import type { ObjectStorage, ObjectStorageMetadata } from "../storage/object-storage";
+
+export interface S3ObjectStorageConfig {
+  bucket: string;
+  region: string;
+  /** Set for MinIO or another non-AWS endpoint; AWS S3 when omitted. */
+  endpoint?: string;
+  /** `https://host/bucket/key` rather than `https://bucket.host/key`; MinIO needs it. */
+  forcePathStyle?: boolean;
+  /** Static credentials; the SDK's default provider chain (instance role, env) when omitted. */
+  credentials?: { accessKeyId: string; secretAccessKey: string };
+}
+
+/**
+ * The configuration from the `OBJECT_STORE_*` variables. `OBJECT_STORE_BUCKET`
+ * is required; `OBJECT_STORE_REGION` defaults to `us-east-1`, the region
+ * MinIO and most S3-compatible services answer to.
+ */
+export function readS3ObjectStorageConfig(
+  env: Record<string, string | undefined>
+): S3ObjectStorageConfig {
+  const bucket = env.OBJECT_STORE_BUCKET;
+  if (!bucket) {
+    throw new Error("OBJECT_STORE_BUCKET is required to use S3 object storage");
+  }
+  return {
+    bucket,
+    region: env.OBJECT_STORE_REGION || "us-east-1",
+    endpoint: env.OBJECT_STORE_ENDPOINT || undefined,
+    forcePathStyle: env.OBJECT_STORE_FORCE_PATH_STYLE === "true",
+  };
+}
+
+type PutValue = Parameters<ObjectStorage["put"]>[1];
+type PutOptions = Parameters<ObjectStorage["put"]>[2];
+type GetOptions = Parameters<ObjectStorage["get"]>[1];
+type StoredObject = NonNullable<Awaited<ReturnType<ObjectStorage["get"]>>>;
+
+class S3ObjectStorage implements ObjectStorage {
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(config: S3ObjectStorageConfig) {
+    this.bucket = config.bucket;
+    this.client = new S3Client({
+      region: config.region,
+      endpoint: config.endpoint,
+      forcePathStyle: config.forcePathStyle ?? false,
+      credentials: config.credentials,
+    });
+  }
+
+  async put(key: string, value: PutValue, options?: PutOptions): Promise<void> {
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: await bodyBytes(value),
+        ContentType: options?.contentType,
+      })
+    );
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
+  async head(key: string): Promise<ObjectStorageMetadata | null> {
+    let output: HeadObjectCommandOutput;
+    try {
+      output = await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+    } catch (error) {
+      if (isMissingObject(error)) return null;
+      throw error;
+    }
+    return metadataOf(output, output.ContentLength ?? 0);
+  }
+
+  async get(key: string, options?: GetOptions): Promise<StoredObject | null> {
+    const range = options?.range;
+    let output: GetObjectCommandOutput;
+    try {
+      output = await this.client.send(
+        new GetObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+          Range: range ? `bytes=${range.offset}-${range.offset + range.length - 1}` : undefined,
+        })
+      );
+    } catch (error) {
+      if (isMissingObject(error)) return null;
+      throw error;
+    }
+    if (!output.Body) return null;
+    return {
+      ...metadataOf(output, totalSize(output)),
+      body: output.Body.transformToWebStream(),
+    };
+  }
+}
+
+export function createS3ObjectStorage(config: S3ObjectStorageConfig): ObjectStorage {
+  return new S3ObjectStorage(config);
+}
+
+/** The object's whole size: from `Content-Range` on a ranged read, else the body length. */
+function totalSize(output: GetObjectCommandOutput): number {
+  const match = /\/(\d+)$/.exec(output.ContentRange ?? "");
+  if (match) return Number(match[1]);
+  return output.ContentLength ?? 0;
+}
+
+function metadataOf(
+  output: HeadObjectCommandOutput | GetObjectCommandOutput,
+  size: number
+): ObjectStorageMetadata {
+  const httpEtag = output.ETag ?? "";
+  const stored: Array<[string, string | undefined]> = [
+    ["Content-Type", output.ContentType],
+    ["Content-Language", output.ContentLanguage],
+    ["Content-Disposition", output.ContentDisposition],
+    ["Content-Encoding", output.ContentEncoding],
+    ["Cache-Control", output.CacheControl],
+    ["Expires", output.Expires?.toUTCString()],
+  ];
+  return {
+    size,
+    httpEtag,
+    writeHttpMetadata(headers: Headers): void {
+      for (const [name, value] of stored) {
+        if (value !== undefined) headers.set(name, value);
+      }
+    },
+  };
+}
+
+/**
+ * Whether the error is S3 saying the key is absent: `NoSuchKey` from
+ * GetObject, and the bare 404 (`NotFound`) HeadObject answers with.
+ */
+function isMissingObject(error: unknown): boolean {
+  const failure = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return (
+    failure.name === "NoSuchKey" ||
+    failure.name === "NotFound" ||
+    failure.$metadata?.httpStatusCode === 404
+  );
+}
+
+/**
+ * The value as bytes. A stream is read to the end first: S3 needs the
+ * content length up front, and every caller today hands over bytes.
+ */
+async function bodyBytes(value: PutValue): Promise<Uint8Array | string> {
+  if (typeof value === "string") return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return new Uint8Array(await new Response(value).arrayBuffer());
+}

--- a/packages/control-plane/src/node/s3-object-storage.ts
+++ b/packages/control-plane/src/node/s3-object-storage.ts
@@ -5,11 +5,13 @@
  * through R2 on Cloudflare.
  *
  * This is the one module that imports `@aws-sdk/*`. The contract mirrors
- * `R2ObjectStorage`: a missing key is `null` from `head` and `get`, never an
- * error; `size` is the whole object's size even for a ranged read; and
- * `writeHttpMetadata` writes the HTTP metadata stored with the object
- * (content type, language, disposition, encoding, cache control, expiry),
- * not the entity headers the response builder sets itself.
+ * `R2ObjectStorage`: a missing key is `null` from `head` and `get`, and only
+ * a missing key; a missing bucket, a wrong endpoint, or a response without
+ * the fields the port promises is an error, so a deployment fault never
+ * reads as an absent artifact. `size` is the whole object's size even for a
+ * ranged read, and `writeHttpMetadata` writes the HTTP metadata stored with
+ * the object (content type, language, disposition, encoding, cache control,
+ * expiry), not the entity headers the response builder sets itself.
  */
 
 import {
@@ -93,10 +95,16 @@ class S3ObjectStorage implements ObjectStorage {
     try {
       output = await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
     } catch (error) {
-      if (isMissingObject(error)) return null;
+      // HeadObject answers a bare 404, which the SDK names NotFound; S3 gives
+      // it no body to say whether the key or the bucket is what is missing.
+      if (isNamed(error, "NotFound")) return null;
       throw error;
     }
-    return metadataOf(output, output.ContentLength ?? 0);
+    return metadataOf(
+      output,
+      required(output.ContentLength, "ContentLength", "HeadObject", key),
+      key
+    );
   }
 
   async get(key: string, options?: GetOptions): Promise<StoredObject | null> {
@@ -111,13 +119,13 @@ class S3ObjectStorage implements ObjectStorage {
         })
       );
     } catch (error) {
-      if (isMissingObject(error)) return null;
+      if (isNamed(error, "NoSuchKey")) return null;
       throw error;
     }
-    if (!output.Body) return null;
+    const body = required(output.Body, "Body", "GetObject", key);
     return {
-      ...metadataOf(output, totalSize(output)),
-      body: output.Body.transformToWebStream(),
+      ...metadataOf(output, totalSize(output, range !== undefined, key), key),
+      body: body.transformToWebStream(),
     };
   }
 }
@@ -127,17 +135,24 @@ export function createS3ObjectStorage(config: S3ObjectStorageConfig): ObjectStor
 }
 
 /** The object's whole size: from `Content-Range` on a ranged read, else the body length. */
-function totalSize(output: GetObjectCommandOutput): number {
-  const match = /\/(\d+)$/.exec(output.ContentRange ?? "");
-  if (match) return Number(match[1]);
-  return output.ContentLength ?? 0;
+function totalSize(output: GetObjectCommandOutput, ranged: boolean, key: string): number {
+  if (!ranged) return required(output.ContentLength, "ContentLength", "GetObject", key);
+  const match = /\/(\d+)$/.exec(required(output.ContentRange, "ContentRange", "GetObject", key));
+  if (!match) {
+    throw new Error(
+      `S3 GetObject for ${key} answered a range with Content-Range ${output.ContentRange}, ` +
+        "which does not carry the object's size"
+    );
+  }
+  return Number(match[1]);
 }
 
 function metadataOf(
   output: HeadObjectCommandOutput | GetObjectCommandOutput,
-  size: number
+  size: number,
+  key: string
 ): ObjectStorageMetadata {
-  const httpEtag = output.ETag ?? "";
+  const httpEtag = required(output.ETag, "ETag", "HeadObject/GetObject", key);
   const stored: Array<[string, string | undefined]> = [
     ["Content-Type", output.ContentType],
     ["Content-Language", output.ContentLanguage],
@@ -157,17 +172,21 @@ function metadataOf(
   };
 }
 
+/** Whether the SDK classified the failure as S3's error `name`. */
+function isNamed(error: unknown, name: string): boolean {
+  return (error as { name?: string }).name === name;
+}
+
 /**
- * Whether the error is S3 saying the key is absent: `NoSuchKey` from
- * GetObject, and the bare 404 (`NotFound`) HeadObject answers with.
+ * The field, which a well-formed S3 response always carries. Its absence
+ * is the provider not speaking the S3 API the port is built on, reported
+ * as such rather than read as an empty or absent object.
  */
-function isMissingObject(error: unknown): boolean {
-  const failure = error as { name?: string; $metadata?: { httpStatusCode?: number } };
-  return (
-    failure.name === "NoSuchKey" ||
-    failure.name === "NotFound" ||
-    failure.$metadata?.httpStatusCode === 404
-  );
+function required<T>(value: T | undefined, field: string, operation: string, key: string): T {
+  if (value === undefined) {
+    throw new Error(`S3 ${operation} for ${key} answered without ${field}`);
+  }
+  return value;
 }
 
 /**


### PR DESCRIPTION
Roadmap **N-3 · COL-90**: the `ObjectStorage` port on S3-compatible storage for the Node host. Node host only; the worker bundle has no `src/node`, `@aws-sdk`, or `@smithy` input (`dist/meta.json` checked). No Cloudflare code changes; `@aws-sdk/client-s3` becomes a runtime dependency of the control plane at the version already in the lockfile.

## What

**`src/node/s3-object-storage.ts`.** `createS3ObjectStorage(config)` implements the four-method port (`src/storage/object-storage.ts`) on `@aws-sdk/client-s3`, with `R2ObjectStorage`'s contract rather than S3's:

- `put(key, value, { contentType })`: string, `ArrayBuffer`, view, or `ReadableStream`, sent as bytes with the content type. A stream is read to the end first: S3 wants the content length up front, and every caller today hands over bytes.
- `head(key)`: `HeadObject` → `{ size: ContentLength, httpEtag: ETag, writeHttpMetadata }`; a missing key is `null`. HeadObject answers a bare 404 with no body, which the SDK names `NotFound`; S3 itself cannot say there whether the key or the bucket is missing.
- `get(key, { range })`: `GetObject` with `Range: bytes=offset-(offset+length-1)`, body as a web `ReadableStream` via `transformToWebStream()`; `NoSuchKey`, and only `NoSuchKey`, → `null`. A missing bucket (`NoSuchBucket`), a wrong endpoint, or any other 404 is the error it is, so a deployment fault never reads as an absent artifact. `size` is the whole object's size even on a ranged read, from `Content-Range`, as `R2Object.size` is.
- A response without the fields the S3 API always carries (`Body`, `ContentLength`, `Content-Range` on a ranged read, `ETag`) is reported as the provider not speaking S3, naming the operation, key, and field, rather than read as an empty object; `null` is reserved for a recognized missing key.
- `delete(key)`: `DeleteObject`; absent keys are not an error, as on R2.
- `writeHttpMetadata` writes what R2's does: the HTTP metadata stored with the object (`Content-Type`, `Content-Language`, `Content-Disposition`, `Content-Encoding`, `Cache-Control`, `Expires`). `ETag` and `Content-Length` are the response builder's (`routes/responses/stored-object-response.ts` sets them from `httpEtag` and `size`), so writing them here would only be overwritten.

`readS3ObjectStorageConfig(env)` reads `OBJECT_STORE_BUCKET` (required), `OBJECT_STORE_REGION` (default `us-east-1`, what MinIO and most S3-compatible services answer to), `OBJECT_STORE_ENDPOINT`, and `OBJECT_STORE_FORCE_PATH_STYLE`; credentials come from the SDK's default provider chain (instance role, env) unless the config carries static ones. This is the only module that imports `@aws-sdk/*`.

Not wired into a platform record: the Node record is P-5 / H-1's; the Cloudflare record keeps `R2ObjectStorage`.

## Deviations from the issue text

- `writeHttpMetadata` does not write `ETag` / `Content-Length` (issue item 2): R2's does not either, and the response builder sets both from the metadata fields. Mirroring R2 keeps one contract.
- No MinIO in CI: the tests run against an in-process fake speaking the S3 REST subset the four methods use, so the wire shape (path-style URL, `Range` header, `NoSuchKey` XML vs bare 404, 206 + `Content-Range`) is what is asserted, not a mocked client.

## Tests

`src/node/s3-object-storage.test.ts` (10), against an in-process fake S3 over `node:http` with SigV4-signed requests from the real client: put with content type reaches the bucket path-style and reads back whole with `size`, `httpEtag`, body, and only stored metadata written; string / `ArrayBuffer` / view / stream bodies land as their bytes; HEAD maps to the metadata shape writing only `Content-Type`; missing keys are `null` from head, get, and ranged get; a ranged read sends `bytes=4-9`, returns those bytes, and reports the whole size; a missing bucket rejects get, put, and delete with `NoSuchBucket` (and head, body-less, answers `null` as R2 does for an unreachable object); a provider answering without `ETag` is reported by operation, key, and field; delete removes the key and deleting an absent key resolves; the config reader's defaults and its required bucket.

Control-plane unit suite 259 files / 3815 tests green; full workerd integration suite green; `npm run typecheck` (all four programs), eslint, prettier clean; knip reports nothing new.

## Follow-ups

- P-5 / H-1: construct it in the Node platform record from `readS3ObjectStorageConfig(process.env)`.
- V-5 (COL-119): the lint that pins `@aws-sdk/*` to this file.
- H-7 (COL-103): MinIO in compose; V-2 (COL-116): media upload and stream routes on the Node host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added S3-compatible object storage support for AWS S3, MinIO, and other compatible services.
  - Supports uploading, downloading, deleting, and inspecting objects, including byte-range reads and metadata such as content type and ETag.
  - Added configuration through environment variables, with support for custom endpoints, path-style addressing, and static credentials.

- **Tests**
  - Added coverage for object operations, missing objects, ranged reads, metadata handling, errors, and configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review round 2

`put` refuses an object past `maxObjectBytes` (default `VIDEO_MAX_BYTES`) and cancels a stream the moment it crosses the limit, so nothing is buffered without bound. An `http:` endpoint is refused unless the deployment opts in with `OBJECT_STORE_ALLOW_HTTP=true` (`allowHttpEndpoint`), meant for the compose stack's MinIO only. Static credentials carry a session token. Three tests added (13 total). The data-only `ObjectStorageMetadata` shape the review asked for is filed as COL-131, to do with P-5.
