### PR TITLE
fix: condition the spawn path's writes after provider awaits on the attempt (COL-99)

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
+  type SandboxGeneration,
   type SandboxStorage,
   type SessionContextReader,
   type SandboxBroadcaster,
@@ -171,12 +172,21 @@ function createMockStorage(
       calls.push(`updateSandboxStatus:${status}`);
       if (sandbox) sandbox.status = status;
     }),
-    transitionSandboxStatus: vi.fn((from: SandboxStatus, to: SandboxStatus) => {
-      calls.push(`transitionSandboxStatus:${from}->${to}`);
-      if (!sandbox || sandbox.status !== from) return false;
-      sandbox.status = to;
-      return true;
-    }),
+    transitionSandboxStatus: vi.fn(
+      (generation: SandboxGeneration, from: SandboxStatus, to: SandboxStatus) => {
+        calls.push(`transitionSandboxStatus:${from}->${to}`);
+        if (
+          !sandbox ||
+          sandbox.modal_sandbox_id !== generation.sandboxId ||
+          sandbox.created_at !== generation.createdAt ||
+          sandbox.status !== from
+        ) {
+          return false;
+        }
+        sandbox.status = to;
+        return true;
+      }
+    ),
     updateSandboxForSpawn: vi.fn((data) => {
       calls.push("updateSandboxForSpawn");
       if (sandbox) {
@@ -634,7 +644,11 @@ describe("SandboxLifecycleManager", () => {
         expect(
           kind === "spawn" ? provider.createSandbox : provider.restoreFromSnapshot
         ).toHaveBeenCalledOnce();
-        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith("spawning", "connecting");
+        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith(
+          expect.objectContaining({ sandboxId: expect.any(String) }),
+          "spawning",
+          "connecting"
+        );
         expect(parseStructuredLogs(warnSpy)).toContainEqual(
           expect.objectContaining({
             msg: "Provider stop failed before sandbox replacement",
@@ -677,7 +691,11 @@ describe("SandboxLifecycleManager", () => {
         await spawning;
 
         expect(provider.createSandbox).toHaveBeenCalledOnce();
-        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith("spawning", "connecting");
+        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith(
+          expect.objectContaining({ sandboxId: expect.any(String) }),
+          "spawning",
+          "connecting"
+        );
         expect(sandbox.modal_object_id).toBe("modal-obj-123");
         expect(parseStructuredLogs(warnSpy)).toContainEqual(
           expect.objectContaining({
@@ -3990,6 +4008,92 @@ describe("status writes after a provider await (COL-99)", () => {
     expect(sandbox.auth_token_hash).toBe("");
     expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->failed");
     expect(storage.incrementCircuitBreakerFailure).not.toHaveBeenCalled();
+  });
+
+  it("does not let a late completion touch a newer reservation that re-entered spawning", async () => {
+    // Attempt A's provider call is slow. Its bridge connects early (clearing
+    // the in-memory flag), goes stale, and attempt B reserves a new identity,
+    // so the row is `spawning` again when A's call returns.
+    const sandbox = createMockSandbox({ status: "failed" });
+    const storage = createMockStorage(createMockSession(), sandbox);
+    const broadcaster = createMockBroadcaster();
+    let attempts = 0;
+    const provider = createMockProvider({
+      createSandbox: vi.fn(async (config) => {
+        attempts += 1;
+        if (attempts === 1) {
+          sandbox.status = "spawning";
+          sandbox.modal_sandbox_id = "sb-B";
+          sandbox.created_at = config.sandboxId.length + Date.now() + 1;
+          throw new SandboxProviderError("late failure of A", "transient");
+        }
+        return {
+          sandboxId: config.sandboxId,
+          providerObjectId: "provider-obj-B",
+          status: "connecting",
+          createdAt: Date.now(),
+        };
+      }),
+    });
+    const manager = new SandboxLifecycleManager(
+      provider,
+      storage,
+      storage,
+      broadcaster,
+      createMockWebSocketManager(false),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+
+    await manager.spawnSandbox();
+
+    // B's row is untouched by A's failure: still spawning, no error reported.
+    expect(sandbox.status).toBe("spawning");
+    expect(sandbox.modal_sandbox_id).toBe("sb-B");
+    expect(storage.setLastSpawnError).not.toHaveBeenCalledWith(
+      "late failure of A",
+      expect.anything()
+    );
+    expect(broadcaster.messages).not.toContainEqual({
+      type: "sandbox_error",
+      error: "late failure of A",
+    });
+  });
+
+  it("does not let a late completion touch a newer generation that re-entered snapshotting", async () => {
+    const sandbox = createMockSandbox({
+      status: "ready",
+      modal_sandbox_id: "sb-A",
+      created_at: 1000,
+    });
+    const storage = createMockStorage(createMockSession(), sandbox);
+    const broadcaster = createMockBroadcaster();
+    const provider = createMockProvider({
+      takeSnapshot: vi.fn(async () => {
+        // A terminated and was replaced; the replacement is itself snapshotting.
+        sandbox.modal_sandbox_id = "sb-B";
+        sandbox.created_at = 2000;
+        sandbox.status = "snapshotting";
+        return { success: true, imageId: "snapshot-of-A" };
+      }),
+    });
+    const manager = new SandboxLifecycleManager(
+      provider,
+      storage,
+      storage,
+      broadcaster,
+      createMockWebSocketManager(),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+
+    await manager.triggerSnapshot("execution_complete");
+
+    expect(sandbox.status).toBe("snapshotting");
+    expect(sandbox.snapshot_image_id).toBeNull();
+    expect(broadcaster.messages).not.toContainEqual({ type: "sandbox_status", status: "ready" });
   });
 
   it("still fails and reports an attempt nothing else touched", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -227,9 +227,9 @@ function createMockStorage(
       if (sandbox) sandbox.runtime_version = runtimeVersion;
     }),
     recordSandboxSnapshot: vi.fn(
-      (modalSandboxId: string | null, imageId: string, runtimeVersion: string | null) => {
+      (sandboxId: string | null, imageId: string, runtimeVersion: string | null) => {
         calls.push(`recordSandboxSnapshot:${imageId}:${runtimeVersion}`);
-        if (!sandbox || sandbox.modal_sandbox_id !== modalSandboxId) return false;
+        if (!sandbox || sandbox.modal_sandbox_id !== sandboxId) return false;
         sandbox.snapshot_image_id = imageId;
         sandbox.snapshot_runtime_version = runtimeVersion;
         return true;

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -171,6 +171,12 @@ function createMockStorage(
       calls.push(`updateSandboxStatus:${status}`);
       if (sandbox) sandbox.status = status;
     }),
+    transitionSandboxStatus: vi.fn((from: SandboxStatus, to: SandboxStatus) => {
+      calls.push(`transitionSandboxStatus:${from}->${to}`);
+      if (!sandbox || sandbox.status !== from) return false;
+      sandbox.status = to;
+      return true;
+    }),
     updateSandboxForSpawn: vi.fn((data) => {
       calls.push("updateSandboxForSpawn");
       if (sandbox) {
@@ -185,7 +191,13 @@ function createMockStorage(
     }),
     updateSandboxAuthTokenHash: vi.fn((modalSandboxId: string, authTokenHash: string) => {
       calls.push("updateSandboxAuthTokenHash");
-      if (!sandbox || sandbox.modal_sandbox_id !== modalSandboxId) return false;
+      if (
+        !sandbox ||
+        sandbox.modal_sandbox_id !== modalSandboxId ||
+        sandbox.status !== "spawning"
+      ) {
+        return false;
+      }
       sandbox.auth_token_hash = authTokenHash;
       return true;
     }),
@@ -204,13 +216,13 @@ function createMockStorage(
       calls.push(`updateSandboxRuntimeVersion:${runtimeVersion}`);
       if (sandbox) sandbox.runtime_version = runtimeVersion;
     }),
-    updateSandboxSnapshotImageId: vi.fn(
-      (sandboxId: string, imageId: string, runtimeVersion: string | null) => {
-        calls.push(`updateSandboxSnapshotImageId:${imageId}:${runtimeVersion}`);
-        if (sandbox) {
-          sandbox.snapshot_image_id = imageId;
-          sandbox.snapshot_runtime_version = runtimeVersion;
-        }
+    recordSandboxSnapshot: vi.fn(
+      (modalSandboxId: string | null, imageId: string, runtimeVersion: string | null) => {
+        calls.push(`recordSandboxSnapshot:${imageId}:${runtimeVersion}`);
+        if (!sandbox || sandbox.modal_sandbox_id !== modalSandboxId) return false;
+        sandbox.snapshot_image_id = imageId;
+        sandbox.snapshot_runtime_version = runtimeVersion;
+        return true;
       }
     ),
     updateSandboxLastActivity: vi.fn((timestamp: number) => {
@@ -459,7 +471,7 @@ async function expectEarlyBridgeStartup(kind: ProviderStartupKind): Promise<void
   await manager.spawnSandbox();
 
   expect(sandbox.status).toBe("ready");
-  expect(storage.calls).not.toContain("updateSandboxStatus:connecting");
+  expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->connecting");
   expect(storage.calls.filter((call) => call === "updateSandboxForResume:connecting")).toHaveLength(
     kind === "resume" ? 1 : 0
   );
@@ -516,7 +528,7 @@ describe("SandboxLifecycleManager", () => {
 
       expect(provider.createSandbox).toHaveBeenCalled();
       expect(storage.calls).toContain("updateSandboxForSpawn");
-      expect(storage.calls).toContain("updateSandboxStatus:connecting");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "sandbox_status")
       ).toBe(true);
@@ -622,7 +634,7 @@ describe("SandboxLifecycleManager", () => {
         expect(
           kind === "spawn" ? provider.createSandbox : provider.restoreFromSnapshot
         ).toHaveBeenCalledOnce();
-        expect(storage.updateSandboxStatus).toHaveBeenCalledWith("connecting");
+        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith("spawning", "connecting");
         expect(parseStructuredLogs(warnSpy)).toContainEqual(
           expect.objectContaining({
             msg: "Provider stop failed before sandbox replacement",
@@ -665,7 +677,7 @@ describe("SandboxLifecycleManager", () => {
         await spawning;
 
         expect(provider.createSandbox).toHaveBeenCalledOnce();
-        expect(storage.updateSandboxStatus).toHaveBeenCalledWith("connecting");
+        expect(storage.transitionSandboxStatus).toHaveBeenCalledWith("spawning", "connecting");
         expect(sandbox.modal_object_id).toBe("modal-obj-123");
         expect(parseStructuredLogs(warnSpy)).toContainEqual(
           expect.objectContaining({
@@ -1471,7 +1483,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.triggerSnapshot("execution_complete");
 
       expect(sandbox.runtime_version).toBeNull();
-      expect(storage.calls).toContain("updateSandboxSnapshotImageId:snapshot-img-123:null");
+      expect(storage.calls).toContain("recordSandboxSnapshot:snapshot-img-123:null");
     });
 
     it("seeds the restored sandbox's runtime version from the snapshot", async () => {
@@ -1586,7 +1598,7 @@ describe("SandboxLifecycleManager", () => {
 
       // After failed restore, isSpawning should be reset to false
       expect(manager.isSpawning()).toBe(false);
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
     });
 
     it("resets isSpawningSandbox flag after restore returns failure", async () => {
@@ -1625,7 +1637,7 @@ describe("SandboxLifecycleManager", () => {
 
       // After failed restore (success=false), isSpawning should be reset to false
       expect(manager.isSpawning()).toBe(false);
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
       expect(
         broadcaster.messages.some(
           (m) => (m as { type: string; error?: string }).error === "Snapshot not found"
@@ -1656,7 +1668,7 @@ describe("SandboxLifecycleManager", () => {
       // Should go: pending -> spawning -> connecting
       const statusCalls = storage.calls.filter((c) => c.startsWith("updateSandbox"));
       expect(statusCalls).toContain("updateSandboxForSpawn");
-      expect(statusCalls).toContain("updateSandboxStatus:connecting");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
     });
 
     it("handles provider errors and increments failure count for permanent errors", async () => {
@@ -1684,7 +1696,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(storage.calls).toContain("incrementCircuitBreakerFailure");
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
     });
 
     it("does not increment circuit breaker for transient errors", async () => {
@@ -1712,7 +1724,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(storage.calls).not.toContain("incrementCircuitBreakerFailure");
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
     });
 
     it("fails spawn when getUserEnvVars rejects", async () => {
@@ -1739,7 +1751,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(provider.createSandbox).not.toHaveBeenCalled();
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
       expect(manager.isSpawning()).toBe(false);
     });
 
@@ -1789,7 +1801,7 @@ describe("SandboxLifecycleManager", () => {
 
       expect(provider.takeSnapshot).toHaveBeenCalled();
       expect(storage.calls).toContain(
-        `updateSandboxSnapshotImageId:snapshot-img-123:${COMPATIBLE_RUNTIME_VERSION}`
+        `recordSandboxSnapshot:snapshot-img-123:${COMPATIBLE_RUNTIME_VERSION}`
       );
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "snapshot_saved")
@@ -1829,7 +1841,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.triggerSnapshot("test_reason");
 
       // Should not crash, just skip
-      expect(storage.calls).not.toContain("updateSandboxSnapshotImageId");
+      expect(storage.calls).not.toContain("recordSandboxSnapshot");
     });
 
     it("stores returned imageId", async () => {
@@ -1857,7 +1869,74 @@ describe("SandboxLifecycleManager", () => {
       await manager.triggerSnapshot("execution_complete");
 
       expect(storage.calls).toContain(
-        `updateSandboxSnapshotImageId:custom-snapshot-id:${COMPATIBLE_RUNTIME_VERSION}`
+        `recordSandboxSnapshot:custom-snapshot-id:${COMPATIBLE_RUNTIME_VERSION}`
+      );
+    });
+
+    it("leaves a status written during the snapshot in place", async () => {
+      const sandbox = createMockSandbox({ status: "ready" });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        takeSnapshot: vi.fn(async () => {
+          // The heartbeat-stale alarm (or a cancel) lands while the provider
+          // call is in flight: status written, access cleared, socket detached.
+          sandbox.status = "stale";
+          return { success: true, imageId: "snapshot-img-123" };
+        }),
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.triggerSnapshot("execution_complete");
+
+      expect(sandbox.status).toBe("stale");
+      expect(storage.calls).toContain("transitionSandboxStatus:snapshotting->ready");
+      expect(broadcaster.messages).not.toContainEqual({ type: "sandbox_status", status: "ready" });
+      expect(broadcaster.messages).not.toContainEqual({ type: "sandbox_access_changed" });
+      // The image itself is still recorded: it describes the filesystem, not the row.
+      expect(sandbox.snapshot_image_id).toBe("snapshot-img-123");
+    });
+
+    it("drops a snapshot of a sandbox that was replaced during the provider call", async () => {
+      const sandbox = createMockSandbox({ status: "ready", modal_sandbox_id: "sb-old" });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        takeSnapshot: vi.fn(async () => {
+          // Terminated and re-reserved while the snapshot was in flight.
+          sandbox.status = "spawning";
+          sandbox.modal_sandbox_id = "sb-new";
+          return { success: true, imageId: "snapshot-of-old" };
+        }),
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.triggerSnapshot("execution_complete");
+
+      expect(sandbox.snapshot_image_id).toBeNull();
+      expect(sandbox.status).toBe("spawning");
+      expect(broadcaster.messages.map((m) => (m as { type: string }).type)).not.toContain(
+        "snapshot_saved"
       );
     });
 
@@ -1886,7 +1965,7 @@ describe("SandboxLifecycleManager", () => {
       // Should not throw
       await manager.triggerSnapshot("test");
 
-      expect(storage.calls).not.toContain("updateSandboxSnapshotImageId");
+      expect(storage.calls).not.toContain("recordSandboxSnapshot");
     });
   });
 
@@ -2777,8 +2856,8 @@ describe("SandboxLifecycleManager", () => {
       const [firstAttempt, retryAttempt] = createSandbox.mock.calls.map(([config]) => config);
       expect(retryAttempt.sandboxAuthToken).not.toBe(firstAttempt.sandboxAuthToken);
       expect(retryAttempt.sandboxId).not.toBe(firstAttempt.sandboxId);
-      expect(storage.calls).toContain("updateSandboxStatus:connecting");
-      expect(storage.calls).not.toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
+      expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->failed");
     });
   });
 
@@ -2916,7 +2995,7 @@ describe("SandboxLifecycleManager", () => {
       expect(provider.createSandbox).toHaveBeenCalledWith(
         expect.objectContaining({ prebuiltImageId: null, prebuiltImageSha: null })
       );
-      expect(storage.calls).toContain("updateSandboxStatus:connecting");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
     });
 
     it("boots from base when no environment image lookup is bound", async () => {
@@ -2978,8 +3057,8 @@ describe("SandboxLifecycleManager", () => {
             ([data]) => data.createdAt + DEFAULT_LIFECYCLE_CONFIG.connectingTimeout.timeoutMs
           )
       );
-      expect(storage.calls).toContain("updateSandboxStatus:connecting");
-      expect(storage.calls).not.toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
+      expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->failed");
     });
 
     it("fails the spawn when the base-image retry also fails", async () => {
@@ -2999,7 +3078,7 @@ describe("SandboxLifecycleManager", () => {
 
       expect(createSandbox).toHaveBeenCalledTimes(2);
       expect(environmentImageLookup.markRestoreFailed).toHaveBeenCalledTimes(1);
-      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
     });
 
     it("still retries from base when marking the row restore-failed fails", async () => {
@@ -3026,7 +3105,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(createSandbox).toHaveBeenCalledTimes(2);
-      expect(storage.calls).toContain("updateSandboxStatus:connecting");
+      expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
     });
   });
 
@@ -3814,6 +3893,120 @@ describe("SandboxLifecycleManager", () => {
   });
 });
 
+describe("status writes after a provider await (COL-99)", () => {
+  // The provider call is a non-storage await: the alarm, a bridge connect, or
+  // a cancel can move the sandbox row while it is in flight, and that verdict
+  // stands over the attempt's own late write.
+  function harness(
+    sandbox: ReturnType<typeof createMockSandbox>,
+    createSandbox: (config: CreateSandboxConfig) => Promise<CreateSandboxResult>
+  ) {
+    const storage = createMockStorage(createMockSession(), sandbox);
+    const broadcaster = createMockBroadcaster();
+    const manager = new SandboxLifecycleManager(
+      createMockProvider({ createSandbox }),
+      storage,
+      storage,
+      broadcaster,
+      createMockWebSocketManager(false),
+      createMockAlarmScheduler(),
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+    return { storage, broadcaster, manager };
+  }
+
+  it("does not resurrect an attempt the alarm failed while the provider call was in flight", async () => {
+    const sandbox = createMockSandbox({ status: "failed" });
+    const { storage, broadcaster, manager } = harness(sandbox, async (config) => {
+      // Connecting timeout fired: the alarm failed the attempt and told the user.
+      sandbox.status = "failed";
+      return {
+        sandboxId: config.sandboxId,
+        providerObjectId: "provider-obj-late",
+        status: "connecting",
+        createdAt: Date.now(),
+      };
+    });
+
+    await manager.spawnSandbox();
+
+    expect(sandbox.status).toBe("failed");
+    expect(storage.calls).toContain("transitionSandboxStatus:spawning->connecting");
+    expect(broadcaster.messages).not.toContainEqual({
+      type: "sandbox_status",
+      status: "connecting",
+    });
+    // The provider-side sandbox exists and a later stop needs its handle.
+    expect(sandbox.modal_object_id).toBe("provider-obj-late");
+  });
+
+  it("leaves a sandbox that connected during the provider call ready when the call then fails", async () => {
+    const sandbox = createMockSandbox({ status: "failed" });
+    const { storage, broadcaster, manager } = harness(sandbox, async () => {
+      // The bridge authenticated and published ready before the provider's
+      // response (a post-create timeout) came back as an error.
+      sandbox.status = "ready";
+      throw new SandboxProviderError("read timed out", "transient");
+    });
+
+    await manager.spawnSandbox();
+
+    expect(sandbox.status).toBe("ready");
+    expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
+    expect(storage.setLastSpawnError).not.toHaveBeenCalledWith("read timed out", expect.anything());
+    expect(broadcaster.messages).not.toContainEqual({
+      type: "sandbox_error",
+      error: "read timed out",
+    });
+  });
+
+  it("abandons a reservation that a cancel stopped while its hash was being published", async () => {
+    const sandbox = createMockSandbox({ status: "failed" });
+    const storage = createMockStorage(createMockSession(), sandbox);
+    const broadcaster = createMockBroadcaster();
+    const provider = createMockProvider();
+    const alarmScheduler = createMockAlarmScheduler();
+    vi.mocked(alarmScheduler.schedule).mockImplementation(async () => {
+      // The reservation's alarm await: the cancel handler lands here and
+      // stops the sandbox without changing its reserved identity.
+      sandbox.status = "stopped";
+    });
+    const manager = new SandboxLifecycleManager(
+      provider,
+      storage,
+      storage,
+      broadcaster,
+      createMockWebSocketManager(false),
+      alarmScheduler,
+      createMockIdGenerator(),
+      createTestConfig()
+    );
+
+    await manager.spawnSandbox();
+
+    expect(provider.createSandbox).not.toHaveBeenCalled();
+    expect(sandbox.status).toBe("stopped");
+    expect(sandbox.auth_token_hash).toBe("");
+    expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->failed");
+    expect(storage.incrementCircuitBreakerFailure).not.toHaveBeenCalled();
+  });
+
+  it("still fails and reports an attempt nothing else touched", async () => {
+    const sandbox = createMockSandbox({ status: "failed" });
+    const { storage, broadcaster, manager } = harness(sandbox, async () => {
+      throw new SandboxProviderError("quota exceeded", "permanent");
+    });
+
+    await manager.spawnSandbox();
+
+    expect(sandbox.status).toBe("failed");
+    expect(storage.calls).toContain("transitionSandboxStatus:spawning->failed");
+    expect(storage.setLastSpawnError).toHaveBeenCalledWith("quota exceeded", expect.anything());
+    expect(broadcaster.messages).toContainEqual({ type: "sandbox_error", error: "quota exceeded" });
+  });
+});
+
 describe("SandboxLifecycleManager log context", () => {
   it("derives session_id from getSessionId per use, upgrading once the id changes", async () => {
     let currentId = "do-fallback-id";
@@ -3977,7 +4170,7 @@ describe("spawn admission race (#1589)", () => {
     // The row and circuit breaker describe the newer reservation now — the
     // superseded attempt must not mark them failed on its way out.
     expect(sandbox.status).toBe("spawning");
-    expect(storage.calls).not.toContain("updateSandboxStatus:failed");
+    expect(storage.calls).not.toContain("transitionSandboxStatus:spawning->failed");
     expect(storage.incrementCircuitBreakerFailure).not.toHaveBeenCalled();
     expect(storage.setLastSpawnError).not.toHaveBeenCalledWith(
       expect.stringContaining("superseded"),

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -169,14 +169,14 @@ export interface SandboxStorage {
   updateSandboxRuntimeVersion(runtimeVersion: string | null): void;
   /**
    * Record `imageId` as the snapshot of the sandbox identified by
-   * `modalSandboxId`, with the runtime version that produced it (null when
+   * `sandboxId`, with the runtime version that produced it (null when
    * the sandbox never reported one). Applies only while that is still the
    * row's sandbox, and reports whether it was: a snapshot completes after a
    * provider await, and a replacement reserved meanwhile must not inherit
    * an image of the sandbox it replaced.
    */
   recordSandboxSnapshot(
-    modalSandboxId: string | null,
+    sandboxId: string | null,
     imageId: string,
     runtimeVersion: string | null
   ): boolean;

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -71,6 +71,18 @@ const PROVIDER_REPLACEMENT_STOP_TIMEOUT_MS = 10_000;
 // ==================== Dependency Interfaces ====================
 
 /**
+ * One occupancy of the sandbox row: the logical sandbox id plus the
+ * `created_at` its reservation or resume stamped. Every write an attempt
+ * makes after its first await names the generation it was started for, so a
+ * completion that outlives its attempt cannot land on a later one, even one
+ * that reached the same status.
+ */
+export interface SandboxGeneration {
+  sandboxId: string | null;
+  createdAt: number;
+}
+
+/**
  * Sandbox state with circuit breaker info (subset of full SandboxRow).
  */
 interface SandboxCircuitBreakerInfo {
@@ -115,12 +127,18 @@ export interface SandboxStorage {
   /** Update sandbox status */
   updateSandboxStatus(status: SandboxStatus): void;
   /**
-   * Move the sandbox from `from` to `to` only while it is still in `from`;
-   * reports whether it was. The status writes that follow a provider await
-   * use this: an alarm, a bridge connect, or a cancel may have moved the row
-   * while the call was in flight, and that verdict stands.
+   * Move the sandbox from `from` to `to` only while the row still belongs to
+   * `generation` and is still in `from`; reports whether it was. The status
+   * writes that follow a provider await use this: an alarm, a bridge connect,
+   * a cancel, or a newer reservation may have moved the row while the call
+   * was in flight, and that verdict stands. Status alone is not enough: a
+   * later attempt can bring the row back to the same status.
    */
-  transitionSandboxStatus(from: SandboxStatus, to: SandboxStatus): boolean;
+  transitionSandboxStatus(
+    generation: SandboxGeneration,
+    from: SandboxStatus,
+    to: SandboxStatus
+  ): boolean;
   /**
    * Reserve a replacement sandbox identity (status, sandbox ID, created_at).
    * Clears every field describing the previous sandbox instance, runtime
@@ -526,6 +544,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     this.providerStartupPending = true;
     const spawnStartedAt = Date.now();
     let session: SessionRow | null = null;
+    let generation: SandboxGeneration | null = null;
 
     try {
       session = this.sessionContext.getSession();
@@ -542,6 +561,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       let { sandboxAuthToken, expectedSandboxId } = await this.reserveSpawnIdentity(session, now, {
         preserveProviderObjectId: true,
       });
+      generation = { sandboxId: expectedSandboxId, createdAt: now };
 
       await this.stopPriorProviderSandbox();
 
@@ -631,6 +651,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           retryNow,
           { preserveProviderObjectId: false }
         ));
+        generation = { sandboxId: expectedSandboxId, createdAt: retryNow };
         result = await this.provider.createSandbox({
           ...createConfig,
           sandboxId: expectedSandboxId,
@@ -654,7 +675,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         await this.storeTtyd(result.ttydUrl, sandboxAuthToken, sessionId, expectedSandboxId);
       }
 
-      await this.finishProviderStartup();
+      await this.finishProviderStartup(generation);
 
       // Reset circuit breaker on successful spawn initiation
       this.storage.resetCircuitBreaker();
@@ -702,7 +723,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         this.log.info("Circuit breaker incremented", { error_type: "unknown" });
       }
 
-      this.failAttempt("spawning", errorMessage);
+      this.failAttempt(generation, "spawning", errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -859,14 +880,21 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    * case the failure is the provider's, not the sandbox's, and reporting it
    * would persist a spawn error on a session that has none.
    */
-  private failAttempt(inFlight: "spawning" | "connecting", reason: string): void {
-    if (this.storage.transitionSandboxStatus(inFlight, "failed")) {
+  private failAttempt(
+    generation: SandboxGeneration | null,
+    inFlight: "spawning" | "connecting",
+    reason: string
+  ): void {
+    // No generation: the attempt failed before it reserved anything, so the
+    // row still describes whatever came before it and is left alone.
+    if (generation && this.storage.transitionSandboxStatus(generation, inFlight, "failed")) {
       this.reportSandboxError(reason);
       return;
     }
-    this.log.warn("Sandbox attempt failed after its status moved; leaving the row as it is", {
+    this.log.warn("Sandbox attempt failed after its row moved on; leaving the row as it is", {
       event: "sandbox.attempt_failed_superseded",
       in_flight_status: inFlight,
+      attempt_sandbox_id: generation?.sandboxId ?? null,
       sandbox_status: this.storage.getSandbox()?.status ?? null,
       error: reason,
     });
@@ -890,6 +918,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     this.providerStartupPending = true;
     const restoreStartedAt = Date.now();
     let session: SessionRow | null = null;
+    let generation: SandboxGeneration | null = null;
 
     try {
       session = this.sessionContext.getSession();
@@ -906,6 +935,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         now,
         { preserveProviderObjectId: true }
       );
+      generation = { sandboxId: expectedSandboxId, createdAt: now };
 
       // A restored sandbox runs the snapshot's binaries whatever the provider
       // exports at launch, so the snapshot's version is the authoritative one.
@@ -966,7 +996,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           );
         }
 
-        await this.finishProviderStartup();
+        await this.finishProviderStartup(generation);
 
         this.broadcaster.broadcast({
           type: "sandbox_restored",
@@ -993,7 +1023,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           repo_owner: session.repo_owner,
           repo_name: session.repo_name,
         });
-        this.failAttempt("spawning", result.error || "Failed to restore from snapshot");
+        this.failAttempt(generation, "spawning", result.error || "Failed to restore from snapshot");
       }
     } catch (error) {
       if (error instanceof SpawnSupersededError) {
@@ -1012,7 +1042,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         repo_owner: session?.repo_owner,
         repo_name: session?.repo_name,
       });
-      this.failAttempt("spawning", errorMessage);
+      this.failAttempt(generation, "spawning", errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -1030,6 +1060,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
     this.isSpawningSandbox = true;
     this.providerStartupPending = true;
+    let generation: SandboxGeneration | null = null;
 
     try {
       const session = this.sessionContext.getSession();
@@ -1040,6 +1071,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
 
       const now = Date.now();
+      generation = { sandboxId: sandbox.modal_sandbox_id, createdAt: now };
       this.storage.setLastSpawnError(null, null);
       await this.enterProviderStartup("connecting", now, () =>
         this.storage.updateSandboxForResume({
@@ -1088,11 +1120,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
 
       await this.storeAndBroadcastTunnelUrls(result.tunnelUrls);
-      await this.finishProviderStartup();
+      await this.finishProviderStartup(generation);
       this.storage.resetCircuitBreaker();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to resume sandbox";
-      this.failAttempt("connecting", errorMessage);
+      this.failAttempt(generation, "connecting", errorMessage);
       this.log.error("Sandbox resume failed", {
         error: error instanceof Error ? error : String(error),
       });
@@ -1129,7 +1161,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     // provider await; the writes below are conditional on it still holding.
     const isTerminalState = isDeadSandboxStatus(sandbox.status);
     const previousStatus = sandbox.status;
-    const snapshotOf = sandbox.modal_sandbox_id;
+    const generation: SandboxGeneration = {
+      sandboxId: sandbox.modal_sandbox_id,
+      createdAt: sandbox.created_at,
+    };
     const runtimeVersion = sandbox.runtime_version;
 
     if (!isTerminalState) {
@@ -1156,7 +1191,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         // gated on, not whatever the session runs next. Recorded for the
         // sandbox it was taken of; a replacement reserved during the provider
         // call keeps its own restore image.
-        if (this.storage.recordSandboxSnapshot(snapshotOf, result.imageId, runtimeVersion)) {
+        if (
+          this.storage.recordSandboxSnapshot(generation.sandboxId, result.imageId, runtimeVersion)
+        ) {
           this.log.info("Snapshot saved", {
             event: "sandbox.snapshot_saved",
             image_id: result.imageId,
@@ -1172,7 +1209,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           this.log.info("Snapshot completed for a replaced sandbox; not recorded", {
             event: "sandbox.snapshot_superseded",
             image_id: result.imageId,
-            sandbox_id: snapshotOf,
+            sandbox_id: generation.sandboxId,
             reason,
           });
         }
@@ -1187,14 +1224,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     }
 
-    // Restore the previous status only while the row still says
-    // `snapshotting`: a cancel, a stale heartbeat, or an unresponsive-sandbox
-    // termination during the provider call has already retired the sandbox
-    // (status written, access cleared, socket detached), and restoring `ready`
-    // over that would make the spawn decision wait for a reconnect that
-    // cannot come.
+    // Restore the previous status only while the row is still this sandbox's
+    // and still says `snapshotting`: a cancel, a stale heartbeat, or an
+    // unresponsive-sandbox termination during the provider call has already
+    // retired the sandbox (status written, access cleared, socket detached),
+    // and restoring `ready` over that would make the spawn decision wait for
+    // a reconnect that cannot come; a replacement that is itself snapshotting
+    // keeps its own status.
     if (!isTerminalState && reason !== "heartbeat_timeout") {
-      if (this.storage.transitionSandboxStatus("snapshotting", previousStatus)) {
+      if (this.storage.transitionSandboxStatus(generation, "snapshotting", previousStatus)) {
         this.broadcaster.broadcast({ type: "sandbox_status", status: previousStatus });
         if (previousStatus === "ready") {
           this.broadcaster.broadcast({ type: "sandbox_access_changed" });
@@ -1717,7 +1755,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     await this.storage.updateSandboxAccess("ttyd", url, token);
   }
 
-  private async finishProviderStartup(): Promise<void> {
+  private async finishProviderStartup(generation: SandboxGeneration): Promise<void> {
     this.providerStartupPending = false;
 
     if (this.wsManager.getSandboxWebSocket()) {
@@ -1727,9 +1765,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
     // Only this attempt's own `spawning` advances to `connecting`. A resume
     // entered as `connecting` already; an alarm that timed the attempt out
-    // during the provider call has written `failed`, and a bridge that
-    // connected and dropped has left `ready` or `stale`. Those stand.
-    if (this.storage.transitionSandboxStatus("spawning", "connecting")) {
+    // during the provider call has written `failed`; a bridge that connected
+    // and dropped has left `ready` or `stale`; a newer reservation owns the
+    // row outright. Those stand.
+    if (this.storage.transitionSandboxStatus(generation, "spawning", "connecting")) {
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
     }
   }

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -115,6 +115,13 @@ export interface SandboxStorage {
   /** Update sandbox status */
   updateSandboxStatus(status: SandboxStatus): void;
   /**
+   * Move the sandbox from `from` to `to` only while it is still in `from`;
+   * reports whether it was. The status writes that follow a provider await
+   * use this: an alarm, a bridge connect, or a cancel may have moved the row
+   * while the call was in flight, and that verdict stands.
+   */
+  transitionSandboxStatus(from: SandboxStatus, to: SandboxStatus): boolean;
+  /**
    * Reserve a replacement sandbox identity (status, sandbox ID, created_at).
    * Clears every field describing the previous sandbox instance, runtime
    * version included, and invalidates the stored credentials — phase 1 of
@@ -130,9 +137,10 @@ export interface SandboxStorage {
   /**
    * Publish the auth-token hash for the identity reserved by
    * `updateSandboxForSpawn` (phase 2 of the two-phase spawn write, #1589).
-   * Applies only while that identity is still the persisted sandbox, and
-   * reports whether it was — a delayed publisher must not attach its hash
-   * to a newer reservation.
+   * Applies only while that identity is still the persisted sandbox and
+   * still `spawning`, and reports whether it was: a delayed publisher must
+   * not attach its hash to a newer reservation, and a reservation that a
+   * cancel stopped while the hash was computed must not go live.
    */
   updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean;
   /** Update sandbox state for in-place resume without rotating auth/token identity */
@@ -142,14 +150,18 @@ export interface SandboxStorage {
   /** Set the runtime version describing the sandbox's current filesystem. */
   updateSandboxRuntimeVersion(runtimeVersion: string | null): void;
   /**
-   * Update sandbox snapshot image ID and the runtime version that produced it
-   * (null when the sandbox never reported one).
+   * Record `imageId` as the snapshot of the sandbox identified by
+   * `modalSandboxId`, with the runtime version that produced it (null when
+   * the sandbox never reported one). Applies only while that is still the
+   * row's sandbox, and reports whether it was: a snapshot completes after a
+   * provider await, and a replacement reserved meanwhile must not inherit
+   * an image of the sandbox it replaced.
    */
-  updateSandboxSnapshotImageId(
-    sandboxId: string,
+  recordSandboxSnapshot(
+    modalSandboxId: string | null,
     imageId: string,
     runtimeVersion: string | null
-  ): void;
+  ): boolean;
   /** Update last activity timestamp */
   updateSandboxLastActivity(timestamp: number): void;
   /** Increment circuit breaker failure count */
@@ -690,8 +702,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         this.log.info("Circuit breaker incremented", { error_type: "unknown" });
       }
 
-      this.storage.updateSandboxStatus("failed");
-      this.reportSandboxError(errorMessage);
+      this.failAttempt("spawning", errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -840,6 +851,28 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   }
 
   /**
+   * Record that this spawn, restore, or resume attempt failed. The status
+   * write applies only while the row still shows the attempt in flight
+   * (`inFlight`): a bridge that connected during the provider call has
+   * already published `ready` and is serving the session, and an alarm that
+   * timed the attempt out has already failed it and told the user. In either
+   * case the failure is the provider's, not the sandbox's, and reporting it
+   * would persist a spawn error on a session that has none.
+   */
+  private failAttempt(inFlight: "spawning" | "connecting", reason: string): void {
+    if (this.storage.transitionSandboxStatus(inFlight, "failed")) {
+      this.reportSandboxError(reason);
+      return;
+    }
+    this.log.warn("Sandbox attempt failed after its status moved; leaving the row as it is", {
+      event: "sandbox.attempt_failed_superseded",
+      in_flight_status: inFlight,
+      sandbox_status: this.storage.getSandbox()?.status ?? null,
+      error: reason,
+    });
+  }
+
+  /**
    * Restore a sandbox from a filesystem snapshot.
    */
   private async restoreFromSnapshot(
@@ -960,8 +993,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
           repo_owner: session.repo_owner,
           repo_name: session.repo_name,
         });
-        this.storage.updateSandboxStatus("failed");
-        this.reportSandboxError(result.error || "Failed to restore from snapshot");
+        this.failAttempt("spawning", result.error || "Failed to restore from snapshot");
       }
     } catch (error) {
       if (error instanceof SpawnSupersededError) {
@@ -980,8 +1012,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         repo_owner: session?.repo_owner,
         repo_name: session?.repo_name,
       });
-      this.storage.updateSandboxStatus("failed");
-      this.reportSandboxError(errorMessage);
+      this.failAttempt("spawning", errorMessage);
     } finally {
       this.isSpawningSandbox = false;
       this.providerStartupPending = false;
@@ -1061,8 +1092,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.storage.resetCircuitBreaker();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to resume sandbox";
-      this.storage.updateSandboxStatus("failed");
-      this.reportSandboxError(errorMessage);
+      this.failAttempt("connecting", errorMessage);
       this.log.error("Sandbox resume failed", {
         error: error instanceof Error ? error : String(error),
       });
@@ -1095,9 +1125,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       return;
     }
 
-    // Track previous status for non-terminal states
+    // Everything the completion writes is decided from this read, before the
+    // provider await; the writes below are conditional on it still holding.
     const isTerminalState = isDeadSandboxStatus(sandbox.status);
     const previousStatus = sandbox.status;
+    const snapshotOf = sandbox.modal_sandbox_id;
+    const runtimeVersion = sandbox.runtime_version;
 
     if (!isTerminalState) {
       this.storage.updateSandboxStatus("snapshotting");
@@ -1120,23 +1153,29 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       if (result.success && result.imageId) {
         // Stamp the snapshot with the runtime that produced it: the image
         // carries that runtime's binaries, so this is what a later restore is
-        // gated on, not whatever the session runs next.
-        this.storage.updateSandboxSnapshotImageId(
-          sandbox.id,
-          result.imageId,
-          sandbox.runtime_version
-        );
-        this.log.info("Snapshot saved", {
-          event: "sandbox.snapshot_saved",
-          image_id: result.imageId,
-          runtime_version: sandbox.runtime_version,
-          reason,
-        });
-        this.broadcaster.broadcast({
-          type: "snapshot_saved",
-          imageId: result.imageId,
-          reason,
-        });
+        // gated on, not whatever the session runs next. Recorded for the
+        // sandbox it was taken of; a replacement reserved during the provider
+        // call keeps its own restore image.
+        if (this.storage.recordSandboxSnapshot(snapshotOf, result.imageId, runtimeVersion)) {
+          this.log.info("Snapshot saved", {
+            event: "sandbox.snapshot_saved",
+            image_id: result.imageId,
+            runtime_version: runtimeVersion,
+            reason,
+          });
+          this.broadcaster.broadcast({
+            type: "snapshot_saved",
+            imageId: result.imageId,
+            reason,
+          });
+        } else {
+          this.log.info("Snapshot completed for a replaced sandbox; not recorded", {
+            event: "sandbox.snapshot_superseded",
+            image_id: result.imageId,
+            sandbox_id: snapshotOf,
+            reason,
+          });
+        }
       } else {
         this.log.error("Snapshot failed", { error: result.error, reason });
       }
@@ -1148,12 +1187,25 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     }
 
-    // Restore previous status if we weren't in a terminal state
+    // Restore the previous status only while the row still says
+    // `snapshotting`: a cancel, a stale heartbeat, or an unresponsive-sandbox
+    // termination during the provider call has already retired the sandbox
+    // (status written, access cleared, socket detached), and restoring `ready`
+    // over that would make the spawn decision wait for a reconnect that
+    // cannot come.
     if (!isTerminalState && reason !== "heartbeat_timeout") {
-      this.storage.updateSandboxStatus(previousStatus);
-      this.broadcaster.broadcast({ type: "sandbox_status", status: previousStatus });
-      if (previousStatus === "ready") {
-        this.broadcaster.broadcast({ type: "sandbox_access_changed" });
+      if (this.storage.transitionSandboxStatus("snapshotting", previousStatus)) {
+        this.broadcaster.broadcast({ type: "sandbox_status", status: previousStatus });
+        if (previousStatus === "ready") {
+          this.broadcaster.broadcast({ type: "sandbox_access_changed" });
+        }
+      } else {
+        this.log.info("Sandbox status moved during snapshot; leaving it", {
+          event: "sandbox.snapshot_status_superseded",
+          previous_status: previousStatus,
+          sandbox_status: this.storage.getSandbox()?.status ?? null,
+          reason,
+        });
       }
     }
   }
@@ -1673,8 +1725,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       return;
     }
 
-    if (this.storage.getSandbox()?.status !== "connecting") {
-      this.storage.updateSandboxStatus("connecting");
+    // Only this attempt's own `spawning` advances to `connecting`. A resume
+    // entered as `connecting` already; an alarm that timed the attempt out
+    // during the provider call has written `failed`, and a bridge that
+    // connected and dropped has left `ready` or `stale`. Those stand.
+    if (this.storage.transitionSandboxStatus("spawning", "connecting")) {
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
     }
   }

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -110,6 +110,23 @@ describe("SandboxRepository", () => {
     });
   });
 
+  describe("transitionSandboxStatus", () => {
+    const query = `UPDATE sandbox SET status = ? WHERE id = (SELECT id FROM sandbox LIMIT 1) AND status = ?`;
+
+    it("moves the row only while it is still in the expected status", () => {
+      mock.setRowsWritten(query, 1);
+
+      expect(repository.transitionSandboxStatus("snapshotting", "ready")).toBe(true);
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toBe(query);
+      expect(mock.calls[0].params).toEqual(["ready", "snapshotting"]);
+    });
+
+    it("reports a row that another event moved instead of overwriting it", () => {
+      expect(repository.transitionSandboxStatus("spawning", "connecting")).toBe(false);
+    });
+  });
+
   describe("updateSandboxForSpawn", () => {
     it("sets all spawn fields atomically and invalidates credentials", () => {
       repository.updateSandboxForSpawn({
@@ -168,7 +185,7 @@ describe("SandboxRepository", () => {
   });
 
   describe("updateSandboxAuthTokenHash", () => {
-    const query = `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ?`;
+    const query = `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ? AND status = 'spawning'`;
 
     it("publishes the hash scoped to the reserved identity", () => {
       mock.setRowsWritten(query, 1);
@@ -179,7 +196,7 @@ describe("SandboxRepository", () => {
       expect(mock.calls[0].params).toEqual(["hash-1", "modal-sb-1"]);
     });
 
-    it("reports a superseded reservation instead of touching the current row", () => {
+    it("reports a superseded or stopped reservation instead of touching the current row", () => {
       expect(repository.updateSandboxAuthTokenHash("modal-sb-stale", "hash-1")).toBe(false);
     });
   });
@@ -194,20 +211,27 @@ describe("SandboxRepository", () => {
     });
   });
 
-  describe("updateSandboxSnapshotImageId", () => {
-    it("stamps the snapshot with the runtime that produced it", () => {
-      repository.updateSandboxSnapshotImageId("sb-1", "img-123", "v59-runtime");
+  describe("recordSandboxSnapshot", () => {
+    const query = `UPDATE sandbox SET snapshot_image_id = ?, snapshot_runtime_version = ?
+       WHERE id = (SELECT id FROM sandbox LIMIT 1) AND modal_sandbox_id IS ?`;
 
+    it("stamps the snapshot with the runtime that produced it, for the sandbox it was taken of", () => {
+      mock.setRowsWritten(query, 1);
+
+      expect(repository.recordSandboxSnapshot("modal-sb-1", "img-123", "v59-runtime")).toBe(true);
       expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("UPDATE sandbox SET snapshot_image_id");
-      expect(mock.calls[0].query).toContain("snapshot_runtime_version");
-      expect(mock.calls[0].params).toEqual(["img-123", "v59-runtime", "sb-1"]);
+      expect(mock.calls[0].query).toBe(query);
+      expect(mock.calls[0].params).toEqual(["img-123", "v59-runtime", "modal-sb-1"]);
     });
 
     it("records a null runtime when the sandbox never reported one", () => {
-      repository.updateSandboxSnapshotImageId("sb-1", "img-123", null);
+      repository.recordSandboxSnapshot("modal-sb-1", "img-123", null);
 
-      expect(mock.calls[0].params).toEqual(["img-123", null, "sb-1"]);
+      expect(mock.calls[0].params).toEqual(["img-123", null, "modal-sb-1"]);
+    });
+
+    it("reports a replaced sandbox instead of stamping its successor", () => {
+      expect(repository.recordSandboxSnapshot("modal-sb-old", "img-123", null)).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.test.ts
+++ b/packages/control-plane/src/session/sandbox-repository.test.ts
@@ -111,19 +111,22 @@ describe("SandboxRepository", () => {
   });
 
   describe("transitionSandboxStatus", () => {
-    const query = `UPDATE sandbox SET status = ? WHERE id = (SELECT id FROM sandbox LIMIT 1) AND status = ?`;
+    const query = `UPDATE sandbox SET status = ?
+       WHERE id = (SELECT id FROM sandbox LIMIT 1)
+         AND modal_sandbox_id IS ? AND created_at = ? AND status = ?`;
+    const generation = { sandboxId: "modal-sb-1", createdAt: 5000 };
 
-    it("moves the row only while it is still in the expected status", () => {
+    it("moves the row only while it is still the generation's and in the expected status", () => {
       mock.setRowsWritten(query, 1);
 
-      expect(repository.transitionSandboxStatus("snapshotting", "ready")).toBe(true);
+      expect(repository.transitionSandboxStatus(generation, "snapshotting", "ready")).toBe(true);
       expect(mock.calls.length).toBe(1);
       expect(mock.calls[0].query).toBe(query);
-      expect(mock.calls[0].params).toEqual(["ready", "snapshotting"]);
+      expect(mock.calls[0].params).toEqual(["ready", "modal-sb-1", 5000, "snapshotting"]);
     });
 
-    it("reports a row that another event moved instead of overwriting it", () => {
-      expect(repository.transitionSandboxStatus("spawning", "connecting")).toBe(false);
+    it("reports a row that another event or attempt moved instead of overwriting it", () => {
+      expect(repository.transitionSandboxStatus(generation, "spawning", "connecting")).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -117,6 +117,22 @@ export class SandboxRepository {
   }
 
   /**
+   * Move the sandbox from `from` to `to` only while it is still in `from`;
+   * reports whether it was. The conditional form of `updateSandboxStatus` for
+   * writes that follow an await, where another event may have moved the row.
+   */
+  transitionSandboxStatus(from: SandboxStatus, to: SandboxStatus): boolean {
+    const result = this.sql.exec(
+      `UPDATE sandbox SET status = ? WHERE id = (SELECT id FROM sandbox LIMIT 1) AND status = ?`,
+      to,
+      from
+    );
+    // Consume the result before reading rowsWritten so the count is final.
+    result.toArray();
+    return (result.rowsWritten ?? 0) > 0;
+  }
+
+  /**
    * Phase 1 of the two-phase spawn write (#1589): the reservation itself
    * invalidates credentials — no token can match the emptied hash — until
    * `updateSandboxAuthTokenHash` publishes the new one.
@@ -169,12 +185,14 @@ export class SandboxRepository {
 
   /**
    * Phase 2 of the two-phase spawn write (#1589): publish the reserved
-   * identity's hash. Scoped to that identity so a delayed publisher cannot
-   * attach its hash to a newer reservation; reports whether it applied.
+   * identity's hash. Scoped to that identity and to the reservation's
+   * `spawning` status, so a delayed publisher cannot attach its hash to a
+   * newer reservation and a reservation that a cancel stopped while the hash
+   * was computed cannot go live; reports whether it applied.
    */
   updateSandboxAuthTokenHash(modalSandboxId: string, authTokenHash: string): boolean {
     const result = this.sql.exec(
-      `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ?`,
+      `UPDATE sandbox SET auth_token_hash = ? WHERE modal_sandbox_id = ? AND status = 'spawning'`,
       authTokenHash,
       modalSandboxId
     );
@@ -202,17 +220,26 @@ export class SandboxRepository {
     );
   }
 
-  updateSandboxSnapshotImageId(
-    sandboxId: string,
+  /**
+   * Record `imageId` as the snapshot of the sandbox identified by
+   * `modalSandboxId`, with the runtime version that produced it. Applies
+   * only while that is still the row's sandbox; reports whether it was.
+   */
+  recordSandboxSnapshot(
+    modalSandboxId: string | null,
     imageId: string,
     runtimeVersion: string | null
-  ): void {
-    this.sql.exec(
-      `UPDATE sandbox SET snapshot_image_id = ?, snapshot_runtime_version = ? WHERE id = ?`,
+  ): boolean {
+    const result = this.sql.exec(
+      `UPDATE sandbox SET snapshot_image_id = ?, snapshot_runtime_version = ?
+       WHERE id = (SELECT id FROM sandbox LIMIT 1) AND modal_sandbox_id IS ?`,
       imageId,
       runtimeVersion,
-      sandboxId
+      modalSandboxId
     );
+    // Consume the result before reading rowsWritten so the count is final.
+    result.toArray();
+    return (result.rowsWritten ?? 0) > 0;
   }
 
   /**

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -233,11 +233,11 @@ export class SandboxRepository {
 
   /**
    * Record `imageId` as the snapshot of the sandbox identified by
-   * `modalSandboxId`, with the runtime version that produced it. Applies
+   * `sandboxId`, with the runtime version that produced it. Applies
    * only while that is still the row's sandbox; reports whether it was.
    */
   recordSandboxSnapshot(
-    modalSandboxId: string | null,
+    sandboxId: string | null,
     imageId: string,
     runtimeVersion: string | null
   ): boolean {
@@ -246,7 +246,7 @@ export class SandboxRepository {
        WHERE id = (SELECT id FROM sandbox LIMIT 1) AND modal_sandbox_id IS ?`,
       imageId,
       runtimeVersion,
-      modalSandboxId
+      sandboxId
     );
     // Consume the result before reading rowsWritten so the count is final.
     result.toArray();

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -117,14 +117,25 @@ export class SandboxRepository {
   }
 
   /**
-   * Move the sandbox from `from` to `to` only while it is still in `from`;
-   * reports whether it was. The conditional form of `updateSandboxStatus` for
-   * writes that follow an await, where another event may have moved the row.
+   * Move the sandbox from `from` to `to` only while the row still carries the
+   * sandbox `generation` names (its logical id and the `created_at` its
+   * reservation or resume stamped) and is still in `from`; reports whether it
+   * was. The conditional form of `updateSandboxStatus` for writes that follow
+   * an await: another event may have moved the row, and a newer attempt may
+   * have brought it back to the same status.
    */
-  transitionSandboxStatus(from: SandboxStatus, to: SandboxStatus): boolean {
+  transitionSandboxStatus(
+    generation: { sandboxId: string | null; createdAt: number },
+    from: SandboxStatus,
+    to: SandboxStatus
+  ): boolean {
     const result = this.sql.exec(
-      `UPDATE sandbox SET status = ? WHERE id = (SELECT id FROM sandbox LIMIT 1) AND status = ?`,
+      `UPDATE sandbox SET status = ?
+       WHERE id = (SELECT id FROM sandbox LIMIT 1)
+         AND modal_sandbox_id IS ? AND created_at = ? AND status = ?`,
       to,
+      generation.sandboxId,
+      generation.createdAt,
       from
     );
     // Consume the result before reading rowsWritten so the count is final.


### PR DESCRIPTION
Roadmap **H-3 · COL-99**, fix 3 from the concurrency audit (#1760, the `manager.ts` rows). One mechanism, five sites: every write the spawn path makes after a provider await now carries the status or identity this attempt owns. Behavior-preserving on Cloudflare outside the interleavings it closes.

## What

`SandboxLifecycleManager` wrote the sandbox row unconditionally after provider awaits. A provider call is a non-storage await, so the input gate is open across it and three other writers can move the row meanwhile: the alarm (connecting timeout → `failed`, stale heartbeat → `stale`, inactivity → `stopped`), the bridge handshake (`ready`), and the cancel handler (`stopped`). Their verdict is the current one; the attempt's late write overwrote it.

- **`triggerSnapshot` status restore.** After `takeSnapshot`, the pre-snapshot status was written back. A cancel, a stale-heartbeat alarm, or an unresponsive-sandbox termination during the snapshot had already written `stopped`/`stale`, cleared access, and detached the socket; restoring `ready` over that made the spawn decision wait `readyWaitMs` for a reconnect that cannot come. Reachable from "stop it right as it finishes": `execution_complete` submits the snapshot in the background and the cancel handler's sandbox write runs while it is in flight. Now `snapshotting → previous` only.
- **`triggerSnapshot` image stamp.** The image was recorded by row id, and spawn reservations reuse the one row, so a snapshot of a sandbox that was terminated and replaced during the provider call became the restore image of its replacement. Now recorded only while the row still carries the sandbox the snapshot was taken of (`recordSandboxSnapshot`, `WHERE modal_sandbox_id IS ?`); the facts the completion writes are captured from the one read before the await.
- **`finishProviderStartup`.** Wrote `connecting` whenever the status was not already `connecting`. A provider call longer than the connecting timeout (the alarm is armed at reservation time) let the alarm mark the row `failed` and tell the user; the late return flipped it to `connecting` and broadcast that. Now `spawning → connecting` only; a resume, which enters as `connecting`, makes no write, as before.
- **The failure branches** (`doSpawn` catch, restore failure and catch, resume catch). Wrote `failed` and reported the error. A bridge that connected during the provider call had already published `ready` and was serving the session; a provider error after that (a post-create read timeout) marked the working sandbox `failed`, which the alarm treats as dead and stops monitoring, and persisted a spawn error the session snapshot then served as `spawnError`. Now `spawning|connecting → failed` only, and the error is reported only when that applied. The circuit-breaker increment stays unconditional: it counts the provider attempt.
- **Hash publication** (`reserveSpawnIdentity`, phase 2 of #1606). Applied `WHERE modal_sandbox_id = ?`, which guards against a newer reservation but not against a cancel that stops this one: the reservation awaits the alarm store and then the hash, a cancel landing there sets the sandbox `stopped` without changing its id, and the hash then went live and the provider was called for a closed session (its bridge rejected at the handshake, the sandbox orphaned until the next stop). Now also `AND status = 'spawning'`, so such an attempt takes the existing superseded exit without failure writes.

`SandboxStorage` gains `transitionSandboxStatus(generation, from, to): boolean` and `recordSandboxSnapshot(modalSandboxId, imageId, runtimeVersion): boolean` (replacing `updateSandboxSnapshotImageId`, whose only caller was this one), both conditional updates reporting `rowsWritten`, implemented on `SandboxRepository`. A status condition alone is not enough (review finding): a late completion can meet a newer attempt that has brought the row back to the same status (A's bridge connects early and clears the in-memory flag, A goes stale, B reserves and is `spawning` when A's provider call returns; or a resume re-entering `connecting` under the same id). So every transition names the **generation** it was started for, `{ sandboxId, createdAt }`: the logical id plus the `created_at` the reservation or resume stamped, which `updateSandboxForSpawn` and `updateSandboxForResume` both set. The predicate is `modal_sandbox_id IS ? AND created_at = ? AND status = ?`. `doSpawn` carries its generation across the base-image retry; the snapshot restore uses the generation read before the provider await. When a write does not apply, the broadcast (and, for a failure, the error report) is skipped and the supersession is logged (`sandbox.snapshot_status_superseded`, `sandbox.snapshot_superseded`, `sandbox.attempt_failed_superseded`). The provider-result writes (object id, access URLs, tunnel URLs, ttyd) stay as they are in this PR: the object id is what a later stop needs whatever the row's status; access publication is a separate finding (it awaits encryption inside the repository) and gets its own PR.

Non-racy paths are unchanged: a fresh spawn still goes `spawning → connecting`, a resume makes no status write at completion, a failed attempt nothing else touched is still marked `failed` and reported, a snapshot of the current sandbox is still recorded and announced.

## Deviations from the issue text

None. The retry-from-base path in `doSpawn` (a prebuilt-image failure re-reserves the identity, which supersedes a bridge that connected before the provider error) is recorded in the audit table and left as is: whether a provider error after a bridge connect is a failure at all is a lifecycle decision, not a guard.

## Tests

- `manager.test.ts` +8 (two ABA cases: a late spawn failure meeting a newer reservation that re-entered `spawning` leaves it untouched and unreported; a late snapshot completion meeting a newer generation that re-entered `snapshotting` neither restores its status nor stamps it), plus the six below: a status written during the snapshot is left in place (image still recorded, no `ready` broadcast); a snapshot of a sandbox replaced during the provider call is dropped (no stamp, no `snapshot_saved`); an attempt the alarm failed mid-call is not resurrected to `connecting` (object id still stored); a sandbox that connected mid-call stays `ready` when the call then fails (no spawn error persisted or broadcast); a reservation a cancel stopped during its awaits is abandoned (no provider call, no failure writes); an attempt nothing else touched is still failed and reported. The first five fail on `main`. Existing assertions on the status writes now name the conditional call.
- `sandbox-repository.test.ts` +5: the two conditional statements (generation + status; identity) and their parameters; a moved row, a stopped reservation, and a replaced sandbox each report false.

Control-plane unit suite green; full workerd integration suite green; typecheck (all four programs), eslint, prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox lifecycle reliability when sandboxes are replaced, cancelled, or superseded during startup and recovery.
  * Prevented outdated lifecycle operations from overwriting the current sandbox status or reporting incorrect failures.
  * Improved snapshot handling so snapshot details are recorded only for the matching sandbox and status is restored safely after snapshot operations.
  * Ensured authentication data is updated only while a sandbox is actively spawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->