### PR TITLE
fix: re-read the prompt and session before spawning for a no-socket dispatch (COL-99)

### DIFF
--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -150,7 +150,7 @@ function buildQueue() {
       messageId: "msg-autofix",
     })),
     getAutofixMessageId: vi.fn(() => null as string | null),
-    getMessageStatus: vi.fn((): MessageStatus | null => "pending"),
+    getMessageStatus: vi.fn((_messageId: string): MessageStatus | null => "pending"),
     cancelPendingMessage: vi.fn(() => false),
     getUnfinishedMessagePosition: vi.fn((): number | null => 1),
     listUnfinishedMessages: vi.fn((): MessageRow[] => []),
@@ -517,6 +517,37 @@ describe("SessionMessageQueue", () => {
       "prompt.dispatch",
       expect.objectContaining({ outcome: "deferred", reason: "superseded_during_auth" })
     );
+  });
+
+  it("dispatches the next prompt when only the head was cancelled during the provider-auth lookup", async () => {
+    const h = buildQueue();
+    const session = createSession();
+    h.repository.getSession.mockImplementation(() => session);
+    h.repository.getNextPendingMessage
+      .mockReturnValueOnce(createMessage({ id: "msg-a" }))
+      .mockReturnValueOnce(createMessage({ id: "msg-b" }))
+      .mockReturnValue(null);
+    h.wsManager.getSandboxSocket.mockReturnValue(null);
+    h.getProviderAuthenticationError.mockImplementationOnce(async () => {
+      // The cancel of the head alone lands at this await: the session stays
+      // open and msg-b stays pending, with nothing else to dispatch it.
+      h.repository.getMessageStatus.mockImplementation((id) => (id === "msg-a" ? null : "pending"));
+      return null;
+    });
+
+    await h.queue.processMessageQueue();
+    await h.backgroundTasks.settle();
+
+    expect(h.log.info).toHaveBeenCalledWith(
+      "prompt.dispatch",
+      expect.objectContaining({ message_id: "msg-a", reason: "superseded_during_auth" })
+    );
+    expect(h.log.info).toHaveBeenCalledWith(
+      "prompt.dispatch",
+      expect.objectContaining({ message_id: "msg-b", reason: "no_sandbox" })
+    );
+    expect(h.sandboxLifecycle.spawnSandbox).toHaveBeenCalledTimes(1);
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_spawning" });
   });
 
   it("does not block queue processing on the sandbox spawn", async () => {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@open-inspect/shared/types/server-messages";
 import { MAX_UNFINISHED_PROMPTS } from "@open-inspect/shared/types/prompts";
 import type { ClientInfo } from "../types";
+import type { MessageStatus } from "@open-inspect/shared/types/sessions";
 import type { MessageRow, ParticipantRow, SessionRow, SessionAttachmentRow } from "./types";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { ParticipantRepository } from "./participant-repository";
@@ -149,7 +150,7 @@ function buildQueue() {
       messageId: "msg-autofix",
     })),
     getAutofixMessageId: vi.fn(() => null as string | null),
-    getMessageStatus: vi.fn(() => "pending" as const),
+    getMessageStatus: vi.fn((): MessageStatus | null => "pending"),
     cancelPendingMessage: vi.fn(() => false),
     getUnfinishedMessagePosition: vi.fn((): number | null => 1),
     listUnfinishedMessages: vi.fn((): MessageRow[] => []),
@@ -492,6 +493,31 @@ describe("SessionMessageQueue", () => {
       expect(h.wsManager.send).not.toHaveBeenCalled();
     }
   );
+
+  it("does not spawn a sandbox for a prompt cancelled during the provider-auth lookup", async () => {
+    const h = buildQueue();
+    const session = createSession();
+    h.repository.getSession.mockImplementation(() => session);
+    h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+    h.wsManager.getSandboxSocket.mockReturnValue(null);
+    h.getProviderAuthenticationError.mockImplementation(async () => {
+      // The cancel lands at this await: it closes the session and fails the
+      // pending prompt in one synchronous turn.
+      session.status = "cancelled";
+      h.repository.getMessageStatus.mockReturnValue("failed");
+      return null;
+    });
+
+    await h.queue.processMessageQueue();
+    await h.backgroundTasks.settle();
+
+    expect(h.sandboxLifecycle.spawnSandbox).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalledWith({ type: "sandbox_spawning" });
+    expect(h.log.info).toHaveBeenCalledWith(
+      "prompt.dispatch",
+      expect.objectContaining({ outcome: "deferred", reason: "superseded_during_auth" })
+    );
+  });
 
   it("does not block queue processing on the sandbox spawn", async () => {
     const h = buildQueue();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -399,7 +399,11 @@ export class SessionMessageQueue {
       // path re-validates through the processing claim; this path has no
       // claim, so it re-reads what it acts on: a cancel or archive that
       // landed meanwhile has closed the session and terminalized the prompt,
-      // and must not get a sandbox spawned for it.
+      // and must not get a sandbox spawned for it. The queue is then pumped
+      // again over the state that moved: a prompt cancelled on its own
+      // leaves the next one pending with nobody else to dispatch it, and the
+      // pump stops by itself for a closed session, a processing owner, a
+      // stop fence, or an empty queue.
       if (!this.isPromptStillDispatchable(message.id)) {
         this.log.info("prompt.dispatch", {
           event: "prompt.dispatch",
@@ -407,6 +411,7 @@ export class SessionMessageQueue {
           outcome: "deferred",
           reason: "superseded_during_auth",
         });
+        await this.processMessageQueue();
         return;
       }
       this.log.info("prompt.dispatch", {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -395,6 +395,20 @@ export class SessionMessageQueue {
 
     const sandboxWs = this.wsManager.getSandboxSocket();
     if (!sandboxWs) {
+      // The provider-auth lookup above is a non-storage await. The socket
+      // path re-validates through the processing claim; this path has no
+      // claim, so it re-reads what it acts on: a cancel or archive that
+      // landed meanwhile has closed the session and terminalized the prompt,
+      // and must not get a sandbox spawned for it.
+      if (!this.isPromptStillDispatchable(message.id)) {
+        this.log.info("prompt.dispatch", {
+          event: "prompt.dispatch",
+          message_id: message.id,
+          outcome: "deferred",
+          reason: "superseded_during_auth",
+        });
+        return;
+      }
       this.log.info("prompt.dispatch", {
         event: "prompt.dispatch",
         message_id: message.id,
@@ -874,6 +888,20 @@ export class SessionMessageQueue {
     });
 
     return { messageId, position };
+  }
+
+  /**
+   * Whether `messageId` is still pending in a session that still accepts
+   * work. Read in the caller's continuation, so the decision it feeds is made
+   * on the same state.
+   */
+  private isPromptStillDispatchable(messageId: string): boolean {
+    const session = this.repository.getSession();
+    return (
+      session !== null &&
+      isSessionPromptable(session.status) &&
+      this.messageRepository.getMessageStatus(messageId) === "pending"
+    );
   }
 
   private assertPromptableSession(): void {


### PR DESCRIPTION
Roadmap **H-3 · COL-99**, fix from the concurrency audit (#1760, table row `processMessageQueue, no-socket path`, raised in that PR's review). Behavior-preserving on Cloudflare outside the interleaving it closes.

## What

`processMessageQueue` reads the next pending message, awaits the provider-authentication lookup (D1, a non-storage await), and then dispatches. The socket path is protected by the #1479 processing claim, which re-validates the message's `pending` status in the write. The no-socket path had no claim: it broadcast `sandbox_spawning` and submitted `spawnSandbox()` on the strength of the pre-await read, and `spawnSandbox` evaluates sandbox state, not session liveness. A cancel or archive landing during the lookup closed the session and failed the prompt in one turn; the continuation then started a sandbox for it. The bridge is rejected at the handshake (`session_terminal`, 410) and the sandbox is orphaned until the next spawn's `stopPriorProviderSandbox`.

The branch now re-reads what it acts on in the spawn's own continuation: the session must still be promptable and the message still `pending`. Otherwise it logs `prompt.dispatch` with `reason: superseded_during_auth` and pumps the queue again: a head cancelled on its own leaves the next prompt pending with nobody else to dispatch it, and the pump stops by itself for a closed session, a processing owner, a stop fence, or an empty queue.

## Tests

`message-queue.test.ts` +2: a prompt whose session is cancelled (and whose row is failed) during the provider-auth lookup gets no `sandbox_spawning` broadcast and no spawn; two queued prompts whose head is cancelled during the lookup while the session stays open still spawn for the second. Both fail on `main`.

Control-plane unit suite green; full workerd integration suite green; typecheck (all four programs), eslint, prettier clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cancelled or archived prompts are no longer dispatched or used to start unnecessary sandboxes.
  - Prompt processing now rechecks the latest session and message state before dispatching, preventing stale prompts from running.
  - When a queued prompt is cancelled, subsequent eligible prompts continue processing normally.
  - Improved handling of prompt cancellation during provider authentication, with clearer deferred outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->