### PR TITLE
refactor: name the global-store instrumentation by the port, not by D1 (COL-97 addendum)

### DIFF
--- a/packages/control-plane/src/db/instrumented-sql-database.test.ts
+++ b/packages/control-plane/src/db/instrumented-sql-database.test.ts
@@ -1,77 +1,64 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createNodeSqlDatabase, type NodeSqlDatabase } from "../node/sqlite-database";
 import { createRequestMetrics, instrumentSqlDatabase } from "./instrumented-sql-database";
 import type { RequestMetrics } from "./instrumented-sql-database";
-import type { SqlDatabase } from "./sql-database";
+import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
 
 // ---------------------------------------------------------------------------
-// Fake D1 implementation for testing the instrumented wrapper
+// A SqlDatabase whose engine reports every metadata field, as D1 does for
+// run() and all(), so the wrapper's arithmetic can be checked exactly.
 // ---------------------------------------------------------------------------
 
-class FakeD1PreparedStatement {
-  private bound: unknown[] = [];
+function result<T>(results: T[], meta: SqlResult["meta"]): SqlResult<T> {
+  return { results, meta };
+}
 
-  constructor(private query: string) {}
+class FakeStatement implements SqlStatement {
+  constructor(
+    readonly query: string,
+    readonly bound: unknown[] = []
+  ) {}
 
-  bind(...args: unknown[]) {
-    const stmt = new FakeD1PreparedStatement(this.query);
-    stmt.bound = args;
-    return stmt;
+  bind(...values: unknown[]): SqlStatement {
+    return new FakeStatement(this.query, values);
   }
 
-  async first<T>(_colName?: string): Promise<T | null> {
-    // Simulate D1 latency
+  async first<T>(): Promise<T | null> {
     await delay(1);
     return { id: 1, name: "test" } as T;
   }
 
-  async run<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+  async run<T>(): Promise<SqlResult<T>> {
     await delay(1);
-    return {
-      results: [],
-      success: true,
-      meta: { duration: 5, rows_read: 0, rows_written: 1 },
-    } as unknown as D1Result<T>;
+    return result<T>([], { changes: 1, duration: 5, rows_read: 0, rows_written: 1 });
   }
 
-  async all<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+  async all<T>(): Promise<SqlResult<T>> {
     await delay(1);
-    return {
-      results: [{ id: 1 }, { id: 2 }] as T[],
-      success: true,
-      meta: { duration: 8, rows_read: 10, rows_written: 0 },
-    } as unknown as D1Result<T>;
-  }
-
-  async raw<T = unknown[]>(_options?: { columnNames?: boolean }): Promise<T[]> {
-    await delay(1);
-    return [[1, "test"]] as T[];
+    return result([{ id: 1 }, { id: 2 }] as T[], {
+      changes: 0,
+      duration: 8,
+      rows_read: 10,
+      rows_written: 0,
+    });
   }
 }
 
-class FakeD1Database {
-  /** Statements received by the last batch() call (for assertion). */
-  lastBatchStatements: D1PreparedStatement[] = [];
+class FakeDatabase implements SqlDatabase {
+  /** Statements received by the last batch() call, for assertion. */
+  lastBatchStatements: SqlStatement[] = [];
 
-  prepare(query: string) {
-    return new FakeD1PreparedStatement(query);
+  prepare(query: string): SqlStatement {
+    return new FakeStatement(query);
   }
 
-  async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+  async batch<T>(statements: SqlStatement[]): Promise<SqlResult<T>[]> {
     this.lastBatchStatements = statements;
     await delay(1);
-    return statements.map(() => ({
-      results: [{ id: 1 }] as T[],
-      success: true,
-      meta: { duration: 3, rows_read: 5, rows_written: 2 },
-    })) as unknown as D1Result<T>[];
-  }
-
-  async exec(_query: string): Promise<D1ExecResult> {
-    return { count: 0, duration: 0 };
-  }
-
-  async dump(): Promise<ArrayBuffer> {
-    return new ArrayBuffer(0);
+    return statements.map(() =>
+      result([{ id: 1 }] as T[], { changes: 2, duration: 3, rows_read: 5, rows_written: 2 })
+    );
   }
 }
 
@@ -95,15 +82,8 @@ describe("createRequestMetrics", () => {
     expect(metrics.spans).toEqual({});
   });
 
-  it("summarize() returns zeros when no queries recorded", () => {
-    const summary = metrics.summarize();
-    expect(summary).toEqual({
-      sql_query_count: 0,
-      sql_total_ms: 0,
-      sql_engine_total_ms: 0,
-      sql_rows_read: 0,
-      sql_rows_written: 0,
-    });
+  it("summarize() reports the count and the caller-observed time alone when nothing ran", () => {
+    expect(metrics.summarize()).toEqual({ sql_query_count: 0, sql_total_ms: 0 });
   });
 
   describe("time()", () => {
@@ -144,15 +124,14 @@ describe("createRequestMetrics", () => {
   });
 
   describe("summarize()", () => {
-    it("computes correct totals from multiple query records", () => {
+    it("totals each engine field over the records that report it", () => {
       metrics.sqlQueries.push(
         { query_ms: 100, engine_ms: 10, rows_read: 5, rows_written: 0 },
         { query_ms: 200, engine_ms: 20, rows_read: 15, rows_written: 3 },
-        { query_ms: 50 } // first() call — no server metadata
+        { query_ms: 50 } // first() call: no engine metadata
       );
 
-      const summary = metrics.summarize();
-      expect(summary).toEqual({
+      expect(metrics.summarize()).toEqual({
         sql_query_count: 3,
         sql_total_ms: 350,
         sql_engine_total_ms: 30,
@@ -160,18 +139,32 @@ describe("createRequestMetrics", () => {
         sql_rows_written: 3,
       });
     });
+
+    it("leaves out a field no record reported instead of totalling it to zero", () => {
+      metrics.sqlQueries.push(
+        { query_ms: 10, engine_ms: 2, rows_written: 1 },
+        { query_ms: 20, engine_ms: 4, rows_written: 0 }
+      );
+
+      expect(metrics.summarize()).toEqual({
+        sql_query_count: 2,
+        sql_total_ms: 30,
+        sql_engine_total_ms: 6,
+        sql_rows_written: 1,
+      });
+    });
   });
 });
 
-describe("instrumentSqlDatabase", () => {
-  let fakeDb: FakeD1Database;
+describe("instrumentSqlDatabase over an engine that reports every field", () => {
+  let fakeDb: FakeDatabase;
   let metrics: RequestMetrics;
   let db: SqlDatabase;
 
   beforeEach(() => {
-    fakeDb = new FakeD1Database();
+    fakeDb = new FakeDatabase();
     metrics = createRequestMetrics();
-    db = instrumentSqlDatabase(fakeDb as unknown as D1Database, metrics);
+    db = instrumentSqlDatabase(fakeDb, metrics);
   });
 
   it("captures timing from run()", async () => {
@@ -193,13 +186,12 @@ describe("instrumentSqlDatabase", () => {
     expect(metrics.sqlQueries[0].rows_written).toBe(0);
   });
 
-  it("captures timing from first()", async () => {
+  it("captures timing from first(), which carries no engine metadata", async () => {
     await db.prepare("SELECT * FROM t WHERE id = ?").bind(1).first();
 
     expect(metrics.sqlQueries).toHaveLength(1);
     expect(metrics.sqlQueries[0].query_ms).toBeGreaterThanOrEqual(0);
-    // first() does not return D1Meta
-    expect(metrics.sqlQueries[0].engine_ms).toBeUndefined();
+    expect(metrics.sqlQueries[0]).not.toHaveProperty("engine_ms");
   });
 
   it("captures batch() as a single query record with aggregated metadata", async () => {
@@ -213,15 +205,15 @@ describe("instrumentSqlDatabase", () => {
 
     expect(metrics.sqlQueries).toHaveLength(1);
     expect(metrics.sqlQueries[0].query_ms).toBeGreaterThanOrEqual(0);
-    // 3 statements × 3ms server time each = 9ms aggregated
+    // 3 statements × 3ms engine time each
     expect(metrics.sqlQueries[0].engine_ms).toBe(9);
-    // 3 statements × 5 rows read each = 15 aggregated
+    // 3 statements × 5 rows read each
     expect(metrics.sqlQueries[0].rows_read).toBe(15);
-    // 3 statements × 2 rows written each = 6 aggregated
+    // 3 statements × 2 rows written each
     expect(metrics.sqlQueries[0].rows_written).toBe(6);
   });
 
-  it("batch() unwraps instrumented statements before passing to real D1", async () => {
+  it("batch() hands the engine its own statements, not the instrumented wrappers", async () => {
     const stmts = [
       db.prepare("SELECT * FROM t WHERE id = ?").bind(1),
       db.prepare("SELECT * FROM t WHERE id = ?").bind(2),
@@ -229,11 +221,11 @@ describe("instrumentSqlDatabase", () => {
 
     await db.batch(stmts);
 
-    // The real D1 should receive FakeD1PreparedStatement instances,
-    // not plain-object instrumented wrappers.
+    expect(fakeDb.lastBatchStatements).toHaveLength(2);
     for (const s of fakeDb.lastBatchStatements) {
-      expect(s).toBeInstanceOf(FakeD1PreparedStatement);
+      expect(s).toBeInstanceOf(FakeStatement);
     }
+    expect((fakeDb.lastBatchStatements[1] as FakeStatement).bound).toEqual([2]);
   });
 
   it("bind() chaining works correctly with instrumented statements", async () => {
@@ -255,13 +247,13 @@ describe("instrumentSqlDatabase", () => {
     const summary = metrics.summarize();
     expect(summary.sql_query_count).toBe(3);
     expect(summary.sql_total_ms as number).toBeGreaterThanOrEqual(0);
-    // first() has no server ms, all() has 8, run() has 5
+    // first() has no engine ms, all() has 8, run() has 5
     expect(summary.sql_engine_total_ms).toBe(13);
     expect(summary.sql_rows_read).toBe(10);
     expect(summary.sql_rows_written).toBe(1);
   });
 
-  it("summarize includes both D1 and span fields", async () => {
+  it("summarize includes both query and span fields", async () => {
     await db.prepare("SELECT * FROM t").all();
     await metrics.time("github_api", async () => "repos");
 
@@ -269,5 +261,65 @@ describe("instrumentSqlDatabase", () => {
     expect(summary.sql_query_count).toBe(1);
     expect(summary.sql_engine_total_ms).toBe(8);
     expect(summary).toHaveProperty("github_api_ms");
+  });
+});
+
+// The Node adapter reports duration and rows_written but never rows_read,
+// and admits only its own statements to batch(): the two contract edges
+// the wrapper has to respect on the host that is not D1.
+describe("instrumentSqlDatabase over the Node SQLite adapter", () => {
+  let engine: NodeSqlDatabase;
+  let metrics: RequestMetrics;
+  let db: SqlDatabase;
+
+  beforeEach(() => {
+    engine = createNodeSqlDatabase(new DatabaseSync(":memory:"));
+    metrics = createRequestMetrics();
+    db = instrumentSqlDatabase(engine, metrics);
+  });
+
+  afterEach(() => {
+    engine.close();
+  });
+
+  it("runs an instrumented batch through the engine's same-origin check", async () => {
+    await engine.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)").run();
+
+    const results = await db.batch([
+      db.prepare("INSERT INTO t (name) VALUES (?)").bind("a"),
+      db.prepare("INSERT INTO t (name) VALUES (?)").bind("b"),
+      db.prepare("SELECT name FROM t ORDER BY id"),
+    ]);
+
+    expect(results.map((r) => r.meta.changes)).toEqual([1, 1, 0]);
+    expect(results[2].results).toEqual([{ name: "a" }, { name: "b" }]);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].rows_written).toBe(2);
+    expect(metrics.sqlQueries[0].engine_ms).toBeGreaterThanOrEqual(0);
+    expect(metrics.sqlQueries[0].rows_read).toBeUndefined();
+  });
+
+  it("reports only what the engine reports: no rows_read, nothing for first()", async () => {
+    await engine.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)").run();
+
+    await db.prepare("INSERT INTO t (name) VALUES (?)").bind("a").run();
+    await db.prepare("SELECT name FROM t WHERE id = ?").bind(1).first();
+
+    const summary = metrics.summarize();
+    expect(summary.sql_query_count).toBe(2);
+    expect(summary.sql_engine_total_ms).toBeGreaterThanOrEqual(0);
+    expect(summary.sql_rows_written).toBe(1);
+    expect(summary).not.toHaveProperty("sql_rows_read");
+  });
+
+  it("emits neither engine field for a request of only first() calls", async () => {
+    await engine.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)").run();
+
+    await db.prepare("SELECT COUNT(*) AS n FROM t").first();
+
+    expect(metrics.summarize()).toEqual({
+      sql_query_count: 1,
+      sql_total_ms: expect.any(Number),
+    });
   });
 });

--- a/packages/control-plane/src/db/instrumented-sql-database.test.ts
+++ b/packages/control-plane/src/db/instrumented-sql-database.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { createRequestMetrics, instrumentD1 } from "./instrumented-d1";
-import type { RequestMetrics } from "./instrumented-d1";
+import { createRequestMetrics, instrumentSqlDatabase } from "./instrumented-sql-database";
+import type { RequestMetrics } from "./instrumented-sql-database";
 import type { SqlDatabase } from "./sql-database";
 
 // ---------------------------------------------------------------------------
@@ -91,18 +91,18 @@ describe("createRequestMetrics", () => {
   });
 
   it("starts with empty queries and spans", () => {
-    expect(metrics.d1Queries).toEqual([]);
+    expect(metrics.sqlQueries).toEqual([]);
     expect(metrics.spans).toEqual({});
   });
 
   it("summarize() returns zeros when no queries recorded", () => {
     const summary = metrics.summarize();
     expect(summary).toEqual({
-      d1_query_count: 0,
-      d1_total_ms: 0,
-      d1_server_total_ms: 0,
-      d1_rows_read: 0,
-      d1_rows_written: 0,
+      sql_query_count: 0,
+      sql_total_ms: 0,
+      sql_engine_total_ms: 0,
+      sql_rows_read: 0,
+      sql_rows_written: 0,
     });
   });
 
@@ -145,25 +145,25 @@ describe("createRequestMetrics", () => {
 
   describe("summarize()", () => {
     it("computes correct totals from multiple query records", () => {
-      metrics.d1Queries.push(
-        { query_ms: 100, d1_server_ms: 10, rows_read: 5, rows_written: 0 },
-        { query_ms: 200, d1_server_ms: 20, rows_read: 15, rows_written: 3 },
+      metrics.sqlQueries.push(
+        { query_ms: 100, engine_ms: 10, rows_read: 5, rows_written: 0 },
+        { query_ms: 200, engine_ms: 20, rows_read: 15, rows_written: 3 },
         { query_ms: 50 } // first() call — no server metadata
       );
 
       const summary = metrics.summarize();
       expect(summary).toEqual({
-        d1_query_count: 3,
-        d1_total_ms: 350,
-        d1_server_total_ms: 30,
-        d1_rows_read: 20,
-        d1_rows_written: 3,
+        sql_query_count: 3,
+        sql_total_ms: 350,
+        sql_engine_total_ms: 30,
+        sql_rows_read: 20,
+        sql_rows_written: 3,
       });
     });
   });
 });
 
-describe("instrumentD1", () => {
+describe("instrumentSqlDatabase", () => {
   let fakeDb: FakeD1Database;
   let metrics: RequestMetrics;
   let db: SqlDatabase;
@@ -171,35 +171,35 @@ describe("instrumentD1", () => {
   beforeEach(() => {
     fakeDb = new FakeD1Database();
     metrics = createRequestMetrics();
-    db = instrumentD1(fakeDb as unknown as D1Database, metrics);
+    db = instrumentSqlDatabase(fakeDb as unknown as D1Database, metrics);
   });
 
   it("captures timing from run()", async () => {
     await db.prepare("INSERT INTO t VALUES (?)").bind(1).run();
 
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].query_ms).toBeGreaterThanOrEqual(0);
-    expect(metrics.d1Queries[0].d1_server_ms).toBe(5);
-    expect(metrics.d1Queries[0].rows_read).toBe(0);
-    expect(metrics.d1Queries[0].rows_written).toBe(1);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].query_ms).toBeGreaterThanOrEqual(0);
+    expect(metrics.sqlQueries[0].engine_ms).toBe(5);
+    expect(metrics.sqlQueries[0].rows_read).toBe(0);
+    expect(metrics.sqlQueries[0].rows_written).toBe(1);
   });
 
   it("captures timing from all()", async () => {
     await db.prepare("SELECT * FROM t").all();
 
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].d1_server_ms).toBe(8);
-    expect(metrics.d1Queries[0].rows_read).toBe(10);
-    expect(metrics.d1Queries[0].rows_written).toBe(0);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].engine_ms).toBe(8);
+    expect(metrics.sqlQueries[0].rows_read).toBe(10);
+    expect(metrics.sqlQueries[0].rows_written).toBe(0);
   });
 
   it("captures timing from first()", async () => {
     await db.prepare("SELECT * FROM t WHERE id = ?").bind(1).first();
 
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].query_ms).toBeGreaterThanOrEqual(0);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].query_ms).toBeGreaterThanOrEqual(0);
     // first() does not return D1Meta
-    expect(metrics.d1Queries[0].d1_server_ms).toBeUndefined();
+    expect(metrics.sqlQueries[0].engine_ms).toBeUndefined();
   });
 
   it("captures batch() as a single query record with aggregated metadata", async () => {
@@ -211,14 +211,14 @@ describe("instrumentD1", () => {
 
     await db.batch(stmts);
 
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].query_ms).toBeGreaterThanOrEqual(0);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].query_ms).toBeGreaterThanOrEqual(0);
     // 3 statements × 3ms server time each = 9ms aggregated
-    expect(metrics.d1Queries[0].d1_server_ms).toBe(9);
+    expect(metrics.sqlQueries[0].engine_ms).toBe(9);
     // 3 statements × 5 rows read each = 15 aggregated
-    expect(metrics.d1Queries[0].rows_read).toBe(15);
+    expect(metrics.sqlQueries[0].rows_read).toBe(15);
     // 3 statements × 2 rows written each = 6 aggregated
-    expect(metrics.d1Queries[0].rows_written).toBe(6);
+    expect(metrics.sqlQueries[0].rows_written).toBe(6);
   });
 
   it("batch() unwraps instrumented statements before passing to real D1", async () => {
@@ -241,8 +241,8 @@ describe("instrumentD1", () => {
     const bound = stmt.bind(1, 2);
     await bound.all();
 
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].d1_server_ms).toBe(8);
+    expect(metrics.sqlQueries).toHaveLength(1);
+    expect(metrics.sqlQueries[0].engine_ms).toBe(8);
   });
 
   it("accumulates queries across multiple calls", async () => {
@@ -250,15 +250,15 @@ describe("instrumentD1", () => {
     await db.prepare("SELECT * FROM t").all();
     await db.prepare("INSERT INTO t VALUES (?)").bind(1).run();
 
-    expect(metrics.d1Queries).toHaveLength(3);
+    expect(metrics.sqlQueries).toHaveLength(3);
 
     const summary = metrics.summarize();
-    expect(summary.d1_query_count).toBe(3);
-    expect(summary.d1_total_ms as number).toBeGreaterThanOrEqual(0);
+    expect(summary.sql_query_count).toBe(3);
+    expect(summary.sql_total_ms as number).toBeGreaterThanOrEqual(0);
     // first() has no server ms, all() has 8, run() has 5
-    expect(summary.d1_server_total_ms).toBe(13);
-    expect(summary.d1_rows_read).toBe(10);
-    expect(summary.d1_rows_written).toBe(1);
+    expect(summary.sql_engine_total_ms).toBe(13);
+    expect(summary.sql_rows_read).toBe(10);
+    expect(summary.sql_rows_written).toBe(1);
   });
 
   it("summarize includes both D1 and span fields", async () => {
@@ -266,8 +266,8 @@ describe("instrumentD1", () => {
     await metrics.time("github_api", async () => "repos");
 
     const summary = metrics.summarize();
-    expect(summary.d1_query_count).toBe(1);
-    expect(summary.d1_server_total_ms).toBe(8);
+    expect(summary.sql_query_count).toBe(1);
+    expect(summary.sql_engine_total_ms).toBe(8);
     expect(summary).toHaveProperty("github_api_ms");
   });
 });

--- a/packages/control-plane/src/db/instrumented-sql-database.ts
+++ b/packages/control-plane/src/db/instrumented-sql-database.ts
@@ -16,16 +16,37 @@ import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
 // Types
 // ---------------------------------------------------------------------------
 
-/** Record of a single query execution against the global store, whichever engine serves it. */
+/**
+ * Record of a single query execution against the global store, whichever
+ * engine serves it. Only `query_ms` is always present: the engine metadata
+ * is optional on `SqlResultMeta`, and `first()` reports none, so a field an
+ * engine did not report stays absent here and in the summary rather than
+ * reading as a measured zero.
+ */
 interface SqlQueryRecord {
   /** Wall-clock time in ms, as the caller saw it (on Workers this includes the round-trip to the D1 primary). */
   query_ms: number;
   /** Engine-reported execution time in ms (`meta.duration`), when the engine reports one. */
   engine_ms?: number;
-  /** Rows read, from result meta. */
+  /** Rows read, when the engine reports it. */
   rows_read?: number;
-  /** Rows written, from result meta. */
+  /** Rows written, when the engine reports it. */
   rows_written?: number;
+}
+
+type ReportedField = "engine_ms" | "rows_read" | "rows_written";
+
+/** The sum of `field` over the records that report it; absent when none does. */
+function reportedTotal(
+  records: readonly Pick<SqlQueryRecord, ReportedField>[],
+  field: ReportedField
+): number | undefined {
+  let total: number | undefined;
+  for (const record of records) {
+    const value = record[field];
+    if (value !== undefined) total = (total ?? 0) + value;
+  }
+  return total;
 }
 
 /**
@@ -77,10 +98,17 @@ export function createRequestMetrics(): RequestMetrics {
       const result: Record<string, unknown> = {
         sql_query_count: sqlQueries.length,
         sql_total_ms: sqlQueries.reduce((sum, q) => sum + q.query_ms, 0),
-        sql_engine_total_ms: sqlQueries.reduce((sum, q) => sum + (q.engine_ms ?? 0), 0),
-        sql_rows_read: sqlQueries.reduce((sum, q) => sum + (q.rows_read ?? 0), 0),
-        sql_rows_written: sqlQueries.reduce((sum, q) => sum + (q.rows_written ?? 0), 0),
       };
+      // Reported by the engine or not in the event at all: a Node SQLite
+      // store reports no rows_read, and a request of only first() calls
+      // reports nothing, so a zero here would be a measurement that never
+      // happened.
+      const engineMs = reportedTotal(sqlQueries, "engine_ms");
+      if (engineMs !== undefined) result.sql_engine_total_ms = engineMs;
+      const rowsRead = reportedTotal(sqlQueries, "rows_read");
+      if (rowsRead !== undefined) result.sql_rows_read = rowsRead;
+      const rowsWritten = reportedTotal(sqlQueries, "rows_written");
+      if (rowsWritten !== undefined) result.sql_rows_written = rowsWritten;
 
       for (const [name, ms] of Object.entries(spans)) {
         result[`${name}_ms`] = ms;
@@ -178,20 +206,18 @@ export function instrumentSqlDatabase(db: SqlDatabase, metrics: RequestMetrics):
       const results = await db.batch<T>(statements.map(unwrapStatement));
       const elapsed = Date.now() - start;
 
-      let serverMs = 0;
-      let rowsRead = 0;
-      let rowsWritten = 0;
-      for (const r of results) {
-        serverMs += r.meta?.duration ?? 0;
-        rowsRead += r.meta?.rows_read ?? 0;
-        rowsWritten += r.meta?.rows_written ?? 0;
-      }
-
+      // One record for the batch, each field the sum over the statements
+      // whose engine reported it.
+      const reported = results.map((r) => ({
+        engine_ms: r.meta?.duration,
+        rows_read: r.meta?.rows_read,
+        rows_written: r.meta?.rows_written,
+      }));
       metrics.sqlQueries.push({
         query_ms: elapsed,
-        engine_ms: serverMs,
-        rows_read: rowsRead,
-        rows_written: rowsWritten,
+        engine_ms: reportedTotal(reported, "engine_ms"),
+        rows_read: reportedTotal(reported, "rows_read"),
+        rows_written: reportedTotal(reported, "rows_written"),
       });
 
       return results;

--- a/packages/control-plane/src/db/instrumented-sql-database.ts
+++ b/packages/control-plane/src/db/instrumented-sql-database.ts
@@ -16,12 +16,12 @@ import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
 // Types
 // ---------------------------------------------------------------------------
 
-/** Record of a single D1 query execution. */
-interface D1QueryRecord {
-  /** Wall-clock time in ms (includes network round-trip from Worker to D1 primary). */
+/** Record of a single query execution against the global store, whichever engine serves it. */
+interface SqlQueryRecord {
+  /** Wall-clock time in ms, as the caller saw it (on Workers this includes the round-trip to the D1 primary). */
   query_ms: number;
-  /** Engine-reported server-side execution time in ms (from meta.duration). */
-  d1_server_ms?: number;
+  /** Engine-reported execution time in ms (`meta.duration`), when the engine reports one. */
+  engine_ms?: number;
   /** Rows read, from result meta. */
   rows_read?: number;
   /** Rows written, from result meta. */
@@ -33,10 +33,10 @@ interface D1QueryRecord {
  * through RequestContext, and summarized into the http.request wide event.
  */
 export interface RequestMetrics {
-  /** Accumulated D1 query records (populated automatically by instrumentD1 wrapper). */
-  readonly d1Queries: D1QueryRecord[];
+  /** Accumulated query records (populated by the instrumentSqlDatabase wrapper). */
+  readonly sqlQueries: SqlQueryRecord[];
 
-  /** Named timing spans for non-D1 operations (populated via time()). */
+  /** Named timing spans for non-database operations (populated via time()). */
   readonly spans: Record<string, number>;
 
   /**
@@ -57,11 +57,11 @@ export interface RequestMetrics {
 // ---------------------------------------------------------------------------
 
 export function createRequestMetrics(): RequestMetrics {
-  const d1Queries: D1QueryRecord[] = [];
+  const sqlQueries: SqlQueryRecord[] = [];
   const spans: Record<string, number> = {};
 
   return {
-    d1Queries,
+    sqlQueries,
     spans,
 
     async time<T>(name: string, fn: () => Promise<T>): Promise<T> {
@@ -75,11 +75,11 @@ export function createRequestMetrics(): RequestMetrics {
 
     summarize(): Record<string, unknown> {
       const result: Record<string, unknown> = {
-        d1_query_count: d1Queries.length,
-        d1_total_ms: d1Queries.reduce((sum, q) => sum + q.query_ms, 0),
-        d1_server_total_ms: d1Queries.reduce((sum, q) => sum + (q.d1_server_ms ?? 0), 0),
-        d1_rows_read: d1Queries.reduce((sum, q) => sum + (q.rows_read ?? 0), 0),
-        d1_rows_written: d1Queries.reduce((sum, q) => sum + (q.rows_written ?? 0), 0),
+        sql_query_count: sqlQueries.length,
+        sql_total_ms: sqlQueries.reduce((sum, q) => sum + q.query_ms, 0),
+        sql_engine_total_ms: sqlQueries.reduce((sum, q) => sum + (q.engine_ms ?? 0), 0),
+        sql_rows_read: sqlQueries.reduce((sum, q) => sum + (q.rows_read ?? 0), 0),
+        sql_rows_written: sqlQueries.reduce((sum, q) => sum + (q.rows_written ?? 0), 0),
       };
 
       for (const [name, ms] of Object.entries(spans)) {
@@ -123,16 +123,16 @@ function instrumentStatement(stmt: SqlStatement, metrics: RequestMetrics): SqlSt
     async first<T = Record<string, unknown>>(): Promise<T | null> {
       const start = Date.now();
       const result = await stmt.first<T>();
-      metrics.d1Queries.push({ query_ms: Date.now() - start });
+      metrics.sqlQueries.push({ query_ms: Date.now() - start });
       return result;
     },
 
     async run<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
       const start = Date.now();
       const result = await stmt.run<T>();
-      metrics.d1Queries.push({
+      metrics.sqlQueries.push({
         query_ms: Date.now() - start,
-        d1_server_ms: result.meta?.duration,
+        engine_ms: result.meta?.duration,
         rows_read: result.meta?.rows_read,
         rows_written: result.meta?.rows_written,
       });
@@ -142,9 +142,9 @@ function instrumentStatement(stmt: SqlStatement, metrics: RequestMetrics): SqlSt
     async all<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
       const start = Date.now();
       const result = await stmt.all<T>();
-      metrics.d1Queries.push({
+      metrics.sqlQueries.push({
         query_ms: Date.now() - start,
-        d1_server_ms: result.meta?.duration,
+        engine_ms: result.meta?.duration,
         rows_read: result.meta?.rows_read,
         rows_written: result.meta?.rows_written,
       });
@@ -167,7 +167,7 @@ function instrumentStatement(stmt: SqlStatement, metrics: RequestMetrics): SqlSt
  * constructor — passing an instrumented DB means all their queries are timed
  * without any changes to the store code.
  */
-export function instrumentD1(db: SqlDatabase, metrics: RequestMetrics): SqlDatabase {
+export function instrumentSqlDatabase(db: SqlDatabase, metrics: RequestMetrics): SqlDatabase {
   return {
     prepare(query: string): SqlStatement {
       return instrumentStatement(db.prepare(query), metrics);
@@ -187,9 +187,9 @@ export function instrumentD1(db: SqlDatabase, metrics: RequestMetrics): SqlDatab
         rowsWritten += r.meta?.rows_written ?? 0;
       }
 
-      metrics.d1Queries.push({
+      metrics.sqlQueries.push({
         query_ms: elapsed,
-        d1_server_ms: serverMs,
+        engine_ms: serverMs,
         rows_read: rowsRead,
         rows_written: rowsWritten,
       });

--- a/packages/control-plane/src/db/sql-database.ts
+++ b/packages/control-plane/src/db/sql-database.ts
@@ -13,7 +13,7 @@
  *
  * Contract the type system cannot express: statements passed to batch() must
  * originate from the same database's prepare(). Adapters must tolerate or
- * unwrap foreign statements (see ORIGINAL_STMT in instrumented-d1.ts, which
+ * unwrap foreign statements (see ORIGINAL_STMT in instrumented-sql-database.ts, which
  * exists exactly because wrapped statements cross into the raw db.batch()).
  *
  * Not to be confused with the session Durable Object's synchronous
@@ -33,7 +33,7 @@ interface SqlResultMeta {
 
   /**
    * Optional observability metadata, read only by query instrumentation
-   * (instrumented-d1.ts). Engines may omit these; consumers must never gate
+   * (instrumented-sql-database.ts). Engines may omit these; consumers must never gate
    * correctness on them — `changes` is the only required field.
    */
   duration?: number;

--- a/packages/control-plane/src/http/create-request-context.ts
+++ b/packages/control-plane/src/http/create-request-context.ts
@@ -1,5 +1,5 @@
 import { getUserAuth, getUserAuthRuntime } from "../auth/user/runtime";
-import { createRequestMetrics, instrumentD1 } from "../db/instrumented-d1";
+import { createRequestMetrics, instrumentSqlDatabase } from "../db/instrumented-sql-database";
 import type { SqlDatabase } from "../db/sql-database";
 import type { BackgroundTasks } from "../platform-ports";
 import type { Env } from "../types";
@@ -19,7 +19,7 @@ export function createRequestContext(input: {
     trace_id: request.headers.get("x-trace-id") || crypto.randomUUID(),
     request_id: crypto.randomUUID().slice(0, 8),
     metrics,
-    db: instrumentD1(database, metrics),
+    db: instrumentSqlDatabase(database, metrics),
     // The stable uninstrumented binding remains the Better Auth cache key.
     getUserAuth: () => getUserAuth(env, database),
     getUserAuthRuntime: () => getUserAuthRuntime(env, database),

--- a/packages/control-plane/src/http/request-context.ts
+++ b/packages/control-plane/src/http/request-context.ts
@@ -3,7 +3,7 @@ import type { AuthenticationContext, Principal } from "../auth/principal";
 import type { AuthenticationRequestServices } from "../auth/request-services";
 import type { UserAuthRuntime } from "../auth/user/runtime";
 import type { AutomationRow } from "../db/automation-store";
-import type { RequestMetrics } from "../db/instrumented-d1";
+import type { RequestMetrics } from "../db/instrumented-sql-database";
 import type { BackgroundTasks } from "../platform-ports";
 
 /** Automation resource admitted for the current mutation. */

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -10,7 +10,11 @@ import type { GitHubAutofixEnvelope } from "@open-inspect/shared";
 import { handleAutofixQueue } from "./autofix/handler";
 import { consumeImageBuildFinalizations } from "./image-builds/finalization-consumer";
 import { createSessionRuntimeClient } from "./session/runtime-client";
-import { createRequestMetrics, instrumentD1, type RequestMetrics } from "./db/instrumented-d1";
+import {
+  createRequestMetrics,
+  instrumentSqlDatabase,
+  type RequestMetrics,
+} from "./db/instrumented-sql-database";
 import { SessionIndexStore } from "./db/session-index";
 import type { SqlDatabase } from "./db/sql-database";
 import { createCloudflareBackgroundTasks } from "./cloudflare/background-tasks";
@@ -36,7 +40,7 @@ export default {
     if (upgradeHeader?.toLowerCase() === "websocket") {
       const metrics = createRequestMetrics();
       // eslint-disable-next-line no-restricted-syntax -- composition root: construct the request-scoped database adapter
-      const db = instrumentD1(bindings.DB, metrics);
+      const db = instrumentSqlDatabase(bindings.DB, metrics);
       return handleWebSocket(request, bindings, url, db, metrics);
     }
 

--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -655,7 +655,7 @@ describe("handleCreateSession D1 ordering", () => {
         db: testEnv["DB"] as never,
         executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
         metrics: {
-          d1Queries: [],
+          sqlQueries: [],
           spans: {},
           time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
           summarize: () => ({}),

--- a/packages/control-plane/src/routes/session-attachments.test.ts
+++ b/packages/control-plane/src/routes/session-attachments.test.ts
@@ -16,7 +16,7 @@ function createContext(): RequestContext {
     db: {} as SqlDatabase,
     executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),

--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -38,7 +38,7 @@ function createCtx(principal?: Principal): RequestContext {
     db: { prepare: vi.fn(() => statement) } as unknown as SqlDatabase,
     executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),

--- a/packages/control-plane/src/routes/session-media-artifacts.test.ts
+++ b/packages/control-plane/src/routes/session-media-artifacts.test.ts
@@ -25,7 +25,7 @@ function createContext(result: Response | Error): SessionRouteContext {
     db: {} as SqlDatabase,
     executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),

--- a/packages/control-plane/src/routes/session-ws-token.test.ts
+++ b/packages/control-plane/src/routes/session-ws-token.test.ts
@@ -43,7 +43,7 @@ function createContext(db: SqlDatabase = accessDatabase().db): RequestContext {
       permissions: ["sessions.read"],
     },
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -50,7 +50,7 @@ function createCtx(): RequestContext {
     db: {} as SqlDatabase,
     executionCtx: TEST_BACKGROUND_TASK_CONTEXT,
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),

--- a/packages/control-plane/src/routing/request-lifecycle.test.ts
+++ b/packages/control-plane/src/routing/request-lifecycle.test.ts
@@ -14,7 +14,7 @@ function requestContext(metrics: Record<string, unknown> = {}): RequestContext {
     request_id: "request-123",
     trace_id: "trace-456",
     metrics: {
-      d1Queries: [],
+      sqlQueries: [],
       spans: {},
       time: async <T>(_name: string, operation: () => Promise<T>): Promise<T> => operation(),
       summarize: () => metrics,
@@ -139,7 +139,7 @@ describe("request lifecycle logging", () => {
 
     logRequest(
       new Response(null, { status }),
-      requestContext({ d1_query_count: 2, d1_total_ms: 7 }),
+      requestContext({ sql_query_count: 2, sql_total_ms: 7 }),
       "POST",
       "/sessions",
       1_000
@@ -155,8 +155,8 @@ describe("request lifecycle logging", () => {
         http_status: status,
         duration_ms: 250,
         outcome,
-        d1_query_count: 2,
-        d1_total_ms: 7,
+        sql_query_count: 2,
+        sql_total_ms: 7,
       })
     );
   });

--- a/packages/control-plane/src/scheduler/scheduler.ts
+++ b/packages/control-plane/src/scheduler/scheduler.ts
@@ -54,7 +54,7 @@ import {
   type SlackCompletionContext,
 } from "./slack-completion";
 import { UserStore } from "../db/user-store";
-import { createRequestMetrics } from "../db/instrumented-d1";
+import { createRequestMetrics } from "../db/instrumented-sql-database";
 import { generateId } from "../auth/crypto";
 import { createLogger, parseLogLevel } from "../logger";
 import type { CorrelationContext, Logger } from "../logger";


### PR DESCRIPTION
## Summary

The request-metrics wrapper over the global store and its wide-event fields were named for D1: `instrumentD1`, `D1QueryRecord`, `d1_query_count`, `d1_total_ms`, `d1_server_total_ms`, `d1_rows_read`, `d1_rows_written`. The Node host (H-1, COL-97) passes its SQLite global store through the same wrapper, and its traffic would then report as D1 activity. The wrapper is over the `SqlDatabase` port, so it is now named for the port.

| Before | After |
|---|---|
| `src/db/instrumented-d1.ts` | `src/db/instrumented-sql-database.ts` |
| `instrumentD1(db, metrics)` | `instrumentSqlDatabase(db, metrics)` |
| `D1QueryRecord` / `metrics.d1Queries` | `SqlQueryRecord` / `metrics.sqlQueries` |
| record field `d1_server_ms` | `engine_ms` |
| `d1_query_count`, `d1_total_ms`, `d1_server_total_ms`, `d1_rows_read`, `d1_rows_written` | `sql_query_count`, `sql_total_ms`, `sql_engine_total_ms`, `sql_rows_read`, `sql_rows_written` |

No behaviour change. Nothing outside `packages/control-plane/src` reads the old field names (`scripts/cf-logs.ts`, web, and docs were grepped), so no dashboard or log query needs updating on our side.

This is the COL-97 addendum from the #1755 review, split out so the Node entry PR is only the Node entry.

## Test plan

- [x] `npm run typecheck` (all four programs)
- [x] `eslint packages/control-plane/src`, prettier
- [x] Unit suites touching the metrics: `instrumented-sql-database`, `request-lifecycle`, `router.create-session`, the four route suites and `slack-notify` (121 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Generalized database instrumentation and request metrics from provider-specific terminology to SQL-generic terminology.
  - Updated query timing, row-count, and summary metrics to use consistent SQL naming.
  - Metrics now omit engine totals and row counts when the database does not report them.
  - Expanded support for SQL database adapters, including SQLite batch and query handling.

- **Tests**
  - Added coverage for generic SQL interfaces, metadata handling, bind preservation, and SQLite integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->