### PR TITLE
feat: Node host entry and build: HTTP server, WebSocket upgrade path, /healthz, cron loop, drain (COL-97)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -218,7 +218,7 @@ export default tseslint.config(
               // this package, so anchoring on it is precise.
               regex: "(?:^|/)components(?:\\.[cm]?[jt]sx?)?$",
               message:
-                "Only the platform adapter (cloudflare/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
+                "Only the platform adapters (cloudflare/durable-object.ts, node/host.ts) may import the composition root. Take dependencies as constructor inputs instead.",
             },
             {
               regex: "(?:^|/)durable-object(?:\\.[cm]?[jt]sx?)?$",
@@ -239,10 +239,12 @@ export default tseslint.config(
     },
   },
   // The Node host's adapters may import each other but not the Cloudflare
-  // edge or the composition root.
+  // edge or the composition root. The Node host itself (src/node/host.ts)
+  // is the Node counterpart of the Durable Object adapter: it builds the
+  // session runtime, so it may import the composition root, and it alone.
   {
     files: ["packages/control-plane/src/node/**/*.ts"],
-    ignores: ["packages/control-plane/src/**/*.test.ts"],
+    ignores: ["packages/control-plane/src/**/*.test.ts", "packages/control-plane/src/node/host.ts"],
     rules: {
       "no-restricted-imports": [
         "error",
@@ -251,8 +253,25 @@ export default tseslint.config(
             {
               regex: "(?:^|/)components(?:\\.[cm]?[jt]sx?)?$",
               message:
-                "Only the platform adapter (cloudflare/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
+                "Only the platform adapters (cloudflare/durable-object.ts, node/host.ts) may import the composition root. Take dependencies as constructor inputs instead.",
             },
+            {
+              regex: "(?:^|/)durable-object(?:\\.[cm]?[jt]sx?)?$",
+              message:
+                "Only the worker entrypoint (src/index.ts) may import the platform adapter. Depend on the session collaborators, not the Durable Object.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["packages/control-plane/src/node/host.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
             {
               regex: "(?:^|/)durable-object(?:\\.[cm]?[jt]sx?)?$",
               message:
@@ -278,7 +297,7 @@ export default tseslint.config(
               // this package, so anchoring on it is precise.
               regex: "(?:^|/)components(?:\\.[cm]?[jt]sx?)?$",
               message:
-                "Only the platform adapter (cloudflare/durable-object.ts) may import the composition root. Take dependencies as constructor inputs instead.",
+                "Only the platform adapters (cloudflare/durable-object.ts, node/host.ts) may import the composition root. Take dependencies as constructor inputs instead.",
             },
             {
               // The directory and anything under it, by relative path or the

--- a/package-lock.json
+++ b/package-lock.json
@@ -2474,6 +2474,18 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -17703,6 +17715,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.984.0",
         "@cloudflare/workers-types": "^4.20241230.0",
+        "@hono/node-server": "^2.1.1",
         "@open-inspect/shared": "file:../shared",
         "better-auth": "1.6.25",
         "hono": "^4.13.5",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js --platform=browser --target=es2022 --conditions=workerd,module --external:cloudflare:* --external:node:* --metafile=dist/meta.json",
+    "build:node": "esbuild src/node/main.ts --bundle --format=esm --outfile=dist/node/main.js --platform=node --target=node22 --external:node:* --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\" --metafile=dist/node/meta.json",
+    "start:node": "node dist/node/main.js",
     "build:vercel-base-snapshot": "esbuild scripts/build-vercel-base-snapshot.ts --bundle --format=esm --platform=node --target=node22 --outfile=dist/vercel-base-snapshot.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -16,6 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.984.0",
     "@cloudflare/workers-types": "^4.20241230.0",
+    "@hono/node-server": "^2.1.1",
     "@open-inspect/shared": "file:../shared",
     "better-auth": "1.6.25",
     "hono": "^4.13.5",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js --platform=browser --target=es2022 --conditions=workerd,module --external:cloudflare:* --external:node:* --metafile=dist/meta.json",
+    "build": "npm run build:worker && npm run build:node",
+    "build:worker": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js --platform=browser --target=es2022 --conditions=workerd,module --external:cloudflare:* --external:node:* --metafile=dist/meta.json",
     "build:node": "esbuild src/node/main.ts --bundle --format=esm --outfile=dist/node/main.js --platform=node --target=node22 --external:node:* --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\" --metafile=dist/node/meta.json",
     "start:node": "node dist/node/main.js",
     "build:vercel-base-snapshot": "esbuild scripts/build-vercel-base-snapshot.ts --bundle --format=esm --platform=node --target=node22 --outfile=dist/vercel-base-snapshot.js",

--- a/packages/control-plane/src/cloudflare/http-host.ts
+++ b/packages/control-plane/src/cloudflare/http-host.ts
@@ -1,0 +1,37 @@
+/** The Cloudflare Worker's ordinary HTTP entrypoint over the control-plane app. */
+
+import { catalog } from "../routes/catalog";
+import {
+  createControlPlaneApp,
+  type ControlPlaneHost,
+  type RouteModule,
+} from "../routing/hono-app";
+import type { Env } from "../types";
+import { createCloudflareBackgroundTasks } from "./background-tasks";
+
+/** The Worker's ordinary HTTP entrypoint signature, shared with the integration adapters. */
+export type ControlPlaneHttpHandler = (
+  request: Request,
+  env: Env,
+  executionCtx: ExecutionContext
+) => Promise<Response>;
+
+/** The Cloudflare Worker host: background tasks ride the event's `waitUntil`. */
+export const cloudflareHost: ControlPlaneHost = {
+  backgroundTasks: (executionCtx) => {
+    if (!executionCtx) throw new Error("The Cloudflare host requires an execution context");
+    return createCloudflareBackgroundTasks(executionCtx);
+  },
+};
+
+/** Build the Worker's ordinary HTTP entrypoint over route modules. */
+export function createControlPlaneHttpHandler(
+  modules: readonly RouteModule[]
+): ControlPlaneHttpHandler {
+  const app = createControlPlaneApp(modules, cloudflareHost);
+  return (request, env, executionCtx) => Promise.resolve(app.fetch(request, env, executionCtx));
+}
+
+/** Production entrypoint over the canonical route catalog. */
+export const handleControlPlaneHttp: ControlPlaneHttpHandler =
+  createControlPlaneHttpHandler(catalog);

--- a/packages/control-plane/src/env-validation.ts
+++ b/packages/control-plane/src/env-validation.ts
@@ -7,7 +7,7 @@
  * absence always means a broken deployment.
  */
 
-import type { Env } from "./types";
+import type { EnvConfig } from "./types";
 
 /** Strict base64 — rejects whitespace and stray characters `atob` may accept. */
 const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
@@ -45,7 +45,9 @@ function requireEncryptionKey(key: string | undefined, name: string, protects: s
   return key;
 }
 
-export function requireRepoSecretsEncryptionKey(env: Env): string {
+export function requireRepoSecretsEncryptionKey(
+  env: Pick<EnvConfig, "REPO_SECRETS_ENCRYPTION_KEY">
+): string {
   return requireEncryptionKey(
     env.REPO_SECRETS_ENCRYPTION_KEY,
     "REPO_SECRETS_ENCRYPTION_KEY",
@@ -53,6 +55,6 @@ export function requireRepoSecretsEncryptionKey(env: Env): string {
   );
 }
 
-export function requireTokenEncryptionKey(env: Env): string {
+export function requireTokenEncryptionKey(env: Pick<EnvConfig, "TOKEN_ENCRYPTION_KEY">): string {
   return requireEncryptionKey(env.TOKEN_ENCRYPTION_KEY, "TOKEN_ENCRYPTION_KEY", "OAuth tokens");
 }

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -4,7 +4,7 @@
  * Cloudflare Workers entry point with Durable Objects for session management.
  */
 
-import { handleControlPlaneHttp } from "./routing/hono-app";
+import { handleControlPlaneHttp } from "./cloudflare/http-host";
 import { createLogger } from "./logger";
 import type { GitHubAutofixEnvelope } from "@open-inspect/shared";
 import { handleAutofixQueue } from "./autofix/handler";

--- a/packages/control-plane/src/node/background-tasks.ts
+++ b/packages/control-plane/src/node/background-tasks.ts
@@ -71,8 +71,8 @@ export function createNodeBackgroundTasks(log: Logger): NodeBackgroundTasks {
   };
 }
 
-/** Whether every task in `tasks` settles within `ms`. */
-function settlesWithin(tasks: Promise<unknown>[], ms: number): Promise<boolean> {
+/** Whether every promise in `tasks` settles within `ms`. */
+export function settlesWithin(tasks: Promise<unknown>[], ms: number): Promise<boolean> {
   return new Promise((resolve) => {
     const timer = setTimeout(() => resolve(false), ms);
     void Promise.allSettled(tasks).then(() => {

--- a/packages/control-plane/src/node/config.test.ts
+++ b/packages/control-plane/src/node/config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MIGRATIONS_DIR, readEnvConfig, readNodeHostSettings } from "./config";
+
+const REQUIRED = {
+  DEPLOYMENT_NAME: "test",
+  GITHUB_BOT_USERNAME: "bot[bot]",
+  TOKEN_ENCRYPTION_KEY: "k1",
+  PROVIDER_ACCOUNTS_ENCRYPTION_KEY: "k2",
+};
+
+describe("readEnvConfig", () => {
+  it("takes every EnvConfig field from the source and nothing else", () => {
+    const config = readEnvConfig({
+      ...REQUIRED,
+      LOG_LEVEL: "debug",
+      SANDBOX_PROVIDER: "e2b",
+      PATH: "/usr/bin",
+      DATA_DIR: "/var/lib/oi",
+    });
+    expect(config).toEqual({ ...REQUIRED, LOG_LEVEL: "debug", SANDBOX_PROVIDER: "e2b" });
+  });
+
+  it("treats an empty variable as unset", () => {
+    const config = readEnvConfig({ ...REQUIRED, LOG_LEVEL: "" });
+    expect("LOG_LEVEL" in config).toBe(false);
+  });
+
+  it("names every missing required variable at once", () => {
+    expect(() => readEnvConfig({ DEPLOYMENT_NAME: "test", TOKEN_ENCRYPTION_KEY: "" })).toThrow(
+      "Missing required configuration: GITHUB_BOT_USERNAME, TOKEN_ENCRYPTION_KEY, PROVIDER_ACCOUNTS_ENCRYPTION_KEY"
+    );
+  });
+});
+
+describe("readNodeHostSettings", () => {
+  it("requires DATA_DIR and defaults the rest", () => {
+    expect(() => readNodeHostSettings({})).toThrow("DATA_DIR is required");
+    const settings = readNodeHostSettings({ DATA_DIR: "/var/lib/oi" });
+    expect(settings).toEqual({
+      host: "0.0.0.0",
+      port: 8787,
+      dataDir: "/var/lib/oi",
+      migrationsDir: DEFAULT_MIGRATIONS_DIR,
+      shutdownTimeoutMs: 30_000,
+    });
+    expect(DEFAULT_MIGRATIONS_DIR.endsWith("/terraform/d1/migrations")).toBe(true);
+  });
+
+  it("reads the overrides and rejects a malformed number", () => {
+    const settings = readNodeHostSettings({
+      DATA_DIR: "data",
+      HOST: "127.0.0.1",
+      PORT: "9000",
+      MIGRATIONS_DIR: "/srv/migrations",
+      SHUTDOWN_TIMEOUT_MS: "5000",
+    });
+    expect(settings.host).toBe("127.0.0.1");
+    expect(settings.port).toBe(9000);
+    expect(settings.dataDir).toBe(`${process.cwd()}/data`);
+    expect(settings.migrationsDir).toBe("/srv/migrations");
+    expect(settings.shutdownTimeoutMs).toBe(5000);
+    expect(() => readNodeHostSettings({ DATA_DIR: "data", PORT: "80a" })).toThrow(
+      "PORT must be a non-negative integer, got 80a"
+    );
+  });
+});

--- a/packages/control-plane/src/node/config.ts
+++ b/packages/control-plane/src/node/config.ts
@@ -1,0 +1,181 @@
+/**
+ * The Node host's configuration from the process environment.
+ *
+ * `EnvConfig` (types.ts) is the deployment's configuration on every host:
+ * on Workers each field is a binding Terraform declares; here each is a
+ * process environment variable of the same name, so one `.env` describes
+ * a deployment on either. The key table below is checked against the type
+ * at compile time, so a field added to `EnvConfig` must be added here too.
+ *
+ * An empty variable counts as unset, as `FOO=` in an env file means "no
+ * value" rather than "the empty string".
+ *
+ * The host's own settings (`PORT`, `HOST`, `DATA_DIR`, `MIGRATIONS_DIR`,
+ * `SHUTDOWN_TIMEOUT_MS`) have no Workers counterpart and are read apart.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { EnvConfig } from "../types";
+
+/** A source of configuration values, `process.env` in production. */
+export type ConfigSource = Record<string, string | undefined>;
+
+/** Every `EnvConfig` field. `satisfies` fails if the table and the type ever disagree. */
+const ENV_CONFIG_KEYS = {
+  GITHUB_CLIENT_ID: true,
+  GITHUB_CLIENT_SECRET: true,
+  GOOGLE_CLIENT_ID: true,
+  GOOGLE_CLIENT_SECRET: true,
+  BROWSER_AUTH_SECRET: true,
+  TOKEN_ENCRYPTION_KEY: true,
+  PROVIDER_ACCOUNTS_ENCRYPTION_KEY: true,
+  REPO_SECRETS_ENCRYPTION_KEY: true,
+  MODAL_TOKEN_ID: true,
+  MODAL_TOKEN_SECRET: true,
+  MODAL_API_SECRET: true,
+  ANTHROPIC_API_KEY: true,
+  DAYTONA_API_KEY: true,
+  OPENCOMPUTER_API_KEY: true,
+  VERCEL_TOKEN: true,
+  IMAGE_CALLBACK_TOKEN_PEPPER: true,
+  SERVICE_AUTH_SECRET_WEB: true,
+  SERVICE_AUTH_SECRET_SLACK_BOT: true,
+  SERVICE_AUTH_SECRET_GITHUB_BOT: true,
+  SERVICE_AUTH_SECRET_LINEAR_BOT: true,
+  SLACK_BOT_TOKEN: true,
+  GITHUB_APP_ID: true,
+  GITHUB_APP_PRIVATE_KEY: true,
+  GITHUB_APP_INSTALLATION_ID: true,
+  GITLAB_ACCESS_TOKEN: true,
+  GITLAB_NAMESPACE: true,
+  DEPLOYMENT_NAME: true,
+  APP_NAME: true,
+  GITHUB_BOT_USERNAME: true,
+  SCM_PROVIDER: true,
+  WORKER_URL: true,
+  WEB_APP_URL: true,
+  ALLOWED_USERS: true,
+  ALLOWED_EMAIL_DOMAINS: true,
+  ALLOWED_EMAILS: true,
+  ALLOWED_GITHUB_ORGS: true,
+  UNSAFE_ALLOW_ALL_USERS: true,
+  CF_ACCOUNT_ID: true,
+  SANDBOX_PROVIDER: true,
+  MODAL_WORKSPACE: true,
+  MODAL_ENVIRONMENT: true,
+  MODAL_ENVIRONMENT_WEB_SUFFIX: true,
+  DAYTONA_API_URL: true,
+  DAYTONA_BASE_SNAPSHOT: true,
+  DAYTONA_AUTO_STOP_INTERVAL_MINUTES: true,
+  DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES: true,
+  DAYTONA_TARGET: true,
+  OPENCOMPUTER_API_URL: true,
+  OPENCOMPUTER_TEMPLATE: true,
+  VERCEL_PROJECT_ID: true,
+  VERCEL_TEAM_ID: true,
+  VERCEL_BASE_SNAPSHOT_ID: true,
+  VERCEL_BASE_SNAPSHOT_NAME: true,
+  VERCEL_RUNTIME: true,
+  VERCEL_SANDBOX_API_BASE_URL: true,
+  VERCEL_SNAPSHOT_EXPIRATION_MS: true,
+  E2B_API_KEY: true,
+  E2B_API_URL: true,
+  E2B_TEMPLATE_ID: true,
+  E2B_SANDBOX_TIMEOUT_SECONDS: true,
+  E2B_AUTO_PAUSE: true,
+  SANDBOX_INACTIVITY_TIMEOUT_MS: true,
+  EXECUTION_TIMEOUT_MS: true,
+  SECRETS_CAP_ENFORCEMENT: true,
+  LOG_LEVEL: true,
+} as const satisfies Record<keyof EnvConfig, true>;
+
+/** The `EnvConfig` fields the type does not mark optional. */
+type RequiredEnvConfigKey = {
+  [K in keyof EnvConfig]-?: undefined extends EnvConfig[K] ? never : K;
+}[keyof EnvConfig];
+
+/** The required fields, checked against the type like the table above. */
+const REQUIRED_ENV_CONFIG_KEYS = {
+  DEPLOYMENT_NAME: true,
+  GITHUB_BOT_USERNAME: true,
+  TOKEN_ENCRYPTION_KEY: true,
+  PROVIDER_ACCOUNTS_ENCRYPTION_KEY: true,
+} as const satisfies Record<RequiredEnvConfigKey, true>;
+
+/**
+ * The deployment's configuration from `source`. Fails naming every required
+ * variable that is missing, so one boot reports the whole gap. Encryption
+ * keys are validated by `env-validation` once the environment is built.
+ */
+export function readEnvConfig(source: ConfigSource): EnvConfig {
+  const config: Partial<Record<keyof EnvConfig, string>> = {};
+  for (const key of Object.keys(ENV_CONFIG_KEYS) as (keyof EnvConfig)[]) {
+    const value = source[key];
+    if (value !== undefined && value !== "") config[key] = value;
+  }
+  const missing = Object.keys(REQUIRED_ENV_CONFIG_KEYS).filter(
+    (key) => config[key as keyof EnvConfig] === undefined
+  );
+  if (missing.length > 0) {
+    throw new Error(`Missing required configuration: ${missing.join(", ")}`);
+  }
+  return config as EnvConfig;
+}
+
+/** What the process itself needs: where to listen and where its files live. */
+export interface NodeHostSettings {
+  /** Interface to listen on; `0.0.0.0` unless `HOST` says otherwise. */
+  host: string;
+  /** `PORT`; 8787 unless set, the port the Worker's local dev server uses. */
+  port: number;
+  /** `DATA_DIR`: the global store, the session files, and the host alarm index live here. */
+  dataDir: string;
+  /** `MIGRATIONS_DIR`: the D1 migration files, applied to the global store at boot. */
+  migrationsDir: string;
+  /** `SHUTDOWN_TIMEOUT_MS`: how long a drain waits for work before the host is forced down. */
+  shutdownTimeoutMs: number;
+}
+
+const DEFAULT_PORT = 8787;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+/**
+ * The migrations as the repository lays them out, relative to this module:
+ * `src/node` and the bundle's `dist/node` sit at the same depth below the
+ * repository root. A container sets `MIGRATIONS_DIR` explicitly.
+ */
+export const DEFAULT_MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../terraform/d1/migrations"
+);
+
+/** The host's settings from `source`; `DATA_DIR` is the one with no default. */
+export function readNodeHostSettings(source: ConfigSource): NodeHostSettings {
+  const dataDir = present(source.DATA_DIR);
+  if (dataDir === undefined) {
+    throw new Error("DATA_DIR is required: the directory that holds the host's databases");
+  }
+  return {
+    host: present(source.HOST) ?? "0.0.0.0",
+    port: integer("PORT", source.PORT, DEFAULT_PORT),
+    dataDir: resolve(dataDir),
+    migrationsDir: resolve(present(source.MIGRATIONS_DIR) ?? DEFAULT_MIGRATIONS_DIR),
+    shutdownTimeoutMs: integer(
+      "SHUTDOWN_TIMEOUT_MS",
+      source.SHUTDOWN_TIMEOUT_MS,
+      DEFAULT_SHUTDOWN_TIMEOUT_MS
+    ),
+  };
+}
+
+function present(value: string | undefined): string | undefined {
+  return value === undefined || value === "" ? undefined : value;
+}
+
+function integer(name: string, value: string | undefined, fallback: number): number {
+  const raw = present(value);
+  if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} must be a non-negative integer, got ${raw}`);
+  return Number(raw);
+}

--- a/packages/control-plane/src/node/cron-loop.test.ts
+++ b/packages/control-plane/src/node/cron-loop.test.ts
@@ -101,6 +101,23 @@ describe("CronLoop", () => {
     expect(vi.getTimerCount()).toBe(1);
   });
 
+  it("reports a run that outlives the drain budget instead of waiting for it", async () => {
+    const run = vi.fn(() => new Promise<void>(() => {}));
+    loop = new CronLoop({ jobs: [job("tick", "* * * * *")], run, log });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    loop.stop();
+    const drained = loop.drain(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await drained).toBe(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "scheduled_job.drain_timeout",
+      expect.objectContaining({ timeout_ms: 1_000, jobs: ["tick"] })
+    );
+  });
+
   it("stops firing once stopped and drains the run in progress", async () => {
     let finish!: () => void;
     const settled = vi.fn();
@@ -115,9 +132,9 @@ describe("CronLoop", () => {
     expect(run).toHaveBeenCalledTimes(1);
 
     loop.stop();
-    const drained = loop.drain();
+    const drained = loop.drain(5_000);
     finish();
-    await drained;
+    expect(await drained).toBe(0);
     expect(settled).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(120_000);
     expect(run).toHaveBeenCalledTimes(1);

--- a/packages/control-plane/src/node/cron-loop.test.ts
+++ b/packages/control-plane/src/node/cron-loop.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import type { ScheduledJob } from "../scheduled-jobs";
+import { CronLoop } from "./cron-loop";
+
+const T0 = Date.UTC(2026, 0, 1, 0, 0, 30);
+
+function fakeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger;
+}
+
+function job(name: string, cron: string): ScheduledJob {
+  return { name, cron, run: async () => {} };
+}
+
+describe("CronLoop", () => {
+  let log: Logger;
+  let loop: CronLoop | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: T0 });
+    log = fakeLogger();
+    loop = null;
+  });
+
+  afterEach(() => {
+    loop?.stop();
+    vi.useRealTimers();
+  });
+
+  it("fires each job at its next slot and re-arms from the slot", async () => {
+    const run = vi.fn<(job: ScheduledJob, nowMs: number) => Promise<void>>(async () => {});
+    loop = new CronLoop({ jobs: [job("tick", "* * * * *"), job("hourly", "0 * * * *")], run, log });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(run).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ name: "tick" }), T0 + 30_000);
+
+    await vi.advanceTimersByTimeAsync(60_000 * 59 + 30_000);
+    const names = run.mock.calls.map(([called]) => called.name);
+    expect(names.filter((name) => name === "tick")).toHaveLength(60);
+    expect(names.filter((name) => name === "hourly")).toHaveLength(1);
+  });
+
+  it("skips a slot while the previous run of the same job is still going", async () => {
+    let finish!: () => void;
+    const run = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    loop = new CronLoop({ jobs: [job("tick", "* * * * *")], run, log });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "scheduled_job.skipped",
+      expect.objectContaining({ job: "tick", reason: "previous_run_in_progress" })
+    );
+
+    finish();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs a failed run and keeps the schedule", async () => {
+    const run = vi
+      .fn<(job: ScheduledJob, nowMs: number) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(undefined);
+    loop = new CronLoop({ jobs: [job("tick", "* * * * *")], run, log });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(log.error).toHaveBeenCalledWith(
+      "scheduled_job.failed",
+      expect.objectContaining({ job: "tick", error: expect.any(Error) })
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds a far slot across the timer's maximum delay", async () => {
+    const run = vi.fn(async () => {});
+    loop = new CronLoop({ jobs: [job("yearly", "0 0 1 1 *")], run, log });
+    loop.start();
+
+    await vi.advanceTimersByTimeAsync(2 ** 31);
+    expect(run).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("stops firing once stopped and drains the run in progress", async () => {
+    let finish!: () => void;
+    const settled = vi.fn();
+    const run = vi.fn(() =>
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }).then(settled)
+    );
+    loop = new CronLoop({ jobs: [job("tick", "* * * * *")], run, log });
+    loop.start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    loop.stop();
+    const drained = loop.drain();
+    finish();
+    await drained;
+    expect(settled).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/control-plane/src/node/cron-loop.ts
+++ b/packages/control-plane/src/node/cron-loop.ts
@@ -13,6 +13,7 @@
 
 import { nextCronOccurrence } from "@open-inspect/shared/cron";
 import type { Logger } from "../logger";
+import { settlesWithin } from "./background-tasks";
 import type { ScheduledJob } from "../scheduled-jobs";
 
 /** The longest delay a single timer can hold; farther slots re-arm. */
@@ -56,9 +57,25 @@ export class CronLoop {
     this.timers.clear();
   }
 
-  /** Resolves once every run that was in progress has settled. */
-  async drain(): Promise<void> {
-    await Promise.allSettled([...this.running.values()]);
+  /**
+   * Wait for every run in progress for at most `timeoutMs`. Runs still
+   * going at the deadline are logged by job and left running; returns how
+   * many there were.
+   */
+  async drain(timeoutMs: number): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.running.size > 0) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0 || !(await settlesWithin([...this.running.values()], remaining))) break;
+    }
+    if (this.running.size > 0) {
+      this.log.warn("scheduled_job.drain_timeout", {
+        event: "scheduled_job.drain_timeout",
+        timeout_ms: timeoutMs,
+        jobs: [...this.running.keys()],
+      });
+    }
+    return this.running.size;
   }
 
   private arm(job: ScheduledJob): void {

--- a/packages/control-plane/src/node/cron-loop.ts
+++ b/packages/control-plane/src/node/cron-loop.ts
@@ -1,0 +1,106 @@
+/**
+ * The Node host's cron: one timer per scheduled job, armed for the job's
+ * next occurrence in UTC (the zone the Worker's triggers fire in) and
+ * re-armed as soon as it fires, so a run's duration never shifts the
+ * schedule. A slot whose previous run is still going is skipped and
+ * logged: the jobs are idempotent and claim their work with compare-and-
+ * swap, so a missed slot costs one interval, while two overlapping runs
+ * of the same job would only contend.
+ *
+ * The clock is read per arm and per fire, so a timer that fired early
+ * against the wall clock re-arms for the same slot instead of running it.
+ */
+
+import { nextCronOccurrence } from "@open-inspect/shared/cron";
+import type { Logger } from "../logger";
+import type { ScheduledJob } from "../scheduled-jobs";
+
+/** The longest delay a single timer can hold; farther slots re-arm. */
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+export interface CronLoopOptions {
+  jobs: readonly ScheduledJob[];
+  /** Run `job` for the slot that fired; the host builds the job's dependencies here. */
+  run: (job: ScheduledJob, nowMs: number) => Promise<void>;
+  log: Logger;
+  now?: () => number;
+}
+
+export class CronLoop {
+  private readonly jobs: readonly ScheduledJob[];
+  private readonly run: (job: ScheduledJob, nowMs: number) => Promise<void>;
+  private readonly log: Logger;
+  private readonly now: () => number;
+  private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly running = new Map<string, Promise<void>>();
+  private started = false;
+
+  constructor(options: CronLoopOptions) {
+    this.jobs = options.jobs;
+    this.run = options.run;
+    this.log = options.log;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Arm every job for its next slot. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    for (const job of this.jobs) this.arm(job);
+  }
+
+  /** Fire nothing further. Runs in progress are not interrupted. */
+  stop(): void {
+    this.started = false;
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+  }
+
+  /** Resolves once every run that was in progress has settled. */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.running.values()]);
+  }
+
+  private arm(job: ScheduledJob): void {
+    if (!this.started) return;
+    const nowMs = this.now();
+    const slotMs = nextCronOccurrence(job.cron, "UTC", new Date(nowMs)).getTime();
+    const timer = setTimeout(
+      () => this.fire(job, slotMs),
+      Math.min(Math.max(0, slotMs - nowMs), MAX_TIMER_DELAY_MS)
+    );
+    this.timers.set(job.name, timer);
+  }
+
+  private fire(job: ScheduledJob, slotMs: number): void {
+    this.timers.delete(job.name);
+    // A capped or early timer: the slot is still ahead, so wait for it.
+    if (this.now() < slotMs) {
+      this.arm(job);
+      return;
+    }
+    this.arm(job);
+    if (this.running.has(job.name)) {
+      this.log.warn("scheduled_job.skipped", {
+        event: "scheduled_job.skipped",
+        job: job.name,
+        slot: new Date(slotMs).toISOString(),
+        reason: "previous_run_in_progress",
+      });
+      return;
+    }
+    const run = this.run(job, this.now())
+      .catch((error: unknown) => {
+        this.log.error("scheduled_job.failed", {
+          event: "scheduled_job.failed",
+          job: job.name,
+          slot: new Date(slotMs).toISOString(),
+          error: error instanceof Error ? error : String(error),
+        });
+      })
+      .finally(() => {
+        this.running.delete(job.name);
+      });
+    this.running.set(job.name, run);
+  }
+}

--- a/packages/control-plane/src/node/host.test.ts
+++ b/packages/control-plane/src/node/host.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket as NodeWebSocket } from "ws";
+import { DEFAULT_MIGRATIONS_DIR, type NodeHostSettings } from "./config";
+import { GLOBAL_STORE_FILE, startNodeHost, type NodeHost } from "./host";
+import type { HealthReport } from "./http-server";
+
+const KEY = Buffer.alloc(32, 7).toString("base64");
+
+const CONFIG = {
+  DEPLOYMENT_NAME: "test",
+  GITHUB_BOT_USERNAME: "open-inspect[bot]",
+  TOKEN_ENCRYPTION_KEY: KEY,
+  PROVIDER_ACCOUNTS_ENCRYPTION_KEY: KEY,
+  REPO_SECRETS_ENCRYPTION_KEY: KEY,
+  LOG_LEVEL: "error",
+};
+
+const OBJECT_STORAGE = { bucket: "media", region: "us-east-1" };
+
+describe("startNodeHost", () => {
+  let dataDir: string;
+  let host: NodeHost | null = null;
+
+  const settings = (): NodeHostSettings => ({
+    host: "127.0.0.1",
+    port: 0,
+    dataDir,
+    migrationsDir: DEFAULT_MIGRATIONS_DIR,
+    shutdownTimeoutMs: 5_000,
+  });
+
+  afterEach(async () => {
+    await host?.shutdown();
+    host = null;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("boots over the migrated global store and answers the health check and the route table", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    host = await startNodeHost({
+      config: CONFIG,
+      settings: settings(),
+      objectStorage: OBJECT_STORAGE,
+    });
+    const base = `http://127.0.0.1:${host.address.port}`;
+    expect(existsSync(join(dataDir, GLOBAL_STORE_FILE))).toBe(true);
+
+    const health = await fetch(`${base}/healthz`);
+    expect(health.status).toBe(200);
+    const report = (await health.json()) as HealthReport;
+    expect(report).toMatchObject({
+      status: "ok",
+      sessions_resident: 0,
+      alarm_clock: "running",
+      cron: "running",
+    });
+    expect(report.migrations_applied).toBeGreaterThan(0);
+
+    const missing = await fetch(`${base}/no-such-route`);
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: "Not found" });
+    expect(missing.headers.get("x-request-id")).toBeTruthy();
+
+    // A catalog route answers through admission: unauthenticated, not unknown.
+    const listed = await fetch(`${base}/sessions`);
+    expect(listed.status).toBe(401);
+  });
+
+  it("refuses a WebSocket upgrade for an unknown session and any other upgrade path", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    host = await startNodeHost({
+      config: CONFIG,
+      settings: settings(),
+      objectStorage: OBJECT_STORAGE,
+    });
+    const base = `ws://127.0.0.1:${host.address.port}`;
+    const rejection = (path: string): Promise<string> =>
+      new Promise((resolve) => {
+        new NodeWebSocket(`${base}${path}`).once("error", (error) => resolve(error.message));
+      });
+    expect(await rejection("/sessions/unknown/ws")).toBe("Unexpected server response: 404");
+    expect(await rejection("/sessions/unknown/events")).toBe("Unexpected server response: 400");
+  });
+
+  it("reports draining once a shutdown begins and stops listening when it ends", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    host = await startNodeHost({
+      config: CONFIG,
+      settings: settings(),
+      objectStorage: OBJECT_STORAGE,
+    });
+    const base = `http://127.0.0.1:${host.address.port}`;
+
+    const stopping = host.shutdown();
+    expect(host.health().status).toBe("draining");
+    await stopping;
+    await expect(host.shutdown()).resolves.toBeUndefined();
+    await expect(fetch(`${base}/healthz`)).rejects.toThrow();
+    host = null;
+  });
+
+  it("fails to boot on a malformed encryption key with the Worker's message", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    await expect(
+      startNodeHost({
+        config: { ...CONFIG, TOKEN_ENCRYPTION_KEY: "c2hvcnQ=" },
+        settings: settings(),
+        objectStorage: OBJECT_STORAGE,
+      })
+    ).rejects.toThrow("TOKEN_ENCRYPTION_KEY must decode to 32 bytes for AES-256, got 5");
+  });
+});

--- a/packages/control-plane/src/node/host.test.ts
+++ b/packages/control-plane/src/node/host.test.ts
@@ -1,10 +1,14 @@
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket } from "ws";
+import { NO_AUTHORIZATION } from "../routes/shared";
+import { admit } from "../routing/admit";
+import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import { DEFAULT_MIGRATIONS_DIR, type NodeHostSettings } from "./config";
-import { GLOBAL_STORE_FILE, startNodeHost, type NodeHost } from "./host";
+import { GLOBAL_STORE_FILE, startNodeHost, type NodeHost, type NodeHostOptions } from "./host";
 import type { HealthReport } from "./http-server";
 
 const KEY = Buffer.alloc(32, 7).toString("base64");
@@ -20,31 +24,60 @@ const CONFIG = {
 
 const OBJECT_STORAGE = { bucket: "media", region: "us-east-1" };
 
+/** A public route that answers once `release` is called, for shutdown against work in flight. */
+function blockingRoute(): { routes: Hono<ControlPlaneHonoEnv>[]; release: () => void } {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const routes = new Hono<ControlPlaneHonoEnv>();
+  routes.get(
+    "/block",
+    admit({
+      authentication: { kind: "public" },
+      supportedScmProviders: "all",
+      authorization: NO_AUTHORIZATION,
+    }),
+    async () => {
+      await held;
+      return Response.json({ released: true });
+    }
+  );
+  return { routes: [routes], release };
+}
+
 describe("startNodeHost", () => {
   let dataDir: string;
   let host: NodeHost | null = null;
 
-  const settings = (): NodeHostSettings => ({
+  const settings = (overrides: Partial<NodeHostSettings> = {}): NodeHostSettings => ({
     host: "127.0.0.1",
     port: 0,
     dataDir,
     migrationsDir: DEFAULT_MIGRATIONS_DIR,
     shutdownTimeoutMs: 5_000,
+    ...overrides,
   });
+
+  const start = (overrides: Partial<NodeHostOptions> = {}): Promise<NodeHost> => {
+    dataDir ??= mkdtempSync(join(tmpdir(), "node-host-"));
+    return startNodeHost({
+      config: CONFIG,
+      settings: settings(),
+      objectStorage: OBJECT_STORAGE,
+      ...overrides,
+    });
+  };
 
   afterEach(async () => {
     await host?.shutdown();
     host = null;
     rmSync(dataDir, { recursive: true, force: true });
+    dataDir = undefined as unknown as string;
   });
 
   it("boots over the migrated global store and answers the health check and the route table", async () => {
-    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
-    host = await startNodeHost({
-      config: CONFIG,
-      settings: settings(),
-      objectStorage: OBJECT_STORAGE,
-    });
+    host = await start();
     const base = `http://127.0.0.1:${host.address.port}`;
     expect(existsSync(join(dataDir, GLOBAL_STORE_FILE))).toBe(true);
 
@@ -70,12 +103,7 @@ describe("startNodeHost", () => {
   });
 
   it("refuses a WebSocket upgrade for an unknown session and any other upgrade path", async () => {
-    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
-    host = await startNodeHost({
-      config: CONFIG,
-      settings: settings(),
-      objectStorage: OBJECT_STORAGE,
-    });
+    host = await start();
     const base = `ws://127.0.0.1:${host.address.port}`;
     const rejection = (path: string): Promise<string> =>
       new Promise((resolve) => {
@@ -86,30 +114,92 @@ describe("startNodeHost", () => {
   });
 
   it("reports draining once a shutdown begins and stops listening when it ends", async () => {
-    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
-    host = await startNodeHost({
-      config: CONFIG,
-      settings: settings(),
-      objectStorage: OBJECT_STORAGE,
-    });
+    host = await start();
     const base = `http://127.0.0.1:${host.address.port}`;
 
     const stopping = host.shutdown();
     expect(host.health().status).toBe("draining");
-    await stopping;
-    await expect(host.shutdown()).resolves.toBeUndefined();
+    expect(await stopping).toEqual({ clean: true, abandoned: [] });
+    await expect(host.shutdown()).resolves.toEqual({ clean: true, abandoned: [] });
     await expect(fetch(`${base}/healthz`)).rejects.toThrow();
     host = null;
   });
 
-  it("fails to boot on a malformed encryption key with the Worker's message", async () => {
+  it("waits for a request in flight before closing the stores, and answers it", async () => {
+    const { routes, release } = blockingRoute();
+    host = await start({ routes });
+    const base = `http://127.0.0.1:${host.address.port}`;
+
+    const blocked = fetch(`${base}/block`);
+    await vi.waitFor(async () => {
+      // The request has reached the handler once a second one is admitted behind it.
+      expect((await fetch(`${base}/healthz`)).status).toBe(200);
+    });
+    const stopping = host.shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Not closed underneath the handler: the shutdown is still waiting.
+    let settled = false;
+    void stopping.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+
+    release();
+    expect(await stopping).toEqual({ clean: true, abandoned: [] });
+    const response = await blocked;
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ released: true });
+    host = null;
+  });
+
+  it("gives up a request that outlives the budget and reports it", async () => {
+    const { routes } = blockingRoute();
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    host = await startNodeHost({
+      config: CONFIG,
+      settings: settings({ shutdownTimeoutMs: 200 }),
+      objectStorage: OBJECT_STORAGE,
+      routes,
+    });
+    const base = `http://127.0.0.1:${host.address.port}`;
+
+    const blocked = fetch(`${base}/block`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const startedAt = Date.now();
+    const report = await host.shutdown();
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(150);
+    expect(report).toEqual({ clean: false, abandoned: ["http_requests:1"] });
+    // The connection was cut at the end; the peer sees no answer.
+    await expect(blocked).rejects.toThrow();
+    host = null;
+  });
+
+  it("fails to boot on a malformed encryption key with the Worker's message, leaving nothing open", async () => {
     dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
     await expect(
+      start({ config: { ...CONFIG, TOKEN_ENCRYPTION_KEY: "c2hvcnQ=" } })
+    ).rejects.toThrow("TOKEN_ENCRYPTION_KEY must decode to 32 bytes for AES-256, got 5");
+    expect(existsSync(join(dataDir, GLOBAL_STORE_FILE))).toBe(false);
+    // A corrected boot over the same directory succeeds.
+    host = await start();
+    expect((await fetch(`http://127.0.0.1:${host.address.port}/healthz`)).status).toBe(200);
+  });
+
+  it("releases what it acquired when a later boot step fails", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    // Take the port first so listen fails after the stores were opened.
+    const occupant = await start();
+    await expect(
       startNodeHost({
-        config: { ...CONFIG, TOKEN_ENCRYPTION_KEY: "c2hvcnQ=" },
-        settings: settings(),
+        config: CONFIG,
+        settings: settings({ port: occupant.address.port }),
         objectStorage: OBJECT_STORAGE,
       })
-    ).rejects.toThrow("TOKEN_ENCRYPTION_KEY must decode to 32 bytes for AES-256, got 5");
+    ).rejects.toThrow(/EADDRINUSE/);
+    await occupant.shutdown();
+    // Both stores were closed by the rollback: a fresh boot opens them again.
+    host = await start();
+    expect((await fetch(`http://127.0.0.1:${host.address.port}/healthz`)).status).toBe(200);
   });
 });

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -5,13 +5,19 @@
  * session Durable Object (`cloudflare/durable-object.ts`) together, over
  * the adapters in this directory.
  *
- * Boot order: the global store is opened and migrated, the alarm clock and
- * the registry are built, the environment is validated, and only then does
- * the server listen and the clock, sweeper, and cron start. Shutdown runs
- * the same in reverse within the configured budget: the health check
- * answers 503, the clocks stop, the server stops accepting, every runtime
- * is quiesced (sockets closed with 1012 so peers reconnect), background
- * work is drained, and the stores are closed.
+ * Boot: the configuration is validated before any file is touched, then
+ * the global store is opened and migrated, the alarm clock and the
+ * registry are built, the server listens, and the clock, sweeper, and
+ * cron start. Everything acquired is released in reverse order if a later
+ * step fails, and owned by the returned host once boot succeeds.
+ *
+ * Shutdown runs one deadline: the health check answers 503 and the clocks
+ * stop, the server stops accepting, then everything that can still reach
+ * a session runtime is drained under the budget (requests in flight,
+ * scheduled runs, alarm deliveries, background tasks), then the registry
+ * quiesces every runtime (sockets closed with 1012 so peers reconnect),
+ * then the transports are closed, the peers that ignored the close are
+ * cut, and the stores are closed. What outlived the budget is reported.
  */
 
 import { once } from "node:events";
@@ -23,12 +29,16 @@ import type { SqlDatabase } from "../db/sql-database";
 import { requireRepoSecretsEncryptionKey, requireTokenEncryptionKey } from "../env-validation";
 import { createLogger, parseLogLevel, type Logger } from "../logger";
 import { catalog } from "../routes/catalog";
-import { createControlPlaneApp, type ControlPlaneHost } from "../routing/hono-app";
+import {
+  createControlPlaneApp,
+  type ControlPlaneHost,
+  type RouteModule,
+} from "../routing/hono-app";
 import { SCHEDULED_JOBS } from "../scheduled-jobs";
 import { createSessionRuntime, type SessionRuntime } from "../session/components";
 import { createSessionRuntimeClient } from "../session/runtime-client";
 import type { Env, EnvConfig, Platform } from "../types";
-import { createNodeBackgroundTasks } from "./background-tasks";
+import { createNodeBackgroundTasks, settlesWithin } from "./background-tasks";
 import type { NodeHostSettings } from "./config";
 import { CronLoop } from "./cron-loop";
 import { HostAlarmClock } from "./host-alarm-clock";
@@ -40,7 +50,7 @@ import { createNodeSessionRuntimeDispatch } from "./runtime-client";
 import { createS3ObjectStorage, type S3ObjectStorageConfig } from "./s3-object-storage";
 import { SessionRuntimeRegistry } from "./session-runtime-registry";
 import { createFileSessionStoreProvider } from "./session-store";
-import { openNodeSqlDatabase, type NodeSqlDatabase } from "./sqlite-database";
+import { openNodeSqlDatabase } from "./sqlite-database";
 import { createSessionUpgradeHandler, MAX_MESSAGE_BYTES } from "./websocket-upgrade";
 
 /** The global store's file inside the data directory. */
@@ -50,6 +60,16 @@ export interface NodeHostOptions {
   config: EnvConfig;
   settings: NodeHostSettings;
   objectStorage: S3ObjectStorageConfig;
+  /** The route modules to serve: the production catalog unless a test supplies its own. */
+  routes?: readonly RouteModule[];
+}
+
+/** What a shutdown left running when its budget ran out. */
+interface ShutdownReport {
+  /** Every drain settled within the budget. */
+  clean: boolean;
+  /** The work abandoned at the deadline, by kind and count; empty when clean. */
+  abandoned: string[];
 }
 
 export interface NodeHost {
@@ -57,39 +77,56 @@ export interface NodeHost {
   readonly address: AddressInfo;
   health(): HealthReport;
   /**
-   * Stop serving, quiesce every runtime, wait for work within the
-   * settings' budget, and close the stores. A second call joins the first.
+   * Stop serving, drain and quiesce within the settings' budget, and close
+   * the stores. A second call joins the first.
    */
-  shutdown(): Promise<void>;
+  shutdown(): Promise<ShutdownReport>;
 }
 
 export async function startNodeHost(options: NodeHostOptions): Promise<NodeHost> {
-  const { config, settings } = options;
+  const { config } = options;
   const log = createLogger("node-host", {}, parseLogLevel(config.LOG_LEVEL));
+  // The same checks the Worker runs at first touch, run before a file is
+  // opened: a misconfigured key never serves a request and leaves nothing behind.
+  requireTokenEncryptionKey(config);
+  requireRepoSecretsEncryptionKey(config);
+
+  // Everything acquired during boot, released in reverse if a later step fails.
+  const acquired: Array<() => void> = [];
+  try {
+    return await boot(options, log, (release) => acquired.push(release));
+  } catch (error) {
+    for (const release of acquired.reverse()) {
+      try {
+        release();
+      } catch (releaseError) {
+        log.error("node_host.boot_release_failed", {
+          event: "node_host.boot_release_failed",
+          error: releaseError instanceof Error ? releaseError : String(releaseError),
+        });
+      }
+    }
+    throw error;
+  }
+}
+
+async function boot(
+  options: NodeHostOptions,
+  log: Logger,
+  acquire: (release: () => void) => void
+): Promise<NodeHost> {
+  const { config, settings } = options;
   const startedAtMs = Date.now();
 
   ensurePrivateDirectory(settings.dataDir);
   const db = openNodeSqlDatabase(join(settings.dataDir, GLOBAL_STORE_FILE), {
     migrationsDir: settings.migrationsDir,
   });
-  try {
-    return await startWithGlobalStore(db, options, log, startedAtMs);
-  } catch (error) {
-    db.close();
-    throw error;
-  }
-}
-
-async function startWithGlobalStore(
-  db: NodeSqlDatabase,
-  options: NodeHostOptions,
-  log: Logger,
-  startedAtMs: number
-): Promise<NodeHost> {
-  const { config, settings } = options;
+  acquire(() => db.close());
   const migrationsApplied = await countMigrations(db);
 
   const alarmIndex = openHostAlarmIndex(settings.dataDir);
+  acquire(() => alarmIndex.close());
   const clock: HostAlarmClock = new HostAlarmClock({
     index: alarmIndex,
     deliver: (sessionId) => registry.deliverScheduledDeadline(sessionId),
@@ -110,14 +147,10 @@ async function startWithGlobalStore(
     MEDIA_BUCKET: createS3ObjectStorage(options.objectStorage),
   };
   const env: Env = { ...config, ...platform };
-  // The same checks the Worker runs at first touch, run here before the
-  // host can answer anything: a misconfigured key never serves a request.
-  requireTokenEncryptionKey(env);
-  requireRepoSecretsEncryptionKey(env);
 
   const processTasks = createNodeBackgroundTasks(log);
   const host: ControlPlaneHost = { backgroundTasks: () => processTasks };
-  const app = createControlPlaneApp(catalog, host);
+  const app = createControlPlaneApp(options.routes ?? catalog, host);
   const webSocketServer = new WebSocketServer({ noServer: true, maxPayload: MAX_MESSAGE_BYTES });
   const upgrade = createSessionUpgradeHandler({ db, runtimes: registry, log, webSocketServer });
   const cron = new CronLoop({
@@ -151,23 +184,28 @@ async function startWithGlobalStore(
     alarm_clock: clocksRunning ? "running" : "stopped",
     cron: clocksRunning ? "running" : "stopped",
   });
-  const server = createNodeHttpServer({
+  const http = createNodeHttpServer({
     fetch: (request) => Promise.resolve(app.fetch(request, env)),
     upgrade,
     health,
+    log,
   });
+  const { server } = http;
 
-  try {
-    server.listen(settings.port, settings.host);
-    await once(server, "listening");
-  } catch (error) {
-    alarmIndex.close();
-    throw error;
-  }
+  server.listen(settings.port, settings.host);
+  acquire(() => {
+    server.closeAllConnections();
+    server.close();
+  });
+  await once(server, "listening");
   const address = server.address() as AddressInfo;
+
   clock.start();
+  acquire(() => clock.stop());
   registry.startSweeper();
+  acquire(() => registry.stopSweeper());
   cron.start();
+  acquire(() => cron.stop());
   clocksRunning = true;
   log.info("node_host.listening", {
     event: "node_host.listening",
@@ -177,41 +215,63 @@ async function startWithGlobalStore(
     migrations_applied: migrationsApplied,
   });
 
-  let stopping: Promise<void> | null = null;
-  const shutdown = async (): Promise<void> => {
+  const shutdown = async (): Promise<ShutdownReport> => {
     draining = true;
     const deadlineMs = Date.now() + settings.shutdownTimeoutMs;
+    const remaining = (): number => Math.max(0, deadlineMs - Date.now());
     log.info("node_host.draining", {
       event: "node_host.draining",
       timeout_ms: settings.shutdownTimeoutMs,
     });
+
+    // Producers first: nothing new starts. `server.close()` stops new
+    // connections; idle keep-alive connections go now, requests in flight
+    // are drained below.
     cron.stop();
     clock.stop();
     clocksRunning = false;
-    // Stop accepting; idle keep-alive connections go now, requests in
-    // flight finish, and whatever is still open at the end is cut.
     const closed = once(server, "close");
     server.close();
     server.closeIdleConnections();
-    await registry.shutdown({ timeoutMs: remaining(deadlineMs) });
-    await Promise.all([processTasks.drain(remaining(deadlineMs)), cron.drain(), clock.drain()]);
+
+    // Everything that can still reach a runtime, under the one budget.
+    const abandoned: string[] = [];
+    const requests = await http.drain(remaining());
+    if (requests > 0) abandoned.push(`http_requests:${requests}`);
+    const runs = await cron.drain(remaining());
+    if (runs > 0) abandoned.push(`scheduled_runs:${runs}`);
+    if (!(await settlesWithin([clock.drain()], remaining()))) abandoned.push("alarm_deliveries");
+    const tasks = await processTasks.drain(remaining());
+    if (tasks > 0) abandoned.push(`background_tasks:${tasks}`);
+
+    // Then the runtimes: sockets closed with 1012, per-session work waited for.
+    await registry.shutdown({ timeoutMs: remaining() });
+
+    // Then the transports. A peer that ignored its close frame is cut, as
+    // is any connection still open, so the server's close can complete.
+    for (const client of webSocketServer.clients) client.terminate();
+    await new Promise<void>((done) => webSocketServer.close(() => done()));
     server.closeAllConnections();
     await closed;
-    webSocketServer.close();
+
     alarmIndex.close();
     db.close();
-    log.info("node_host.stopped", { event: "node_host.stopped" });
+
+    const report: ShutdownReport = { clean: abandoned.length === 0, abandoned };
+    if (report.clean) {
+      log.info("node_host.stopped", { event: "node_host.stopped" });
+    } else {
+      log.warn("node_host.stopped_unclean", { event: "node_host.stopped_unclean", abandoned });
+    }
+    return report;
   };
 
+  let stopping: Promise<ShutdownReport> | null = null;
   return {
     address,
     health,
     shutdown: () => (stopping ??= shutdown()),
   };
-}
-
-function remaining(deadlineMs: number): number {
-  return Math.max(0, deadlineMs - Date.now());
 }
 
 /** How many migrations the global store's ledger records, for the health report. */

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -1,0 +1,223 @@
+/**
+ * The Node host: one process that serves the control plane's routes, runs
+ * session runtimes in a registry, and drives the scheduled jobs. It is the
+ * Node counterpart of the Worker entrypoint (`src/index.ts`) and the
+ * session Durable Object (`cloudflare/durable-object.ts`) together, over
+ * the adapters in this directory.
+ *
+ * Boot order: the global store is opened and migrated, the alarm clock and
+ * the registry are built, the environment is validated, and only then does
+ * the server listen and the clock, sweeper, and cron start. Shutdown runs
+ * the same in reverse within the configured budget: the health check
+ * answers 503, the clocks stop, the server stops accepting, every runtime
+ * is quiesced (sockets closed with 1012 so peers reconnect), background
+ * work is drained, and the stores are closed.
+ */
+
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import { WebSocketServer } from "ws";
+import { SessionIndexStore } from "../db/session-index";
+import type { SqlDatabase } from "../db/sql-database";
+import { requireRepoSecretsEncryptionKey, requireTokenEncryptionKey } from "../env-validation";
+import { createLogger, parseLogLevel, type Logger } from "../logger";
+import { catalog } from "../routes/catalog";
+import { createControlPlaneApp, type ControlPlaneHost } from "../routing/hono-app";
+import { SCHEDULED_JOBS } from "../scheduled-jobs";
+import { createSessionRuntime, type SessionRuntime } from "../session/components";
+import { createSessionRuntimeClient } from "../session/runtime-client";
+import type { Env, EnvConfig, Platform } from "../types";
+import { createNodeBackgroundTasks } from "./background-tasks";
+import type { NodeHostSettings } from "./config";
+import { CronLoop } from "./cron-loop";
+import { HostAlarmClock } from "./host-alarm-clock";
+import { openHostAlarmIndex } from "./host-alarm-index";
+import { createNodeHttpServer, type HealthReport } from "./http-server";
+import { createMemoryCacheStore } from "./memory-cache-store";
+import { ensurePrivateDirectory } from "./private-paths";
+import { createNodeSessionRuntimeDispatch } from "./runtime-client";
+import { createS3ObjectStorage, type S3ObjectStorageConfig } from "./s3-object-storage";
+import { SessionRuntimeRegistry } from "./session-runtime-registry";
+import { createFileSessionStoreProvider } from "./session-store";
+import { openNodeSqlDatabase, type NodeSqlDatabase } from "./sqlite-database";
+import { createSessionUpgradeHandler, MAX_MESSAGE_BYTES } from "./websocket-upgrade";
+
+/** The global store's file inside the data directory. */
+export const GLOBAL_STORE_FILE = "global.db";
+
+export interface NodeHostOptions {
+  config: EnvConfig;
+  settings: NodeHostSettings;
+  objectStorage: S3ObjectStorageConfig;
+}
+
+export interface NodeHost {
+  /** Where the server is listening. */
+  readonly address: AddressInfo;
+  health(): HealthReport;
+  /**
+   * Stop serving, quiesce every runtime, wait for work within the
+   * settings' budget, and close the stores. A second call joins the first.
+   */
+  shutdown(): Promise<void>;
+}
+
+export async function startNodeHost(options: NodeHostOptions): Promise<NodeHost> {
+  const { config, settings } = options;
+  const log = createLogger("node-host", {}, parseLogLevel(config.LOG_LEVEL));
+  const startedAtMs = Date.now();
+
+  ensurePrivateDirectory(settings.dataDir);
+  const db = openNodeSqlDatabase(join(settings.dataDir, GLOBAL_STORE_FILE), {
+    migrationsDir: settings.migrationsDir,
+  });
+  try {
+    return await startWithGlobalStore(db, options, log, startedAtMs);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}
+
+async function startWithGlobalStore(
+  db: NodeSqlDatabase,
+  options: NodeHostOptions,
+  log: Logger,
+  startedAtMs: number
+): Promise<NodeHost> {
+  const { config, settings } = options;
+  const migrationsApplied = await countMigrations(db);
+
+  const alarmIndex = openHostAlarmIndex(settings.dataDir);
+  const clock: HostAlarmClock = new HostAlarmClock({
+    index: alarmIndex,
+    deliver: (sessionId) => registry.deliverScheduledDeadline(sessionId),
+    log,
+  });
+  const registry: SessionRuntimeRegistry<SessionRuntime> = new SessionRuntimeRegistry({
+    db,
+    storeProvider: createFileSessionStoreProvider(settings.dataDir),
+    sessionIndex: new SessionIndexStore(db),
+    alarmStoreFor: (sessionId) => clock.storeFor(sessionId),
+    buildRuntime: (platform) => createSessionRuntime(platform, env),
+    log,
+  });
+  const platform: Platform = {
+    DB: db,
+    SESSION: createNodeSessionRuntimeDispatch(registry),
+    REPOS_CACHE: createMemoryCacheStore(),
+    MEDIA_BUCKET: createS3ObjectStorage(options.objectStorage),
+  };
+  const env: Env = { ...config, ...platform };
+  // The same checks the Worker runs at first touch, run here before the
+  // host can answer anything: a misconfigured key never serves a request.
+  requireTokenEncryptionKey(env);
+  requireRepoSecretsEncryptionKey(env);
+
+  const processTasks = createNodeBackgroundTasks(log);
+  const host: ControlPlaneHost = { backgroundTasks: () => processTasks };
+  const app = createControlPlaneApp(catalog, host);
+  const webSocketServer = new WebSocketServer({ noServer: true, maxPayload: MAX_MESSAGE_BYTES });
+  const upgrade = createSessionUpgradeHandler({ db, runtimes: registry, log, webSocketServer });
+  const cron = new CronLoop({
+    jobs: SCHEDULED_JOBS,
+    log,
+    run: async (job, nowMs) => {
+      const runId = crypto.randomUUID();
+      const correlation = { trace_id: runId, request_id: runId };
+      await job.run(
+        {
+          env,
+          db,
+          sessions: createSessionRuntimeClient(env, correlation),
+          backgroundTasks: processTasks,
+          log,
+          correlation,
+        },
+        nowMs
+      );
+    },
+  });
+
+  let draining = false;
+  let clocksRunning = false;
+  const health = (): HealthReport => ({
+    status: draining ? "draining" : "ok",
+    uptime_s: Math.round((Date.now() - startedAtMs) / 1000),
+    migrations_applied: migrationsApplied,
+    sessions_resident: registry.residentSessionIds().length,
+    background_tasks: processTasks.size,
+    alarm_clock: clocksRunning ? "running" : "stopped",
+    cron: clocksRunning ? "running" : "stopped",
+  });
+  const server = createNodeHttpServer({
+    fetch: (request) => Promise.resolve(app.fetch(request, env)),
+    upgrade,
+    health,
+  });
+
+  try {
+    server.listen(settings.port, settings.host);
+    await once(server, "listening");
+  } catch (error) {
+    alarmIndex.close();
+    throw error;
+  }
+  const address = server.address() as AddressInfo;
+  clock.start();
+  registry.startSweeper();
+  cron.start();
+  clocksRunning = true;
+  log.info("node_host.listening", {
+    event: "node_host.listening",
+    host: address.address,
+    port: address.port,
+    data_dir: settings.dataDir,
+    migrations_applied: migrationsApplied,
+  });
+
+  let stopping: Promise<void> | null = null;
+  const shutdown = async (): Promise<void> => {
+    draining = true;
+    const deadlineMs = Date.now() + settings.shutdownTimeoutMs;
+    log.info("node_host.draining", {
+      event: "node_host.draining",
+      timeout_ms: settings.shutdownTimeoutMs,
+    });
+    cron.stop();
+    clock.stop();
+    clocksRunning = false;
+    // Stop accepting; idle keep-alive connections go now, requests in
+    // flight finish, and whatever is still open at the end is cut.
+    const closed = once(server, "close");
+    server.close();
+    server.closeIdleConnections();
+    await registry.shutdown({ timeoutMs: remaining(deadlineMs) });
+    await Promise.all([processTasks.drain(remaining(deadlineMs)), cron.drain(), clock.drain()]);
+    server.closeAllConnections();
+    await closed;
+    webSocketServer.close();
+    alarmIndex.close();
+    db.close();
+    log.info("node_host.stopped", { event: "node_host.stopped" });
+  };
+
+  return {
+    address,
+    health,
+    shutdown: () => (stopping ??= shutdown()),
+  };
+}
+
+function remaining(deadlineMs: number): number {
+  return Math.max(0, deadlineMs - Date.now());
+}
+
+/** How many migrations the global store's ledger records, for the health report. */
+async function countMigrations(db: SqlDatabase): Promise<number> {
+  const row = await db
+    .prepare("SELECT COUNT(*) AS applied FROM _schema_migrations")
+    .first<{ applied: number }>();
+  return row?.applied ?? 0;
+}

--- a/packages/control-plane/src/node/http-server.test.ts
+++ b/packages/control-plane/src/node/http-server.test.ts
@@ -1,0 +1,90 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket as NodeWebSocket } from "ws";
+import { createNodeHttpServer, type HealthReport } from "./http-server";
+
+function report(status: HealthReport["status"]): HealthReport {
+  return {
+    status,
+    uptime_s: 1,
+    migrations_applied: 74,
+    sessions_resident: 0,
+    background_tasks: 0,
+    alarm_clock: "running",
+    cron: "running",
+  };
+}
+
+describe("createNodeHttpServer", () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (!server) return;
+    server.closeAllConnections();
+    server.close();
+    await once(server, "close");
+    server = null;
+  });
+
+  async function listen(options: Parameters<typeof createNodeHttpServer>[0]): Promise<string> {
+    server = createNodeHttpServer(options);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  }
+
+  it("answers /healthz itself, 200 while serving and 503 while draining", async () => {
+    const health = vi.fn(() => report("ok"));
+    const fetchApp = vi.fn(async () => new Response("app"));
+    const base = await listen({ fetch: fetchApp, upgrade: vi.fn(), health });
+
+    const ok = await fetch(`${base}/healthz`);
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("cache-control")).toBe("no-store");
+    expect(await ok.json()).toEqual(report("ok"));
+
+    health.mockReturnValue(report("draining"));
+    expect((await fetch(`${base}/healthz`)).status).toBe(503);
+    expect(fetchApp).not.toHaveBeenCalled();
+
+    // Only reads are the host's; anything else on the path is the app's.
+    const posted = await fetch(`${base}/healthz`, { method: "POST" });
+    expect(await posted.text()).toBe("app");
+  });
+
+  it("hands every other request to the app as a fetch Request", async () => {
+    const seen: Request[] = [];
+    const base = await listen({
+      fetch: async (request) => {
+        seen.push(request);
+        return Response.json({ body: await request.text() }, { status: 201 });
+      },
+      upgrade: vi.fn(),
+      health: () => report("ok"),
+    });
+    const response = await fetch(`${base}/sessions?x=1`, {
+      method: "POST",
+      body: "payload",
+      headers: { "x-trace-id": "t1" },
+    });
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ body: "payload" });
+    expect(seen[0].url).toBe(`${base}/sessions?x=1`);
+    expect(seen[0].headers.get("x-trace-id")).toBe("t1");
+  });
+
+  it("routes an upgrade to the upgrade handler", async () => {
+    const upgrade = vi.fn(async (_request, socket) => {
+      socket.end("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
+    });
+    const base = await listen({ fetch: vi.fn(), upgrade, health: () => report("ok") });
+    const ws = new NodeWebSocket(`${base.replace("http", "ws")}/sessions/s1/ws`);
+    const message = await new Promise<string>((resolve) =>
+      ws.once("error", (error) => resolve(error.message))
+    );
+    expect(message).toBe("Unexpected server response: 418");
+    expect(upgrade).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/control-plane/src/node/http-server.test.ts
+++ b/packages/control-plane/src/node/http-server.test.ts
@@ -1,9 +1,13 @@
 import { once } from "node:events";
 import type { AddressInfo } from "node:net";
-import type { Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket } from "ws";
-import { createNodeHttpServer, type HealthReport } from "./http-server";
+import type { Logger } from "../logger";
+import { createNodeHttpServer, type HealthReport, type NodeHttpServer } from "./http-server";
+
+function fakeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+}
 
 function report(status: HealthReport["status"]): HealthReport {
   return {
@@ -17,28 +21,38 @@ function report(status: HealthReport["status"]): HealthReport {
   };
 }
 
+type Options = Parameters<typeof createNodeHttpServer>[0];
+
 describe("createNodeHttpServer", () => {
-  let server: Server | null = null;
+  let http: NodeHttpServer | null = null;
+  let log: Logger;
 
   afterEach(async () => {
-    if (!server) return;
-    server.closeAllConnections();
-    server.close();
-    await once(server, "close");
-    server = null;
+    if (!http) return;
+    http.server.closeAllConnections();
+    http.server.close();
+    await once(http.server, "close");
+    http = null;
   });
 
-  async function listen(options: Parameters<typeof createNodeHttpServer>[0]): Promise<string> {
-    server = createNodeHttpServer(options);
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  async function listen(options: Partial<Options>): Promise<string> {
+    log = fakeLogger();
+    http = createNodeHttpServer({
+      fetch: vi.fn(async () => new Response("app")),
+      upgrade: vi.fn(async () => {}),
+      health: () => report("ok"),
+      log,
+      ...options,
+    });
+    http.server.listen(0, "127.0.0.1");
+    await once(http.server, "listening");
+    return `http://127.0.0.1:${(http.server.address() as AddressInfo).port}`;
   }
 
   it("answers /healthz itself, 200 while serving and 503 while draining", async () => {
     const health = vi.fn(() => report("ok"));
     const fetchApp = vi.fn(async () => new Response("app"));
-    const base = await listen({ fetch: fetchApp, upgrade: vi.fn(), health });
+    const base = await listen({ fetch: fetchApp, health });
 
     const ok = await fetch(`${base}/healthz`);
     expect(ok.status).toBe(200);
@@ -61,8 +75,6 @@ describe("createNodeHttpServer", () => {
         seen.push(request);
         return Response.json({ body: await request.text() }, { status: 201 });
       },
-      upgrade: vi.fn(),
-      health: () => report("ok"),
     });
     const response = await fetch(`${base}/sessions?x=1`, {
       method: "POST",
@@ -79,12 +91,68 @@ describe("createNodeHttpServer", () => {
     const upgrade = vi.fn(async (_request, socket) => {
       socket.end("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
     });
-    const base = await listen({ fetch: vi.fn(), upgrade, health: () => report("ok") });
+    const base = await listen({ upgrade });
     const ws = new NodeWebSocket(`${base.replace("http", "ws")}/sessions/s1/ws`);
     const message = await new Promise<string>((resolve) =>
       ws.once("error", (error) => resolve(error.message))
     );
     expect(message).toBe("Unexpected server response: 418");
     expect(upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a rejecting upgrade handler and destroys the socket instead of leaking the rejection", async () => {
+    const base = await listen({
+      upgrade: vi.fn(async () => {
+        throw new Error("index unavailable");
+      }),
+    });
+    const ws = new NodeWebSocket(`${base.replace("http", "ws")}/sessions/s1/ws`);
+    const failure = await new Promise<Error>((resolve) => ws.once("error", resolve));
+    expect(failure.message).toMatch(/socket hang up|ECONNRESET/);
+    expect(log.error).toHaveBeenCalledWith(
+      "WebSocket upgrade path failed",
+      expect.objectContaining({ event: "ws.upgrade_failed", http_path: "/sessions/s1/ws" })
+    );
+  });
+
+  it("tracks requests in flight and drains them within a budget", async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const base = await listen({
+      fetch: async () => {
+        await held;
+        return new Response("done");
+      },
+    });
+    const server = http!;
+    expect(server.inFlight).toBe(0);
+    const response = fetch(`${base}/slow`);
+    await vi.waitFor(() => expect(server.inFlight).toBe(1));
+
+    // Still held at a short budget: reported, not waited for.
+    expect(await server.drain(20)).toBe(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "http.drain_timeout",
+      expect.objectContaining({ pending: 1 })
+    );
+
+    const drained = server.drain(5_000);
+    release();
+    expect(await drained).toBe(0);
+    expect(await (await response).text()).toBe("done");
+    expect(server.inFlight).toBe(0);
+  });
+
+  it("stops tracking a request whose handler rejected", async () => {
+    const base = await listen({
+      fetch: async () => {
+        throw new Error("handler exploded");
+      },
+    });
+    const response = await fetch(`${base}/boom`);
+    expect(response.status).toBe(500);
+    expect(http!.inFlight).toBe(0);
   });
 });

--- a/packages/control-plane/src/node/http-server.ts
+++ b/packages/control-plane/src/node/http-server.ts
@@ -2,10 +2,18 @@
  * The Node host's HTTP server: the control-plane app behind a fetch
  * listener, `/healthz` answered ahead of it, and WebSocket upgrades routed
  * to the session upgrade path.
+ *
+ * Requests the app is handling are tracked so a shutdown can wait for them:
+ * `server.close()` only stops new connections, and a handler that has
+ * yielded resumes after it. The upgrade boundary is total: whatever the
+ * upgrade path throws is logged and the raw socket is destroyed, so no
+ * failure becomes an unhandled rejection and no peer is left hanging.
  */
 
 import { getRequestListener } from "@hono/node-server";
 import { createServer, type Server } from "node:http";
+import type { Logger } from "../logger";
+import { settlesWithin } from "./background-tasks";
 import type { UpgradeHandler } from "./websocket-upgrade";
 
 /** What the host reports about itself; a checker reads `status`. */
@@ -26,6 +34,19 @@ export interface NodeHttpServerOptions {
   fetch: (request: Request) => Promise<Response>;
   upgrade: UpgradeHandler;
   health: () => HealthReport;
+  log: Logger;
+}
+
+export interface NodeHttpServer {
+  readonly server: Server;
+  /** Requests the app is handling right now. */
+  readonly inFlight: number;
+  /**
+   * Wait for every request in flight, including ones accepted meanwhile,
+   * for at most `timeoutMs`. Requests still running at the deadline are
+   * left to the caller; returns how many there were.
+   */
+  drain(timeoutMs: number): Promise<number>;
 }
 
 /** The health response: 200 while serving, 503 while draining. */
@@ -36,7 +57,10 @@ function healthResponse(report: HealthReport): Response {
   });
 }
 
-export function createNodeHttpServer(options: NodeHttpServerOptions): Server {
+export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpServer {
+  const { log } = options;
+  const inFlight = new Set<Promise<void>>();
+
   const listener = getRequestListener((request) => {
     if (
       (request.method === "GET" || request.method === "HEAD") &&
@@ -44,11 +68,50 @@ export function createNodeHttpServer(options: NodeHttpServerOptions): Server {
     ) {
       return healthResponse(options.health());
     }
-    return options.fetch(request);
+    const pending = options.fetch(request);
+    // Tracked as settled-or-not only; the outcome, a rejection included,
+    // is the listener's to answer.
+    const tracked: Promise<void> = pending
+      .then(
+        () => undefined,
+        () => undefined
+      )
+      .finally(() => inFlight.delete(tracked));
+    inFlight.add(tracked);
+    return pending;
   });
+
   const server = createServer(listener);
   server.on("upgrade", (request, socket, head) => {
-    void options.upgrade(request, socket, head);
+    options.upgrade(request, socket, head).catch((error: unknown) => {
+      log.error("WebSocket upgrade path failed", {
+        event: "ws.upgrade_failed",
+        http_path: request.url,
+        error: error instanceof Error ? error : String(error),
+      });
+      socket.destroy();
+    });
   });
-  return server;
+
+  return {
+    server,
+    get inFlight() {
+      return inFlight.size;
+    },
+    async drain(timeoutMs: number): Promise<number> {
+      const deadline = Date.now() + timeoutMs;
+      while (inFlight.size > 0) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0 || !(await settlesWithin([...inFlight], remaining))) break;
+      }
+      if (inFlight.size > 0) {
+        log.warn("http.drain_timeout", {
+          event: "http.drain_timeout",
+          timeout_ms: timeoutMs,
+          pending: inFlight.size,
+        });
+      }
+      return inFlight.size;
+    },
+  };
 }

--- a/packages/control-plane/src/node/http-server.ts
+++ b/packages/control-plane/src/node/http-server.ts
@@ -1,0 +1,54 @@
+/**
+ * The Node host's HTTP server: the control-plane app behind a fetch
+ * listener, `/healthz` answered ahead of it, and WebSocket upgrades routed
+ * to the session upgrade path.
+ */
+
+import { getRequestListener } from "@hono/node-server";
+import { createServer, type Server } from "node:http";
+import type { UpgradeHandler } from "./websocket-upgrade";
+
+/** What the host reports about itself; a checker reads `status`. */
+export interface HealthReport {
+  /** `draining` once a shutdown has begun: the load balancer should send nothing further. */
+  status: "ok" | "draining";
+  uptime_s: number;
+  /** The global store's migrations applied at boot, by count. */
+  migrations_applied: number;
+  sessions_resident: number;
+  background_tasks: number;
+  alarm_clock: "running" | "stopped";
+  cron: "running" | "stopped";
+}
+
+export interface NodeHttpServerOptions {
+  /** Ordinary requests: the control-plane app. */
+  fetch: (request: Request) => Promise<Response>;
+  upgrade: UpgradeHandler;
+  health: () => HealthReport;
+}
+
+/** The health response: 200 while serving, 503 while draining. */
+function healthResponse(report: HealthReport): Response {
+  return Response.json(report, {
+    status: report.status === "ok" ? 200 : 503,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+export function createNodeHttpServer(options: NodeHttpServerOptions): Server {
+  const listener = getRequestListener((request) => {
+    if (
+      (request.method === "GET" || request.method === "HEAD") &&
+      new URL(request.url).pathname === "/healthz"
+    ) {
+      return healthResponse(options.health());
+    }
+    return options.fetch(request);
+  });
+  const server = createServer(listener);
+  server.on("upgrade", (request, socket, head) => {
+    void options.upgrade(request, socket, head);
+  });
+  return server;
+}

--- a/packages/control-plane/src/node/main.ts
+++ b/packages/control-plane/src/node/main.ts
@@ -1,0 +1,54 @@
+/**
+ * The Node host's process entry: configuration from the environment, the
+ * host started, and the process signals turned into an orderly shutdown.
+ * Everything else is `host.ts`, so a test can boot the host in-process.
+ */
+
+import { createLogger, parseLogLevel } from "../logger";
+import { readEnvConfig, readNodeHostSettings } from "./config";
+import { startNodeHost } from "./host";
+import { readS3ObjectStorageConfig } from "./s3-object-storage";
+
+/** Past the drain budget, how much longer the process gets before it is forced down. */
+const FORCE_EXIT_GRACE_MS = 5_000;
+
+const log = createLogger("node-main", {}, parseLogLevel(process.env.LOG_LEVEL));
+
+async function main(): Promise<void> {
+  const settings = readNodeHostSettings(process.env);
+  const config = readEnvConfig(process.env);
+  const objectStorage = readS3ObjectStorageConfig(process.env);
+  const host = await startNodeHost({ config, settings, objectStorage });
+
+  const stop = (signal: NodeJS.Signals): void => {
+    log.info("node_host.signal", { event: "node_host.signal", signal });
+    const forced = setTimeout(() => {
+      log.error("node_host.shutdown_forced", {
+        event: "node_host.shutdown_forced",
+        timeout_ms: settings.shutdownTimeoutMs + FORCE_EXIT_GRACE_MS,
+      });
+      process.exit(1);
+    }, settings.shutdownTimeoutMs + FORCE_EXIT_GRACE_MS);
+    forced.unref();
+    host.shutdown().then(
+      () => clearTimeout(forced),
+      (error: unknown) => {
+        log.error("node_host.shutdown_failed", {
+          event: "node_host.shutdown_failed",
+          error: error instanceof Error ? error : String(error),
+        });
+        process.exitCode = 1;
+      }
+    );
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+}
+
+main().catch((error: unknown) => {
+  log.error("node_host.boot_failed", {
+    event: "node_host.boot_failed",
+    error: error instanceof Error ? error : String(error),
+  });
+  process.exit(1);
+});

--- a/packages/control-plane/src/node/main.ts
+++ b/packages/control-plane/src/node/main.ts
@@ -22,24 +22,23 @@ async function main(): Promise<void> {
 
   const stop = (signal: NodeJS.Signals): void => {
     log.info("node_host.signal", { event: "node_host.signal", signal });
-    const forced = setTimeout(() => {
+    // Unreferenced, so it never holds the process open: a clean shutdown
+    // exits on its own, and one whose abandoned work keeps the event loop
+    // alive is forced down here.
+    setTimeout(() => {
       log.error("node_host.shutdown_forced", {
         event: "node_host.shutdown_forced",
         timeout_ms: settings.shutdownTimeoutMs + FORCE_EXIT_GRACE_MS,
       });
       process.exit(1);
-    }, settings.shutdownTimeoutMs + FORCE_EXIT_GRACE_MS);
-    forced.unref();
-    host.shutdown().then(
-      () => clearTimeout(forced),
-      (error: unknown) => {
-        log.error("node_host.shutdown_failed", {
-          event: "node_host.shutdown_failed",
-          error: error instanceof Error ? error : String(error),
-        });
-        process.exitCode = 1;
-      }
-    );
+    }, settings.shutdownTimeoutMs + FORCE_EXIT_GRACE_MS).unref();
+    host.shutdown().catch((error: unknown) => {
+      log.error("node_host.shutdown_failed", {
+        event: "node_host.shutdown_failed",
+        error: error instanceof Error ? error : String(error),
+      });
+      process.exitCode = 1;
+    });
   };
   process.once("SIGTERM", stop);
   process.once("SIGINT", stop);

--- a/packages/control-plane/src/node/memory-cache-store.test.ts
+++ b/packages/control-plane/src/node/memory-cache-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryCacheStore } from "./memory-cache-store";
+
+describe("createMemoryCacheStore", () => {
+  it("stores strings and parses them as json on request", async () => {
+    const cache = createMemoryCacheStore();
+    expect(await cache.get("missing")).toBeNull();
+    await cache.put("repos", JSON.stringify({ items: [1] }));
+    expect(await cache.get("repos")).toBe('{"items":[1]}');
+    expect(await cache.get<{ items: number[] }>("repos", "json")).toEqual({ items: [1] });
+    await cache.delete("repos");
+    expect(await cache.get("repos")).toBeNull();
+  });
+
+  it("expires an entry after its ttl in seconds", async () => {
+    let clock = 1_000_000;
+    const cache = createMemoryCacheStore({ now: () => clock });
+    await cache.put("k", "v", { expirationTtl: 60 });
+    clock += 59_999;
+    expect(await cache.get("k")).toBe("v");
+    clock += 1;
+    expect(await cache.get("k")).toBeNull();
+  });
+
+  it("drops the oldest entry past the bound, counting a refreshed key as new", async () => {
+    const cache = createMemoryCacheStore({ maxEntries: 2 });
+    await cache.put("a", "1");
+    await cache.put("b", "2");
+    await cache.put("a", "3");
+    await cache.put("c", "4");
+    expect(await cache.get("b")).toBeNull();
+    expect(await cache.get("a")).toBe("3");
+    expect(await cache.get("c")).toBe("4");
+  });
+});

--- a/packages/control-plane/src/node/memory-cache-store.ts
+++ b/packages/control-plane/src/node/memory-cache-store.ts
@@ -1,0 +1,62 @@
+/**
+ * The Node host's `CacheStore`: an in-process map with KV's expiry
+ * semantics (`expirationTtl` in seconds, read on access). The host is one
+ * process, so a process-local cache is the whole cache; a restart starts
+ * cold, which for the repos listing costs one upstream fetch per user.
+ */
+
+import type { CacheStore, CacheStorePutOptions } from "@open-inspect/shared/cache-store";
+
+/** Entries kept before the oldest is dropped, bounding memory on a long-lived process. */
+const DEFAULT_MAX_ENTRIES = 1_000;
+
+interface Entry {
+  value: string;
+  /** Epoch ms after which the entry reads as absent; `null` never expires. */
+  expiresAt: number | null;
+}
+
+export interface MemoryCacheStoreOptions {
+  maxEntries?: number;
+  now?: () => number;
+}
+
+export function createMemoryCacheStore(options: MemoryCacheStoreOptions = {}): CacheStore {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const now = options.now ?? (() => Date.now());
+  // Insertion-ordered, so the first key is the oldest put.
+  const entries = new Map<string, Entry>();
+
+  const read = (key: string): string | null => {
+    const entry = entries.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt !== null && entry.expiresAt <= now()) {
+      entries.delete(key);
+      return null;
+    }
+    return entry.value;
+  };
+
+  return {
+    get: (async (key: string, type?: "json") => {
+      const value = read(key);
+      return value !== null && type === "json" ? JSON.parse(value) : value;
+    }) as CacheStore["get"],
+    async put(key: string, value: string, opts?: CacheStorePutOptions): Promise<void> {
+      // Re-inserted last, so a refreshed key is the newest again.
+      entries.delete(key);
+      entries.set(key, {
+        value,
+        expiresAt: opts?.expirationTtl === undefined ? null : now() + opts.expirationTtl * 1000,
+      });
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) break;
+        entries.delete(oldest);
+      }
+    },
+    async delete(key: string): Promise<void> {
+      entries.delete(key);
+    },
+  };
+}

--- a/packages/control-plane/src/node/runtime-client.ts
+++ b/packages/control-plane/src/node/runtime-client.ts
@@ -29,7 +29,7 @@ export interface RequestServingRuntime {
 }
 
 /** Leased access to an existing session's runtime; `SessionRuntimeRegistry` satisfies it. */
-export interface SessionRuntimeLookup<Runtime extends RequestServingRuntime> {
+export interface SessionRuntimeLookup<Runtime> {
   withRuntimeIfPresent<T>(
     sessionId: string,
     use: (runtime: Runtime) => Promise<T>

--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -607,6 +607,41 @@ describe("SessionRuntimeRegistry", () => {
     });
   });
 
+  it("shutdown closes a socket adopted under a lease that predates it", async () => {
+    // The upgrade path authorizes under a lease and adopts afterwards; a
+    // shutdown that began during the authorization still closes the socket.
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((done) => wss.once("listening", done));
+    const client = new NodeWebSocket(`ws://127.0.0.1:${(wss.address() as AddressInfo).port}`);
+    try {
+      const serverSide = new Promise<NodeWebSocket>((done) => wss.once("connection", done));
+      await new Promise<void>((done) => client.once("open", done));
+      const server = await serverSide;
+      const closed = new Promise<number>((done) => client.once("close", (code) => done(code)));
+
+      const registry = makeRegistry();
+      const authorizing = deferred();
+      const attached = registry.withRuntime("s1", async (runtime) => {
+        await authorizing.promise;
+        runtime.platform.sockets.adopt(server, ["wsid:late"]);
+      });
+      await flush();
+
+      const shutdown = registry.shutdown({ timeoutMs: 2_000 });
+      await flush();
+      authorizing.resolve();
+      await attached;
+
+      await shutdown;
+      expect(await closed).toBe(SERVICE_RESTART_CLOSE_CODE);
+      expect(registry.residentSessionIds()).toEqual([]);
+      expect(log.warn).not.toHaveBeenCalled();
+    } finally {
+      client.terminate();
+      await new Promise<void>((done) => wss.close(() => done()));
+    }
+  });
+
   it("shutdown refuses new leases on resident runtimes and waits for held ones", async () => {
     const registry = makeRegistry();
     const held = deferred();

--- a/packages/control-plane/src/node/session-runtime-registry.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.ts
@@ -277,9 +277,6 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
 
   private async quiesce(session: ResidentSession<Runtime>, deadlineMs: number): Promise<void> {
     session.state = "quiescing";
-    for (const socket of session.sockets.sockets()) {
-      socket.close(SERVICE_RESTART_CLOSE_CODE, "Service restart");
-    }
     const quiescent = await this.waitForQuiescence(session, deadlineMs);
     if (!quiescent) {
       this.log.warn("session_registry.retired_busy", {
@@ -292,12 +289,20 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
     this.retire(session, "shutdown");
   }
 
-  /** Whether the runtime reached quiescence before `deadlineMs` (wall clock). */
+  /**
+   * Whether the runtime reached quiescence before `deadlineMs` (wall clock).
+   * Every pass closes the sockets the runtime holds: a lease taken before
+   * the shutdown began (an upgrade being authorized, say) may still adopt
+   * one, and it must be closed like those that were there at the start.
+   */
   private async waitForQuiescence(
     session: ResidentSession<Runtime>,
     deadlineMs: number
   ): Promise<boolean> {
     for (;;) {
+      for (const socket of session.sockets.sockets()) {
+        socket.close(SERVICE_RESTART_CLOSE_CODE, "Service restart");
+      }
       const remainingMs = deadlineMs - Date.now();
       if (remainingMs <= 0) return this.isQuiescent(session);
       const tasks = session.tasks.current;

--- a/packages/control-plane/src/node/websocket-upgrade.test.ts
+++ b/packages/control-plane/src/node/websocket-upgrade.test.ts
@@ -1,0 +1,208 @@
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket as NodeWebSocket } from "ws";
+import type { SqlDatabase, SqlStatement } from "../db/sql-database";
+import type { Logger } from "../logger";
+import type { SessionWebSocket } from "../platform-ports";
+import type { UpgradeDecision } from "../session/connection-authenticator";
+import { createSessionUpgradeHandler, type UpgradeServingRuntime } from "./websocket-upgrade";
+
+function fakeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+}
+
+/** A global store whose session index knows `known`. */
+function indexDatabase(known: Set<string>): SqlDatabase {
+  return {
+    prepare() {
+      let bound: unknown[] = [];
+      const statement: SqlStatement = {
+        bind: (...values) => {
+          bound = values;
+          return statement;
+        },
+        first: async <T>() => (known.has(String(bound[0])) ? ({ ok: 1 } as T) : null),
+        all: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+        run: async <T>() => ({ results: [] as T[], meta: { changes: 0 } }),
+      };
+      return statement;
+    },
+    batch: async () => [],
+  };
+}
+
+function runtimeDeciding(decide: (request: Request) => UpgradeDecision): UpgradeServingRuntime {
+  return {
+    upgrades: { authorize: vi.fn(async (request: Request) => decide(request)) },
+    log: fakeLogger(),
+  };
+}
+
+function accept(attach: (ws: SessionWebSocket) => void | Promise<void>): UpgradeDecision {
+  return { kind: "accept", role: "client", attach: async (ws) => attach(ws) };
+}
+
+/** The `ws` socket behind the port, as a test's attachment sees it. */
+function asNodeSocket(ws: SessionWebSocket): NodeWebSocket {
+  return ws as unknown as NodeWebSocket;
+}
+
+function rejected(ws: NodeWebSocket): Promise<string> {
+  return new Promise((resolve) => ws.once("error", (error) => resolve(error.message)));
+}
+
+describe("createSessionUpgradeHandler", () => {
+  const known = new Set(["s1", "s2"]);
+  const runtimes = new Map<string, UpgradeServingRuntime>();
+  let log: Logger;
+  let server: Server;
+  let port: number;
+  const clients: NodeWebSocket[] = [];
+
+  const connect = (path: string): NodeWebSocket => {
+    const ws = new NodeWebSocket(`ws://127.0.0.1:${port}${path}`);
+    clients.push(ws);
+    return ws;
+  };
+
+  beforeEach(async () => {
+    log = fakeLogger();
+    runtimes.clear();
+    const handler = createSessionUpgradeHandler({
+      db: indexDatabase(known),
+      runtimes: {
+        withRuntimeIfPresent: async (sessionId, use) => {
+          const runtime = runtimes.get(sessionId);
+          return runtime ? use(runtime) : undefined;
+        },
+      },
+      log,
+    });
+    server = createServer((_request, response) => response.writeHead(426).end());
+    server.on("upgrade", (request, socket, head) => void handler(request, socket, head));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    for (const ws of clients.splice(0)) ws.terminate();
+    server.closeAllConnections();
+    server.close();
+    await once(server, "close");
+  });
+
+  it("answers 400 on any path but a session's", async () => {
+    expect(await rejected(connect("/sessions/s1/events"))).toBe("Unexpected server response: 400");
+    expect(log.warn).toHaveBeenCalledWith(
+      "Invalid WebSocket path",
+      expect.objectContaining({ event: "ws.invalid_path" })
+    );
+  });
+
+  it("answers 404 for a session the index does not know, without opening a runtime", async () => {
+    const authorize = vi.fn();
+    runtimes.set("nope", { upgrades: { authorize }, log: fakeLogger() });
+    expect(await rejected(connect("/sessions/nope/ws"))).toBe("Unexpected server response: 404");
+    expect(authorize).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      "WebSocket session not found",
+      expect.objectContaining({ session_id: "nope", sql_query_count: 1 })
+    );
+  });
+
+  it("answers 404 when the index knows the session but nothing is behind it", async () => {
+    expect(await rejected(connect("/sessions/s2/ws"))).toBe("Unexpected server response: 404");
+  });
+
+  it("writes the session's rejection as the handshake's status", async () => {
+    runtimes.set(
+      "s1",
+      runtimeDeciding(() => ({
+        kind: "reject",
+        response: new Response("Unauthorized", { status: 401 }),
+      }))
+    );
+    expect(await rejected(connect("/sessions/s1/ws"))).toBe("Unexpected server response: 401");
+  });
+
+  it("hands the session the upgrade as a request with its URL and headers", async () => {
+    const seen: Request[] = [];
+    runtimes.set(
+      "s1",
+      runtimeDeciding((request) => {
+        seen.push(request);
+        return { kind: "reject", response: new Response(null, { status: 403 }) };
+      })
+    );
+    await rejected(connect("/sessions/s1/ws?token=abc"));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].method).toBe("GET");
+    expect(seen[0].url).toBe(`http://127.0.0.1:${port}/sessions/s1/ws?token=abc`);
+    expect(seen[0].headers.get("upgrade")).toBe("websocket");
+    expect(seen[0].headers.get("sec-websocket-key")).toBeTruthy();
+  });
+
+  it("completes an accepted upgrade and the runtime exchanges messages on the socket", async () => {
+    runtimes.set(
+      "s1",
+      runtimeDeciding(() =>
+        accept((ws) => {
+          asNodeSocket(ws).on("message", (data) => ws.send(`echo:${String(data)}`));
+        })
+      )
+    );
+    const ws = connect("/sessions/s1/ws");
+    await once(ws, "open");
+    ws.send("hi");
+    const [reply] = await once(ws, "message");
+    expect(String(reply)).toBe("echo:hi");
+    expect(log.info).toHaveBeenCalledWith(
+      "WebSocket upgrade",
+      expect.objectContaining({ event: "ws.connect", session_id: "s1" })
+    );
+  });
+
+  it("holds a frame sent on the 101 until the runtime has attached", async () => {
+    let attachNow!: () => void;
+    const attached = new Promise<void>((resolve) => {
+      attachNow = resolve;
+    });
+    runtimes.set(
+      "s1",
+      runtimeDeciding(() =>
+        accept(async (ws) => {
+          await attached;
+          asNodeSocket(ws).on("message", (data) => ws.send(`echo:${String(data)}`));
+        })
+      )
+    );
+    const ws = connect("/sessions/s1/ws");
+    await once(ws, "open");
+    ws.send("early");
+    // Long enough for the frame to reach the server while attachment waits.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    attachNow();
+    const [reply] = await once(ws, "message");
+    expect(String(reply)).toBe("echo:early");
+  });
+
+  it("closes the socket with 1011 when attachment fails", async () => {
+    const runtime = runtimeDeciding(() =>
+      accept(() => {
+        throw new Error("no room");
+      })
+    );
+    runtimes.set("s1", runtime);
+    const ws = connect("/sessions/s1/ws");
+    const [code, reason] = await once(ws, "close");
+    expect(code).toBe(1011);
+    expect(String(reason)).toBe("WebSocket upgrade failed");
+    expect(runtime.log.error).toHaveBeenCalledWith(
+      "WebSocket upgrade failed",
+      expect.objectContaining({ ws_type: "client" })
+    );
+  });
+});

--- a/packages/control-plane/src/node/websocket-upgrade.test.ts
+++ b/packages/control-plane/src/node/websocket-upgrade.test.ts
@@ -1,6 +1,6 @@
 import { once } from "node:events";
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
+import { connect as connectTcp, type AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket } from "ws";
 import type { SqlDatabase, SqlStatement } from "../db/sql-database";
@@ -53,8 +53,23 @@ function rejected(ws: NodeWebSocket): Promise<string> {
   return new Promise((resolve) => ws.once("error", (error) => resolve(error.message)));
 }
 
+/** Send a raw upgrade request and collect the server's answer, for requests a client library would not send. */
+function rawUpgrade(port: number, requestText: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = connectTcp(port, "127.0.0.1");
+    let received = "";
+    socket.on("connect", () => socket.write(requestText));
+    socket.on("data", (chunk) => {
+      received += chunk.toString();
+    });
+    socket.on("close", () => resolve(received));
+    socket.on("error", reject);
+  });
+}
+
 describe("createSessionUpgradeHandler", () => {
   const known = new Set(["s1", "s2"]);
+  let indexFailure: Error | null = null;
   const runtimes = new Map<string, UpgradeServingRuntime>();
   let log: Logger;
   let server: Server;
@@ -70,8 +85,16 @@ describe("createSessionUpgradeHandler", () => {
   beforeEach(async () => {
     log = fakeLogger();
     runtimes.clear();
+    indexFailure = null;
+    const index = indexDatabase(known);
     const handler = createSessionUpgradeHandler({
-      db: indexDatabase(known),
+      db: {
+        prepare: (query) => {
+          if (indexFailure) throw indexFailure;
+          return index.prepare(query);
+        },
+        batch: index.batch,
+      },
       runtimes: {
         withRuntimeIfPresent: async (sessionId, use) => {
           const runtime = runtimes.get(sessionId);
@@ -99,6 +122,29 @@ describe("createSessionUpgradeHandler", () => {
     expect(log.warn).toHaveBeenCalledWith(
       "Invalid WebSocket path",
       expect.objectContaining({ event: "ws.invalid_path" })
+    );
+  });
+
+  it("answers 400 to an upgrade whose Host makes no URL", async () => {
+    const answer = await rawUpgrade(
+      port,
+      "GET /sessions/s1/ws HTTP/1.1\r\nHost: [::1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+    );
+    expect(answer.startsWith("HTTP/1.1 400 Bad Request")).toBe(true);
+    expect(answer.endsWith("Invalid WebSocket request")).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      "Invalid WebSocket request",
+      expect.objectContaining({ event: "ws.invalid_request" })
+    );
+  });
+
+  it("answers 500 and logs when the path itself fails, so nothing rejects past it", async () => {
+    indexFailure = new Error("index unavailable");
+    expect(await rejected(connect("/sessions/s1/ws"))).toBe("Unexpected server response: 500");
+    expect(log.error).toHaveBeenCalledWith(
+      "WebSocket upgrade failed",
+      expect.objectContaining({ event: "ws.upgrade_failed", error: indexFailure })
     );
   });
 

--- a/packages/control-plane/src/node/websocket-upgrade.ts
+++ b/packages/control-plane/src/node/websocket-upgrade.ts
@@ -1,0 +1,211 @@
+/**
+ * The Node host's WebSocket upgrade path for `/sessions/:id/ws`, doing on
+ * one process what the Worker and the Durable Object do between them: the
+ * session must exist in the index (404 otherwise; any other upgrade path
+ * is 400), the session decides the upgrade, and the host completes the
+ * handshake and hands the runtime its socket.
+ *
+ * The decision is made under the runtime's lease, so the runtime is there
+ * to attach to, and the socket is paused from the moment the handshake
+ * completes until the runtime has adopted it: the peer may send as soon as
+ * it sees the 101, and a frame that arrived before adoption would have no
+ * listener. A rejection carries the session's response; it is written to
+ * the raw socket as the status line the peer's client library reports.
+ */
+
+import { STATUS_CODES, type IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocketServer, type WebSocket as NodeWebSocket } from "ws";
+import { createRequestMetrics, instrumentSqlDatabase } from "../db/instrumented-sql-database";
+import { SessionIndexStore } from "../db/session-index";
+import type { SqlDatabase } from "../db/sql-database";
+import type { Logger } from "../logger";
+import type { SessionUpgradeAdmission } from "../session/connection-authenticator";
+import type { SessionRuntimeLookup } from "./runtime-client";
+
+/**
+ * The largest frame a peer may send, the Workers runtime's WebSocket
+ * message limit, so a bridge or browser sees the same bound on both hosts.
+ */
+export const MAX_MESSAGE_BYTES = 1024 * 1024;
+
+const SESSION_WS_PATH = /^\/sessions\/([^/]+)\/ws$/;
+
+/** What the upgrade needs of a runtime: the decision, and a logger for its failures. */
+export interface UpgradeServingRuntime {
+  readonly upgrades: SessionUpgradeAdmission;
+  readonly log: Logger;
+}
+
+export interface SessionUpgradeHandlerOptions<Runtime extends UpgradeServingRuntime> {
+  /** The global store; the session index is read through it, instrumented as the Worker does. */
+  db: SqlDatabase;
+  runtimes: SessionRuntimeLookup<Runtime>;
+  log: Logger;
+  /** The handshake server; one without its own listener is created otherwise. */
+  webSocketServer?: WebSocketServer;
+}
+
+/** The `upgrade` listener of a Node HTTP server. */
+export type UpgradeHandler = (
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+) => Promise<void>;
+
+export function createSessionUpgradeHandler<Runtime extends UpgradeServingRuntime>(
+  options: SessionUpgradeHandlerOptions<Runtime>
+): UpgradeHandler {
+  const { db, runtimes, log } = options;
+  const server =
+    options.webSocketServer ??
+    new WebSocketServer({ noServer: true, maxPayload: MAX_MESSAGE_BYTES });
+
+  return async (request, socket, head) => {
+    // The HTTP server hands the socket over with no error listener: a peer
+    // that resets while the index is read must not take the process down.
+    socket.on("error", (error: Error) => {
+      log.debug("ws.socket_error", { event: "ws.socket_error", error_message: error.message });
+    });
+
+    const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+    const match = url.pathname.match(SESSION_WS_PATH);
+    if (!match) {
+      log.warn("Invalid WebSocket path", { event: "ws.invalid_path", http_path: url.pathname });
+      refuse(socket, 400, "Invalid WebSocket path");
+      return;
+    }
+    const sessionId = match[1];
+
+    const metrics = createRequestMetrics();
+    if (!(await new SessionIndexStore(instrumentSqlDatabase(db, metrics)).exists(sessionId))) {
+      log.warn("WebSocket session not found", {
+        event: "ws.session_not_found",
+        http_path: url.pathname,
+        session_id: sessionId,
+        ...metrics.summarize(),
+      });
+      refuse(socket, 404, "Session not found");
+      return;
+    }
+    log.info("WebSocket upgrade", {
+      event: "ws.connect",
+      http_path: url.pathname,
+      session_id: sessionId,
+      ...metrics.summarize(),
+    });
+
+    const upgradeRequest = toRequest(request, url);
+    const rejection = await runtimes.withRuntimeIfPresent(sessionId, (runtime) =>
+      admit(runtime, upgradeRequest, server, request, socket, head)
+    );
+    if (rejection === undefined) {
+      // Indexed a moment ago, gone by the time the runtime was opened.
+      refuse(socket, 404, "Session not found");
+      return;
+    }
+    if (rejection !== null) refuse(socket, rejection.status, await rejection.text());
+  };
+}
+
+/**
+ * Decide and, if accepted, complete the upgrade and attach the socket.
+ * Resolves with the rejection to write, or `null` once the socket is the
+ * runtime's or the handshake failed on the wire.
+ */
+async function admit(
+  runtime: UpgradeServingRuntime,
+  upgradeRequest: Request,
+  server: WebSocketServer,
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+): Promise<Response | null> {
+  const decision = await runtime.upgrades.authorize(upgradeRequest);
+  if (decision.kind === "reject") return decision.response;
+
+  const ws = await completeHandshake(server, request, socket, head);
+  if (ws === null) {
+    runtime.log.warn("WebSocket handshake aborted", {
+      event: "ws.handshake_aborted",
+      ws_type: decision.role,
+    });
+    return null;
+  }
+  try {
+    await decision.attach(ws);
+  } catch (error) {
+    runtime.log.error("WebSocket upgrade failed", {
+      ws_type: decision.role,
+      error: error instanceof Error ? error : String(error),
+    });
+    // Attachment commits nothing before its one await, so the socket is
+    // either unadopted or fully attached; closing covers both. Resumed
+    // first so the peer's close frame is read and the close completes.
+    ws.resume();
+    ws.close(1011, "WebSocket upgrade failed");
+    return null;
+  }
+  ws.resume();
+  return null;
+}
+
+/**
+ * The 101 and the socket, paused, or `null` when the handshake could not
+ * complete: the peer had gone, or its handshake was malformed and `ws`
+ * answered it. `ws` reports the latter only by closing the socket, so the
+ * socket's close is the other way this settles.
+ */
+function completeHandshake(
+  server: WebSocketServer,
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer
+): Promise<NodeWebSocket | null> {
+  return new Promise((resolve) => {
+    if (socket.destroyed || !socket.readable || !socket.writable) {
+      socket.destroy();
+      resolve(null);
+      return;
+    }
+    const onClose = (): void => resolve(null);
+    socket.once("close", onClose);
+    server.handleUpgrade(request, socket, head, (ws) => {
+      socket.off("close", onClose);
+      ws.pause();
+      resolve(ws);
+    });
+  });
+}
+
+/** The upgrade request as the session's authenticator reads it: the URL and the headers. */
+function toRequest(request: IncomingMessage, url: URL): Request {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item);
+    } else {
+      headers.set(name, value);
+    }
+  }
+  return new Request(url, { method: request.method ?? "GET", headers });
+}
+
+/** Answer the upgrade with a plain HTTP response and close the connection, as `ws` does. */
+function refuse(socket: Duplex, status: number, body: string): void {
+  if (socket.destroyed || !socket.writable) {
+    socket.destroy();
+    return;
+  }
+  const payload = Buffer.from(body, "utf8");
+  socket.once("finish", () => socket.destroy());
+  socket.end(
+    `HTTP/1.1 ${status} ${STATUS_CODES[status] ?? ""}\r\n` +
+      "Connection: close\r\n" +
+      "Content-Type: text/plain; charset=utf-8\r\n" +
+      `Content-Length: ${payload.length}\r\n` +
+      "\r\n" +
+      body
+  );
+}

--- a/packages/control-plane/src/node/websocket-upgrade.ts
+++ b/packages/control-plane/src/node/websocket-upgrade.ts
@@ -11,6 +11,10 @@
  * it sees the 101, and a frame that arrived before adoption would have no
  * listener. A rejection carries the session's response; it is written to
  * the raw socket as the status line the peer's client library reports.
+ *
+ * The handler is total: every outcome answers the socket or destroys it,
+ * and nothing it awaits can reject past it. The HTTP server's boundary
+ * catches whatever might still escape.
  */
 
 import { STATUS_CODES, type IncomingMessage } from "node:http";
@@ -61,14 +65,18 @@ export function createSessionUpgradeHandler<Runtime extends UpgradeServingRuntim
     options.webSocketServer ??
     new WebSocketServer({ noServer: true, maxPayload: MAX_MESSAGE_BYTES });
 
-  return async (request, socket, head) => {
-    // The HTTP server hands the socket over with no error listener: a peer
-    // that resets while the index is read must not take the process down.
-    socket.on("error", (error: Error) => {
-      log.debug("ws.socket_error", { event: "ws.socket_error", error_message: error.message });
-    });
-
-    const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+  const serve = async (request: IncomingMessage, socket: Duplex, head: Buffer): Promise<void> => {
+    let url: URL;
+    try {
+      url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+    } catch {
+      log.warn("Invalid WebSocket request", {
+        event: "ws.invalid_request",
+        http_path: request.url,
+      });
+      refuse(socket, 400, "Invalid WebSocket request");
+      return;
+    }
     const match = url.pathname.match(SESSION_WS_PATH);
     if (!match) {
       log.warn("Invalid WebSocket path", { event: "ws.invalid_path", http_path: url.pathname });
@@ -105,6 +113,24 @@ export function createSessionUpgradeHandler<Runtime extends UpgradeServingRuntim
       return;
     }
     if (rejection !== null) refuse(socket, rejection.status, await rejection.text());
+  };
+
+  return async (request, socket, head) => {
+    // The HTTP server hands the socket over with no error listener: a peer
+    // that resets while the index is read must not take the process down.
+    socket.on("error", (error: Error) => {
+      log.debug("ws.socket_error", { event: "ws.socket_error", error_message: error.message });
+    });
+    try {
+      await serve(request, socket, head);
+    } catch (error) {
+      log.error("WebSocket upgrade failed", {
+        event: "ws.upgrade_failed",
+        http_path: request.url,
+        error: error instanceof Error ? error : String(error),
+      });
+      refuse(socket, 500, "WebSocket upgrade failed");
+    }
   };
 }
 

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -13,7 +13,8 @@ import { BUILT_IN_ROLE_REGISTRY, type PermissionId } from "@open-inspect/shared/
 import type { CacheStore } from "@open-inspect/shared/cache-store";
 import type { SqlDatabase, SqlStatement } from "./db/sql-database";
 import type { SessionRuntimeDispatch } from "./session/runtime-client";
-import { cloudflareHost, createControlPlaneApp, type RouteModule } from "./routing/hono-app";
+import { cloudflareHost } from "./cloudflare/http-host";
+import { createControlPlaneApp, type RouteModule } from "./routing/hono-app";
 import { listRouteContracts, type RouteContract } from "./routing/route-contracts";
 import { catalog } from "./routes/catalog";
 import type { RouteParams } from "./routes/shared";

--- a/packages/control-plane/src/routing/hono-app.ts
+++ b/packages/control-plane/src/routing/hono-app.ts
@@ -7,12 +7,10 @@ import {
   auditRouteAuthorizationDecision,
   shouldAuditAllowedDecision,
 } from "../authorization/request-audit";
-import { createCloudflareBackgroundTasks } from "../cloudflare/background-tasks";
 import { createRequestContext } from "../http/create-request-context";
 import type { RequestContext } from "../http/request-context";
 import { error, HttpError } from "../http/responses";
 import { createLogger } from "../logger";
-import { catalog } from "../routes/catalog";
 import type { Env } from "../types";
 import type {
   ControlPlaneHonoEnv,
@@ -22,19 +20,7 @@ import type {
 } from "./hono-env";
 import { finalizeRouteResponse, logRequest, withCorsAndTraceHeaders } from "./request-lifecycle";
 
-export type {
-  ControlPlaneHonoEnv,
-  ControlPlaneHost,
-  PlatformExecutionContext,
-  RouteModule,
-} from "./hono-env";
-
-/** Ordinary HTTP entrypoint signature shared by the Worker and test adapters. */
-export type ControlPlaneHttpHandler = (
-  request: Request,
-  env: Env,
-  executionCtx: ExecutionContext
-) => Promise<Response>;
+export type { ControlPlaneHonoEnv, ControlPlaneHost, RouteModule } from "./hono-env";
 
 const logger = createLogger("router");
 
@@ -269,23 +255,3 @@ function internalError(
   });
   return error("Internal server error", 500);
 }
-
-/** The Cloudflare Worker host: background tasks ride the event's `waitUntil`. */
-export const cloudflareHost: ControlPlaneHost = {
-  backgroundTasks: (executionCtx) => {
-    if (!executionCtx) throw new Error("The Cloudflare host requires an execution context");
-    return createCloudflareBackgroundTasks(executionCtx);
-  },
-};
-
-/** Build the Worker's ordinary HTTP entrypoint over route modules. */
-export function createControlPlaneHttpHandler(
-  modules: readonly RouteModule[]
-): ControlPlaneHttpHandler {
-  const app = createControlPlaneApp(modules, cloudflareHost);
-  return (request, env, executionCtx) => Promise.resolve(app.fetch(request, env, executionCtx));
-}
-
-/** Production entrypoint over the canonical route catalog. */
-export const handleControlPlaneHttp: ControlPlaneHttpHandler =
-  createControlPlaneHttpHandler(catalog);

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -55,7 +55,7 @@ async function trackPullRequestLifecycle(
           method: "GET",
         });
         if (!response.ok) return [];
-        const body = await response.json<{ artifacts?: SessionArtifactSummary[] }>();
+        const body = (await response.json()) as { artifacts?: SessionArtifactSummary[] };
         return body.artifacts ?? [];
       },
       pushSnapshotToSession: async (sessionId, artifactId, snapshot) => {

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -1,6 +1,6 @@
 import { SELF, env } from "cloudflare:test";
 import { createCloudflareEnv, type WorkerBindings } from "../../src/cloudflare/platform";
-import { handleControlPlaneHttp } from "../../src/routing/hono-app";
+import { handleControlPlaneHttp } from "../../src/cloudflare/http-host";
 import { runInSessionDO } from "./session-do-access";
 import type { SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";

--- a/packages/control-plane/test/integration/hono-route-catalog-conformance.test.ts
+++ b/packages/control-plane/test/integration/hono-route-catalog-conformance.test.ts
@@ -6,11 +6,8 @@ import { NO_AUTHORIZATION } from "../../src/routes/shared";
 import { admit } from "../../src/routing/admit";
 import type { ControlPlaneHonoEnv } from "../../src/routing/hono-env";
 import { rawRouteParams } from "../../src/routing/route-params";
-import {
-  cloudflareHost,
-  createControlPlaneApp,
-  createControlPlaneHttpHandler,
-} from "../../src/routing/hono-app";
+import { cloudflareHost, createControlPlaneHttpHandler } from "../../src/cloudflare/http-host";
+import { createControlPlaneApp } from "../../src/routing/hono-app";
 import { listRouteContracts } from "../../src/routing/route-contracts";
 import { createCloudflareEnv } from "../../src/cloudflare/platform";
 

--- a/packages/control-plane/test/integration/route-admission-matrix.test.ts
+++ b/packages/control-plane/test/integration/route-admission-matrix.test.ts
@@ -12,11 +12,8 @@ import { SELF, env } from "cloudflare:test";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import { createExecutionContext } from "cloudflare:test";
-import {
-  cloudflareHost,
-  createControlPlaneApp,
-  createControlPlaneHttpHandler,
-} from "../../src/routing/hono-app";
+import { cloudflareHost, createControlPlaneHttpHandler } from "../../src/cloudflare/http-host";
+import { createControlPlaneApp } from "../../src/routing/hono-app";
 import { listRouteContracts, type RouteContract } from "../../src/routing/route-contracts";
 import { createCloudflareEnv } from "../../src/cloudflare/platform";
 import { AutomationStore, type AutomationRow } from "../../src/db/automation-store";

--- a/packages/control-plane/tsconfig.node.json
+++ b/packages/control-plane/tsconfig.node.json
@@ -1,13 +1,15 @@
 {
   // The Node host's program: src/node/** is the only production code that
   // imports Node built-ins (node:sqlite, node:fs), so it is excluded from the
-  // workerd-typed tsconfig.json and checked here with Node types only. The
-  // session core names no Cloudflare global, so nothing this program reaches
-  // needs workers-types; a Cloudflare type leaking into the core fails here.
+  // workerd-typed tsconfig.json and checked here with Node types only. From
+  // src/node/host.ts the program reaches the whole application, which names
+  // no Cloudflare global; a Cloudflare type leaking into it fails here.
+  // types/node-web.d.ts names the few web-standard types Node implements
+  // but @types/node does not declare globally.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["src/node/**/*.ts"],
+  "include": ["src/node/**/*.ts", "types/node-web.d.ts"],
   "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/packages/control-plane/types/node-web.d.ts
+++ b/packages/control-plane/types/node-web.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Web-standard names the application uses as types and Node implements at
+ * runtime, but that @types/node does not declare globally. Only the Node
+ * host's program (tsconfig.node.json) loads this file; the workerd programs
+ * take these names from workers-types.
+ */
+
+type CryptoKey = import("node:crypto").webcrypto.CryptoKey;
+type HeadersInit = NonNullable<ConstructorParameters<typeof Headers>[0]>;
+type RequestInfo = NonNullable<ConstructorParameters<typeof Request>[0]>;


### PR DESCRIPTION
Closes the build half of COL-97 (H-1). Rebased onto `main` after #1769 (the `instrumentSqlDatabase` rename) merged.

## What this is

The Node host is now a process. `node dist/node/main.js` boots the control plane over the adapters landed by N-1 … N-9, answers `/healthz` and the route table, completes WebSocket upgrades for sessions, drives the scheduled-job table, and shuts down in order on SIGTERM.

```
$ DATA_DIR=./data OBJECT_STORE_BUCKET=media … node dist/node/main.js
{"msg":"node_host.listening","host":"127.0.0.1","port":8787,"data_dir":"…","migrations_applied":73}
$ curl -s localhost:8787/healthz
{"status":"ok","uptime_s":0,"migrations_applied":73,"sessions_resident":0,"background_tasks":0,"alarm_clock":"running","cron":"running"}
$ curl -s localhost:8787/sessions          → {"error":"Unauthorized"}   (401, through admission)
$ curl -s localhost:8787/nope              → {"error":"Not found"}      (404)
$ kill -TERM …                             → node_host.draining … node_host.stopped, exit 0
```

## Files

| File | Role |
|---|---|
| `src/node/host.ts` | Composition root: the Node counterpart of `src/index.ts` and `SessionDO` together. Opens and migrates the global store, builds the alarm clock and the `SessionRuntimeRegistry`, assembles `Env`, validates the encryption keys **before listening**, serves the app, starts the clocks. `startNodeHost()` returns a handle so a test (and V-2) can boot it in-process. |
| `src/node/main.ts` | Process entry: reads `process.env`, starts the host, turns SIGTERM/SIGINT into `shutdown()` with a hard deadline (`SHUTDOWN_TIMEOUT_MS` + 5s → exit 1). |
| `src/node/config.ts` | `EnvConfig` from the environment. Every field is listed once in a table that `satisfies Record<keyof EnvConfig, true>`, so adding a field to `types.ts` without adding it here fails typecheck; the required subset is checked the same way. Host settings: `HOST`, `PORT` (8787), `DATA_DIR` (required), `MIGRATIONS_DIR` (defaults to the repo layout), `SHUTDOWN_TIMEOUT_MS` (30s). Empty variables count as unset. |
| `src/node/websocket-upgrade.ts` | `/sessions/:id/ws` on one process: index check (404; other upgrade paths 400) → runtime decides under its lease (P-2 `UpgradeDecision`) → `ws.handleUpgrade` → `decision.attach(ws)`. The socket is **paused from the 101 until the runtime has adopted it**; a test proves a frame sent on `open` survives an attach that awaits. Rejections are written as the status line ws clients report; attach failure closes 1011 as the Durable Object path does. `maxPayload` is the Workers 1 MiB message limit so bridges see the same bound on both hosts. |
| `src/node/http-server.ts` | `getRequestListener` from `@hono/node-server` over the app, `/healthz` answered ahead of it (200 / 503 while draining), upgrades routed to the handler above. |
| `src/node/cron-loop.ts` | One timer per P-7 job over `nextCronOccurrence(…, "UTC")`, re-armed from the slot so run duration never shifts the schedule; a slot whose previous run is still going is skipped and logged (the jobs are idempotent / CAS-claimed). Fake-timer tests cover the minute boundary, the skip, failure logging, the far-slot timer cap, and stop + drain. |
| `src/node/memory-cache-store.ts` | `REPOS_CACHE` for one process: KV's `expirationTtl` semantics, bounded (1000 entries, oldest out). |
| `src/cloudflare/http-host.ts` | `cloudflareHost`, `createControlPlaneHttpHandler`, `handleControlPlaneHttp` moved here out of `routing/hono-app.ts`, so the app module names no Cloudflare type (the Node typecheck program now reaches it). |
| `types/node-web.d.ts` | `CryptoKey`, `HeadersInit`, `RequestInfo`: web-standard types the app names, Node implements, and `@types/node` does not declare globally. Loaded only by `tsconfig.node.json`. |

Boot validates the encryption keys before any file is opened and unwinds a release stack in reverse if a later step fails.

Shutdown order (`host.shutdown()`), one deadline (`SHUTDOWN_TIMEOUT_MS`): health → 503, cron and alarm clock stop, server stops accepting (idle keep-alives closed); then requests in flight (tracked by the HTTP server), scheduled runs, alarm deliveries, and process-level background tasks are each drained within what remains of the budget; then `registry.shutdown()` quiesces every runtime (sockets closed 1012 so peers reconnect, re-closed on every wait pass so one adopted under an older lease is covered); then ws peers that ignored the close are terminated, remaining connections cut, stores closed. Returns `{ clean, abandoned }`; idempotent, a second call joins the first.

## Build

- `npm run build -w @open-inspect/control-plane` now runs `build:worker` and `build:node`, so the package build (what `terraform.yml` invokes) produces both artifacts; `build:node` alone → `dist/node/main.js` (ESM, `--platform=node --target=node22`; a `createRequire` banner serves the CommonJS dependencies' `require` calls). No `cloudflare:*` reference in the output.
- `npm run start:node`.
- `typecheck` already ran `tsconfig.node.json`; from `host.ts` that program now covers the whole application under Node types only, which is the leak check the roadmap wanted. It surfaced one real leak, `response.json<T>()` in `webhooks/github.ts` (a workers-types-only generic), fixed here.
- New dependency: `@hono/node-server@2.1.1` (the issue's stated choice now that D-5 has landed). It is not in the workerd bundle.

## Workerd bundle

Not byte-identical, and this is the honest number: after normalizing esbuild's path comments the two bundles are **4,440,740 vs 4,440,773 bytes**, the same module set plus `src/cloudflare/http-host.ts`, no Node input and no new package. The remaining textual diff is esbuild's identifier numbering (`logger2` → `logger16`), which follows module discovery order, and the `http-host.ts` split changes that order. Verified from `dist/meta.json` on both.

## Scope notes

- H-4 (crash-recovery marker, the session-file rescan from the N-7 addendum) and H-5 (jobs poller, `checkAutofixQueueHealth` on Node) stay theirs; this PR wires the cron loop and the orderly drain because the process cannot boot or stop without them.
- H-6 keeps the rest: `.env.example`, secrets from SSM. `readEnvConfig` here is the "list every string field once" half.
- `OBJECT_STORE_BUCKET` is required at boot (`MEDIA_BUCKET` is a required port); H-7's compose brings MinIO.
- `SLACK_BOT` / `LINEAR_BOT` / queues are left unset on Node until T-1 / N-5.

## Test plan

- [x] `npm run typecheck` (all four programs green, Node program now spans the app)
- [x] `eslint` + prettier, knip (branch vs base: `PlatformExecutionContext` no longer reported, nothing new)
- [x] Unit: 268 files / 3900 tests from `packages/control-plane`; new suites: config, memory cache, cron loop (fake timers), upgrade path (real `http` server + `ws` clients: 400, 404 ×2, rejection status, request fidelity, echo, paused-frame, 1011), HTTP server, **host boot** (real migrations dir, `/healthz`, 404 route, 401 catalog route, ws 404/400, draining + close, a blocked request held and answered, a blocked request past the budget reported and cut, malformed-key boot failure with the Worker's message and a clean retry, listen failure releasing both stores)
- [x] Integration (workerd): 98 files / 1161 tests
- [x] `build:node` + smoke above; `build` (workerd) input set compared against base via `meta.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the control plane as a Node.js service alongside the existing worker deployment.
  * Added configurable host, port, data, migration, and shutdown settings with validation for required environment variables.
  * Added WebSocket session upgrades for Node.js deployments.
  * Added health monitoring, graceful shutdown, request draining, and cleanup of active connections.
  * Added in-memory caching with expiration and bounded size controls.

* **Tests**
  * Expanded coverage for configuration, scheduling, HTTP handling, WebSockets, caching, startup, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->