### PR TITLE
docs: .env.example for the Node host, checked against EnvConfig (COL-102)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,21 @@
-# Configuration for the control plane running as a Node process (a container
-# on AWS, or `docker compose up` locally). Copy to `.env` and fill in the
-# values; `.env` is gitignored.
+# Configuration for the control plane running as a Node process. Copy to
+# `.env` and fill it in; `.env` is gitignored. The host reads its process
+# environment, so any loader works:
+#   node --env-file=.env packages/control-plane/dist/node/main.js
 #
-# Every deployment variable here has the same name and meaning on Cloudflare,
-# where Terraform sets it as a Worker variable (`var`) or secret (`secret`)
-# from the `terraform.tfvars` entry named after each line. The Node host reads
-# the same names from the process environment, so this file describes one
-# deployment on either platform. An empty value counts as unset.
+# The deployment variables have the same names and meanings on Cloudflare,
+# where they are Worker variables and secrets. Each line names its source
+# there: a `terraform.tfvars` entry (var.…), a value Terraform computes or
+# generates (local.…, random_password.…, a module output), or "not set by
+# Terraform". The Node-only settings at the top have no Cloudflare
+# counterpart. An empty value counts as unset.
 #
 # On AWS the container's environment is materialized from SSM Parameter Store
 # by the deploy step; nothing in this file is baked into the image.
 #
-# `packages/control-plane/src/node/env-example.test.ts` checks that this file names
-# every field of `EnvConfig` and nothing the host does not read.
+# `packages/control-plane/src/node/env-example.test.ts` checks that this file
+# names every variable the host reads and nothing else, and that the keys the
+# host requires at boot are exactly the ones marked "Required.".
 
 # ---------------------------------------------------------------------------
 # Node host (no Cloudflare equivalent: the platform provides these there)
@@ -48,6 +51,8 @@ OBJECT_STORE_FORCE_PATH_STYLE=true
 # use the instance role. For the compose stack they are the MinIO root user.
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin
+# Only with temporary (STS) credentials; empty for static keys or a role.
+AWS_SESSION_TOKEN=
 
 # ---------------------------------------------------------------------------
 # Deployment identity (Cloudflare: var)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,223 @@
+# Configuration for the control plane running as a Node process (a container
+# on AWS, or `docker compose up` locally). Copy to `.env` and fill in the
+# values; `.env` is gitignored.
+#
+# Every deployment variable here has the same name and meaning on Cloudflare,
+# where Terraform sets it as a Worker variable (`var`) or secret (`secret`)
+# from the `terraform.tfvars` entry named after each line. The Node host reads
+# the same names from the process environment, so this file describes one
+# deployment on either platform. An empty value counts as unset.
+#
+# On AWS the container's environment is materialized from SSM Parameter Store
+# by the deploy step; nothing in this file is baked into the image.
+#
+# `packages/control-plane/src/node/env-example.test.ts` checks that this file names
+# every field of `EnvConfig` and nothing the host does not read.
+
+# ---------------------------------------------------------------------------
+# Node host (no Cloudflare equivalent: the platform provides these there)
+# ---------------------------------------------------------------------------
+
+# Interface and port to listen on. 8787 matches the Worker's local dev port.
+HOST=0.0.0.0
+PORT=8787
+# Directory holding the global store (global.db), the per-session files
+# (sessions/<id>.db) and the host alarm index. A volume in the container.
+DATA_DIR=/data
+# The D1 migration files, applied to the global store at boot. The image sets
+# this to its own copy; leave empty to use terraform/d1/migrations from a
+# repository checkout.
+MIGRATIONS_DIR=
+# How long a shutdown waits for in-flight work before the process is forced down.
+SHUTDOWN_TIMEOUT_MS=30000
+
+# ---------------------------------------------------------------------------
+# Object storage for media (Cloudflare: the MEDIA_BUCKET R2 binding)
+# ---------------------------------------------------------------------------
+
+# Any S3-compatible bucket. The compose stack points these at its MinIO service.
+OBJECT_STORE_BUCKET=media
+OBJECT_STORE_REGION=us-east-1
+# Leave empty for AWS S3. MinIO and other S3-compatible services need it.
+OBJECT_STORE_ENDPOINT=http://minio:9000
+# Plain-http endpoints are refused unless this is "true" (local MinIO only).
+OBJECT_STORE_ALLOW_HTTP=true
+# "true" for MinIO (bucket in the path, not the hostname).
+OBJECT_STORE_FORCE_PATH_STYLE=true
+# Credentials through the AWS SDK's default chain. Leave both empty on EC2 to
+# use the instance role. For the compose stack they are the MinIO root user.
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+
+# ---------------------------------------------------------------------------
+# Deployment identity (Cloudflare: var)
+# ---------------------------------------------------------------------------
+
+# Required. Cloudflare: var.deployment_name
+DEPLOYMENT_NAME=local
+# Display name in the UI, PR footers and User-Agent headers. Cloudflare: var.app_name
+APP_NAME=Open-Inspect
+# Required. The GitHub App's bot login, `<app-slug>[bot]`. Cloudflare: var.github_bot_username
+GITHUB_BOT_USERNAME=
+# Public base URL of this control plane; sandboxes and image builds call back
+# to it, so it must be reachable from the sandbox provider. Cloudflare: local.control_plane_url
+WORKER_URL=http://localhost:8787
+# Base URL of the web app, for PR links and browser-auth origin checks. Cloudflare: local.web_app_url
+WEB_APP_URL=http://localhost:3000
+# "github" (default) or "gitlab". Cloudflare: not set by Terraform; a Worker var if needed.
+SCM_PROVIDER=github
+# Cloudflare account id; only used to derive a workers.dev callback URL when
+# WORKER_URL is unset. Cloudflare: not set by Terraform.
+CF_ACCOUNT_ID=
+
+# ---------------------------------------------------------------------------
+# Encryption keys (Cloudflare: secret). Each is 32 random bytes, base64:
+#   openssl rand -base64 32
+# A key that is not 32 bytes is rejected (the token and repo-secrets keys at
+# boot, the provider-accounts key at first use). Rotating one invalidates what
+# it encrypted, so generate them once per deployment and keep them.
+# ---------------------------------------------------------------------------
+
+# Required. OAuth tokens at rest. Cloudflare: var.token_encryption_key
+TOKEN_ENCRYPTION_KEY=
+# Required. Model-provider account credentials. Cloudflare: var.provider_accounts_encryption_key
+PROVIDER_ACCOUNTS_ENCRYPTION_KEY=
+# Repo-scoped secrets and MCP server configuration. Cloudflare: var.repo_secrets_encryption_key
+REPO_SECRETS_ENCRYPTION_KEY=
+# Pepper for image-build callback token hashes. Cloudflare: generated (random_password.image_callback_token_pepper)
+IMAGE_CALLBACK_TOKEN_PEPPER=
+
+# ---------------------------------------------------------------------------
+# Browser sign-in and access control
+# ---------------------------------------------------------------------------
+
+# Signs Better Auth state. Cloudflare: secret, var.nextauth_secret
+BROWSER_AUTH_SECRET=
+# GitHub OAuth app for sign-in. Cloudflare: var / secret, var.github_client_id / var.github_client_secret
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+# Google OAuth app for sign-in (optional). Cloudflare: var / secret, var.google_client_id / var.google_client_secret
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Who may sign in: comma-separated lists. Cloudflare: var.allowed_users,
+# var.allowed_email_domains, var.allowed_emails, var.allowed_github_orgs
+ALLOWED_USERS=
+ALLOWED_EMAIL_DOMAINS=
+ALLOWED_EMAILS=
+ALLOWED_GITHUB_ORGS=
+# "true" disables the allowlists entirely. Cloudflare: var.unsafe_allow_all_users
+UNSAFE_ALLOW_ALL_USERS=
+
+# ---------------------------------------------------------------------------
+# Service-to-service authentication (Cloudflare: secret, generated by
+# Terraform as random_password.service_auth_secret_*). Each service signs its
+# requests with its own secret; an unset secret means that service cannot
+# authenticate. The web app's SERVICE_AUTH_SECRET must equal SERVICE_AUTH_SECRET_WEB.
+# ---------------------------------------------------------------------------
+
+SERVICE_AUTH_SECRET_WEB=
+SERVICE_AUTH_SECRET_SLACK_BOT=
+SERVICE_AUTH_SECRET_GITHUB_BOT=
+SERVICE_AUTH_SECRET_LINEAR_BOT=
+# Bot token for agent-initiated Slack messages (optional). Cloudflare: secret, var.slack_bot_token
+SLACK_BOT_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Source control (Cloudflare: secret)
+# ---------------------------------------------------------------------------
+
+# GitHub App credentials for repository access and git operations. The private
+# key is the PEM text (PKCS#8), newlines escaped as \n inside one line.
+# Cloudflare: var.github_app_id, var.github_app_private_key, var.github_app_installation_id
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_INSTALLATION_ID=
+# GitLab, when SCM_PROVIDER=gitlab. Cloudflare: not set by Terraform; a Worker
+# secret and var of the same names if needed.
+GITLAB_ACCESS_TOKEN=
+GITLAB_NAMESPACE=
+
+# ---------------------------------------------------------------------------
+# Sandbox provider. One of "modal" (default), "daytona", "vercel",
+# "opencomputer", "e2b"; only that provider's block needs values.
+# Cloudflare: var.sandbox_provider
+# ---------------------------------------------------------------------------
+
+SANDBOX_PROVIDER=modal
+
+# Modal. The API secret is shared with the Modal deployment for HMAC-signed
+# endpoint calls; the workspace and environment build the endpoint URLs.
+# Cloudflare: secret var.modal_api_secret; var.modal_workspace,
+# var.modal_environment, var.modal_environment_web_suffix
+MODAL_API_SECRET=
+MODAL_WORKSPACE=
+MODAL_ENVIRONMENT=
+MODAL_ENVIRONMENT_WEB_SUFFIX=
+# Modal API tokens; not read by the control plane today (the Modal app is
+# deployed with them separately). Cloudflare: not set by Terraform.
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=
+
+# Daytona. Cloudflare: secret var.daytona_api_key; var.daytona_api_url,
+# var.daytona_base_snapshot, var.daytona_target. The two interval settings are
+# not set by Terraform.
+DAYTONA_API_KEY=
+DAYTONA_API_URL=
+DAYTONA_BASE_SNAPSHOT=
+DAYTONA_TARGET=
+DAYTONA_AUTO_STOP_INTERVAL_MINUTES=
+DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES=
+
+# Vercel Sandboxes. Cloudflare: secret var.vercel_sandbox_token;
+# var.vercel_sandbox_project_id, var.vercel_sandbox_team_id,
+# var.vercel_base_snapshot_id, var.vercel_sandbox_runtime,
+# var.vercel_sandbox_api_base_url, var.vercel_snapshot_expiration_ms
+VERCEL_TOKEN=
+VERCEL_PROJECT_ID=
+VERCEL_TEAM_ID=
+VERCEL_BASE_SNAPSHOT_ID=
+VERCEL_BASE_SNAPSHOT_NAME=
+VERCEL_RUNTIME=
+VERCEL_SANDBOX_API_BASE_URL=
+VERCEL_SNAPSHOT_EXPIRATION_MS=
+
+# OpenComputer. Cloudflare: secret var.opencomputer_api_key;
+# var.opencomputer_api_url, var.opencomputer_template
+OPENCOMPUTER_API_KEY=
+OPENCOMPUTER_API_URL=
+OPENCOMPUTER_TEMPLATE=
+
+# E2B. Cloudflare: secret var.e2b_api_key; var.e2b_api_url,
+# var.e2b_template_id, var.e2b_sandbox_timeout_seconds, var.e2b_auto_pause
+E2B_API_KEY=
+E2B_API_URL=
+E2B_TEMPLATE_ID=
+E2B_SANDBOX_TIMEOUT_SECONDS=
+E2B_AUTO_PAUSE=
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+# Anthropic API key for Claude models. Cloudflare: secret, var.anthropic_api_key
+ANTHROPIC_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Sandbox lifecycle (Cloudflare: var)
+# ---------------------------------------------------------------------------
+
+# Idle time before a sandbox is stopped, in ms (default 600000). Cloudflare: var.sandbox_inactivity_timeout_ms
+SANDBOX_INACTIVITY_TIMEOUT_MS=
+# Longest a turn may run before it is failed, in ms (default 5400000).
+# Cloudflare: not set by Terraform.
+EXECUTION_TIMEOUT_MS=
+# "enforce" (default) fails spawn and build on oversized secret payloads;
+# "warn" only logs. Cloudflare: not set by Terraform.
+SECRETS_CAP_ENFORCEMENT=
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+# "debug" | "info" | "warn" | "error" (default "info"). Cloudflare: not set by Terraform.
+LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -82,7 +82,7 @@ CF_ACCOUNT_ID=
 TOKEN_ENCRYPTION_KEY=
 # Required. Model-provider account credentials. Cloudflare: var.provider_accounts_encryption_key
 PROVIDER_ACCOUNTS_ENCRYPTION_KEY=
-# Repo-scoped secrets and MCP server configuration. Cloudflare: var.repo_secrets_encryption_key
+# Required. Repo-scoped secrets and MCP server configuration. Cloudflare: var.repo_secrets_encryption_key
 REPO_SECRETS_ENCRYPTION_KEY=
 # Pepper for image-build callback token hashes. Cloudflare: generated (random_password.image_callback_token_pepper)
 IMAGE_CALLBACK_TOKEN_PEPPER=
@@ -127,7 +127,9 @@ SLACK_BOT_TOKEN=
 # ---------------------------------------------------------------------------
 
 # GitHub App credentials for repository access and git operations. The private
-# key is the PEM text (PKCS#8), newlines escaped as \n inside one line.
+# key is the PEM text (PKCS#8) on one line, either double-quoted with real
+# newlines (compose decodes "\n" inside double quotes) or with the two
+# characters \n in place of each newline, which the key parser strips.
 # Cloudflare: var.github_app_id, var.github_app_private_key, var.github_app_installation_id
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
@@ -171,7 +173,9 @@ DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES=
 # Vercel Sandboxes. Cloudflare: secret var.vercel_sandbox_token;
 # var.vercel_sandbox_project_id, var.vercel_sandbox_team_id,
 # var.vercel_base_snapshot_id, var.vercel_sandbox_runtime,
-# var.vercel_sandbox_api_base_url, var.vercel_snapshot_expiration_ms
+# var.vercel_sandbox_api_base_url, var.vercel_snapshot_expiration_ms.
+# VERCEL_BASE_SNAPSHOT_NAME is generated (module.vercel_sandbox_infra[0].snapshot_name)
+# when no snapshot id is supplied.
 VERCEL_TOKEN=
 VERCEL_PROJECT_ID=
 VERCEL_TEAM_ID=
@@ -208,8 +212,10 @@ ANTHROPIC_API_KEY=
 
 # Idle time before a sandbox is stopped, in ms (default 600000). Cloudflare: var.sandbox_inactivity_timeout_ms
 SANDBOX_INACTIVITY_TIMEOUT_MS=
-# Longest a turn may run before it is failed, in ms (default 5400000).
-# Cloudflare: not set by Terraform.
+# Longest a turn may run before it is failed, in ms. A session without its
+# own sandbox timeout setting falls back to the sandbox timeout (7200000);
+# the automation recovery sweep falls back to 5400000. Cloudflare: not set
+# by Terraform.
 EXECUTION_TIMEOUT_MS=
 # "enforce" (default) fails spawn and build on oversized secret payloads;
 # "warn" only logs. Cloudflare: not set by Terraform.

--- a/packages/control-plane/src/auth/github-app.test.ts
+++ b/packages/control-plane/src/auth/github-app.test.ts
@@ -308,7 +308,7 @@ describe("github-app utilities", () => {
           installationId: "installation-escaped-key",
         },
         undefined,
-        { cacheStore: new FakeCacheStore() }
+        { forceRefresh: true }
       );
 
       expect(result.token).toBe("escaped-key-token");

--- a/packages/control-plane/src/auth/github-app.test.ts
+++ b/packages/control-plane/src/auth/github-app.test.ts
@@ -291,6 +291,29 @@ describe("github-app utilities", () => {
       expect(result).toEqual({ token: "fresh-token", expiresAtEpochMs: Date.parse(expiresAt) });
     });
 
+    it("signs with a key whose newlines are the two characters backslash-n", async () => {
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      const { privateKeyPem } = await generateTestKeyPair();
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ token: "escaped-key-token", expires_at: expiresAt }), {
+          status: 201,
+        })
+      );
+
+      const result = await getCachedInstallationTokenWithExpiry(
+        {
+          appId: `app-escaped-key-${Date.now()}`,
+          privateKey: privateKeyPem.replace(/\n/g, "\\n"),
+          installationId: "installation-escaped-key",
+        },
+        undefined,
+        { cacheStore: new FakeCacheStore() }
+      );
+
+      expect(result.token).toBe("escaped-key-token");
+    });
+
     it("rejects a malformed GitHub installation token response", async () => {
       const fetchMock = vi.spyOn(globalThis, "fetch");
       const { privateKeyPem } = await generateTestKeyPair();

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -135,12 +135,14 @@ const repositoryBranchesResponseSchema = z.array(z.object({ name: z.string() }))
  * Parse PEM-encoded private key to raw bytes.
  */
 function parsePemPrivateKey(pem: string): Uint8Array {
-  // Remove PEM header/footer and newlines
+  // Remove PEM header/footer and newlines, including the two-character
+  // `\n` an environment file leaves in place of a newline.
   const pemContents = pem
     .replace(/-----BEGIN RSA PRIVATE KEY-----/g, "")
     .replace(/-----END RSA PRIVATE KEY-----/g, "")
     .replace(/-----BEGIN PRIVATE KEY-----/g, "")
     .replace(/-----END PRIVATE KEY-----/g, "")
+    .replace(/\\n/g, "")
     .replace(/\s/g, "");
 
   // Decode base64

--- a/packages/control-plane/src/node/config.test.ts
+++ b/packages/control-plane/src/node/config.test.ts
@@ -6,6 +6,7 @@ const REQUIRED = {
   GITHUB_BOT_USERNAME: "bot[bot]",
   TOKEN_ENCRYPTION_KEY: "k1",
   PROVIDER_ACCOUNTS_ENCRYPTION_KEY: "k2",
+  REPO_SECRETS_ENCRYPTION_KEY: "k3",
 };
 
 describe("readEnvConfig", () => {
@@ -27,7 +28,7 @@ describe("readEnvConfig", () => {
 
   it("names every missing required variable at once", () => {
     expect(() => readEnvConfig({ DEPLOYMENT_NAME: "test", TOKEN_ENCRYPTION_KEY: "" })).toThrow(
-      "Missing required configuration: GITHUB_BOT_USERNAME, TOKEN_ENCRYPTION_KEY, PROVIDER_ACCOUNTS_ENCRYPTION_KEY"
+      "Missing required configuration: GITHUB_BOT_USERNAME, TOKEN_ENCRYPTION_KEY, PROVIDER_ACCOUNTS_ENCRYPTION_KEY, REPO_SECRETS_ENCRYPTION_KEY"
     );
   });
 });

--- a/packages/control-plane/src/node/config.ts
+++ b/packages/control-plane/src/node/config.ts
@@ -90,6 +90,11 @@ const ENV_CONFIG_KEYS = {
   LOG_LEVEL: true,
 } as const satisfies Record<keyof EnvConfig, true>;
 
+/** The `EnvConfig` field names, for checking documentation against the type. */
+export const ENV_CONFIG_KEY_NAMES: readonly (keyof EnvConfig)[] = Object.keys(
+  ENV_CONFIG_KEYS
+) as (keyof EnvConfig)[];
+
 /** The `EnvConfig` fields the type does not mark optional. */
 type RequiredEnvConfigKey = {
   [K in keyof EnvConfig]-?: undefined extends EnvConfig[K] ? never : K;

--- a/packages/control-plane/src/node/config.ts
+++ b/packages/control-plane/src/node/config.ts
@@ -165,9 +165,9 @@ export const NODE_HOST_VARIABLE_NAMES = [
 
 /** What the process itself needs: where to listen and where its files live. */
 export interface NodeHostSettings {
-  /** Interface to listen on; `0.0.0.0` unless `HOST` says otherwise. */
+  /** Interface to listen on; `HOST`, else DEFAULT_HOST. */
   host: string;
-  /** `PORT`; 8787 unless set, the port the Worker's local dev server uses. */
+  /** `PORT`, else DEFAULT_PORT, the port the Worker's local dev server uses. */
   port: number;
   /** `DATA_DIR`: the global store, the session files, and the host alarm index live here. */
   dataDir: string;
@@ -177,6 +177,7 @@ export interface NodeHostSettings {
   shutdownTimeoutMs: number;
 }
 
+const DEFAULT_HOST = "0.0.0.0";
 const DEFAULT_PORT = 8787;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
 
@@ -198,7 +199,7 @@ export function readNodeHostSettings(source: ConfigSource): NodeHostSettings {
     throw new Error("DATA_DIR is required: the directory that holds the host's databases");
   }
   return {
-    host: present(variables.HOST) ?? "0.0.0.0",
+    host: present(variables.HOST) ?? DEFAULT_HOST,
     port: integer("PORT", variables.PORT, DEFAULT_PORT),
     dataDir: resolve(dataDir),
     migrationsDir: resolve(present(variables.MIGRATIONS_DIR) ?? DEFAULT_MIGRATIONS_DIR),

--- a/packages/control-plane/src/node/config.ts
+++ b/packages/control-plane/src/node/config.ts
@@ -100,13 +100,39 @@ type RequiredEnvConfigKey = {
   [K in keyof EnvConfig]-?: undefined extends EnvConfig[K] ? never : K;
 }[keyof EnvConfig];
 
-/** The required fields, checked against the type like the table above. */
+/**
+ * Fields the type leaves optional that the Node host nevertheless needs at
+ * boot: `startNodeHost` validates the repo-secrets key before listening.
+ */
+type NodeRequiredEnvConfigKey = "REPO_SECRETS_ENCRYPTION_KEY";
+
+/** The fields a boot must have, checked against the type like the table above. */
 const REQUIRED_ENV_CONFIG_KEYS = {
   DEPLOYMENT_NAME: true,
   GITHUB_BOT_USERNAME: true,
   TOKEN_ENCRYPTION_KEY: true,
   PROVIDER_ACCOUNTS_ENCRYPTION_KEY: true,
-} as const satisfies Record<RequiredEnvConfigKey, true>;
+  REPO_SECRETS_ENCRYPTION_KEY: true,
+} as const satisfies Record<RequiredEnvConfigKey | NodeRequiredEnvConfigKey, true>;
+
+/** The names a boot must have, for checking documentation against the table. */
+export const REQUIRED_ENV_CONFIG_KEY_NAMES: readonly (keyof EnvConfig)[] = Object.keys(
+  REQUIRED_ENV_CONFIG_KEYS
+) as (keyof EnvConfig)[];
+
+/**
+ * The variables in `source` named by `names`, and no other: a reader that
+ * takes its input through here cannot read a variable its table omits, so
+ * the table stays the one list of what the reader depends on.
+ */
+export function pickVariables<Name extends string>(
+  source: ConfigSource,
+  names: readonly Name[]
+): Record<Name, string | undefined> {
+  const picked = {} as Record<Name, string | undefined>;
+  for (const name of names) picked[name] = source[name];
+  return picked;
+}
 
 /**
  * The deployment's configuration from `source`. Fails naming every required
@@ -127,6 +153,15 @@ export function readEnvConfig(source: ConfigSource): EnvConfig {
   }
   return config as EnvConfig;
 }
+
+/** The host's own variables; `readNodeHostSettings` reads through this table only. */
+export const NODE_HOST_VARIABLE_NAMES = [
+  "HOST",
+  "PORT",
+  "DATA_DIR",
+  "MIGRATIONS_DIR",
+  "SHUTDOWN_TIMEOUT_MS",
+] as const;
 
 /** What the process itself needs: where to listen and where its files live. */
 export interface NodeHostSettings {
@@ -157,18 +192,19 @@ export const DEFAULT_MIGRATIONS_DIR = resolve(
 
 /** The host's settings from `source`; `DATA_DIR` is the one with no default. */
 export function readNodeHostSettings(source: ConfigSource): NodeHostSettings {
-  const dataDir = present(source.DATA_DIR);
+  const variables = pickVariables(source, NODE_HOST_VARIABLE_NAMES);
+  const dataDir = present(variables.DATA_DIR);
   if (dataDir === undefined) {
     throw new Error("DATA_DIR is required: the directory that holds the host's databases");
   }
   return {
-    host: present(source.HOST) ?? "0.0.0.0",
-    port: integer("PORT", source.PORT, DEFAULT_PORT),
+    host: present(variables.HOST) ?? "0.0.0.0",
+    port: integer("PORT", variables.PORT, DEFAULT_PORT),
     dataDir: resolve(dataDir),
-    migrationsDir: resolve(present(source.MIGRATIONS_DIR) ?? DEFAULT_MIGRATIONS_DIR),
+    migrationsDir: resolve(present(variables.MIGRATIONS_DIR) ?? DEFAULT_MIGRATIONS_DIR),
     shutdownTimeoutMs: integer(
       "SHUTDOWN_TIMEOUT_MS",
-      source.SHUTDOWN_TIMEOUT_MS,
+      variables.SHUTDOWN_TIMEOUT_MS,
       DEFAULT_SHUTDOWN_TIMEOUT_MS
     ),
   };

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -2,7 +2,12 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { ENV_CONFIG_KEY_NAMES } from "./config";
+import {
+  ENV_CONFIG_KEY_NAMES,
+  NODE_HOST_VARIABLE_NAMES,
+  REQUIRED_ENV_CONFIG_KEY_NAMES,
+} from "./config";
+import { AWS_CREDENTIAL_VARIABLE_NAMES, OBJECT_STORAGE_VARIABLE_NAMES } from "./s3-object-storage";
 
 /** The repository's `.env.example`, the documented configuration of a Node host. */
 const ENV_EXAMPLE_PATH = resolve(
@@ -10,36 +15,67 @@ const ENV_EXAMPLE_PATH = resolve(
   "../../../../.env.example"
 );
 
-/** Variables the Node host reads that are not `EnvConfig` fields. */
-const NODE_HOST_VARIABLES = [
-  "HOST",
-  "PORT",
-  "DATA_DIR",
-  "MIGRATIONS_DIR",
-  "SHUTDOWN_TIMEOUT_MS",
-  "OBJECT_STORE_BUCKET",
-  "OBJECT_STORE_REGION",
-  "OBJECT_STORE_ENDPOINT",
-  "OBJECT_STORE_ALLOW_HTTP",
-  "OBJECT_STORE_FORCE_PATH_STYLE",
-  // Read by the AWS SDK's default credential chain, not by the host itself.
-  "AWS_ACCESS_KEY_ID",
-  "AWS_SECRET_ACCESS_KEY",
-];
+/** A key's comment block opens with this when a boot cannot do without the key. */
+const REQUIRED_MARKER = "# Required.";
 
-function documentedVariables(): string[] {
-  const names: string[] = [];
+interface DocumentedVariable {
+  name: string;
+  /** The comment lines directly above the assignment, up to the previous blank line. */
+  comment: string[];
+}
+
+interface EnvExample {
+  variables: DocumentedVariable[];
+  /** Lines that are neither blank, a comment, nor a `NAME=value` assignment. */
+  malformed: string[];
+}
+
+function parseEnvExample(): EnvExample {
+  const variables: DocumentedVariable[] = [];
+  const malformed: string[] = [];
+  let comment: string[] = [];
   for (const line of readFileSync(ENV_EXAMPLE_PATH, "utf8").split("\n")) {
-    const match = /^([A-Z][A-Z0-9_]*)=/.exec(line);
-    if (match) names.push(match[1]);
+    if (line.trim() === "") {
+      comment = [];
+      continue;
+    }
+    if (line.startsWith("#")) {
+      comment.push(line);
+      continue;
+    }
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=/.exec(line);
+    if (match) {
+      variables.push({ name: match[1], comment });
+      comment = [];
+    } else {
+      malformed.push(line);
+    }
   }
-  return names;
+  return { variables, malformed };
 }
 
 describe(".env.example", () => {
-  it("names every EnvConfig field and every Node host variable, each once", () => {
-    const documented = documentedVariables();
-    const expected = [...ENV_CONFIG_KEY_NAMES, ...NODE_HOST_VARIABLES];
+  const example = parseEnvExample();
+
+  it("holds only comments, blank lines and NAME=value assignments", () => {
+    expect(example.malformed).toEqual([]);
+  });
+
+  it("names every variable the host reads, and nothing else, each once", () => {
+    const documented = example.variables.map((variable) => variable.name);
+    const expected = [
+      ...ENV_CONFIG_KEY_NAMES,
+      ...NODE_HOST_VARIABLE_NAMES,
+      ...OBJECT_STORAGE_VARIABLE_NAMES,
+      ...AWS_CREDENTIAL_VARIABLE_NAMES,
+    ];
     expect([...documented].sort()).toEqual([...expected].sort());
+  });
+
+  it("marks exactly the keys a boot requires as Required.", () => {
+    const marked = example.variables
+      .filter((variable) => variable.comment[0]?.startsWith(REQUIRED_MARKER))
+      .map((variable) => variable.name);
+    expect(marked.sort()).toEqual([...REQUIRED_ENV_CONFIG_KEY_NAMES].sort());
   });
 });

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ENV_CONFIG_KEY_NAMES } from "./config";
+
+/** The repository's `.env.example`, the documented configuration of a Node host. */
+const ENV_EXAMPLE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../.env.example"
+);
+
+/** Variables the Node host reads that are not `EnvConfig` fields. */
+const NODE_HOST_VARIABLES = [
+  "HOST",
+  "PORT",
+  "DATA_DIR",
+  "MIGRATIONS_DIR",
+  "SHUTDOWN_TIMEOUT_MS",
+  "OBJECT_STORE_BUCKET",
+  "OBJECT_STORE_REGION",
+  "OBJECT_STORE_ENDPOINT",
+  "OBJECT_STORE_ALLOW_HTTP",
+  "OBJECT_STORE_FORCE_PATH_STYLE",
+  // Read by the AWS SDK's default credential chain, not by the host itself.
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+];
+
+function documentedVariables(): string[] {
+  const names: string[] = [];
+  for (const line of readFileSync(ENV_EXAMPLE_PATH, "utf8").split("\n")) {
+    const match = /^([A-Z][A-Z0-9_]*)=/.exec(line);
+    if (match) names.push(match[1]);
+  }
+  return names;
+}
+
+describe(".env.example", () => {
+  it("names every EnvConfig field and every Node host variable, each once", () => {
+    const documented = documentedVariables();
+    const expected = [...ENV_CONFIG_KEY_NAMES, ...NODE_HOST_VARIABLES];
+    expect([...documented].sort()).toEqual([...expected].sort());
+  });
+});

--- a/packages/control-plane/src/node/s3-object-storage.ts
+++ b/packages/control-plane/src/node/s3-object-storage.ts
@@ -72,11 +72,13 @@ export const AWS_CREDENTIAL_VARIABLE_NAMES = [
   "AWS_SESSION_TOKEN",
 ] as const;
 
+/** The region MinIO and most S3-compatible services answer to. */
+const DEFAULT_OBJECT_STORE_REGION = "us-east-1";
+
 /**
  * The configuration from the `OBJECT_STORE_*` variables. `OBJECT_STORE_BUCKET`
- * is required; `OBJECT_STORE_REGION` defaults to `us-east-1`, the region
- * MinIO and most S3-compatible services answer to; `OBJECT_STORE_ALLOW_HTTP`
- * is the opt-in for a plaintext endpoint.
+ * is required; `OBJECT_STORE_REGION` defaults to DEFAULT_OBJECT_STORE_REGION;
+ * `OBJECT_STORE_ALLOW_HTTP` is the opt-in for a plaintext endpoint.
  */
 export function readS3ObjectStorageConfig(env: ConfigSource): S3ObjectStorageConfig {
   const variables = pickVariables(env, OBJECT_STORAGE_VARIABLE_NAMES);
@@ -86,7 +88,7 @@ export function readS3ObjectStorageConfig(env: ConfigSource): S3ObjectStorageCon
   }
   return {
     bucket,
-    region: variables.OBJECT_STORE_REGION || "us-east-1",
+    region: variables.OBJECT_STORE_REGION || DEFAULT_OBJECT_STORE_REGION,
     endpoint: variables.OBJECT_STORE_ENDPOINT || undefined,
     allowHttpEndpoint: variables.OBJECT_STORE_ALLOW_HTTP === "true",
     forcePathStyle: variables.OBJECT_STORE_FORCE_PATH_STYLE === "true",

--- a/packages/control-plane/src/node/s3-object-storage.ts
+++ b/packages/control-plane/src/node/s3-object-storage.ts
@@ -24,6 +24,7 @@ import {
   type HeadObjectCommandOutput,
 } from "@aws-sdk/client-s3";
 import { VIDEO_MAX_BYTES } from "../media";
+import { pickVariables, type ConfigSource } from "./config";
 import type { ObjectStorage, ObjectStorageMetadata } from "../storage/object-storage";
 
 export interface S3ObjectStorageConfig {
@@ -51,25 +52,44 @@ export interface S3ObjectStorageConfig {
   maxObjectBytes?: number;
 }
 
+/** The object-store variables; `readS3ObjectStorageConfig` reads through this table only. */
+export const OBJECT_STORAGE_VARIABLE_NAMES = [
+  "OBJECT_STORE_BUCKET",
+  "OBJECT_STORE_REGION",
+  "OBJECT_STORE_ENDPOINT",
+  "OBJECT_STORE_ALLOW_HTTP",
+  "OBJECT_STORE_FORCE_PATH_STYLE",
+] as const;
+
+/**
+ * The static-credential variables of the SDK's default provider chain that
+ * a deployment may set. The chain's other sources (an instance role, a
+ * shared credentials file) take nothing from the environment we document.
+ */
+export const AWS_CREDENTIAL_VARIABLE_NAMES = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+] as const;
+
 /**
  * The configuration from the `OBJECT_STORE_*` variables. `OBJECT_STORE_BUCKET`
  * is required; `OBJECT_STORE_REGION` defaults to `us-east-1`, the region
  * MinIO and most S3-compatible services answer to; `OBJECT_STORE_ALLOW_HTTP`
  * is the opt-in for a plaintext endpoint.
  */
-export function readS3ObjectStorageConfig(
-  env: Record<string, string | undefined>
-): S3ObjectStorageConfig {
-  const bucket = env.OBJECT_STORE_BUCKET;
+export function readS3ObjectStorageConfig(env: ConfigSource): S3ObjectStorageConfig {
+  const variables = pickVariables(env, OBJECT_STORAGE_VARIABLE_NAMES);
+  const bucket = variables.OBJECT_STORE_BUCKET;
   if (!bucket) {
     throw new Error("OBJECT_STORE_BUCKET is required to use S3 object storage");
   }
   return {
     bucket,
-    region: env.OBJECT_STORE_REGION || "us-east-1",
-    endpoint: env.OBJECT_STORE_ENDPOINT || undefined,
-    allowHttpEndpoint: env.OBJECT_STORE_ALLOW_HTTP === "true",
-    forcePathStyle: env.OBJECT_STORE_FORCE_PATH_STYLE === "true",
+    region: variables.OBJECT_STORE_REGION || "us-east-1",
+    endpoint: variables.OBJECT_STORE_ENDPOINT || undefined,
+    allowHttpEndpoint: variables.OBJECT_STORE_ALLOW_HTTP === "true",
+    forcePathStyle: variables.OBJECT_STORE_FORCE_PATH_STYLE === "true",
   };
 }
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -89,7 +89,7 @@ export interface EnvConfig {
 
   // Sandbox lifecycle configuration
   SANDBOX_INACTIVITY_TIMEOUT_MS?: string; // Inactivity timeout in ms (default: 600000 = 10 min)
-  EXECUTION_TIMEOUT_MS?: string; // Max processing time before auto-fail (default: 5400000 = 90 min)
+  EXECUTION_TIMEOUT_MS?: string; // Max processing time before auto-fail; sessions fall back to DEFAULT_SANDBOX_TIMEOUT_SECONDS, the scheduler's recovery sweep to its DEFAULT_EXECUTION_TIMEOUT_MS
   SECRETS_CAP_ENFORCEMENT?: string; // "enforce" (default) fails spawn/build on oversized secret payloads; set "warn" to only log
 
   // Logging


### PR DESCRIPTION
Closes the documentation half of H-6 (COL-102). The Node host's configuration reader and boot-time key validation shipped in #1770; this adds the file that describes a deployment and a test that keeps it honest.

## What

- **`.env.example`** at the repository root: every `EnvConfig` field the control plane reads, grouped by concern, each with its Cloudflare counterpart named (Worker var or secret, and the `terraform.tfvars` entry it comes from, or "not set by Terraform" where that is the case), plus the Node-only host settings (`HOST`, `PORT`, `DATA_DIR`, `MIGRATIONS_DIR`, `SHUTDOWN_TIMEOUT_MS`) and the S3 object-store settings. It lives at the root because the compose stack in the follow-up PR reads `.env` from there; `.gitignore` already tracks `.env.example` and ignores `.env`.
- **`env-example.test.ts`**: parses the file and asserts its variable set equals `EnvConfig`'s keys plus the host variables, each named once. A field added to `EnvConfig` without a line here fails the unit suite, as does a stale line.
- `ENV_CONFIG_KEY_NAMES` exported from `src/node/config.ts` for that test; the `satisfies` check against `EnvConfig` is unchanged.

## Not in this PR

- The SSM Parameter Store path (I-2/I-3 materialize the container environment from it; the file's header says so).
- `SLACK_BOT_URL` / `LINEAR_BOT_URL`: they land with T-1, when the control plane can reach the bots over HTTPS.

## Test plan

- `npx vitest run src/node/env-example.test.ts src/node/config.test.ts` green.
- Control-plane unit suite: 269 files, 3901 tests green.
- `tsc -p tsconfig.node.json`, `tsc -p tsconfig.test.json`, eslint on the touched files, knip (unused-export count unchanged), `npm run format:check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive `.env.example` covering environment variables, configuration requirements, deployment mappings, and runtime settings.
  * Documented AWS temporary credentials, encryption-key requirements, GitHub private-key formatting, and sandbox timeout fallbacks.

* **Bug Fixes**
  * Improved GitHub App authentication when private keys contain literal `\n` characters instead of actual line breaks.

* **Tests**
  * Added validation to keep the example environment file synchronized with supported and required configuration.
  * Added coverage for escaped private-key line breaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->