### PR TITLE
feat: Dockerfile and compose stack for the control plane: app, MinIO, Litestream (COL-103)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# The control-plane image builds from the repository root; only what it
+# needs enters the build context.
+*
+!package.json
+!package-lock.json
+!packages/shared/
+!packages/control-plane/
+!packages/sandbox-runtime/src/sandbox_runtime/*.json
+!terraform/d1/migrations/
+packages/**/node_modules/
+packages/**/dist/
+packages/**/coverage/
+packages/control-plane/.wrangler/

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@ DATA_DIR=/data
 # this to its own copy; leave empty to use terraform/d1/migrations from a
 # repository checkout.
 MIGRATIONS_DIR=
-# How long a shutdown waits for in-flight work before the process is forced down.
+# How long a shutdown waits for in-flight work before the process is forced
+# down. The compose stack pins this together with its stop grace period.
 SHUTDOWN_TIMEOUT_MS=30000
 
 # ---------------------------------------------------------------------------
@@ -238,13 +239,20 @@ LOG_LEVEL=info
 # Compose stack only (docker-compose.yml). Not read by the control plane.
 # ---------------------------------------------------------------------------
 
+# Host interface the app's port is published on. Loopback keeps the plaintext
+# listener local; Caddy (the "tls" profile) reaches the app over the compose
+# network. Use 0.0.0.0 only where a firewall or security group fronts the
+# host, such as behind the AWS load balancer. MinIO's API and console are
+# published on loopback only.
+APP_BIND_ADDRESS=127.0.0.1
 # MinIO root credentials; the AWS_* and LITESTREAM_* credentials above and
 # below are these same values when the stack's MinIO is the object store.
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 # Where Litestream replicates DATA_DIR/global.db, read by the sidecar and by
-# the app image's restore-on-empty entrypoint. Leave LITESTREAM_BUCKET empty
-# to run without a replica. LITESTREAM_ENDPOINT is empty for AWS S3.
+# the app image's restore-on-empty entrypoint. The compose stack requires a
+# bucket name; only the image run on its own treats an empty value as "no
+# replica". LITESTREAM_ENDPOINT is empty for AWS S3.
 LITESTREAM_BUCKET=backups
 LITESTREAM_ENDPOINT=http://minio:9000
 LITESTREAM_ACCESS_KEY_ID=minioadmin

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # `.env` and fill it in; `.env` is gitignored. The host reads its process
 # environment, so any loader works:
 #   node --env-file=.env packages/control-plane/dist/node/main.js
+# The compose stack (docker-compose.yml) reads it as the app's env_file.
 #
 # The deployment variables have the same names and meanings on Cloudflare,
 # where they are Worker variables and secrets. Each line names its source
@@ -232,3 +233,21 @@ SECRETS_CAP_ENFORCEMENT=
 
 # "debug" | "info" | "warn" | "error" (default "info"). Cloudflare: not set by Terraform.
 LOG_LEVEL=info
+
+# ---------------------------------------------------------------------------
+# Compose stack only (docker-compose.yml). Not read by the control plane.
+# ---------------------------------------------------------------------------
+
+# MinIO root credentials; the AWS_* and LITESTREAM_* credentials above and
+# below are these same values when the stack's MinIO is the object store.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+# Where Litestream replicates DATA_DIR/global.db, read by the sidecar and by
+# the app image's restore-on-empty entrypoint. Leave LITESTREAM_BUCKET empty
+# to run without a replica. LITESTREAM_ENDPOINT is empty for AWS S3.
+LITESTREAM_BUCKET=backups
+LITESTREAM_ENDPOINT=http://minio:9000
+LITESTREAM_ACCESS_KEY_ID=minioadmin
+LITESTREAM_SECRET_ACCESS_KEY=minioadmin
+# Hostname Caddy obtains a certificate for under the "tls" profile.
+CADDY_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -50,9 +50,10 @@ OBJECT_STORE_ALLOW_HTTP=true
 # "true" for MinIO (bucket in the path, not the hostname).
 OBJECT_STORE_FORCE_PATH_STYLE=true
 # Credentials through the AWS SDK's default chain. Leave both empty on EC2 to
-# use the instance role. For the compose stack they are the MinIO root user.
+# use the instance role. For the compose stack they are the MinIO root user
+# and password (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD below).
 AWS_ACCESS_KEY_ID=minioadmin
-AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_SECRET_ACCESS_KEY=
 # Only with temporary (STS) credentials; empty for static keys or a role.
 AWS_SESSION_TOKEN=
 
@@ -245,10 +246,12 @@ LOG_LEVEL=info
 # host, such as behind the AWS load balancer. MinIO's API and console are
 # published on loopback only.
 APP_BIND_ADDRESS=127.0.0.1
-# MinIO root credentials; the AWS_* and LITESTREAM_* credentials above and
-# below are these same values when the stack's MinIO is the object store.
+# MinIO root credentials. The password is required and has no default:
+#   openssl rand -hex 16
+# The AWS_* and LITESTREAM_* credentials are these same values when the
+# stack's MinIO is the object store.
 MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=minioadmin
+MINIO_ROOT_PASSWORD=
 # Where Litestream replicates DATA_DIR/global.db, read by the sidecar and by
 # the app image's restore-on-empty entrypoint. The compose stack requires a
 # bucket name; only the image run on its own treats an empty value as "no
@@ -256,6 +259,6 @@ MINIO_ROOT_PASSWORD=minioadmin
 LITESTREAM_BUCKET=backups
 LITESTREAM_ENDPOINT=http://minio:9000
 LITESTREAM_ACCESS_KEY_ID=minioadmin
-LITESTREAM_SECRET_ACCESS_KEY=minioadmin
+LITESTREAM_SECRET_ACCESS_KEY=
 # Hostname Caddy obtains a certificate for under the "tls" profile.
 CADDY_DOMAIN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set; generate one with openssl rand -hex 16}
     # Loopback only: the app and the sidecar reach MinIO over the compose
     # network, and the console is a local convenience.
     ports:
@@ -63,7 +63,7 @@ services:
     image: minio/mc:RELEASE.2025-04-16T18-13-26Z
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set; generate one with openssl rand -hex 16}
       MEDIA_BUCKET: ${OBJECT_STORE_BUCKET:?OBJECT_STORE_BUCKET must name the media bucket}
       BACKUP_BUCKET: ${LITESTREAM_BUCKET:?LITESTREAM_BUCKET must name the backup bucket}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+# The control plane without Cloudflare: the Node host, MinIO for media and
+# backups, and a Litestream sidecar replicating the global store. This is
+# the stack the AWS instance runs and the local stand-in for it. The web app
+# is not part of it (it stays on Vercel; run `next dev` locally).
+#
+#   cp .env.example .env   # then fill it in
+#   docker compose up --build
+#
+# See docs/CONTROL_PLANE_CONTAINER.md.
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: packages/control-plane/Dockerfile
+    image: open-inspect-control-plane:local
+    env_file: .env
+    # Pinned here so a .env edit cannot move the host off its volume or its
+    # published port; PORT in .env is the host-side port below.
+    environment:
+      HOST: 0.0.0.0
+      PORT: "8787"
+      DATA_DIR: /data
+    ports:
+      - "${PORT:-8787}:8787"
+    volumes:
+      - control-plane-data:/data
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    restart: unless-stopped
+
+  # Creates the media and backup buckets once, then exits.
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    env_file: .env
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        mc alias set local http://minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" &&
+        mc mb --ignore-existing "local/$$OBJECT_STORE_BUCKET" "local/$$LITESTREAM_BUCKET"
+
+  litestream:
+    image: litestream/litestream:0.3.13
+    # The app's user, so the shadow WAL it writes beside the database is
+    # owned like the database.
+    user: "1000:1000"
+    command: replicate -config /etc/litestream.yml
+    env_file: .env
+    volumes:
+      - control-plane-data:/data
+      - ./packages/control-plane/docker/litestream.yml:/etc/litestream.yml:ro
+    depends_on:
+      app:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Optional TLS termination: `docker compose --profile tls up` with
+  # CADDY_DOMAIN set and ports 80/443 reachable from the internet.
+  caddy:
+    image: caddy:2-alpine
+    profiles: ["tls"]
+    environment:
+      CADDY_DOMAIN: ${CADDY_DOMAIN:-}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./packages/control-plane/docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  control-plane-data:
+  minio-data:
+  caddy-data:
+  caddy-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@
 #   cp .env.example .env   # then fill it in
 #   docker compose up --build
 #
-# See docs/CONTROL_PLANE_CONTAINER.md.
+# Only the app reads .env; the sidecars get the few variables they need by
+# name. The app's port is published on APP_BIND_ADDRESS (loopback unless
+# .env says otherwise) and MinIO's ports on loopback only, so nothing here
+# listens on a public interface by default. See docs/CONTROL_PLANE_CONTAINER.md.
 
 services:
   app:
@@ -15,14 +18,18 @@ services:
       dockerfile: packages/control-plane/Dockerfile
     image: open-inspect-control-plane:local
     env_file: .env
-    # Pinned here so a .env edit cannot move the host off its volume or its
-    # published port; PORT in .env is the host-side port below.
+    # Pinned here so a .env edit cannot move the host off its volume, its
+    # published port, or its drain budget; PORT in .env is the host-side port
+    # below. The stop grace period must outlast SHUTDOWN_TIMEOUT_MS plus the
+    # 5 s the host keeps before forcing its own exit, so both live here.
     environment:
       HOST: 0.0.0.0
       PORT: "8787"
       DATA_DIR: /data
+      SHUTDOWN_TIMEOUT_MS: "30000"
+    stop_grace_period: 40s
     ports:
-      - "${PORT:-8787}:8787"
+      - "${APP_BIND_ADDRESS:-127.0.0.1}:${PORT:-8787}:8787"
     volumes:
       - control-plane-data:/data
     depends_on:
@@ -36,9 +43,11 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    # Loopback only: the app and the sidecar reach MinIO over the compose
+    # network, and the console is a local convenience.
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     volumes:
       - minio-data:/data
     healthcheck:
@@ -48,10 +57,15 @@ services:
       retries: 12
     restart: unless-stopped
 
-  # Creates the media and backup buckets once, then exits.
+  # Creates the media and backup buckets once, then exits. It sees only the
+  # variables named here, never the app's secrets.
   minio-init:
     image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    env_file: .env
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MEDIA_BUCKET: ${OBJECT_STORE_BUCKET:?OBJECT_STORE_BUCKET must name the media bucket}
+      BACKUP_BUCKET: ${LITESTREAM_BUCKET:?LITESTREAM_BUCKET must name the backup bucket}
     depends_on:
       minio:
         condition: service_healthy
@@ -59,7 +73,7 @@ services:
     command:
       - |
         mc alias set local http://minio:9000 "$$MINIO_ROOT_USER" "$$MINIO_ROOT_PASSWORD" &&
-        mc mb --ignore-existing "local/$$OBJECT_STORE_BUCKET" "local/$$LITESTREAM_BUCKET"
+        mc mb --ignore-existing "local/$$MEDIA_BUCKET" "local/$$BACKUP_BUCKET"
 
   litestream:
     image: litestream/litestream:0.3.13
@@ -67,7 +81,11 @@ services:
     # owned like the database.
     user: "1000:1000"
     command: replicate -config /etc/litestream.yml
-    env_file: .env
+    environment:
+      LITESTREAM_BUCKET: ${LITESTREAM_BUCKET:?LITESTREAM_BUCKET must name the backup bucket}
+      LITESTREAM_ENDPOINT: ${LITESTREAM_ENDPOINT:-}
+      LITESTREAM_ACCESS_KEY_ID: ${LITESTREAM_ACCESS_KEY_ID:-}
+      LITESTREAM_SECRET_ACCESS_KEY: ${LITESTREAM_SECRET_ACCESS_KEY:-}
     volumes:
       - control-plane-data:/data
       - ./packages/control-plane/docker/litestream.yml:/etc/litestream.yml:ro

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -1,0 +1,137 @@
+# Running the Control Plane in a Container
+
+The control plane runs on Cloudflare Workers in the deployment described in
+[GETTING_STARTED.md](./GETTING_STARTED.md). It also runs as one Node process on a container, with
+SQLite files on a volume in place of Durable Objects and D1, and an S3-compatible bucket in place of
+R2. This is how it runs on AWS, and `docker compose up` is the local stand-in for that instance.
+
+The same application code serves both platforms. Sessions, routes, authentication and the sandbox
+providers behave the same; only the platform adapters differ.
+
+## What the stack contains
+
+| Service      | Image                   | Role                                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------------------- |
+| `app`        | built from this repo    | The control plane: HTTP API, session WebSockets, cron jobs. Port 8787.                |
+| `minio`      | `minio/minio`           | S3-compatible object storage for media and backups. Console on port 9001.             |
+| `minio-init` | `minio/mc`              | Creates the `media` and `backups` buckets, then exits.                                |
+| `litestream` | `litestream/litestream` | Replicates the global store (`/data/global.db`) to the `backups` bucket every second. |
+| `caddy`      | `caddy` (profile `tls`) | Optional TLS termination for a public hostname.                                       |
+
+The web app is not part of the stack. It stays on Vercel in production and runs with `next dev`
+locally, pointed at the container (see below).
+
+## Quick start
+
+Prerequisites: Docker with Compose v2, a GitHub App and OAuth app as in
+[GETTING_STARTED.md](./GETTING_STARTED.md), and a sandbox provider (Modal by default).
+
+1. Create the configuration file and fill it in:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Every variable is documented in place. The three encryption keys are generated with
+   `openssl rand -base64 32`. The file's MinIO and Litestream defaults work as they are.
+
+2. Build and start:
+
+   ```bash
+   docker compose up --build
+   ```
+
+3. Check it is up:
+
+   ```bash
+   curl -s http://localhost:8787/healthz
+   ```
+
+   The response reports the migrations applied, the resident sessions, and the state of the cron
+   loop and alarm clock. Litestream logs `snapshot written` once the first snapshot is in the
+   `backups` bucket; the MinIO console at http://localhost:9001 shows both buckets.
+
+Stop with `docker compose down`. The data volume survives; `docker compose down -v` deletes it.
+
+## Connecting the web app
+
+In `packages/web/.env.local`:
+
+```bash
+CONTROL_PLANE_URL=http://localhost:8787
+NEXT_PUBLIC_WS_URL=ws://localhost:8787
+SERVICE_AUTH_SECRET=<the SERVICE_AUTH_SECRET_WEB value from .env>
+```
+
+Then `npm run dev -w @open-inspect/web`. The container's `WEB_APP_URL` must be the web app's origin
+(`http://localhost:3000` by default), because browser sign-in is origin-bound.
+
+## Reaching the container from a sandbox
+
+A sandbox connects back to the control plane over a WebSocket at `WORKER_URL`, so that URL has to be
+reachable from the sandbox provider. On a laptop that means a tunnel (for example
+`cloudflared tunnel --url http://localhost:8787`) and setting `WORKER_URL` to the tunnel's public
+URL. The Modal deployment additionally refuses callbacks to hosts outside its
+`ALLOWED_CONTROL_PLANE_HOSTS` list, so add the tunnel host there. Use a Modal environment that is
+not serving a production control plane.
+
+## Data, backups and restore
+
+Everything the host persists is under `/data` on the `control-plane-data` volume:
+
+- `global.db`: the global store (the tables D1 holds on Cloudflare).
+- `sessions/<id>.db`: one file per session (the Durable Object storage on Cloudflare).
+- `host-alarms.db`: the index of every session's next scheduled deadline.
+
+Litestream replicates `global.db` continuously to `LITESTREAM_BUCKET`. When the app starts on an
+empty volume and a replica exists, its entrypoint restores `global.db` from the replica before the
+host boots, so a lost or replaced instance comes back with its users, sessions index and settings.
+The per-session files are not replicated by this stack.
+
+To rehearse a restore, remove the containers that hold the volume open, delete the volume (its name
+is prefixed with the compose project name, the checkout's directory name by default), and start the
+app again:
+
+```bash
+docker compose rm -sf app litestream
+docker volume rm "$(basename "$PWD")_control-plane-data"
+docker compose up -d --wait app
+docker compose logs app | grep litestream.restore
+```
+
+## TLS
+
+For a public hostname, set `CADDY_DOMAIN` in `.env`, point the DNS record at the host, open ports 80
+and 443, and start with the profile:
+
+```bash
+docker compose --profile tls up -d
+```
+
+Caddy obtains the certificate and proxies HTTP and WebSocket traffic to the app. `WORKER_URL` is
+then `https://<CADDY_DOMAIN>` and the web app's `NEXT_PUBLIC_WS_URL` is `wss://<CADDY_DOMAIN>`.
+
+## Configuration on AWS
+
+On AWS the container reads the same `.env` variables from its environment. The deploy step
+materializes them from SSM Parameter Store; nothing is baked into the image. With an instance role,
+leave `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` empty and the SDK uses the role.
+
+## Not yet available on the container
+
+- Repository image builds: the finalization step needs the jobs queue, which has no container
+  implementation yet. Sessions start from the base sandbox image.
+- The GitHub autofix queue and the Slack and Linear bots: the bots remain Cloudflare Workers and
+  reach a container-hosted control plane over HTTPS once that transport lands.
+- Crash recovery of scheduled deadlines after an unclean stop.
+
+## Building the image alone
+
+```bash
+docker build -f packages/control-plane/Dockerfile -t open-inspect-control-plane .
+docker run --rm -p 8787:8787 --env-file .env -v control-plane-data:/data open-inspect-control-plane
+```
+
+The build runs from the repository root so that `packages/shared` and the D1 migrations are in the
+context. The runtime image contains the bundled host, the migrations and the `litestream` binary; no
+`node_modules`.

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -33,7 +33,9 @@ Prerequisites: Docker with Compose v2, a GitHub App and OAuth app as in
    ```
 
    Every variable is documented in place. The three encryption keys are generated with
-   `openssl rand -base64 32`. The file's MinIO and Litestream defaults work as they are.
+   `openssl rand -base64 32`. Generate a MinIO root password with `openssl rand -hex 16` and set it
+   as `MINIO_ROOT_PASSWORD`, `AWS_SECRET_ACCESS_KEY` and `LITESTREAM_SECRET_ACCESS_KEY`; the stack
+   refuses to start without it. The other MinIO and Litestream defaults work as they are.
 
 2. Build and start:
 
@@ -147,8 +149,16 @@ leave `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` empty and the SDK uses the
 
 ```bash
 docker build -f packages/control-plane/Dockerfile -t open-inspect-control-plane .
-docker run --rm -p 8787:8787 --env-file .env -v control-plane-data:/data open-inspect-control-plane
+docker run --rm -p 127.0.0.1:8787:8787 --env-file .env -e LITESTREAM_BUCKET= \
+  -v control-plane-data:/data open-inspect-control-plane
 ```
+
+`LITESTREAM_BUCKET=` turns the restore-on-empty step off: outside the compose network there is no
+`minio` host, and the entrypoint would otherwise try to reach it before the host boots. Point
+`LITESTREAM_ENDPOINT` at a reachable bucket instead to keep the restore. The entrypoint refuses a
+plain-`http://` endpoint unless `OBJECT_STORE_ALLOW_HTTP=true`, the same opt-in the host applies to
+its own object store, and removes a stray `global.db-wal` or `-shm` left without its database so it
+cannot be replayed over the restored or new file.
 
 The build runs from the repository root so that `packages/shared` and the D1 migrations are in the
 context. The runtime image contains the bundled host, the migrations and the `litestream` binary; no

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -49,9 +49,17 @@ Prerequisites: Docker with Compose v2, a GitHub App and OAuth app as in
 
    The response reports the migrations applied, the resident sessions, and the state of the cron
    loop and alarm clock. Litestream logs `snapshot written` once the first snapshot is in the
-   `backups` bucket; the MinIO console at http://localhost:9001 shows both buckets.
+   `backups` bucket; the MinIO console at http://127.0.0.1:9001 shows both buckets.
+
+The app's port and MinIO's ports are published on loopback only. `APP_BIND_ADDRESS` in `.env` moves
+the app's port to another interface where something in front of the host restricts access, such as a
+security group on AWS. Only the app reads `.env`; the sidecars receive the few variables they need
+by name, never the app's secrets.
 
 Stop with `docker compose down`. The data volume survives; `docker compose down -v` deletes it.
+Compose gives the app 40 seconds to drain before killing it, which covers the host's 30-second
+shutdown budget and the 5 seconds it keeps before forcing its own exit; both values are pinned in
+`docker-compose.yml` so a `.env` edit cannot separate them.
 
 ## Connecting the web app
 
@@ -83,20 +91,28 @@ Everything the host persists is under `/data` on the `control-plane-data` volume
 - `sessions/<id>.db`: one file per session (the Durable Object storage on Cloudflare).
 - `host-alarms.db`: the index of every session's next scheduled deadline.
 
-Litestream replicates `global.db` continuously to `LITESTREAM_BUCKET`. When the app starts on an
-empty volume and a replica exists, its entrypoint restores `global.db` from the replica before the
-host boots, so a lost or replaced instance comes back with its users, sessions index and settings.
-The per-session files are not replicated by this stack.
+These three are one deployment's state, and the unit of a deployment backup is the whole volume:
+stop the app, snapshot the volume (an EBS snapshot on AWS), start it again. That procedure and its
+rehearsal are tracked separately from this stack.
 
-To rehearse a restore, remove the containers that hold the volume open, delete the volume (its name
-is prefixed with the compose project name, the checkout's directory name by default), and start the
-app again:
+What this stack provides is narrower. Litestream replicates `global.db` continuously to
+`LITESTREAM_BUCKET`, and when the app starts on an empty volume and a replica exists, its entrypoint
+restores `global.db` before the host boots. That brings back users, settings and the session index.
+It does not bring back the session files or the alarm index: the restored index lists sessions whose
+files are gone, and the host opens each of those as an empty session when it is next touched, with
+no pending deadlines. The entrypoint logs a warning to that effect after every restore. Treat the
+replica as protection for the global store, not as recovery of a deployment.
+
+To rehearse the restore, remove the containers that hold the volume open, delete the volume (its
+name is prefixed with the compose project name, the checkout's directory name by default), then
+bring the whole stack back and confirm replication resumed:
 
 ```bash
 docker compose rm -sf app litestream
 docker volume rm "$(basename "$PWD")_control-plane-data"
-docker compose up -d --wait app
+docker compose up -d --wait
 docker compose logs app | grep litestream.restore
+docker compose logs litestream | grep "snapshot written"
 ```
 
 ## TLS
@@ -108,8 +124,10 @@ and 443, and start with the profile:
 docker compose --profile tls up -d
 ```
 
-Caddy obtains the certificate and proxies HTTP and WebSocket traffic to the app. `WORKER_URL` is
-then `https://<CADDY_DOMAIN>` and the web app's `NEXT_PUBLIC_WS_URL` is `wss://<CADDY_DOMAIN>`.
+Caddy obtains the certificate and proxies HTTP and WebSocket traffic to the app over the compose
+network, so `APP_BIND_ADDRESS` stays on loopback and the plaintext port is never reachable from
+outside. `WORKER_URL` is then `https://<CADDY_DOMAIN>` and the web app's `NEXT_PUBLIC_WS_URL` is
+`wss://<CADDY_DOMAIN>`.
 
 ## Configuration on AWS
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -245,6 +245,8 @@ configured/deployed.
 
 - Architecture and internals: [docs/HOW_IT_WORKS.md](./HOW_IT_WORKS.md)
 - Full production deployment: [docs/GETTING_STARTED.md](./GETTING_STARTED.md)
+- Control plane in a container (no Cloudflare):
+  [docs/CONTROL_PLANE_CONTAINER.md](./CONTROL_PLANE_CONTAINER.md)
 - GitHub integration usage: [docs/integrations/GITHUB.md](./integrations/GITHUB.md)
 - Linear integration usage: [docs/integrations/LINEAR.md](./integrations/LINEAR.md)
 - Debugging and observability: [docs/DEBUGGING_PLAYBOOK.md](./DEBUGGING_PLAYBOOK.md)

--- a/packages/control-plane/Dockerfile
+++ b/packages/control-plane/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+#
+# The control plane as a container: the Node host (src/node/main.ts) bundled
+# by `build:node`, the D1 migrations it applies at boot, and the litestream
+# binary the entrypoint uses to restore the global store from a replica.
+#
+# Build from the repository root so the shared package and the migrations
+# are in the context:
+#   docker build -f packages/control-plane/Dockerfile -t open-inspect-control-plane .
+
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/control-plane/package.json packages/control-plane/
+# --ignore-scripts: the root package's prepare script installs git hooks
+# through husky, which a workspace-scoped install does not bring along.
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --ignore-scripts --workspace=@open-inspect/shared --workspace=@open-inspect/control-plane
+COPY packages/shared/ packages/shared/
+COPY packages/control-plane/ packages/control-plane/
+# Contracts the control plane shares with the sandbox runtime, imported by path.
+COPY packages/sandbox-runtime/src/sandbox_runtime/*.json packages/sandbox-runtime/src/sandbox_runtime/
+RUN npm run build -w @open-inspect/shared \
+    && npm run build:node -w @open-inspect/control-plane
+
+FROM litestream/litestream:0.3.13 AS litestream
+
+FROM node:22-slim
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=8787 \
+    DATA_DIR=/data
+# The bundle and the migrations sit where they sit in the repository, so the
+# host's default migrations path resolves without MIGRATIONS_DIR being set.
+WORKDIR /app
+COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream
+COPY --from=build /app/packages/control-plane/dist/node/main.js packages/control-plane/dist/node/main.js
+COPY terraform/d1/migrations/ terraform/d1/migrations/
+COPY --chmod=755 packages/control-plane/docker/entrypoint.sh /app/entrypoint.sh
+COPY packages/control-plane/docker/litestream.yml /etc/litestream.yml
+RUN mkdir -p /data && chown node:node /data && chmod 700 /data
+USER node
+VOLUME ["/data"]
+EXPOSE 8787
+HEALTHCHECK --interval=10s --timeout=3s --start-period=20s --retries=3 \
+    CMD ["node", "-e", "fetch(`http://127.0.0.1:${process.env.PORT}/healthz`).then((r) => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["node", "/app/packages/control-plane/dist/node/main.js"]

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -273,8 +273,15 @@ npm install
 
 ```bash
 npm run build
-# Outputs to dist/index.js
+# Outputs the Worker bundle to dist/index.js and the Node host to dist/node/main.js
 ```
+
+### Run as a container
+
+The control plane also runs as a Node process on a container, with SQLite on a volume and an
+S3-compatible bucket for media. See
+[docs/CONTROL_PLANE_CONTAINER.md](../../docs/CONTROL_PLANE_CONTAINER.md) for `docker compose up` and
+the image build.
 
 ### Deploy
 

--- a/packages/control-plane/docker/Caddyfile
+++ b/packages/control-plane/docker/Caddyfile
@@ -1,0 +1,7 @@
+# TLS in front of the control plane, for the compose "tls" profile.
+# Caddy obtains and renews a certificate for CADDY_DOMAIN and proxies
+# HTTP and WebSocket traffic to the app.
+
+{$CADDY_DOMAIN} {
+	reverse_proxy app:8787
+}

--- a/packages/control-plane/docker/entrypoint.sh
+++ b/packages/control-plane/docker/entrypoint.sh
@@ -11,6 +11,30 @@
 set -eu
 
 db="${DATA_DIR:-/data}/global.db"
+
+# A WAL or journal left behind without its database would be replayed over
+# whatever file appears next, restored or new; without the database they
+# belong to they are meaningless, so they go first.
+if [ ! -f "$db" ]; then
+  for orphan in "$db-wal" "$db-shm" "$db-journal"; do
+    if [ -e "$orphan" ]; then
+      echo "{\"level\":\"warn\",\"event\":\"litestream.restore.orphan_removed\",\"path\":\"$orphan\"}"
+      rm -f "$orphan"
+    fi
+  done
+fi
+
+# The same rule the host applies to its own object-store endpoint: plaintext
+# only by explicit opt-in, since the endpoint carries the replica credentials.
+case "${LITESTREAM_ENDPOINT:-}" in
+  http://*)
+    if [ "${OBJECT_STORE_ALLOW_HTTP:-}" != "true" ]; then
+      echo "{\"level\":\"error\",\"event\":\"litestream.endpoint_plaintext\",\"msg\":\"LITESTREAM_ENDPOINT is plain http; set OBJECT_STORE_ALLOW_HTTP=true only for a local MinIO\"}" >&2
+      exit 1
+    fi
+    ;;
+esac
+
 if [ -n "${LITESTREAM_BUCKET:-}" ] && [ ! -f "$db" ]; then
   echo "{\"level\":\"info\",\"event\":\"litestream.restore\",\"db\":\"$db\"}"
   litestream restore -if-replica-exists -config /etc/litestream.yml "$db"

--- a/packages/control-plane/docker/entrypoint.sh
+++ b/packages/control-plane/docker/entrypoint.sh
@@ -3,12 +3,20 @@
 # is empty (a fresh instance, or one rebuilt after a loss), then hands off to
 # the host. LITESTREAM_BUCKET unset means no replica is configured, so a
 # fresh volume simply starts empty.
+#
+# The replica holds the global store only. The per-session files and the
+# host alarm index are not in it, so a restore brings back users, settings
+# and the session index but not the sessions' own state; the whole data
+# volume is the unit of a deployment backup.
 set -eu
 
 db="${DATA_DIR:-/data}/global.db"
 if [ -n "${LITESTREAM_BUCKET:-}" ] && [ ! -f "$db" ]; then
   echo "{\"level\":\"info\",\"event\":\"litestream.restore\",\"db\":\"$db\"}"
   litestream restore -if-replica-exists -config /etc/litestream.yml "$db"
+  if [ -f "$db" ]; then
+    echo "{\"level\":\"warn\",\"event\":\"litestream.restore.global_store_only\",\"msg\":\"global store restored from its replica; session files and the host alarm index are not replicated and start empty\"}"
+  fi
 fi
 
 exec "$@"

--- a/packages/control-plane/docker/entrypoint.sh
+++ b/packages/control-plane/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Restores the global store from its Litestream replica when the data volume
+# is empty (a fresh instance, or one rebuilt after a loss), then hands off to
+# the host. LITESTREAM_BUCKET unset means no replica is configured, so a
+# fresh volume simply starts empty.
+set -eu
+
+db="${DATA_DIR:-/data}/global.db"
+if [ -n "${LITESTREAM_BUCKET:-}" ] && [ ! -f "$db" ]; then
+  echo "{\"level\":\"info\",\"event\":\"litestream.restore\",\"db\":\"$db\"}"
+  litestream restore -if-replica-exists -config /etc/litestream.yml "$db"
+fi
+
+exec "$@"

--- a/packages/control-plane/docker/litestream.yml
+++ b/packages/control-plane/docker/litestream.yml
@@ -5,7 +5,10 @@
 # from the replica when the data volume is empty. The LITESTREAM_* variables
 # come from .env; an empty LITESTREAM_ENDPOINT means AWS S3.
 #
-# The per-session files under /data/sessions are not replicated here.
+# Only the global store is replicated. The per-session files under
+# /data/sessions and the host alarm index are not, so this protects users,
+# settings and the session index, not a whole deployment; the data volume
+# is the unit for that.
 
 dbs:
   - path: /data/global.db

--- a/packages/control-plane/docker/litestream.yml
+++ b/packages/control-plane/docker/litestream.yml
@@ -1,0 +1,20 @@
+# Litestream configuration for the control plane's global store.
+#
+# Used twice: by the litestream sidecar in docker-compose.yml, which
+# replicates continuously, and by the app image's entrypoint, which restores
+# from the replica when the data volume is empty. The LITESTREAM_* variables
+# come from .env; an empty LITESTREAM_ENDPOINT means AWS S3.
+#
+# The per-session files under /data/sessions are not replicated here.
+
+dbs:
+  - path: /data/global.db
+    replicas:
+      - type: s3
+        bucket: ${LITESTREAM_BUCKET}
+        path: control-plane/global.db
+        endpoint: ${LITESTREAM_ENDPOINT}
+        force-path-style: true
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        sync-interval: 1s

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -17,6 +17,7 @@ const ENV_EXAMPLE_PATH = resolve(
 
 /** Variables docker-compose.yml and its sidecars read; the host never sees them. */
 const COMPOSE_VARIABLES = [
+  "APP_BIND_ADDRESS",
   "MINIO_ROOT_USER",
   "MINIO_ROOT_PASSWORD",
   "LITESTREAM_BUCKET",

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -15,6 +15,17 @@ const ENV_EXAMPLE_PATH = resolve(
   "../../../../.env.example"
 );
 
+/** Variables docker-compose.yml and its sidecars read; the host never sees them. */
+const COMPOSE_VARIABLES = [
+  "MINIO_ROOT_USER",
+  "MINIO_ROOT_PASSWORD",
+  "LITESTREAM_BUCKET",
+  "LITESTREAM_ENDPOINT",
+  "LITESTREAM_ACCESS_KEY_ID",
+  "LITESTREAM_SECRET_ACCESS_KEY",
+  "CADDY_DOMAIN",
+];
+
 /** A key's comment block opens with this when a boot cannot do without the key. */
 const REQUIRED_MARKER = "# Required.";
 
@@ -61,13 +72,14 @@ describe(".env.example", () => {
     expect(example.malformed).toEqual([]);
   });
 
-  it("names every variable the host reads, and nothing else, each once", () => {
+  it("names every variable the host or the compose stack reads, and nothing else, each once", () => {
     const documented = example.variables.map((variable) => variable.name);
     const expected = [
       ...ENV_CONFIG_KEY_NAMES,
       ...NODE_HOST_VARIABLE_NAMES,
       ...OBJECT_STORAGE_VARIABLE_NAMES,
       ...AWS_CREDENTIAL_VARIABLE_NAMES,
+      ...COMPOSE_VARIABLES,
     ];
     expect([...documented].sort()).toEqual([...expected].sort());
   });


### PR DESCRIPTION
H-7 (COL-103): the container image for the Node host and the compose stack that runs it with MinIO and a Litestream sidecar. Stacked on #1771 for `.env.example`. Nothing here runs on Cloudflare; the Worker build and bundle are untouched.

## What

- **`packages/control-plane/Dockerfile`**, two stages. Build: `npm ci` for `shared` and `control-plane`, then `build:node`. Runtime: `node:22-slim`, the bundled host, the D1 migrations, the `litestream` binary copied from the official image, a non-root user, `/data` as the volume, a `HEALTHCHECK` on `/healthz`. No `node_modules` in the runtime image and no native build step (`node:sqlite`).
- **`docker-compose.yml`** at the root: `app`, `minio` with a one-shot `minio-init` that creates the `media` and `backups` buckets, `litestream` replicating `/data/global.db` to the `backups` bucket, and an optional `caddy` service under the `tls` profile.
- **`packages/control-plane/docker/`**: `entrypoint.sh` (runs `litestream restore -if-replica-exists` when the volume has no `global.db` and a replica is configured, then execs the host), `litestream.yml` (shared by the sidecar and the entrypoint), `Caddyfile`.
- **`.dockerignore`**: allowlist of what the image needs.
- **`docs/CONTROL_PLANE_CONTAINER.md`**: quick start, connecting the web app, reaching the container from a sandbox (tunnel + Modal allowlist), data layout and the restore drill, TLS, configuration on AWS, and what is not yet available on the container. Linked from `SETUP_GUIDE.md` and the control-plane README.
- `.env.example` gains the compose-only variables (MinIO root credentials, `LITESTREAM_*`, `CADDY_DOMAIN`); the drift test learns about them.

## Decisions

- **Repository layout preserved in the image.** The bundle sits at `/app/packages/control-plane/dist/node/main.js` and the migrations at `/app/terraform/d1/migrations`, so the host's default migrations path resolves and `MIGRATIONS_DIR` need not be set anywhere.
- **`npm ci --ignore-scripts`** in the build stage: the root `prepare` script runs husky, which a workspace-scoped install does not bring along. esbuild still resolves its platform binary from the optional dependency.
- **The build copies `packages/sandbox-runtime/src/sandbox_runtime/*.json`**: the control plane imports the runtime manifest by relative path. `Dockerfile.test` predates that import and is not referenced anywhere; it is left alone here.
- **A named volume rather than `./data:/data`.** Bind mounts on Linux collide with the non-root user's ownership; a named volume inherits `/data`'s ownership from the image. The Litestream sidecar runs as the same uid so its shadow WAL beside the database is owned like the database.
- **Container-side `HOST`, `PORT`, `DATA_DIR` pinned in compose**, so `PORT` in `.env` only moves the published host port and cannot break the port mapping.
- Image pins: `minio/minio:RELEASE.2025-04-22T22-12-26Z`, `minio/mc:RELEASE.2025-04-16T18-13-26Z`, `litestream/litestream:0.3.13`, `caddy:2-alpine`, `node:22-slim`.

## Measurements

| | |
|---|---|
| Runtime image | 282 MB |
| Uncached build (warm npm cache mount) | 19 s |
| Cached rebuild | 4 s |

## Test plan

- `docker compose up -d --wait`: `minio` healthy, `minio-init` exited 0, `app` healthy, `litestream` up.
- `GET /healthz` → `{"status":"ok","migrations_applied":73,"sessions_resident":0,"background_tasks":0,"alarm_clock":"running","cron":"running"}`.
- `mc ls` shows `backups/` and `media/`; `backups/control-plane/global.db/generations/…` holds a snapshot and a WAL segment; the sidecar logs `snapshot written` and `wal segment written`.
- `docker compose stop app` → `node_host.signal` then `node_host.stopped`, container exit code 0.
- Restore drill: insert a marker row, wait for replication, remove `app` and `litestream`, delete the data volume, `docker compose up -d --wait app` → the entrypoint logs `litestream.restore`, the marker row is present, `/healthz` 200.
- `docker compose config --quiet` clean; `npm run format:check`, `tsc -p tsconfig.test.json`, the `.env.example` drift test, and the control-plane unit suite (269 files, 3901 tests) green.

## Not covered here

- The per-session files under `/data/sessions` are not replicated by this stack (I-5).
- The compose smoke in CI with a fake bridge is V-3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added containerized control-plane deployment with Docker Compose.
  - Added optional MinIO-compatible object storage, Litestream database replication, and Caddy-managed TLS.
  - Added persistent storage, health checks, backup restoration, and WebSocket support.
  - Added configurable app binding with loopback-only service exposure by default.
  - Added required credential configuration for secure object storage and replication.

- **Documentation**
  - Added deployment guidance covering setup, storage, backups, TLS, connectivity, and service limitations.
  - Documented required Compose environment variables and shutdown behavior.
  - Updated control-plane documentation with container build and deployment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->