### PR TITLE
feat: add GPT-6 Astra model

### DIFF
--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -31,16 +31,16 @@ unattended mode.
 OpenAI models support connected ChatGPT provider accounts or `OPENAI_API_KEY` mode. See
 [Using OpenAI Models](OPENAI_MODELS.md) for account setup and coexistence details.
 
-| Model ID                     | Display name        | Description                                  | Reasoning efforts              | Default effort |
-| ---------------------------- | ------------------- | -------------------------------------------- | ------------------------------ | -------------- |
-| `openai/gpt-5.4`             | GPT 5.4             | Flagship model                               | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-5.5`             | GPT 5.5             | Latest flagship model                        | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-5.6-sol`         | GPT 5.6 Sol         | Frontier model for complex professional work | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-5.6-terra`       | GPT 5.6 Terra       | Balanced, cost-efficient everyday work       | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-5.6-luna`        | GPT 5.6 Luna        | Fast, cost-efficient high-volume workloads   | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-6-astra`         | GPT-6 Astra         | Most capable model for complex, demanding work | low, medium, high, xhigh, max | medium         |
-| `openai/gpt-5.3-codex`       | GPT 5.3 Codex       | Latest codex                                 | low, medium, high, xhigh       | high           |
-| `openai/gpt-5.3-codex-spark` | GPT 5.3 Codex Spark | Low-latency codex variant                    | low, medium, high, xhigh       | high           |
+| Model ID                     | Display name        | Description                                    | Reasoning efforts              | Default effort |
+| ---------------------------- | ------------------- | ---------------------------------------------- | ------------------------------ | -------------- |
+| `openai/gpt-5.4`             | GPT 5.4             | Flagship model                                 | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-5.5`             | GPT 5.5             | Latest flagship model                          | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-5.6-sol`         | GPT 5.6 Sol         | Frontier model for complex professional work   | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-5.6-terra`       | GPT 5.6 Terra       | Balanced, cost-efficient everyday work         | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-5.6-luna`        | GPT 5.6 Luna        | Fast, cost-efficient high-volume workloads     | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-6-astra`         | GPT-6 Astra         | Most capable model for complex, demanding work | low, medium, high, xhigh, max  | medium         |
+| `openai/gpt-5.3-codex`       | GPT 5.3 Codex       | Latest codex                                   | low, medium, high, xhigh       | high           |
+| `openai/gpt-5.3-codex-spark` | GPT 5.3 Codex Spark | Low-latency codex variant                      | low, medium, high, xhigh       | high           |
 
 ## xAI / SuperGrok
 

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -38,6 +38,7 @@ OpenAI models support connected ChatGPT provider accounts or `OPENAI_API_KEY` mo
 | `openai/gpt-5.6-sol`         | GPT 5.6 Sol         | Frontier model for complex professional work | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.6-terra`       | GPT 5.6 Terra       | Balanced, cost-efficient everyday work       | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.6-luna`        | GPT 5.6 Luna        | Fast, cost-efficient high-volume workloads   | none, low, medium, high, xhigh | Not set        |
+| `openai/gpt-6-astra`         | GPT-6 Astra         | Most capable model for complex, demanding work | low, medium, high, xhigh, max | medium         |
 | `openai/gpt-5.3-codex`       | GPT 5.3 Codex       | Latest codex                                 | low, medium, high, xhigh       | high           |
 | `openai/gpt-5.3-codex-spark` | GPT 5.3 Codex Spark | Low-latency codex variant                    | low, medium, high, xhigh       | high           |
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -92,6 +92,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:gpt-5.4" }])).toBe("openai/gpt-5.4");
   });
 
+  it("returns GPT-6 Astra for model:gpt-6-astra label", () => {
+    expect(extractModelFromLabels([{ name: "model:gpt-6-astra" }])).toBe("openai/gpt-6-astra");
+  });
+
   it("returns GPT 5.5 for model:gpt-5.5 label", () => {
     expect(extractModelFromLabels([{ name: "model:gpt-5.5" }])).toBe("openai/gpt-5.5");
   });

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -46,6 +46,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "gpt-5.6-sol": "openai/gpt-5.6-sol",
   "gpt-5.6-terra": "openai/gpt-5.6-terra",
   "gpt-5.6-luna": "openai/gpt-5.6-luna",
+  "gpt-6-astra": "openai/gpt-6-astra",
   "gpt-5.3-codex": "openai/gpt-5.3-codex",
 };
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -24,6 +24,7 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "gpt-6-astra",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.1-codex",

--- a/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
+++ b/packages/sandbox-runtime/tests/codex-auth-plugin.test.mjs
@@ -61,3 +61,19 @@ test("preserves caller authorization after switching away from OAuth", async () 
 
   assert.equal(upstreamRequest.headers.get("authorization"), "Bearer caller-token");
 });
+
+test("keeps GPT-6 Astra available for Codex subscriptions", async () => {
+  const astra = {
+    name: "GPT-6 Astra",
+    cost: { input: 1, output: 1 },
+  };
+  const provider = { models: { "gpt-6-astra": astra, "unsupported-model": {} } };
+  const plugin = await CodexAuthProxy({ client: { auth: { set: async () => undefined } } });
+
+  await plugin.auth.loader(async () => ({ type: "oauth", refresh: "managed" }), provider);
+
+  assert.equal(provider.models["gpt-6-astra"], astra);
+  assert.equal(provider.models["unsupported-model"], undefined);
+  assert.equal(astra.cost.input, 0);
+  assert.equal(astra.cost.output, 0);
+});

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -38,6 +38,7 @@ const OPENAI_MODELS = [
   "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
+  "openai/gpt-6-astra",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
 ] as const;
@@ -314,6 +315,10 @@ describe("model utilities", () => {
       efforts: ["none", "low", "medium", "high", "xhigh"],
       default: undefined,
     });
+    expect(getReasoningConfig("openai/gpt-6-astra")).toEqual({
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      default: "medium",
+    });
     expect(getReasoningConfig("openai/gpt-5.6-sol")).toEqual({
       efforts: ["none", "low", "medium", "high", "xhigh"],
       default: "medium",
@@ -348,6 +353,9 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("anthropic/claude-opus-5", "none")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-fable-5", "max")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
+    expect(isValidReasoningEffort("openai/gpt-6-astra", "max")).toBe(true);
+    expect(isValidReasoningEffort("openai/gpt-6-astra", "ultra")).toBe(false);
+    expect(isValidReasoningEffort("openai/gpt-6-astra", "none")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.6-luna", "max")).toBe(true);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -176,6 +176,15 @@ export const MODEL_CATALOG = [
         },
       },
       {
+        id: "openai/gpt-6-astra",
+        name: "GPT-6 Astra",
+        description: "Most capable model for complex, demanding work",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "medium",
+        },
+      },
+      {
         id: "openai/gpt-5.3-codex",
         name: "GPT 5.3 Codex",
         description: "Latest codex",


### PR DESCRIPTION
Adds `openai/gpt-6-astra` to the shared model catalog so it is available in model selectors and enabled by default alongside the existing OpenAI models. Adds the Codex subscription allowlist entry, Linear `model:gpt-6-astra` label, and model documentation.

Astra offers low, medium, high, xhigh, and max reasoning, defaulting to medium. Max already exists in the shared reasoning type and OpenAI request path. Ultra is deliberately deferred because the application does not yet support it. The system default model is unchanged.

Validation:
- Shared build and 806 shared tests passed.
- 234 Linear tests passed.
- Three Codex auth plugin tests passed, including preserving Astra through the subscription model filter.
- ESLint passed for changed TypeScript files.
- Full workspace typecheck passed.

This follows the existing provider catalog discovery path; no live OpenAI inference request was run.

Compatibility follow-up: the live models.dev OpenAI catalog checked on 2026-09-04 does not yet contain `gpt-6-astra`. The subscription allowlist preserves existing entries but does not register Astra with OpenCode. This PR remains draft until catalog discovery is confirmed or an explicit OpenCode model definition is added and verified. OpenAI's published Astra documentation confirms low, medium, high, xhigh, and max reasoning: https://developers.openai.com/api/docs/models/gpt-6-astra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the GPT-6 Astra model.
  - GPT-6 Astra supports low, medium, high, xhigh, and max reasoning levels, with medium selected by default.
  - GPT-6 Astra can be selected through model labels and remains available for eligible Codex subscriptions.
  - Added validation and display support for GPT-6 Astra across model selection workflows.
- **Documentation**
  - Added GPT-6 Astra to the available models list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->