### PR TITLE
refactor: one jobs seam for background work, wired to Cloudflare Queues (COL-52)

### DIFF
--- a/packages/control-plane/src/autofix/handler.ts
+++ b/packages/control-plane/src/autofix/handler.ts
@@ -1,21 +1,17 @@
 import {
   GITHUB_AUTOFIX_DEFAULTS,
   resolveAppName,
-  type GitHubAutofixEnvelope,
   type ResolvedGitHubAutofixSettings,
 } from "@open-inspect/shared";
 import { getGitHubAppConfig } from "../auth/github-app";
 import { IntegrationSettingsStore } from "../db/integration-settings";
-import type { SqlDatabase } from "../db/sql-database";
 import { PrAutofixFeedbackStore } from "../db/pr-autofix-feedback-store";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
+import type { JobConsumer, JobDeps } from "../jobs";
 import { createSessionRuntimeClient } from "../session/runtime-client";
 import { GitHubSourceControlProvider } from "../source-control/providers/github-provider";
-import type { Env } from "../types";
 import { AutofixQueueConsumer } from "./queue-consumer";
 import { AutofixService } from "./service";
-
-const MAX_DELIVERY_ATTEMPTS = 5;
 
 function completeAutofixSettings(
   settings:
@@ -36,11 +32,8 @@ function completeAutofixSettings(
   };
 }
 
-export async function handleAutofixQueue(
-  batch: MessageBatch<GitHubAutofixEnvelope>,
-  env: Env,
-  db: SqlDatabase
-): Promise<void> {
+/** Composition root for the autofix consumer. */
+export function createAutofixConsumer({ env, db }: JobDeps): JobConsumer {
   const feedbackStore = new PrAutofixFeedbackStore(db);
   const integrationSettings = new IntegrationSettingsStore(db);
   const appConfig = getGitHubAppConfig(env);
@@ -70,14 +63,5 @@ export async function handleAutofixQueue(
     env.GITHUB_BOT_USERNAME,
     () => Date.now()
   );
-  const consumer = new AutofixQueueConsumer(
-    service,
-    feedbackStore,
-    () => Date.now(),
-    MAX_DELIVERY_ATTEMPTS
-  );
-
-  for (const message of batch.messages) {
-    await consumer.consume(message);
-  }
+  return new AutofixQueueConsumer(service, feedbackStore, () => Date.now());
 }

--- a/packages/control-plane/src/autofix/queue-consumer.test.ts
+++ b/packages/control-plane/src/autofix/queue-consumer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GitHubAutofixEnvelope } from "@open-inspect/shared";
+import { JOBS, type JobDelivery } from "../jobs";
 import { AutofixQueueConsumer } from "./queue-consumer";
 import { SourceControlProviderError } from "../source-control/errors";
 
@@ -14,13 +15,9 @@ const ENVELOPE: GitHubAutofixEnvelope = {
   receivedAt: "2026-07-30T05:00:00.000Z",
 };
 
-function message(attempts = 1) {
-  return {
-    body: ENVELOPE,
-    attempts,
-    ack: vi.fn(),
-    retry: vi.fn(),
-  };
+/** One delivery of an autofix job, at the kind's own attempt budget. */
+function delivery(attempts = 1): JobDelivery {
+  return { id: "job-1", attempts, maxAttempts: JOBS["github.autofix"].maxAttempts };
 }
 
 describe("AutofixQueueConsumer", () => {
@@ -33,13 +30,9 @@ describe("AutofixQueueConsumer", () => {
       markFailed: vi.fn(),
       markSkipped: vi.fn(),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = { ...message(), body: { version: 1 } };
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run({ version: 1 }, delivery())).toBe("retry");
 
-    await consumer.consume(input);
-
-    expect(input.retry).toHaveBeenCalledOnce();
-    expect(input.ack).not.toHaveBeenCalled();
     expect(service.process).not.toHaveBeenCalled();
     expect(feedbackStore.recordError).not.toHaveBeenCalled();
     expect(feedbackStore.markFailed).not.toHaveBeenCalled();
@@ -59,13 +52,8 @@ describe("AutofixQueueConsumer", () => {
       recordError: vi.fn(),
       markFailed: vi.fn(),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = message();
-
-    await consumer.consume(input);
-
-    expect(input.ack).toHaveBeenCalledOnce();
-    expect(input.retry).not.toHaveBeenCalled();
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run(ENVELOPE, delivery())).toBe("ack");
   });
 
   it("retries transient processing failures without making the ledger terminal", async () => {
@@ -78,18 +66,14 @@ describe("AutofixQueueConsumer", () => {
       recordError: vi.fn(async () => undefined),
       markFailed: vi.fn(async () => true),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = message(2);
-
-    await consumer.consume(input);
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run(ENVELOPE, delivery(2))).toBe("retry");
 
     expect(feedbackStore.recordError).toHaveBeenCalledWith(
       "github:pr_comment:1234",
       "GitHub rate limited"
     );
     expect(feedbackStore.markFailed).not.toHaveBeenCalled();
-    expect(input.retry).toHaveBeenCalledOnce();
-    expect(input.ack).not.toHaveBeenCalled();
   });
 
   it("records a terminal failure before the exhausted delivery moves to the DLQ", async () => {
@@ -102,10 +86,8 @@ describe("AutofixQueueConsumer", () => {
       recordError: vi.fn(async () => undefined),
       markFailed: vi.fn(async () => true),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = message(5);
-
-    await consumer.consume(input);
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run(ENVELOPE, delivery(5))).toBe("retry");
 
     expect(feedbackStore.markFailed).toHaveBeenCalledWith(
       "github:pr_comment:1234",
@@ -113,7 +95,6 @@ describe("AutofixQueueConsumer", () => {
       "GitHub unavailable",
       2_000
     );
-    expect(input.retry).toHaveBeenCalledOnce();
   });
 
   it("acknowledges an exhausted delivery when another worker already made it terminal", async () => {
@@ -126,13 +107,8 @@ describe("AutofixQueueConsumer", () => {
       recordError: vi.fn(async () => undefined),
       markFailed: vi.fn(async () => false),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = message(5);
-
-    await consumer.consume(input);
-
-    expect(input.ack).toHaveBeenCalledOnce();
-    expect(input.retry).not.toHaveBeenCalled();
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run(ENVELOPE, delivery(5))).toBe("ack");
   });
 
   it("fails and acknowledges permanent provider errors without retrying", async () => {
@@ -145,10 +121,8 @@ describe("AutofixQueueConsumer", () => {
       recordError: vi.fn(async () => undefined),
       markFailed: vi.fn(async () => true),
     };
-    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000, 5);
-    const input = message(1);
-
-    await consumer.consume(input);
+    const consumer = new AutofixQueueConsumer(service, feedbackStore, () => 2_000);
+    expect(await consumer.run(ENVELOPE, delivery())).toBe("ack");
 
     expect(feedbackStore.markFailed).toHaveBeenCalledWith(
       "github:pr_comment:1234",
@@ -156,7 +130,5 @@ describe("AutofixQueueConsumer", () => {
       "Comment not found",
       2_000
     );
-    expect(input.ack).toHaveBeenCalledOnce();
-    expect(input.retry).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/autofix/queue-consumer.ts
+++ b/packages/control-plane/src/autofix/queue-consumer.ts
@@ -1,5 +1,6 @@
 import { githubAutofixEnvelopeSchema, type GitHubAutofixEnvelope } from "@open-inspect/shared";
 import { githubAutofixFeedbackKey } from "../db/pr-autofix-feedback-store";
+import type { JobConsumer, JobDelivery, JobOutcome } from "../jobs";
 import { SourceControlProviderError } from "../source-control/errors";
 import type { AutofixProcessResult } from "./service";
 
@@ -17,35 +18,24 @@ interface FailureStore {
   ): Promise<boolean>;
 }
 
-interface QueueMessage {
-  body: unknown;
-  attempts: number;
-  ack(): void;
-  retry(): void;
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export class AutofixQueueConsumer {
+export class AutofixQueueConsumer implements JobConsumer {
   constructor(
     private readonly service: AutofixProcessor,
     private readonly feedbackStore: FailureStore,
-    private readonly now: () => number,
-    private readonly maxDeliveryAttempts: number
+    private readonly now: () => number
   ) {}
 
-  async consume(message: QueueMessage): Promise<void> {
-    const parsed = githubAutofixEnvelopeSchema.safeParse(message.body);
-    if (!parsed.success) {
-      message.retry();
-      return;
-    }
+  async run(body: unknown, delivery: JobDelivery): Promise<JobOutcome> {
+    const parsed = githubAutofixEnvelopeSchema.safeParse(body);
+    if (!parsed.success) return "retry";
 
     try {
       await this.service.process(parsed.data);
-      message.ack();
+      return "ack";
     } catch (error) {
       const feedbackKey = githubAutofixFeedbackKey(parsed.data);
       const detail = errorMessage(error);
@@ -56,23 +46,21 @@ export class AutofixQueueConsumer {
           detail,
           this.now()
         );
-        message.ack();
-        return;
+        return "ack";
       }
       await this.feedbackStore.recordError(feedbackKey, detail);
-      if (message.attempts >= this.maxDeliveryAttempts) {
+      if (delivery.attempts >= delivery.maxAttempts) {
         const failed = await this.feedbackStore.markFailed(
           feedbackKey,
           "delivery_attempts_exhausted",
           detail,
           this.now()
         );
-        if (!failed) {
-          message.ack();
-          return;
-        }
+        // A key another delivery already failed is not this one's to end:
+        // acknowledge and leave the recorded verdict alone.
+        if (!failed) return "ack";
       }
-      message.retry();
+      return "retry";
     }
   }
 }

--- a/packages/control-plane/src/cloudflare/job-queue.test.ts
+++ b/packages/control-plane/src/cloudflare/job-queue.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JOBS, type JobConsumer, type JobDeps, type JobOutcome } from "../jobs";
+import { consumeJobBatch, createCloudflareJobQueue, jobKindForQueue } from "./job-queue";
+
+const COMMAND = { version: 1 as const, buildId: "build-1", completionHash: "a".repeat(64) };
+
+function message(body: unknown, attempts = 1) {
+  return {
+    id: `message-${attempts}`,
+    timestamp: new Date(),
+    body,
+    attempts,
+    ack: vi.fn(),
+    retry: vi.fn(),
+    retryAll: vi.fn(),
+  };
+}
+
+function batch(queue: string, ...messages: ReturnType<typeof message>[]): MessageBatch<unknown> {
+  return {
+    queue,
+    messages,
+    ackAll: vi.fn(),
+    retryAll: vi.fn(),
+  } as unknown as MessageBatch<unknown>;
+}
+
+/** Stands in for the kind's real consumer, so a batch exercises only the mapping. */
+function stubConsumer(kind: keyof typeof JOBS, ...outcomes: JobOutcome[]): JobConsumer {
+  const run = vi.fn(async () => outcomes.shift() ?? "ack");
+  vi.spyOn(JOBS[kind], "consumer").mockReturnValue({ run } as JobConsumer);
+  return { run } as JobConsumer;
+}
+
+const deps = {} as JobDeps;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("jobKindForQueue", () => {
+  it("reads the kind off the queue a message arrived on", () => {
+    expect(jobKindForQueue("open-inspect-github-autofix-prod")).toBe("github.autofix");
+    expect(jobKindForQueue("open-inspect-image-build-finalization-prod")).toBe(
+      "image_build.finalize"
+    );
+  });
+
+  it("does not mistake a deployment named for autofix for the autofix queue", () => {
+    expect(jobKindForQueue("open-inspect-image-build-finalization-github-autofix-test")).toBe(
+      "image_build.finalize"
+    );
+  });
+});
+
+describe("createCloudflareJobQueue", () => {
+  it("sends the payload alone, on the kind's own queue", async () => {
+    const send = vi.fn(async () => undefined);
+    const jobs = createCloudflareJobQueue({
+      IMAGE_BUILD_FINALIZATION_QUEUE: { send } as unknown as Queue<typeof COMMAND>,
+    });
+
+    await jobs.send({ kind: "image_build.finalize", payload: COMMAND });
+
+    expect(send).toHaveBeenCalledWith(COMMAND);
+  });
+});
+
+describe("consumeJobBatch", () => {
+  it("acknowledges and retries each message on its own outcome", async () => {
+    const consumer = stubConsumer("image_build.finalize", "ack", { retry: true, delaySeconds: 90 });
+    const acked = message(COMMAND, 1);
+    const delayed = message(COMMAND, 2);
+
+    await consumeJobBatch(
+      batch("open-inspect-image-build-finalization-prod", acked, delayed),
+      deps
+    );
+
+    expect(acked.ack).toHaveBeenCalledOnce();
+    expect(acked.retry).not.toHaveBeenCalled();
+    expect(delayed.retry).toHaveBeenCalledWith({ delaySeconds: 90 });
+    expect(consumer.run).toHaveBeenCalledWith(COMMAND, {
+      id: "message-1",
+      attempts: 1,
+      maxAttempts: JOBS["image_build.finalize"].maxAttempts,
+    });
+  });
+
+  it("gives a plain retry the kind's declared delay", async () => {
+    stubConsumer("github.autofix", "retry");
+    const queued = message({ version: 1 });
+
+    await consumeJobBatch(batch("open-inspect-github-autofix-prod", queued), deps);
+
+    expect(queued.retry).toHaveBeenCalledWith({
+      delaySeconds: JOBS["github.autofix"].retryDelaySeconds,
+    });
+  });
+
+  it("builds the consumer once for the whole batch", async () => {
+    stubConsumer("image_build.finalize");
+
+    await consumeJobBatch(
+      batch("open-inspect-image-build-finalization-prod", message(COMMAND), message(COMMAND, 2)),
+      deps
+    );
+
+    expect(JOBS["image_build.finalize"].consumer).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/control-plane/src/cloudflare/job-queue.ts
+++ b/packages/control-plane/src/cloudflare/job-queue.ts
@@ -1,0 +1,67 @@
+/**
+ * Cloudflare's wiring of the jobs seam: one Queue per job kind.
+ *
+ * A message carries the job's payload alone, exactly as it did before the
+ * seam existed. A queue holds messages across a deploy, and the autofix
+ * producer is a different Worker on its own release cycle, so the wire shape
+ * is not ours to restate; the kind is recovered from the queue a message
+ * arrived on rather than read out of its body.
+ */
+
+import { JOBS, type Job, type JobDeps, type JobKind, type JobQueue } from "../jobs";
+import type { ImageBuildFinalizationJob } from "../image-builds/finalization-job";
+
+/** Queue names Terraform derives from the deployment name. */
+const AUTOFIX_QUEUE_NAME_PREFIX = "open-inspect-github-autofix-";
+
+/** The Queue bindings the producible kinds are sent on. */
+export interface JobQueueBindings {
+  IMAGE_BUILD_FINALIZATION_QUEUE: Queue<ImageBuildFinalizationJob>;
+}
+
+/**
+ * The kind delivered on `queueName`. Only the finalization and autofix queues
+ * have a consumer bound (their dead-letter queues have none), so the autofix
+ * prefix decides and every other name is a finalization — including the one
+ * the integration tests deliver on.
+ */
+export function jobKindForQueue(queueName: string): JobKind {
+  return queueName.startsWith(AUTOFIX_QUEUE_NAME_PREFIX)
+    ? "github.autofix"
+    : "image_build.finalize";
+}
+
+export function createCloudflareJobQueue(bindings: JobQueueBindings): JobQueue {
+  const queues: { [K in Job["kind"]]: Queue<Extract<Job, { kind: K }>["payload"]> } = {
+    "image_build.finalize": bindings.IMAGE_BUILD_FINALIZATION_QUEUE,
+  };
+  return {
+    async send(job: Job): Promise<void> {
+      await queues[job.kind].send(job.payload);
+    },
+  };
+}
+
+/**
+ * Runs one batch: the queue picks the kind, and each message's outcome maps
+ * onto its own ack or retry so one failure does not hold up the rest.
+ */
+export async function consumeJobBatch(batch: MessageBatch<unknown>, deps: JobDeps): Promise<void> {
+  const definition = JOBS[jobKindForQueue(batch.queue)];
+  const consumer = definition.consumer(deps);
+
+  for (const message of batch.messages) {
+    const outcome = await consumer.run(message.body, {
+      id: message.id,
+      attempts: message.attempts,
+      maxAttempts: definition.maxAttempts,
+    });
+    if (outcome === "ack") {
+      message.ack();
+    } else if (outcome === "retry") {
+      message.retry({ delaySeconds: definition.retryDelaySeconds });
+    } else {
+      message.retry({ delaySeconds: outcome.delaySeconds });
+    }
+  }
+}

--- a/packages/control-plane/src/cloudflare/platform.ts
+++ b/packages/control-plane/src/cloudflare/platform.ts
@@ -9,6 +9,7 @@
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { ImageBuildFinalizationJob } from "../image-builds/finalization-job";
 import type { Env, EnvConfig, Platform } from "../types";
+import { createCloudflareJobQueue } from "./job-queue";
 import { R2ObjectStorage } from "./object-storage";
 import { createDurableObjectSessionRuntimeDispatch } from "./session-runtime-dispatch";
 
@@ -21,7 +22,7 @@ export interface WorkerBindings extends EnvConfig {
   AUTOFIX_QUEUE?: Queue<unknown>;
   AUTOFIX_DLQ?: Queue<unknown>;
   DB: D1Database;
-  IMAGE_BUILD_FINALIZATION_QUEUE?: Queue<ImageBuildFinalizationJob>;
+  IMAGE_BUILD_FINALIZATION_QUEUE: Queue<ImageBuildFinalizationJob>;
   MEDIA_BUCKET: R2Bucket;
 }
 
@@ -53,15 +54,23 @@ export function createCloudflareEnv(bindings: WorkerBindings): Env {
     LINEAR_BOT,
     AUTOFIX_QUEUE,
     AUTOFIX_DLQ,
-    IMAGE_BUILD_FINALIZATION_QUEUE,
+    JOBS: createCloudflareJobQueue({ IMAGE_BUILD_FINALIZATION_QUEUE }),
   };
   return { ...config, ...platform };
 }
 
-// Every field of WorkerBindings is either a platform port (adapted above) or
-// configuration: a new binding that is neither fails to compile here.
+/**
+ * Bindings the composition above folds into a port named for the seam rather
+ * than for the binding. Listed so the assertion below still refuses a binding
+ * nobody composed.
+ */
+type FoldedBindings = "IMAGE_BUILD_FINALIZATION_QUEUE";
+
+// Every field of WorkerBindings is a platform port (adapted above), one of the
+// bindings folded into one, or configuration: a new binding that is none of
+// those fails to compile here.
 type _AssertExtends<A extends B, B> = A;
-type _BindingsAreConfigOrPlatform = _AssertExtends<
-  Exclude<keyof WorkerBindings, keyof Platform>,
+type _EveryBindingIsComposed = _AssertExtends<
+  Exclude<keyof WorkerBindings, keyof Platform | FoldedBindings>,
   keyof EnvConfig
 >;

--- a/packages/control-plane/src/image-builds/finalization-consumer.test.ts
+++ b/packages/control-plane/src/image-builds/finalization-consumer.test.ts
@@ -1,55 +1,54 @@
 import { describe, expect, it, vi } from "vitest";
-import { consumeImageBuildFinalizationBatch } from "./finalization-consumer";
+import { JOBS, type JobDelivery } from "../jobs";
+import { IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS } from "./finalizer";
+import { imageBuildFinalizationConsumer } from "./finalization-consumer";
 
-function message(body: unknown) {
-  return {
-    id: "message-1",
-    timestamp: new Date(),
-    body,
-    attempts: 1,
-    ack: vi.fn(),
-    retry: vi.fn(),
-  };
+const COMMAND = { version: 1, buildId: "build-1", completionHash: "a".repeat(64) };
+
+function delivery(attempts = 1): JobDelivery {
+  return { id: "job-1", attempts, maxAttempts: JOBS["image_build.finalize"].maxAttempts };
 }
 
-function batch(...messages: ReturnType<typeof message>[]): MessageBatch<unknown> {
-  return {
-    queue: "image-build-finalization",
-    messages,
-    ackAll: vi.fn(),
-    retryAll: vi.fn(),
-  } as unknown as MessageBatch<unknown>;
-}
-
-describe("image build finalization Queue consumer", () => {
-  it("acknowledges completed work", async () => {
-    const queued = message({
-      version: 1,
-      buildId: "build-1",
-      completionHash: "a".repeat(64),
-    });
+describe("image build finalization consumer", () => {
+  it("acknowledges completed work, naming the job in the finalizer's correlation", async () => {
     const process = vi.fn(async () => ({ type: "completed" as const }));
 
-    await consumeImageBuildFinalizationBatch(batch(queued), process);
+    const outcome = await imageBuildFinalizationConsumer(process).run(COMMAND, delivery());
 
-    expect(process).toHaveBeenCalledWith(queued.body, "message-1");
-    expect(queued.ack).toHaveBeenCalledOnce();
-    expect(queued.retry).not.toHaveBeenCalled();
+    expect(outcome).toBe("ack");
+    expect(process).toHaveBeenCalledWith(COMMAND, "job-1");
   });
 
-  it("retries busy or failed processing and rejects malformed commands", async () => {
-    const retry = message({
-      version: 1,
-      buildId: "build-1",
-      completionHash: "a".repeat(64),
-    });
-    const malformed = message({ buildId: "build-2", callbackToken: "secret" });
+  it("retries busy or failed processing for as long as the finalizer asks", async () => {
     const process = vi.fn(async () => ({ type: "retry" as const, delaySeconds: 365 }));
 
-    await consumeImageBuildFinalizationBatch(batch(retry, malformed), process);
+    const outcome = await imageBuildFinalizationConsumer(process).run(COMMAND, delivery());
 
-    expect(retry.retry).toHaveBeenCalledWith({ delaySeconds: 365 });
-    expect(malformed.ack).toHaveBeenCalledOnce();
-    expect(process).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ retry: true, delaySeconds: 365 });
+  });
+
+  it("retries a throwing finalizer after the kind's own delay", async () => {
+    const process = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    });
+
+    const outcome = await imageBuildFinalizationConsumer(process).run(COMMAND, delivery());
+
+    expect(outcome).toEqual({
+      retry: true,
+      delaySeconds: IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS,
+    });
+  });
+
+  it("discards a malformed command rather than redelivering it forever", async () => {
+    const process = vi.fn();
+
+    const outcome = await imageBuildFinalizationConsumer(process).run(
+      { buildId: "build-2", callbackToken: "secret" },
+      delivery()
+    );
+
+    expect(outcome).toBe("ack");
+    expect(process).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/image-builds/finalization-consumer.ts
+++ b/packages/control-plane/src/image-builds/finalization-consumer.ts
@@ -1,6 +1,6 @@
 import { ImageBuildStore } from "../db/image-builds";
+import type { JobConsumer, JobDeps } from "../jobs";
 import { createLogger } from "../logger";
-import type { Env } from "../types";
 import {
   IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS,
   ImageBuildFinalizer,
@@ -20,56 +20,45 @@ type FinalizationProcessor = (
 ) => Promise<ImageBuildFinalizationResult>;
 
 /**
- * Applies Queue delivery semantics to one batch: invalid commands are
- * discarded, completed work is acknowledged, and busy or failed work is
- * retried without aborting later messages in the batch.
+ * Applies delivery semantics to one finalization command: an invalid command
+ * is discarded, completed work is acknowledged, and busy or failed work is
+ * retried.
  */
-export async function consumeImageBuildFinalizationBatch(
-  batch: MessageBatch<unknown>,
-  process: FinalizationProcessor
-): Promise<void> {
-  for (const message of batch.messages) {
-    const parsed = imageBuildFinalizationJobSchema.safeParse(message.body);
-    if (!parsed.success) {
-      logger.error("image_build.finalization_job_invalid", {
-        queue_message_id: message.id,
-        attempts: message.attempts,
-      });
-      message.ack();
-      continue;
-    }
-
-    try {
-      const result = await process(parsed.data, message.id);
-      if (result.type === "retry") {
-        message.retry({ delaySeconds: result.delaySeconds });
-      } else {
-        message.ack();
+export function imageBuildFinalizationConsumer(process: FinalizationProcessor): JobConsumer {
+  return {
+    async run(body, delivery) {
+      const parsed = imageBuildFinalizationJobSchema.safeParse(body);
+      if (!parsed.success) {
+        logger.error("image_build.finalization_job_invalid", {
+          job_id: delivery.id,
+          attempts: delivery.attempts,
+        });
+        return "ack";
       }
-    } catch (error) {
-      logger.error("image_build.finalization_error", {
-        build_id: parsed.data.buildId,
-        queue_message_id: message.id,
-        attempts: message.attempts,
-        error: error instanceof Error ? error : new Error(String(error)),
-      });
-      message.retry({ delaySeconds: IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS });
-    }
-  }
+
+      try {
+        const result = await process(parsed.data, delivery.id);
+        return result.type === "retry" ? { retry: true, delaySeconds: result.delaySeconds } : "ack";
+      } catch (error) {
+        logger.error("image_build.finalization_error", {
+          build_id: parsed.data.buildId,
+          job_id: delivery.id,
+          attempts: delivery.attempts,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        return { retry: true, delaySeconds: IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS };
+      }
+    },
+  };
 }
 
-/** Cloudflare Queue composition root for the production finalizer. */
-export async function consumeImageBuildFinalizations(
-  batch: MessageBatch<unknown>,
-  env: Env
-): Promise<void> {
-  // eslint-disable-next-line no-restricted-syntax -- Queue composition root: the one consumer env.DB read
-  const db = env.DB;
+/** Composition root for the production finalizer. */
+export function createImageBuildFinalizationConsumer({ env, db }: JobDeps): JobConsumer {
   const finalizer = new ImageBuildFinalizer(
     new ImageBuildStore(db),
     createImageBuildAdapterFactory(env)
   );
-  await consumeImageBuildFinalizationBatch(batch, (job, requestId) =>
+  return imageBuildFinalizationConsumer((job, requestId) =>
     finalizer.process(job, { request_id: requestId, trace_id: requestId })
   );
 }

--- a/packages/control-plane/src/image-builds/finalization-job.ts
+++ b/packages/control-plane/src/image-builds/finalization-job.ts
@@ -10,15 +10,6 @@ export const imageBuildFinalizationJobSchema = z.object({
 
 export type ImageBuildFinalizationJob = z.infer<typeof imageBuildFinalizationJobSchema>;
 
-/**
- * Minimal producer boundary used by callback workflows, satisfied directly by
- * the Queue binding. The send response is never consumed — callers only await
- * delivery.
- */
-export interface ImageBuildFinalizationQueue {
-  send(job: ImageBuildFinalizationJob): Promise<unknown>;
-}
-
 /** The one constructor of the versioned Queue command shape. */
 export function imageBuildFinalizationJob(
   buildId: string,

--- a/packages/control-plane/src/image-builds/scheduler.test.ts
+++ b/packages/control-plane/src/image-builds/scheduler.test.ts
@@ -302,7 +302,7 @@ describe("ImageBuildScheduler", () => {
   it("republishes persisted artifacts left behind by exhausted Queue delivery", async () => {
     const send = vi.fn(async () => undefined);
     const { scheduler, listRecoverableFinalizations } = harness({
-      env: { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
+      env: { JOBS: { send } } as unknown as Env,
     });
     listRecoverableFinalizations.mockResolvedValue([
       {
@@ -316,18 +316,21 @@ describe("ImageBuildScheduler", () => {
 
     expect(stats.finalizationsRepublished).toBe(1);
     expect(send).toHaveBeenCalledWith({
-      version: 1,
-      buildId: "build-recover",
-      completionHash: "a".repeat(64),
+      kind: "image_build.finalize",
+      payload: {
+        version: 1,
+        buildId: "build-recover",
+        completionHash: "a".repeat(64),
+      },
     });
   });
 
   it("republishes every recoverable finalization and contains a publish failure", async () => {
-    const send = vi.fn(async ({ buildId }: { buildId: string }) => {
-      if (buildId === "build-05") throw new Error("queue unavailable");
+    const send = vi.fn(async ({ payload }: { payload: { buildId: string } }) => {
+      if (payload.buildId === "build-05") throw new Error("queue unavailable");
     });
     const { scheduler, listRecoverableFinalizations } = harness({
-      env: { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
+      env: { JOBS: { send } } as unknown as Env,
     });
     const recoverable = Array.from({ length: 21 }, (_, index) => ({
       id: `build-${String(index + 1).padStart(2, "0")}`,
@@ -342,9 +345,8 @@ describe("ImageBuildScheduler", () => {
     expect(send).toHaveBeenCalledTimes(21);
     expect(listRecoverableFinalizations).toHaveBeenCalledWith(expect.any(Number));
     expect(send).toHaveBeenCalledWith({
-      version: 1,
-      buildId: "build-21",
-      completionHash: "21".repeat(32),
+      kind: "image_build.finalize",
+      payload: { version: 1, buildId: "build-21", completionHash: "21".repeat(32) },
     });
   });
 });

--- a/packages/control-plane/src/image-builds/scheduler.ts
+++ b/packages/control-plane/src/image-builds/scheduler.ts
@@ -135,14 +135,15 @@ export class ImageBuildScheduler {
   }
 
   private async republishRecoverableFinalizations(): Promise<number> {
-    const queue = this.env.IMAGE_BUILD_FINALIZATION_QUEUE;
-    if (!queue) return 0;
     const rows = await this.store.listRecoverableFinalizations(Date.now());
 
     let published = 0;
     for (const row of rows) {
       try {
-        await queue.send(imageBuildFinalizationJob(row.id, row.completion_hash));
+        await this.env.JOBS.send({
+          kind: "image_build.finalize",
+          payload: imageBuildFinalizationJob(row.id, row.completion_hash),
+        });
         published += 1;
       } catch (error) {
         logger.warn("image_build.scheduler_finalization_republish_row_failed", {

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -12,7 +12,7 @@ import {
 import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
-import type { ImageBuildFinalizationQueue } from "./finalization-job";
+import type { JobQueue } from "../jobs";
 import type { ImageBuildPlan } from "./types";
 import { COMPATIBLE_RUNTIME_VERSION } from "./test-helpers";
 import { ImageBuildWorkflow } from "./workflow";
@@ -112,7 +112,7 @@ function createWorkflow(options: {
   createCallbackAuth?: ReturnType<typeof vi.fn>;
   env?: Env;
   provider?: "modal" | "vercel" | "opencomputer" | null;
-  queue?: ImageBuildFinalizationQueue;
+  jobs?: JobQueue;
 }) {
   const store = options.store ?? createStore();
   const adapter = options.adapter ?? createAdapter();
@@ -142,7 +142,7 @@ function createWorkflow(options: {
     store as unknown as ImageBuildStore,
     factory,
     provider ? { provider, planner } : null,
-    options.queue ?? { send: vi.fn().mockResolvedValue(undefined) }
+    options.jobs ?? { send: vi.fn().mockResolvedValue(undefined) }
   );
   return { workflow, store, adapter, factory, planBuild, resolveTarget, createCallbackAuth };
 }
@@ -333,7 +333,8 @@ describe("ImageBuildWorkflow", () => {
           } as unknown as NonNullable<
             ConstructorParameters<typeof ImageBuildWorkflow>[3]
           >["planner"],
-        }
+        },
+        { send: vi.fn().mockResolvedValue(undefined) }
       );
 
       await expect(workflow.triggerBuild(ENV_SCOPE, ctx)).rejects.toMatchObject({
@@ -560,8 +561,8 @@ describe("ImageBuildWorkflow", () => {
 
     it("atomically accepts completion before publishing it", async () => {
       const store = sessionBuildStore();
-      const queue = { send: vi.fn().mockResolvedValue(undefined) };
-      const { workflow } = createWorkflow({ store, queue });
+      const jobs = { send: vi.fn().mockResolvedValue(undefined) };
+      const { workflow } = createWorkflow({ store, jobs });
 
       await workflow.acceptBuildComplete({
         completion: validCompletion({
@@ -571,10 +572,13 @@ describe("ImageBuildWorkflow", () => {
         context: ctx,
       });
 
-      expect(queue.send).toHaveBeenCalledWith({
-        version: 1,
-        buildId: "imgb-env_1-1-abcd",
-        completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect(jobs.send).toHaveBeenCalledWith({
+        kind: "image_build.finalize",
+        payload: {
+          version: 1,
+          buildId: "imgb-env_1-1-abcd",
+          completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
       });
       expect(store.acceptSuccessfulCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -591,14 +595,14 @@ describe("ImageBuildWorkflow", () => {
         })
       );
       expect(store.acceptSuccessfulCompletion.mock.invocationCallOrder[0]).toBeLessThan(
-        queue.send.mock.invocationCallOrder[0]
+        jobs.send.mock.invocationCallOrder[0]
       );
     });
 
     it("leaves an accepted completion recoverable when publishing fails", async () => {
       const store = sessionBuildStore();
-      const queue = { send: vi.fn().mockRejectedValue(new Error("queue unavailable")) };
-      const { workflow } = createWorkflow({ store, queue });
+      const jobs = { send: vi.fn().mockRejectedValue(new Error("jobs unavailable")) };
+      const { workflow } = createWorkflow({ store, jobs });
 
       await expect(
         workflow.acceptBuildComplete({
@@ -608,11 +612,11 @@ describe("ImageBuildWorkflow", () => {
           callbackToken: "callback-token",
           context: ctx,
         })
-      ).rejects.toThrow("queue unavailable");
+      ).rejects.toThrow("jobs unavailable");
 
       expect(store.acceptSuccessfulCompletion).toHaveBeenCalledOnce();
       expect(store.acceptSuccessfulCompletion.mock.invocationCallOrder[0]).toBeLessThan(
-        queue.send.mock.invocationCallOrder[0]
+        jobs.send.mock.invocationCallOrder[0]
       );
     });
 
@@ -648,8 +652,8 @@ describe("ImageBuildWorkflow", () => {
 
     it("atomically accepts failures before publishing them", async () => {
       const store = sessionBuildStore();
-      const queue = { send: vi.fn().mockResolvedValue(undefined) };
-      const { workflow } = createWorkflow({ store, queue });
+      const jobs = { send: vi.fn().mockResolvedValue(undefined) };
+      const { workflow } = createWorkflow({ store, jobs });
 
       await workflow.acceptBuildFailed({
         failure: {
@@ -661,10 +665,13 @@ describe("ImageBuildWorkflow", () => {
         context: ctx,
       });
 
-      expect(queue.send).toHaveBeenCalledWith({
-        version: 1,
-        buildId: "imgb-env_1-1-abcd",
-        completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect(jobs.send).toHaveBeenCalledWith({
+        kind: "image_build.finalize",
+        payload: {
+          version: 1,
+          buildId: "imgb-env_1-1-abcd",
+          completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
       });
       expect(store.acceptFailedCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -675,7 +682,7 @@ describe("ImageBuildWorkflow", () => {
         })
       );
       expect(store.acceptFailedCompletion.mock.invocationCallOrder[0]).toBeLessThan(
-        queue.send.mock.invocationCallOrder[0]
+        jobs.send.mock.invocationCallOrder[0]
       );
     });
 
@@ -688,8 +695,8 @@ describe("ImageBuildWorkflow", () => {
         status: "building",
       });
       store.acceptSuccessfulCompletion.mockResolvedValue("replayed");
-      const queue = { send: vi.fn().mockResolvedValue(undefined) };
-      const { workflow } = createWorkflow({ store, queue });
+      const jobs = { send: vi.fn().mockResolvedValue(undefined) };
+      const { workflow } = createWorkflow({ store, jobs });
 
       await expect(
         workflow.acceptBuildComplete({
@@ -701,10 +708,13 @@ describe("ImageBuildWorkflow", () => {
         })
       ).resolves.toBeUndefined();
 
-      expect(queue.send).toHaveBeenCalledWith({
-        version: 1,
-        buildId: "imgb-env_1-1-abcd",
-        completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect(jobs.send).toHaveBeenCalledWith({
+        kind: "image_build.finalize",
+        payload: {
+          version: 1,
+          buildId: "imgb-env_1-1-abcd",
+          completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
       });
     });
 
@@ -717,8 +727,8 @@ describe("ImageBuildWorkflow", () => {
         status: "failed",
       });
       store.acceptFailedCompletion.mockResolvedValue("replayed");
-      const queue = { send: vi.fn().mockResolvedValue(undefined) };
-      const { workflow } = createWorkflow({ store, queue });
+      const jobs = { send: vi.fn().mockResolvedValue(undefined) };
+      const { workflow } = createWorkflow({ store, jobs });
 
       await expect(
         workflow.acceptBuildFailed({
@@ -732,10 +742,13 @@ describe("ImageBuildWorkflow", () => {
         })
       ).resolves.toBeUndefined();
 
-      expect(queue.send).toHaveBeenCalledWith({
-        version: 1,
-        buildId: "imgb-env_1-1-abcd",
-        completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect(jobs.send).toHaveBeenCalledWith({
+        kind: "image_build.finalize",
+        payload: {
+          version: 1,
+          buildId: "imgb-env_1-1-abcd",
+          completionHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
       });
     });
 

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -1,13 +1,11 @@
 import { generateId } from "../auth/crypto";
 import { ImageBuildStore, type ImageBuildRegistration } from "../db/image-builds";
+import type { JobQueue } from "../jobs";
 import { createLogger } from "../logger";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import { hashImageBuildCallbackToken, type ImageBuildCallbackAuthFailure } from "./callback-auth";
-import {
-  createImageBuildFinalizationJob,
-  type ImageBuildFinalizationQueue,
-} from "./finalization-job";
+import { createImageBuildFinalizationJob } from "./finalization-job";
 import {
   errorMessage,
   ImageBuildCallbackAuthRejectedError,
@@ -80,7 +78,7 @@ export class ImageBuildWorkflow {
     private readonly store: ImageBuildStore,
     private readonly adapterFactory: ImageBuildAdapterFactory,
     private readonly providerDeps: ImageBuildProviderDeps,
-    private readonly finalizationQueue: ImageBuildFinalizationQueue | null = null
+    private readonly jobs: JobQueue
   ) {}
 
   /**
@@ -186,9 +184,6 @@ export class ImageBuildWorkflow {
         trace_id: ctx.trace_id,
       });
       throw new ImageBuildProviderUnconfiguredError("Image build provider is not configured", e);
-    }
-    if (!this.finalizationQueue) {
-      throw new ImageBuildWorkflowUnavailableError("Image build finalization Queue not configured");
     }
 
     await this.failStaleScopeBuild(scope, provider, ctx);
@@ -365,7 +360,7 @@ export class ImageBuildWorkflow {
       throw new ImageBuildCompletionNotAcceptedError("Build is not accepting completion");
     }
     if (authenticated.build.status === "building") {
-      await this.requireFinalizationQueue().send(job);
+      await this.jobs.send({ kind: "image_build.finalize", payload: job });
     }
 
     logger.info("image_build.build_complete_received", {
@@ -409,7 +404,7 @@ export class ImageBuildWorkflow {
     if (acceptance === "rejected") {
       throw new ImageBuildFailureNotAcceptedError("Build is not accepting failure");
     }
-    await this.requireFinalizationQueue().send(job);
+    await this.jobs.send({ kind: "image_build.finalize", payload: job });
 
     logger.info("image_build.build_failed", {
       build_id: failure.buildId,
@@ -458,13 +453,6 @@ export class ImageBuildWorkflow {
     return { build, tokenHash };
   }
 
-  private requireFinalizationQueue(): ImageBuildFinalizationQueue {
-    if (!this.finalizationQueue) {
-      throw new ImageBuildWorkflowUnavailableError("Image build finalization Queue not configured");
-    }
-    return this.finalizationQueue;
-  }
-
   private loggedCallbackAuthError(
     failure: ImageBuildCallbackAuthFailure,
     params: {
@@ -501,7 +489,7 @@ export function createImageBuildWorkflowFromEnv(env: Env, db: SqlDatabase): Imag
     new ImageBuildStore(db),
     createImageBuildAdapterFactory(env),
     provider ? { provider, planner: new ImageBuildPlanner(env, db) } : null,
-    env.IMAGE_BUILD_FINALIZATION_QUEUE ?? null
+    env.JOBS
   );
 }
 

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -6,9 +6,7 @@
 
 import { handleControlPlaneHttp } from "./cloudflare/http-host";
 import { createLogger } from "./logger";
-import type { GitHubAutofixEnvelope } from "@open-inspect/shared";
-import { handleAutofixQueue } from "./autofix/handler";
-import { consumeImageBuildFinalizations } from "./image-builds/finalization-consumer";
+import { consumeJobBatch } from "./cloudflare/job-queue";
 import { createSessionRuntimeClient } from "./session/runtime-client";
 import {
   createRequestMetrics,
@@ -20,7 +18,6 @@ import type { SqlDatabase } from "./db/sql-database";
 import { createCloudflareBackgroundTasks } from "./cloudflare/background-tasks";
 import { createCloudflareEnv, type WorkerBindings } from "./cloudflare/platform";
 import { findScheduledJob } from "./scheduled-jobs";
-import { isAutofixQueue } from "./queue-routing";
 
 const logger = createLogger("worker");
 
@@ -81,12 +78,8 @@ export default {
 
   async queue(batch: MessageBatch<unknown>, bindings: WorkerBindings): Promise<void> {
     const env = createCloudflareEnv(bindings);
-    if (!isAutofixQueue(batch.queue)) {
-      await consumeImageBuildFinalizations(batch, env);
-      return;
-    }
-    // eslint-disable-next-line no-restricted-syntax -- worker composition root: inject D1 once
-    await handleAutofixQueue(batch as MessageBatch<GitHubAutofixEnvelope>, env, env.DB);
+    // eslint-disable-next-line no-restricted-syntax -- Queue composition root: the one consumer env.DB read
+    await consumeJobBatch(batch, { env, db: env.DB });
   },
 };
 

--- a/packages/control-plane/src/jobs.test.ts
+++ b/packages/control-plane/src/jobs.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { JOBS, findJob, type JobKind } from "./jobs";
+
+const TERRAFORM_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../terraform/environments/production"
+);
+
+/** Where Terraform declares the queue consumer that delivers each kind. */
+const QUEUE_CONSUMERS: Record<JobKind, { file: string; resource: string }> = {
+  "image_build.finalize": {
+    file: "workers-control-plane.tf",
+    resource: "image_build_finalization",
+  },
+  "github.autofix": { file: "workers-github.tf", resource: "github_autofix" },
+};
+
+/** The `settings` block of one `cloudflare_queue_consumer` resource. */
+function consumerSettings(
+  file: string,
+  resource: string
+): { max_retries: number; retry_delay: number } {
+  const source = readFileSync(resolve(TERRAFORM_DIR, file), "utf8");
+  const block = new RegExp(
+    `resource\\s+"cloudflare_queue_consumer"\\s+"${resource}"\\s*\\{[\\s\\S]*?\\n\\}`
+  ).exec(source);
+  if (!block) throw new Error(`No cloudflare_queue_consumer "${resource}" in ${file}`);
+  const read = (setting: string): number => {
+    const match = new RegExp(`\\b${setting}\\s*=\\s*(\\d+)`).exec(block[0]);
+    if (!match) throw new Error(`No ${setting} on cloudflare_queue_consumer "${resource}"`);
+    return Number(match[1]);
+  };
+  return { max_retries: read("max_retries"), retry_delay: read("retry_delay") };
+}
+
+describe("JOBS", () => {
+  it("keys every definition by its own kind", () => {
+    for (const [key, definition] of Object.entries(JOBS)) {
+      expect(definition.kind).toBe(key);
+      expect(findJob(key)).toBe(definition);
+    }
+    expect(findJob("session.completed")).toBeUndefined();
+    // `findJob` reads a kind off the wire: a prototype member is not a job.
+    expect(findJob("toString")).toBeUndefined();
+  });
+
+  it("declares the delivery policy Terraform deploys for each kind", () => {
+    for (const [kind, location] of Object.entries(QUEUE_CONSUMERS) as Array<
+      [JobKind, { file: string; resource: string }]
+    >) {
+      const settings = consumerSettings(location.file, location.resource);
+      const definition = JOBS[kind];
+      // Cloudflare counts redeliveries; a definition counts deliveries.
+      expect(definition.maxAttempts).toBe(settings.max_retries + 1);
+      expect(definition.retryDelaySeconds).toBe(settings.retry_delay);
+    }
+  });
+});

--- a/packages/control-plane/src/jobs.ts
+++ b/packages/control-plane/src/jobs.ts
@@ -1,0 +1,112 @@
+/**
+ * The control plane's background jobs: work one request hands off so that a
+ * consumer runs it later, once, durably. `scheduled-jobs.ts` is the clock's
+ * table; this is the queue's.
+ *
+ * Cloudflare delivers a job as a Queue message, one queue per kind, and
+ * `cloudflare/job-queue.ts` maps between the two. A container has no queue
+ * service: it writes a row and polls it. Neither host appears below — a
+ * definition names its kind, its delivery policy and how to run one delivery,
+ * which is all either host needs to drive it.
+ *
+ * A body reaching a consumer has crossed a durable medium and may predate the
+ * code reading it, so `Job` types the send side and `unknown` is what the
+ * receive side is honestly given: a consumer validates before it acts.
+ */
+
+import { createAutofixConsumer } from "./autofix/handler";
+import type { SqlDatabase } from "./db/sql-database";
+import { createImageBuildFinalizationConsumer } from "./image-builds/finalization-consumer";
+import type { ImageBuildFinalizationJob } from "./image-builds/finalization-job";
+import { IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS } from "./image-builds/finalizer";
+import type { Env } from "./types";
+
+/** Every kind of background job this worker runs. */
+export type JobKind = "image_build.finalize" | "github.autofix";
+
+/**
+ * A job the control plane produces. `github.autofix` is absent on purpose:
+ * the github-bot worker produces those and this one only runs them, so the
+ * kind appears in `JOBS` below but never in a `send`.
+ */
+export type Job = { kind: "image_build.finalize"; payload: ImageBuildFinalizationJob };
+
+/** Hands a job off to run later; resolves once the job is durable. */
+export interface JobQueue {
+  send(job: Job): Promise<void>;
+}
+
+/** One attempt at running one job. */
+export interface JobDelivery {
+  /** Identifies the job in logs, and is the same across its deliveries. */
+  readonly id: string;
+  /** 1 on the first delivery. */
+  readonly attempts: number;
+  /** The kind's `maxAttempts`, so a consumer can recognise its last chance. */
+  readonly maxAttempts: number;
+}
+
+/** What a consumer decides about one delivery. */
+export type JobOutcome =
+  /** Done with this job, successfully or not; do not redeliver. */
+  | "ack"
+  /** Redeliver after the kind's `retryDelaySeconds`. */
+  | "retry"
+  /** Redeliver after a delay this delivery chose. */
+  | { retry: true; delaySeconds: number };
+
+/**
+ * What building a consumer is given; the host builds it per batch or poll.
+ * `db` is the global store the host already opened, passed rather than read
+ * off `env` so that consumers stay out of the composition root, exactly as
+ * `ScheduledJobDeps` does for the clock.
+ */
+export interface JobDeps {
+  env: Env;
+  db: SqlDatabase;
+}
+
+/** Runs deliveries of one kind. */
+export interface JobConsumer {
+  run(body: unknown, delivery: JobDelivery): Promise<JobOutcome>;
+}
+
+export interface JobDefinition {
+  readonly kind: JobKind;
+  /**
+   * Deliveries after which the host stops redelivering and the job is dead.
+   * Cloudflare enforces this from the queue consumer's `max_retries`; a
+   * poller enforces it from here. `jobs.test.ts` holds the two equal.
+   */
+  readonly maxAttempts: number;
+  /** How long a plain `"retry"` waits. Mirrors the consumer's `retry_delay`. */
+  readonly retryDelaySeconds: number;
+  /**
+   * Build the consumer for one batch or poll. Two steps rather than one call
+   * so that a batch shares the service graph its deliveries need instead of
+   * rebuilding it per message.
+   */
+  consumer(deps: JobDeps): JobConsumer;
+}
+
+export const JOBS = {
+  "image_build.finalize": {
+    kind: "image_build.finalize",
+    // Terraform: max_retries = 12, retry_delay = 15.
+    maxAttempts: 13,
+    retryDelaySeconds: IMAGE_BUILD_FINALIZATION_RETRY_DELAY_SECONDS,
+    consumer: createImageBuildFinalizationConsumer,
+  },
+  "github.autofix": {
+    kind: "github.autofix",
+    // Terraform: max_retries = 4, retry_delay = 30.
+    maxAttempts: 5,
+    retryDelaySeconds: 30,
+    consumer: createAutofixConsumer,
+  },
+} as const satisfies { [K in JobKind]: JobDefinition & { kind: K } };
+
+/** The definition for a kind read back off the wire, where it is a string. */
+export function findJob(kind: string): JobDefinition | undefined {
+  return Object.hasOwn(JOBS, kind) ? JOBS[kind as JobKind] : undefined;
+}

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -28,6 +28,7 @@ import { SessionIndexStore } from "../db/session-index";
 import { SqlCacheStore } from "../db/sql-cache-store";
 import type { SqlDatabase } from "../db/sql-database";
 import { requireRepoSecretsEncryptionKey, requireTokenEncryptionKey } from "../env-validation";
+import type { JobQueue } from "../jobs";
 import { createLogger, parseLogLevel, type Logger } from "../logger";
 import { catalog } from "../routes/catalog";
 import {
@@ -53,6 +54,18 @@ import { SessionRuntimeRegistry } from "./session-runtime-registry";
 import { createFileSessionStoreProvider } from "./session-store";
 import { openNodeSqlDatabase } from "./sqlite-database";
 import { createSessionUpgradeHandler, MAX_MESSAGE_BYTES } from "./websocket-upgrade";
+
+/**
+ * Background jobs have no home on this host yet: there is no queue service on
+ * a container and no jobs table behind the seam. Sending throws rather than
+ * dropping the job silently, which is what the image-build workflow already
+ * did here when the Cloudflare Queue binding was the only producer.
+ */
+const unavailableJobQueue: JobQueue = {
+  send() {
+    return Promise.reject(new Error("Background jobs are not available on the Node host"));
+  },
+};
 
 /** The global store's file inside the data directory. */
 export const GLOBAL_STORE_FILE = "global.db";
@@ -163,6 +176,7 @@ async function boot(
     SESSION: createNodeSessionRuntimeDispatch(registry),
     REPOS_CACHE: new SqlCacheStore(cacheDb),
     MEDIA_BUCKET: createS3ObjectStorage(options.objectStorage),
+    JOBS: unavailableJobQueue,
   };
   const env: Env = { ...config, ...platform };
 

--- a/packages/control-plane/src/queue-routing.test.ts
+++ b/packages/control-plane/src/queue-routing.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { isAutofixQueue } from "./queue-routing";
-
-describe("queue routing", () => {
-  it("does not route image finalization queues with Autofix in the deployment name", () => {
-    expect(isAutofixQueue("open-inspect-image-build-finalization-github-autofix-test")).toBe(false);
-    expect(isAutofixQueue("open-inspect-github-autofix-test")).toBe(true);
-  });
-});

--- a/packages/control-plane/src/queue-routing.ts
+++ b/packages/control-plane/src/queue-routing.ts
@@ -1,3 +1,0 @@
-export function isAutofixQueue(queueName: string): boolean {
-  return queueName.startsWith("open-inspect-github-autofix-");
-}

--- a/packages/control-plane/src/router.test-support.ts
+++ b/packages/control-plane/src/router.test-support.ts
@@ -198,6 +198,7 @@ export function createTestEnv(overrides: Partial<Env> = {}): Env {
       head: unwired("MEDIA_BUCKET", "head"),
       get: unwired("MEDIA_BUCKET", "get"),
     },
+    JOBS: { send: unwired("JOBS", "send") },
     ...overrides,
   };
 }

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../background-tasks.test-support";
 import { ImageBuildStore } from "../db/image-builds";
 import { RepoMetadataStore } from "../db/repo-metadata";
+import type { JobQueue } from "../jobs";
 import { imageBuildRoutes } from "./image-builds";
 import type { Env } from "../types";
 import type { RepositoryAccessResult } from "../source-control";
@@ -61,9 +62,7 @@ const integrationSettings = vi.hoisted(() => ({
   resolveSandboxSettings: vi.fn(),
 }));
 
-const finalizationQueue = {
-  send: vi.fn(async () => undefined),
-} as unknown as Queue;
+const jobs: JobQueue = { send: vi.fn(async () => undefined) };
 
 vi.mock("../source-control", async (importOriginal) => {
   const actual = await importOriginal<typeof SourceControlModule>();
@@ -133,7 +132,7 @@ function createModalEnv(): Env {
     WORKER_URL: "https://cp.test",
     MODAL_API_SECRET: "modal-secret",
     MODAL_WORKSPACE: "modal-ws",
-    IMAGE_BUILD_FINALIZATION_QUEUE: finalizationQueue,
+    JOBS: jobs,
     // Modal builds mint callback tokens like every provider.
     IMAGE_CALLBACK_TOKEN_PEPPER: "test-callback-pepper",
   });
@@ -148,7 +147,7 @@ function createVercelEnv(): Env {
     IMAGE_CALLBACK_TOKEN_PEPPER: "test-callback-pepper",
     VERCEL_TOKEN: "vercel-token",
     VERCEL_PROJECT_ID: "project-123",
-    IMAGE_BUILD_FINALIZATION_QUEUE: finalizationQueue,
+    JOBS: jobs,
   });
 }
 
@@ -162,7 +161,7 @@ function createOpenComputerEnv(): Env {
     OPENCOMPUTER_API_URL: "https://opencomputer.test",
     OPENCOMPUTER_API_KEY: "oc-token",
     OPENCOMPUTER_TEMPLATE: "openinspect-runtime",
-    IMAGE_BUILD_FINALIZATION_QUEUE: finalizationQueue,
+    JOBS: jobs,
   });
 }
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -4,7 +4,7 @@
 
 import type { CacheStore } from "@open-inspect/shared/cache-store";
 import type { SqlDatabase } from "./db/sql-database";
-import type { ImageBuildFinalizationQueue } from "./image-builds/finalization-job";
+import type { JobQueue } from "./jobs";
 import type { FetchClient, QueueMetricsSource } from "./platform-ports";
 import type { SessionRuntimeDispatch } from "./session/runtime-client";
 import type { ObjectStorage } from "./storage/object-storage";
@@ -122,8 +122,8 @@ export interface Platform {
   /** GitHub Autofix queues, read for health metrics only. */
   AUTOFIX_QUEUE?: QueueMetricsSource;
   AUTOFIX_DLQ?: QueueMetricsSource;
-  /** Durable callback-to-finalizer handoff for provider-session image builds. */
-  IMAGE_BUILD_FINALIZATION_QUEUE?: ImageBuildFinalizationQueue;
+  /** Durable handoff for background jobs (`jobs.ts`). */
+  JOBS: JobQueue;
 }
 
 /** What the application runs against: its configuration and the platform ports. */

--- a/packages/control-plane/test/integration/image-build-scheduler.test.ts
+++ b/packages/control-plane/test/integration/image-build-scheduler.test.ts
@@ -55,7 +55,7 @@ describe("image build scheduler integration", () => {
     const send = vi.fn(async () => undefined);
     const workflow = {} as unknown as ImageBuildWorkflow;
     const scheduler = new ImageBuildScheduler(
-      { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
+      { JOBS: { send } } as unknown as Env,
       env.DB,
       null,
       store,
@@ -69,9 +69,8 @@ describe("image build scheduler integration", () => {
     expect(stats.finalizationsRepublished).toBe(1);
     expect(stats.staleMarked).toBe(0);
     expect(send).toHaveBeenCalledWith({
-      version: 1,
-      buildId: "recover-before-stale",
-      completionHash,
+      kind: "image_build.finalize",
+      payload: { version: 1, buildId: "recover-before-stale", completionHash },
     });
     expect(await getRow("recover-before-stale")).toMatchObject({
       status: "building",
@@ -110,7 +109,7 @@ describe("image build scheduler integration", () => {
     const send = vi.fn(async () => undefined);
     const workflow = {} as unknown as ImageBuildWorkflow;
     const scheduler = new ImageBuildScheduler(
-      { IMAGE_BUILD_FINALIZATION_QUEUE: { send } } as unknown as Env,
+      { JOBS: { send } } as unknown as Env,
       env.DB,
       null,
       store,


### PR DESCRIPTION
Part of the [Control plane on AWS (multi-cloud)](https://linear.app/colemurray/project/control-plane-on-aws-multi-cloud-52df5e47330d) roadmap — **P-6 / COL-52**, the last M1 port. It unblocks N-5 (the container's jobs table and poller) and H-5.

## Why

Background work reached its consumer through Cloudflare's Queue types. A producer held a `Queue` binding, `index.ts` routed a `MessageBatch` by queue name, and each consumer called `message.ack()` or `message.retry()` itself. A container has no queue service, so none of that can be the application's vocabulary.

## What this is

`src/jobs.ts` is that vocabulary, and it is the queue's counterpart to `scheduled-jobs.ts`:

- **Producing** — `JobQueue.send(job)`, where `Job` is a discriminated union of what this control plane hands off.
- **Consuming** — one definition per kind, giving its delivery policy and building a consumer that returns `"ack" | "retry" | { retry: true, delaySeconds }`. A body has crossed a durable medium, so a consumer is handed `unknown` and validates before it acts.

`src/cloudflare/job-queue.ts` is now the only place that knows a job travels as a Queue message: it maps a kind to its binding on the way out and an outcome to `ack`/`retry` on the way back.

**No `Queue<` or `MessageBatch` survives outside `src/cloudflare/` and `src/index.ts`** — the first of this issue's done-when boxes.

## What deliberately did not change

**The wire shape.** A message still carries the job's payload alone. A queue holds messages across a deploy, and the autofix producer is a *different* Worker on its own release cycle, so restating the envelope would have opened a skew window for no gain. The kind is recovered from the queue a message arrived on instead — the same branch `isAutofixQueue` made, now returning a kind rather than a boolean.

**The retry taxonomy.** A malformed finalization command is discarded, a malformed autofix envelope is redelivered, a permanent provider error is acknowledged, an exhausted delivery records its verdict first. What is new is that each kind now *states* the budget it was already deployed with, and `jobs.test.ts` fails if that drifts from the `cloudflare_queue_consumer` settings Terraform applies — the same parity check P-7 introduced for cron triggers.

| kind | Terraform | declared |
|---|---|---|
| `image_build.finalize` | `max_retries = 12`, `retry_delay = 15` | `maxAttempts: 13`, `retryDelaySeconds: 15` |
| `github.autofix` | `max_retries = 4`, `retry_delay = 30` | `maxAttempts: 5`, `retryDelaySeconds: 30` |

That table is why `"retry"` and `{ retry: true, delaySeconds }` are separate outcomes: autofix asked for the queue's own backoff and image-build names its own, and both keep saying exactly that.

## The one behavioural change

`IMAGE_BUILD_FINALIZATION_QUEUE` becomes a **required** binding. Terraform binds it unconditionally (`queue_bindings` in `workers-control-plane.tf` is not conditional), so the absent case only ever existed in tests, and it cost the workflow a nullable field plus two guards that reported an unconfigured deployment as an unavailable build. The scheduler's silent `return 0` when the binding was missing goes with them. This is the stance the P-1 review settled on for `db`.

Also worth naming: the finalization consumer's two log lines now carry `job_id` where they carried `queue_message_id`. The field is about to hold a table row id on the other host, so the queue-specific name would have become wrong in the next PR.

`src/node/host.ts` declares the seam **unavailable** rather than pretending. The jobs table and poller are N-5; sending throws there today exactly as the image-build workflow already did on that host.

## Verification

- `npx tsc` clean on all four programs (worker, test, node, integration).
- Unit **3928 passed** (272 files); workerd integration **1176 passed / 1 skipped** (99 files).
- `eslint`, `prettier --check`, `knip` clean; `npm run build` produces both bundles.
- The Terraform parity test was checked red: changing `maxAttempts` to 14 fails with `expected 14 to be 13`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified background jobs system for image-build finalization and autofix processing.
  * Jobs now use standardized envelopes and are routed through a shared queue.
  * Added consistent retry handling, delays, attempt limits, and acknowledgment behavior.
  * Image-build workflows now publish finalization jobs through the shared jobs service.

* **Bug Fixes**
  * Invalid jobs are acknowledged safely, while retryable failures are retried according to job-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->