### PR TITLE
feat: a jobs table and in-process poller for the Node host (COL-92)

### DIFF
--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -92,21 +92,29 @@ Everything the host persists is under `/data` on the `control-plane-data` volume
 - `global.db`: the global store (the tables D1 holds on Cloudflare).
 - `sessions/<id>.db`: one file per session (the Durable Object storage on Cloudflare).
 - `host-alarms.db`: the index of every session's next scheduled deadline.
+- `jobs.db`: background jobs waiting to run, leased to a delivery, or dead — what a Cloudflare Queue
+  and its dead-letter queue hold on the other host.
 - `cache.db`: the cache the host uses where Cloudflare uses KV. Alone among these, it is not
   deployment state — every entry is rebuilt by being used, so a file that cannot be opened is
   discarded and recreated rather than failing the boot.
 
-The first three are one deployment's state, and the unit of a deployment backup is the whole volume:
-stop the app, snapshot the volume (an EBS snapshot on AWS), start it again. That procedure and its
-rehearsal are tracked separately from this stack.
+All but the last are one deployment's state, and the unit of a deployment backup is the whole
+volume: stop the app, snapshot the volume (an EBS snapshot on AWS), start it again. That procedure
+and its rehearsal are tracked separately from this stack.
 
 What this stack provides is narrower. Litestream replicates `global.db` continuously to
 `LITESTREAM_BUCKET`, and when the app starts on an empty volume and a replica exists, its entrypoint
 restores `global.db` before the host boots. That brings back users, settings and the session index.
-It does not bring back the session files or the alarm index: the restored index lists sessions whose
-files are gone, and the host opens each of those as an empty session when it is next touched, with
-no pending deadlines. The entrypoint logs a warning to that effect after every restore. Treat the
-replica as protection for the global store, not as recovery of a deployment.
+It does not bring back the session files, the alarm index or the jobs table: the restored index
+lists sessions whose files are gone, and the host opens each of those as an empty session when it is
+next touched, with no pending deadlines. The entrypoint logs a warning to that effect after every
+restore. Treat the replica as protection for the global store, not as recovery of a deployment.
+
+`jobs.db` is left out of the replica for the same reason the alarm index is: what it holds is
+reconstructible from what _is_ replicated. Every job the control plane produces today is an
+image-build finalization, and the image-build scheduler republishes those from `global.db` on its
+cron slot — a build still `building` with an accepted completion and no live lease. A future job
+kind that cannot be rebuilt that way, such as a session callback, would have to revisit this.
 
 `cache.db` is deliberately excluded from that replication: it holds the repositories listing and a
 live GitHub installation token, neither of which belongs in a backup bucket, and a cache refills by

--- a/packages/control-plane/docker/litestream.yml
+++ b/packages/control-plane/docker/litestream.yml
@@ -6,10 +6,12 @@
 # come from .env; an empty LITESTREAM_ENDPOINT means AWS S3.
 #
 # Only the global store is replicated. The per-session files under
-# /data/sessions, the host alarm index and the cache are not, so this protects
-# users, settings and the session index, not a whole deployment; the data
-# volume is the unit for that. The cache is excluded on purpose as well as by
-# omission: it holds a live GitHub installation token.
+# /data/sessions, the host alarm index, the jobs table and the cache are not,
+# so this protects users, settings and the session index, not a whole
+# deployment; the data volume is the unit for that. Two of those exclusions
+# are deliberate rather than incidental: the cache holds a live GitHub
+# installation token, and every job the jobs table holds is republished from
+# the global store by the image-build scheduler.
 
 dbs:
   - path: /data/global.db

--- a/packages/control-plane/src/node/host.test.ts
+++ b/packages/control-plane/src/node/host.test.ts
@@ -10,6 +10,7 @@ import type { ControlPlaneHonoEnv } from "../routing/hono-env";
 import { CACHE_STORE_FILE } from "./cache-database";
 import { DEFAULT_MIGRATIONS_DIR, type NodeHostSettings } from "./config";
 import { GLOBAL_STORE_FILE, startNodeHost, type NodeHost, type NodeHostOptions } from "./host";
+import { JOB_STORE_FILE } from "./job-store";
 import type { HealthReport } from "./http-server";
 
 const KEY = Buffer.alloc(32, 7).toString("base64");
@@ -108,8 +109,10 @@ describe("startNodeHost", () => {
       sessions_resident: 0,
       alarm_clock: "running",
       cron: "running",
+      jobs: { poller: "running", pending: 0, running: 0, dead: 0, oldestRunnableLagMs: null },
     });
     expect(report.migrations_applied).toBeGreaterThan(0);
+    expect(existsSync(join(dataDir, JOB_STORE_FILE))).toBe(true);
 
     const missing = await fetch(`${base}/no-such-route`);
     expect(missing.status).toBe(404);

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -46,6 +46,8 @@ import { CronLoop } from "./cron-loop";
 import { HostAlarmClock } from "./host-alarm-clock";
 import { openHostAlarmIndex } from "./host-alarm-index";
 import { createNodeHttpServer, type HealthReport } from "./http-server";
+import { NodeJobs } from "./job-queue";
+import { openJobStore } from "./job-store";
 import { ensurePrivateDirectory } from "./private-paths";
 import { createNodeSessionRuntimeDispatch } from "./runtime-client";
 import { createS3ObjectStorage, type S3ObjectStorageConfig } from "./s3-object-storage";
@@ -144,6 +146,9 @@ async function boot(
 
   const cacheDb = ownStore(openNodeCacheDatabase(settings.dataDir, log));
 
+  const jobStore = ownStore(openJobStore(settings.dataDir));
+  const jobs = new NodeJobs({ store: jobStore, deps: () => ({ env, db, log }), log });
+
   const alarmIndex = ownStore(openHostAlarmIndex(settings.dataDir));
   const clock: HostAlarmClock = new HostAlarmClock({
     index: alarmIndex,
@@ -163,7 +168,7 @@ async function boot(
     SESSION: createNodeSessionRuntimeDispatch(registry),
     REPOS_CACHE: new SqlCacheStore(cacheDb),
     MEDIA_BUCKET: createS3ObjectStorage(options.objectStorage),
-    JOBS: null, // Unavailable until this host has a durable jobs table and poller.
+    JOBS: jobs,
   };
   const env: Env = { ...config, ...platform };
 
@@ -202,6 +207,7 @@ async function boot(
     background_tasks: processTasks.size,
     alarm_clock: clocksRunning ? "running" : "stopped",
     cron: clocksRunning ? "running" : "stopped",
+    jobs: { poller: clocksRunning ? "running" : "stopped", ...jobs.stats() },
   });
   const http = createNodeHttpServer({
     fetch: (request) => Promise.resolve(app.fetch(request, env)),
@@ -225,6 +231,8 @@ async function boot(
   acquire(() => registry.stopSweeper());
   cron.start();
   acquire(() => cron.stop());
+  jobs.start();
+  acquire(() => jobs.stop());
   clocksRunning = true;
   log.info("node_host.listening", {
     event: "node_host.listening",
@@ -248,6 +256,7 @@ async function boot(
     // are drained below.
     cron.stop();
     clock.stop();
+    jobs.stop();
     clocksRunning = false;
     const closed = once(server, "close");
     server.close();
@@ -260,6 +269,7 @@ async function boot(
     const runs = await cron.drain(remaining());
     if (runs > 0) abandoned.push(`scheduled_runs:${runs}`);
     if (!(await settlesWithin([clock.drain()], remaining()))) abandoned.push("alarm_deliveries");
+    if (!(await settlesWithin([jobs.drain()], remaining()))) abandoned.push("job_deliveries");
     const tasks = await processTasks.drain(remaining());
     if (tasks > 0) abandoned.push(`background_tasks:${tasks}`);
 

--- a/packages/control-plane/src/node/http-server.test.ts
+++ b/packages/control-plane/src/node/http-server.test.ts
@@ -18,6 +18,7 @@ function report(status: HealthReport["status"]): HealthReport {
     background_tasks: 0,
     alarm_clock: "running",
     cron: "running",
+    jobs: { poller: "running", pending: 0, running: 0, dead: 0, oldestRunnableLagMs: null },
   };
 }
 

--- a/packages/control-plane/src/node/http-server.ts
+++ b/packages/control-plane/src/node/http-server.ts
@@ -13,6 +13,7 @@
 import { getRequestListener } from "@hono/node-server";
 import { createServer, type Server } from "node:http";
 import type { Logger } from "../logger";
+import type { JobStoreStats } from "./job-store";
 import { settlesWithin } from "./background-tasks";
 import type { UpgradeHandler } from "./websocket-upgrade";
 
@@ -27,6 +28,8 @@ export interface HealthReport {
   background_tasks: number;
   alarm_clock: "running" | "stopped";
   cron: "running" | "stopped";
+  /** The jobs poller, and the jobs table's rows by status. */
+  jobs: { poller: "running" | "stopped" } & JobStoreStats;
 }
 
 export interface NodeHttpServerOptions {

--- a/packages/control-plane/src/node/job-queue.test.ts
+++ b/packages/control-plane/src/node/job-queue.test.ts
@@ -1,0 +1,364 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JOB_KINDS, type JobDeps, type JobOutcome } from "../jobs";
+import type { Logger } from "../logger";
+import { JOB_CLAIM_LEASE_MS, NodeJobs } from "./job-queue";
+import { openJobStore, type JobStore } from "./job-store";
+
+const KIND = "image_build.finalize" as const;
+const PAYLOAD = { version: 1 as const, buildId: "build-1", completionHash: "a".repeat(64) };
+const { maxAttempts, retryDelayMs } = JOB_KINDS[KIND].retry;
+
+let dataDir: string;
+let store: JobStore;
+let log: Logger;
+let ids = 0;
+
+function fakeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+}
+
+/**
+ * A queue whose only handler is `handle`, over a real store. Time is the
+ * caller's: `vi.useFakeTimers` drives both the poller's timer and its clock.
+ */
+function createQueue(
+  handle: (typeof JOB_KINDS)[typeof KIND]["handle"],
+  maxConcurrentJobs?: number
+) {
+  vi.spyOn(JOB_KINDS[KIND], "handle").mockImplementation(handle);
+  return new NodeJobs({
+    store,
+    deps: () => ({ env: {}, db: {}, log }) as unknown as Omit<JobDeps, "correlation">,
+    log,
+    now: () => Date.now(),
+    maxConcurrentJobs,
+    newId: () => `job-${++ids}`,
+  });
+}
+
+/** Let the poller's timer fire and every delivery it started settle. */
+async function runPoller(queue: NodeJobs): Promise<void> {
+  await vi.advanceTimersByTimeAsync(1);
+  await queue.drain();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(10_000);
+  ids = 0;
+  dataDir = mkdtempSync(join(tmpdir(), "oi-job-queue-"));
+  store = openJobStore(dataDir);
+  log = fakeLogger();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  store.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("NodeJobs", () => {
+  it("records a sent job as runnable at once and delivers it after start", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    expect(store.earliest()).toBe(10_000);
+    queue.start();
+    await runPoller(queue);
+
+    expect(handle).toHaveBeenCalledWith(
+      PAYLOAD,
+      { attempts: 1, maxAttempts },
+      expect.objectContaining({ correlation: { trace_id: "job-1", request_id: "job-1" } })
+    );
+    expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 0 });
+  });
+
+  it("delivers nothing before start, or after stop", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(handle).not.toHaveBeenCalled();
+
+    queue.start();
+    queue.stop();
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(handle).not.toHaveBeenCalled();
+    expect(queue.stats().pending).toBe(2);
+  });
+
+  it("delivers a retry again after the kind's own delay", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => ({ retry: true }));
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await runPoller(queue);
+
+    expect(handle).toHaveBeenCalledOnce();
+    expect(store.earliest()).toBe(10_000 + retryDelayMs);
+
+    await vi.advanceTimersByTimeAsync(retryDelayMs);
+    await queue.drain();
+    expect(handle).toHaveBeenCalledTimes(2);
+    expect(handle).toHaveBeenLastCalledWith(
+      PAYLOAD,
+      { attempts: 2, maxAttempts },
+      expect.anything()
+    );
+  });
+
+  it("honours a delay the handler chose", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => ({ retry: true, delayMs: 300_000 }));
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await runPoller(queue);
+
+    expect(store.earliest()).toBe(10_000 + 300_000);
+  });
+
+  it("buries a job that used its last attempt, keeping the row and the reason", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => ({ retry: true }));
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(retryDelayMs);
+      await queue.drain();
+    }
+
+    expect(handle).toHaveBeenCalledTimes(maxAttempts);
+    expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 1 });
+    expect(log.error).toHaveBeenCalledWith(
+      "Job will not be delivered again",
+      expect.objectContaining({ event: "jobs.dead", attempts: maxAttempts })
+    );
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    expect(handle).toHaveBeenCalledTimes(maxAttempts);
+  });
+
+  it("buries a recovered job that was interrupted on its final attempt, without delivering it again", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+    store.add(
+      { id: "interrupted", kind: KIND, payload: JSON.stringify(PAYLOAD), runAt: 10_000 },
+      10_000
+    );
+    // The process died on the last delivery the policy allows.
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      store.claim(10_000, 1, [KIND], 10_000 + JOB_CLAIM_LEASE_MS);
+      store.recoverExpiredClaims(10_000 + JOB_CLAIM_LEASE_MS);
+    }
+
+    queue.start();
+    await runPoller(queue);
+
+    expect(handle).not.toHaveBeenCalled();
+    expect(queue.stats()).toMatchObject({ dead: 1 });
+    expect(log.error).toHaveBeenCalledWith(
+      "Job will not be delivered again",
+      expect.objectContaining({
+        attempts: maxAttempts + 1,
+        error_message: "Attempts were exhausted before this delivery",
+      })
+    );
+  });
+
+  it("leaves a job whose kind this build does not know for the build that does", async () => {
+    const queue = createQueue(vi.fn());
+    store.add({ id: "future", kind: "session.completed", payload: "{}", runAt: 10_000 }, 10_000);
+
+    queue.start();
+    await runPoller(queue);
+
+    // Still pending, not dead: a rollback must not consume a newer build's work.
+    expect(queue.stats()).toMatchObject({ pending: 1, running: 0, dead: 0 });
+  });
+
+  it("retries an unreadable payload on the kind's policy rather than losing it", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+    store.add({ id: "corrupt", kind: KIND, payload: "{not json", runAt: 10_000 }, 10_000);
+
+    queue.start();
+    await runPoller(queue);
+
+    expect(handle).not.toHaveBeenCalled();
+    expect(queue.stats()).toMatchObject({ pending: 1, dead: 0 });
+    expect(store.earliest()).toBe(10_000 + retryDelayMs);
+  });
+
+  it("delivers no more than the concurrency bound at once, and starts the rest as they settle", async () => {
+    let running = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+    const handle = vi.fn(async (): Promise<JobOutcome> => {
+      running += 1;
+      peak = Math.max(peak, running);
+      await new Promise<void>((resolve) => release.push(resolve));
+      running -= 1;
+      return "ack";
+    });
+    const queue = createQueue(handle, 2);
+
+    for (let i = 0; i < 5; i += 1) await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handle).toHaveBeenCalledTimes(2);
+
+    while (release.length > 0) {
+      release.shift()!();
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    await queue.drain();
+
+    expect(peak).toBe(2);
+    expect(handle).toHaveBeenCalledTimes(5);
+    expect(queue.stats().pending).toBe(0);
+  });
+
+  it("frees the slot a hung delivery holds once its lease runs out", async () => {
+    const handle = vi.fn(
+      () => new Promise<JobOutcome>(() => {}) // never settles
+    );
+    const queue = createQueue(handle, 1);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handle).toHaveBeenCalledOnce();
+    expect(queue.stats()).toMatchObject({ running: 1, pending: 1 });
+
+    // Nothing moves while the lease holds: the slot is legitimately busy.
+    await vi.advanceTimersByTimeAsync(JOB_CLAIM_LEASE_MS - 2);
+    expect(handle).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      "Returning jobs whose claim expired",
+      expect.objectContaining({ event: "jobs.claims_recovered" })
+    );
+    expect(handle).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets a redelivery finish even when the delivery it replaced comes back", async () => {
+    let releaseFirst = (): void => {};
+    const handle = vi
+      .fn(async (): Promise<JobOutcome> => "ack")
+      .mockImplementationOnce(async (): Promise<JobOutcome> => {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        return "ack";
+      });
+    const queue = createQueue(handle);
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The lease runs out, the job is redelivered, and the second delivery acks.
+    await vi.advanceTimersByTimeAsync(JOB_CLAIM_LEASE_MS);
+    expect(log.error).toHaveBeenCalledWith(
+      "Job deliveries outlived their lease and were abandoned",
+      expect.objectContaining({ event: "jobs.delivery_abandoned" })
+    );
+    expect(handle).toHaveBeenCalledTimes(2);
+    expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 0 });
+
+    // Now the abandoned delivery returns. Its token is stale, so it changes
+    // nothing, and it does not evict the delivery that replaced it.
+    releaseFirst();
+    await queue.drain();
+    expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 0 });
+  });
+
+  it("does not let a second poller take a job the first is still delivering", async () => {
+    let release = (): void => {};
+    const handle = vi.fn(async (): Promise<JobOutcome> => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return "ack";
+    });
+    const first = createQueue(handle);
+    const second = new NodeJobs({
+      store,
+      deps: () => ({ env: {}, db: {}, log }) as unknown as Omit<JobDeps, "correlation">,
+      log,
+      now: () => Date.now(),
+      newId: () => `other-${++ids}`,
+    });
+
+    await first.send({ kind: KIND, payload: PAYLOAD });
+    first.start();
+    // The first poller has claimed and is blocked before the second starts.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handle).toHaveBeenCalledOnce();
+
+    second.start();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handle).toHaveBeenCalledOnce();
+
+    release();
+    await Promise.all([first.drain(), second.drain()]);
+    second.stop();
+    expect(queueIsEmpty()).toBe(true);
+  });
+
+  it("keeps polling when the store fails, rather than rejecting out of the timer", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+    const claim = vi.spyOn(store, "claim").mockImplementationOnce(() => {
+      throw new Error("database is locked");
+    });
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await runPoller(queue);
+
+    expect(log.error).toHaveBeenCalledWith(
+      "Jobs poller failed to claim work",
+      expect.objectContaining({ event: "jobs.poll_failed", error_message: "database is locked" })
+    );
+    claim.mockRestore();
+    await runPoller(queue);
+    expect(handle).toHaveBeenCalledOnce();
+  });
+
+  it("logs a settlement it could not write, leaving the lease to return the job", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+    vi.spyOn(store, "complete").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    await runPoller(queue);
+
+    expect(log.error).toHaveBeenCalledWith(
+      "Job delivery could not be settled",
+      expect.objectContaining({ event: "jobs.settle_failed", error_message: "disk full" })
+    );
+    expect(queue.stats()).toMatchObject({ running: 1 });
+  });
+});
+
+function queueIsEmpty(): boolean {
+  const { pending, running, dead } = store.stats(Date.now());
+  return pending === 0 && running === 0 && dead === 0;
+}

--- a/packages/control-plane/src/node/job-queue.ts
+++ b/packages/control-plane/src/node/job-queue.ts
@@ -1,0 +1,304 @@
+/**
+ * The Node host's wiring of the jobs seam: `send` writes a row and one timer
+ * for the whole process delivers what is due.
+ *
+ * This is the container's answer to a Cloudflare Queue consumer, and it
+ * keeps that consumer's contract. `deliverJob` is the same entry point on
+ * both hosts, so parsing, handler failures and the retry answer are decided
+ * in one place; what differs is only who enforces the policy. Cloudflare
+ * enforces `max_retries` and `retry_delay` from the queue consumer's
+ * settings; here the kind's own `JobRetryPolicy` does it, which is what
+ * `job-queue.test.ts` holds equal to the deployed settings.
+ *
+ * A job out of attempts becomes `dead` rather than being dropped: that row,
+ * with the error that ended it, is what the dead-letter queue holds on the
+ * other host. Nothing consumes or sweeps it; it is there to be seen, and it
+ * is counted in the health report. A completed job's row goes at once, so
+ * the table grows only by what failed for good.
+ *
+ * Jobs run concurrently up to a bound, so a host coming back to a backlog
+ * works through it a few at a time; the next ones start as soon as one
+ * settles. Every claim is a lease, and when a lease runs out the poller lets
+ * go of that delivery in both places at once: the row goes back to pending,
+ * and the slot it held stops counting against the bound. A hung handler
+ * therefore costs one lease, not a permanently narrower queue — and it
+ * cannot corrupt the redelivery that replaces it, because settling is fenced
+ * on the claim token it no longer owns.
+ *
+ * Polling and delivery are total: a store that throws is logged and the
+ * timer re-armed, never left as an unhandled rejection from a timer task.
+ */
+
+import { JOB_KINDS, deliverJob, type Job, type JobDeps, type JobKind, type Jobs } from "../jobs";
+import type { CorrelationContext, Logger } from "../logger";
+import type { ClaimedJob, JobStore, JobStoreStats } from "./job-store";
+
+/** The longest delay a single timer can hold; later jobs re-arm. */
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+/** Jobs delivered at the same time, unless the host says otherwise. */
+const DEFAULT_MAX_CONCURRENT_JOBS = 8;
+/**
+ * How long a claim holds a job before it may be delivered again. Comfortably
+ * longer than the slowest handler's own deadline — the image-build finalizer
+ * bounds a provider attempt at five minutes and holds its store lease for
+ * six — so a live delivery is never overtaken, while a host that died or a
+ * handler that hung frees the job within the quarter hour.
+ */
+export const JOB_CLAIM_LEASE_MS = 15 * 60 * 1000;
+/** How often expired leases are swept when nothing else wakes the timer. */
+const LEASE_SWEEP_INTERVAL_MS = 60 * 1000;
+/** The clock source, unless a test supplies one; read per call so fake timers apply. */
+const DEFAULT_NOW = (): number => Date.now();
+
+export interface NodeJobsOptions {
+  store: JobStore;
+  /**
+   * What a delivery is given, minus the correlation this host mints per job.
+   * A thunk because the deps hold the host's `Env`, which holds this queue:
+   * the record does not exist yet when the queue is constructed.
+   */
+  deps: () => Omit<JobDeps, "correlation">;
+  log: Logger;
+  now?: () => number;
+  /** How many jobs may be delivered at once. */
+  maxConcurrentJobs?: number;
+  /** Mints job ids; the default is a random uuid. */
+  newId?: () => string;
+}
+
+export class NodeJobs implements Jobs {
+  private readonly store: JobStore;
+  private readonly deps: () => Omit<JobDeps, "correlation">;
+  private readonly log: Logger;
+  private readonly now: () => number;
+  private readonly maxConcurrentJobs: number;
+  private readonly newId: () => string;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  /** Deliveries this process started, by job id, with the lease each holds. */
+  private readonly inFlight = new Map<string, { delivery: Promise<void>; leaseUntil: number }>();
+
+  constructor(options: NodeJobsOptions) {
+    this.store = options.store;
+    this.deps = options.deps;
+    this.log = options.log;
+    this.now = options.now ?? DEFAULT_NOW;
+    this.maxConcurrentJobs = options.maxConcurrentJobs ?? DEFAULT_MAX_CONCURRENT_JOBS;
+    this.newId = options.newId ?? (() => crypto.randomUUID());
+  }
+
+  /**
+   * Record the job, runnable at once. Resolves when the row is written: that
+   * is what makes it durable, exactly as a Queue send does on Cloudflare.
+   * The write is synchronous, and `async` is what turns a failed one into a
+   * rejection rather than a throw the Cloudflare adapter would never produce.
+   */
+  async send(job: Job): Promise<void> {
+    const now = this.now();
+    this.store.add(
+      { id: this.newId(), kind: job.kind, payload: JSON.stringify(job.payload), runAt: now },
+      now
+    );
+    this.arm();
+  }
+
+  /**
+   * Start delivering. Idempotent: recovery takes only claims whose lease has
+   * run out, so starting again never takes a job away from a delivery that
+   * is still running.
+   */
+  start(): void {
+    this.running = true;
+    this.arm();
+  }
+
+  /** Stop claiming. Jobs already running are not interrupted. */
+  stop(): void {
+    this.running = false;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Resolves once every delivery still counted has settled. A delivery whose
+   * lease has run out is not among them: the poller has already let go of it.
+   */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.inFlight.values()].map((entry) => entry.delivery));
+  }
+
+  /** What the table holds right now. */
+  stats(): JobStoreStats {
+    return this.store.stats(this.now());
+  }
+
+  /**
+   * Wake at the soonest of: the next runnable job, and the next lease sweep.
+   * At capacity only the sweep is armed — a settling delivery re-arms for
+   * the rest, and expired leases still have to be reclaimed meanwhile.
+   */
+  private arm(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (!this.running) return;
+    const now = this.now();
+    let wakeAt = now + LEASE_SWEEP_INTERVAL_MS;
+    if (this.inFlight.size < this.maxConcurrentJobs) {
+      const next = this.store.earliest();
+      if (next !== null) wakeAt = Math.min(wakeAt, next);
+    }
+    const delay = Math.min(Math.max(0, wakeAt - now), MAX_TIMER_DELAY_MS);
+    this.timer = setTimeout(() => this.tick(), delay);
+  }
+
+  /** One wake-up. Total: nothing here may reject out of the timer task. */
+  private tick(): void {
+    this.timer = null;
+    try {
+      this.forgetExpiredDeliveries();
+      this.recoverExpiredClaims();
+      this.claimAndRun();
+    } catch (error) {
+      // The store is unusable for now. Keep the timer alive so the host
+      // recovers on its own if the failure was transient.
+      this.log.error("Jobs poller failed to claim work", {
+        event: "jobs.poll_failed",
+        error_message: message(error),
+      });
+    }
+    this.arm();
+  }
+
+  /**
+   * Stop counting deliveries whose lease has run out. The promise itself
+   * cannot be cancelled, so it is simply no longer ours: whatever it does
+   * later is fenced by a claim token the row no longer carries.
+   */
+  private forgetExpiredDeliveries(): void {
+    const now = this.now();
+    const abandoned: string[] = [];
+    for (const [id, entry] of this.inFlight) {
+      if (entry.leaseUntil > now) continue;
+      this.inFlight.delete(id);
+      abandoned.push(id);
+    }
+    if (abandoned.length === 0) return;
+    this.log.error("Job deliveries outlived their lease and were abandoned", {
+      event: "jobs.delivery_abandoned",
+      job_ids: abandoned,
+    });
+  }
+
+  private recoverExpiredClaims(): void {
+    const recovered = this.store.recoverExpiredClaims(this.now());
+    if (recovered.length === 0) return;
+    this.log.warn("Returning jobs whose claim expired", {
+      event: "jobs.claims_recovered",
+      job_ids: recovered,
+    });
+  }
+
+  private claimAndRun(): void {
+    const capacity = this.maxConcurrentJobs - this.inFlight.size;
+    if (capacity <= 0) return;
+    const now = this.now();
+    const leaseUntil = now + JOB_CLAIM_LEASE_MS;
+    for (const job of this.store.claim(now, capacity, KNOWN_KINDS, leaseUntil)) {
+      // Registered before the delivery starts, so a job it sends is left to
+      // the next wake-up rather than counted against this tick's capacity.
+      const delivery = Promise.resolve()
+        .then(() => this.deliver(job))
+        .catch((error: unknown) => {
+          // Settling failed, so the row is still leased; it comes back when
+          // the lease runs out rather than being lost here.
+          this.log.error("Job delivery could not be settled", {
+            event: "jobs.settle_failed",
+            job_id: job.id,
+            job_kind: job.kind,
+            error_message: message(error),
+          });
+        })
+        .finally(() => {
+          // Only if this delivery is still the one being counted: an
+          // abandoned delivery must not evict the one that replaced it.
+          if (this.inFlight.get(job.id)?.delivery === delivery) this.inFlight.delete(job.id);
+          this.arm();
+        });
+      this.inFlight.set(job.id, { delivery, leaseUntil });
+    }
+  }
+
+  private async deliver(job: ClaimedJob): Promise<void> {
+    const kind = job.kind as JobKind;
+    const { retry } = JOB_KINDS[kind];
+    // Only a recovered claim can arrive over budget: the settlement below
+    // buries a job that spends its last attempt, so the normal path never
+    // hands one back. Running it again would break the parity with
+    // Cloudflare, which stops after `max_retries`.
+    if (job.attempts > retry.maxAttempts) {
+      this.bury(job, "Attempts were exhausted before this delivery");
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(job.payload);
+    } catch (error) {
+      // The stored text is this host's own encoding, so this is corruption
+      // rather than a poison message. It still follows the retry policy, so
+      // it ends in the dead-letter rows instead of vanishing.
+      this.failed(
+        job,
+        retry.maxAttempts,
+        retry.retryDelayMs,
+        `Unreadable payload: ${message(error)}`
+      );
+      return;
+    }
+
+    const correlation: CorrelationContext = { trace_id: job.id, request_id: job.id };
+    const outcome = await deliverJob(kind, payload, job.attempts, { ...this.deps(), correlation });
+    if (outcome === "ack") {
+      this.store.complete(job.id, job.token);
+      return;
+    }
+    this.failed(
+      job,
+      retry.maxAttempts,
+      outcome.delayMs ?? retry.retryDelayMs,
+      "The handler asked for a retry"
+    );
+  }
+
+  /** Run the job again after `delayMs`, or bury it if that was its last attempt. */
+  private failed(job: ClaimedJob, maxAttempts: number, delayMs: number, error: string): void {
+    if (job.attempts >= maxAttempts) {
+      this.bury(job, error);
+      return;
+    }
+    this.store.retry(job.id, job.token, this.now() + delayMs);
+  }
+
+  /** Keep the row, with what ended it, where a dead-letter queue would hold it. */
+  private bury(job: ClaimedJob, error: string): void {
+    this.store.bury(job.id, job.token, error);
+    this.log.error("Job will not be delivered again", {
+      event: "jobs.dead",
+      job_id: job.id,
+      job_kind: job.kind,
+      attempts: job.attempts,
+      error_message: error,
+    });
+  }
+}
+
+/** The kinds this build can deliver; a row of any other kind is left alone. */
+const KNOWN_KINDS: readonly string[] = Object.keys(JOB_KINDS);
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/control-plane/src/node/job-store.test.ts
+++ b/packages/control-plane/src/node/job-store.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openJobStore, type ClaimedJob, type JobStore } from "./job-store";
+
+const KINDS = ["image_build.finalize", "github.autofix"] as const;
+const LEASE_MS = 60_000;
+
+let dataDir: string;
+let store: JobStore;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "oi-jobs-"));
+  store = openJobStore(dataDir);
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+function add(id: string, runAt: number, kind: string = KINDS[0]): void {
+  store.add({ id, kind, payload: JSON.stringify({ id }), runAt }, 1_000);
+}
+
+function claim(now: number, limit = 10): ClaimedJob[] {
+  return store.claim(now, limit, KINDS, now + LEASE_MS);
+}
+
+describe("openJobStore", () => {
+  it("reports the soonest runnable job", () => {
+    add("late", 5_000);
+    add("soon", 2_000);
+
+    expect(store.earliest()).toBe(2_000);
+    expect(
+      claim(5_000)
+        .map((job) => job.id)
+        .sort()
+    ).toEqual(["late", "soon"]);
+  });
+
+  it("takes the soonest jobs when it cannot take them all", () => {
+    add("third", 7_000);
+    add("first", 2_000);
+    add("second", 5_000);
+
+    expect(
+      claim(9_000, 2)
+        .map((job) => job.id)
+        .sort()
+    ).toEqual(["first", "second"]);
+    expect(claim(9_000, 2).map((job) => job.id)).toEqual(["third"]);
+  });
+
+  it("leaves a job that is not yet runnable alone", () => {
+    add("later", 9_000);
+
+    expect(claim(8_999)).toEqual([]);
+    expect(claim(9_000).map((job) => job.id)).toEqual(["later"]);
+  });
+
+  it("never claims a kind the caller does not know", () => {
+    add("future-build", 1_000, "session.completed");
+
+    expect(claim(9_000)).toEqual([]);
+    // The row is untouched, so the build that understands it can still run it.
+    expect(store.stats(9_000)).toMatchObject({ pending: 1, running: 0, dead: 0 });
+    expect(store.claim(9_000, 10, ["session.completed"], 9_000 + LEASE_MS)).toHaveLength(1);
+  });
+
+  it("counts the attempt and does not hand the same job out twice", () => {
+    add("once", 1_000);
+
+    const [claimed] = claim(1_000);
+
+    expect(claimed).toMatchObject({ kind: KINDS[0], attempts: 1 });
+    expect(claimed!.token).toEqual(expect.any(String));
+    expect(claim(1_000)).toEqual([]);
+    expect(store.earliest()).toBeNull();
+  });
+
+  it("removes a completed job and reschedules a retried one, keeping its attempts", () => {
+    add("done", 1_000);
+    add("again", 1_000);
+    const claimed = claim(1_000);
+    const tokenOf = (id: string): string => claimed.find((job) => job.id === id)!.token;
+
+    store.complete("done", tokenOf("done"));
+    store.retry("again", tokenOf("again"), 4_000);
+
+    expect(store.earliest()).toBe(4_000);
+    expect(claim(4_000)).toEqual([expect.objectContaining({ id: "again", attempts: 2 })]);
+  });
+
+  it("keeps a buried job out of every later claim, with the error that ended it", () => {
+    add("doomed", 1_000);
+    const [claimed] = claim(1_000);
+
+    store.bury("doomed", claimed!.token, "provider gone");
+
+    expect(claim(9_000)).toEqual([]);
+    expect(store.stats(1_000)).toMatchObject({ pending: 0, running: 0, dead: 1 });
+  });
+
+  describe("leases", () => {
+    it("leaves a claim alone while its lease holds", () => {
+      add("busy", 1_000);
+      claim(1_000);
+
+      expect(store.recoverExpiredClaims(1_000 + LEASE_MS - 1)).toEqual([]);
+      expect(claim(1_000 + LEASE_MS - 1)).toEqual([]);
+    });
+
+    it("returns a claim whose lease ran out, and survives the restart", () => {
+      add("interrupted", 1_000);
+      claim(1_000);
+      store.close();
+
+      store = openJobStore(dataDir);
+      expect(store.recoverExpiredClaims(1_000 + LEASE_MS)).toEqual(["interrupted"]);
+      // The attempt the dead process spent is still spent.
+      expect(claim(1_000 + LEASE_MS)).toEqual([
+        expect.objectContaining({ id: "interrupted", attempts: 2 }),
+      ]);
+    });
+
+    it("refuses a settlement from a delivery its lease already outlived", () => {
+      add("overtaken", 1_000);
+      const [stale] = claim(1_000);
+      store.recoverExpiredClaims(1_000 + LEASE_MS);
+      const [fresh] = claim(1_000 + LEASE_MS);
+
+      // The delivery that lost its lease comes back and tries to finish.
+      store.complete("overtaken", stale!.token);
+
+      expect(store.stats(9_000)).toMatchObject({ running: 1 });
+      store.complete("overtaken", fresh!.token);
+      expect(store.stats(9_000)).toMatchObject({ pending: 0, running: 0, dead: 0 });
+    });
+
+    it("refuses a stale retry and a stale bury as well", () => {
+      add("overtaken", 1_000);
+      const [stale] = claim(1_000);
+      store.recoverExpiredClaims(1_000 + LEASE_MS);
+      claim(1_000 + LEASE_MS);
+
+      store.retry("overtaken", stale!.token, 99_000);
+      store.bury("overtaken", stale!.token, "not yours to end");
+
+      expect(store.stats(9_000)).toMatchObject({ running: 1, dead: 0 });
+    });
+  });
+
+  describe("stats", () => {
+    it("reports rows by status and how overdue the most overdue runnable job is", () => {
+      add("waiting", 1_000);
+      add("busy", 1_000);
+      claim(1_000, 1);
+
+      expect(store.stats(3_500)).toEqual({
+        pending: 1,
+        running: 1,
+        dead: 0,
+        oldestRunnableLagMs: 2_500,
+      });
+    });
+
+    it("does not count a job deliberately delayed into the future as late", () => {
+      add("backing-off", 50_000);
+
+      expect(store.stats(10_000)).toMatchObject({ pending: 1, oldestRunnableLagMs: null });
+      expect(store.stats(50_000)).toMatchObject({ oldestRunnableLagMs: 0 });
+    });
+
+    it("reports no lag when nothing is pending", () => {
+      expect(store.stats(5_000)).toEqual({
+        pending: 0,
+        running: 0,
+        dead: 0,
+        oldestRunnableLagMs: null,
+      });
+    });
+  });
+});

--- a/packages/control-plane/src/node/job-store.ts
+++ b/packages/control-plane/src/node/job-store.ts
@@ -1,0 +1,232 @@
+/**
+ * The Node host's jobs table: `<dataDir>/jobs.db`.
+ *
+ * Cloudflare hands a job to a Queue and the platform redelivers it until a
+ * consumer acknowledges. A container has no queue service, so the same
+ * guarantee is a row: `send` writes one, the poller claims it, and the row
+ * lives until a handler is done with it.
+ *
+ * A claim is a **lease**, as a queue's invisibility window is. Claiming
+ * writes a fresh token and an expiry; settling names the token, so a
+ * delivery that comes back after its lease expired cannot settle the
+ * redelivery that replaced it. A claim whose lease has run out is the only
+ * thing recovery touches, which covers both a process that died mid-job and
+ * a handler that never returns — one rule for both, and it makes starting a
+ * poller twice harmless. The cost is Cloudflare's own: two deliveries of one
+ * job can overlap, which `jobs.ts` already requires every handler to
+ * tolerate.
+ *
+ * It is deliberately not part of the global store, whose schema is
+ * `terraform/d1/migrations` and lands on D1 as well: nothing on Cloudflare
+ * reads a jobs table. This is the arrangement the host alarm index and the
+ * cache file already use — a Node-local file whose schema is a
+ * `CREATE TABLE IF NOT EXISTS` in code, applied on open.
+ *
+ * Litestream does not replicate it, and that is a decision with a condition
+ * attached. Every job the control plane produces today is
+ * `image_build.finalize`, which the image-build scheduler republishes from
+ * the global store on its cron slot (`listRecoverableFinalizations`: a build
+ * still `building` with an accepted completion and no live lease). So a lost
+ * volume loses no work, only time — the same reasoning that leaves the alarm
+ * index unreplicated, where the session's own file re-arms the deadline. A
+ * job kind that is *not* reconstructible from replicated state — session
+ * callbacks, when those move onto this seam — has to revisit that.
+ *
+ * A row carries a status rather than a nullable slot per state, because
+ * `dead` is a real destination here and not the absence of one: it is what a
+ * dead-letter queue holds on the other host, kept with the error that put it
+ * there. `run_at` is read only while a job is pending.
+ */
+
+import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { ensurePrivateDirectory } from "./private-paths";
+import { openPrivateSqliteFile } from "./sqlite-file";
+
+export const JOB_STORE_FILE = "jobs.db";
+
+/** A job as it was handed to `send`. */
+interface StoredJob {
+  id: string;
+  kind: string;
+  /** The job's payload, serialized. */
+  payload: string;
+  /** Not to be claimed before this time. */
+  runAt: number;
+}
+
+/** A job leased for one attempt at running it. */
+export interface ClaimedJob {
+  id: string;
+  kind: string;
+  payload: string;
+  /** Attempts including this one; 1 on the first. */
+  attempts: number;
+  /** This claim's token; settling the job requires it. */
+  token: string;
+}
+
+/** What the jobs table holds right now, for the health report. */
+export interface JobStoreStats {
+  pending: number;
+  running: number;
+  dead: number;
+  /**
+   * How long the most overdue runnable job has been waiting past the time it
+   * became runnable, or null when nothing is runnable. A job deliberately
+   * delayed into the future is not late and is not counted.
+   */
+  oldestRunnableLagMs: number | null;
+}
+
+export interface JobStore {
+  /** Record a job to run at or after `job.runAt`. */
+  add(job: StoredJob, now: number): void;
+  /** The soonest time a pending job may run, or null when none is pending. */
+  earliest(): number | null;
+  /**
+   * Lease up to `limit` of the jobs runnable at `now` whose kind is one of
+   * `kinds`, counting the attempt. Which jobs are taken is ordered — the
+   * soonest runnable first — but the rows come back in whatever order the
+   * update visited them, and callers run them concurrently anyway.
+   *
+   * A kind this build does not know is never claimed, so a job written by a
+   * newer build waits for that build to come back rather than being consumed
+   * by an older one.
+   */
+  claim(now: number, limit: number, kinds: readonly string[], leaseUntil: number): ClaimedJob[];
+  /** The leased job succeeded: it is done and the row goes. */
+  complete(id: string, token: string): void;
+  /** The leased job failed or asked to be redelivered; run it again at `at`. */
+  retry(id: string, token: string, at: number): void;
+  /** The leased job will not be delivered again: keep the row with what ended it. */
+  bury(id: string, token: string, error: string): void;
+  /**
+   * Return every claim whose lease has run out to pending, runnable at once.
+   * Returns the job ids recovered.
+   */
+  recoverExpiredClaims(now: number): string[];
+  stats(now: number): JobStoreStats;
+  close(): void;
+}
+
+const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS jobs (
+  id TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'dead')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  run_at INTEGER NOT NULL,
+  claim_token TEXT,
+  lease_expires_at INTEGER,
+  last_error TEXT,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_runnable ON jobs (status, run_at);
+CREATE INDEX IF NOT EXISTS idx_jobs_leases ON jobs (status, lease_expires_at);`;
+
+function open(path: string): DatabaseSync {
+  const db = openPrivateSqliteFile(path);
+  try {
+    db.exec(SCHEMA_SQL);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+  return db;
+}
+
+/** Open (creating if needed) the host's jobs database. */
+export function openJobStore(dataDir: string): JobStore {
+  ensurePrivateDirectory(dataDir);
+  const db = open(join(dataDir, JOB_STORE_FILE));
+
+  const insert = db.prepare(
+    `INSERT INTO jobs (id, kind, payload, status, run_at, created_at)
+     VALUES (?, ?, ?, 'pending', ?, ?)`
+  );
+  const soonest = db.prepare("SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending'");
+  const remove = db.prepare("DELETE FROM jobs WHERE id = ? AND claim_token = ?");
+  const reschedule = db.prepare(
+    `UPDATE jobs SET status = 'pending', run_at = ?, claim_token = NULL, lease_expires_at = NULL
+     WHERE id = ? AND claim_token = ?`
+  );
+  const kill = db.prepare(
+    `UPDATE jobs SET status = 'dead', claim_token = NULL, lease_expires_at = NULL, last_error = ?
+     WHERE id = ? AND claim_token = ?`
+  );
+  const recover = db.prepare(
+    `UPDATE jobs SET status = 'pending', claim_token = NULL, lease_expires_at = NULL
+     WHERE status = 'running' AND lease_expires_at <= ? RETURNING id`
+  );
+  const countByStatus = db.prepare("SELECT status, COUNT(*) AS count FROM jobs GROUP BY status");
+  const oldestRunnable = db.prepare(
+    "SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending' AND run_at <= ?"
+  );
+
+  // The claim is one statement, so two pollers in this process cannot take
+  // the same row: node:sqlite runs it to completion before either yields.
+  // The kind list is a handful of literals from the code, so it is inlined as
+  // placeholders rather than kept in a table.
+  const claimStatements = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
+  const claimFor = (kinds: number): ReturnType<DatabaseSync["prepare"]> => {
+    const cached = claimStatements.get(kinds);
+    if (cached) return cached;
+    const statement = db.prepare(
+      `UPDATE jobs SET status = 'running', attempts = attempts + 1, claim_token = ?, lease_expires_at = ?
+       WHERE id IN (
+         SELECT id FROM jobs
+         WHERE status = 'pending' AND run_at <= ? AND kind IN (${Array.from({ length: kinds }, () => "?").join(", ")})
+         ORDER BY run_at, id LIMIT ?
+       )
+       RETURNING id, kind, payload, attempts`
+    );
+    claimStatements.set(kinds, statement);
+    return statement;
+  };
+
+  return {
+    add: ({ id, kind, payload, runAt }, now) => {
+      insert.run(id, kind, payload, runAt, now);
+    },
+    earliest: () => (soonest.get() as { run_at: number | null }).run_at,
+    claim: (now, limit, kinds, leaseUntil) => {
+      if (kinds.length === 0) return [];
+      const token = crypto.randomUUID();
+      return claimFor(kinds.length)
+        .all(token, leaseUntil, now, ...kinds, limit)
+        .map((row) => {
+          const { id, kind, payload, attempts } = row as {
+            id: string;
+            kind: string;
+            payload: string;
+            attempts: number;
+          };
+          return { id, kind, payload, attempts, token };
+        });
+    },
+    complete: (id, token) => {
+      remove.run(id, token);
+    },
+    retry: (id, token, at) => {
+      reschedule.run(at, id, token);
+    },
+    bury: (id, token, error) => {
+      kill.run(error, id, token);
+    },
+    recoverExpiredClaims: (now) => (recover.all(now) as Array<{ id: string }>).map((row) => row.id),
+    stats: (now) => {
+      const counts = countByStatus.all() as Array<{ status: string; count: number }>;
+      const countOf = (status: string): number =>
+        counts.find((row) => row.status === status)?.count ?? 0;
+      const oldest = (oldestRunnable.get(now) as { run_at: number | null }).run_at;
+      return {
+        pending: countOf("pending"),
+        running: countOf("running"),
+        dead: countOf("dead"),
+        oldestRunnableLagMs: oldest === null ? null : Math.max(0, now - oldest),
+      };
+    },
+    close: () => db.close(),
+  };
+}


### PR DESCRIPTION
Part of the [Control plane on AWS (multi-cloud)](https://linear.app/colemurray/project/control-plane-on-aws-multi-cloud-52df5e47330d) roadmap: **N-5 / COL-92**, the container's wiring of the jobs seam. It unblocks H-5.

**Re-cut on #1784.** The earlier revision of this branch targeted the seam from #1780, which #1784 superseded; this one is rebuilt on the merged API — `deliverJob`, `JOB_KINDS`, milliseconds throughout — and carries the deep review's findings. **Nothing here runs on Cloudflare:** every file is `src/node/**` or a comment, and the worker bundle is unchanged.

## What it is

`send` writes a row to `<dataDir>/jobs.db`; one timer for the whole process delivers what is due through `deliverJob`, the entry point both hosts share. Parsing, handler failures and the retry answer are decided in one place; what differs is only who enforces the policy. Cloudflare enforces `max_retries` and `retry_delay` from the queue consumer's settings; here the kind's own `JobRetryPolicy` does it, which is what `job-queue.test.ts` already holds equal to the deployed settings.

## A claim is a lease

This is the change the review asked for, and it replaced the whole recovery model rather than patching it.

Claiming writes a fresh token and an expiry. Settling names that token, so a delivery that comes back after its lease expired **cannot finish the redelivery that replaced it**. When a lease runs out the poller lets go in both places at once: the row returns to pending, *and* the in-memory slot stops counting against the concurrency bound — freeing only the row would have left a hung handler permanently narrowing the queue, which was the second half of that finding.

One rule now covers a process that died mid-job and a handler that never returns. `start()` is idempotent as a consequence: recovery only ever takes claims whose lease has run out, so starting twice can never take a job from a delivery still running. The cost is Cloudflare's own — two deliveries of one job can overlap — which `jobs.ts` already requires every handler to tolerate. The lease is 15 minutes, comfortably past the slowest handler's own deadline (the image-build finalizer bounds a provider attempt at five minutes and holds its store lease for six).

## Three things the poller refuses to do

- **Run a job whose attempts were already spent.** A claim recovered after an interruption on its final attempt arrives at `maxAttempts + 1`; it is buried before the handler is invoked rather than running one delivery past the budget Cloudflare would have stopped at.
- **Claim a kind this build does not know.** The claim filters on the kinds in `JOB_KINDS`, so a job written by a newer build is left pending for that build to come back to — not consumed, and not dead-lettered, by an older one.
- **Let a store failure escape a timer task.** Polling and settlement are total: a throw is logged and the timer re-armed, never an unhandled rejection out of a `setTimeout`.

A job out of attempts becomes `dead` rather than being dropped — that row, with the error that ended it, is what the dead-letter queue holds on the other host. A completed job's row goes at once, so the table grows only by what failed for good. `/healthz` carries the counts by status and **how overdue the most overdue *runnable* job is**: a retry deliberately delayed into the future is not late and is not counted.

## Where the table lives, and the condition on that

Not in `terraform/d1/migrations`: that is the **global store's** schema and it lands on D1, where a jobs table has no reader. The file is Node-local with a `CREATE TABLE IF NOT EXISTS` applied on open — the arrangement `host-alarms.db` and `cache.db` already use.

Not replicated by Litestream either, and that one is a durability decision, not tidiness. Everything the table can hold **today** is reconstructible from what *is* replicated: every job this control plane produces is `image_build.finalize`, and `ImageBuildScheduler.republishRecoverableFinalizations` re-sends those from `global.db` on its cron slot (a build still `building`, with an accepted completion and no live lease). A lost volume costs time, not work — the same reasoning that leaves the alarm index unreplicated.

**The condition:** a job kind that is *not* reconstructible that way — session callbacks, when #1567 moves those onto the seam — has to revisit it. That is written into the module comment, `litestream.yml` and `docs/CONTROL_PLANE_CONTAINER.md`, so the next PR meets it rather than trips over it.

## Verification

Store, 14 tests: ordered selection under a limit, attempts kept across retry and across a reopen, an unknown kind never claimed, a lease left alone while it holds, an expired one recovered, and stale `complete`/`retry`/`bury` all refused.

Poller, 14 tests on fake timers over a real store: the kind's delay and a handler's own delay, death after exactly `maxAttempts`, a recovered final-attempt claim buried without being delivered, an unknown kind left pending, an unreadable payload retried on policy rather than lost, the concurrency bound with the rest starting as jobs settle, a hung delivery's slot freed at lease expiry, a redelivery that finishes even when the delivery it replaced returns, two pollers where the second cannot take the first's in-flight job, and a store that throws from both the claim and the settlement paths.

Three of those were checked red by removing the fix: the exhausted-recovery guard (`expected not to be called, called 1 times`), the abandoned-slot release (`expected 2 times, got 1`), and the settlement fence (`expected running: 1`).

Unit **3968 passed** (274 files); `tsc` clean on all four programs; eslint, prettier and knip clean (knip byte-identical to the baseline). Workerd integration **1178 passed / 1 skipped** (100 files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added background job processing with scheduling, retries, concurrency limits, lease recovery, and dead-letter handling.
  - Added job status information to health reports, including pending, running, and failed job counts.
  - Jobs now drain safely during host shutdown, helping prevent work from being lost.

- **Documentation**
  - Updated data and backup documentation to explain job storage, restoration behavior, and replication exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

