### PR TITLE
fix: register GPT-6 Astra in sandbox runtime

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -51,6 +51,7 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # v59: OpenCode past the message-ID wraparound (see OPENCODE_VERSION)
 # v60: generic provider-account token broker plugin
 # v61: account/init helpers and /usr/sbin on PATH
+# v62: register GPT-6 Astra in OpenCode's runtime catalog
 CACHE_BUSTER = RUNTIME_VERSION
 
 # Base image with all development tools

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
@@ -501,7 +501,43 @@ class OpenCodeServer:
                             "claude-opus-4-5",
                         )
                     }
-                }
+                },
+                "openai": {
+                    "models": {
+                        "gpt-6-astra": {
+                            "name": "GPT-6 Astra",
+                            "family": "gpt-astra",
+                            "attachment": True,
+                            "reasoning": True,
+                            "temperature": False,
+                            "tool_call": True,
+                            "release_date": "2026-09-04",
+                            "modalities": {
+                                "input": ["text", "image", "pdf"],
+                                "output": ["text"],
+                            },
+                            "limit": {
+                                "context": 1_050_000,
+                                "input": 922_000,
+                                "output": 128_000,
+                            },
+                            "cost": {
+                                "input": 10,
+                                "output": 50,
+                                "cache_read": 1,
+                                "cache_write": 12.5,
+                            },
+                            "variants": {
+                                effort: {
+                                    "reasoningEffort": effort,
+                                    "reasoningSummary": "auto",
+                                    "include": ["reasoning.encrypted_content"],
+                                }
+                                for effort in ("low", "medium", "high", "xhigh", "max")
+                            },
+                        }
+                    }
+                },
             },
         }
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "v61-sandbox-sbin-path",
-  "generation": 61,
+  "runtimeVersion": "v62-gpt6-astra",
+  "generation": 62,
   "minimumCompatibleGeneration": 60,
-  "minimumRebuildGeneration": 60
+  "minimumRebuildGeneration": 62
 }

--- a/packages/sandbox-runtime/tests/test_opencode_reasoning_contract.py
+++ b/packages/sandbox-runtime/tests/test_opencode_reasoning_contract.py
@@ -249,6 +249,30 @@ async def test_all_fixture_efforts_reach_provider(wire_server):
                     assert sent["output_config"]["effort"] == effort, context
 
 
+async def test_runtime_config_registers_gpt_6_astra(tmp_path, reasoning_config):
+    catalog = json.loads(CATALOG.read_text())
+    assert "gpt-6-astra" not in catalog["openai"]["models"]
+
+    env = {key: os.environ[key] for key in ("PATH", "HOME", "SYSTEMROOT") if key in os.environ}
+    env.update(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+            "XDG_CACHE_HOME": str(tmp_path / "cache"),
+            "XDG_STATE_HOME": str(tmp_path / "state"),
+            "OPENCODE_MODELS_PATH": str(CATALOG),
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_CONFIG_CONTENT": json.dumps(reasoning_config),
+            "OPENAI_API_KEY": "test-only",
+        }
+    )
+    models = subprocess.check_output(
+        [BINARY, "models", "openai"], cwd=tmp_path, env=env, text=True
+    ).splitlines()
+
+    assert "openai/gpt-6-astra" in models
+
+
 async def test_defaults_and_switching(wire_server):
     call, captured = wire_server
     # The configured agent's High default must survive omission and yield to a variant.

--- a/packages/sandbox-runtime/tests/test_reasoning_config.py
+++ b/packages/sandbox-runtime/tests/test_reasoning_config.py
@@ -38,3 +38,29 @@ async def test_manual_variants_available_when_switching_from_adaptive_model(reas
                 "max": {"thinking": {"type": "enabled", "budgetTokens": 31_999}},
             }
         }
+
+
+async def test_gpt_6_astra_is_registered_for_opencode(reasoning_config):
+    astra = reasoning_config["provider"]["openai"]["models"]["gpt-6-astra"]
+
+    assert astra["name"] == "GPT-6 Astra"
+    assert astra["reasoning"] is True
+    assert astra["attachment"] is True
+    assert astra["temperature"] is False
+    assert astra["tool_call"] is True
+    assert astra["modalities"] == {
+        "input": ["text", "image", "pdf"],
+        "output": ["text"],
+    }
+    assert astra["limit"] == {
+        "context": 1_050_000,
+        "input": 922_000,
+        "output": 128_000,
+    }
+    assert set(astra["variants"]) == {"low", "medium", "high", "xhigh", "max"}
+    for effort, options in astra["variants"].items():
+        assert options == {
+            "reasoningEffort": effort,
+            "reasoningSummary": "auto",
+            "include": ["reasoning.encrypted_content"],
+        }


### PR DESCRIPTION
## Summary

- register `gpt-6-astra` explicitly in generated OpenCode provider configuration so it works when the sandbox's models.dev catalog is stale
- configure Astra's capabilities, token limits, pricing metadata, and supported reasoning variants
- bump the sandbox runtime to generation 62 and require repository images to rebuild with the corrected runtime
- add config-level coverage and a pinned OpenCode 1.18.18 model-resolution regression test

## Root cause

Open-Inspect's shared catalog accepted `openai/gpt-6-astra`, but OpenCode 1.18.18 did not know the model when its models.dev catalog lacked Astra. The Codex OAuth allowlist only retained an existing model entry and did not register a missing one, so OpenCode rejected the model before making an OpenAI request.

## Verification

- `pytest tests/test_reasoning_config.py -v` (2 passed)
- pinned OpenCode 1.18.18 stale-catalog regression test (1 passed)
- `pytest tests/test_runtime_manifest.py -v` in modal-infra (1 passed)
- control-plane runtime manifest Vitest (1 passed)
- Ruff lint and format checks passed
- Codex auth plugin tests passed (3 passed)
- full sandbox-runtime suite: 789 passed, 4 skipped; 4 unrelated environment-sensitive failures caused by inherited live control-plane credentials and the local Git signer argument format

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2d3204dd9b336b13f29582e639c5d146)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GPT-6 Astra to OpenCode’s available model catalog.
  - Added support for attachments, reasoning, temperature controls, and tool calls.
  - Added support for text and image inputs, text outputs, configurable reasoning effort, and expanded context and output limits.

- **Improvements**
  - Updated the runtime to support the latest GPT-6 Astra configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->