### PR TITLE
fix(control-plane): keep the jobs poller from spinning on a kind it cannot claim

### DIFF
--- a/packages/control-plane/src/node/job-queue.test.ts
+++ b/packages/control-plane/src/node/job-queue.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JOB_KINDS, type JobDeps, type JobOutcome } from "../jobs";
 import type { Logger } from "../logger";
-import { JOB_CLAIM_LEASE_MS, NodeJobs } from "./job-queue";
+import { JOB_CLAIM_LEASE_MS, LEASE_SWEEP_INTERVAL_MS, NodeJobs } from "./job-queue";
 import { openJobStore, type JobStore } from "./job-store";
 
 const KIND = "image_build.finalize" as const;
@@ -67,7 +67,7 @@ describe("NodeJobs", () => {
     const queue = createQueue(handle);
 
     await queue.send({ kind: KIND, payload: PAYLOAD });
-    expect(store.earliest()).toBe(10_000);
+    expect(store.earliest([KIND])).toBe(10_000);
     queue.start();
     await runPoller(queue);
 
@@ -104,7 +104,7 @@ describe("NodeJobs", () => {
     await runPoller(queue);
 
     expect(handle).toHaveBeenCalledOnce();
-    expect(store.earliest()).toBe(10_000 + retryDelayMs);
+    expect(store.earliest([KIND])).toBe(10_000 + retryDelayMs);
 
     await vi.advanceTimersByTimeAsync(retryDelayMs);
     await queue.drain();
@@ -124,7 +124,7 @@ describe("NodeJobs", () => {
     queue.start();
     await runPoller(queue);
 
-    expect(store.earliest()).toBe(10_000 + 300_000);
+    expect(store.earliest([KIND])).toBe(10_000 + 300_000);
   });
 
   it("buries a job that used its last attempt, keeping the row and the reason", async () => {
@@ -187,6 +187,47 @@ describe("NodeJobs", () => {
     expect(queue.stats()).toMatchObject({ pending: 1, running: 0, dead: 0 });
   });
 
+  it("does not schedule itself for a due job whose kind it cannot claim", async () => {
+    const queue = createQueue(vi.fn());
+    store.add({ id: "future", kind: "session.completed", payload: "{}", runAt: 10_000 }, 10_000);
+    const claim = vi.spyOn(store, "claim");
+
+    queue.start();
+    await vi.advanceTimersByTimeAsync(LEASE_SWEEP_INTERVAL_MS - 1);
+
+    // The row is due and never claimable, so waking for it would be a spin
+    // that never makes progress: the poller waits for the lease sweep instead.
+    expect(claim).not.toHaveBeenCalled();
+    expect(queue.stats()).toMatchObject({ pending: 1, dead: 0 });
+  });
+
+  it("keeps the send durable and the timer alive when the store cannot say what is next", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    const queue = createQueue(handle);
+    const earliest = vi.spyOn(store, "earliest").mockImplementation(() => {
+      throw new Error("database is locked");
+    });
+
+    // The row is written before the poller is armed, so the send succeeded
+    // however scheduling went.
+    await expect(queue.send({ kind: KIND, payload: PAYLOAD })).resolves.toBeUndefined();
+    queue.start();
+    await vi.advanceTimersByTimeAsync(LEASE_SWEEP_INTERVAL_MS);
+    await queue.drain();
+
+    // Blind to what is due, the poller still wakes on its own interval.
+    expect(handle).toHaveBeenCalledOnce();
+    expect(log.error).toHaveBeenCalledWith(
+      "Jobs poller could not schedule its next wake-up",
+      expect.objectContaining({ event: "jobs.arm_failed", error_message: "database is locked" })
+    );
+
+    earliest.mockRestore();
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    await runPoller(queue);
+    expect(handle).toHaveBeenCalledTimes(2);
+  });
+
   it("retries an unreadable payload on the kind's policy rather than losing it", async () => {
     const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
     const queue = createQueue(handle);
@@ -197,7 +238,7 @@ describe("NodeJobs", () => {
 
     expect(handle).not.toHaveBeenCalled();
     expect(queue.stats()).toMatchObject({ pending: 1, dead: 0 });
-    expect(store.earliest()).toBe(10_000 + retryDelayMs);
+    expect(store.earliest([KIND])).toBe(10_000 + retryDelayMs);
   });
 
   it("delivers no more than the concurrency bound at once, and starts the rest as they settle", async () => {

--- a/packages/control-plane/src/node/job-queue.ts
+++ b/packages/control-plane/src/node/job-queue.ts
@@ -25,8 +25,10 @@
  * cannot corrupt the redelivery that replaces it, because settling is fenced
  * on the claim token it no longer owns.
  *
- * Polling and delivery are total: a store that throws is logged and the
- * timer re-armed, never left as an unhandled rejection from a timer task.
+ * Polling, delivery and arming are total: a store that throws is logged and
+ * the timer re-armed, never left as an unhandled rejection from a timer task.
+ * The poller schedules itself only for the kinds it can actually claim, so a
+ * job left for a newer build waits quietly instead of being polled for.
  */
 
 import { JOB_KINDS, deliverJob, type Job, type JobDeps, type JobKind, type Jobs } from "../jobs";
@@ -46,9 +48,11 @@ const DEFAULT_MAX_CONCURRENT_JOBS = 8;
  */
 export const JOB_CLAIM_LEASE_MS = 15 * 60 * 1000;
 /** How often expired leases are swept when nothing else wakes the timer. */
-const LEASE_SWEEP_INTERVAL_MS = 60 * 1000;
+export const LEASE_SWEEP_INTERVAL_MS = 60 * 1000;
 /** The clock source, unless a test supplies one; read per call so fake timers apply. */
 const DEFAULT_NOW = (): number => Date.now();
+/** How job ids are minted, unless a test supplies its own. */
+const DEFAULT_NEW_ID = (): string => crypto.randomUUID();
 
 export interface NodeJobsOptions {
   store: JobStore;
@@ -84,7 +88,7 @@ export class NodeJobs implements Jobs {
     this.log = options.log;
     this.now = options.now ?? DEFAULT_NOW;
     this.maxConcurrentJobs = options.maxConcurrentJobs ?? DEFAULT_MAX_CONCURRENT_JOBS;
-    this.newId = options.newId ?? (() => crypto.randomUUID());
+    this.newId = options.newId ?? DEFAULT_NEW_ID;
   }
 
   /**
@@ -148,8 +152,20 @@ export class NodeJobs implements Jobs {
     const now = this.now();
     let wakeAt = now + LEASE_SWEEP_INTERVAL_MS;
     if (this.inFlight.size < this.maxConcurrentJobs) {
-      const next = this.store.earliest();
-      if (next !== null) wakeAt = Math.min(wakeAt, next);
+      try {
+        const next = this.store.earliest(KNOWN_KINDS);
+        if (next !== null) wakeAt = Math.min(wakeAt, next);
+      } catch (error) {
+        // Arming ends every path — a send, a tick, a settling delivery — so a
+        // throw here would reject a send whose row is already durable, or
+        // escape a timer task and take the process with it. The sweep
+        // interval is the fallback: the host keeps waking, just without
+        // knowing what is due until the store answers again.
+        this.log.error("Jobs poller could not schedule its next wake-up", {
+          event: "jobs.arm_failed",
+          error_message: message(error),
+        });
+      }
     }
     const delay = Math.min(Math.max(0, wakeAt - now), MAX_TIMER_DELAY_MS);
     this.timer = setTimeout(() => this.tick(), delay);

--- a/packages/control-plane/src/node/job-store.test.ts
+++ b/packages/control-plane/src/node/job-store.test.ts
@@ -33,12 +33,22 @@ describe("openJobStore", () => {
     add("late", 5_000);
     add("soon", 2_000);
 
-    expect(store.earliest()).toBe(2_000);
+    expect(store.earliest(KINDS)).toBe(2_000);
     expect(
       claim(5_000)
         .map((job) => job.id)
         .sort()
     ).toEqual(["late", "soon"]);
+  });
+
+  it("leaves a kind it was not asked about out of the soonest runnable job", () => {
+    add("mine", 5_000);
+    add("theirs", 1_000, "session.completed");
+
+    // Symmetric with claim: a kind this build cannot take must not be what
+    // the poller schedules itself for.
+    expect(store.earliest(KINDS)).toBe(5_000);
+    expect(store.earliest([])).toBeNull();
   });
 
   it("takes the soonest jobs when it cannot take them all", () => {
@@ -78,7 +88,7 @@ describe("openJobStore", () => {
     expect(claimed).toMatchObject({ kind: KINDS[0], attempts: 1 });
     expect(claimed!.token).toEqual(expect.any(String));
     expect(claim(1_000)).toEqual([]);
-    expect(store.earliest()).toBeNull();
+    expect(store.earliest(KINDS)).toBeNull();
   });
 
   it("removes a completed job and reschedules a retried one, keeping its attempts", () => {
@@ -90,7 +100,7 @@ describe("openJobStore", () => {
     store.complete("done", tokenOf("done"));
     store.retry("again", tokenOf("again"), 4_000);
 
-    expect(store.earliest()).toBe(4_000);
+    expect(store.earliest(KINDS)).toBe(4_000);
     expect(claim(4_000)).toEqual([expect.objectContaining({ id: "again", attempts: 2 })]);
   });
 

--- a/packages/control-plane/src/node/job-store.ts
+++ b/packages/control-plane/src/node/job-store.ts
@@ -74,7 +74,9 @@ export interface JobStoreStats {
   /**
    * How long the most overdue runnable job has been waiting past the time it
    * became runnable, or null when nothing is runnable. A job deliberately
-   * delayed into the future is not late and is not counted.
+   * delayed into the future is not late and is not counted. Every kind
+   * counts, including one this build cannot claim: a lag that never clears
+   * is how a stranded job gets noticed.
    */
   oldestRunnableLagMs: number | null;
 }
@@ -82,8 +84,14 @@ export interface JobStoreStats {
 export interface JobStore {
   /** Record a job to run at or after `job.runAt`. */
   add(job: StoredJob, now: number): void;
-  /** The soonest time a pending job may run, or null when none is pending. */
-  earliest(): number | null;
+  /**
+   * The soonest time a pending job of one of `kinds` may run, or null when
+   * none is. Filtered exactly as `claim` is: a kind this build cannot claim
+   * must not schedule a wake-up either, or a due one would be polled for
+   * without end. Such a row is still counted by `stats`, where a lag that no
+   * delivery clears is what a human needs to see.
+   */
+  earliest(kinds: readonly string[]): number | null;
   /**
    * Lease up to `limit` of the jobs runnable at `now` whose kind is one of
    * `kinds`, counting the attempt. Which jobs are taken is ordered — the
@@ -145,7 +153,6 @@ export function openJobStore(dataDir: string): JobStore {
     `INSERT INTO jobs (id, kind, payload, status, run_at, created_at)
      VALUES (?, ?, ?, 'pending', ?, ?)`
   );
-  const soonest = db.prepare("SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending'");
   const remove = db.prepare("DELETE FROM jobs WHERE id = ? AND claim_token = ?");
   const reschedule = db.prepare(
     `UPDATE jobs SET status = 'pending', run_at = ?, claim_token = NULL, lease_expires_at = NULL
@@ -164,32 +171,48 @@ export function openJobStore(dataDir: string): JobStore {
     "SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending' AND run_at <= ?"
   );
 
+  // Both kind-filtered queries take the list as inlined placeholders — it is a
+  // handful of literals from the code, not a table — so each is prepared once
+  // per list length and kept.
+  const byKindCount = (
+    sql: (placeholders: string) => string
+  ): ((kinds: number) => ReturnType<DatabaseSync["prepare"]>) => {
+    const prepared = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
+    return (kinds) => {
+      const cached = prepared.get(kinds);
+      if (cached) return cached;
+      const statement = db.prepare(sql(Array.from({ length: kinds }, () => "?").join(", ")));
+      prepared.set(kinds, statement);
+      return statement;
+    };
+  };
+
+  const soonestFor = byKindCount(
+    (placeholders) =>
+      `SELECT MIN(run_at) AS run_at FROM jobs
+       WHERE status = 'pending' AND kind IN (${placeholders})`
+  );
   // The claim is one statement, so two pollers in this process cannot take
   // the same row: node:sqlite runs it to completion before either yields.
-  // The kind list is a handful of literals from the code, so it is inlined as
-  // placeholders rather than kept in a table.
-  const claimStatements = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
-  const claimFor = (kinds: number): ReturnType<DatabaseSync["prepare"]> => {
-    const cached = claimStatements.get(kinds);
-    if (cached) return cached;
-    const statement = db.prepare(
+  const claimFor = byKindCount(
+    (placeholders) =>
       `UPDATE jobs SET status = 'running', attempts = attempts + 1, claim_token = ?, lease_expires_at = ?
        WHERE id IN (
          SELECT id FROM jobs
-         WHERE status = 'pending' AND run_at <= ? AND kind IN (${Array.from({ length: kinds }, () => "?").join(", ")})
+         WHERE status = 'pending' AND run_at <= ? AND kind IN (${placeholders})
          ORDER BY run_at, id LIMIT ?
        )
        RETURNING id, kind, payload, attempts`
-    );
-    claimStatements.set(kinds, statement);
-    return statement;
-  };
+  );
 
   return {
     add: ({ id, kind, payload, runAt }, now) => {
       insert.run(id, kind, payload, runAt, now);
     },
-    earliest: () => (soonest.get() as { run_at: number | null }).run_at,
+    earliest: (kinds) =>
+      kinds.length === 0
+        ? null
+        : (soonestFor(kinds.length).get(...kinds) as { run_at: number | null }).run_at,
     claim: (now, limit, kinds, leaseUntil) => {
       if (kinds.length === 0) return [];
       const token = crypto.randomUUID();


### PR DESCRIPTION
Two findings from CodeRabbit's review of #1781 that arrived after it was squash-merged, so they land here instead. Both are real, both are consequences of fixes made *during* that review, and both are covered by tests checked red. **Nothing here runs on Cloudflare:** every changed file is `src/node/**`.

## A filter added to `claim` had to be added to `earliest` too

#1781's review established that a kind this build does not know must be left pending rather than buried — `dead` is irreversible, and a rollback would otherwise permanently kill work a newer build wrote. `claim` got the `kind IN (known)` filter. `earliest` did not.

So a due row of an unknown kind kept answering "now" to the question *when should I wake?*, while `claim` would never take it. `arm()` computed a zero delay, `tick()` claimed nothing, and it went round again. Not a slow poll — a busy loop. The regression test measures it at **60,000 `claim` calls per 60 seconds of clock**, one per millisecond, pinning a core and hammering SQLite for as long as the row sits there.

`earliest(kinds)` now takes the same list `claim` does, so the two agree on what this build can take. Both are prepared once per list length through one shared cache. `host-alarm-index.ts:42` already had the filtered-`earliest` shape, so this follows the existing pattern rather than inventing one.

One deliberate exception: `stats()` still counts every kind, so `pending` and `oldestRunnableLagMs` include a stranded row. Scheduling and observability are different questions — a row nobody can run *is* backlog, and hiding it from `/healthz` is exactly how a rollback that stranded work goes unnoticed.

## `arm()` was outside every boundary that was supposed to contain it

`arm()` ends every path: a `send`, a `tick`, a settling delivery's `.finally`. A throw from `earliest()` therefore had three ways out, two of them serious:

- after `tick()`'s `try` block it escapes the timer callback, which takes the process down;
- in `.finally()` it rejects a promise nothing but `drain()`'s `allSettled` ever looks at;
- in `send()` it rejects a send **whose row is already durably written** — the producer retries and the job runs twice.

The module comment claimed polling and delivery were total, so the code was contradicting its own documented contract. `arm()` now catches, logs `jobs.arm_failed`, and falls through to the lease-sweep interval: the host keeps waking while the store is unwell, just without knowing what is due until it answers again.

Also taken from the review body: `DEFAULT_NEW_ID` is now a named constant beside `DEFAULT_NOW`, per the "define each default exactly once" rule the file was already inconsistent about.

## Verification

Both regressions checked red by removing their fix:

- kind-filtered `earliest` — `expected "claim" to not be called at all, but actually been called 60000 times`
- the arming boundary — `Error: database is locked` thrown straight out of the timer task

Three new tests: the store leaves an unasked-for kind out of the soonest runnable job; the poller does not schedule itself for a due kind it cannot claim; and a store that cannot say what is next still keeps the send durable, still delivers on the sweep, and resumes normal scheduling once it recovers.

Unit **3971 passed** (274 files); workerd integration **1178 passed / 1 skipped** (100 files); `tsc` clean on all four programs; eslint, prettier and knip clean.

Threads: [`earliest`](https://github.com/ColeMurray/background-agents/pull/1781#discussion_r3939687642), [`arm()`](https://github.com/ColeMurray/background-agents/pull/1781#discussion_r3939687637).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job scheduling reliability when storage errors occur; polling continues and queued work remains durable.
  - Prevented unnecessary polling loops for unsupported job types.
  - Scheduling now considers only supported job types when determining the next runnable job.
  - Improved selection of the earliest eligible job, including correct handling when no job types are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->