### PR TITLE
test(control-plane): hold both storage lanes of the session-core conformance suite (COL-115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Run shared tests
         run: npm test -w @open-inspect/shared
 
+      # Runs the node:sqlite lane of the session-core conformance suite
+      # (test/conformance). The Durable Object lane of the same suite runs in
+      # test-cp-integration; a session repository or migration has to pass both.
       - name: Run control-plane unit tests
         run: npm test -w @open-inspect/control-plane
 
@@ -199,6 +202,8 @@ jobs:
       - name: Build shared package
         run: npm run build -w @open-inspect/shared
 
+      # Runs the Durable Object lane of the session-core conformance suite.
+      # The node:sqlite lane of the same suite runs in test-cp-unit.
       - name: Run control-plane integration tests
         run: npm run test:integration -w @open-inspect/control-plane -- --shard=${{ matrix.shard }}
 

--- a/packages/control-plane/test/conformance/manifest.test.ts
+++ b/packages/control-plane/test/conformance/manifest.test.ts
@@ -1,11 +1,12 @@
 /**
  * Every host contract is declared somewhere in the host's integration suites
- * through `hostContract(id, …)`, which owns the title and has no skipped form.
- * The scan is what makes omission visible: a host that forgets a contract
- * fails here rather than silently running fewer tests.
+ * through `hostContract(id, …)`, which owns the title and has no skipped form,
+ * and every storage lane registers the whole storage suite. The scan is what
+ * makes omission visible: a host that forgets a contract, or a lane that stops
+ * registering the suite, fails here rather than silently running fewer tests.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -16,6 +17,16 @@ import {
 } from "./session-core-conformance";
 
 const integrationDir = resolve(__dirname, "../integration");
+
+/**
+ * The storage lanes and the file that registers the suite for each. Both run
+ * in CI: the node:sqlite lane in `test-cp-unit`, the Durable Object lane in
+ * `test-cp-integration`.
+ */
+const STORAGE_LANES: Record<string, string> = {
+  "node:sqlite": join(__dirname, "session-core-conformance.node.test.ts"),
+  "Durable Object storage": join(integrationDir, "session-core-conformance.test.ts"),
+};
 
 function declaredHostContracts(): Map<HostContractId, string[]> {
   const declared = new Map<HostContractId, string[]>();
@@ -42,6 +53,14 @@ describe("session-core conformance manifest", () => {
     "%s is declared by the Cloudflare host",
     (id) => {
       expect(declaredHostContracts().get(id) ?? []).not.toEqual([]);
+    }
+  );
+
+  it.each(Object.entries(STORAGE_LANES))(
+    "the %s lane registers every storage contract",
+    (_lane, file) => {
+      expect(existsSync(file)).toBe(true);
+      expect(readFileSync(file, "utf8")).toContain("registerSessionCoreConformanceSuite(");
     }
   );
 });


### PR DESCRIPTION
COL-115 (V-1) asks for the session-core conformance suite to run on both `node:sqlite` and Durable Object storage as a required CI gate. Most of that is already true on `main`, and this PR closes the part that is not.

## What already existed

`#1746` (COL-87) landed the pairing:

- `packages/control-plane/vitest.config.ts` already includes `test/conformance/**/*.test.ts`, so `npm test -w @open-inspect/control-plane` runs `session-core-conformance.node.test.ts`, which registers the suite twice — once against an in-memory `DatabaseSync` and once against the per-session file `openSessionStore` manages.
- `test/integration/session-core-conformance.test.ts` registers the same suite against Durable Object storage, and `vitest.integration.config.ts` needs no change.
- Both lanes import the same file, `test/conformance/session-core-conformance.ts`.

`#1755` and `#1776` added the same shape for `SqlDatabase` and `CacheStore`, so the conformance directory now holds four test files.

So steps 1 and 2 of the issue were already done. Nothing in this PR touches how either lane is configured.

## What this PR adds

**A guard that the pairing stays a pairing.** `manifest.test.ts` already scanned the integration directory so that a host which forgets a `hostContract` fails rather than silently running fewer tests. There was no equivalent for the storage lanes: if either registration file were deleted or stopped calling `registerSessionCoreConformanceSuite`, the storage contracts would quietly stop running on that host and CI would stay green. The manifest now asserts both lane files exist and register the suite.

Removing `session-core-conformance.node.test.ts` currently changes nothing in CI; with this change it fails:

```
 FAIL  test/conformance/manifest.test.ts > session-core conformance manifest > the node:sqlite lane registers every storage contract
- true
+ false
 ❯ test/conformance/manifest.test.ts:62:32
```

**Comments in `ci.yml`** naming which lane each job carries, on the `test-cp-unit` and `test-cp-integration` steps.

## Both lanes fail on a broken repository

Deliberately deleted the single-claim guard from `MessageRepository.startMessageProcessing`:

```
-           AND NOT EXISTS (SELECT 1 FROM messages WHERE status = 'processing')
```

Node lane — `npx vitest run --root packages/control-plane test/conformance/session-core-conformance.node.test.ts`:

```
 FAIL  test/conformance/session-core-conformance.node.test.ts > node:sqlite in memory > message repository conformance > allows one processing claim and applies a redelivered completion once
Error: UNIQUE constraint failed: messages.status
 ❯ Object.exec src/node/sqlite-storage.ts:52:25
 ❯ MessageRepository.startMessageProcessing src/session/message-repository.ts:321:17

 FAIL  test/conformance/session-core-conformance.node.test.ts > node:sqlite session file > message repository conformance > allows one processing claim and applies a redelivered completion once
Error: UNIQUE constraint failed: messages.status

 Test Files  1 failed (1)
      Tests  2 failed | 28 passed (30)
```

workerd lane — `npm run test:integration -w @open-inspect/control-plane -- test/integration/session-core-conformance.test.ts`:

```
 FAIL  test/integration/session-core-conformance.test.ts > message repository conformance > allows one processing claim and applies a redelivered completion once
Error: UNIQUE constraint failed: messages.status: SQLITE_CONSTRAINT (extended: SQLITE_CONSTRAINT_UNIQUE)
 ❯ src/session/message-repository.ts:322:32
 ❯ MessageRepository.startMessageProcessing src/session/message-repository.ts:321:17

 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
```

Same contract, same failure, on both hosts. Reverted afterwards; the diff here contains no source change.

## Node lane runtime

The four conformance files on their own: **65 tests in 0.355s / 0.360s** over two runs.

Inside the full unit suite the cost disappears into the existing parallelism:

| | Test files | Tests | Duration |
|---|---|---|---|
| unit suite without `test/conformance` | 270 | 3906 | 6.07s / 6.11s |
| unit suite with it (before this PR) | 274 | 3971 | 6.19s / 6.58s |
| unit suite with it (after this PR) | 274 | 3973 | 6.85s |

The two extra tests are the new lane assertions.

## Verification

- `npm run typecheck -w @open-inspect/control-plane` (4 tsconfig programs) — exit 0
- `npx vitest run --root packages/control-plane` — 274 files, 3973 passed, 6.85s
- `npm run test:integration -w @open-inspect/control-plane` — 100 files, 1178 passed | 1 skipped, 107.79s, exit 0, no `EnvironmentTeardownError`
- `npm run lint` — exit 0
- `npx knip` from the repo root — 22 unused exports + 4 unused exported types, identical to the same run on the unmodified tree (all in `src/routes/**` and `src/routing/**`); CI runs it with `--no-exit-code`

Nothing here runs on Cloudflare: the diff is one test file and two YAML comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded conformance validation to verify that all storage testing lanes are registered and have corresponding test coverage.
* **Documentation**
  * Added explanatory notes to clarify which test jobs cover each storage lane in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->