### PR TITLE
fix(control-plane): make an alarm claim a lease the clock can take back

### DIFF
--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -91,7 +91,8 @@ Everything the host persists is under `/data` on the `control-plane-data` volume
 
 - `global.db`: the global store (the tables D1 holds on Cloudflare).
 - `sessions/<id>.db`: one file per session (the Durable Object storage on Cloudflare).
-- `host-alarms.db`: the index of every session's next scheduled deadline.
+- `host-alarms.db`: the index of every session's next scheduled deadline, and the claim each
+  deadline being delivered is leased under.
 - `jobs.db`: background jobs waiting to run, leased to a delivery, or dead — what a Cloudflare Queue
   and its dead-letter queue hold on the other host.
 - `cache.db`: the cache the host uses where Cloudflare uses KV. Alone among these, it is not

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -111,6 +111,19 @@ describe("HostAlarmClock", () => {
     clock.stop();
   });
 
+  it("does not spin on the elapsed lease of a delivery it has already abandoned", async () => {
+    deliver.mockImplementationOnce(() => new Promise<void>(() => {}));
+    await clock.storeFor("hung").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const due = vi.spyOn(index, "due");
+
+    // Past the lease, the claim stays on disk with an expiry already behind
+    // us. Waking for it would arm at zero delay and never make progress.
+    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS + BLIND_RETRY_INTERVAL_MS * 5);
+
+    expect(due.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
   it("re-arms a claim a dead process left, and refuses the delivery that outlived it", async () => {
     const releases: Array<() => void> = [];
     deliver.mockImplementation(

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -10,7 +10,13 @@ import {
   PersistedAlarmDeadlineStore,
 } from "../session/alarm/scheduler";
 import { initSchema } from "../session/schema";
-import { HostAlarmClock, MAX_RETRIES, RETRY_BASE_DELAY_MS } from "./host-alarm-clock";
+import {
+  ALARM_CLAIM_LEASE_MS,
+  HostAlarmClock,
+  BLIND_RETRY_INTERVAL_MS,
+  MAX_RETRIES,
+  RETRY_BASE_DELAY_MS,
+} from "./host-alarm-clock";
 import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
 import { createNodeSqlStorage } from "./sqlite-storage";
 
@@ -75,6 +81,97 @@ describe("HostAlarmClock", () => {
     expect(delivered).toEqual(["soon"]);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(delivered).toEqual(["soon", "late"]);
+  });
+
+  it("frees the session a hung delivery holds once its lease runs out", async () => {
+    let release!: () => void;
+    deliver.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // The handler never returns. The row is not armed and the slot is held.
+    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS - 1);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // At the lease boundary both are released: the row is armed again, and
+    // the slot it held stops counting, so the redelivery can start.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(deliver).toHaveBeenCalledTimes(2);
+    // Only the redelivery ran to completion; the first is still hanging.
+    expect(delivered).toEqual(["s1"]);
+
+    // The abandoned delivery finally returns; it must not settle the claim
+    // that replaced it.
+    release();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await clock.storeFor("s1").getAlarm()).toBeNull();
+  });
+
+  it("keeps ticking when the index throws, rather than rejecting out of the timer", async () => {
+    const due = vi.spyOn(index, "due").mockImplementationOnce(() => {
+      throw new Error("database is locked");
+    });
+    const failed = vi.spyOn(log, "error");
+    await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(failed).toHaveBeenCalledWith(
+      "Alarm clock failed to claim work",
+      expect.objectContaining({ event: "alarm.poll_failed", error_message: "database is locked" })
+    );
+
+    // The timer survived: the next sweep delivers the deadline it missed.
+    due.mockRestore();
+    await vi.advanceTimersByTimeAsync(BLIND_RETRY_INTERVAL_MS);
+    expect(delivered).toEqual(["s1"]);
+  });
+
+  it("keeps the armed deadline and a live timer when the index cannot say what is next", async () => {
+    const earliest = vi.spyOn(index, "earliest").mockImplementation(() => {
+      throw new Error("database is locked");
+    });
+    const failed = vi.spyOn(log, "error");
+
+    // Arming ends setAlarm, so a throw here must not reject a recorded deadline.
+    await expect(clock.storeFor("s1").setAlarm(Date.now() + 1_000)).resolves.toBeUndefined();
+    expect(failed).toHaveBeenCalledWith(
+      "Alarm clock could not schedule its next wake-up",
+      expect.objectContaining({ event: "alarm.arm_failed", error_message: "database is locked" })
+    );
+
+    // Blind to what is due, the clock still wakes on its own interval.
+    await vi.advanceTimersByTimeAsync(BLIND_RETRY_INTERVAL_MS);
+    expect(delivered).toEqual(["s1"]);
+    earliest.mockRestore();
+  });
+
+  it("logs a settlement it could not write, leaving the lease to return the session", async () => {
+    // The index cannot be written at all, so neither settlement can land.
+    for (const method of ["complete", "retry"] as const) {
+      vi.spyOn(index, method).mockImplementation(() => {
+        throw new Error("disk I/O error");
+      });
+    }
+    const failed = vi.spyOn(log, "error");
+    await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(failed).toHaveBeenCalledWith(
+      "Deadline delivery could not be settled",
+      expect.objectContaining({ event: "alarm.settle_failed", session_id: "s1" })
+    );
+    // Still claimed, so the session is not lost: the lease brings it back.
+    expect(index.get("s1")).toBeNull();
+    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS);
+    expect(deliver).toHaveBeenCalledTimes(2);
   });
 
   it("does not fire a deleted deadline", async () => {

--- a/packages/control-plane/src/node/host-alarm-clock.test.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.test.ts
@@ -83,37 +83,104 @@ describe("HostAlarmClock", () => {
     expect(delivered).toEqual(["soon", "late"]);
   });
 
-  it("frees the session a hung delivery holds once its lease runs out", async () => {
-    let release!: () => void;
-    deliver.mockImplementationOnce(
+  it("stops counting a hung delivery against the bound without redelivering it", async () => {
+    const clock = new HostAlarmClock({ index, deliver, log, maxConcurrentDeliveries: 1 });
+    clock.start();
+    deliver.mockImplementationOnce(() => new Promise<void>(() => {}));
+    await clock.storeFor("hung").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // The bound is one, so a second session cannot be delivered to while the
+    // hung handler still counts.
+    await clock.storeFor("other").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(delivered).toEqual([]);
+
+    // At the lease boundary the hung delivery stops counting and the waiting
+    // session goes through.
+    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS);
+    expect(delivered).toEqual(["other"]);
+
+    // The hung session itself is never delivered to twice: nothing can stop
+    // the handler still running, and a second one would race it in the same
+    // runtime. Its claim stays on disk for the next start.
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(deliver.mock.calls.map(([id]) => id)).toEqual(["hung", "other"]);
+    expect(index.earliestLease()).not.toBeNull();
+    clock.stop();
+  });
+
+  it("re-arms a claim a dead process left, and refuses the delivery that outlived it", async () => {
+    const releases: Array<() => void> = [];
+    deliver.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
-          release = resolve;
+          releases.push(resolve);
         })
     );
     await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
     await vi.advanceTimersByTimeAsync(1_000);
     expect(deliver).toHaveBeenCalledTimes(1);
 
-    // The handler never returns. The row is not armed and the slot is held.
-    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS - 1);
-    expect(deliver).toHaveBeenCalledTimes(1);
+    // What a restart sees: no delivery in the new process owns the claim on
+    // disk, so it is armed again at the deadline it was taken from.
 
-    // At the lease boundary both are released: the row is armed again, and
-    // the slot it held stops counting, so the redelivery can start.
-    await vi.advanceTimersByTimeAsync(1);
-    expect(deliver).toHaveBeenCalledTimes(2);
-    // Only the redelivery ran to completion; the first is still hanging.
-    expect(delivered).toEqual(["s1"]);
-
-    // The abandoned delivery finally returns; it must not settle the claim
-    // that replaced it.
-    release();
+    // A replacement process opens the same index and takes it under a claim
+    // of its own. (Recovery here is what `start` does; the first clock never
+    // redelivers a session whose delivery it is still holding.)
+    const restarted = new HostAlarmClock({
+      index,
+      deliver: vi.fn(() => new Promise<void>(() => {})),
+      log,
+    });
+    restarted.start();
     await vi.advanceTimersByTimeAsync(0);
+    const held = index.earliestLease();
+    expect(held).not.toBeNull();
+    expect(index.get("s1")).toBeNull();
+
+    // The delivery from before finally returns. Its settlement names a claim
+    // it no longer holds, so the one running now is untouched.
+    releases[0]!();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(index.earliestLease()).toBe(held);
+    expect(index.get("s1")).toBeNull();
+    restarted.stop();
+  });
+
+  it("backs off instead of spinning while the index keeps failing to claim", async () => {
+    const due = vi.spyOn(index, "due").mockImplementation(() => {
+      throw new Error("database is locked");
+    });
+    await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(due).toHaveBeenCalledTimes(1);
+
+    // The deadline stays overdue, so arming for it would fire at once and
+    // spin. One attempt per backoff interval, not thousands.
+    await vi.advanceTimersByTimeAsync(BLIND_RETRY_INTERVAL_MS * 5);
+    expect(due.mock.calls.length).toBeLessThanOrEqual(6);
+
+    due.mockRestore();
+    await vi.advanceTimersByTimeAsync(BLIND_RETRY_INTERVAL_MS);
+    expect(delivered).toEqual(["s1"]);
+  });
+
+  it("gives up a recovered claim that has no attempts left instead of delivering it", async () => {
+    await clock.storeFor("s1").setAlarm(Date.now() + 1_000);
+    // A claim recovered after its final attempt comes back over budget.
+    const held = index.claim("s1", Date.now() + ALARM_CLAIM_LEASE_MS)!;
+    for (let n = 0; n <= MAX_RETRIES; n += 1) {
+      index.retry("s1", n === 0 ? held.token : index.claim("s1", Date.now() + 1)!.token, 1);
+    }
+    await vi.advanceTimersByTimeAsync(BLIND_RETRY_INTERVAL_MS);
+
+    expect(deliver).not.toHaveBeenCalled();
     expect(await clock.storeFor("s1").getAlarm()).toBeNull();
   });
 
-  it("keeps ticking when the index throws, rather than rejecting out of the timer", async () => {
+  it("keeps ticking when the index throws once, rather than rejecting out of the timer", async () => {
     const due = vi.spyOn(index, "due").mockImplementationOnce(() => {
       throw new Error("database is locked");
     });
@@ -168,10 +235,11 @@ describe("HostAlarmClock", () => {
       "Deadline delivery could not be settled",
       expect.objectContaining({ event: "alarm.settle_failed", session_id: "s1" })
     );
-    // Still claimed, so the session is not lost: the lease brings it back.
+    // Still claimed, so the session is not lost: the claim stays on disk and
+    // the next start recovers it.
     expect(index.get("s1")).toBeNull();
-    await vi.advanceTimersByTimeAsync(ALARM_CLAIM_LEASE_MS);
-    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(index.recoverForeignClaims([])).toEqual(["s1"]);
+    expect(index.get("s1")).toBe(1_001_000);
   });
 
   it("does not fire a deleted deadline", async () => {

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -179,8 +179,12 @@ export class HostAlarmClock {
     const now = this.now();
     let wakeAt: number | null = notBefore ?? null;
     try {
+      // Only a lease still to come is worth waking for. One already behind
+      // us belongs to a delivery this clock has let go of, or to a claim a
+      // settlement could not clear; either way the tick would find nothing to
+      // do and arm again at once. The next start recovers both.
       const lease = this.index.earliestLease();
-      if (lease !== null) wakeAt = Math.max(lease, notBefore ?? lease);
+      if (lease !== null && lease > now) wakeAt = Math.max(lease, notBefore ?? lease);
       // A session being delivered to is left out: its next deadline is
       // picked up when this delivery settles.
       if (this.liveDeliveries() < this.maxConcurrentDeliveries) {

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -24,6 +24,16 @@
  * Deliveries run concurrently across sessions up to a bound, so a host that
  * comes back after downtime opens overdue sessions a few at a time rather
  * than all at once; the next ones start as soon as one settles.
+ *
+ * Every claim is a lease. When one runs out the clock lets go of that
+ * delivery in both places at once: the row goes back to armed, and the slot
+ * it held stops counting against the bound. A handler that never returns
+ * therefore costs one lease rather than a permanently narrower clock, and it
+ * cannot corrupt the redelivery that replaces it, because settling is fenced
+ * on the claim token it no longer owns.
+ *
+ * Polling, delivery and arming are total: an index that throws is logged and
+ * the timer re-armed, never left as an unhandled rejection from a timer task.
  */
 
 import type { Logger } from "../logger";
@@ -38,6 +48,16 @@ export const RETRY_BASE_DELAY_MS = 2_000;
 export const MAX_RETRIES = 6;
 /** Sessions delivered to at the same time, unless the host says otherwise. */
 const DEFAULT_MAX_CONCURRENT_DELIVERIES = 8;
+/**
+ * How long a claim holds a session before it may be delivered again. Long
+ * enough that a slow handler is never overtaken — opening an evicted session
+ * and running its handler is bounded by the session's own work, not by this —
+ * while a host that died or a handler that hung frees the session within the
+ * quarter hour.
+ */
+export const ALARM_CLAIM_LEASE_MS = 15 * 60 * 1000;
+/** How long the clock waits before trying again when the index cannot be read. */
+export const BLIND_RETRY_INTERVAL_MS = 60 * 1000;
 /** The clock source, unless a test supplies one; read per call so fake timers apply. */
 const DEFAULT_NOW = (): number => Date.now();
 
@@ -62,7 +82,11 @@ export class HostAlarmClock {
   private readonly maxConcurrentDeliveries: number;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
-  private readonly inFlight = new Map<string, Promise<void>>();
+  /** Deliveries this process started, by session id, with the claim each holds. */
+  private readonly inFlight = new Map<
+    string,
+    { delivery: Promise<void>; token: string; leaseUntil: number }
+  >();
 
   constructor(options: HostAlarmClockOptions) {
     this.index = options.index;
@@ -89,12 +113,15 @@ export class HostAlarmClock {
   }
 
   /**
-   * Arm for whatever the index holds. Claims a previous process left in
-   * flight are delivered again: their handlers may not have run.
+   * Arm for whatever the index holds. A claim on disk that no delivery here
+   * owns was left by a process that is gone, and is armed again at once: its
+   * handler may not have run. Idempotent, because the claims this process is
+   * still delivering are named and left alone.
    */
   start(): void {
     this.running = true;
-    const recovered = this.index.recoverClaims();
+    const owned = [...this.inFlight.values()].map((entry) => entry.token);
+    const recovered = this.index.recoverForeignClaims(owned);
     if (recovered.length > 0) {
       this.log.warn("Re-arming deadlines a previous process left in flight", {
         event: "alarm.claims_recovered",
@@ -113,50 +140,135 @@ export class HostAlarmClock {
     }
   }
 
-  /** Resolves once every delivery that was running has settled. */
+  /**
+   * Resolves once every delivery still counted has settled. A delivery whose
+   * lease ran out is not among them: the clock has already let go of it.
+   */
   async drain(): Promise<void> {
-    await Promise.allSettled([...this.inFlight.values()]);
+    await Promise.allSettled([...this.inFlight.values()].map((entry) => entry.delivery));
   }
 
+  /**
+   * Wake at the soonest of: the next armed deadline, and the moment the
+   * soonest claim's lease runs out. Both come from the index, so a claim
+   * whose delivery this process has already let go of is still woken for.
+   * With neither, there is nothing to wake for and no timer is set. At
+   * capacity only the lease matters — a settling delivery re-arms for the
+   * rest, and expired leases still have to be reclaimed meanwhile.
+   */
   private arm(): void {
     if (this.timer !== null) {
       clearTimeout(this.timer);
       this.timer = null;
     }
     if (!this.running) return;
-    // At capacity, the settling delivery re-arms the clock. A session being
-    // delivered to is left out: its next deadline is picked up the same way.
-    if (this.inFlight.size >= this.maxConcurrentDeliveries) return;
-    const next = this.index.earliest(this.inFlight.keys());
-    if (next === null) return;
-    const delay = Math.min(Math.max(0, next.deadline - this.now()), MAX_TIMER_DELAY_MS);
+    const now = this.now();
+    let wakeAt: number | null = null;
+    try {
+      wakeAt = this.index.earliestLease();
+      // A session being delivered to is left out: its next deadline is
+      // picked up when this delivery settles.
+      if (this.inFlight.size < this.maxConcurrentDeliveries) {
+        const next = this.index.earliest(this.inFlight.keys());
+        if (next !== null) wakeAt = Math.min(wakeAt ?? next.deadline, next.deadline);
+      }
+    } catch (error) {
+      // Arming ends every path — setting a deadline, a tick, a settling
+      // delivery — so a throw here would escape a timer task and take the
+      // process with it. Waking blind keeps the clock alive until the index
+      // can say what is due again.
+      this.log.error("Alarm clock could not schedule its next wake-up", {
+        event: "alarm.arm_failed",
+        error_message: message(error),
+      });
+      wakeAt = now + BLIND_RETRY_INTERVAL_MS;
+    }
+    if (wakeAt === null) return;
+    const delay = Math.min(Math.max(0, wakeAt - now), MAX_TIMER_DELAY_MS);
     this.timer = setTimeout(() => this.tick(), delay);
   }
 
+  /** One wake-up. Total: nothing here may reject out of the timer task. */
   private tick(): void {
     this.timer = null;
+    try {
+      this.forgetExpiredDeliveries();
+      this.recoverExpiredClaims();
+      this.claimAndDeliver();
+    } catch (error) {
+      // The index is unusable for now. Keep the timer alive so the host
+      // recovers on its own if the failure was transient.
+      this.log.error("Alarm clock failed to claim work", {
+        event: "alarm.poll_failed",
+        error_message: message(error),
+      });
+    }
+    this.arm();
+  }
+
+  /**
+   * Stop counting deliveries whose lease has run out. The promise itself
+   * cannot be cancelled, so it is simply no longer ours: whatever it does
+   * later is fenced by a claim token the row no longer carries.
+   */
+  private forgetExpiredDeliveries(): void {
+    const now = this.now();
+    const abandoned: string[] = [];
+    for (const [sessionId, entry] of this.inFlight) {
+      if (entry.leaseUntil > now) continue;
+      this.inFlight.delete(sessionId);
+      abandoned.push(sessionId);
+    }
+    if (abandoned.length === 0) return;
+    this.log.error("Deadline deliveries outlived their lease and were abandoned", {
+      event: "alarm.delivery_abandoned",
+      session_ids: abandoned,
+    });
+  }
+
+  private recoverExpiredClaims(): void {
+    const recovered = this.index.recoverExpiredClaims(this.now());
+    if (recovered.length === 0) return;
+    this.log.warn("Re-arming deadlines whose claim expired", {
+      event: "alarm.claims_expired",
+      session_ids: recovered,
+    });
+  }
+
+  private claimAndDeliver(): void {
     const capacity = this.maxConcurrentDeliveries - this.inFlight.size;
     if (capacity <= 0) return;
+    const leaseUntil = this.now() + ALARM_CLAIM_LEASE_MS;
     for (const { sessionId } of this.index.due(this.now(), this.inFlight.keys(), capacity)) {
-      const claimed = this.index.claim(sessionId);
+      const claimed = this.index.claim(sessionId, leaseUntil);
       if (claimed === null) continue;
       // Registered before the handler starts, so a deadline it arms at once
       // is excluded from the next wake-up until this delivery settles.
       const delivery = Promise.resolve()
         .then(() => this.deliverTo(sessionId, claimed))
+        .catch((error: unknown) => {
+          // Settling failed, so the claim still stands; it comes back when
+          // the lease runs out rather than being lost here.
+          this.log.error("Deadline delivery could not be settled", {
+            event: "alarm.settle_failed",
+            session_id: sessionId,
+            error_message: message(error),
+          });
+        })
         .finally(() => {
-          this.inFlight.delete(sessionId);
+          // Only if this delivery is still the one being counted: an
+          // abandoned delivery must not evict the one that replaced it.
+          if (this.inFlight.get(sessionId)?.delivery === delivery) this.inFlight.delete(sessionId);
           this.arm();
         });
-      this.inFlight.set(sessionId, delivery);
+      this.inFlight.set(sessionId, { delivery, token: claimed.token, leaseUntil });
     }
-    this.arm();
   }
 
   private async deliverTo(sessionId: string, claimed: ClaimedDeadline): Promise<void> {
     try {
       await this.deliver(sessionId);
-      this.index.complete(sessionId);
+      this.index.complete(sessionId, claimed.token);
     } catch (error) {
       const retry = claimed.failures < MAX_RETRIES;
       this.log.error("Scheduled deadline delivery failed", {
@@ -165,15 +277,23 @@ export class HostAlarmClock {
         deadline: claimed.deadline,
         attempt: claimed.failures + 1,
         will_retry: retry,
-        error_message: error instanceof Error ? error.message : String(error),
+        error_message: message(error),
       });
       if (!retry) {
         // The session file keeps the deadline; its next activation re-arms it.
-        this.index.complete(sessionId);
+        this.index.complete(sessionId, claimed.token);
         return;
       }
       // Sooner than a replacement the handler armed, never later than it.
-      this.index.retry(sessionId, this.now() + RETRY_BASE_DELAY_MS * 2 ** claimed.failures);
+      this.index.retry(
+        sessionId,
+        claimed.token,
+        this.now() + RETRY_BASE_DELAY_MS * 2 ** claimed.failures
+      );
     }
   }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/control-plane/src/node/host-alarm-clock.ts
+++ b/packages/control-plane/src/node/host-alarm-clock.ts
@@ -25,15 +25,24 @@
  * comes back after downtime opens overdue sessions a few at a time rather
  * than all at once; the next ones start as soon as one settles.
  *
- * Every claim is a lease. When one runs out the clock lets go of that
- * delivery in both places at once: the row goes back to armed, and the slot
- * it held stops counting against the bound. A handler that never returns
- * therefore costs one lease rather than a permanently narrower clock, and it
- * cannot corrupt the redelivery that replaces it, because settling is fenced
- * on the claim token it no longer owns.
+ * Every claim is a lease, held by the delivery that took it. Settling names
+ * that token, so a claim recovered from a process that is gone cannot be
+ * settled by a delivery that outlived it, and starting twice never takes a
+ * claim away from a delivery still running here.
+ *
+ * When a lease runs out in a live process the clock stops counting that
+ * delivery against the concurrency bound, so one handler that never returns
+ * cannot narrow the clock for every other session. It does *not* redeliver
+ * that session. The promise cannot be cancelled, the registry's leases count
+ * rather than exclude, and the session's own alarm state carries no claim
+ * token — so a second delivery would run into the same runtime beside the
+ * first, and the stale one could clear a deadline the new one owns. Until
+ * that fence reaches the session core, the abandoned session stays excluded
+ * and its claim stays on disk, for the next start to recover.
  *
  * Polling, delivery and arming are total: an index that throws is logged and
- * the timer re-armed, never left as an unhandled rejection from a timer task.
+ * the timer re-armed — behind a backoff, so a failure that persists is not a
+ * spin — never left as an unhandled rejection from a timer task.
  */
 
 import type { Logger } from "../logger";
@@ -82,10 +91,15 @@ export class HostAlarmClock {
   private readonly maxConcurrentDeliveries: number;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
-  /** Deliveries this process started, by session id, with the claim each holds. */
+  /**
+   * Deliveries this process started, by session id, with the claim each
+   * holds. An entry past its lease is `abandoned`: it no longer counts
+   * against the bound, but the session stays excluded while the promise it
+   * cannot cancel is still running.
+   */
   private readonly inFlight = new Map<
     string,
-    { delivery: Promise<void>; token: string; leaseUntil: number }
+    { delivery: Promise<void>; token: string; leaseUntil: number; abandoned: boolean }
   >();
 
   constructor(options: HostAlarmClockOptions) {
@@ -156,21 +170,25 @@ export class HostAlarmClock {
    * capacity only the lease matters — a settling delivery re-arms for the
    * rest, and expired leases still have to be reclaimed meanwhile.
    */
-  private arm(): void {
+  private arm(notBefore?: number): void {
     if (this.timer !== null) {
       clearTimeout(this.timer);
       this.timer = null;
     }
     if (!this.running) return;
     const now = this.now();
-    let wakeAt: number | null = null;
+    let wakeAt: number | null = notBefore ?? null;
     try {
-      wakeAt = this.index.earliestLease();
+      const lease = this.index.earliestLease();
+      if (lease !== null) wakeAt = Math.max(lease, notBefore ?? lease);
       // A session being delivered to is left out: its next deadline is
       // picked up when this delivery settles.
-      if (this.inFlight.size < this.maxConcurrentDeliveries) {
+      if (this.liveDeliveries() < this.maxConcurrentDeliveries) {
         const next = this.index.earliest(this.inFlight.keys());
-        if (next !== null) wakeAt = Math.min(wakeAt ?? next.deadline, next.deadline);
+        if (next !== null) {
+          const deadline = Math.max(next.deadline, notBefore ?? next.deadline);
+          wakeAt = Math.min(wakeAt ?? deadline, deadline);
+        }
       }
     } catch (error) {
       // Arming ends every path — setting a deadline, a tick, a settling
@@ -192,51 +210,52 @@ export class HostAlarmClock {
   private tick(): void {
     this.timer = null;
     try {
-      this.forgetExpiredDeliveries();
-      this.recoverExpiredClaims();
+      this.abandonExpiredDeliveries();
       this.claimAndDeliver();
     } catch (error) {
-      // The index is unusable for now. Keep the timer alive so the host
-      // recovers on its own if the failure was transient.
+      // The index is unusable for now. Back off before waking again: the
+      // deadline that could not be claimed is still overdue, so arming for it
+      // would schedule another zero-delay tick and spin.
       this.log.error("Alarm clock failed to claim work", {
         event: "alarm.poll_failed",
         error_message: message(error),
       });
+      this.arm(this.now() + BLIND_RETRY_INTERVAL_MS);
+      return;
     }
     this.arm();
   }
 
   /**
-   * Stop counting deliveries whose lease has run out. The promise itself
-   * cannot be cancelled, so it is simply no longer ours: whatever it does
-   * later is fenced by a claim token the row no longer carries.
+   * Stop counting deliveries whose lease has run out against the bound, so
+   * one handler that never returns does not narrow the clock for every other
+   * session. The entry stays: the promise cannot be cancelled, and this
+   * session must not be delivered to again while it runs.
    */
-  private forgetExpiredDeliveries(): void {
+  private abandonExpiredDeliveries(): void {
     const now = this.now();
     const abandoned: string[] = [];
     for (const [sessionId, entry] of this.inFlight) {
-      if (entry.leaseUntil > now) continue;
-      this.inFlight.delete(sessionId);
+      if (entry.abandoned || entry.leaseUntil > now) continue;
+      entry.abandoned = true;
       abandoned.push(sessionId);
     }
     if (abandoned.length === 0) return;
-    this.log.error("Deadline deliveries outlived their lease and were abandoned", {
+    this.log.error("Deadline deliveries outlived their lease and stopped counting", {
       event: "alarm.delivery_abandoned",
       session_ids: abandoned,
     });
   }
 
-  private recoverExpiredClaims(): void {
-    const recovered = this.index.recoverExpiredClaims(this.now());
-    if (recovered.length === 0) return;
-    this.log.warn("Re-arming deadlines whose claim expired", {
-      event: "alarm.claims_expired",
-      session_ids: recovered,
-    });
+  /** Deliveries still counted against the bound; an abandoned one is not. */
+  private liveDeliveries(): number {
+    let live = 0;
+    for (const entry of this.inFlight.values()) if (!entry.abandoned) live += 1;
+    return live;
   }
 
   private claimAndDeliver(): void {
-    const capacity = this.maxConcurrentDeliveries - this.inFlight.size;
+    const capacity = this.maxConcurrentDeliveries - this.liveDeliveries();
     if (capacity <= 0) return;
     const leaseUntil = this.now() + ALARM_CLAIM_LEASE_MS;
     for (const { sessionId } of this.index.due(this.now(), this.inFlight.keys(), capacity)) {
@@ -261,11 +280,23 @@ export class HostAlarmClock {
           if (this.inFlight.get(sessionId)?.delivery === delivery) this.inFlight.delete(sessionId);
           this.arm();
         });
-      this.inFlight.set(sessionId, { delivery, token: claimed.token, leaseUntil });
+      this.inFlight.set(sessionId, {
+        delivery,
+        token: claimed.token,
+        leaseUntil,
+        abandoned: false,
+      });
     }
   }
 
   private async deliverTo(sessionId: string, claimed: ClaimedDeadline): Promise<void> {
+    // Only a recovered claim can arrive over budget: the settlement below
+    // stops retrying a deadline that spent its last attempt, so the normal
+    // path never hands one back.
+    if (claimed.failures > MAX_RETRIES) {
+      this.index.complete(sessionId, claimed.token);
+      return;
+    }
     try {
       await this.deliver(sessionId);
       this.index.complete(sessionId, claimed.token);

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -196,7 +196,8 @@ describe("openHostAlarmIndex", () => {
     // What it already held is intact, and a claim carrying no lease is one
     // whose lease has run out — which is what it is.
     expect(index.get("armed")).toBe(700);
-    expect(index.earliestLease()).toBe(0);
+    // It carries no lease, so nothing waits on one; recovery takes it back.
+    expect(index.earliestLease()).toBeNull();
     expect(index.recoverForeignClaims([])).toEqual(["legacy"]);
     expect(index.get("legacy")).toBe(100);
   });

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -178,20 +178,29 @@ describe("openHostAlarmIndex", () => {
     expect(second.recoverForeignClaims([])).toEqual([]);
   });
 
-  it("treats a claim written before leases existed as one whose lease has run out", () => {
-    const first = open();
-    first.set("legacy", 100);
-    first.claim("legacy", LEASE_UNTIL);
-    first.close();
+  it("opens a file written before the lease columns existed, and frees the claims in it", () => {
+    // The table an older build wrote: no claim_token, no lease_expires_at,
+    // and one deadline already taken for delivery.
+    const older = new DatabaseSync(join(dataDir, "host-alarms.db"));
+    older.exec(`CREATE TABLE session_deadlines (
+      session_id TEXT PRIMARY KEY,
+      deadline INTEGER,
+      in_flight INTEGER,
+      failures INTEGER NOT NULL DEFAULT 0,
+      CHECK (deadline IS NOT NULL OR in_flight IS NOT NULL)
+    );
+    CREATE INDEX idx_session_deadlines_deadline ON session_deadlines (deadline);`);
+    older.exec("INSERT INTO session_deadlines (session_id, deadline) VALUES ('armed', 700)");
+    older.exec("INSERT INTO session_deadlines (session_id, in_flight) VALUES ('legacy', 100)");
+    older.close();
 
-    // The shape an older build left behind: a claim with no lease recorded.
-    const db = new DatabaseSync(join(dataDir, "host-alarms.db"));
-    db.exec("UPDATE session_deadlines SET claim_token = NULL, lease_expires_at = NULL");
-    db.close();
-
-    const second = open();
-    expect(second.recoverExpiredClaims(0)).toEqual(["legacy"]);
-    expect(second.get("legacy")).toBe(100);
+    const index = open();
+    // What it already held is intact, and a claim carrying no lease is one
+    // whose lease has run out — which is what it is.
+    expect(index.get("armed")).toBe(700);
+    expect(index.earliestLease()).toBe(0);
+    expect(index.recoverExpiredClaims(0)).toEqual(["legacy"]);
+    expect(index.get("legacy")).toBe(100);
   });
 
   it("leaves excluded sessions out of earliest and due", () => {

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -80,8 +80,8 @@ describe("openHostAlarmIndex", () => {
     index.set("s1", 100);
     const stale = index.claim("s1", 500)!;
 
-    // The lease runs out and the session is claimed again.
-    expect(index.recoverExpiredClaims(500)).toEqual(["s1"]);
+    // A restart recovers the claim, and the session is claimed again.
+    expect(index.recoverForeignClaims([])).toEqual(["s1"]);
     const live = index.claim("s1", LEASE_UNTIL)!;
     expect(live.token).not.toBe(stale.token);
 
@@ -96,28 +96,26 @@ describe("openHostAlarmIndex", () => {
     expect(index.get("s1")).toBe(9_000);
   });
 
-  it("counts an expired claim as a failure but a foreign one as nothing", () => {
+  it("recovers a claim without spending its retry budget", () => {
     const index = open();
-    index.set("hung", 100);
-    index.claim("hung", 500);
-    // A handler that never returned: the abandoned delivery is a failed one.
-    expect(index.recoverExpiredClaims(500)).toEqual(["hung"]);
-    expect(index.claim("hung", LEASE_UNTIL)).toMatchObject({ failures: 1 });
-
     index.set("killed", 100);
+    const held = index.claim("killed", LEASE_UNTIL)!;
+    index.retry("killed", held.token, 200);
     index.claim("killed", LEASE_UNTIL);
-    // A host that was killed did not fail to deliver; its budget is untouched.
+
+    // A host that was killed did not fail to deliver; the count it already
+    // carried stands, and recovery adds nothing to it.
     expect(index.recoverForeignClaims([])).toContain("killed");
-    expect(index.claim("killed", LEASE_UNTIL)).toMatchObject({ failures: 0 });
+    expect(index.claim("killed", LEASE_UNTIL)).toMatchObject({ failures: 1 });
   });
 
-  it("leaves a lease that still holds, and the claims a caller still owns", () => {
+  it("leaves the claims a caller still owns, however long their leases have run", () => {
     const index = open();
     index.set("live", 100);
     const live = index.claim("live", 500)!;
 
-    expect(index.recoverExpiredClaims(499)).toEqual([]);
-    // Starting again must not take back a delivery this process is running.
+    // Starting again must not take back a delivery this process is running,
+    // and an expired lease is not on its own a reason to take one back.
     expect(index.recoverForeignClaims([live.token])).toEqual([]);
     expect(index.get("live")).toBeNull();
 
@@ -199,7 +197,7 @@ describe("openHostAlarmIndex", () => {
     // whose lease has run out — which is what it is.
     expect(index.get("armed")).toBe(700);
     expect(index.earliestLease()).toBe(0);
-    expect(index.recoverExpiredClaims(0)).toEqual(["legacy"]);
+    expect(index.recoverForeignClaims([])).toEqual(["legacy"]);
     expect(index.get("legacy")).toBe(100);
   });
 

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -1,8 +1,12 @@
 import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
+import { openHostAlarmIndex, type ClaimedDeadline, type HostAlarmIndex } from "./host-alarm-index";
+
+/** A lease no test outlives unless it means to. */
+const LEASE_UNTIL = 10_000_000;
 
 describe("openHostAlarmIndex", () => {
   let dataDir: string;
@@ -57,50 +61,107 @@ describe("openHostAlarmIndex", () => {
   it("claims a deadline for delivery, hides it while in flight, and completes it", () => {
     const index = open();
     index.set("s1", 100);
-    expect(index.claim("s1")).toEqual({ deadline: 100, failures: 0 });
+    const claimed = index.claim("s1", LEASE_UNTIL);
+    expect(claimed).toMatchObject({ deadline: 100, failures: 0 });
+    expect(claimed!.token).toEqual(expect.any(String));
     expect(index.get("s1")).toBeNull();
     expect(index.earliest()).toBeNull();
-    expect(index.claim("s1")).toBeNull();
+    expect(index.claim("s1", LEASE_UNTIL)).toBeNull();
     // A deadline armed during delivery is visible and survives completion.
     index.set("s1", 900);
-    index.complete("s1");
+    index.complete("s1", claimed!.token);
     expect(index.get("s1")).toBe(900);
     index.delete("s1");
     expect(index.earliest()).toBeNull();
   });
 
+  it("refuses a settlement from a claim that no longer holds the session", () => {
+    const index = open();
+    index.set("s1", 100);
+    const stale = index.claim("s1", 500)!;
+
+    // The lease runs out and the session is claimed again.
+    expect(index.recoverExpiredClaims(500)).toEqual(["s1"]);
+    const live = index.claim("s1", LEASE_UNTIL)!;
+    expect(live.token).not.toBe(stale.token);
+
+    // The abandoned delivery comes back: neither settlement may touch the row.
+    index.complete("s1", stale.token);
+    index.retry("s1", stale.token, 9_000);
+    expect(index.get("s1")).toBeNull();
+    expect(index.claim("s1", LEASE_UNTIL)).toBeNull();
+
+    // The delivery that does hold the claim settles it.
+    index.retry("s1", live.token, 9_000);
+    expect(index.get("s1")).toBe(9_000);
+  });
+
+  it("counts an expired claim as a failure but a foreign one as nothing", () => {
+    const index = open();
+    index.set("hung", 100);
+    index.claim("hung", 500);
+    // A handler that never returned: the abandoned delivery is a failed one.
+    expect(index.recoverExpiredClaims(500)).toEqual(["hung"]);
+    expect(index.claim("hung", LEASE_UNTIL)).toMatchObject({ failures: 1 });
+
+    index.set("killed", 100);
+    index.claim("killed", LEASE_UNTIL);
+    // A host that was killed did not fail to deliver; its budget is untouched.
+    expect(index.recoverForeignClaims([])).toContain("killed");
+    expect(index.claim("killed", LEASE_UNTIL)).toMatchObject({ failures: 0 });
+  });
+
+  it("leaves a lease that still holds, and the claims a caller still owns", () => {
+    const index = open();
+    index.set("live", 100);
+    const live = index.claim("live", 500)!;
+
+    expect(index.recoverExpiredClaims(499)).toEqual([]);
+    // Starting again must not take back a delivery this process is running.
+    expect(index.recoverForeignClaims([live.token])).toEqual([]);
+    expect(index.get("live")).toBeNull();
+
+    expect(index.recoverForeignClaims(["someone-elses-token"])).toEqual(["live"]);
+    expect(index.get("live")).toBe(100);
+  });
+
   it("re-arms a failed claim at the retry time, or sooner if the session armed sooner", () => {
     const index = open();
+    const take = (sessionId: string): ClaimedDeadline => index.claim(sessionId, LEASE_UNTIL)!;
     index.set("later", 100);
-    index.claim("later");
+    let held = take("later");
     index.set("later", 5_000);
-    index.retry("later", 1_000);
+    index.retry("later", held.token, 1_000);
     expect(index.get("later")).toBe(1_000);
     // The failure is counted for the next claim of the same alarm.
-    expect(index.claim("later")).toEqual({ deadline: 1_000, failures: 1 });
-    index.retry("later", 2_000);
-    expect(index.claim("later")).toEqual({ deadline: 2_000, failures: 2 });
+    held = take("later");
+    expect(held).toMatchObject({ deadline: 1_000, failures: 1 });
+    index.retry("later", held.token, 2_000);
+    held = take("later");
+    expect(held).toMatchObject({ deadline: 2_000, failures: 2 });
     // Arming anew, or completing, starts the count over.
     index.set("later", 3_000);
-    expect(index.claim("later")).toEqual({ deadline: 3_000, failures: 0 });
-    index.retry("later", 4_000);
-    index.complete("later");
+    held = take("later");
+    expect(held).toMatchObject({ deadline: 3_000, failures: 0 });
+    index.retry("later", held.token, 4_000);
+    held = take("later");
+    index.complete("later", held.token);
     index.set("later", 5_000);
-    expect(index.claim("later")).toEqual({ deadline: 5_000, failures: 0 });
+    expect(take("later")).toMatchObject({ deadline: 5_000, failures: 0 });
 
     index.set("sooner", 100);
-    index.claim("sooner");
+    const sooner = take("sooner");
     index.set("sooner", 200);
-    index.retry("sooner", 1_000);
+    index.retry("sooner", sooner.token, 1_000);
     expect(index.get("sooner")).toBe(200);
   });
 
   it("recovers claims left in flight at their original deadline, or sooner", () => {
     const first = open();
     first.set("crashed", 100);
-    first.claim("crashed");
+    first.claim("crashed", LEASE_UNTIL);
     first.set("rearmed", 100);
-    first.claim("rearmed");
+    first.claim("rearmed", LEASE_UNTIL);
     first.set("rearmed", 50);
     first.set("idle", 700);
     first.close();
@@ -108,12 +169,29 @@ describe("openHostAlarmIndex", () => {
     const second = open();
     // Before recovery only armed deadlines count: the crashed claim is invisible.
     expect(second.earliest(["rearmed"])).toEqual({ sessionId: "idle", deadline: 700 });
-    expect(second.recoverClaims().sort()).toEqual(["crashed", "rearmed"]);
+    // No delivery here owns them, however long their leases had left to run.
+    expect(second.recoverForeignClaims([]).sort()).toEqual(["crashed", "rearmed"]);
     expect(second.due(100, [], 10)).toEqual([
       { sessionId: "rearmed", deadline: 50 },
       { sessionId: "crashed", deadline: 100 },
     ]);
-    expect(second.recoverClaims()).toEqual([]);
+    expect(second.recoverForeignClaims([])).toEqual([]);
+  });
+
+  it("treats a claim written before leases existed as one whose lease has run out", () => {
+    const first = open();
+    first.set("legacy", 100);
+    first.claim("legacy", LEASE_UNTIL);
+    first.close();
+
+    // The shape an older build left behind: a claim with no lease recorded.
+    const db = new DatabaseSync(join(dataDir, "host-alarms.db"));
+    db.exec("UPDATE session_deadlines SET claim_token = NULL, lease_expires_at = NULL");
+    db.close();
+
+    const second = open();
+    expect(second.recoverExpiredClaims(0)).toEqual(["legacy"]);
+    expect(second.get("legacy")).toBe(100);
   });
 
   it("leaves excluded sessions out of earliest and due", () => {

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -14,11 +14,22 @@
  * mid-delivery finds the claim at the next start and fires it again instead
  * of stranding an evicted session. `failures` counts failed deliveries of
  * the current alarm, on disk so a restart does not renew the retry budget.
+ *
+ * A claim is a lease. It carries the token of the delivery that holds it and
+ * the time that hold runs out, and settling names the token, so a delivery
+ * that comes back after its lease expired cannot settle the redelivery that
+ * replaced it. Two things end a claim early, and they are different
+ * questions: a claim no live delivery owns belongs to a process that is gone
+ * (`recoverForeignClaims`, at start), and a claim whose lease ran out belongs
+ * to a delivery that hung (`recoverExpiredClaims`, on every sweep). Only the
+ * second counts a failure — a host that was killed did not fail to deliver,
+ * but a handler that never returned did.
  */
 
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
-import { ensurePrivateDirectory, makeFilePrivate } from "./private-paths";
+import type { DatabaseSync } from "node:sqlite";
+import { ensurePrivateDirectory } from "./private-paths";
+import { openPrivateSqliteFile } from "./sqlite-file";
 
 interface SessionDeadline {
   sessionId: string;
@@ -29,6 +40,8 @@ export interface ClaimedDeadline {
   deadline: number;
   /** Failed deliveries of this alarm so far; arming a new deadline resets it. */
   failures: number;
+  /** This claim's token; settling the delivery requires it. */
+  token: string;
 }
 
 export interface HostAlarmIndex {
@@ -41,30 +54,47 @@ export interface HostAlarmIndex {
   /** The soonest armed deadline, ignoring the sessions in `excluding`. */
   earliest(excluding?: Iterable<string>): SessionDeadline | null;
   /**
+   * When the soonest claim's lease runs out, or null when nothing is
+   * claimed. A claim recorded before leases existed reads as already
+   * expired. This is on disk rather than in the clock's memory because a
+   * claim outlives the delivery that held it — a settlement that could not
+   * be written leaves one behind.
+   */
+  earliestLease(): number | null;
+  /**
    * Up to `limit` sessions armed at or before `now`, soonest first, ignoring
    * `excluding`.
    */
   due(now: number, excluding: Iterable<string>, limit: number): SessionDeadline[];
   /**
-   * Take the session's armed deadline for delivery, with the number of
-   * deliveries of this alarm that have already failed. Returns null when
-   * nothing was armed. Until `complete` or `retry`, the session reads as
-   * disarmed, so a handler that arms a new deadline replaces nothing.
+   * Take the session's armed deadline for delivery until `leaseUntil`, with
+   * the number of deliveries of this alarm that have already failed. Returns
+   * null when nothing was armed. Until the claim is settled or recovered the
+   * session reads as disarmed, so a handler that arms a new deadline replaces
+   * nothing.
    */
-  claim(sessionId: string): ClaimedDeadline | null;
-  /** The claimed delivery succeeded. */
-  complete(sessionId: string): void;
+  claim(sessionId: string, leaseUntil: number): ClaimedDeadline | null;
+  /** The claimed delivery succeeded. Ignored unless `token` still holds it. */
+  complete(sessionId: string, token: string): void;
   /**
    * The claimed delivery failed: count the failure and arm again at `at`, or
-   * sooner if already armed.
+   * sooner if already armed. Ignored unless `token` still holds the claim.
    */
-  retry(sessionId: string, at: number): void;
+  retry(sessionId: string, token: string, at: number): void;
   /**
-   * Re-arm every claim a previous process left in flight, at its original
-   * deadline (or sooner if the session armed one meanwhile). Returns the
-   * session ids recovered.
+   * Re-arm every claim no live delivery owns, at its original deadline (or
+   * sooner if the session armed one meanwhile), leaving the retry budget
+   * alone. `ownedTokens` are the claims this process is still delivering, so
+   * starting twice never takes one of them back. Returns the session ids
+   * recovered.
    */
-  recoverClaims(): string[];
+  recoverForeignClaims(ownedTokens: readonly string[]): string[];
+  /**
+   * Re-arm every claim whose lease has run out, counting the abandoned
+   * delivery as a failure so a handler that always hangs runs out of retries
+   * like one that always throws. Returns the session ids recovered.
+   */
+  recoverExpiredClaims(now: number): string[];
   close(): void;
 }
 
@@ -73,18 +103,42 @@ const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
   deadline INTEGER,
   in_flight INTEGER,
   failures INTEGER NOT NULL DEFAULT 0,
+  claim_token TEXT,
+  lease_expires_at INTEGER,
   CHECK (deadline IS NOT NULL OR in_flight IS NOT NULL)
 );
-CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);`;
+CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);
+CREATE INDEX IF NOT EXISTS idx_session_deadlines_leases ON session_deadlines (lease_expires_at);`;
+
+/**
+ * The lease columns, for a file written before claims carried one. Both are
+ * nullable with no default, so an existing row reads as a claim whose lease
+ * has already run out — which is what a claim left by an older build is.
+ */
+const LEASE_COLUMNS = ["claim_token TEXT", "lease_expires_at INTEGER"] as const;
+
+function addMissingColumns(db: DatabaseSync): void {
+  const present = new Set(
+    (
+      db.prepare("SELECT name FROM pragma_table_info('session_deadlines')").all() as Array<{
+        name: string;
+      }>
+    ).map((row) => row.name)
+  );
+  for (const column of LEASE_COLUMNS) {
+    const [name] = column.split(" ");
+    if (present.has(name!)) continue;
+    db.exec(`ALTER TABLE session_deadlines ADD COLUMN ${column}`);
+  }
+}
 
 /** Open (creating if needed) the host's deadline index. */
 export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   ensurePrivateDirectory(dataDir);
-  const path = join(dataDir, "host-alarms.db");
-  const db = new DatabaseSync(path);
+  const db = openPrivateSqliteFile(join(dataDir, "host-alarms.db"));
   try {
-    makeFilePrivate(path);
     db.exec(SCHEMA_SQL);
+    addMissingColumns(db);
   } catch (error) {
     db.close();
     throw error;
@@ -101,23 +155,51 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   );
   const disarm = db.prepare("UPDATE session_deadlines SET deadline = NULL WHERE session_id = ?");
   const dropDisarmed = db.prepare(
-    "DELETE FROM session_deadlines WHERE session_id = ? AND deadline IS NULL"
+    "DELETE FROM session_deadlines WHERE session_id = ? AND deadline IS NULL AND claim_token = ?"
   );
   const claimRow = db.prepare(
-    `UPDATE session_deadlines SET in_flight = deadline, deadline = NULL
+    `UPDATE session_deadlines
+     SET in_flight = deadline, deadline = NULL, claim_token = ?, lease_expires_at = ?
      WHERE session_id = ? AND deadline IS NOT NULL RETURNING in_flight, failures`
   );
+  // Every settlement names the claim it holds, so a delivery that came back
+  // after its lease ran out cannot settle the one that replaced it.
   const settle = db.prepare(
-    "UPDATE session_deadlines SET in_flight = NULL, failures = 0 WHERE session_id = ?"
+    `UPDATE session_deadlines SET in_flight = NULL, failures = 0, claim_token = NULL, lease_expires_at = NULL
+     WHERE session_id = ? AND claim_token = ?`
   );
   const armSooner = db.prepare(
     `UPDATE session_deadlines
-     SET deadline = MIN(COALESCE(deadline, ?), ?), in_flight = NULL, failures = failures + 1
-     WHERE session_id = ?`
+     SET deadline = MIN(COALESCE(deadline, ?), ?), in_flight = NULL, failures = failures + 1,
+         claim_token = NULL, lease_expires_at = NULL
+     WHERE session_id = ? AND claim_token = ?`
   );
-  const recover = db.prepare(
-    `UPDATE session_deadlines SET deadline = MIN(COALESCE(deadline, in_flight), in_flight), in_flight = NULL
-     WHERE in_flight IS NOT NULL RETURNING session_id`
+  const releaseClaims = (condition: string, countFailure: boolean) =>
+    db.prepare(
+      `UPDATE session_deadlines
+       SET deadline = MIN(COALESCE(deadline, in_flight), in_flight), in_flight = NULL,
+           failures = failures ${countFailure ? "+ 1" : "+ 0"},
+           claim_token = NULL, lease_expires_at = NULL
+       WHERE in_flight IS NOT NULL${condition} RETURNING session_id`
+    );
+  const recoverExpired = releaseClaims(" AND COALESCE(lease_expires_at, 0) <= ?", true);
+  // Prepared per owned-token count and kept: a host delivers to a handful of
+  // sessions at most, so the token list is inlined as placeholders.
+  const foreignStatements = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
+  const recoverForeign = (owned: number): ReturnType<DatabaseSync["prepare"]> => {
+    const cached = foreignStatements.get(owned);
+    if (cached) return cached;
+    const exclusion =
+      owned > 0
+        ? ` AND COALESCE(claim_token, '') NOT IN (${Array.from({ length: owned }, () => "?").join(", ")})`
+        : "";
+    const statement = releaseClaims(exclusion, false);
+    foreignStatements.set(owned, statement);
+    return statement;
+  };
+  const soonestLease = db.prepare(
+    `SELECT MIN(COALESCE(lease_expires_at, 0)) AS lease_expires_at FROM session_deadlines
+     WHERE in_flight IS NOT NULL`
   );
   const toDeadline = (row: unknown): SessionDeadline => {
     const { session_id, deadline } = row as { session_id: string; deadline: number };
@@ -157,20 +239,31 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
       disarm.run(sessionId);
     },
     earliest: (excluding = []) => armedRows("", [], excluding, 1)[0] ?? null,
+    earliestLease: () =>
+      (soonestLease.get() as { lease_expires_at: number | null }).lease_expires_at,
     due: (now, excluding, limit) => armedRows(" AND deadline <= ?", [now], excluding, limit),
-    claim: (sessionId) => {
-      const row = claimRow.get(sessionId) as { in_flight: number; failures: number } | undefined;
-      return row === undefined ? null : { deadline: row.in_flight, failures: row.failures };
+    claim: (sessionId, leaseUntil) => {
+      const token = crypto.randomUUID();
+      const row = claimRow.get(token, leaseUntil, sessionId) as
+        | { in_flight: number; failures: number }
+        | undefined;
+      return row === undefined ? null : { deadline: row.in_flight, failures: row.failures, token };
     },
-    complete: (sessionId) => {
-      dropDisarmed.run(sessionId);
-      settle.run(sessionId);
+    complete: (sessionId, token) => {
+      // Dropping first keeps the row's CHECK true: clearing `in_flight` on a
+      // row with no armed deadline would leave both slots empty.
+      dropDisarmed.run(sessionId, token);
+      settle.run(sessionId, token);
     },
-    retry: (sessionId, at) => {
-      armSooner.run(at, at, sessionId);
+    retry: (sessionId, token, at) => {
+      armSooner.run(at, at, sessionId, token);
     },
-    recoverClaims: () =>
-      (recover.all() as Array<{ session_id: string }>).map((row) => row.session_id),
+    recoverForeignClaims: (ownedTokens) =>
+      (recoverForeign(ownedTokens.length).all(...ownedTokens) as Array<{ session_id: string }>).map(
+        (row) => row.session_id
+      ),
+    recoverExpiredClaims: (now) =>
+      (recoverExpired.all(now) as Array<{ session_id: string }>).map((row) => row.session_id),
     close: () => db.close(),
   };
 }

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -58,10 +58,11 @@ export interface HostAlarmIndex {
   earliest(excluding?: Iterable<string>): SessionDeadline | null;
   /**
    * When the soonest claim's lease runs out, or null when nothing is
-   * claimed. A claim recorded before leases existed reads as already
-   * expired. This is on disk rather than in the clock's memory because a
+   * claimed. This is on disk rather than in the clock's memory because a
    * claim outlives the delivery that held it — a settlement that could not
-   * be written leaves one behind.
+   * be written leaves one behind. A claim recorded before leases existed
+   * carries none and is not counted: nothing here acts on an expired lease,
+   * and the next `recoverForeignClaims` takes such a claim back anyway.
    */
   earliestLease(): number | null;
   /**
@@ -109,7 +110,8 @@ const TABLE_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
 // the lease columns, the table statement above is a no-op and the lease index
 // would name a column that is only added below.
 const INDEX_SQL = `CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);
-CREATE INDEX IF NOT EXISTS idx_session_deadlines_leases ON session_deadlines (lease_expires_at);`;
+CREATE INDEX IF NOT EXISTS idx_session_deadlines_leases ON session_deadlines (lease_expires_at)
+  WHERE in_flight IS NOT NULL;`;
 
 /**
  * The lease columns, for a file written before claims carried one. Both are
@@ -196,8 +198,11 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
     foreignStatements.set(owned, statement);
     return statement;
   };
+  // Partial index territory: the predicate matches the index's own, and the
+  // aggregate is over the bare column, so this reads one entry rather than
+  // scanning every armed session.
   const soonestLease = db.prepare(
-    `SELECT MIN(COALESCE(lease_expires_at, 0)) AS lease_expires_at FROM session_deadlines
+    `SELECT MIN(lease_expires_at) AS lease_expires_at FROM session_deadlines
      WHERE in_flight IS NOT NULL`
   );
   const toDeadline = (row: unknown): SessionDeadline => {

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -98,7 +98,7 @@ export interface HostAlarmIndex {
   close(): void;
 }
 
-const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
+const TABLE_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
   session_id TEXT PRIMARY KEY,
   deadline INTEGER,
   in_flight INTEGER,
@@ -106,8 +106,12 @@ const SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS session_deadlines (
   claim_token TEXT,
   lease_expires_at INTEGER,
   CHECK (deadline IS NOT NULL OR in_flight IS NOT NULL)
-);
-CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);
+);`;
+
+// Indexes come after the columns are known to exist: on a file written before
+// the lease columns, the table statement above is a no-op and the lease index
+// would name a column that is only added below.
+const INDEX_SQL = `CREATE INDEX IF NOT EXISTS idx_session_deadlines_deadline ON session_deadlines (deadline);
 CREATE INDEX IF NOT EXISTS idx_session_deadlines_leases ON session_deadlines (lease_expires_at);`;
 
 /**
@@ -137,8 +141,9 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   ensurePrivateDirectory(dataDir);
   const db = openPrivateSqliteFile(join(dataDir, "host-alarms.db"));
   try {
-    db.exec(SCHEMA_SQL);
+    db.exec(TABLE_SQL);
     addMissingColumns(db);
+    db.exec(INDEX_SQL);
   } catch (error) {
     db.close();
     throw error;

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -15,15 +15,18 @@
  * of stranding an evicted session. `failures` counts failed deliveries of
  * the current alarm, on disk so a restart does not renew the retry budget.
  *
- * A claim is a lease. It carries the token of the delivery that holds it and
- * the time that hold runs out, and settling names the token, so a delivery
- * that comes back after its lease expired cannot settle the redelivery that
- * replaced it. Two things end a claim early, and they are different
- * questions: a claim no live delivery owns belongs to a process that is gone
- * (`recoverForeignClaims`, at start), and a claim whose lease ran out belongs
- * to a delivery that hung (`recoverExpiredClaims`, on every sweep). Only the
- * second counts a failure — a host that was killed did not fail to deliver,
- * but a handler that never returned did.
+ * A claim is a lease: it carries the token of the delivery holding it and the
+ * time that hold runs out. Settling names the token, so a claim recovered
+ * from a process that is gone cannot be settled by a delivery that outlived
+ * it. `recoverForeignClaims` is what recovers one — a claim no live delivery
+ * owns belongs to a process that is gone — and naming the claims the caller
+ * still holds is what lets it run more than once safely.
+ *
+ * `lease_expires_at` is read but never acted on here. The clock uses it to
+ * stop counting a delivery that outlived its lease, and deliberately leaves
+ * the claim on disk for the next start rather than re-arming it: nothing can
+ * cancel the delivery still running, so redelivering would put two of them
+ * into one session.
  */
 
 import { join } from "node:path";
@@ -89,12 +92,6 @@ export interface HostAlarmIndex {
    * recovered.
    */
   recoverForeignClaims(ownedTokens: readonly string[]): string[];
-  /**
-   * Re-arm every claim whose lease has run out, counting the abandoned
-   * delivery as a failure so a handler that always hangs runs out of retries
-   * like one that always throws. Returns the session ids recovered.
-   */
-  recoverExpiredClaims(now: number): string[];
   close(): void;
 }
 
@@ -179,17 +176,9 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
          claim_token = NULL, lease_expires_at = NULL
      WHERE session_id = ? AND claim_token = ?`
   );
-  const releaseClaims = (condition: string, countFailure: boolean) =>
-    db.prepare(
-      `UPDATE session_deadlines
-       SET deadline = MIN(COALESCE(deadline, in_flight), in_flight), in_flight = NULL,
-           failures = failures ${countFailure ? "+ 1" : "+ 0"},
-           claim_token = NULL, lease_expires_at = NULL
-       WHERE in_flight IS NOT NULL${condition} RETURNING session_id`
-    );
-  const recoverExpired = releaseClaims(" AND COALESCE(lease_expires_at, 0) <= ?", true);
   // Prepared per owned-token count and kept: a host delivers to a handful of
-  // sessions at most, so the token list is inlined as placeholders.
+  // sessions at most, so the token list is inlined as placeholders. The retry
+  // budget is untouched — a host that was killed did not fail to deliver.
   const foreignStatements = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
   const recoverForeign = (owned: number): ReturnType<DatabaseSync["prepare"]> => {
     const cached = foreignStatements.get(owned);
@@ -198,7 +187,12 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
       owned > 0
         ? ` AND COALESCE(claim_token, '') NOT IN (${Array.from({ length: owned }, () => "?").join(", ")})`
         : "";
-    const statement = releaseClaims(exclusion, false);
+    const statement = db.prepare(
+      `UPDATE session_deadlines
+       SET deadline = MIN(COALESCE(deadline, in_flight), in_flight), in_flight = NULL,
+           claim_token = NULL, lease_expires_at = NULL
+       WHERE in_flight IS NOT NULL${exclusion} RETURNING session_id`
+    );
     foreignStatements.set(owned, statement);
     return statement;
   };
@@ -267,8 +261,6 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
       (recoverForeign(ownedTokens.length).all(...ownedTokens) as Array<{ session_id: string }>).map(
         (row) => row.session_id
       ),
-    recoverExpiredClaims: (now) =>
-      (recoverExpired.all(now) as Array<{ session_id: string }>).map((row) => row.session_id),
     close: () => db.close(),
   };
 }


### PR DESCRIPTION
Part of the [Control plane on AWS (multi-cloud)](https://linear.app/colemurray/project/control-plane-on-aws-multi-cloud-52df5e47330d) roadmap: **N-7b / COL-133**. The jobs poller's review (#1781, #1786) established this host's delivery contract. `HostAlarmClock` merged before it and never got the same treatment, so it carries the same four defects. **Nothing here runs on Cloudflare:** every changed file is `src/node/**` or a doc line, and the worker bundle is unchanged.

## A claim is now a lease

Claiming writes a token and an expiry. Every settlement names the token, so a delivery that comes back after its claim was recovered **cannot settle the claim that replaced it** — previously `complete()` from such a delivery would clear a live claim's `in_flight` and reset its retry count, and the unfenced `dropDisarmed` would delete the row outright.

A claim no live delivery owns belongs to a process that is gone. `recoverForeignClaims(ownedTokens)` runs at start and re-arms it at once — the existing restart behaviour, kept. Naming the claims this process still holds is what makes `start()` idempotent; the old blanket reset would have taken a running delivery's session away from it.

## What an expired lease does, and deliberately does not do

An expired lease stops the delivery **counting against the concurrency bound**, so one handler that never returns cannot narrow the clock for every other session. That is the whole of it. The session is **not** redelivered, and its claim stays on disk for the next start.

The first revision of this PR did redeliver, and that was wrong. `deliver` is `registry.deliverScheduledDeadline`, and the registry's activity leases *count* rather than exclude (`session-runtime-registry.ts:364`), so a second delivery would enter the same runtime beside the handler still executing. Nothing can cancel that handler, and `session_alarm_state` carries no claim token — so the stale one could call `completeDelivery()` and clear a deadline the new one owns. The host-index fence stops the index being corrupted; it is not an end-to-end fence, and freeing the session for redelivery would have introduced a hazard `main` does not have.

So the limitation stands and is now written down: a hung handler still pins its own session until the process restarts. Closing that needs the generation fence to reach the session core, which is a change to shared code on both hosts and does not belong here.

With no redelivery there is nothing to charge, so recovery does not count a failure and the expiry-driven recovery path is gone entirely.

## Three things the clock refuses to do

- **Let a store failure escape a timer task, or spin on one.** `tick()` ran `index.due()` and `index.claim()` — synchronous SQLite — straight out of a `setTimeout`, with the trailing `arm()` outside any guard, so a throw killed the process or silently stopped the clock forever. Catching it was not enough: re-arming then read the deadline it had just failed to claim, still overdue, and scheduled a zero-delay timer, so a failure that persisted became a tight loop. `arm()` takes a floor and the failure path passes one; the regression times out at 5 s without it.
- **Run a deadline past its retry budget.** A recovered claim is refused before delivery once its attempts are spent, as the jobs poller does.
- **Reject a deadline it has already recorded.** `arm()` ends every path, `setAlarm()` included, so a throw from `earliest()` rejected a write that had already landed. It is now total, and falls back to a blind retry interval.
- **Lose a session whose settlement could not be written.** That rejection reached nothing but `drain()`'s `allSettled`. It is logged as `alarm.settle_failed` and the claim is left to its lease.

## Two things this changed on the way

**Two spins, both found by review rather than by me.** A tick that failed re-armed for the deadline it had just failed to claim; and once a delivery is abandoned its claim sits on disk with an expiry already behind us, so arming for *that* scheduled another zero-delay timer. Both regressions hang rather than fail — `Test timed out in 5000ms` — which is the signature worth remembering for a poller. Arming now takes a floor, and only a lease still to come is worth waking for.

**The wake-up is exact, not a poll.** The first cut swept every 60 s, which turned the "deadline farther than one timer can hold" case into ~35,000 timer firings and failed two existing tests. Gating the sweep on `inFlight` was also wrong — a claim outlives the delivery that held it, which the settlement-failure test caught. The clock now asks the index for `earliestLease()` and wakes at the soonest of that and the next deadline. With neither, no timer is set, exactly as before.

**The index opens through the shared helper.** It was the only store this host owns still calling `new DatabaseSync` directly — no WAL, no busy timeout — which made the `SQLITE_BUSY` throw the guards above catch more likely in the first place.

The two lease columns are added to an existing file with `ALTER TABLE`, between the table statement and its indexes — the lease index names a column the migration adds, so creating it in the same batch as the table meant opening any pre-lease file threw `no such column: lease_expires_at` and the host could not boot on an existing volume. A claim written before the columns existed reads as one whose lease has already run out, which is what it is.

## Verification

Index, 11 tests (was 9): the fence refusing both stale settlements, an expired claim counting a failure where a foreign one does not, a live lease and an owned token both left alone, and a file written by an older build — the real pre-lease table, created by the test itself rather than the current schema with its values blanked — opened and its claim freed.

Clock, 27 tests (was 19), on fake timers over a real index: a hung delivery freeing its row and its slot at the lease boundary with the redelivery running, the index throwing from the claim path, from the scheduling path, and from both settlement paths.

Nine regressions checked red by removing each fix:

| Removed | Failure |
|---|---|
| lease release | `expected "vi.fn()" to be called 2 times, but got 1 times` (×2 tests) |
| `tick` guard | `Error: database is locked` out of the timer |
| `arm` guard | `promise rejected "Error: database is locked" instead of resolving` |
| settlement guard | `expected "error" to be called with arguments` + unhandled `disk I/O error` |
| settlement fence | stale `complete`/`retry` mutating a live claim |
| column-before-index ordering | `Error: no such column: lease_expires_at` on opening a pre-lease file |
| abandoned deliveries still counted | `expected [] to deeply equal [ 'other' ]` — one hung session wedges the bound |
| tick-failure backoff | `Test timed out in 5000ms` — the spin |
| over-budget gate | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| elapsed-lease wake-up | `Test timed out in 5000ms` — the second spin |

Unit **3983 passed** (274 files); workerd integration **1178 passed / 1 skipped** (100 files); `tsc` clean on all four programs; eslint, prettier and knip clean (no new knip entries).

## Noted, not changed

`index.complete()` throwing is caught by `deliverTo`'s own `catch` and treated as a delivery failure, so a successful handler whose completion could not be recorded is redelivered and charged a retry. That is at-least-once and safe, but it conflates two things; worth a follow-up rather than widening this change.

`NodeJobs.arm()` still arms a fixed 60-second sweep whenever the poller is running, so an idle host with an empty jobs table wakes every minute forever to find nothing. Harmless, but the exact wake-up this PR gives the clock is strictly better, and the jobs store could answer the same `earliestLease()` question. Left alone to keep this change to one subsystem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alarm delivery reliability when processing hangs or fails.
  - Expired deliveries remain safely tracked and recover after restart without duplicate same-process delivery.
  - Late responses from abandoned deliveries no longer interfere with replacement deliveries.
  - Temporary indexing or scheduling errors no longer stop alarm processing; missed deadlines are retried automatically.
  - Improved recovery when completion or retry operations fail.
  - Excessively failed deliveries are completed instead of retried indefinitely.
  - Existing alarm databases continue working with lease-based delivery recovery.

- **Documentation**
  - Clarified that the host alarm database records delivery lease information alongside scheduled deadlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



