### PR TITLE
feat: hold control-plane SQL to a portable subset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Test complexity reporter
         run: npm run test:lint-complexity
 
+      - name: Check SQL portability
+        run: npm run lint:sql-portability
+
+      - name: Test SQL portability check
+        run: npm run test:lint-sql-portability
+
       - name: Test Owner bootstrap CLI
         run: npm run test:rbac-bootstrap-owner
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,11 @@ Use clear, descriptive commit messages:
 4. Update documentation if needed
 5. Provide a clear description of your changes
 
+### Database Changes
+
+SQL in the control plane must stay inside the portable subset — see
+[docs/PORTABLE_SQL.md](docs/PORTABLE_SQL.md). `npm run lint:sql-portability` checks it.
+
 ### Source Control Provider Contributions
 
 For SCM/provider changes, follow:

--- a/docs/PORTABLE_SQL.md
+++ b/docs/PORTABLE_SQL.md
@@ -1,0 +1,55 @@
+# Portable SQL
+
+Control-plane stores speak to more than one engine. Today that is Cloudflare D1 and the Node host's
+local SQLite; Postgres is the planned engine for container deployments. A store written against
+SQLite-only syntax does not simply fail to compile on the new engine — it has to be rewritten, and
+its migrations have to be forked into a per-engine twin. That cost is paid once per construct, so
+the cheapest time to avoid it is while the statement is being written.
+
+`npm run lint:sql-portability` enforces the subset below over `packages/control-plane/src`
+(excluding tests and `src/node`) and over D1 migrations numbered above the baseline in
+`scripts/sql-portability-baseline.json`. It runs in the `Lint & Format (TypeScript)` CI job.
+
+## The subset
+
+| Instead of                              | Write                                                     |
+| --------------------------------------- | --------------------------------------------------------- |
+| `INSERT OR IGNORE INTO t …`             | `INSERT INTO t … ON CONFLICT DO NOTHING`                  |
+| `INSERT OR REPLACE INTO t …`            | `INSERT INTO t … ON CONFLICT (key) DO UPDATE SET …`       |
+| `?1`, `?2` numbered placeholders        | positional `?`, bound once per occurrence                 |
+| `unixepoch()`, `strftime(…)`            | pass `Date.now()` from TypeScript; format dates there too |
+| `json_object(…)`, `json_group_array(…)` | build the JSON in TypeScript and bind it as a parameter   |
+| `COLLATE NOCASE`                        | `LOWER(column) = LOWER(?)`                                |
+| `AUTOINCREMENT`                         | an application-generated id, or `INTEGER PRIMARY KEY`     |
+| `CREATE TRIGGER`                        | enforce the invariant in the store                        |
+| `PRAGMA …`                              | nothing — pragmas belong in the engine adapter            |
+
+Notes on the two that are easy to get wrong:
+
+- **`OR REPLACE` is not an upsert.** It deletes the conflicting row and inserts a new one, so every
+  column absent from the statement is reset to its default and any delete-side trigger or cascade
+  fires. `ON CONFLICT … DO UPDATE` leaves unlisted columns alone. When converting one, check the
+  table for columns the statement does not name and decide deliberately which behaviour you want.
+- **Date bucketing.** `date(col / 1000, 'unixepoch')` has no Postgres equivalent. Group by the
+  integer day instead — `col / 86400000`, which is integer division on both engines — and render the
+  calendar date in TypeScript with `utcDateFromDayIndex`.
+
+## Scope, and what is deliberately outside it
+
+`packages/control-plane/src/node` is the SQLite adapter itself. Its `PRAGMA journal_mode = WAL`,
+`PRAGMA busy_timeout` and `PRAGMA foreign_keys` calls are the point of the module, and a Postgres
+host would bring its own adapter rather than reinterpret this one. The check skips that directory;
+in exchange, store logic does not belong there — anything a Postgres deployment would also need
+lives in `src/db` or `src/session` and is checked.
+
+Migrations already merged are grandfathered by number, not rewritten. Converting them is a separate
+piece of work; the baseline exists so the pile stops growing meanwhile.
+
+## Exceptions
+
+A construct that genuinely has no portable form is listed in `scripts/sql-portability-baseline.json`
+with a count and a written reason. The counts ratchet: adding an occurrence fails the check, and so
+does removing one until the count is lowered, which keeps the file honest as the debt is paid down.
+
+Adding an entry is a review decision. The reason field should say what the portable form would cost
+here, not merely that one does not exist.

--- a/docs/PORTABLE_SQL.md
+++ b/docs/PORTABLE_SQL.md
@@ -19,12 +19,19 @@ the cheapest time to avoid it is while the statement is being written.
 | `?1`, `?2` numbered placeholders        | positional `?`, bound once per occurrence                 |
 | `unixepoch()`, `strftime(…)`            | pass `Date.now()` from TypeScript; format dates there too |
 | `json_object(…)`, `json_group_array(…)` | build the JSON in TypeScript and bind it as a parameter   |
-| `COLLATE NOCASE`                        | `LOWER(column) = LOWER(?)`                                |
+| `COLLATE NOCASE`                        | see below — the portable form depends on the clause       |
 | `AUTOINCREMENT`                         | an application-generated id, or `INTEGER PRIMARY KEY`     |
 | `CREATE TRIGGER`                        | enforce the invariant in the store                        |
 | `PRAGMA …`                              | nothing — pragmas belong in the engine adapter            |
 
-Notes on the two that are easy to get wrong:
+Notes on the three that are easy to get wrong:
+
+- **`COLLATE NOCASE` has no single replacement.** It is a property of a comparison, so the portable
+  form depends on the clause it sits in: `LOWER(lhs) = LOWER(?)` for equality,
+  `LOWER(lhs) LIKE LOWER(?)` for a pattern match, and `ORDER BY LOWER(expr)` for a sort. Rewriting a
+  `LIKE` or an `ORDER BY` as an equality is not the same query. Note also that `LOWER(expr)` in an
+  `ORDER BY` or a predicate will not use a plain index on `expr`; where that matters, the portable
+  answer is an expression index on `LOWER(expr)`, which both engines support.
 
 - **`OR REPLACE` is not an upsert.** It deletes the conflicting row and inserts a new one, so every
   column absent from the statement is reset to its default and any delete-side trigger or cascade

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   "scripts": {
     "lint": "eslint .",
     "lint:complexity": "node scripts/lint-complexity.mjs",
+    "lint:sql-portability": "node scripts/lint-sql-portability.mjs",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "npm run test --workspaces --if-present",
     "test:lint-complexity": "node --test scripts/lint-complexity-message.test.mjs",
+    "test:lint-sql-portability": "node --test scripts/lint-sql-portability.test.mjs",
     "test:rbac-bootstrap-owner": "node --experimental-transform-types --test scripts/bootstrap-workspace-owner.test.ts",
     "test:user-merge-cli": "node --experimental-transform-types --test scripts/merge-split-users.test.ts",
     "test:coverage": "npm run test:coverage --workspaces --if-present",

--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -7,6 +7,7 @@ import type {
 } from "@open-inspect/shared/types/analytics";
 import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
+import { MS_PER_DAY, utcDateFromDayIndex } from "./utc-day";
 
 /** Spawn sources that represent direct human-initiated sessions. */
 export const HUMAN_SPAWN_SOURCES: SpawnSource[] = ["user", "slack-bot", "linear-bot", "github-bot"];
@@ -31,7 +32,7 @@ interface SummaryRow {
 }
 
 interface TimeseriesRow {
-  date: string;
+  day_index: number;
   group_key: string;
   count: number;
 }
@@ -123,15 +124,15 @@ export class AnalyticsStore {
     return this.db
       .prepare(
         `SELECT
-           date(s.created_at / 1000, 'unixepoch') AS date,
+           s.created_at / ${MS_PER_DAY} AS day_index,
            COALESCE(MAX(NULLIF(u.display_name, '')), MAX(NULLIF(s.scm_login, '')), '__unknown__') AS group_key,
            COUNT(*) AS count
          FROM sessions s
          LEFT JOIN users u ON s.user_id = u.id
          WHERE s.created_at >= ? AND s.created_at < ?
            AND s.spawn_source IN (${placeholders})
-         GROUP BY date, COALESCE(s.user_id, '__unlinked__' || COALESCE(s.scm_login, '__none__'))
-         ORDER BY date ASC, group_key ASC`
+         GROUP BY day_index, COALESCE(s.user_id, '__unlinked__' || COALESCE(s.scm_login, '__none__'))
+         ORDER BY day_index ASC, group_key ASC`
       )
       .bind(filters.startAt, filters.endAt, ...sources);
   }
@@ -139,14 +140,15 @@ export class AnalyticsStore {
   decodeTimeseries(result: SqlResult): AnalyticsTimeseriesResponse {
     const series: AnalyticsTimeseriesResponse["series"] = [];
     for (const row of (result.results ?? []) as TimeseriesRow[]) {
+      const date = utcDateFromDayIndex(row.day_index);
       const lastPoint = series[series.length - 1];
-      if (lastPoint?.date === row.date) {
+      if (lastPoint?.date === date) {
         lastPoint.groups[row.group_key] = (lastPoint.groups[row.group_key] ?? 0) + row.count;
         continue;
       }
 
       series.push({
-        date: row.date,
+        date,
         groups: { [row.group_key]: row.count },
       });
     }

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -1030,7 +1030,7 @@ export class AutomationStore {
   /**
    * Record a skipped firing: a childless invocation carrying skip_reason,
    * atomically paired with the schedule advance when the skip serves a cron
-   * slot. INSERT OR IGNORE tolerates an idempotency-index race without
+   * slot. The conflict-tolerant insert absorbs an idempotency-index race without
    * blocking the advance — a skip recorded without the advance would
    * re-collide on (automation_id, scheduled_at) every tick thereafter. The
    * advance is a compare-and-set on the claimed slot, so a firing that lost
@@ -1043,10 +1043,11 @@ export class AutomationStore {
     const statements: SqlStatement[] = [
       this.db
         .prepare(
-          `INSERT OR IGNORE INTO automation_invocations
+          `INSERT INTO automation_invocations
            (id, automation_id, source, scheduled_at, trigger_key, concurrency_key,
             trigger_metadata, skip_reason, failure_counted_at, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT DO NOTHING`
         )
         .bind(
           invocation.id,
@@ -1091,10 +1092,11 @@ export class AutomationStore {
     const results = await this.db.batch([
       this.db
         .prepare(
-          `INSERT OR IGNORE INTO automation_invocations
+          `INSERT INTO automation_invocations
            (id, automation_id, source, scheduled_at, trigger_key, concurrency_key,
             trigger_metadata, skip_reason, failure_counted_at, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT DO NOTHING`
         )
         .bind(
           invocation.id,

--- a/packages/control-plane/src/db/pull-request-analytics-store.ts
+++ b/packages/control-plane/src/db/pull-request-analytics-store.ts
@@ -13,6 +13,7 @@
 import type { AnalyticsPullRequestsResponse } from "@open-inspect/shared/types/analytics";
 import type { SpawnSource } from "@open-inspect/shared/types/sessions";
 import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
+import { MS_PER_DAY, utcDateFromDayIndex } from "./utc-day";
 
 /** `now` anchors the open-inventory age computation. */
 export interface PullRequestAnalyticsFilters {
@@ -44,7 +45,7 @@ interface InventoryRow {
 }
 
 interface DailyCountRow {
-  date: string;
+  day_index: number;
   count: number;
 }
 
@@ -146,20 +147,20 @@ export class PullRequestAnalyticsStore {
         .bind(filters.now),
       this.db
         .prepare(
-          `SELECT date(${prCreatedAt} / 1000, 'unixepoch') AS date, COUNT(*) AS count
+          `SELECT ${prCreatedAt} / ${MS_PER_DAY} AS day_index, COUNT(*) AS count
              FROM session_pull_requests
              WHERE ${cohortWindow}
-             GROUP BY date
-             ORDER BY date ASC`
+             GROUP BY day_index
+             ORDER BY day_index ASC`
         )
         .bind(...cohortBinds),
       this.db
         .prepare(
-          `SELECT date(merged_at / 1000, 'unixepoch') AS date, COUNT(*) AS count
+          `SELECT merged_at / ${MS_PER_DAY} AS day_index, COUNT(*) AS count
              FROM session_pull_requests
              WHERE lifecycle_state = 'merged' AND merged_at >= ? AND merged_at < ?
-             GROUP BY date
-             ORDER BY date ASC`
+             GROUP BY day_index
+             ORDER BY day_index ASC`
         )
         .bind(filters.startAt, filters.endAt),
       this.db
@@ -210,16 +211,16 @@ export class PullRequestAnalyticsStore {
     const merges = firstRow<MergeRow>(mergesResult);
     const inventory = firstRow<InventoryRow>(inventoryResult);
 
-    const timeseries = new Map<string, { created: number; merged: number }>();
+    const timeseries = new Map<number, { created: number; merged: number }>();
     for (const row of rows<DailyCountRow>(createdResult)) {
-      timeseries.set(row.date, { created: row.count, merged: 0 });
+      timeseries.set(row.day_index, { created: row.count, merged: 0 });
     }
     for (const row of rows<DailyCountRow>(mergedResult)) {
-      const point = timeseries.get(row.date);
+      const point = timeseries.get(row.day_index);
       if (point) {
         point.merged = row.count;
       } else {
-        timeseries.set(row.date, { created: 0, merged: row.count });
+        timeseries.set(row.day_index, { created: 0, merged: row.count });
       }
     }
 
@@ -239,8 +240,8 @@ export class PullRequestAnalyticsStore {
         avgAgeMs: inventory?.avg_age_ms ?? null,
       },
       timeseries: Array.from(timeseries.entries())
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([date, counts]) => ({ date, ...counts })),
+        .sort(([a], [b]) => a - b)
+        .map(([dayIndex, counts]) => ({ date: utcDateFromDayIndex(dayIndex), ...counts })),
       repos: rows<RepoRow>(reposResult).map((row) => ({
         key: row.key,
         created: row.created,

--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -235,7 +235,7 @@ class FakeD1Database {
         number,
         number,
       ];
-      // INSERT OR IGNORE — skip if exists
+      // ON CONFLICT DO NOTHING — skip if exists
       const inserted = !this.rows.has(id);
       if (inserted) {
         const rootSessionId = rootParentId

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -318,10 +318,16 @@ export class SessionIndexStore {
     const providerAuthStmts = (session.providerAuth ?? []).map((auth) =>
       this.db
         .prepare(
-          `INSERT OR REPLACE INTO session_model_provider_auth (
+          `INSERT INTO session_model_provider_auth (
              session_id, provider, auth_mode, provider_account_id, selection_source,
              inherited_from_session_id, created_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+           ) VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (session_id, provider) DO UPDATE SET
+             auth_mode = excluded.auth_mode,
+             provider_account_id = excluded.provider_account_id,
+             selection_source = excluded.selection_source,
+             inherited_from_session_id = excluded.inherited_from_session_id,
+             created_at = excluded.created_at`
         )
         .bind(
           session.id,
@@ -486,18 +492,18 @@ export class SessionIndexStore {
     const row = await this.db
       .prepare(
         `SELECT 1 AS ok FROM sessions
-         WHERE id = ?1
+         WHERE id = ?
            AND (
-             (LOWER(repo_owner) = LOWER(?2) AND LOWER(repo_name) = LOWER(?3))
+             (LOWER(repo_owner) = LOWER(?) AND LOWER(repo_name) = LOWER(?))
              OR EXISTS (
                SELECT 1 FROM session_repositories sr
                WHERE sr.session_id = sessions.id
-                 AND LOWER(sr.repo_owner) = LOWER(?2)
-                 AND LOWER(sr.repo_name) = LOWER(?3)
+                 AND LOWER(sr.repo_owner) = LOWER(?)
+                 AND LOWER(sr.repo_name) = LOWER(?)
              )
            )`
       )
-      .bind(sessionId, repoOwner, repoName)
+      .bind(sessionId, repoOwner, repoName, repoOwner, repoName)
       .first<{ ok: number }>();
 
     return row !== null;

--- a/packages/control-plane/src/db/slack-channel-store.ts
+++ b/packages/control-plane/src/db/slack-channel-store.ts
@@ -61,7 +61,8 @@ export class SlackChannelStore {
       statements.push(
         this.db
           .prepare(
-            "INSERT OR IGNORE INTO automation_slack_channels (automation_id, channel_id) VALUES (?, ?)"
+            `INSERT INTO automation_slack_channels (automation_id, channel_id)
+             VALUES (?, ?) ON CONFLICT DO NOTHING`
           )
           .bind(automationId, channelId)
       );

--- a/packages/control-plane/src/db/user-merge.ts
+++ b/packages/control-plane/src/db/user-merge.ts
@@ -446,13 +446,14 @@ export async function mergeUsers(
     "skillProfileItemsMerged",
     db
       .prepare(
-        `INSERT OR IGNORE INTO skill_profile_items (profile_id, skill_id)
+        `INSERT INTO skill_profile_items (profile_id, skill_id)
          SELECT survivor_profile.id, loser_item.skill_id
          FROM skill_profiles loser_profile
          JOIN skill_profiles survivor_profile
            ON survivor_profile.user_id = ? AND survivor_profile.name = loser_profile.name
          JOIN skill_profile_items loser_item ON loser_item.profile_id = loser_profile.id
-         WHERE loser_profile.user_id = ?`
+         WHERE loser_profile.user_id = ?
+         ON CONFLICT DO NOTHING`
       )
       .bind(survivorId, loserId)
   );

--- a/packages/control-plane/src/db/utc-day.ts
+++ b/packages/control-plane/src/db/utc-day.ts
@@ -1,0 +1,13 @@
+/** Milliseconds in one UTC day. */
+export const MS_PER_DAY = 86_400_000;
+
+/**
+ * Renders a UTC day index — a millisecond epoch integer-divided by
+ * {@link MS_PER_DAY} — as `YYYY-MM-DD`.
+ *
+ * Day bucketing stays in SQL as `<column> / 86400000`, which is integer
+ * division on SQLite and Postgres alike; calendar formatting stays here.
+ */
+export function utcDateFromDayIndex(dayIndex: number): string {
+  return new Date(dayIndex * MS_PER_DAY).toISOString().slice(0, 10);
+}

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -76,9 +76,7 @@ describe("applyMigrations", () => {
     expect(selectCall).toBeDefined();
 
     // Each migration produces an exec call + an INSERT
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     expect(inserts).toHaveLength(MIGRATIONS.length);
 
     // Verify all IDs are recorded
@@ -94,9 +92,7 @@ describe("applyMigrations", () => {
     applyMigrations(mock.sql);
 
     // Should only have CREATE TABLE + SELECT, no migration execs or inserts
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     expect(inserts).toHaveLength(0);
 
     const alterCalls = mock.calls.filter((c) => c.query.includes("ALTER TABLE"));
@@ -110,9 +106,7 @@ describe("applyMigrations", () => {
 
     applyMigrations(mock.sql);
 
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     // Migrations 11 through MIGRATIONS.length
     const unappliedCount = MIGRATIONS.length - 10;
     expect(inserts).toHaveLength(unappliedCount);
@@ -144,8 +138,7 @@ describe("applyMigrations", () => {
 
     expect(
       mock.calls.some(
-        ({ query, params }) =>
-          query.includes("INSERT OR IGNORE INTO _schema_migrations") && params[0] === 23
+        ({ query, params }) => query.includes("INSERT INTO _schema_migrations") && params[0] === 23
       )
     ).toBe(false);
   });
@@ -193,9 +186,7 @@ describe("applyMigrations", () => {
     expect(() => applyMigrations(mock.sql)).not.toThrow();
 
     // All migrations should still be recorded
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     expect(inserts).toHaveLength(MIGRATIONS.length);
   });
 
@@ -209,9 +200,7 @@ describe("applyMigrations", () => {
 
     applyMigrations(mock.sql);
 
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     expect(inserts).toHaveLength(0);
   });
 
@@ -229,9 +218,7 @@ describe("applyMigrations", () => {
   it("records applied_at timestamp", () => {
     applyMigrations(mock.sql);
 
-    const inserts = mock.calls.filter((c) =>
-      c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
-    );
+    const inserts = mock.calls.filter((c) => c.query.includes("INSERT INTO _schema_migrations"));
     // Second param should be the timestamp
     for (const insert of inserts) {
       expect(insert.params[1]).toBe(1000);

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -695,7 +695,7 @@ export function applyMigrations(sql: SqlStorage): void {
     }
 
     sql.exec(
-      `INSERT OR IGNORE INTO _schema_migrations (id, applied_at) VALUES (?, ?)`,
+      `INSERT INTO _schema_migrations (id, applied_at) VALUES (?, ?) ON CONFLICT DO NOTHING`,
       migration.id,
       Date.now()
     );

--- a/packages/control-plane/src/session/session-core-repository.test.ts
+++ b/packages/control-plane/src/session/session-core-repository.test.ts
@@ -4,7 +4,10 @@
  * Uses a mock SqlStorage to verify SQL operations are called correctly.
  */
 
+import { DatabaseSync } from "node:sqlite";
 import { describe, it, expect, beforeEach } from "vitest";
+import { createNodeSqlStorage } from "../node/sqlite-storage";
+import { initSchema } from "./schema";
 import { SessionCoreRepository } from "./session-core-repository";
 import type { SqlResult, SqlStorage } from "./sql-storage";
 
@@ -110,7 +113,8 @@ describe("SessionCoreRepository", () => {
       });
 
       expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("INSERT OR REPLACE INTO session");
+      expect(mock.calls[0].query).toContain("INSERT INTO session");
+      expect(mock.calls[0].query).toContain("ON CONFLICT (id) DO UPDATE SET");
       expect(mock.calls[0].params).toEqual([
         "sess-1",
         "test-session",
@@ -243,6 +247,45 @@ describe("SessionCoreRepository", () => {
       expect(mock.calls[0].query).toContain("SET total_cost = total_cost + ?");
       expect(mock.calls[0].query).toContain("updated_at = ?");
       expect(mock.calls[0].params).toEqual([0.0123, 5000]);
+    });
+  });
+
+  describe("upsertSession against real storage", () => {
+    it("overwrites the columns it names and leaves working state alone", () => {
+      const db = new DatabaseSync(":memory:");
+      const storage = createNodeSqlStorage(db);
+      const realRepo = new SessionCoreRepository(storage.sql, storage.transactionSync);
+
+      try {
+        initSchema(storage.sql);
+        const base = {
+          id: "sess-1",
+          sessionName: "test-session",
+          title: "First",
+          repoOwner: "owner",
+          repoName: "repo",
+          repoId: 42,
+          model: "claude-sonnet-4",
+          status: "created" as const,
+          createdAt: 1000,
+          updatedAt: 1000,
+        };
+        realRepo.upsertSession(base);
+        realRepo.updateSessionBranch("sess-1", "feature/x");
+        realRepo.addSessionCost(1.5, 2000);
+
+        realRepo.upsertSession({ ...base, title: "Second", updatedAt: 3000 });
+
+        expect(realRepo.getSession()).toMatchObject({
+          id: "sess-1",
+          title: "Second",
+          updated_at: 3000,
+          branch_name: "feature/x",
+          total_cost: 1.5,
+        });
+      } finally {
+        db.close();
+      }
     });
   });
 

--- a/packages/control-plane/src/session/session-core-repository.ts
+++ b/packages/control-plane/src/session/session-core-repository.ts
@@ -61,6 +61,12 @@ export class SessionCoreRepository {
     return rows[0] ?? null;
   }
 
+  /**
+   * Writes the session row. On a repeat for the same id every named column
+   * takes the new value; working state the aggregate accumulates elsewhere
+   * (branch_name, base_sha, current_sha, opencode_session_id, total_cost) is
+   * left as it stands.
+   */
   upsertSession(data: UpsertSessionData): void {
     const hasRepoOwner = data.repoOwner !== null;
     const hasRepoName = data.repoName !== null;
@@ -72,8 +78,27 @@ export class SessionCoreRepository {
     }
 
     this.sql.exec(
-      `INSERT OR REPLACE INTO session (id, session_name, title, repo_owner, repo_name, repo_id, base_branch, model, reasoning_effort, status, parent_session_id, spawn_source, spawn_depth, code_server_enabled, vnc_enabled, sandbox_settings, environment_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO session (id, session_name, title, repo_owner, repo_name, repo_id, base_branch, model, reasoning_effort, status, parent_session_id, spawn_source, spawn_depth, code_server_enabled, vnc_enabled, sandbox_settings, environment_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO UPDATE SET
+         session_name = excluded.session_name,
+         title = excluded.title,
+         repo_owner = excluded.repo_owner,
+         repo_name = excluded.repo_name,
+         repo_id = excluded.repo_id,
+         base_branch = excluded.base_branch,
+         model = excluded.model,
+         reasoning_effort = excluded.reasoning_effort,
+         status = excluded.status,
+         parent_session_id = excluded.parent_session_id,
+         spawn_source = excluded.spawn_source,
+         spawn_depth = excluded.spawn_depth,
+         code_server_enabled = excluded.code_server_enabled,
+         vnc_enabled = excluded.vnc_enabled,
+         sandbox_settings = excluded.sandbox_settings,
+         environment_id = excluded.environment_id,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at`,
       data.id,
       data.sessionName,
       data.title,

--- a/packages/control-plane/src/session/ws-client-mapping-repository.test.ts
+++ b/packages/control-plane/src/session/ws-client-mapping-repository.test.ts
@@ -31,7 +31,8 @@ describe("WsClientMappingRepository", () => {
       createdAt: 1000,
       authorizationExpiresAt: 2000,
     });
-    expect(mock.calls[0].query).toContain("INSERT OR REPLACE INTO ws_client_mapping");
+    expect(mock.calls[0].query).toContain("INSERT INTO ws_client_mapping");
+    expect(mock.calls[0].query).toContain("ON CONFLICT (ws_id) DO UPDATE SET");
     expect(mock.calls[0].params).toEqual(["ws-1", "p-1", "client-1", 1000, 2000]);
   });
 

--- a/packages/control-plane/src/session/ws-client-mapping-repository.ts
+++ b/packages/control-plane/src/session/ws-client-mapping-repository.ts
@@ -31,9 +31,14 @@ export class WsClientMappingRepository {
   /** Persist a client mapping and its authorization expiration. */
   upsertWsClientMapping(data: WsClientMappingData): void {
     this.sql.exec(
-      `INSERT OR REPLACE INTO ws_client_mapping
+      `INSERT INTO ws_client_mapping
          (ws_id, participant_id, client_id, created_at, authorization_expires_at)
-       VALUES (?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT (ws_id) DO UPDATE SET
+         participant_id = excluded.participant_id,
+         client_id = excluded.client_id,
+         created_at = excluded.created_at,
+         authorization_expires_at = excluded.authorization_expires_at`,
       data.wsId,
       data.participantId,
       data.clientId,

--- a/packages/control-plane/test/integration/automation-invocations.test.ts
+++ b/packages/control-plane/test/integration/automation-invocations.test.ts
@@ -536,7 +536,7 @@ describe("automation invocations (D1 integration)", () => {
       expect(await countRows("automation_invocations", "skip_reason IS NOT NULL")).toBe(1);
     });
 
-    it("hands the slot over exactly once when two skips collide (INSERT OR IGNORE)", async () => {
+    it("hands the slot over exactly once when two skips collide (ON CONFLICT DO NOTHING)", async () => {
       const store = new AutomationStore(env.DB);
       await store.create(makeAutomation({ id: "auto-s2", next_run_at: 1_000 }));
 

--- a/scripts/lint-sql-portability.mjs
+++ b/scripts/lint-sql-portability.mjs
@@ -7,16 +7,24 @@
  * becomes a migration twin or a store rewrite then, so this check holds the
  * line at the portable subset documented in docs/PORTABLE_SQL.md.
  *
- * Scope:
- *   - TypeScript under packages/control-plane/src, excluding tests and
- *     src/node (that directory is the SQLite driver itself: its job is to
- *     speak SQLite).
- *   - terraform/d1/migrations/NNNN_*.sql numbered above the checked-in
- *     baseline. Migrations at or below it are grandfathered.
+ * Scope is the storage contract, not the directory tree. Checked: TypeScript
+ * under packages/control-plane/src whose SQL goes to the engine-neutral
+ * `SqlDatabase`. Not checked:
+ *   - src/node, the SQLite adapter itself; speaking SQLite is its job.
+ *   - any file naming `SqlStorage`, the session Durable Object's synchronous
+ *     engine, which src/db/sql-database.ts states is "a different engine with
+ *     a load-bearing sync contract, and is intentionally not covered by this
+ *     port". Holding it to Postgres policy would be a category error — its
+ *     PRAGMA introspection is adapter surface, not portability debt.
+ *   - every terraform/d1/migrations/*.sql except the ones named in the
+ *     baseline's `grandfatheredMigrations`. Naming them rather than taking
+ *     everything below a number is what stops a new migration from being
+ *     written into the gap the numbering leaves.
  *
  * Occurrences that must stay are listed with a reason in
- * scripts/sql-portability-baseline.json. The counts there are a ratchet:
- * adding one fails, and removing one fails until the baseline is lowered.
+ * scripts/sql-portability-baseline.json, which lists the exact text of each
+ * one rather than a count: a ratchet in both directions, and one that a
+ * swapped construct cannot slip through while the total stays the same.
  *
  * Usage: node scripts/lint-sql-portability.mjs
  */
@@ -58,7 +66,8 @@ export const RULES = [
   {
     id: "collate-nocase",
     pattern: /\bCOLLATE\s+NOCASE\b/gi,
-    portable: "LOWER(column) = LOWER(?)",
+    portable:
+      "LOWER(lhs) = LOWER(?) for equality, LOWER(lhs) LIKE LOWER(?) for a match, ORDER BY LOWER(expr) for a sort",
   },
   {
     id: "autoincrement",
@@ -67,35 +76,136 @@ export const RULES = [
   },
   {
     id: "json-function",
-    pattern: /\bjson(?:_[a-z_]+)?\s*\(/g,
+    pattern: /\bjson(?:_[a-z_]+)?\s*\(/gi,
     portable: "build the JSON in TypeScript and bind it as a parameter",
+  },
+  {
+    id: "numbered-placeholder",
+    pattern: /\?\d+/g,
+    portable: "positional ?, bound in order",
   },
 ];
 
-/** A literal reads as SQL when it contains a statement this codebase issues. */
-const SQL_SHAPE =
-  /\b(SELECT\s|INSERT\s+INTO\b|INSERT\s+OR\s+(IGNORE|REPLACE|ABORT|FAIL|ROLLBACK)\b|UPDATE\s+[a-z_"]+\s+SET\b|DELETE\s+FROM\b|CREATE\s+(TABLE|INDEX|TRIGGER|VIEW|UNIQUE)\b|ALTER\s+TABLE\b|DROP\s+(TABLE|INDEX|TRIGGER|VIEW)\b|WITH\s+[a-z_]+\s+AS\s*\()/i;
+/**
+ * A pragma is the whole statement, so it is recognised only as a literal of
+ * the shape `PRAGMA name`, `PRAGMA name = value` or `PRAGMA name(argument)`.
+ * Prose that opens with the word does not qualify. Every other rule matches a
+ * token that means nothing outside SQL, so those run over every literal —
+ * including a fragment that carries no statement of its own, which is how
+ * this codebase composes a `WHERE` clause.
+ */
+const SQL_PRAGMA = /^\s*PRAGMA\s+[a-z_]+\s*(?:[(=]|$)/i;
 
 /**
- * A pragma is always the whole statement, so it is recognised only as a
- * literal of the shape `PRAGMA name`, `PRAGMA name = value` or
- * `PRAGMA name(argument)`. Prose that opens with the word does not qualify.
+ * The contents of every string and template literal in TypeScript source,
+ * with the offset each begins at.
+ *
+ * A scanner rather than a regex: a regex cannot tell a quote that opens a
+ * literal from one inside another literal or a comment, and desynchronising
+ * once makes the rest of the file one long "literal". Comments are skipped,
+ * because SQL quoted in one is documentation and reporting it would make the
+ * check reject its own explanations. A template yields one literal per chunk
+ * between substitutions, and the substitutions themselves are scanned as the
+ * code they are.
  */
-const SQL_PRAGMA = /^[`'"]\s*PRAGMA\s+[a-z_]+\s*[(=]|^[`'"]\s*PRAGMA\s+[a-z_]+\s*[`'"]/i;
-
-/**
- * String and template literals in TypeScript source, with the offset of each.
- * A regex scan rather than a parse: it over-reports at worst, and SQL_SHAPE
- * then discards anything that is not a statement.
- */
-function stringLiterals(source) {
+export function stringLiterals(source) {
   const literals = [];
-  const scanner = /`(?:\\.|\$\{[^}]*\}|[^\\`])*`|"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/gs;
-  let match;
-  while ((match = scanner.exec(source)) !== null) {
-    literals.push({ text: match[0], offset: match.index });
-  }
+  scanCode(source, 0, literals, false);
   return literals;
+}
+
+/**
+ * Scan code, collecting the literals in it. With `untilBrace`, stops after
+ * the `}` that closes the substitution this call is scanning and returns the
+ * index past it.
+ */
+function scanCode(source, start, literals, untilBrace) {
+  let i = start;
+  let depth = 0;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === "/" && source[i + 1] === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && source[i + 1] === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      i = scanQuoted(source, i, literals);
+      continue;
+    }
+    if (c === "`") {
+      i = scanTemplate(source, i, literals);
+      continue;
+    }
+    if (untilBrace) {
+      if (c === "{") depth++;
+      else if (c === "}") {
+        if (depth === 0) return i + 1;
+        depth--;
+      }
+    }
+    i++;
+  }
+  return i;
+}
+
+/** Read one `'`- or `"`-quoted literal; an unterminated one is not a literal. */
+function scanQuoted(source, start, literals) {
+  const quote = source[start];
+  let i = start + 1;
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (source[i] === "\n") return start + 1;
+    if (source[i] === quote) {
+      literals.push({ text: source.slice(start + 1, i), offset: start + 1 });
+      return i + 1;
+    }
+    i++;
+  }
+  return start + 1;
+}
+
+/** Read a template literal, emitting each chunk between substitutions. */
+function scanTemplate(source, start, literals) {
+  let i = start + 1;
+  let chunk = i;
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (source[i] === "`") {
+      literals.push({ text: source.slice(chunk, i), offset: chunk });
+      return i + 1;
+    }
+    if (source[i] === "$" && source[i + 1] === "{") {
+      literals.push({ text: source.slice(chunk, i), offset: chunk });
+      i = scanCode(source, i + 2, literals, true);
+      chunk = i;
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/** The members of `from` left after removing one of each member of `remove`. */
+function withoutFirst(from, remove) {
+  const left = [...remove];
+  return from.filter((item) => {
+    const at = left.indexOf(item);
+    if (at === -1) return true;
+    left.splice(at, 1);
+    return false;
+  });
 }
 
 function lineOf(source, offset) {
@@ -104,9 +214,9 @@ function lineOf(source, offset) {
   return line;
 }
 
-export function findingsInSql(text, baseOffset, source, file) {
+export function findingsIn(text, baseOffset, source, file, rules = RULES) {
   const found = [];
-  for (const rule of RULES) {
+  for (const rule of rules) {
     rule.pattern.lastIndex = 0;
     let match;
     while ((match = rule.pattern.exec(text)) !== null) {
@@ -125,8 +235,8 @@ export function findingsInSql(text, baseOffset, source, file) {
 export function scanTypeScript(file, source) {
   const found = [];
   for (const literal of stringLiterals(source)) {
-    if (!SQL_SHAPE.test(literal.text) && !SQL_PRAGMA.test(literal.text)) continue;
-    found.push(...findingsInSql(literal.text, literal.offset, source, file));
+    const rules = SQL_PRAGMA.test(literal.text) ? RULES : RULES.filter((r) => r.id !== "pragma");
+    found.push(...findingsIn(literal.text, literal.offset, source, file, rules));
   }
   return found;
 }
@@ -140,22 +250,67 @@ function walk(dir, out = []) {
   return out;
 }
 
+/** Whether the file's SQL belongs to the session engine rather than the port. */
+export function targetsSessionEngine(source) {
+  return /\bSqlStorage\b/.test(source);
+}
+
 function controlPlaneSources() {
   const root = join(repoRoot, "packages/control-plane/src");
   return walk(root)
     .filter((file) => file.endsWith(".ts") && !file.endsWith(".test.ts"))
     .filter((file) => !relative(root, file).split(sep).includes("node"))
+    .filter((file) => !targetsSessionEngine(readFileSync(file, "utf8")))
     .sort();
+}
+
+/**
+ * Migration text with its comments blanked, offsets preserved so a finding
+ * still reports the line it is on. A comment is documentation: a migration
+ * that says why it avoids AUTOINCREMENT must not be read as using it.
+ */
+export function maskSqlComments(sql) {
+  let out = "";
+  let i = 0;
+  while (i < sql.length) {
+    if (sql[i] === "'" || sql[i] === '"') {
+      const quote = sql[i];
+      let j = i + 1;
+      // SQL escapes a quote by doubling it, so a pair is not the end.
+      while (j < sql.length && !(sql[j] === quote && sql[j + 1] !== quote)) {
+        j += sql[j] === quote ? 2 : 1;
+      }
+      out += sql.slice(i, Math.min(j + 1, sql.length));
+      i = j + 1;
+      continue;
+    }
+    if (sql[i] === "-" && sql[i + 1] === "-") {
+      while (i < sql.length && sql[i] !== "\n") {
+        out += " ";
+        i++;
+      }
+      continue;
+    }
+    if (sql[i] === "/" && sql[i + 1] === "*") {
+      while (i < sql.length && !(sql[i] === "*" && sql[i + 1] === "/")) {
+        out += sql[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      out += "  ";
+      i += 2;
+      continue;
+    }
+    out += sql[i];
+    i++;
+  }
+  return out;
 }
 
 function newMigrations() {
   const root = join(repoRoot, "terraform/d1/migrations");
   return readdirSync(root)
     .filter((name) => name.endsWith(".sql"))
-    .filter((name) => {
-      const number = Number.parseInt(name.slice(0, 4), 10);
-      return Number.isInteger(number) && number > baseline.migrationBaseline;
-    })
+    .filter((name) => !baseline.grandfatheredMigrations.includes(name))
     .map((name) => join(root, name))
     .sort();
 }
@@ -169,32 +324,45 @@ function main() {
   for (const file of newMigrations()) {
     const rel = relative(repoRoot, file);
     const source = readFileSync(file, "utf8");
-    findings.push(...findingsInSql(source, 0, source, rel));
+    findings.push(...findingsIn(maskSqlComments(source), 0, source, rel));
   }
 
-  const counted = new Map();
+  // Grouped by file and rule, and compared as a multiset of the matched text
+  // rather than a count: swapping one allowed construct for a different one
+  // of the same rule would keep the count and change the SQL.
+  const found = new Map();
   for (const finding of findings) {
     const key = `${finding.file} ${finding.rule}`;
-    counted.set(key, (counted.get(key) ?? 0) + 1);
+    if (!found.has(key)) found.set(key, []);
+    found.get(key).push(finding);
   }
 
   const errors = [];
-  for (const finding of findings) {
-    const allowed = baseline.allowed[finding.file]?.[finding.rule]?.count ?? 0;
-    if (counted.get(`${finding.file} ${finding.rule}`) <= allowed) continue;
-    errors.push(
-      `${finding.file}:${finding.line}  ${finding.rule}  ${finding.text}\n` +
-        `    portable form: ${finding.portable}`
-    );
-  }
-
   const stale = [];
-  for (const [file, rules] of Object.entries(baseline.allowed)) {
-    for (const [rule, entry] of Object.entries(rules)) {
-      const actual = counted.get(`${file} ${rule}`) ?? 0;
-      if (actual < entry.count) {
-        stale.push(`${file}  ${rule}: baseline allows ${entry.count}, found ${actual}`);
-      }
+  const keys = new Set([
+    ...found.keys(),
+    ...Object.entries(baseline.allowed).flatMap(([file, rules]) =>
+      Object.keys(rules).map((rule) => `${file} ${rule}`)
+    ),
+  ]);
+  for (const key of [...keys].sort()) {
+    const [file, rule] = [key.slice(0, key.lastIndexOf(" ")), key.slice(key.lastIndexOf(" ") + 1)];
+    const occurrences = found.get(key) ?? [];
+    const allowed = [...(baseline.allowed[file]?.[rule]?.occurrences ?? [])].sort();
+    const actual = occurrences.map((finding) => finding.text).sort();
+    if (allowed.join("\u0000") === actual.join("\u0000")) continue;
+    const surplus = withoutFirst(actual, allowed);
+    for (const finding of occurrences.filter((f) => surplus.includes(f.text))) {
+      errors.push(
+        `${finding.file}:${finding.line}  ${finding.rule}  ${finding.text}\n` +
+          `    portable form: ${finding.portable}`
+      );
+    }
+    const missing = withoutFirst(allowed, actual);
+    if (missing.length > 0) {
+      stale.push(
+        `${file}  ${rule}: baseline still allows ${missing.join(", ")}, no longer present`
+      );
     }
   }
 
@@ -203,7 +371,7 @@ function main() {
     for (const error of errors) console.error(error);
     console.error(
       "\nRewrite in the portable subset (docs/PORTABLE_SQL.md), or, if the " +
-        "construct must stay, raise its count in scripts/sql-portability-baseline.json " +
+        "construct must stay, list it in scripts/sql-portability-baseline.json " +
         "with a reason."
     );
   }

--- a/scripts/lint-sql-portability.mjs
+++ b/scripts/lint-sql-portability.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Fails when control-plane SQL uses a construct that only SQLite understands.
+ *
+ * The control plane's stores run today on D1 and on Node-hosted SQLite, and
+ * are slated to run on Postgres. Every SQLite-only construct written now
+ * becomes a migration twin or a store rewrite then, so this check holds the
+ * line at the portable subset documented in docs/PORTABLE_SQL.md.
+ *
+ * Scope:
+ *   - TypeScript under packages/control-plane/src, excluding tests and
+ *     src/node (that directory is the SQLite driver itself: its job is to
+ *     speak SQLite).
+ *   - terraform/d1/migrations/NNNN_*.sql numbered above the checked-in
+ *     baseline. Migrations at or below it are grandfathered.
+ *
+ * Occurrences that must stay are listed with a reason in
+ * scripts/sql-portability-baseline.json. The counts there are a ratchet:
+ * adding one fails, and removing one fails until the baseline is lowered.
+ *
+ * Usage: node scripts/lint-sql-portability.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const baselinePath = join(repoRoot, "scripts/sql-portability-baseline.json");
+const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+
+export const RULES = [
+  {
+    id: "insert-or",
+    pattern: /\bINSERT\s+OR\s+(IGNORE|REPLACE|ABORT|FAIL|ROLLBACK)\b/gi,
+    portable: "INSERT ... ON CONFLICT DO NOTHING / ON CONFLICT (...) DO UPDATE SET ...",
+  },
+  {
+    id: "create-trigger",
+    pattern: /\bCREATE\s+(?:TEMP\s+|TEMPORARY\s+)?TRIGGER\b/gi,
+    portable: "enforce the invariant in the store, not in a trigger",
+  },
+  {
+    id: "strftime",
+    pattern: /\bstrftime\s*\(/gi,
+    portable: "format the timestamp in TypeScript",
+  },
+  {
+    id: "unixepoch",
+    pattern: /\bunixepoch\b/gi,
+    portable: "pass Date.now() in the column's unit, or bucket with integer division",
+  },
+  {
+    id: "pragma",
+    pattern: /\bPRAGMA\b/gi,
+    portable: "no portable form; keep engine setup and introspection in the adapter",
+  },
+  {
+    id: "collate-nocase",
+    pattern: /\bCOLLATE\s+NOCASE\b/gi,
+    portable: "LOWER(column) = LOWER(?)",
+  },
+  {
+    id: "autoincrement",
+    pattern: /\bAUTOINCREMENT\b/gi,
+    portable: "an application-generated id, or a plain INTEGER PRIMARY KEY",
+  },
+  {
+    id: "json-function",
+    pattern: /\bjson(?:_[a-z_]+)?\s*\(/g,
+    portable: "build the JSON in TypeScript and bind it as a parameter",
+  },
+];
+
+/** A literal reads as SQL when it contains a statement this codebase issues. */
+const SQL_SHAPE =
+  /\b(SELECT\s|INSERT\s+INTO\b|INSERT\s+OR\s+(IGNORE|REPLACE|ABORT|FAIL|ROLLBACK)\b|UPDATE\s+[a-z_"]+\s+SET\b|DELETE\s+FROM\b|CREATE\s+(TABLE|INDEX|TRIGGER|VIEW|UNIQUE)\b|ALTER\s+TABLE\b|DROP\s+(TABLE|INDEX|TRIGGER|VIEW)\b|WITH\s+[a-z_]+\s+AS\s*\()/i;
+
+/**
+ * A pragma is always the whole statement, so it is recognised only as a
+ * literal of the shape `PRAGMA name`, `PRAGMA name = value` or
+ * `PRAGMA name(argument)`. Prose that opens with the word does not qualify.
+ */
+const SQL_PRAGMA = /^[`'"]\s*PRAGMA\s+[a-z_]+\s*[(=]|^[`'"]\s*PRAGMA\s+[a-z_]+\s*[`'"]/i;
+
+/**
+ * String and template literals in TypeScript source, with the offset of each.
+ * A regex scan rather than a parse: it over-reports at worst, and SQL_SHAPE
+ * then discards anything that is not a statement.
+ */
+function stringLiterals(source) {
+  const literals = [];
+  const scanner = /`(?:\\.|\$\{[^}]*\}|[^\\`])*`|"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'/gs;
+  let match;
+  while ((match = scanner.exec(source)) !== null) {
+    literals.push({ text: match[0], offset: match.index });
+  }
+  return literals;
+}
+
+function lineOf(source, offset) {
+  let line = 1;
+  for (let i = 0; i < offset; i++) if (source[i] === "\n") line++;
+  return line;
+}
+
+export function findingsInSql(text, baseOffset, source, file) {
+  const found = [];
+  for (const rule of RULES) {
+    rule.pattern.lastIndex = 0;
+    let match;
+    while ((match = rule.pattern.exec(text)) !== null) {
+      found.push({
+        file,
+        line: lineOf(source, baseOffset + match.index),
+        rule: rule.id,
+        text: match[0].replace(/\s+/g, " "),
+        portable: rule.portable,
+      });
+    }
+  }
+  return found;
+}
+
+export function scanTypeScript(file, source) {
+  const found = [];
+  for (const literal of stringLiterals(source)) {
+    if (!SQL_SHAPE.test(literal.text) && !SQL_PRAGMA.test(literal.text)) continue;
+    found.push(...findingsInSql(literal.text, literal.offset, source, file));
+  }
+  return found;
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+function controlPlaneSources() {
+  const root = join(repoRoot, "packages/control-plane/src");
+  return walk(root)
+    .filter((file) => file.endsWith(".ts") && !file.endsWith(".test.ts"))
+    .filter((file) => !relative(root, file).split(sep).includes("node"))
+    .sort();
+}
+
+function newMigrations() {
+  const root = join(repoRoot, "terraform/d1/migrations");
+  return readdirSync(root)
+    .filter((name) => name.endsWith(".sql"))
+    .filter((name) => {
+      const number = Number.parseInt(name.slice(0, 4), 10);
+      return Number.isInteger(number) && number > baseline.migrationBaseline;
+    })
+    .map((name) => join(root, name))
+    .sort();
+}
+
+function main() {
+  const findings = [];
+  for (const file of controlPlaneSources()) {
+    const rel = relative(repoRoot, file);
+    findings.push(...scanTypeScript(rel, readFileSync(file, "utf8")));
+  }
+  for (const file of newMigrations()) {
+    const rel = relative(repoRoot, file);
+    const source = readFileSync(file, "utf8");
+    findings.push(...findingsInSql(source, 0, source, rel));
+  }
+
+  const counted = new Map();
+  for (const finding of findings) {
+    const key = `${finding.file} ${finding.rule}`;
+    counted.set(key, (counted.get(key) ?? 0) + 1);
+  }
+
+  const errors = [];
+  for (const finding of findings) {
+    const allowed = baseline.allowed[finding.file]?.[finding.rule]?.count ?? 0;
+    if (counted.get(`${finding.file} ${finding.rule}`) <= allowed) continue;
+    errors.push(
+      `${finding.file}:${finding.line}  ${finding.rule}  ${finding.text}\n` +
+        `    portable form: ${finding.portable}`
+    );
+  }
+
+  const stale = [];
+  for (const [file, rules] of Object.entries(baseline.allowed)) {
+    for (const [rule, entry] of Object.entries(rules)) {
+      const actual = counted.get(`${file} ${rule}`) ?? 0;
+      if (actual < entry.count) {
+        stale.push(`${file}  ${rule}: baseline allows ${entry.count}, found ${actual}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`SQL portability: ${errors.length} disallowed construct(s).\n`);
+    for (const error of errors) console.error(error);
+    console.error(
+      "\nRewrite in the portable subset (docs/PORTABLE_SQL.md), or, if the " +
+        "construct must stay, raise its count in scripts/sql-portability-baseline.json " +
+        "with a reason."
+    );
+  }
+  if (stale.length > 0) {
+    console.error(
+      `\nSQL portability: ${stale.length} stale baseline entr(ies) — lower the ` +
+        `count in scripts/sql-portability-baseline.json.\n`
+    );
+    for (const entry of stale) console.error(`  ${entry}`);
+  }
+  if (errors.length > 0 || stale.length > 0) process.exit(1);
+
+  console.log(
+    `SQL portability: clean (${findings.length} baselined occurrence(s) across ` +
+      `${Object.keys(baseline.allowed).length} file(s)).`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/lint-sql-portability.mjs
+++ b/scripts/lint-sql-portability.mjs
@@ -250,9 +250,63 @@ function walk(dir, out = []) {
   return out;
 }
 
-/** Whether the file's SQL belongs to the session engine rather than the port. */
+/**
+ * Source with every comment blanked, offsets preserved. Literals are left
+ * as they are: a module specifier is one, so blanking them would hide the
+ * import this is read from. `stringLiterals` says where they are, and the
+ * caller uses that to reject a match that sits inside one.
+ */
+export function withoutComments(source) {
+  let out = "";
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i];
+    if (c === "/" && source[i + 1] === "/") {
+      while (i < source.length && source[i] !== "\n") {
+        out += " ";
+        i++;
+      }
+      continue;
+    }
+    if (c === "/" && source[i + 1] === "*") {
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+        out += source[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      out += "  ";
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === "`") {
+      const end = c === "`" ? scanTemplate(source, i, []) : scanQuoted(source, i, []);
+      out += source.slice(i, end);
+      i = end;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Whether the file's SQL belongs to the session engine rather than the port.
+ * Read from an import of the engine's own module in the code — not from the
+ * type's name appearing anywhere in the text, which a comment could supply
+ * and so turn the check off for a whole file.
+ */
+const SESSION_ENGINE_IMPORT = /^\s*import\b[^;]*?\bfrom\s*["'][^"']*sql-storage["']/gm;
+
 export function targetsSessionEngine(source) {
-  return /\bSqlStorage\b/.test(source);
+  const code = withoutComments(source);
+  const literals = stringLiterals(source).map((l) => [l.offset, l.offset + l.text.length]);
+  SESSION_ENGINE_IMPORT.lastIndex = 0;
+  let match;
+  while ((match = SESSION_ENGINE_IMPORT.exec(code)) !== null) {
+    // An import inside a literal is text about an import, not one.
+    if (!literals.some(([from, to]) => match.index >= from && match.index < to)) return true;
+  }
+  return false;
 }
 
 function controlPlaneSources() {
@@ -315,6 +369,58 @@ function newMigrations() {
     .sort();
 }
 
+/**
+ * Findings weighed against the baseline. `errors` are the occurrences it does
+ * not cover; `stale` names the entries it still lists that are gone.
+ *
+ * Grouped by file and rule and compared as a multiset of the matched text
+ * rather than a count: swapping one allowed construct for a different one of
+ * the same rule would keep the count and change the SQL.
+ */
+export function compareToBaseline(findings, allowed) {
+  const found = new Map();
+  for (const finding of findings) {
+    const key = `${finding.file} ${finding.rule}`;
+    if (!found.has(key)) found.set(key, []);
+    found.get(key).push(finding);
+  }
+
+  const errors = [];
+  const stale = [];
+  const keys = new Set([
+    ...found.keys(),
+    ...Object.entries(allowed).flatMap(([file, rules]) =>
+      Object.keys(rules).map((rule) => `${file} ${rule}`)
+    ),
+  ]);
+  for (const key of [...keys].sort()) {
+    const [file, rule] = [key.slice(0, key.lastIndexOf(" ")), key.slice(key.lastIndexOf(" ") + 1)];
+    const occurrences = found.get(key) ?? [];
+    const permitted = [...(allowed[file]?.[rule]?.occurrences ?? [])].sort();
+    const actual = occurrences.map((finding) => finding.text).sort();
+    if (permitted.join("\u0000") === actual.join("\u0000")) continue;
+    // One report per surplus occurrence, not per occurrence whose text is
+    // over budget: with two `json(` and one allowed, only one is disallowed.
+    const surplus = withoutFirst(actual, permitted);
+    for (const finding of occurrences) {
+      const at = surplus.indexOf(finding.text);
+      if (at === -1) continue;
+      surplus.splice(at, 1);
+      errors.push(
+        `${finding.file}:${finding.line}  ${finding.rule}  ${finding.text}\n` +
+          `    portable form: ${finding.portable}`
+      );
+    }
+    const missing = withoutFirst(permitted, actual);
+    if (missing.length > 0) {
+      stale.push(
+        `${file}  ${rule}: baseline still allows ${missing.join(", ")}, no longer present`
+      );
+    }
+  }
+  return { errors, stale };
+}
+
 function main() {
   const findings = [];
   for (const file of controlPlaneSources()) {
@@ -327,44 +433,7 @@ function main() {
     findings.push(...findingsIn(maskSqlComments(source), 0, source, rel));
   }
 
-  // Grouped by file and rule, and compared as a multiset of the matched text
-  // rather than a count: swapping one allowed construct for a different one
-  // of the same rule would keep the count and change the SQL.
-  const found = new Map();
-  for (const finding of findings) {
-    const key = `${finding.file} ${finding.rule}`;
-    if (!found.has(key)) found.set(key, []);
-    found.get(key).push(finding);
-  }
-
-  const errors = [];
-  const stale = [];
-  const keys = new Set([
-    ...found.keys(),
-    ...Object.entries(baseline.allowed).flatMap(([file, rules]) =>
-      Object.keys(rules).map((rule) => `${file} ${rule}`)
-    ),
-  ]);
-  for (const key of [...keys].sort()) {
-    const [file, rule] = [key.slice(0, key.lastIndexOf(" ")), key.slice(key.lastIndexOf(" ") + 1)];
-    const occurrences = found.get(key) ?? [];
-    const allowed = [...(baseline.allowed[file]?.[rule]?.occurrences ?? [])].sort();
-    const actual = occurrences.map((finding) => finding.text).sort();
-    if (allowed.join("\u0000") === actual.join("\u0000")) continue;
-    const surplus = withoutFirst(actual, allowed);
-    for (const finding of occurrences.filter((f) => surplus.includes(f.text))) {
-      errors.push(
-        `${finding.file}:${finding.line}  ${finding.rule}  ${finding.text}\n` +
-          `    portable form: ${finding.portable}`
-      );
-    }
-    const missing = withoutFirst(allowed, actual);
-    if (missing.length > 0) {
-      stale.push(
-        `${file}  ${rule}: baseline still allows ${missing.join(", ")}, no longer present`
-      );
-    }
-  }
+  const { errors, stale } = compareToBaseline(findings, baseline.allowed);
 
   if (errors.length > 0) {
     console.error(`SQL portability: ${errors.length} disallowed construct(s).\n`);

--- a/scripts/lint-sql-portability.test.mjs
+++ b/scripts/lint-sql-portability.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   RULES,
+  compareToBaseline,
   findingsIn,
   maskSqlComments,
   scanTypeScript,
@@ -114,6 +115,51 @@ test("leaves the session engine's own SQL out of scope", () => {
     targetsSessionEngine("import type { SqlDatabase } from '../db/sql-database';"),
     false
   );
+});
+
+test("does not let a comment or a string turn the check off for a file", () => {
+  // Naming the type is not importing it; either of these would otherwise
+  // exempt every statement in the file.
+  assert.equal(
+    targetsSessionEngine('db.prepare("INSERT OR IGNORE INTO t VALUES (?)"); // SqlStorage'),
+    false
+  );
+  assert.equal(targetsSessionEngine("// import type { SqlStorage } from './sql-storage';"), false);
+  assert.equal(
+    targetsSessionEngine("const doc = `\nimport { SqlStorage } from './sql-storage';\n`;"),
+    false
+  );
+});
+
+test("counts a surplus occurrence once, not every occurrence sharing its text", () => {
+  const finding = (line) => ({
+    file: "f.ts",
+    line,
+    rule: "json-function",
+    text: "json(",
+    portable: "p",
+  });
+  const allowed = { "f.ts": { "json-function": { occurrences: ["json("], reason: "r" } } };
+
+  // Two occurrences, one allowed: one is over budget, not both.
+  const { errors, stale } = compareToBaseline([finding(1), finding(2)], allowed);
+  assert.equal(errors.length, 1);
+  assert.deepEqual(stale, []);
+});
+
+test("reports a swapped construct even when the total is unchanged", () => {
+  const allowed = { "f.ts": { "json-function": { occurrences: ["json_object("], reason: "r" } } };
+  const swapped = {
+    file: "f.ts",
+    line: 1,
+    rule: "json-function",
+    text: "json_group_array(",
+    portable: "p",
+  };
+
+  const { errors, stale } = compareToBaseline([swapped], allowed);
+  assert.match(errors[0], /json_group_array\(/);
+  assert.match(stale[0], /still allows json_object\(/);
 });
 
 test("reports the line the construct sits on", () => {

--- a/scripts/lint-sql-portability.test.mjs
+++ b/scripts/lint-sql-portability.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { RULES, findingsInSql, scanTypeScript } from "./lint-sql-portability.mjs";
+import {
+  RULES,
+  findingsIn,
+  maskSqlComments,
+  scanTypeScript,
+  targetsSessionEngine,
+} from "./lint-sql-portability.mjs";
 
 test("flags every banned construct in a SQL literal", () => {
   const source = [
@@ -13,14 +19,100 @@ test("flags every banned construct in a SQL literal", () => {
     'const f = db.prepare("SELECT id FROM t ORDER BY name COLLATE NOCASE");',
     'const g = db.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT)");',
     'const h = db.prepare("SELECT json_group_array(id) FROM t");',
+    'const i = db.prepare("SELECT id FROM t WHERE id = ?1 AND owner = ?2");',
   ].join("\n");
 
   const flagged = scanTypeScript("example.ts", source).map((finding) => finding.rule);
 
+  // Enumerated here rather than derived from RULES: taking the expectation
+  // from the thing under test would let a rule that was never written pass.
+  const expected = [
+    "autoincrement",
+    "collate-nocase",
+    "create-trigger",
+    "insert-or",
+    "json-function",
+    "numbered-placeholder",
+    "pragma",
+    "strftime",
+    "unixepoch",
+  ];
+  assert.deepEqual([...new Set(flagged)].sort(), expected, "every banned construct fires");
   assert.deepEqual(
-    [...new Set(flagged)].sort(),
     RULES.map((rule) => rule.id).sort(),
-    "each rule should fire exactly once over the fixture"
+    expected,
+    "and the fixture covers every rule there is"
+  );
+});
+
+test("does not read SQL quoted in a comment as SQL", () => {
+  const source = [
+    '// "INSERT OR IGNORE INTO t VALUES (?)" is what we used to do',
+    "/* CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN SELECT 1; END */",
+    "const a = 1;",
+  ].join("\n");
+
+  assert.deepEqual(scanTypeScript("example.ts", source), []);
+});
+
+test("sees a clause fragment that carries no statement of its own", () => {
+  // How this codebase composes a WHERE: the fragment is a literal on its own,
+  // and only becomes a statement after interpolation.
+  const source = [
+    "conditions.push(\"name LIKE ? ESCAPE '\\\\' COLLATE NOCASE\");",
+    'const sql = `SELECT * FROM t WHERE ${conditions.join(" AND ")}`;',
+  ].join("\n");
+
+  assert.deepEqual(
+    scanTypeScript("example.ts", source).map((finding) => finding.rule),
+    ["collate-nocase"]
+  );
+});
+
+test("does not desynchronise on an escaped quote", () => {
+  // A scanner that mistook the escaped quote for an opener would swallow the
+  // rest of the file and report findings from anywhere in it.
+  const source = [
+    "const a = \"ESCAPE '\\\\'\";",
+    "const b = 1;",
+    'const c = db.prepare("SELECT 1");',
+  ].join("\n");
+
+  assert.deepEqual(scanTypeScript("example.ts", source), []);
+});
+
+test("matches SQL function names whatever their case", () => {
+  const flagged = scanTypeScript(
+    "example.ts",
+    "const a = db.prepare(\"SELECT JSON_OBJECT('x', id) FROM t\");"
+  );
+  assert.deepEqual(
+    flagged.map((finding) => finding.rule),
+    ["json-function"]
+  );
+});
+
+test("reads a migration's comments as documentation, not as SQL", () => {
+  const sql = [
+    "-- Avoid AUTOINCREMENT here; ids come from the application.",
+    "/* An INSERT OR IGNORE would hide a duplicate. */",
+    "CREATE TABLE t (id INTEGER PRIMARY KEY);",
+  ].join("\n");
+
+  assert.deepEqual(findingsIn(maskSqlComments(sql), 0, sql, "0075_example.sql"), []);
+  // Masking keeps offsets, so a real finding still reports its own line.
+  const real = "-- comment\nCREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT);";
+  assert.deepEqual(
+    findingsIn(maskSqlComments(real), 0, real, "0075_example.sql").map((f) => f.line),
+    [2]
+  );
+});
+
+test("leaves the session engine's own SQL out of scope", () => {
+  assert.equal(targetsSessionEngine("import type { SqlStorage } from './sql-storage';"), true);
+  assert.equal(
+    targetsSessionEngine("import type { SqlDatabase } from '../db/sql-database';"),
+    false
   );
 });
 
@@ -67,7 +159,7 @@ test("scans a migration file as one SQL body", () => {
   const source = "CREATE TABLE t (\n  id INTEGER PRIMARY KEY AUTOINCREMENT\n);\n";
 
   assert.deepEqual(
-    findingsInSql(source, 0, source, "0075_example.sql").map((finding) => [
+    findingsIn(source, 0, source, "0075_example.sql").map((finding) => [
       finding.rule,
       finding.line,
     ]),

--- a/scripts/lint-sql-portability.test.mjs
+++ b/scripts/lint-sql-portability.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RULES, findingsInSql, scanTypeScript } from "./lint-sql-portability.mjs";
+
+test("flags every banned construct in a SQL literal", () => {
+  const source = [
+    'const a = db.prepare("INSERT OR IGNORE INTO t (id) VALUES (?)");',
+    'const b = db.prepare("CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN SELECT 1; END");',
+    "const c = db.prepare(\"SELECT strftime('%Y', created_at) FROM t\");",
+    "const d = db.prepare(\"SELECT date(created_at, 'unixepoch') FROM t\");",
+    'const e = db.prepare("PRAGMA table_info(t)");',
+    'const f = db.prepare("SELECT id FROM t ORDER BY name COLLATE NOCASE");',
+    'const g = db.prepare("CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT)");',
+    'const h = db.prepare("SELECT json_group_array(id) FROM t");',
+  ].join("\n");
+
+  const flagged = scanTypeScript("example.ts", source).map((finding) => finding.rule);
+
+  assert.deepEqual(
+    [...new Set(flagged)].sort(),
+    RULES.map((rule) => rule.id).sort(),
+    "each rule should fire exactly once over the fixture"
+  );
+});
+
+test("reports the line the construct sits on", () => {
+  const source = [
+    "const noop = 1;",
+    "",
+    'const a = db.prepare("INSERT OR REPLACE INTO t VALUES (?)");',
+  ].join("\n");
+
+  assert.deepEqual(scanTypeScript("example.ts", source), [
+    {
+      file: "example.ts",
+      line: 3,
+      rule: "insert-or",
+      text: "INSERT OR REPLACE",
+      portable: RULES.find((rule) => rule.id === "insert-or").portable,
+    },
+  ]);
+});
+
+test("ignores TypeScript that merely looks like SQL", () => {
+  const source = [
+    "const body = await request.json();",
+    "return Response.json({ ok: true });",
+    'log.info("Pragma header ignored; insert or update decided downstream");',
+  ].join("\n");
+
+  assert.deepEqual(scanTypeScript("example.ts", source), []);
+});
+
+test("accepts the portable forms these rules exist to steer toward", () => {
+  const source = [
+    'const a = db.prepare("INSERT INTO t (id) VALUES (?) ON CONFLICT DO NOTHING");',
+    'const b = db.prepare("INSERT INTO t (id, n) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET n = excluded.n");',
+    'const c = db.prepare("SELECT created_at / 86400000 AS day_index FROM t GROUP BY day_index");',
+    'const d = db.prepare("SELECT id FROM t WHERE LOWER(name) = LOWER(?)");',
+  ].join("\n");
+
+  assert.deepEqual(scanTypeScript("example.ts", source), []);
+});
+
+test("scans a migration file as one SQL body", () => {
+  const source = "CREATE TABLE t (\n  id INTEGER PRIMARY KEY AUTOINCREMENT\n);\n";
+
+  assert.deepEqual(
+    findingsInSql(source, 0, source, "0075_example.sql").map((finding) => [
+      finding.rule,
+      finding.line,
+    ]),
+    [["autoincrement", 2]]
+  );
+});

--- a/scripts/sql-portability-baseline.json
+++ b/scripts/sql-portability-baseline.json
@@ -1,0 +1,39 @@
+{
+  "migrationBaseline": 74,
+  "allowed": {
+    "packages/control-plane/src/db/authorization-store.ts": {
+      "collate-nocase": {
+        "count": 1,
+        "reason": "Member listing orders by display name case-insensitively. LOWER() over the COALESCE would drop the index the ORDER BY relies on."
+      },
+      "json-function": {
+        "count": 5,
+        "reason": "The audit row's before/requested/after payload is assembled from subqueries inside the same batch as the mutation, so it observes exactly the state the write saw. Building it in TypeScript would need a separate read and lose that. Postgres form is json_build_object."
+      }
+    },
+    "packages/control-plane/src/db/automation-store.ts": {
+      "collate-nocase": {
+        "count": 1,
+        "reason": "Case-insensitive automation name search. Portable form is LOWER(name) LIKE LOWER(?), deferred with the rest of the name-search query."
+      }
+    },
+    "packages/control-plane/src/db/user-merge.ts": {
+      "json-function": {
+        "count": 7,
+        "reason": "Merge audit payload, same constraint as authorization-store: before/after state is read inside the mutating batch. Postgres form is json_build_object."
+      }
+    },
+    "packages/control-plane/src/session/schema.ts": {
+      "pragma": {
+        "count": 4,
+        "reason": "Column introspection that decides whether a session-storage migration still has work to do. Postgres reads information_schema instead; there is no shared spelling."
+      }
+    },
+    "packages/control-plane/src/session/session-core-repository.ts": {
+      "collate-nocase": {
+        "count": 4,
+        "reason": "Case-insensitive repository match against session-local storage. Portable form is LOWER(col) = LOWER(?); deferred so this change stays confined to writes."
+      }
+    }
+  }
+}

--- a/scripts/sql-portability-baseline.json
+++ b/scripts/sql-portability-baseline.json
@@ -1,39 +1,124 @@
 {
-  "migrationBaseline": 74,
   "allowed": {
     "packages/control-plane/src/db/authorization-store.ts": {
       "collate-nocase": {
-        "count": 1,
+        "occurrences": ["COLLATE NOCASE"],
         "reason": "Member listing orders by display name case-insensitively. LOWER() over the COALESCE would drop the index the ORDER BY relies on."
       },
       "json-function": {
-        "count": 5,
+        "occurrences": [
+          "json(",
+          "json(",
+          "json(",
+          "json(",
+          "json(",
+          "json(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object("
+        ],
         "reason": "The audit row's before/requested/after payload is assembled from subqueries inside the same batch as the mutation, so it observes exactly the state the write saw. Building it in TypeScript would need a separate read and lose that. Postgres form is json_build_object."
       }
     },
     "packages/control-plane/src/db/automation-store.ts": {
       "collate-nocase": {
-        "count": 1,
+        "occurrences": ["COLLATE NOCASE"],
         "reason": "Case-insensitive automation name search. Portable form is LOWER(name) LIKE LOWER(?), deferred with the rest of the name-search query."
       }
     },
     "packages/control-plane/src/db/user-merge.ts": {
       "json-function": {
-        "count": 7,
+        "occurrences": [
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object(",
+          "json_object("
+        ],
         "reason": "Merge audit payload, same constraint as authorization-store: before/after state is read inside the mutating batch. Postgres form is json_build_object."
       }
-    },
-    "packages/control-plane/src/session/schema.ts": {
-      "pragma": {
-        "count": 4,
-        "reason": "Column introspection that decides whether a session-storage migration still has work to do. Postgres reads information_schema instead; there is no shared spelling."
-      }
-    },
-    "packages/control-plane/src/session/session-core-repository.ts": {
-      "collate-nocase": {
-        "count": 4,
-        "reason": "Case-insensitive repository match against session-local storage. Portable form is LOWER(col) = LOWER(?); deferred so this change stays confined to writes."
-      }
     }
-  }
+  },
+  "grandfatheredMigrations": [
+    "0001_create_repo_secrets.sql",
+    "0002_create_session_index.sql",
+    "0003_prefix_model_ids.sql",
+    "0004_create_global_secrets.sql",
+    "0005_add_reasoning_effort_to_sessions.sql",
+    "0006_create_model_preferences.sql",
+    "0007_create_integration_settings.sql",
+    "0008_create_user_scm_tokens.sql",
+    "0009_create_repo_images.sql",
+    "0010_add_image_build_enabled.sql",
+    "0011_add_branch_to_sessions.sql",
+    "0012_add_parent_session.sql",
+    "0013_create_automations.sql",
+    "0014_add_reasoning_effort_to_automations.sql",
+    "0015_trigger_automations.sql",
+    "0016_rename_trigger_auth_data.sql",
+    "0017_add_analytics_columns.sql",
+    "0018_create_mcp_servers.sql",
+    "0019_create_users.sql",
+    "0020_add_sessions_updated_at_index.sql",
+    "0021_add_sessions_user_updated_at_index.sql",
+    "0022_add_repo_image_provider.sql",
+    "0023_bind_repo_image_callbacks.sql",
+    "0024_fix_recovery_sweep_indexes.sql",
+    "0025_optimize_active_run_lookup.sql",
+    "0026_slack_triggers.sql",
+    "0027_drop_max_runs_per_hour.sql",
+    "0028_slack_thread_continuity_index.sql",
+    "0029_allow_no_repository_context.sql",
+    "0030_automation_repositories_and_invocations.sql",
+    "0031_drop_deprecated_automation_columns.sql",
+    "0032_session_repositories.sql",
+    "0033_environments.sql",
+    "0034_rename_environment_image_provenance_columns.sql",
+    "0035_environment_channel_associations.sql",
+    "0036_repo_metadata_default_environment.sql",
+    "0037_automation_environments.sql",
+    "0038_integration_environment_settings.sql",
+    "0039_image_builds.sql",
+    "0040_drop_repo_images.sql",
+    "0041_session_pull_requests.sql",
+    "0042_session_pull_request_timestamps.sql",
+    "0043_commit_signing_configuration.sql",
+    "0044_api_tokens.sql",
+    "0045_api_tokens_family_expiry_index.sql",
+    "0047_terminal_browser_auth.sql",
+    "0048_better_auth_core.sql",
+    "0049_backfill_better_auth_accounts.sql",
+    "0050_purge_retired_api_tokens.sql",
+    "0051_drop_retired_custom_auth.sql",
+    "0052_image_build_finalization.sql",
+    "0053_image_build_scheduler.sql",
+    "0054_index_non_automation_sessions.sql",
+    "0055_session_read_states.sql",
+    "0056_backfill_user_identity_issuers.sql",
+    "0057_reconcile_canonical_auth_identities.sql",
+    "0058_child_admission_leases.sql",
+    "0059_require_automation_run_invocation.sql",
+    "0060_automation_list_index.sql",
+    "0061_managed_skills.sql",
+    "0062_mcp_server_revisions.sql",
+    "0063_session_root.sql",
+    "0064_provider_accounts.sql",
+    "0065_provider_account_authorizations.sql",
+    "0066_drop_automation_environment_id.sql",
+    "0067_keyboard_shortcut_preferences.sql",
+    "0068_default_single_provider_accounts.sql",
+    "0069_skill_import_sources.sql",
+    "0070_pr_autofix_feedback.sql",
+    "0071_rbac_foundation.sql",
+    "0072_rbac_audit_fidelity.sql",
+    "0073_rbac_audit_decision_outcomes.sql",
+    "0074_audit_event_list_index.sql"
+  ]
 }


### PR DESCRIPTION
Closes COL-126.

Postgres is the planned engine for container deployments. Every SQLite-only construct written between now and that port turns into either a per-engine migration twin or a store rewrite. The statements below all have a portable form that is valid on D1 and SQLite today, so they cost nothing to fix now, and a CI check keeps new ones from landing.

## What the audit predicted vs. what is actually on `main`

The counts in the issue came from an audit on 2026-09-02 and `main` has moved. Verified with `git grep` over `packages/control-plane/src/**` (non-test), since `src/integrations.ts` carries raw NUL bytes and is invisible to plain `grep`/`rg`:

| Construct | Issue said | Actually found | Notes |
| --- | --- | --- | --- |
| `INSERT OR IGNORE` | 5 | **5** | matches |
| `INSERT OR REPLACE` | 1 | **3** | two more in `src/session/**` (session DO storage): `session-core-repository.ts` and `ws-client-mapping-repository.ts` |
| numbered `?1` placeholder | 1 site | **1 site** | `session-index.ts` `isRepositoryAssociated`, using `?1`/`?2`/`?3` with `?2` and `?3` reused |
| `unixepoch()` | 3 | **3, but not the shape described** | all three are `date(col / 1000, 'unixepoch')` — the modifier string, not a `unixepoch()` call. See below. |
| `json_group_array` | 1 | **0** | already gone; `skill-profiles.ts` now groups in two statements, and its comment says so |

Two of the three `INSERT OR REPLACE` sites the audit missed live behind the `SqlStorage` seam rather than in `src/db`, which is probably why.

## The rewrites

**`INSERT OR IGNORE` → `ON CONFLICT DO NOTHING`** (`automation-store.ts` ×2, `slack-channel-store.ts`, `user-merge.ts`, `session/schema.ts`). Untargeted `DO NOTHING` covers any unique-constraint conflict on both engines, which is exactly what these sites want. It is narrower than `OR IGNORE`, which also swallows `CHECK` and `NOT NULL` violations — none of these sites relies on that, and swallowing them was never the intent. The `user-merge.ts` one is an `INSERT ... SELECT`; SQLite needs the `SELECT` to carry a `WHERE` clause before it will parse a trailing upsert, and that query already has one.

**`INSERT OR REPLACE` → upsert.** Three sites, and the semantics question the issue flags only bites at one of them:

- `session-index.ts` (`session_model_provider_auth`, D1): the statement names all seven columns and the primary key is `(session_id, provider)`. `DO UPDATE SET` on the six non-key columns is byte-for-byte the same outcome. No delete-side cascade or trigger is attached.
- `ws-client-mapping-repository.ts` (`ws_client_mapping`, session DO): same shape — all five columns named, `ws_id` is the primary key, nothing references the table. Equivalent.
- `session-core-repository.ts` (`session`, session DO): **this is the one where the two forms differ.** The statement names 19 columns; the table has five more — `branch_name`, `base_sha`, `current_sha`, `opencode_session_id`, `total_cost` — that other methods write as the session runs. `OR REPLACE` deletes the row first, so a second call would blank all five and reset `total_cost` to 0.

  **I chose the upsert, which preserves them.** Reasons: the only caller is `/internal/init`, whose doc comment already records it as single-caller and which `initialize.ts` invokes once, after the D1 index insert has asserted the id was fresh. At that point all five columns are still `NULL`/`0`, so on every reachable path the two forms produce identical rows. Where they diverge — a retried or repeated init against a session that has already done work — the delete-then-insert silently destroys that work, and nothing in the codebase wants it: the method is named `upsertSession` and no caller depends on a reset. No foreign key references `session(id)` and the DO schema has no triggers, so there are no cascade or trigger side effects to preserve either.

  Because that is a real (if unreachable) behaviour change, it is now pinned by a test against real `node:sqlite` storage rather than the call-recording mock: `upsertSession` twice with a `updateSessionBranch` and an `addSessionCost` in between, asserting the second write updates `title`/`updated_at` and leaves `branch_name`/`total_cost` alone. I confirmed the test fails on the old statement (`branch_name: "feature/x"` → `null`, `total_cost: 1.5` → `0`) before keeping it.

**Numbered → positional placeholders** in `session-index.ts`. `?2`/`?3` each appeared twice, so the bind list grows from three values to five.

**`unixepoch`.** These are not `unixepoch()` calls, so the remedy the issue suggests (pass `Date.now()` from application code) does not apply — they bucket rows into calendar days for a `GROUP BY`, they do not produce "now". `date(col / 1000, 'unixepoch')` has no Postgres equivalent, but the bucketing does: `col / 86400000` is integer division on SQLite and Postgres alike, and nested truncating division makes it exactly equal to the old expression for positive epochs. So the query now groups and orders by an integer day index and TypeScript renders the `YYYY-MM-DD` string (`utcDateFromDayIndex` in the new `src/db/utc-day.ts`). Three sites, in `analytics-store.ts` and `pull-request-analytics-store.ts`; the response shape is unchanged, and `prepareTimeseries`/`decodeTimeseries` are only ever used as a pair.

**`json_group_array`**: nothing to do. Postgres would want `json_agg`; noted in the doc for whoever does that port.

## The CI check

`scripts/lint-sql-portability.mjs`, wired into the existing `lint-typescript` job as `npm run lint:sql-portability`.

It scans string and template literals rather than raw source, and only those that read as a SQL statement, so `Response.json(...)` and `await request.json()` are not mistaken for `json_` functions. That filter is worth a look in review: `PRAGMA` is only recognised in the shape `PRAGMA name`, `PRAGMA name = value` or `PRAGMA name(arg)`, because prose starting with the word was a real false positive while I was writing this.

**`src/node/**` is out of scope, deliberately.** That directory is the SQLite adapter: `PRAGMA journal_mode = WAL`, `PRAGMA busy_timeout`, `PRAGMA foreign_keys` are its job, not accidents, and a Postgres host brings its own adapter rather than reinterpreting this one. The line I am drawing is engine-adapter vs. engine-agnostic store, which puts `src/db/**` and `src/session/**` in scope and gives the directory a rule: store logic a Postgres deployment would also need does not belong in `src/node`. Migrations are baselined by number at 0074, so `0075+` are checked.

Existing occurrences that have no portable form are listed in `scripts/sql-portability-baseline.json` with a written reason — 22 across 5 files: `json_object` in the RBAC and user-merge audit payloads (built from subqueries inside the mutating batch, so they observe exactly the state the write saw; Postgres form is `json_build_object`), `PRAGMA table_info` in the session-storage migrations, and `COLLATE NOCASE` in three query sites. The counts ratchet in both directions: adding one fails, and removing one fails until the baseline is lowered, so the file cannot quietly go stale as the debt is paid.

`docs/PORTABLE_SQL.md` documents the subset, the `OR REPLACE`-is-not-an-upsert trap, the date-bucketing recipe, and the exception process. Linked from `CONTRIBUTING.md`.

## Red-testing the check

A guardrail nobody has watched fail is not a guardrail.

Reverting `slack-channel-store.ts` to `INSERT OR IGNORE`:

```
SQL portability: 1 disallowed construct(s).

packages/control-plane/src/db/slack-channel-store.ts:64  insert-or  INSERT OR IGNORE
    portable form: INSERT ... ON CONFLICT DO NOTHING / ON CONFLICT (...) DO UPDATE SET ...

Rewrite in the portable subset (docs/PORTABLE_SQL.md), or, if the construct must stay, raise its
count in scripts/sql-portability-baseline.json with a reason.
```
exit 1.

Dropping a `terraform/d1/migrations/0075_red_test.sql` with `AUTOINCREMENT` and `COLLATE NOCASE` alongside it:

```
SQL portability: 3 disallowed construct(s).

packages/control-plane/src/db/slack-channel-store.ts:64  insert-or  INSERT OR IGNORE
terraform/d1/migrations/0075_red_test.sql:3  collate-nocase  COLLATE NOCASE
terraform/d1/migrations/0075_red_test.sql:2  autoincrement  AUTOINCREMENT
```

Both reverted. The check also has its own test (`npm run test:lint-sql-portability`, 5 cases): every rule fires over a fixture, line numbers are right, portable forms and TypeScript-that-looks-like-SQL are not flagged, and a `.sql` file is scanned as one body.

## Verification

Run in the worktree after `rm -rf node_modules && npm ci` and a `@open-inspect/shared` build.

| | |
| --- | --- |
| `npm run typecheck -w @open-inspect/control-plane` | pass, all 4 tsconfig programs |
| `npx vitest run --root packages/control-plane` | **274 files, 3972 tests passed** (3971 on `main`; +1 is the new upsert test) |
| `npm run test:integration -w @open-inspect/control-plane` | **100 files, 1178 passed, 1 skipped**, 109s — the workerd/D1 proof that every rewritten statement is valid on Cloudflare |
| `npm run lint` | clean |
| `npx prettier --check` on touched files | clean |
| `npx knip` | 28 lines, **byte-identical to `origin/main`** (diffed against a throwaway worktree at `origin/main` with its own `npm ci`) |
| `npm run lint:sql-portability` | clean, 22 baselined occurrences |
| `npm run test:lint-sql-portability` | 5/5 |

## Not done

- The 6 `COLLATE NOCASE` sites are baselined, not rewritten. `LOWER(col) = LOWER(?)` is the portable form and it is in the doc, but converting them changes index selection on the `ORDER BY` in `authorization-store.ts` and touches read paths this change otherwise leaves alone. The issue scoped item 1 to writes.
- Existing migrations `0001`–`0074` are untouched, per the issue.
- The `json_object` audit payloads stay in SQL. Building them in TypeScript would need a separate read outside the batch and lose the guarantee that the audit row reflects the state the mutation saw.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Daily analytics now group data more consistently by UTC date.
  - Repeated session and client-mapping updates preserve existing working-state data.
  - Database writes use more portable conflict-handling behavior across supported environments.

- **Documentation**
  - Added guidance for portable SQL usage and database-related contributions.

- **Tests and Validation**
  - Added automated SQL portability checks to continuous integration.
  - Expanded coverage for upsert behavior, analytics date handling, and portability rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->