### PR TITLE
feat: recover deadlines and stale job claims after an unclean stop (COL-100)

### DIFF
--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -94,6 +94,8 @@ Everything the host persists is under `/data` on the `control-plane-data` volume
 - `host-alarms.db`: the index of every session's next scheduled deadline.
 - `jobs.db`: background jobs waiting to run, leased to a delivery, or dead — what a Cloudflare Queue
   and its dead-letter queue hold on the other host.
+- `host-state.json`: the marker that says whether the host stopped cleanly, and the time through
+  which the alarm index is known to be complete. See "Recovering from an unclean stop".
 - `cache.db`: the cache the host uses where Cloudflare uses KV. Alone among these, it is not
   deployment state — every entry is rebuilt by being used, so a file that cannot be opened is
   discarded and recreated rather than failing the boot.
@@ -132,6 +134,44 @@ docker compose up -d --wait
 docker compose logs app | grep litestream.restore
 docker compose logs litestream | grep "snapshot written"
 ```
+
+## Recovering from an unclean stop
+
+A `docker compose down`, a `docker compose up -d` that recreates the app, and a stopped instance all
+end in `SIGTERM`, which the host drains: it stops accepting, finishes what is in flight, quiesces
+every session, closes the files, and writes `host-state.json` saying the stop was clean. A kill, an
+OOM, a power loss or a drain that ran out of budget writes no such marker, and the next boot has two
+things to put right.
+
+**Deadlines the index never recorded.** A session's scheduled wake-up is written twice: the session
+core commits it to the session's own file and then arms the runtime alarm, which here is a row in
+`host-alarms.db`. On Cloudflare both writes land in one Durable Object storage; here they are two
+files, so a process that dies between them leaves a deadline the session knows about and the index
+does not. The session would still fire it the next time anything touched it, but a session nobody
+touches again would not. So a boot that finds no clean marker reads the session files written since
+the last time the index was known complete, and arms each file's earliest deadline. That can only
+bring a wake-up forward — it never postpones or replaces what the index already holds — and a
+session file that cannot be read is logged and skipped rather than failing the boot. On a fresh
+volume there are no session files and the scan costs nothing; on a volume written by a build that
+predates the marker it is one full pass.
+
+**Jobs the dead process was running.** A claim on a job is a lease, and a lease runs for fifteen
+minutes. Waiting one out after every restart would leave a build finalization sitting for a quarter
+of an hour, so starting the poller returns every claim no delivery in this process owns — a claim
+belonging to a process that is gone — to pending at once. The attempt that process spent stays
+spent, exactly as a queue counts a delivery however it ended, so a job whose handler takes the
+process down with it still runs out of attempts and ends in the dead rows. A claim whose lease
+simply ran out is a different thing, a handler that hung, and is still recovered on the sweep.
+
+**Two processes at once.** Neither recovery guards against another live process holding the same
+volume: a boot-time reclaim assumes the claims it finds belong to nobody. That assumption is the
+deploy shape's, not the code's. Compose recreates the app container in place, and the new container
+cannot start until the old one has released the volume; the AWS deploy replaces the instance the
+same way. If that ever changes — two app containers behind a load balancer, a blue/green deploy that
+overlaps the old and new instances, or anything else that lets two hosts open one data directory —
+these recoveries stop being safe, and the claims would have to carry the boot id of the process that
+holds them so a live one could be told from a dead one. Until then that column would only be a
+column nothing reads.
 
 ## TLS
 
@@ -186,7 +226,6 @@ SMOKE_APP_PORT=8798 SMOKE_MINIO_PORT=9010 SMOKE_MINIO_CONSOLE_PORT=9011 \
   startup. Sessions start from the base sandbox image.
 - The GitHub autofix queue and the Slack and Linear bots: the bots remain Cloudflare Workers and
   reach a container-hosted control plane over HTTPS once that transport lands.
-- Crash recovery of scheduled deadlines after an unclean stop.
 
 ## Building the image alone
 

--- a/packages/control-plane/src/node/crash-recovery.test.ts
+++ b/packages/control-plane/src/node/crash-recovery.test.ts
@@ -158,6 +158,23 @@ describe("recoverSessionDeadlines", () => {
     );
   });
 
+  it("keeps a session file it could not read in the next scan's range", () => {
+    writeSessionDeadline("broken", 1_000);
+    const broken = join(dataDir, "sessions", "broken.db");
+    rmSync(`${broken}-wal`, { force: true });
+    writeFileSync(broken, "not a database at all");
+    chmodSync(broken, 0o600);
+    // A boot after every file was last written, so the point it records is
+    // what decides whether the file is looked at again.
+    const bootMs = Date.now() + 1_000;
+
+    expect(recover(bootMs)).toMatchObject({ scanned: 1, unreadable: 1 });
+    expect(marker()).toEqual({ indexedThroughMs: 0, cleanShutdown: false });
+
+    // The file has not been written since, and is read again all the same.
+    expect(recover(bootMs + 1)).toMatchObject({ scanned: 1, unreadable: 1 });
+  });
+
   it("treats a data directory with no sessions as nothing to do", () => {
     expect(recover()).toEqual({
       previousStop: "no_marker",

--- a/packages/control-plane/src/node/crash-recovery.test.ts
+++ b/packages/control-plane/src/node/crash-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
@@ -173,6 +174,59 @@ describe("recoverSessionDeadlines", () => {
 
     // The file has not been written since, and is read again all the same.
     expect(recover(bootMs + 1)).toMatchObject({ scanned: 1, unreadable: 1 });
+  });
+
+  it("counts a file it cannot even stat as unreadable rather than as an old one", () => {
+    writeSessionDeadline("fine", 6_000);
+    // A complete scan, so the next one is incremental and rests on mtimes.
+    recover();
+    // A link that resolves to itself: statting it fails with ELOOP, not
+    // ENOENT. Reading that as "written long ago" would skip the session and
+    // still advance the point past it.
+    symlinkSync("loop.db", join(dataDir, "sessions", "loop.db"));
+
+    const report = recover(BOOT_MS + 1);
+
+    expect(report.unreadable).toBe(1);
+    expect(marker().indexedThroughMs).toBe(0);
+  });
+
+  it("fails the boot when the index rejects a deadline it just read", () => {
+    writeSessionDeadline("s1", 5_000);
+    vi.spyOn(index, "armIfSooner").mockImplementation(() => {
+      throw new Error("database is locked");
+    });
+
+    // An index that cannot be written is not an unreadable session file: the
+    // host must not serve with an index it knows is missing a deadline.
+    expect(() => recover()).toThrow("database is locked");
+  });
+
+  it("does not claim a clean stop while a file it could not read is still unread", () => {
+    writeSessionDeadline("s1", 5_000);
+    const path = join(dataDir, "sessions", "broken.db");
+    writeFileSync(path, "not a database");
+    expect(recover().unreadable).toBe(1);
+    expect(marker().indexedThroughMs).toBe(0);
+
+    markCleanShutdown(dataDir, BOOT_MS + 1_000);
+
+    // Stopping cleanly does not repair that file. A clean marker would let
+    // the next boot skip its scan altogether, which is how the deadline in it
+    // would be lost for good.
+    expect(marker()).toEqual({ indexedThroughMs: 0, cleanShutdown: false });
+  });
+
+  it("distrusts a marker from the future and scans everything", () => {
+    writeSessionDeadline("s1", 5_000);
+    markCleanShutdown(dataDir, BOOT_MS + 60_000);
+
+    // The clock stepped backwards, so every file looks older than the point
+    // and an incremental scan would find nothing — and the marker's claim of
+    // a clean stop cannot be trusted either.
+    const report = recover();
+    expect(report).toMatchObject({ previousStop: "no_marker", scanned: 1, rearmed: 1 });
+    expect(index.get("s1")).toBe(5_000);
   });
 
   it("treats a data directory with no sessions as nothing to do", () => {

--- a/packages/control-plane/src/node/crash-recovery.test.ts
+++ b/packages/control-plane/src/node/crash-recovery.test.ts
@@ -1,0 +1,185 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import { PersistedAlarmDeadlineStore } from "../session/alarm/scheduler";
+import {
+  HOST_STATE_FILE,
+  markCleanShutdown,
+  recoverSessionDeadlines,
+  type DeadlineRecoveryReport,
+} from "./crash-recovery";
+import { openHostAlarmIndex, type HostAlarmIndex } from "./host-alarm-index";
+import { openSessionStore } from "./session-store";
+
+const BOOT_MS = 1_000_000;
+
+let dataDir: string;
+let index: HostAlarmIndex;
+let log: Logger;
+
+function fakeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+}
+
+/** A session file holding `deadline` as its pending deadline, and nothing else. */
+function writeSessionDeadline(sessionId: string, deadline: number | null): void {
+  const store = openSessionStore({ dataDir, sessionId });
+  try {
+    const deadlines = new PersistedAlarmDeadlineStore(store.storage.sql);
+    if (deadline === null) deadlines.clear();
+    else deadlines.setPending(deadline);
+  } finally {
+    store.close();
+  }
+}
+
+function recover(nowMs = BOOT_MS): DeadlineRecoveryReport {
+  return recoverSessionDeadlines({ dataDir, index, log, nowMs });
+}
+
+function marker(): { indexedThroughMs: number; cleanShutdown: boolean } {
+  return JSON.parse(readFileSync(join(dataDir, HOST_STATE_FILE), "utf8")) as {
+    indexedThroughMs: number;
+    cleanShutdown: boolean;
+  };
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "oi-crash-recovery-"));
+  index = openHostAlarmIndex(dataDir);
+  log = fakeLogger();
+});
+
+afterEach(() => {
+  index.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("recoverSessionDeadlines", () => {
+  it("arms a deadline the session persisted and the index never recorded", () => {
+    // Exactly the window the recovery exists for: the session committed its
+    // deadline and the process died before the index row was written.
+    writeSessionDeadline("stranded", 4_242);
+
+    expect(recover()).toEqual({
+      previousStop: "no_marker",
+      scanned: 1,
+      rearmed: 1,
+      unreadable: 0,
+    });
+    expect(index.get("stranded")).toBe(4_242);
+  });
+
+  it("scans nothing after a clean shutdown, and invalidates the marker it read", () => {
+    markCleanShutdown(dataDir, 500);
+    writeSessionDeadline("stranded", 4_242);
+
+    expect(recover()).toEqual({
+      previousStop: "clean_shutdown",
+      scanned: 0,
+      rearmed: 0,
+      unreadable: 0,
+    });
+    expect(index.get("stranded")).toBeNull();
+    // The clean point stays where it was, so an unclean stop from here scans
+    // forward from the shutdown rather than from this boot.
+    expect(marker()).toEqual({ indexedThroughMs: 500, cleanShutdown: false });
+  });
+
+  it("scans after a boot that never wrote a clean marker of its own", () => {
+    markCleanShutdown(dataDir, 500);
+    recover(BOOT_MS);
+    // That boot ran and died: no new clean marker, so its work is suspect.
+    writeSessionDeadline("stranded", 4_242);
+
+    expect(recover(BOOT_MS + 1)).toMatchObject({ previousStop: "unclean_stop", rearmed: 1 });
+    expect(index.get("stranded")).toBe(4_242);
+  });
+
+  it("reads only the session files written since the last known-complete point", () => {
+    writeSessionDeadline("before", 1_111);
+    writeSessionDeadline("after", 2_222);
+    // The clean point falls between the two writes: `before` was armed while
+    // the previous process was still indexing, `after` may not have been.
+    const secondsAt = (ms: number): number => ms / 1_000;
+    utimesSync(join(dataDir, "sessions", "before.db"), secondsAt(BOOT_MS), secondsAt(BOOT_MS - 1));
+    utimesSync(join(dataDir, "sessions", "after.db"), secondsAt(BOOT_MS), secondsAt(BOOT_MS + 1));
+    writeFileSync(
+      join(dataDir, HOST_STATE_FILE),
+      JSON.stringify({ indexedThroughMs: BOOT_MS, cleanShutdown: false })
+    );
+
+    expect(recover()).toMatchObject({ previousStop: "unclean_stop", scanned: 1, rearmed: 1 });
+    expect(index.get("after")).toBe(2_222);
+    expect(index.get("before")).toBeNull();
+  });
+
+  it("does not postpone or replace a deadline the index already holds", () => {
+    writeSessionDeadline("s1", 9_000);
+    index.set("s1", 3_000);
+
+    expect(recover()).toMatchObject({ scanned: 1, rearmed: 0 });
+    expect(index.get("s1")).toBe(3_000);
+  });
+
+  it("arms nothing for a session whose alarm was cancelled", () => {
+    writeSessionDeadline("cancelled", null);
+
+    expect(recover()).toMatchObject({ scanned: 1, rearmed: 0 });
+    expect(index.get("cancelled")).toBeNull();
+  });
+
+  it("skips a session file it cannot read and recovers the rest", () => {
+    writeSessionDeadline("broken", 1_000);
+    writeSessionDeadline("fine", 2_000);
+    const broken = join(dataDir, "sessions", "broken.db");
+    rmSync(`${broken}-wal`, { force: true });
+    writeFileSync(broken, "not a database at all");
+    chmodSync(broken, 0o600);
+
+    expect(recover()).toMatchObject({ scanned: 2, rearmed: 1, unreadable: 1 });
+    expect(index.get("fine")).toBe(2_000);
+    expect(log.error).toHaveBeenCalledWith(
+      "A session file could not be read for its scheduled deadline",
+      expect.objectContaining({
+        event: "node_host.deadline_recovery_failed",
+        session_id: "broken",
+      })
+    );
+  });
+
+  it("treats a data directory with no sessions as nothing to do", () => {
+    expect(recover()).toEqual({
+      previousStop: "no_marker",
+      scanned: 0,
+      rearmed: 0,
+      unreadable: 0,
+    });
+    // A first boot is not a crash: nothing is reported as recovered.
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(marker()).toEqual({ indexedThroughMs: BOOT_MS, cleanShutdown: false });
+  });
+
+  it("reads an unusable marker as no marker and scans everything", () => {
+    writeSessionDeadline("stranded", 4_242);
+    writeFileSync(join(dataDir, HOST_STATE_FILE), "{ truncated");
+
+    expect(recover()).toMatchObject({ previousStop: "no_marker", scanned: 1, rearmed: 1 });
+  });
+
+  it("leaves no partial marker behind when it replaces one", () => {
+    markCleanShutdown(dataDir, 500);
+    expect(existsSync(join(dataDir, `${HOST_STATE_FILE}.tmp`))).toBe(false);
+    expect(marker()).toEqual({ indexedThroughMs: 500, cleanShutdown: true });
+  });
+});

--- a/packages/control-plane/src/node/crash-recovery.ts
+++ b/packages/control-plane/src/node/crash-recovery.ts
@@ -46,6 +46,8 @@ const SESSIONS_DIRECTORY = "sessions";
 const SESSION_FILE_SUFFIX = ".db";
 /** The session table holding what the session has scheduled. */
 const ALARM_STATE_TABLE = "session_alarm_state";
+/** A point before any file's timestamp: the next scan reads every session. */
+const SCAN_EVERYTHING_MS = 0;
 
 /** What the marker file holds. */
 interface HostState {
@@ -107,7 +109,13 @@ export function recoverSessionDeadlines(options: DeadlineRecoveryOptions): Deadl
   // after which a marker exists.
   const previousStop: PreviousStop = previous === null ? "no_marker" : "unclean_stop";
   const scan = scanSessionFiles(dataDir, index, previous?.indexedThroughMs ?? null, log);
-  writeHostState(dataDir, { indexedThroughMs: nowMs, cleanShutdown: false });
+  // The point moves forward only over a scan that read everything it looked
+  // at. A file this boot could not read has to stay in the next scan's range,
+  // or one unreadable moment would put its deadline out of reach for good.
+  writeHostState(dataDir, {
+    indexedThroughMs: scan.unreadable === 0 ? nowMs : SCAN_EVERYTHING_MS,
+    cleanShutdown: false,
+  });
 
   const report: DeadlineRecoveryReport = { previousStop, ...scan };
   if (scan.scanned > 0) {

--- a/packages/control-plane/src/node/crash-recovery.ts
+++ b/packages/control-plane/src/node/crash-recovery.ts
@@ -28,12 +28,20 @@
  * boot exactly the same work.
  */
 
-import { readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import type { Logger } from "../logger";
 import { PersistedAlarmDeadlineStore } from "../session/alarm/scheduler";
 import type { HostAlarmIndex } from "./host-alarm-index";
-import { makeFilePrivate } from "./private-paths";
 import { openPrivateSqliteFile } from "./sqlite-file";
 import { createNodeSqlStorage } from "./sqlite-storage";
 
@@ -90,7 +98,13 @@ export interface DeadlineRecoveryOptions {
  */
 export function recoverSessionDeadlines(options: DeadlineRecoveryOptions): DeadlineRecoveryReport {
   const { dataDir, index, log, nowMs } = options;
-  const previous = readHostState(dataDir);
+  // The scan compares the marker's wall-clock time against file timestamps,
+  // so a clock that stepped backwards would hide every write made since. A
+  // point that has not happened yet is the symptom, and a marker that cannot
+  // be trusted is no marker: scanning everything is the answer that cannot be
+  // wrong, and that includes not trusting its claim of a clean stop.
+  const stored = readHostState(dataDir);
+  const previous = stored !== null && stored.indexedThroughMs <= nowMs ? stored : null;
 
   if (previous?.cleanShutdown === true) {
     // Nothing to scan, but the marker still has to stop saying so: the time
@@ -134,6 +148,16 @@ export function recoverSessionDeadlines(options: DeadlineRecoveryOptions): Deadl
  * missing.
  */
 export function markCleanShutdown(dataDir: string, atMs: number): void {
+  if (readHostState(dataDir)?.indexedThroughMs === SCAN_EVERYTHING_MS) {
+    // This boot could not read a session file, and stopping cleanly does not
+    // repair it. Claiming a clean stop would let the next boot skip its scan
+    // entirely, which is how that one deadline would be lost for good.
+    writeHostState(dataDir, {
+      indexedThroughMs: SCAN_EVERYTHING_MS,
+      cleanShutdown: false,
+    });
+    return;
+  }
   writeHostState(dataDir, { indexedThroughMs: atMs, cleanShutdown: true });
 }
 
@@ -165,23 +189,31 @@ function scanSessionFiles(
   for (const entry of entries) {
     if (!entry.endsWith(SESSION_FILE_SUFFIX)) continue;
     const path = join(directory, entry);
-    if (sinceMs !== null && lastWriteMs(path) < sinceMs) continue;
-    counts.scanned += 1;
     const sessionId = entry.slice(0, -SESSION_FILE_SUFFIX.length);
+    let deadline: number | null;
     try {
-      const deadline = earliestDeadline(path);
-      if (deadline !== null && index.armIfSooner(sessionId, deadline)) counts.rearmed += 1;
+      // Reading when the file was written is part of reading the file: a
+      // permission or I/O error here is a session this boot did not examine,
+      // not a session written long ago.
+      if (sinceMs !== null && lastWriteMs(path) < sinceMs) continue;
+      counts.scanned += 1;
+      deadline = earliestDeadline(path);
     } catch (error) {
       // One unreadable file is one session that will not fire on its own.
       // It is not a reason to refuse the boot, which would take every other
-      // session down with it.
+      // session down with it — but it does hold the recovery point back.
       counts.unreadable += 1;
       log.error("A session file could not be read for its scheduled deadline", {
         event: "node_host.deadline_recovery_failed",
         session_id: sessionId,
         error: error instanceof Error ? error : String(error),
       });
+      continue;
     }
+    // Outside the catch on purpose: an index that cannot be written is not an
+    // unreadable session, and a boot must not continue with an index it knows
+    // is missing a deadline it just read.
+    if (deadline !== null && index.armIfSooner(sessionId, deadline)) counts.rearmed += 1;
   }
   return counts;
 }
@@ -215,12 +247,17 @@ function lastWriteMs(path: string): number {
   return Math.max(modifiedAtMs(path), modifiedAtMs(`${path}-wal`));
 }
 
-/** The file's last write, or 0 when there is no such file. */
+/**
+ * The file's last write, or 0 when there is no such file — a session with no
+ * write-ahead log has none, and that is not a failure. Every other error is
+ * the caller's to handle: a file that cannot be stat'd has not been examined.
+ */
 function modifiedAtMs(path: string): number {
   try {
     return statSync(path).mtimeMs;
-  } catch {
-    return 0;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw error;
   }
 }
 
@@ -249,14 +286,29 @@ function readHostState(dataDir: string): HostState | null {
 }
 
 /**
- * Replace the marker. Written beside its target and renamed over it, so a
- * process that dies mid-write leaves the previous marker rather than a
- * truncated one.
+ * Replace the marker, durably. Written beside its target and renamed over it,
+ * so a process that dies mid-write leaves the previous marker rather than a
+ * truncated one — and flushed before the rename and the directory after it,
+ * because the case this whole file exists for is losing power. A rename that
+ * only reached the page cache would let the previous `cleanShutdown: true`
+ * come back while the session writes that outran it survived, and the next
+ * boot would skip the scan that was meant to catch exactly that.
  */
 function writeHostState(dataDir: string, state: HostState): void {
   const path = join(dataDir, HOST_STATE_FILE);
   const temporary = `${path}.tmp`;
-  writeFileSync(temporary, JSON.stringify(state));
-  makeFilePrivate(temporary);
+  const file = openSync(temporary, "w", 0o600);
+  try {
+    writeFileSync(file, JSON.stringify(state));
+    fsyncSync(file);
+  } finally {
+    closeSync(file);
+  }
   renameSync(temporary, path);
+  const directory = openSync(dataDir, "r");
+  try {
+    fsyncSync(directory);
+  } finally {
+    closeSync(directory);
+  }
 }

--- a/packages/control-plane/src/node/crash-recovery.ts
+++ b/packages/control-plane/src/node/crash-recovery.ts
@@ -1,0 +1,254 @@
+/**
+ * What the host does at boot about a stop it did not choose.
+ *
+ * A scheduled deadline is written twice. The session core commits it to the
+ * session's own file (`session_alarm_state`) and then arms the runtime
+ * alarm, which on this host is a row in the host alarm index. A Durable
+ * Object writes both into one storage; here they are two files, so a process
+ * that dies between them leaves a deadline the session knows about and the
+ * index does not. Nothing is lost while the session stays resident — its
+ * next activation re-arms the index through `rehydrate()` — but a session
+ * that is never touched again never fires.
+ *
+ * The marker file (`<dataDir>/host-state.json`) is what tells the two stops
+ * apart. It records the time through which the index is known to hold every
+ * armed deadline, and whether the host reached that time by stopping
+ * cleanly. A clean stop needs nothing at the next boot. Any other stop makes
+ * the boot read the session files written since that time and arm each
+ * file's earliest deadline into the index, which can only bring a wake-up
+ * forward, never postpone or replace what the index already holds. The
+ * marker is invalidated before the host serves anything, so a boot that
+ * itself dies is the next boot's unclean stop.
+ *
+ * The files are read directly rather than opened through the registry: the
+ * question is a two-column read, while activating a runtime reaches the
+ * sockets and the sandbox provider, and a boot must not do that for every
+ * session written since the last clean stop. Reading also leaves the session
+ * unchanged, so a boot that dies part-way through a scan leaves the next
+ * boot exactly the same work.
+ */
+
+import { readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Logger } from "../logger";
+import { PersistedAlarmDeadlineStore } from "../session/alarm/scheduler";
+import type { HostAlarmIndex } from "./host-alarm-index";
+import { makeFilePrivate } from "./private-paths";
+import { openPrivateSqliteFile } from "./sqlite-file";
+import { createNodeSqlStorage } from "./sqlite-storage";
+
+/** The marker's file inside the data directory. */
+export const HOST_STATE_FILE = "host-state.json";
+
+/** Where the per-session files live inside the data directory. */
+const SESSIONS_DIRECTORY = "sessions";
+/** What a session file is called; the rest of the name is the session id. */
+const SESSION_FILE_SUFFIX = ".db";
+/** The session table holding what the session has scheduled. */
+const ALARM_STATE_TABLE = "session_alarm_state";
+
+/** What the marker file holds. */
+interface HostState {
+  /** Every deadline armed before this time is in the host alarm index. */
+  indexedThroughMs: number;
+  /** The host stopped cleanly at that time, and armed nothing after it. */
+  cleanShutdown: boolean;
+}
+
+/** How the previous process stopped, as the marker reports it. */
+type PreviousStop = "clean_shutdown" | "unclean_stop" | "no_marker";
+
+/** What a boot's recovery found and did. */
+export interface DeadlineRecoveryReport {
+  previousStop: PreviousStop;
+  /** Session files read; zero after a clean stop. */
+  scanned: number;
+  /** Deadlines the index did not hold and now does. */
+  rearmed: number;
+  /** Session files that could not be read; each is logged and skipped. */
+  unreadable: number;
+}
+
+export interface DeadlineRecoveryOptions {
+  dataDir: string;
+  index: HostAlarmIndex;
+  log: Logger;
+  /**
+   * The boot's own time. Read before the scan, so a session written while
+   * the scan runs is covered by the next one rather than missed.
+   */
+  nowMs: number;
+}
+
+/**
+ * Restore into the index every deadline a session's file holds that the
+ * index may have missed, and leave the marker saying the host is running.
+ * Runs before anything can arm a deadline, and is safe to run when nothing
+ * was lost: arming is a no-op for a deadline the index already holds.
+ */
+export function recoverSessionDeadlines(options: DeadlineRecoveryOptions): DeadlineRecoveryReport {
+  const { dataDir, index, log, nowMs } = options;
+  const previous = readHostState(dataDir);
+
+  if (previous?.cleanShutdown === true) {
+    // Nothing to scan, but the marker still has to stop saying so: the time
+    // it names stays the last moment the index was known complete, and an
+    // unclean stop from here scans forward from it.
+    writeHostState(dataDir, {
+      indexedThroughMs: previous.indexedThroughMs,
+      cleanShutdown: false,
+    });
+    return { previousStop: "clean_shutdown", scanned: 0, rearmed: 0, unreadable: 0 };
+  }
+
+  // No marker at all names no clean point to scan from, so every session
+  // file is read. On a fresh volume that is no files and no cost; on a
+  // volume written by a build that predates the marker it is one full pass,
+  // after which a marker exists.
+  const previousStop: PreviousStop = previous === null ? "no_marker" : "unclean_stop";
+  const scan = scanSessionFiles(dataDir, index, previous?.indexedThroughMs ?? null, log);
+  writeHostState(dataDir, { indexedThroughMs: nowMs, cleanShutdown: false });
+
+  const report: DeadlineRecoveryReport = { previousStop, ...scan };
+  if (scan.scanned > 0) {
+    log.warn("Re-armed scheduled deadlines from the session files after an unclean stop", {
+      event: "node_host.deadlines_recovered",
+      ...report,
+    });
+  }
+  return report;
+}
+
+/**
+ * Record that the host stopped cleanly at `atMs`, so the next boot scans
+ * nothing. Only a shutdown that abandoned no work may call this: work that
+ * outlived the drain budget can still arm a deadline the index would then be
+ * missing.
+ */
+export function markCleanShutdown(dataDir: string, atMs: number): void {
+  writeHostState(dataDir, { indexedThroughMs: atMs, cleanShutdown: true });
+}
+
+/** What `recoverSessionDeadlines` counts, before the reason is attached. */
+type ScanCounts = Omit<DeadlineRecoveryReport, "previousStop">;
+
+/**
+ * Arm the earliest deadline of every session file written at or after
+ * `sinceMs`, or of every session file when that is null.
+ */
+function scanSessionFiles(
+  dataDir: string,
+  index: HostAlarmIndex,
+  sinceMs: number | null,
+  log: Logger
+): ScanCounts {
+  const directory = join(dataDir, SESSIONS_DIRECTORY);
+  let entries: string[];
+  try {
+    entries = readdirSync(directory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { scanned: 0, rearmed: 0, unreadable: 0 };
+    }
+    throw error;
+  }
+
+  const counts: ScanCounts = { scanned: 0, rearmed: 0, unreadable: 0 };
+  for (const entry of entries) {
+    if (!entry.endsWith(SESSION_FILE_SUFFIX)) continue;
+    const path = join(directory, entry);
+    if (sinceMs !== null && lastWriteMs(path) < sinceMs) continue;
+    counts.scanned += 1;
+    const sessionId = entry.slice(0, -SESSION_FILE_SUFFIX.length);
+    try {
+      const deadline = earliestDeadline(path);
+      if (deadline !== null && index.armIfSooner(sessionId, deadline)) counts.rearmed += 1;
+    } catch (error) {
+      // One unreadable file is one session that will not fire on its own.
+      // It is not a reason to refuse the boot, which would take every other
+      // session down with it.
+      counts.unreadable += 1;
+      log.error("A session file could not be read for its scheduled deadline", {
+        event: "node_host.deadline_recovery_failed",
+        session_id: sessionId,
+        error: error instanceof Error ? error : String(error),
+      });
+    }
+  }
+  return counts;
+}
+
+/**
+ * The soonest deadline the session's own file holds, or null when it holds
+ * none. The file is opened the way the host opens it, so a write-ahead log
+ * the dead process left is recovered before the read, and the rule for what
+ * counts as pending is the session core's own.
+ */
+function earliestDeadline(path: string): number | null {
+  const db = openPrivateSqliteFile(path);
+  try {
+    const table = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(ALARM_STATE_TABLE);
+    // A file whose schema was never applied has nothing scheduled.
+    if (table === undefined) return null;
+    return new PersistedAlarmDeadlineStore(createNodeSqlStorage(db).sql).earliest();
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * When the session was last written. A commit lands in the write-ahead log
+ * and leaves the database file's own timestamp alone until a checkpoint, so
+ * the log counts as a write to the session.
+ */
+function lastWriteMs(path: string): number {
+  return Math.max(modifiedAtMs(path), modifiedAtMs(`${path}-wal`));
+}
+
+/** The file's last write, or 0 when there is no such file. */
+function modifiedAtMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The marker, or null when there is none. A marker that cannot be read or
+ * does not carry both fields is no marker: the boot has no clean point to
+ * trust, and scanning everything is the answer that cannot be wrong.
+ */
+function readHostState(dataDir: string): HostState | null {
+  let text: string;
+  try {
+    text = readFileSync(join(dataDir, HOST_STATE_FILE), "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const state = parsed as Partial<HostState> | null;
+  if (typeof state?.indexedThroughMs !== "number") return null;
+  if (typeof state.cleanShutdown !== "boolean") return null;
+  return { indexedThroughMs: state.indexedThroughMs, cleanShutdown: state.cleanShutdown };
+}
+
+/**
+ * Replace the marker. Written beside its target and renamed over it, so a
+ * process that dies mid-write leaves the previous marker rather than a
+ * truncated one.
+ */
+function writeHostState(dataDir: string, state: HostState): void {
+  const path = join(dataDir, HOST_STATE_FILE);
+  const temporary = `${path}.tmp`;
+  writeFileSync(temporary, JSON.stringify(state));
+  makeFilePrivate(temporary);
+  renameSync(temporary, path);
+}

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -40,6 +40,36 @@ describe("openHostAlarmIndex", () => {
     expect(index.earliest()).toBeNull();
   });
 
+  it("arms a deadline the index is missing and leaves a sooner one alone", () => {
+    const index = open();
+    // Nothing armed: the deadline read back from the session file is taken.
+    expect(index.armIfSooner("lost", 500)).toBe(true);
+    expect(index.get("lost")).toBe(500);
+    // Already armed sooner, and already armed at the same time: no change.
+    expect(index.armIfSooner("lost", 700)).toBe(false);
+    expect(index.armIfSooner("lost", 500)).toBe(false);
+    expect(index.get("lost")).toBe(500);
+    // Sooner than what is armed: brought forward.
+    expect(index.armIfSooner("lost", 200)).toBe(true);
+    expect(index.get("lost")).toBe(200);
+  });
+
+  it("leaves a claim in flight and the retry budget alone when it arms a missing deadline", () => {
+    const index = open();
+    index.set("s1", 500);
+    index.claim("s1");
+    index.retry("s1", 800);
+    index.claim("s1");
+    expect(index.get("s1")).toBeNull();
+
+    expect(index.armIfSooner("s1", 900)).toBe(true);
+    // The claim still stands and still carries its failure, so recovery
+    // re-arms it at the deadline it was claimed at rather than the later one.
+    expect(index.recoverClaims()).toEqual(["s1"]);
+    expect(index.get("s1")).toBe(800);
+    expect(index.claim("s1")).toEqual({ deadline: 800, failures: 1 });
+  });
+
   it("orders the earliest and the due deadlines soonest first", () => {
     const index = open();
     index.set("late", 900);

--- a/packages/control-plane/src/node/host-alarm-index.test.ts
+++ b/packages/control-plane/src/node/host-alarm-index.test.ts
@@ -61,17 +61,17 @@ describe("openHostAlarmIndex", () => {
   it("leaves a claim in flight and the retry budget alone when it arms a missing deadline", () => {
     const index = open();
     index.set("s1", 500);
-    index.claim("s1");
-    index.retry("s1", 800);
-    index.claim("s1");
+    const first = index.claim("s1", LEASE_UNTIL)!;
+    index.retry("s1", first.token, 800);
+    index.claim("s1", LEASE_UNTIL);
     expect(index.get("s1")).toBeNull();
 
     expect(index.armIfSooner("s1", 900)).toBe(true);
     // The claim still stands and still carries its failure, so recovery
     // re-arms it at the deadline it was claimed at rather than the later one.
-    expect(index.recoverClaims()).toEqual(["s1"]);
+    expect(index.recoverForeignClaims([])).toEqual(["s1"]);
     expect(index.get("s1")).toBe(800);
-    expect(index.claim("s1")).toEqual({ deadline: 800, failures: 1 });
+    expect(index.claim("s1", LEASE_UNTIL)).toMatchObject({ deadline: 800, failures: 1 });
   });
 
   it("orders the earliest and the due deadlines soonest first", () => {

--- a/packages/control-plane/src/node/host-alarm-index.ts
+++ b/packages/control-plane/src/node/host-alarm-index.ts
@@ -36,6 +36,14 @@ export interface HostAlarmIndex {
   get(sessionId: string): number | null;
   /** Arm (replacing any earlier armed deadline) the session's next deadline. */
   set(sessionId: string, deadline: number): void;
+  /**
+   * Arm `deadline` unless the index already holds one at or before it,
+   * leaving the retry budget and any claim in flight alone. Returns whether
+   * the index changed. This is how a deadline read back from a session's own
+   * file is restored after an unclean stop: it can only bring the session's
+   * next wake-up forward, never postpone or replace what the index holds.
+   */
+  armIfSooner(sessionId: string, deadline: number): boolean;
   /** Disarm the session. A claim in flight is unaffected. */
   delete(sessionId: string): void;
   /** The soonest armed deadline, ignoring the sessions in `excluding`. */
@@ -103,6 +111,12 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
   const dropDisarmed = db.prepare(
     "DELETE FROM session_deadlines WHERE session_id = ? AND deadline IS NULL"
   );
+  const armSoonerUnlessArmed = db.prepare(
+    `INSERT INTO session_deadlines (session_id, deadline) VALUES (?, ?)
+     ON CONFLICT(session_id) DO UPDATE SET deadline = excluded.deadline
+     WHERE deadline IS NULL OR deadline > excluded.deadline
+     RETURNING session_id`
+  );
   const claimRow = db.prepare(
     `UPDATE session_deadlines SET in_flight = deadline, deadline = NULL
      WHERE session_id = ? AND deadline IS NOT NULL RETURNING in_flight, failures`
@@ -152,6 +166,8 @@ export function openHostAlarmIndex(dataDir: string): HostAlarmIndex {
     set: (sessionId, deadline) => {
       arm.run(sessionId, deadline);
     },
+    armIfSooner: (sessionId, deadline) =>
+      armSoonerUnlessArmed.get(sessionId, deadline) !== undefined,
     delete: (sessionId) => {
       dropUnclaimed.run(sessionId);
       disarm.run(sessionId);

--- a/packages/control-plane/src/node/host.test.ts
+++ b/packages/control-plane/src/node/host.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
@@ -7,11 +7,15 @@ import { WebSocket as NodeWebSocket } from "ws";
 import { NO_AUTHORIZATION } from "../routes/shared";
 import { admit } from "../routing/admit";
 import type { ControlPlaneHonoEnv } from "../routing/hono-env";
+import { PersistedAlarmDeadlineStore } from "../session/alarm/scheduler";
 import { CACHE_STORE_FILE } from "./cache-database";
 import { DEFAULT_MIGRATIONS_DIR, type NodeHostSettings } from "./config";
+import { HOST_STATE_FILE } from "./crash-recovery";
+import { openHostAlarmIndex } from "./host-alarm-index";
 import { GLOBAL_STORE_FILE, startNodeHost, type NodeHost, type NodeHostOptions } from "./host";
 import { JOB_STORE_FILE } from "./job-store";
 import type { HealthReport } from "./http-server";
+import { openSessionStore } from "./session-store";
 
 const KEY = Buffer.alloc(32, 7).toString("base64");
 
@@ -88,6 +92,12 @@ describe("startNodeHost", () => {
       ...overrides,
     });
   };
+
+  const marker = (): { indexedThroughMs: number; cleanShutdown: boolean } =>
+    JSON.parse(readFileSync(join(dataDir, HOST_STATE_FILE), "utf8")) as {
+      indexedThroughMs: number;
+      cleanShutdown: boolean;
+    };
 
   afterEach(async () => {
     await host?.shutdown();
@@ -205,9 +215,44 @@ describe("startNodeHost", () => {
     const report = await host.shutdown();
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(150);
     expect(report).toEqual({ clean: false, abandoned: ["http_requests:1"] });
+    // No clean marker: the handler that outlived the budget could still have
+    // armed a deadline, so the next boot goes looking for it.
+    expect(marker()).toMatchObject({ cleanShutdown: false });
     // The connection was cut at the end; the peer sees no answer.
     await expect(blocked).rejects.toThrow();
     host = null;
+  });
+
+  it("marks a stop that abandoned nothing as clean", async () => {
+    host = await start();
+    // Running, the marker says nothing about a clean stop.
+    expect(marker()).toMatchObject({ cleanShutdown: false });
+
+    await host.shutdown();
+    host = null;
+
+    expect(marker()).toEqual({ indexedThroughMs: expect.any(Number), cleanShutdown: true });
+  });
+
+  it("arms a deadline a previous process left only in the session file", async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "node-host-"));
+    // The session committed its deadline and the process died before the row
+    // reached the index. Far enough out that the clock only arms a timer.
+    const deadline = Date.now() + 60 * 60 * 1000;
+    const session = openSessionStore({ dataDir, sessionId: "stranded" });
+    new PersistedAlarmDeadlineStore(session.storage.sql).setPending(deadline);
+    session.close();
+
+    host = await start();
+    await host.shutdown();
+    host = null;
+
+    const index = openHostAlarmIndex(dataDir);
+    try {
+      expect(index.get("stranded")).toBe(deadline);
+    } finally {
+      index.close();
+    }
   });
 
   it("fails to boot on a malformed encryption key with the Worker's message, leaving nothing open", async () => {

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -6,10 +6,12 @@
  * the adapters in this directory.
  *
  * Boot: the configuration is validated before any file is touched, then
- * the global store is opened and migrated, the alarm clock and the
- * registry are built, the server listens, and the clock, sweeper, and
- * cron start. Everything acquired is released in reverse order if a later
- * step fails, and owned by the returned host once boot succeeds.
+ * the global store is opened and migrated, the deadlines a previous
+ * process may not have indexed are recovered (crash-recovery.ts), the
+ * alarm clock and the registry are built, the server listens, and the
+ * clock, sweeper, and cron start. Everything acquired is released in
+ * reverse order if a later step fails, and owned by the returned host once
+ * boot succeeds.
  *
  * Shutdown runs one deadline: the health check answers 503 and the clocks
  * stop, the server stops accepting, then everything that can still reach
@@ -17,7 +19,9 @@
  * scheduled runs, alarm deliveries, background tasks), then the registry
  * quiesces every runtime (sockets closed with 1012 so peers reconnect),
  * then the transports are closed, the peers that ignored the close are
- * cut, and the stores are closed. What outlived the budget is reported.
+ * cut, and the stores are closed. What outlived the budget is reported. A
+ * drain that abandoned nothing leaves the clean-shutdown marker the next
+ * boot reads.
  */
 
 import { once } from "node:events";
@@ -42,6 +46,7 @@ import type { Env, EnvConfig, Platform } from "../types";
 import { createNodeBackgroundTasks, settlesWithin } from "./background-tasks";
 import { openNodeCacheDatabase } from "./cache-database";
 import type { NodeHostSettings } from "./config";
+import { markCleanShutdown, recoverSessionDeadlines } from "./crash-recovery";
 import { CronLoop } from "./cron-loop";
 import { HostAlarmClock } from "./host-alarm-clock";
 import { openHostAlarmIndex } from "./host-alarm-index";
@@ -150,6 +155,14 @@ async function boot(
   const jobs = new NodeJobs({ store: jobStore, deps: () => ({ env, db, log }), log });
 
   const alarmIndex = ownStore(openHostAlarmIndex(settings.dataDir));
+  // Before anything can arm a deadline: a stop that left no clean marker may
+  // have left deadlines in session files that never reached the index.
+  const recovery = recoverSessionDeadlines({
+    dataDir: settings.dataDir,
+    index: alarmIndex,
+    log,
+    nowMs: startedAtMs,
+  });
   const clock: HostAlarmClock = new HostAlarmClock({
     index: alarmIndex,
     deliver: (sessionId) => registry.deliverScheduledDeadline(sessionId),
@@ -240,6 +253,8 @@ async function boot(
     port: address.port,
     data_dir: settings.dataDir,
     migrations_applied: migrationsApplied,
+    previous_stop: recovery.previousStop,
+    deadlines_rearmed: recovery.rearmed,
   });
 
   const shutdown = async (): Promise<ShutdownReport> => {
@@ -283,9 +298,13 @@ async function boot(
     server.closeAllConnections();
     await closed;
 
+    const report: ShutdownReport = { clean: abandoned.length === 0, abandoned };
+    // Only a drain that abandoned nothing may claim a clean stop: work that
+    // outlived the budget can still arm a deadline the index would then be
+    // missing, and the next boot has to go looking for it.
+    if (report.clean) markCleanShutdown(settings.dataDir, Date.now());
     closeStores();
 
-    const report: ShutdownReport = { clean: abandoned.length === 0, abandoned };
     if (report.clean) {
       log.info("node_host.stopped", { event: "node_host.stopped" });
     } else {

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -302,8 +302,11 @@ async function boot(
     // Only a drain that abandoned nothing may claim a clean stop: work that
     // outlived the budget can still arm a deadline the index would then be
     // missing, and the next boot has to go looking for it.
-    if (report.clean) markCleanShutdown(settings.dataDir, Date.now());
-    closeStores();
+    try {
+      if (report.clean) markCleanShutdown(settings.dataDir, Date.now());
+    } finally {
+      closeStores();
+    }
 
     if (report.clean) {
       log.info("node_host.stopped", { event: "node_host.stopped" });

--- a/packages/control-plane/src/node/host.ts
+++ b/packages/control-plane/src/node/host.ts
@@ -163,6 +163,17 @@ async function boot(
     log,
     nowMs: startedAtMs,
   });
+  // The same question for the jobs table, and the same moment to ask it: one
+  // host holds this volume, so a claim already on disk was left by a process
+  // that is gone. Returning them here rather than from the poller is what
+  // makes it a boot concern — the poller has no way to tell whose a claim is.
+  const reclaimed = jobStore.recoverAllClaims();
+  if (reclaimed.length > 0) {
+    log.warn("Returning jobs a previous process left claimed", {
+      event: "jobs.claims_recovered",
+      job_ids: reclaimed,
+    });
+  }
   const clock: HostAlarmClock = new HostAlarmClock({
     index: alarmIndex,
     deliver: (sessionId) => registry.deliverScheduledDeadline(sessionId),
@@ -289,7 +300,11 @@ async function boot(
     if (tasks > 0) abandoned.push(`background_tasks:${tasks}`);
 
     // Then the runtimes: sockets closed with 1012, per-session work waited for.
-    await registry.shutdown({ timeoutMs: remaining() });
+    // A runtime forced at the budget is abandoned work like any other: it can
+    // have persisted a deadline without arming it, and only the next boot's
+    // scan would find that.
+    const { forced } = await registry.shutdown({ timeoutMs: remaining() });
+    if (forced.length > 0) abandoned.push(`sessions_forced:${forced.length}`);
 
     // Then the transports. A peer that ignored its close frame is cut, as
     // is any connection still open, so the server's close can complete.

--- a/packages/control-plane/src/node/job-queue.test.ts
+++ b/packages/control-plane/src/node/job-queue.test.ts
@@ -327,7 +327,7 @@ describe("NodeJobs", () => {
     expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 0 });
   });
 
-  it("takes back a claim a dead process left, rather than waiting out its lease", async () => {
+  it("takes back every claim on disk when the boot returns them", async () => {
     const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
     // A row left `running` on disk by a process that is gone, its lease with
     // most of the quarter hour still to run.
@@ -335,19 +335,19 @@ describe("NodeJobs", () => {
     store.claim(9_000, 1, [KIND], 9_000 + JOB_CLAIM_LEASE_MS);
     expect(store.stats(10_000)).toMatchObject({ running: 1, pending: 0 });
 
+    // The boot's job, not the poller's: one host holds the volume, so a claim
+    // already on disk is a dead process's.
+    expect(store.recoverAllClaims()).toEqual(["orphan"]);
+
     const queue = createQueue(handle);
     queue.start();
     await runPoller(queue);
 
     expect(handle).toHaveBeenCalledOnce();
     expect(queueIsEmpty()).toBe(true);
-    expect(log.warn).toHaveBeenCalledWith(
-      "Returning jobs a previous process left claimed",
-      expect.objectContaining({ event: "jobs.claims_recovered", job_ids: ["orphan"] })
-    );
   });
 
-  it("does not take back a job it is still delivering when it is started again", async () => {
+  it("does not let a second poller take a job the first is still delivering", async () => {
     let release = (): void => {};
     const handle = vi.fn(async (): Promise<JobOutcome> => {
       await new Promise<void>((resolve) => {
@@ -355,21 +355,28 @@ describe("NodeJobs", () => {
       });
       return "ack";
     });
-    const queue = createQueue(handle);
+    const first = createQueue(handle);
+    const second = new NodeJobs({
+      store,
+      deps: () => ({ env: {}, db: {}, log }) as unknown as Omit<JobDeps, "correlation">,
+      log,
+      now: () => Date.now(),
+      newId: () => `other-${++ids}`,
+    });
 
-    await queue.send({ kind: KIND, payload: PAYLOAD });
-    queue.start();
-    // The delivery has claimed the job and is blocked in the handler.
+    await first.send({ kind: KIND, payload: PAYLOAD });
+    first.start();
+    // The first poller has claimed and is blocked before the second starts.
     await vi.advanceTimersByTimeAsync(1);
     expect(handle).toHaveBeenCalledOnce();
 
-    queue.start();
+    second.start();
     await vi.advanceTimersByTimeAsync(1);
     expect(handle).toHaveBeenCalledOnce();
-    expect(queue.stats()).toMatchObject({ running: 1, pending: 0 });
 
     release();
-    await queue.drain();
+    await Promise.all([first.drain(), second.drain()]);
+    second.stop();
     expect(queueIsEmpty()).toBe(true);
   });
 

--- a/packages/control-plane/src/node/job-queue.test.ts
+++ b/packages/control-plane/src/node/job-queue.test.ts
@@ -290,7 +290,7 @@ describe("NodeJobs", () => {
     await vi.advanceTimersByTimeAsync(2);
     expect(log.warn).toHaveBeenCalledWith(
       "Returning jobs whose claim expired",
-      expect.objectContaining({ event: "jobs.claims_recovered" })
+      expect.objectContaining({ event: "jobs.claims_expired" })
     );
     expect(handle).toHaveBeenCalledTimes(2);
   });
@@ -327,7 +327,27 @@ describe("NodeJobs", () => {
     expect(queue.stats()).toMatchObject({ pending: 0, running: 0, dead: 0 });
   });
 
-  it("does not let a second poller take a job the first is still delivering", async () => {
+  it("takes back a claim a dead process left, rather than waiting out its lease", async () => {
+    const handle = vi.fn(async (): Promise<JobOutcome> => "ack");
+    // A row left `running` on disk by a process that is gone, its lease with
+    // most of the quarter hour still to run.
+    store.add({ id: "orphan", kind: KIND, payload: JSON.stringify(PAYLOAD), runAt: 9_000 }, 9_000);
+    store.claim(9_000, 1, [KIND], 9_000 + JOB_CLAIM_LEASE_MS);
+    expect(store.stats(10_000)).toMatchObject({ running: 1, pending: 0 });
+
+    const queue = createQueue(handle);
+    queue.start();
+    await runPoller(queue);
+
+    expect(handle).toHaveBeenCalledOnce();
+    expect(queueIsEmpty()).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      "Returning jobs a previous process left claimed",
+      expect.objectContaining({ event: "jobs.claims_recovered", job_ids: ["orphan"] })
+    );
+  });
+
+  it("does not take back a job it is still delivering when it is started again", async () => {
     let release = (): void => {};
     const handle = vi.fn(async (): Promise<JobOutcome> => {
       await new Promise<void>((resolve) => {
@@ -335,28 +355,21 @@ describe("NodeJobs", () => {
       });
       return "ack";
     });
-    const first = createQueue(handle);
-    const second = new NodeJobs({
-      store,
-      deps: () => ({ env: {}, db: {}, log }) as unknown as Omit<JobDeps, "correlation">,
-      log,
-      now: () => Date.now(),
-      newId: () => `other-${++ids}`,
-    });
+    const queue = createQueue(handle);
 
-    await first.send({ kind: KIND, payload: PAYLOAD });
-    first.start();
-    // The first poller has claimed and is blocked before the second starts.
+    await queue.send({ kind: KIND, payload: PAYLOAD });
+    queue.start();
+    // The delivery has claimed the job and is blocked in the handler.
     await vi.advanceTimersByTimeAsync(1);
     expect(handle).toHaveBeenCalledOnce();
 
-    second.start();
+    queue.start();
     await vi.advanceTimersByTimeAsync(1);
     expect(handle).toHaveBeenCalledOnce();
+    expect(queue.stats()).toMatchObject({ running: 1, pending: 0 });
 
     release();
-    await Promise.all([first.drain(), second.drain()]);
-    second.stop();
+    await queue.drain();
     expect(queueIsEmpty()).toBe(true);
   });
 

--- a/packages/control-plane/src/node/job-queue.ts
+++ b/packages/control-plane/src/node/job-queue.ts
@@ -18,12 +18,14 @@
  *
  * Jobs run concurrently up to a bound, so a host coming back to a backlog
  * works through it a few at a time; the next ones start as soon as one
- * settles. Every claim is a lease, and when a lease runs out the poller lets
- * go of that delivery in both places at once: the row goes back to pending,
- * and the slot it held stops counting against the bound. A hung handler
- * therefore costs one lease, not a permanently narrower queue — and it
- * cannot corrupt the redelivery that replaces it, because settling is fenced
- * on the claim token it no longer owns.
+ * settles. Starting the poller takes back every claim no delivery here owns,
+ * so a job the process that died was running is retried at once instead of
+ * waiting out its lease. Every claim is a lease, and when a lease runs out
+ * the poller lets go of that delivery in both places at once: the row goes
+ * back to pending, and the slot it held stops counting against the bound. A
+ * hung handler therefore costs one lease, not a permanently narrower queue —
+ * and it cannot corrupt the redelivery that replaces it, because settling is
+ * fenced on the claim token it no longer owns.
  *
  * Polling, delivery and arming are total: a store that throws is logged and
  * the timer re-armed, never left as an unhandled rejection from a timer task.
@@ -79,8 +81,11 @@ export class NodeJobs implements Jobs {
   private readonly newId: () => string;
   private timer: NodeJS.Timeout | null = null;
   private running = false;
-  /** Deliveries this process started, by job id, with the lease each holds. */
-  private readonly inFlight = new Map<string, { delivery: Promise<void>; leaseUntil: number }>();
+  /** Deliveries this process started, by job id, with the claim each holds. */
+  private readonly inFlight = new Map<
+    string,
+    { delivery: Promise<void>; token: string; leaseUntil: number }
+  >();
 
   constructor(options: NodeJobsOptions) {
     this.store = options.store;
@@ -107,12 +112,22 @@ export class NodeJobs implements Jobs {
   }
 
   /**
-   * Start delivering. Idempotent: recovery takes only claims whose lease has
-   * run out, so starting again never takes a job away from a delivery that
-   * is still running.
+   * Start delivering. A claim on disk that no delivery here owns was left by
+   * a process that is gone, and is returned to pending at once: its handler
+   * may not have run, and waiting out its lease would leave the job sitting
+   * for a quarter of an hour after every restart. Idempotent, because the
+   * claims this process is still delivering are named and left alone.
    */
   start(): void {
     this.running = true;
+    const owned = [...this.inFlight.values()].map((entry) => entry.token);
+    const recovered = this.store.recoverForeignClaims(owned);
+    if (recovered.length > 0) {
+      this.log.warn("Returning jobs a previous process left claimed", {
+        event: "jobs.claims_recovered",
+        job_ids: recovered,
+      });
+    }
     this.arm();
   }
 
@@ -213,7 +228,7 @@ export class NodeJobs implements Jobs {
     const recovered = this.store.recoverExpiredClaims(this.now());
     if (recovered.length === 0) return;
     this.log.warn("Returning jobs whose claim expired", {
-      event: "jobs.claims_recovered",
+      event: "jobs.claims_expired",
       job_ids: recovered,
     });
   }
@@ -244,7 +259,7 @@ export class NodeJobs implements Jobs {
           if (this.inFlight.get(job.id)?.delivery === delivery) this.inFlight.delete(job.id);
           this.arm();
         });
-      this.inFlight.set(job.id, { delivery, leaseUntil });
+      this.inFlight.set(job.id, { delivery, token: job.token, leaseUntil });
     }
   }
 

--- a/packages/control-plane/src/node/job-queue.ts
+++ b/packages/control-plane/src/node/job-queue.ts
@@ -112,22 +112,14 @@ export class NodeJobs implements Jobs {
   }
 
   /**
-   * Start delivering. A claim on disk that no delivery here owns was left by
-   * a process that is gone, and is returned to pending at once: its handler
-   * may not have run, and waiting out its lease would leave the job sitting
-   * for a quarter of an hour after every restart. Idempotent, because the
-   * claims this process is still delivering are named and left alone.
+   * Start delivering. Carries no recovery: a claim left by a dead process is
+   * the boot's to return, once, before any poller runs. This process cannot
+   * tell from its own memory which claims are someone else's — one token
+   * covers a whole claimed batch — so it does not try, and starting twice is
+   * harmless for the simpler reason that it does nothing but arm a timer.
    */
   start(): void {
     this.running = true;
-    const owned = [...this.inFlight.values()].map((entry) => entry.token);
-    const recovered = this.store.recoverForeignClaims(owned);
-    if (recovered.length > 0) {
-      this.log.warn("Returning jobs a previous process left claimed", {
-        event: "jobs.claims_recovered",
-        job_ids: recovered,
-      });
-    }
     this.arm();
   }
 

--- a/packages/control-plane/src/node/job-store.test.ts
+++ b/packages/control-plane/src/node/job-store.test.ts
@@ -144,21 +144,25 @@ describe("openJobStore", () => {
       store.close();
       store = openJobStore(dataDir);
 
-      expect(store.recoverForeignClaims([])).toEqual(["interrupted"]);
+      expect(store.recoverAllClaims()).toEqual(["interrupted"]);
       // The attempt the dead process spent is still spent: a queue counts a
       // delivery however it ended.
       expect(claim(1_100)).toEqual([expect.objectContaining({ id: "interrupted", attempts: 2 })]);
     });
 
-    it("leaves a claim a live delivery still owns", () => {
-      add("running", 1_000);
-      const [held] = claim(1_000);
+    it("takes a claim back whatever its lease still has to run", () => {
+      add("early", 1_000);
+      add("later", 1_000);
+      const held = claim(1_000);
+      expect(held).toHaveLength(2);
 
-      expect(store.recoverForeignClaims([held!.token])).toEqual([]);
-      expect(store.stats(9_000)).toMatchObject({ running: 1, pending: 0 });
-      // And the delivery that holds it can still settle it.
-      store.complete("running", held!.token);
-      expect(store.stats(9_000)).toMatchObject({ running: 0, pending: 0, dead: 0 });
+      // One statement, one token, both rows: which is why the store cannot be
+      // asked whose a claim is, and why this belongs to the boot alone.
+      expect(store.recoverAllClaims().sort()).toEqual(["early", "later"]);
+      expect(store.stats(9_000)).toMatchObject({ running: 0, pending: 2 });
+      // The claims are gone, so the settlement that outlived them is refused.
+      store.complete("early", held[0]!.token);
+      expect(store.stats(9_000)).toMatchObject({ pending: 2 });
     });
 
     it("refuses a settlement from a delivery its lease already outlived", () => {

--- a/packages/control-plane/src/node/job-store.test.ts
+++ b/packages/control-plane/src/node/job-store.test.ts
@@ -136,6 +136,31 @@ describe("openJobStore", () => {
       ]);
     });
 
+    it("returns a claim no live delivery owns, without waiting out its lease", () => {
+      add("interrupted", 1_000);
+      claim(1_000);
+      // The process that held the claim is gone; the store is reopened by
+      // its replacement while the lease still has a quarter hour to run.
+      store.close();
+      store = openJobStore(dataDir);
+
+      expect(store.recoverForeignClaims([])).toEqual(["interrupted"]);
+      // The attempt the dead process spent is still spent: a queue counts a
+      // delivery however it ended.
+      expect(claim(1_100)).toEqual([expect.objectContaining({ id: "interrupted", attempts: 2 })]);
+    });
+
+    it("leaves a claim a live delivery still owns", () => {
+      add("running", 1_000);
+      const [held] = claim(1_000);
+
+      expect(store.recoverForeignClaims([held!.token])).toEqual([]);
+      expect(store.stats(9_000)).toMatchObject({ running: 1, pending: 0 });
+      // And the delivery that holds it can still settle it.
+      store.complete("running", held!.token);
+      expect(store.stats(9_000)).toMatchObject({ running: 0, pending: 0, dead: 0 });
+    });
+
     it("refuses a settlement from a delivery its lease already outlived", () => {
       add("overtaken", 1_000);
       const [stale] = claim(1_000);

--- a/packages/control-plane/src/node/job-store.ts
+++ b/packages/control-plane/src/node/job-store.ts
@@ -9,12 +9,20 @@
  * A claim is a **lease**, as a queue's invisibility window is. Claiming
  * writes a fresh token and an expiry; settling names the token, so a
  * delivery that comes back after its lease expired cannot settle the
- * redelivery that replaced it. A claim whose lease has run out is the only
- * thing recovery touches, which covers both a process that died mid-job and
- * a handler that never returns — one rule for both, and it makes starting a
- * poller twice harmless. The cost is Cloudflare's own: two deliveries of one
- * job can overlap, which `jobs.ts` already requires every handler to
- * tolerate.
+ * redelivery that replaced it. Two things end a claim early, and they answer
+ * different questions: a claim no live delivery owns belongs to a process
+ * that is gone (`recoverForeignClaims`, at start), and a claim whose lease
+ * ran out belongs to a handler that hung (`recoverExpiredClaims`, on every
+ * sweep). Naming the claims this process still holds is what keeps the first
+ * from taking a job away from a delivery that is still running, so starting a
+ * poller twice stays harmless. The cost of both is Cloudflare's own: two
+ * deliveries of one job can overlap, which `jobs.ts` already requires every
+ * handler to tolerate.
+ *
+ * Neither recovery refunds an attempt. The attempt is counted when the job
+ * is claimed, exactly as a queue counts a delivery however it ended, so a
+ * job whose handler takes the process down with it still runs out of
+ * attempts and reaches the dead rows instead of being redelivered for ever.
  *
  * It is deliberately not part of the global store, whose schema is
  * `terraform/d1/migrations` and lands on D1 as well: nothing on Cloudflare
@@ -110,6 +118,13 @@ export interface JobStore {
   /** The leased job will not be delivered again: keep the row with what ended it. */
   bury(id: string, token: string, error: string): void;
   /**
+   * Return every claim no live delivery owns to pending, runnable at once.
+   * `ownedTokens` are the claims this process is still delivering, so
+   * starting a poller again never takes one of them back. Returns the job
+   * ids recovered.
+   */
+  recoverForeignClaims(ownedTokens: readonly string[]): string[];
+  /**
    * Return every claim whose lease has run out to pending, runnable at once.
    * Returns the job ids recovered.
    */
@@ -162,39 +177,48 @@ export function openJobStore(dataDir: string): JobStore {
     `UPDATE jobs SET status = 'dead', claim_token = NULL, lease_expires_at = NULL, last_error = ?
      WHERE id = ? AND claim_token = ?`
   );
-  const recover = db.prepare(
+  const releaseClaimsSql = (condition: string): string =>
     `UPDATE jobs SET status = 'pending', claim_token = NULL, lease_expires_at = NULL
-     WHERE status = 'running' AND lease_expires_at <= ? RETURNING id`
-  );
+     WHERE status = 'running'${condition} RETURNING id`;
+  const recoverExpired = db.prepare(releaseClaimsSql(" AND lease_expires_at <= ?"));
   const countByStatus = db.prepare("SELECT status, COUNT(*) AS count FROM jobs GROUP BY status");
   const oldestRunnable = db.prepare(
     "SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending' AND run_at <= ?"
   );
 
-  // Both kind-filtered queries take the list as inlined placeholders — it is a
-  // handful of literals from the code, not a table — so each is prepared once
-  // per list length and kept.
-  const byKindCount = (
+  // Every list-filtered statement takes its list as inlined placeholders — a
+  // handful of kinds from the code, or the tokens of the jobs this process is
+  // delivering, neither of them a table — so each is prepared once per list
+  // length and kept.
+  const byListLength = (
     sql: (placeholders: string) => string
-  ): ((kinds: number) => ReturnType<DatabaseSync["prepare"]>) => {
+  ): ((length: number) => ReturnType<DatabaseSync["prepare"]>) => {
     const prepared = new Map<number, ReturnType<DatabaseSync["prepare"]>>();
-    return (kinds) => {
-      const cached = prepared.get(kinds);
+    return (length) => {
+      const cached = prepared.get(length);
       if (cached) return cached;
-      const statement = db.prepare(sql(Array.from({ length: kinds }, () => "?").join(", ")));
-      prepared.set(kinds, statement);
+      const statement = db.prepare(sql(Array.from({ length }, () => "?").join(", ")));
+      prepared.set(length, statement);
       return statement;
     };
   };
 
-  const soonestFor = byKindCount(
+  // A claim carrying no token at all predates leases, and is owned by no live
+  // delivery whatever tokens this process holds.
+  const recoverForeign = byListLength((placeholders) =>
+    releaseClaimsSql(
+      placeholders === "" ? "" : ` AND COALESCE(claim_token, '') NOT IN (${placeholders})`
+    )
+  );
+
+  const soonestFor = byListLength(
     (placeholders) =>
       `SELECT MIN(run_at) AS run_at FROM jobs
        WHERE status = 'pending' AND kind IN (${placeholders})`
   );
   // The claim is one statement, so two pollers in this process cannot take
   // the same row: node:sqlite runs it to completion before either yields.
-  const claimFor = byKindCount(
+  const claimFor = byListLength(
     (placeholders) =>
       `UPDATE jobs SET status = 'running', attempts = attempts + 1, claim_token = ?, lease_expires_at = ?
        WHERE id IN (
@@ -237,7 +261,12 @@ export function openJobStore(dataDir: string): JobStore {
     bury: (id, token, error) => {
       kill.run(error, id, token);
     },
-    recoverExpiredClaims: (now) => (recover.all(now) as Array<{ id: string }>).map((row) => row.id),
+    recoverForeignClaims: (ownedTokens) =>
+      (recoverForeign(ownedTokens.length).all(...ownedTokens) as Array<{ id: string }>).map(
+        (row) => row.id
+      ),
+    recoverExpiredClaims: (now) =>
+      (recoverExpired.all(now) as Array<{ id: string }>).map((row) => row.id),
     stats: (now) => {
       const counts = countByStatus.all() as Array<{ status: string; count: number }>;
       const countOf = (status: string): number =>

--- a/packages/control-plane/src/node/job-store.ts
+++ b/packages/control-plane/src/node/job-store.ts
@@ -10,14 +10,13 @@
  * writes a fresh token and an expiry; settling names the token, so a
  * delivery that comes back after its lease expired cannot settle the
  * redelivery that replaced it. Two things end a claim early, and they answer
- * different questions: a claim no live delivery owns belongs to a process
- * that is gone (`recoverForeignClaims`, at start), and a claim whose lease
- * ran out belongs to a handler that hung (`recoverExpiredClaims`, on every
- * sweep). Naming the claims this process still holds is what keeps the first
- * from taking a job away from a delivery that is still running, so starting a
- * poller twice stays harmless. The cost of both is Cloudflare's own: two
- * deliveries of one job can overlap, which `jobs.ts` already requires every
- * handler to tolerate.
+ * different questions asked at different moments: at boot every claim on disk
+ * belongs to a process that is gone (`recoverAllClaims`, called once before
+ * any poller runs, because only one host may hold this volume), and while
+ * running, a claim whose lease has run out belongs to a handler that hung
+ * (`recoverExpiredClaims`, on every sweep). The cost of both is Cloudflare's
+ * own: two deliveries of one job can overlap, which `jobs.ts` already
+ * requires every handler to tolerate.
  *
  * Neither recovery refunds an attempt. The attempt is counted when the job
  * is claimed, exactly as a queue counts a delivery however it ended, so a
@@ -118,12 +117,12 @@ export interface JobStore {
   /** The leased job will not be delivered again: keep the row with what ended it. */
   bury(id: string, token: string, error: string): void;
   /**
-   * Return every claim no live delivery owns to pending, runnable at once.
-   * `ownedTokens` are the claims this process is still delivering, so
-   * starting a poller again never takes one of them back. Returns the job
-   * ids recovered.
+   * Return every claim to pending, runnable at once. For the boot that opens
+   * the store, before any poller can claim: one host holds this volume, so a
+   * claim already on disk is a dead process's and its handler may not have
+   * run. Returns the job ids recovered.
    */
-  recoverForeignClaims(ownedTokens: readonly string[]): string[];
+  recoverAllClaims(): string[];
   /**
    * Return every claim whose lease has run out to pending, runnable at once.
    * Returns the job ids recovered.
@@ -186,10 +185,11 @@ export function openJobStore(dataDir: string): JobStore {
     "SELECT MIN(run_at) AS run_at FROM jobs WHERE status = 'pending' AND run_at <= ?"
   );
 
+  const recoverAll = db.prepare(releaseClaimsSql(""));
+
   // Every list-filtered statement takes its list as inlined placeholders — a
-  // handful of kinds from the code, or the tokens of the jobs this process is
-  // delivering, neither of them a table — so each is prepared once per list
-  // length and kept.
+  // handful of kinds from the code, not a table — so each is prepared once
+  // per list length and kept.
   const byListLength = (
     sql: (placeholders: string) => string
   ): ((length: number) => ReturnType<DatabaseSync["prepare"]>) => {
@@ -202,14 +202,6 @@ export function openJobStore(dataDir: string): JobStore {
       return statement;
     };
   };
-
-  // A claim carrying no token at all predates leases, and is owned by no live
-  // delivery whatever tokens this process holds.
-  const recoverForeign = byListLength((placeholders) =>
-    releaseClaimsSql(
-      placeholders === "" ? "" : ` AND COALESCE(claim_token, '') NOT IN (${placeholders})`
-    )
-  );
 
   const soonestFor = byListLength(
     (placeholders) =>
@@ -261,10 +253,7 @@ export function openJobStore(dataDir: string): JobStore {
     bury: (id, token, error) => {
       kill.run(error, id, token);
     },
-    recoverForeignClaims: (ownedTokens) =>
-      (recoverForeign(ownedTokens.length).all(...ownedTokens) as Array<{ id: string }>).map(
-        (row) => row.id
-      ),
+    recoverAllClaims: () => (recoverAll.all() as Array<{ id: string }>).map((row) => row.id),
     recoverExpiredClaims: (now) =>
       (recoverExpired.all(now) as Array<{ id: string }>).map((row) => row.id),
     stats: (now) => {

--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -657,7 +657,7 @@ describe("SessionRuntimeRegistry", () => {
 
     held.resolve();
     await pending;
-    await shutdown;
+    expect(await shutdown).toEqual({ forced: [] });
     expect(stores.opened[0]!.closes).toBe(1);
     expect(log.warn).not.toHaveBeenCalled();
   });
@@ -668,8 +668,11 @@ describe("SessionRuntimeRegistry", () => {
     const pending = registry.withRuntime("s1", () => never.promise);
     await flush();
 
-    await registry.shutdown({ timeoutMs: 20 });
+    const report = await registry.shutdown({ timeoutMs: 20 });
 
+    // Reported, not only logged: the host writes a clean-stop marker from
+    // this, and forced work can have persisted a deadline without arming it.
+    expect(report).toEqual({ forced: ["s1"] });
     expect(stores.opened[0]!.closes).toBe(1);
     expect(log.warn).toHaveBeenCalledWith("session_registry.retired_busy", {
       session_id: "s1",

--- a/packages/control-plane/src/node/session-runtime-registry.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.ts
@@ -259,8 +259,13 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
    * runtime's leases (including those close deliveries) and background
    * tasks are waited for; only then is its store closed. A runtime still
    * busy at the budget is logged and forced.
+   *
+   * Returns the sessions that were forced. A caller deciding whether the
+   * process stopped cleanly needs those: work cut off mid-flight can have
+   * persisted a deadline without arming it, which is exactly what the next
+   * boot's recovery scan exists to find.
    */
-  async shutdown(options: ShutdownOptions = {}): Promise<void> {
+  async shutdown(options: ShutdownOptions = {}): Promise<{ forced: string[] }> {
     const deadlineMs = Date.now() + (options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS);
     this.shuttingDown = true;
     this.stopSweeper();
@@ -270,12 +275,17 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
       await Promise.allSettled([...this.opening.values()].map((o) => o.promise));
     }
     if (this.sweeping) await this.sweeping;
-    await Promise.all(
+    const outcomes = await Promise.all(
       [...this.resident.values()].map((session) => this.quiesce(session, deadlineMs))
     );
+    return { forced: outcomes.filter((outcome) => outcome !== null) };
   }
 
-  private async quiesce(session: ResidentSession<Runtime>, deadlineMs: number): Promise<void> {
+  /** The session id when it had to be forced, and null when it quiesced. */
+  private async quiesce(
+    session: ResidentSession<Runtime>,
+    deadlineMs: number
+  ): Promise<string | null> {
     session.state = "quiescing";
     const quiescent = await this.waitForQuiescence(session, deadlineMs);
     if (!quiescent) {
@@ -287,6 +297,7 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
       });
     }
     this.retire(session, "shutdown");
+    return quiescent ? null : session.id;
   }
 
   /**


### PR DESCRIPTION
Closes the remaining scope of COL-100 (H-4). Step 1, the orderly SIGTERM drain, shipped earlier; this is steps 2 and 3 plus the deadline rescan the issue's addendum asked for.

## What a kill costs today

A Node host that is drained loses nothing. One that is killed loses two things a Durable Object would not.

**A deadline the index never recorded.** A session's next wake-up is written twice on this host. The session core commits the pending deadline to the session's own file (`session_alarm_state`) and then arms the runtime alarm, which here is a row in `host-alarms.db`. On Cloudflare both writes land in one Durable Object storage; here they are two files, so a process that dies between them leaves a deadline the session knows about and the index does not. While the session stays resident nothing is lost — its next activation re-arms the index through `rehydrate()` — but if the host restarts and the session is never touched again, that deadline never fires.

**A job the dead process was delivering.** `job-store.ts` recovered a claim only when its lease expired, and `JOB_CLAIM_LEASE_MS` is fifteen minutes. So after a crash, an image-build finalization the dead process had claimed sat for a quarter of an hour before anything retried it.

## The marker, and the rescan

`<dataDir>/host-state.json` holds two fields: the time through which the alarm index is known to hold every armed deadline, and whether the host reached that time by stopping cleanly.

- A clean shutdown writes it with `cleanShutdown: true`. Only a drain that abandoned nothing does so — work that outlived the budget can still arm a deadline afterwards, so the "gives up a request that outlives the budget" path deliberately leaves the marker false.
- Every boot invalidates the marker before the server listens, keeping the time it names. So a boot that itself dies is the next boot's unclean stop, and the point it scans from is the last moment the index was known complete rather than the last boot.
- A boot that finds no clean marker reads the session files written since that time, computes each file's earliest deadline through the session core's own `PersistedAlarmDeadlineStore.earliest()` (so the cancelled/pending/in-flight rule cannot drift), and arms it with a new `HostAlarmIndex.armIfSooner`. After a successful scan the marker advances to the boot instant, captured *before* the scan so a session written while it ran is covered by the next one rather than missed.

Three design calls worth stating, since the issue asked for them:

- **Read the files, don't rehydrate through the registry.** Opening a session through the registry would activate a runtime — sandbox provider, sockets, the whole session — for what is a two-column read, and a boot must not do that for every session written since the last clean stop. Reading also leaves the session unchanged, so a boot that dies part-way through a scan leaves the next boot exactly the same work.
- **`armIfSooner`, not `set`.** The rescan can only bring a wake-up forward. It never postpones or replaces a deadline the index already holds, never resets the retry-failure count, and never disturbs a claim in flight — recovery of that claim still re-arms it at its own deadline.
- **No marker at all is not treated as a crash, but it is scanned.** A first boot on a fresh volume has no session files, so scanning everything costs nothing and nothing is logged as recovered. A volume written by a build that predates the marker does have session files, and one full pass is the only correct answer there; after it, a marker exists. A marker that is truncated or malformed reads as no marker for the same reason.
- **One bad file does not fail the boot, and does not fall out of range.** An unreadable session file is counted, logged at `node_host.deadline_recovery_failed` with its session id, and skipped; refusing to boot would take every other session down with it. The recorded point then does not advance at all, because a file this boot could not read has not been written since and a watermark at this boot would put it out of every later scan's range.

The mtime bound stats both `<id>.db` and `<id>.db-wal`, because these files are in WAL mode: a commit lands in the log and leaves the database file's own timestamp alone until a checkpoint.

## Jobs: reclaim at boot

The jobs store now splits recovery exactly the way the alarm index does on #1788, with the same names and the same reasoning:

- `recoverForeignClaims(ownedTokens)` — a claim no live delivery owns belongs to a process that is gone. Called from `NodeJobs.start()`, so a restart retries the job at once instead of waiting out the lease. Passing the tokens currently in flight is what keeps `start()` idempotent: starting twice never takes a job away from a delivery still running.
- `recoverExpiredClaims(now)` — a claim whose lease ran out belongs to a handler that hung. Unchanged, still on every sweep. Its log event is renamed `jobs.claims_expired` so the two read distinctly; `jobs.claims_recovered` is now the boot reclaim, matching the alarm clock's split.

Neither path refunds an attempt. The attempt is counted when the job is claimed, exactly as a queue counts a delivery however it ended — so a job whose handler takes the process down with it still runs out of attempts and reaches the dead rows instead of being redelivered for ever. A claim carrying no token at all (written by a build before leases) counts as foreign.

The existing test "does not let a second poller take a job the first is still delivering" became "does not take back a job it is still delivering when it is started again". Two `NodeJobs` over one store is a stand-in for two processes, and boot reclaim assumes a claim it finds belongs to nobody; the invariant that survives, and the one the design actually preserves, is that starting the same poller again is a no-op for its own deliveries.

## Step 3: the boot-id guard, documented not built

The issue's step 3 was a boot-id claim guard on session rows, needed only if the deploy shape can run two processes over one data directory. `docs/CONTROL_PLANE_CONTAINER.md` gains a "Recovering from an unclean stop" section that describes both recoveries and names that condition explicitly: compose recreates the app container in place and the new one cannot start until the old has released the volume; the AWS deploy replaces the instance the same way. If that ever changes — two app containers behind a load balancer, a blue/green deploy that overlaps instances, anything that lets two hosts open one `/data` — these recoveries stop being safe and the claims would have to carry the boot id of the process holding them. Until then it would be a column nothing reads. The stale "Crash recovery of scheduled deadlines after an unclean stop" bullet under "Not yet available on the container" is removed, and `host-state.json` is listed with the other files on the volume.

## Cloudflare

Every code change is under `packages/control-plane/src/node/**`. No D1 migration: the alarm index's schema is the `CREATE TABLE IF NOT EXISTS` applied on open, as before, and the marker is a JSON file. The workerd suite is the proof.

## Red tests

Each behaviour was removed and the test watched to fail before being restored.

Rescan removed (`scanSessionFiles` returns zero counts):

```
FAIL  src/node/crash-recovery.test.ts > recoverSessionDeadlines > arms a deadline the session persisted and the index never recorded
AssertionError: expected { previousStop: 'no_marker', …(3) } to deeply equal { previousStop: 'no_marker', …(3) }
-   "rearmed": 1,  -   "scanned": 1,
+   "rearmed": 0,  +   "scanned": 0,
```

Same mutation, at the host:

```
FAIL  src/node/host.test.ts > startNodeHost > arms a deadline a previous process left only in the session file
- Expected: 1788595377059
+ Received: null
```

Clean-stop branch removed (every boot scans):

```
FAIL  src/node/crash-recovery.test.ts > recoverSessionDeadlines > scans nothing after a clean shutdown, and invalidates the marker it read
-   "previousStop": "clean_shutdown",  -   "rearmed": 0,  -   "scanned": 0,
+   "previousStop": "unclean_stop",    +   "rearmed": 1,  +   "scanned": 1,
```

`markCleanShutdown` call removed:

```
FAIL  src/node/host.test.ts > startNodeHost > marks a stop that abandoned nothing as clean
-   "cleanShutdown": true,
+   "cleanShutdown": false,
```

`markCleanShutdown` called unconditionally:

```
FAIL  src/node/host.test.ts > startNodeHost > gives up a request that outlives the budget and reports it
AssertionError: expected { …(2) } to match object { cleanShutdown: false }
-   "cleanShutdown": false,
+   "cleanShutdown": true,
```

`armIfSooner` degraded to `set`:

```
FAIL  src/node/host-alarm-index.test.ts > openHostAlarmIndex > arms a deadline the index is missing and leaves a sooner one alone
AssertionError: expected true to be false // Object.is equality
FAIL  src/node/host-alarm-index.test.ts > openHostAlarmIndex > leaves a claim in flight and the retry budget alone when it arms a missing deadline
AssertionError: expected { deadline: 800, failures: +0 } to deeply equal { deadline: 800, failures: 1 }
FAIL  src/node/crash-recovery.test.ts > recoverSessionDeadlines > does not postpone or replace a deadline the index already holds
-   "rearmed": 0,
+   "rearmed": 1,
```

Boot reclaim removed from `NodeJobs.start()`:

```
FAIL  src/node/job-queue.test.ts > NodeJobs > takes back a claim a dead process left, rather than waiting out its lease
AssertionError: expected "vi.fn()" to be called once, but got 0 times
```

Owned tokens dropped (`recoverForeignClaims([])`):

```
FAIL  src/node/job-queue.test.ts > NodeJobs > does not take back a job it is still delivering when it is started again
AssertionError: expected "vi.fn()" to be called once, but got 2 times
```

Watermark advanced unconditionally (`indexedThroughMs: nowMs`), from the review fix:

```
FAIL  src/node/crash-recovery.test.ts > recoverSessionDeadlines > keeps a session file it could not read in the next scan's range
-   "indexedThroughMs": 0,
+   "indexedThroughMs": 1788592791537,
```

and with the marker assertion dropped, the behavioural half of the same mutation:

```
FAIL  src/node/crash-recovery.test.ts > recoverSessionDeadlines > keeps a session file it could not read in the next scan's range
-   "scanned": 1,     -   "unreadable": 1,
+   "scanned": 0,     +   "unreadable": 0,
```

Recovery made to refund the attempt (`attempts = attempts - 1`):

```
FAIL  src/node/job-store.test.ts > openJobStore > leases > returns a claim no live delivery owns, without waiting out its lease
FAIL  src/node/job-store.test.ts > openJobStore > leases > returns a claim whose lease ran out, and survives the restart
AssertionError: expected [ { id: 'interrupted', …(4) } ] to deeply equal [ ObjectContaining{…} ]
-     "attempts": 2,
+     "attempts": 1,
```

## Verification

```
npm run typecheck -w @open-inspect/control-plane   4 tsconfig programs, clean
npx vitest run --root packages/control-plane       275 files, 3989 tests passed
npm run test:integration -w @open-inspect/...      100 files, 1178 passed / 1 skipped, 107.6s (workerd)
npm run lint                                       clean
npx knip                                           22 unused exports + 4 unused types, all pre-existing;
                                                   nothing from this change appears (CI runs it --no-exit-code)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically restores scheduled deadlines after an unclean stop.
  - Recovers unfinished jobs on host restart for prompt retry.
  - Adds lease-based protection for job delivery claims.
  - Records clean-shutdown state and forced session work.

- **Bug Fixes**
  - Prevents unresolved session data from being marked fully recovered.
  - Preserves delivery attempts during job recovery.
  - Rejects stale job completion or retry results.

- **Documentation**
  - Documents persisted host state and unclean-stop recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->