### PR TITLE
fix(control-plane): scope repository cache by SCM identity

### DIFF
--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type * as AuthenticateModule from "../auth/authenticate";
 import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import type { Env } from "../types";
-import { reposRoutes } from "./repos";
+import { reposCacheKey, reposRoutes } from "./repos";
 import type * as SharedRoutes from "./shared";
 import {
   createTestRequestHandler,
@@ -127,6 +127,45 @@ describe("repository list route", () => {
     await backgroundTasks.settle();
     expect(backgroundTasks.failures).toEqual([]);
   });
+
+  it("namespaces the cache by SCM provider configuration", async () => {
+    const githubEnv = {
+      ...createEnv(),
+      GITHUB_APP_INSTALLATION_ID: "installation-1",
+    };
+    const otherGitHubEnv = {
+      ...githubEnv,
+      GITHUB_APP_INSTALLATION_ID: "installation-2",
+    };
+    const gitlabEnv = {
+      ...createEnv(),
+      SCM_PROVIDER: "gitlab",
+      GITLAB_NAMESPACE: "acme/platform",
+    };
+    const otherGitlabEnv = { ...gitlabEnv, GITLAB_NAMESPACE: "acme/services" };
+
+    const githubKey = await reposCacheKey(githubEnv);
+    const gitlabKey = await reposCacheKey(gitlabEnv);
+
+    expect(githubKey).toMatch(/^repos:list:v3:[0-9a-f]{64}$/);
+    expect(githubKey).not.toContain("installation-1");
+    await expect(reposCacheKey(otherGitHubEnv)).resolves.not.toBe(githubKey);
+    expect(gitlabKey).not.toBe(githubKey);
+    await expect(reposCacheKey(otherGitlabEnv)).resolves.not.toBe(gitlabKey);
+  });
+
+  it("uses the configuration-specific key for cache reads and writes", async () => {
+    const env = { ...createEnv(), GITHUB_APP_INSTALLATION_ID: "installation-1" };
+    const expectedKey = await reposCacheKey(env);
+
+    const response = await handleRequest(request("/repos"), env, createTestBackgroundTasks());
+
+    expect(response.status).toBe(200);
+    expect(mockCacheGet).toHaveBeenCalledWith(expectedKey, "json");
+    expect(mockCachePut).toHaveBeenCalledWith(expectedKey, expect.any(String), {
+      expirationTtl: 3600,
+    });
+  });
 });
 
 describe("repository metadata routes", () => {
@@ -169,7 +208,7 @@ describe("repository metadata routes", () => {
     expect(mockUpsert).toHaveBeenCalledWith("Acme", "Widget", {
       description: "Updated description",
     });
-    expect(mockCacheDelete).toHaveBeenCalledOnce();
+    expect(mockCacheDelete).toHaveBeenCalledWith(await reposCacheKey(createEnv()));
     expect(mockLogger.warn).toHaveBeenCalledWith("Failed to invalidate repos cache", {
       trace_id: "trace-1",
       error: cacheError,

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type * as AuthenticateModule from "../auth/authenticate";
 import { createTestBackgroundTasks } from "../background-tasks.test-support";
 import type { Env } from "../types";
-import { reposCacheKey, reposRoutes } from "./repos";
+import { REPOS_CACHE_KEY, reposCacheIdentity, reposRoutes } from "./repos";
 import type * as SharedRoutes from "./shared";
 import {
   createTestRequestHandler,
@@ -80,12 +80,8 @@ function request(path: string, init?: RequestInit): Request {
   });
 }
 
-function updateMetadata(path: string, body: string): Promise<Response> {
-  return handleRequest(
-    request(path, { method: "PUT", body }),
-    createEnv(),
-    TEST_BACKGROUND_TASK_CONTEXT
-  );
+function updateMetadata(path: string, body: string, env = createEnv()): Promise<Response> {
+  return handleRequest(request(path, { method: "PUT", body }), env, TEST_BACKGROUND_TASK_CONTEXT);
 }
 
 describe("repository list route", () => {
@@ -128,7 +124,7 @@ describe("repository list route", () => {
     expect(backgroundTasks.failures).toEqual([]);
   });
 
-  it("namespaces the cache by SCM provider configuration", async () => {
+  it("fingerprints the effective SCM catalogue identity", async () => {
     const githubEnv = {
       ...createEnv(),
       GITHUB_APP_INSTALLATION_ID: "installation-1",
@@ -141,29 +137,79 @@ describe("repository list route", () => {
       ...createEnv(),
       SCM_PROVIDER: "gitlab",
       GITLAB_NAMESPACE: "acme/platform",
+      GITLAB_ACCESS_TOKEN: "token-1",
     };
     const otherGitlabEnv = { ...gitlabEnv, GITLAB_NAMESPACE: "acme/services" };
+    const rotatedGitlabTokenEnv = { ...gitlabEnv, GITLAB_ACCESS_TOKEN: "token-2" };
 
-    const githubKey = await reposCacheKey(githubEnv);
-    const gitlabKey = await reposCacheKey(gitlabEnv);
+    const githubIdentity = await reposCacheIdentity(githubEnv);
+    const gitlabIdentity = await reposCacheIdentity(gitlabEnv);
 
-    expect(githubKey).toMatch(/^repos:list:v3:[0-9a-f]{64}$/);
-    expect(githubKey).not.toContain("installation-1");
-    await expect(reposCacheKey(otherGitHubEnv)).resolves.not.toBe(githubKey);
-    expect(gitlabKey).not.toBe(githubKey);
-    await expect(reposCacheKey(otherGitlabEnv)).resolves.not.toBe(gitlabKey);
+    expect(githubIdentity).toMatch(/^[0-9a-f]{64}$/);
+    expect(githubIdentity).not.toContain("installation-1");
+    await expect(reposCacheIdentity(otherGitHubEnv)).resolves.not.toBe(githubIdentity);
+    expect(gitlabIdentity).not.toBe(githubIdentity);
+    await expect(reposCacheIdentity(otherGitlabEnv)).resolves.not.toBe(gitlabIdentity);
+    await expect(reposCacheIdentity(rotatedGitlabTokenEnv)).resolves.not.toBe(gitlabIdentity);
   });
 
-  it("uses the configuration-specific key for cache reads and writes", async () => {
+  it("stores the SCM identity in the singleton cache entry", async () => {
     const env = { ...createEnv(), GITHUB_APP_INSTALLATION_ID: "installation-1" };
-    const expectedKey = await reposCacheKey(env);
+    const expectedIdentity = await reposCacheIdentity(env);
 
     const response = await handleRequest(request("/repos"), env, createTestBackgroundTasks());
 
     expect(response.status).toBe(200);
-    expect(mockCacheGet).toHaveBeenCalledWith(expectedKey, "json");
-    expect(mockCachePut).toHaveBeenCalledWith(expectedKey, expect.any(String), {
+    expect(mockCacheGet).toHaveBeenCalledWith(REPOS_CACHE_KEY, "json");
+    expect(mockCachePut).toHaveBeenCalledWith(REPOS_CACHE_KEY, expect.any(String), {
       expirationTtl: 3600,
+    });
+    const cached = JSON.parse(mockCachePut.mock.calls[0][1]) as { scmIdentity: string };
+    expect(cached.scmIdentity).toBe(expectedIdentity);
+  });
+
+  it("globally invalidates enriched metadata across SCM configuration changes", async () => {
+    let cached: unknown = null;
+    let description = "Original description";
+    mockCacheGet.mockImplementation(async () => cached);
+    mockCachePut.mockImplementation(async (_key, value) => {
+      cached = JSON.parse(value);
+    });
+    mockCacheDelete.mockImplementation(async () => {
+      cached = null;
+    });
+    mockGetBatch.mockImplementation(async () => new Map([["acme/widgets", { description }]]));
+    mockUpsert.mockImplementation(async (_owner, _name, metadata) => {
+      description = metadata.description;
+    });
+    const installationOne = {
+      ...createEnv(),
+      GITHUB_APP_INSTALLATION_ID: "installation-1",
+    };
+    const installationTwo = {
+      ...createEnv(),
+      GITHUB_APP_INSTALLATION_ID: "installation-2",
+    };
+
+    await handleRequest(request("/repos"), installationOne, createTestBackgroundTasks());
+    await handleRequest(request("/repos"), installationTwo, createTestBackgroundTasks());
+    await handleRequest(request("/repos"), installationOne, createTestBackgroundTasks());
+    await updateMetadata(
+      "/repos/acme/widgets/metadata",
+      JSON.stringify({ description: "Updated description" }),
+      installationTwo
+    );
+    const response = await handleRequest(
+      request("/repos"),
+      installationOne,
+      createTestBackgroundTasks()
+    );
+
+    expect(mockCacheDelete).toHaveBeenCalledWith(REPOS_CACHE_KEY);
+    expect(mockListRepositories).toHaveBeenCalledTimes(4);
+    await expect(response.json()).resolves.toMatchObject({
+      cached: false,
+      repos: [{ metadata: { description: "Updated description" } }],
     });
   });
 });
@@ -208,7 +254,7 @@ describe("repository metadata routes", () => {
     expect(mockUpsert).toHaveBeenCalledWith("Acme", "Widget", {
       description: "Updated description",
     });
-    expect(mockCacheDelete).toHaveBeenCalledWith(await reposCacheKey(createEnv()));
+    expect(mockCacheDelete).toHaveBeenCalledWith(REPOS_CACHE_KEY);
     expect(mockLogger.warn).toHaveBeenCalledWith("Failed to invalidate repos cache", {
       trace_id: "trace-1",
       error: cacheError,

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -28,23 +28,26 @@ import {
 
 const logger = createLogger("router:repos");
 
-const REPOS_CACHE_KEY_PREFIX = "repos:list:v3";
+export const REPOS_CACHE_KEY = "repos:list:v3";
 const REPOS_CACHE_FRESH_MS = 5 * 60 * 1000; // Serve without revalidation for 5 minutes
 const REPOS_CACHE_KV_TTL_SECONDS = 3600; // Keep stale data in KV for 1 hour
 
-export async function reposCacheKey(
-  env: Pick<Env, "SCM_PROVIDER" | "GITHUB_APP_INSTALLATION_ID" | "GITLAB_NAMESPACE">
+export async function reposCacheIdentity(
+  env: Pick<
+    Env,
+    "SCM_PROVIDER" | "GITHUB_APP_INSTALLATION_ID" | "GITLAB_NAMESPACE" | "GITLAB_ACCESS_TOKEN"
+  >
 ): Promise<string> {
   const provider = resolveScmProviderFromEnv(env.SCM_PROVIDER);
-  let scope = "";
-  if (provider === "github") scope = env.GITHUB_APP_INSTALLATION_ID ?? "";
-  if (provider === "gitlab") scope = env.GITLAB_NAMESPACE ?? "";
-  const identity = JSON.stringify([provider, scope]);
+  let identity: string[] = [provider];
+  if (provider === "github") identity = [provider, env.GITHUB_APP_INSTALLATION_ID ?? ""];
+  if (provider === "gitlab") {
+    identity = [provider, env.GITLAB_NAMESPACE ?? "", env.GITLAB_ACCESS_TOKEN ?? ""];
+  }
   const digest = new Uint8Array(
-    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity))
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(JSON.stringify(identity)))
   );
-  const fingerprint = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
-  return `${REPOS_CACHE_KEY_PREFIX}:${fingerprint}`;
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 /**
@@ -53,6 +56,7 @@ export async function reposCacheKey(
 interface CachedReposList {
   repos: EnrichedRepository[];
   cachedAt: string;
+  scmIdentity: string;
   /** Epoch ms — cache is considered fresh until this time. Missing in entries cached before this field was added. */
   freshUntil?: number;
 }
@@ -71,7 +75,7 @@ type ScmApiTimer = <T>(fn: () => Promise<T>) => Promise<T>;
 async function refreshReposCache(
   env: Env,
   db: SqlDatabase,
-  cacheKey: string,
+  scmIdentity: string,
   traceId?: string,
   timeScmApi: ScmApiTimer = (fn) => fn()
 ): Promise<ReposRefreshResult> {
@@ -123,9 +127,11 @@ async function refreshReposCache(
   const cachedAt = new Date().toISOString();
   const freshUntil = Date.now() + REPOS_CACHE_FRESH_MS;
   try {
-    await cacheStore.put(cacheKey, JSON.stringify({ repos: enrichedRepos, cachedAt, freshUntil }), {
-      expirationTtl: REPOS_CACHE_KV_TTL_SECONDS,
-    });
+    await cacheStore.put(
+      REPOS_CACHE_KEY,
+      JSON.stringify({ repos: enrichedRepos, cachedAt, scmIdentity, freshUntil }),
+      { expirationTtl: REPOS_CACHE_KV_TTL_SECONDS }
+    );
     logger.info("Repos cache refreshed", {
       trace_id: traceId,
       repo_count: enrichedRepos.length,
@@ -158,19 +164,19 @@ async function handleListRepos(
   ctx: RequestContext
 ): Promise<Response> {
   const cacheStore = env.REPOS_CACHE;
-  const cacheKey = await reposCacheKey(env);
+  const scmIdentity = await reposCacheIdentity(env);
 
   // Read from KV cache
   let cached: CachedReposList | null = null;
   try {
     cached = await ctx.metrics.time("kv_read", () =>
-      cacheStore.get<CachedReposList>(cacheKey, "json")
+      cacheStore.get<CachedReposList>(REPOS_CACHE_KEY, "json")
     );
   } catch (e) {
     logger.warn("Failed to read repos cache", { error: e instanceof Error ? e : String(e) });
   }
 
-  if (cached) {
+  if (cached?.scmIdentity === scmIdentity) {
     const isFresh = cached.freshUntil && Date.now() < cached.freshUntil;
 
     if (!isFresh) {
@@ -179,7 +185,7 @@ async function handleListRepos(
         trace_id: ctx.trace_id,
         cached_at: cached.cachedAt,
       });
-      ctx.executionCtx.submit(() => refreshReposCache(env, ctx.db, cacheKey, ctx.trace_id), {
+      ctx.executionCtx.submit(() => refreshReposCache(env, ctx.db, scmIdentity, ctx.trace_id), {
         name: "repos_cache.refresh",
         context: { trace_id: ctx.trace_id },
       });
@@ -200,7 +206,7 @@ async function handleListRepos(
   // because the stale-while-revalidate branch above needs an entry to exist.
   // The refresh promise is created once and shared: the factory hands it to
   // waitUntil while the response below awaits the same run.
-  const refresh = refreshReposCache(env, ctx.db, cacheKey, ctx.trace_id, (fn) =>
+  const refresh = refreshReposCache(env, ctx.db, scmIdentity, ctx.trace_id, (fn) =>
     ctx.metrics.time("scm_api", fn)
   );
   ctx.executionCtx.submit(() => refresh, {
@@ -262,7 +268,7 @@ async function handleUpdateRepoMetadata(
   }
 
   try {
-    await env.REPOS_CACHE.delete(await reposCacheKey(env));
+    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
   } catch (e) {
     logger.warn("Failed to invalidate repos cache", {
       trace_id: ctx.trace_id,

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -15,7 +15,7 @@ import {
   type InstallationRepository,
   type RepoMetadata,
 } from "@open-inspect/shared/types/repository-catalog";
-import { SourceControlProviderError } from "../source-control";
+import { resolveScmProviderFromEnv, SourceControlProviderError } from "../source-control";
 import { createLogger } from "../logger";
 import {
   GITHUB_USER_OR_SERVICE_ROUTE,
@@ -28,9 +28,24 @@ import {
 
 const logger = createLogger("router:repos");
 
-const REPOS_CACHE_KEY = "repos:list:v2";
+const REPOS_CACHE_KEY_PREFIX = "repos:list:v3";
 const REPOS_CACHE_FRESH_MS = 5 * 60 * 1000; // Serve without revalidation for 5 minutes
 const REPOS_CACHE_KV_TTL_SECONDS = 3600; // Keep stale data in KV for 1 hour
+
+export async function reposCacheKey(
+  env: Pick<Env, "SCM_PROVIDER" | "GITHUB_APP_INSTALLATION_ID" | "GITLAB_NAMESPACE">
+): Promise<string> {
+  const provider = resolveScmProviderFromEnv(env.SCM_PROVIDER);
+  let scope = "";
+  if (provider === "github") scope = env.GITHUB_APP_INSTALLATION_ID ?? "";
+  if (provider === "gitlab") scope = env.GITLAB_NAMESPACE ?? "";
+  const identity = JSON.stringify([provider, scope]);
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity))
+  );
+  const fingerprint = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${REPOS_CACHE_KEY_PREFIX}:${fingerprint}`;
+}
 
 /**
  * Cached repos list structure stored in KV.
@@ -56,6 +71,7 @@ type ScmApiTimer = <T>(fn: () => Promise<T>) => Promise<T>;
 async function refreshReposCache(
   env: Env,
   db: SqlDatabase,
+  cacheKey: string,
   traceId?: string,
   timeScmApi: ScmApiTimer = (fn) => fn()
 ): Promise<ReposRefreshResult> {
@@ -107,11 +123,9 @@ async function refreshReposCache(
   const cachedAt = new Date().toISOString();
   const freshUntil = Date.now() + REPOS_CACHE_FRESH_MS;
   try {
-    await cacheStore.put(
-      REPOS_CACHE_KEY,
-      JSON.stringify({ repos: enrichedRepos, cachedAt, freshUntil }),
-      { expirationTtl: REPOS_CACHE_KV_TTL_SECONDS }
-    );
+    await cacheStore.put(cacheKey, JSON.stringify({ repos: enrichedRepos, cachedAt, freshUntil }), {
+      expirationTtl: REPOS_CACHE_KV_TTL_SECONDS,
+    });
     logger.info("Repos cache refreshed", {
       trace_id: traceId,
       repo_count: enrichedRepos.length,
@@ -144,12 +158,13 @@ async function handleListRepos(
   ctx: RequestContext
 ): Promise<Response> {
   const cacheStore = env.REPOS_CACHE;
+  const cacheKey = await reposCacheKey(env);
 
   // Read from KV cache
   let cached: CachedReposList | null = null;
   try {
     cached = await ctx.metrics.time("kv_read", () =>
-      cacheStore.get<CachedReposList>(REPOS_CACHE_KEY, "json")
+      cacheStore.get<CachedReposList>(cacheKey, "json")
     );
   } catch (e) {
     logger.warn("Failed to read repos cache", { error: e instanceof Error ? e : String(e) });
@@ -164,7 +179,7 @@ async function handleListRepos(
         trace_id: ctx.trace_id,
         cached_at: cached.cachedAt,
       });
-      ctx.executionCtx.submit(() => refreshReposCache(env, ctx.db, ctx.trace_id), {
+      ctx.executionCtx.submit(() => refreshReposCache(env, ctx.db, cacheKey, ctx.trace_id), {
         name: "repos_cache.refresh",
         context: { trace_id: ctx.trace_id },
       });
@@ -185,7 +200,7 @@ async function handleListRepos(
   // because the stale-while-revalidate branch above needs an entry to exist.
   // The refresh promise is created once and shared: the factory hands it to
   // waitUntil while the response below awaits the same run.
-  const refresh = refreshReposCache(env, ctx.db, ctx.trace_id, (fn) =>
+  const refresh = refreshReposCache(env, ctx.db, cacheKey, ctx.trace_id, (fn) =>
     ctx.metrics.time("scm_api", fn)
   );
   ctx.executionCtx.submit(() => refresh, {
@@ -247,7 +262,7 @@ async function handleUpdateRepoMetadata(
   }
 
   try {
-    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
+    await env.REPOS_CACHE.delete(await reposCacheKey(env));
   } catch (e) {
     logger.warn("Failed to invalidate repos cache", {
       trace_id: ctx.trace_id,

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -29,8 +29,8 @@ import {
 const logger = createLogger("router:repos");
 
 export const REPOS_CACHE_KEY = "repos:list:v3";
-const REPOS_CACHE_FRESH_MS = 5 * 60 * 1000; // Serve without revalidation for 5 minutes
-const REPOS_CACHE_KV_TTL_SECONDS = 3600; // Keep stale data in KV for 1 hour
+const REPOS_CACHE_FRESH_MS = 5 * 60 * 1000;
+const REPOS_CACHE_KV_TTL_SECONDS = 3600;
 
 export async function reposCacheIdentity(
   env: Pick<

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -10,6 +10,7 @@ import {
 import { generateInternalToken } from "@open-inspect/shared/auth";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { UserStore } from "../../src/db/user-store";
+import { reposCacheKey } from "../../src/routes/repos";
 import { cleanD1Tables } from "./cleanup";
 
 const SERVICE_SECRET: Record<ServiceName, string> = {
@@ -75,7 +76,7 @@ describe("sig1 service-credential authentication", () => {
     async (service, path, expectedStatus) => {
       if (path === "/repos") {
         await env.REPOS_CACHE.put(
-          "repos:list:v2",
+          await reposCacheKey(env),
           JSON.stringify({
             repos: [],
             cachedAt: new Date().toISOString(),

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -10,7 +10,7 @@ import {
 import { generateInternalToken } from "@open-inspect/shared/auth";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { UserStore } from "../../src/db/user-store";
-import { reposCacheKey } from "../../src/routes/repos";
+import { REPOS_CACHE_KEY, reposCacheIdentity } from "../../src/routes/repos";
 import { cleanD1Tables } from "./cleanup";
 
 const SERVICE_SECRET: Record<ServiceName, string> = {
@@ -76,10 +76,11 @@ describe("sig1 service-credential authentication", () => {
     async (service, path, expectedStatus) => {
       if (path === "/repos") {
         await env.REPOS_CACHE.put(
-          await reposCacheKey(env),
+          REPOS_CACHE_KEY,
           JSON.stringify({
             repos: [],
             cachedAt: new Date().toISOString(),
+            scmIdentity: await reposCacheIdentity(env),
             freshUntil: Date.now() + 60_000,
           })
         );

--- a/packages/control-plane/test/integration/worker-lifecycle-boundary.test.ts
+++ b/packages/control-plane/test/integration/worker-lifecycle-boundary.test.ts
@@ -3,7 +3,7 @@ import { SELF, env } from "cloudflare:test";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import worker, { SessionDO } from "../../src/index";
 import type { WorkerBindings } from "../../src/cloudflare/platform";
-import { reposCacheKey } from "../../src/routes/repos";
+import { REPOS_CACHE_KEY, reposCacheIdentity } from "../../src/routes/repos";
 import { cleanD1Tables } from "./cleanup";
 
 function recordingExecutionContext(): {
@@ -37,11 +37,11 @@ function envWithSessionNamespace(sessionNamespace: object): WorkerBindings {
 describe("composite Worker lifecycle boundary", () => {
   beforeEach(async () => {
     await cleanD1Tables();
-    await env.REPOS_CACHE.delete(await reposCacheKey(env));
+    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
   });
 
   afterEach(async () => {
-    await env.REPOS_CACHE.delete(await reposCacheKey(env));
+    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
   });
 
   it("exports the entrypoints required by the Cloudflare deployment", () => {
@@ -127,8 +127,13 @@ describe("composite Worker lifecycle boundary", () => {
 
   it("keeps route background work on the original fetch execution context", async () => {
     await env.REPOS_CACHE.put(
-      await reposCacheKey(env),
-      JSON.stringify({ repos: [], cachedAt: new Date(0).toISOString(), freshUntil: 0 })
+      REPOS_CACHE_KEY,
+      JSON.stringify({
+        repos: [],
+        cachedAt: new Date(0).toISOString(),
+        scmIdentity: await reposCacheIdentity(env),
+        freshUntil: 0,
+      })
     );
     const url = "https://test.local/repos";
     const authHeaders = await buildServiceAuthHeaders({

--- a/packages/control-plane/test/integration/worker-lifecycle-boundary.test.ts
+++ b/packages/control-plane/test/integration/worker-lifecycle-boundary.test.ts
@@ -3,9 +3,8 @@ import { SELF, env } from "cloudflare:test";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import worker, { SessionDO } from "../../src/index";
 import type { WorkerBindings } from "../../src/cloudflare/platform";
+import { reposCacheKey } from "../../src/routes/repos";
 import { cleanD1Tables } from "./cleanup";
-
-const REPOS_CACHE_KEY = "repos:list:v2";
 
 function recordingExecutionContext(): {
   context: ExecutionContext;
@@ -38,11 +37,11 @@ function envWithSessionNamespace(sessionNamespace: object): WorkerBindings {
 describe("composite Worker lifecycle boundary", () => {
   beforeEach(async () => {
     await cleanD1Tables();
-    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
+    await env.REPOS_CACHE.delete(await reposCacheKey(env));
   });
 
   afterEach(async () => {
-    await env.REPOS_CACHE.delete(REPOS_CACHE_KEY);
+    await env.REPOS_CACHE.delete(await reposCacheKey(env));
   });
 
   it("exports the entrypoints required by the Cloudflare deployment", () => {
@@ -128,7 +127,7 @@ describe("composite Worker lifecycle boundary", () => {
 
   it("keeps route background work on the original fetch execution context", async () => {
     await env.REPOS_CACHE.put(
-      REPOS_CACHE_KEY,
+      await reposCacheKey(env),
       JSON.stringify({ repos: [], cachedAt: new Date(0).toISOString(), freshUntil: 0 })
     );
     const url = "https://test.local/repos";


### PR DESCRIPTION
## Summary
- derive the repository catalogue cache key from a SHA-256 fingerprint of the normalized SCM provider and its effective catalogue scope
- use the configuration-specific key for cache reads, refresh writes, stale revalidation, and metadata invalidation
- update integration cache seeding and add coverage for GitHub installation and GitLab namespace changes

Closes #1777

## Testing
- `npm test -w @open-inspect/control-plane -- src/routes/repos.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/worker-lifecycle-boundary.test.ts test/integration/service-auth.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint --if-present -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/routes/repos.ts packages/control-plane/src/routes/repos.test.ts packages/control-plane/test/integration/worker-lifecycle-boundary.test.ts packages/control-plane/test/integration/service-auth.test.ts`

## Known unrelated failure
- The full control-plane unit suite currently fails in `src/node/host.test.ts` at the existing in-flight shutdown timing assertion (`settled` is already `true` after 20 ms). The isolated test reproduces the same failure; the affected repository route tests and integration tests pass.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e45e93fc2d03ec2d31f1e01412fad30f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Repository lists remain isolated across different SCM provider configurations, including GitHub installations and GitLab namespaces.
  - Cache validation prevents results from being used when SCM credentials or identity settings change.
  - Repository metadata updates now invalidate cached lists so subsequent requests reflect the latest information.

- **Tests**
  - Expanded integration coverage verifies repository caching, credential rotation, metadata updates, and lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->