### PR TITLE
refactor(control-plane): require the global store in the session collaborators (COL-127)

### DIFF
--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -21,6 +21,9 @@ import { createFileSessionStoreProvider, type SessionStoreProvider } from "./ses
 
 const GC_CHILD = "SESSION_REGISTRY_GC_CHILD";
 const GC_CHILD_TIMEOUT_MS = 60_000;
+/** The one test the child is spawned to run; everything else in this file would
+ *  otherwise run a second time inside it. */
+const GC_CHILD_TEST = "opens, reads, retires, and lets the collector run afterwards";
 const isGcChild = process.env[GC_CHILD] === "1";
 
 interface Deferred<T = void> {
@@ -811,31 +814,45 @@ describe("SessionRuntimeRegistry", () => {
     expect(stores.opened.map((s) => s.closes)).toEqual([0, 1]);
   });
 
-  it("survives late garbage collection of a retired session's store", () => {
-    if (isGcChild) return;
-    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-    const vitestRoot = dirname(dirname(fileURLToPath(import.meta.resolve("vitest"))));
-    const child = spawnSync(
-      process.execPath,
-      ["--expose-gc", "--no-warnings", join(vitestRoot, "vitest.mjs"), "run", import.meta.filename],
-      {
-        cwd: packageRoot,
-        encoding: "utf8",
-        env: { ...process.env, [GC_CHILD]: "1" },
-        timeout: GC_CHILD_TIMEOUT_MS,
-      }
-    );
+  it(
+    "survives late garbage collection of a retired session's store",
+    () => {
+      if (isGcChild) return;
+      const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+      const vitestRoot = dirname(dirname(fileURLToPath(import.meta.resolve("vitest"))));
+      const child = spawnSync(
+        process.execPath,
+        [
+          "--expose-gc",
+          "--no-warnings",
+          join(vitestRoot, "vitest.mjs"),
+          "run",
+          import.meta.filename,
+          "-t",
+          GC_CHILD_TEST,
+        ],
+        {
+          cwd: packageRoot,
+          encoding: "utf8",
+          env: { ...process.env, [GC_CHILD]: "1" },
+          timeout: GC_CHILD_TIMEOUT_MS,
+        }
+      );
 
-    expect(
-      { status: child.status, signal: child.signal, stdout: child.stdout, stderr: child.stderr },
-      "the isolated registry eviction probe must exit normally"
-    ).toMatchObject({ status: 0, signal: null });
-  });
+      expect(
+        { status: child.status, signal: child.signal, stdout: child.stdout, stderr: child.stderr },
+        "the isolated registry eviction probe must exit normally"
+      ).toMatchObject({ status: 0, signal: null });
+    },
+    // Spawning a vitest run costs more than the default 5s per-test budget on a
+    // loaded machine; hold this test to the same bound as the child itself.
+    GC_CHILD_TIMEOUT_MS
+  );
 });
 
 if (isGcChild) {
   describe("session registry eviction under late garbage collection", () => {
-    it("opens, reads, retires, and lets the collector run afterwards", async () => {
+    it(GC_CHILD_TEST, async () => {
       const dataDir = mkdtempSync(join(tmpdir(), "session-registry-gc-"));
       const alarms = fakeAlarms();
       const registry = new SessionRuntimeRegistry<FakeRuntime>({

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -12,6 +12,7 @@ import type { ClientInfo } from "../types";
 import type { MessageStatus } from "@open-inspect/shared/types/sessions";
 import type { MessageRow, ParticipantRow, SessionRow, SessionAttachmentRow } from "./types";
 import type { SessionCoreRepository } from "./session-core-repository";
+import type { SessionIndexStore } from "../db/session-index";
 import type { ParticipantRepository } from "./participant-repository";
 import type { MessageRepository } from "./message-repository";
 import type { SessionWebSocketManager } from "./websocket-manager";
@@ -215,6 +216,7 @@ function buildQueue() {
     reportSandboxError: vi.fn((_reason: string) => {}),
   };
   const backgroundTasks = createTestBackgroundTasks();
+  const sessionIndex = { touchUpdatedAt: vi.fn(async () => {}) };
   const getAlarm = vi.fn(async () => null as number | null);
   const setAlarm = vi.fn(async (_timestamp: number) => {});
   const projectTerminalMessage = vi.fn(async () => {});
@@ -235,7 +237,7 @@ function buildQueue() {
     getProviderAuthenticationError,
     projectTerminalMessage,
     sandboxLifecycle,
-    null,
+    sessionIndex as unknown as SessionIndexStore,
     "github",
     createEarliestAlarmScheduler(
       { getAlarm, setAlarm, deleteAlarm: vi.fn(async () => {}) },
@@ -262,6 +264,7 @@ function buildQueue() {
     broadcast,
     sessionStatus,
     sandboxLifecycle,
+    sessionIndex,
     backgroundTasks,
     getAlarm,
     setAlarm,
@@ -659,6 +662,21 @@ describe("SessionMessageQueue", () => {
         messageId: "msg-existing",
       })
     );
+  });
+
+  it("touches the session index when a prompt is queued", async () => {
+    const h = buildQueue();
+
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
+      clientRequestId: "request-touch",
+      content: "hello",
+    });
+    await h.backgroundTasks.settle();
+
+    expect(h.backgroundTasks.submissions).toContainEqual(
+      expect.objectContaining({ name: "session_index.touch_updated_at" })
+    );
+    expect(h.sessionIndex.touchUpdatedAt).toHaveBeenCalledWith("s1");
   });
 
   it("returns a null position when retrying a completed correlated prompt", async () => {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -12,7 +12,6 @@ import type { ClientInfo } from "../types";
 import type { MessageStatus } from "@open-inspect/shared/types/sessions";
 import type { MessageRow, ParticipantRow, SessionRow, SessionAttachmentRow } from "./types";
 import type { SessionCoreRepository } from "./session-core-repository";
-import type { SessionIndexStore } from "../db/session-index";
 import type { ParticipantRepository } from "./participant-repository";
 import type { MessageRepository } from "./message-repository";
 import type { SessionWebSocketManager } from "./websocket-manager";
@@ -216,7 +215,7 @@ function buildQueue() {
     reportSandboxError: vi.fn((_reason: string) => {}),
   };
   const backgroundTasks = createTestBackgroundTasks();
-  const sessionIndex = { touchUpdatedAt: vi.fn(async () => {}) };
+  const sessionIndex = { touchUpdatedAt: vi.fn(async () => true) };
   const getAlarm = vi.fn(async () => null as number | null);
   const setAlarm = vi.fn(async (_timestamp: number) => {});
   const projectTerminalMessage = vi.fn(async () => {});
@@ -237,7 +236,7 @@ function buildQueue() {
     getProviderAuthenticationError,
     projectTerminalMessage,
     sandboxLifecycle,
-    sessionIndex as unknown as SessionIndexStore,
+    sessionIndex,
     "github",
     createEarliestAlarmScheduler(
       { getAlarm, setAlarm, deleteAlarm: vi.fn(async () => {}) },

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -165,7 +165,7 @@ export class SessionMessageQueue {
       completedAt: number
     ) => Promise<void>,
     private readonly sandboxLifecycle: SandboxLifecycle,
-    private readonly sessionIndex: SessionIndexStore | null,
+    private readonly sessionIndex: SessionIndexStore,
     private readonly scmProvider: SourceControlProviderName,
     private readonly alarmScheduler: AlarmScheduler,
     /** Resolved per use so it honors settings persisted after construction. */
@@ -302,16 +302,13 @@ export class SessionMessageQueue {
       throw error;
     }
 
-    const sessionIndex = this.sessionIndex;
-    if (sessionIndex) {
-      const session = this.repository.getSession();
-      const sessionId = session?.session_name || session?.id;
-      if (sessionId) {
-        this.backgroundTasks.submit(() => sessionIndex.touchUpdatedAt(sessionId), {
-          name: "session_index.touch_updated_at",
-          context: { session_id: sessionId },
-        });
-      }
+    const session = this.repository.getSession();
+    const sessionId = session?.session_name || session?.id;
+    if (sessionId) {
+      this.backgroundTasks.submit(() => this.sessionIndex.touchUpdatedAt(sessionId), {
+        name: "session_index.touch_updated_at",
+        context: { session_id: sessionId },
+      });
     }
 
     this.wsManager.send(ws, {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -165,7 +165,7 @@ export class SessionMessageQueue {
       completedAt: number
     ) => Promise<void>,
     private readonly sandboxLifecycle: SandboxLifecycle,
-    private readonly sessionIndex: SessionIndexStore,
+    private readonly sessionIndex: Pick<SessionIndexStore, "touchUpdatedAt">,
     private readonly scmProvider: SourceControlProviderName,
     private readonly alarmScheduler: AlarmScheduler,
     /** Resolved per use so it honors settings persisted after construction. */

--- a/packages/control-plane/src/session/participant-service.test.ts
+++ b/packages/control-plane/src/session/participant-service.test.ts
@@ -110,7 +110,7 @@ function createMockUserScmTokenStore(): {
 
 function createTestHarness(overrides?: {
   env?: Partial<ParticipantServiceEnv>;
-  userScmTokenStore?: UserScmTokenStore | null;
+  userScmTokenStore?: UserScmTokenStore;
 }) {
   const log = createMockLogger();
   const repository = createMockRepository();
@@ -129,7 +129,7 @@ function createTestHarness(overrides?: {
     env,
     log,
     generateId: () => `gen-id-${++idCounter}`,
-    userScmTokenStore: overrides?.userScmTokenStore,
+    userScmTokenStore: overrides?.userScmTokenStore ?? createMockUserScmTokenStore().store,
   };
 
   return {
@@ -298,7 +298,7 @@ describe("ParticipantService", () => {
     });
   });
 
-  describe("refreshToken (local-only, no D1 store)", () => {
+  describe("refreshToken (local-only, no scm_user_id)", () => {
     it("returns null when no refresh token stored", async () => {
       const participant = createParticipant({ scm_refresh_token_encrypted: null });
 
@@ -338,19 +338,6 @@ describe("ParticipantService", () => {
 
       // Should not call D1 store at all
       expect(mockStore.getTokens).not.toHaveBeenCalled();
-    });
-
-    it("falls back to local when userScmTokenStore is null", async () => {
-      const h = createTestHarness({ userScmTokenStore: null });
-
-      const participant = createParticipant({
-        scm_user_id: "gh-123",
-        scm_refresh_token_encrypted: null,
-      });
-
-      const result = await h.service.refreshToken(participant);
-
-      expect(result).toBeNull();
     });
   });
 

--- a/packages/control-plane/src/session/participant-service.ts
+++ b/packages/control-plane/src/session/participant-service.ts
@@ -33,7 +33,7 @@ export interface ParticipantServiceDeps {
   env: ParticipantServiceEnv;
   log: Logger;
   generateId: () => string;
-  userScmTokenStore?: UserScmTokenStore | null;
+  userScmTokenStore: UserScmTokenStore;
 }
 
 /**
@@ -54,7 +54,7 @@ export class ParticipantService {
   private readonly env: ParticipantServiceEnv;
   private readonly log: Logger;
   private readonly generateId: () => string;
-  private readonly userScmTokenStore: UserScmTokenStore | null;
+  private readonly userScmTokenStore: UserScmTokenStore;
   private readonly getProcessingMessageAuthor: () => { author_id: string } | null;
 
   constructor(deps: ParticipantServiceDeps) {
@@ -62,7 +62,7 @@ export class ParticipantService {
     this.env = deps.env;
     this.log = deps.log;
     this.generateId = deps.generateId;
-    this.userScmTokenStore = deps.userScmTokenStore ?? null;
+    this.userScmTokenStore = deps.userScmTokenStore;
     this.getProcessingMessageAuthor = deps.getProcessingMessageAuthor;
   }
 
@@ -161,7 +161,7 @@ export class ParticipantService {
    * Dispatches to centralized (D1) or local (per-DO SQLite) refresh path.
    */
   async refreshToken(participant: ParticipantRow): Promise<ParticipantRow | null> {
-    if (this.userScmTokenStore && participant.scm_user_id) {
+    if (participant.scm_user_id) {
       return this.refreshTokenCentralized(participant);
     }
     return this.refreshTokenLocal(participant);
@@ -179,7 +179,7 @@ export class ParticipantService {
   private async refreshTokenCentralized(
     participant: ParticipantRow
   ): Promise<ParticipantRow | null> {
-    const store = this.userScmTokenStore!;
+    const store = this.userScmTokenStore;
     const scmUserId = participant.scm_user_id!;
 
     try {
@@ -289,7 +289,6 @@ export class ParticipantService {
    */
   private async seedD1AfterLocalRefresh(participant: ParticipantRow): Promise<void> {
     if (
-      !this.userScmTokenStore ||
       !participant.scm_user_id ||
       !participant.scm_access_token_encrypted ||
       !participant.scm_refresh_token_encrypted ||
@@ -321,8 +320,9 @@ export class ParticipantService {
   }
 
   /**
-   * Local-only refresh using the per-DO SQLite refresh token.
-   * Original refreshToken logic — used as fallback when D1 is unavailable.
+   * Local-only refresh using the per-DO SQLite refresh token. Taken by a
+   * participant with no `scm_user_id`, who has no row in the shared token
+   * store to refresh centrally, and as the fallback when that row is missing.
    */
   private async refreshTokenLocal(participant: ParticipantRow): Promise<ParticipantRow | null> {
     if (!participant.scm_refresh_token_encrypted) {

--- a/packages/control-plane/src/session/pull-request-refresh.test.ts
+++ b/packages/control-plane/src/session/pull-request-refresh.test.ts
@@ -291,21 +291,6 @@ describe("refreshSessionPullRequests", () => {
     expect(harness.artifactRepository.updateArtifact).not.toHaveBeenCalled();
   });
 
-  it("updates the DO mirror without a D1 store", async () => {
-    const harness = createHarness([createPrArtifact()]);
-
-    const result = await refreshSessionPullRequests(
-      harness.repository,
-      harness.artifactRepository,
-      { getPullRequest: harness.getPullRequest },
-      null
-    );
-
-    expect(result.updated).toHaveLength(1);
-    expect(result.failures).toEqual([]);
-    expect(harness.artifactRepository.updateArtifact).toHaveBeenCalledTimes(1);
-  });
-
   it("no-ops without a session row", async () => {
     const harness = createHarness([createPrArtifact()], null);
 

--- a/packages/control-plane/src/session/pull-request-refresh.ts
+++ b/packages/control-plane/src/session/pull-request-refresh.ts
@@ -74,14 +74,14 @@ function resolveRefreshTarget(
  * The D1 write is the authority step: a snapshot the monotonic guard rejects
  * as stale (a newer webhook write won while this read was in flight) never
  * reaches the mirror. It is otherwise best-effort — the mirror still updates
- * when D1 is absent (`sessionPullRequests` null) or errors, and the upsert
- * repairs records whose creation write failed.
+ * when the upsert errors, and the upsert repairs records whose creation write
+ * failed.
  */
 export async function refreshSessionPullRequests(
   repository: PullRequestRefreshRepository,
   artifactRepository: ArtifactRepository,
   sourceControlProvider: Pick<SourceControlProvider, "getPullRequest">,
-  sessionPullRequests: Pick<SessionPullRequestStore, "upsert"> | null
+  sessionPullRequests: Pick<SessionPullRequestStore, "upsert">
 ): Promise<PullRequestRefreshResult> {
   const updated: SessionArtifact[] = [];
   const failures: PullRequestRefreshFailure[] = [];

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -960,16 +960,5 @@ describe("SessionPullRequestService", () => {
         expect.objectContaining({ artifact_id: "id-1", pr_number: 42 })
       );
     });
-
-    it("skips the D1 write when no store is configured", async () => {
-      const deps = { ...harness.deps };
-      delete deps.sessionPullRequests;
-      const service = new SessionPullRequestService(deps);
-
-      const result = await service.createPullRequest(createInput());
-
-      expect(result.kind).toBe("created");
-      expect(harness.sessionPullRequests.upsert).not.toHaveBeenCalled();
-    });
   });
 });

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -158,10 +158,10 @@ export interface PullRequestServiceDeps {
   /** Display name used in the PR body footer (e.g. "Created with [name](url)"). */
   appName: string;
   /**
-   * D1 authority store for session PR records (design §4). Absent when the
-   * deployment has no D1 binding; the write is best-effort either way.
+   * D1 authority store for session PR records (design §4). The write is
+   * best-effort: an upsert failure still leaves the mirror updated.
    */
-  sessionPullRequests?: Pick<SessionPullRequestStore, "upsert">;
+  sessionPullRequests: Pick<SessionPullRequestStore, "upsert">;
   /** Resolves SCM policy for the pull request's target repository. */
   resolveScmSettings: (repo: RepoIdentity) => Promise<ScmSettings>;
 }
@@ -610,7 +610,7 @@ export class SessionPullRequestService {
     const applied = await applyPullRequestSnapshot(
       {
         artifactRepository: this.deps.artifactRepository,
-        sessionPullRequests: this.deps.sessionPullRequests ?? null,
+        sessionPullRequests: this.deps.sessionPullRequests,
       },
       { artifactId: artifact.id, sessionId, artifactCreatedAt: artifact.created_at },
       live

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -464,10 +464,8 @@ export class SessionPullRequestService {
    * webhook or read-through repairs a missing record (design §5).
    */
   private async writeSessionPullRequestRecord(record: SessionPullRequestRecord): Promise<void> {
-    const store = this.deps.sessionPullRequests;
-    if (!store) return;
     try {
-      await store.upsert(record);
+      await this.deps.sessionPullRequests.upsert(record);
     } catch (error) {
       this.deps.log.error("Failed to write session pull request record", {
         artifact_id: record.artifactId,

--- a/packages/control-plane/src/session/pull-request-snapshot-apply.ts
+++ b/packages/control-plane/src/session/pull-request-snapshot-apply.ts
@@ -21,7 +21,7 @@ import {
 
 export interface ApplyPullRequestSnapshotDeps {
   artifactRepository: Pick<ArtifactRepository, "getArtifactById" | "updateArtifact">;
-  sessionPullRequests: Pick<SessionPullRequestStore, "upsert"> | null;
+  sessionPullRequests: Pick<SessionPullRequestStore, "upsert">;
 }
 
 export interface ApplyPullRequestSnapshotTarget {
@@ -44,19 +44,17 @@ export async function applyPullRequestSnapshot(
   snapshot: PullRequestSnapshotInput
 ): Promise<ApplyPullRequestSnapshotResult> {
   let recordWriteError: unknown | null = null;
-  if (deps.sessionPullRequests) {
-    const record = snapshotToRecord(snapshot, {
-      artifactId: target.artifactId,
-      sessionId: target.sessionId,
-      createdAt: target.artifactCreatedAt,
-      updatedAt: Date.now(),
-    });
-    try {
-      const { applied } = await deps.sessionPullRequests.upsert(record);
-      if (!applied) return { updatedArtifact: null, recordWriteError: null };
-    } catch (error) {
-      recordWriteError = error ?? new Error("session pull request upsert failed");
-    }
+  const record = snapshotToRecord(snapshot, {
+    artifactId: target.artifactId,
+    sessionId: target.sessionId,
+    createdAt: target.artifactCreatedAt,
+    updatedAt: Date.now(),
+  });
+  try {
+    const { applied } = await deps.sessionPullRequests.upsert(record);
+    if (!applied) return { updatedArtifact: null, recordWriteError: null };
+  } catch (error) {
+    recordWriteError = error ?? new Error("session pull request upsert failed");
   }
 
   const currentArtifact = deps.artifactRepository.getArtifactById(target.artifactId);

--- a/packages/control-plane/src/session/scm-settings-resolution.test.ts
+++ b/packages/control-plane/src/session/scm-settings-resolution.test.ts
@@ -25,12 +25,6 @@ function fakeDb(rows: { global?: object; repo?: object } = {}): {
 }
 
 describe("resolveScmSettings", () => {
-  it("returns the built-in defaults when the deployment has no database", async () => {
-    await expect(resolveScmSettings(null, { repoOwner: "acme", repoName: "web" })).resolves.toEqual(
-      {}
-    );
-  });
-
   it("keys the per-repo lookup by owner/name", async () => {
     const { db, bindings } = fakeDb();
 

--- a/packages/control-plane/src/session/scm-settings-resolution.ts
+++ b/packages/control-plane/src/session/scm-settings-resolution.ts
@@ -6,15 +6,12 @@ import type { RepoIdentity } from "./repository-target";
 
 /**
  * Resolves SCM settings (global defaults merged with the per-repo override) for
- * a pull request's target repository. A deployment without D1 cannot have this
- * policy configured, so it retains the built-in defaults; storage failures
- * propagate to fail closed.
+ * a pull request's target repository. Storage failures propagate to fail closed.
  */
 export async function resolveScmSettings(
-  db: SqlDatabase | null,
+  db: SqlDatabase,
   repo: RepoIdentity
 ): Promise<ScmSettings> {
-  if (!db) return {};
   const scmSettingsStore = new ScmSettingsStore(db);
   return scmSettingsStore.getResolvedSettings(formatRepositoryFullName(repo));
 }

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -4,7 +4,6 @@ import { SessionStatusService } from "./session-status-service";
 import { SessionInternalPaths } from "./contracts";
 import type { SessionRuntimeClient } from "./runtime-client";
 import type { Logger } from "../logger";
-import type { SessionIndexStore } from "../db/session-index";
 import type { SessionRow, ArtifactRow, MessageRow } from "./types";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { ArtifactRepository } from "./artifact-repository";
@@ -90,7 +89,7 @@ function harness(options: { session?: SessionRow | null } = {}) {
     repository as unknown as MessageRepository,
     artifactRepository,
     messenger,
-    sessionIndex as unknown as SessionIndexStore,
+    sessionIndex,
     parentSessions
   );
 

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -41,7 +41,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   } as SessionRow;
 }
 
-function harness(options: { session?: SessionRow | null; sessionIndex?: null } = {}) {
+function harness(options: { session?: SessionRow | null } = {}) {
   const session = options.session === undefined ? createSession() : options.session;
 
   const repository = {
@@ -61,15 +61,12 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
   const broadcast = vi.fn();
   const messenger = { broadcast, sendToSandbox: vi.fn(async () => {}) } as SessionMessenger;
 
-  const sessionIndex =
-    options.sessionIndex === null
-      ? null
-      : {
-          updateStatus: vi.fn(async () => true),
-          repairStatus: vi.fn(async () => true),
-          finalizeChildAdmission: vi.fn(async () => {}),
-          updateMetrics: vi.fn(async () => true),
-        };
+  const sessionIndex = {
+    updateStatus: vi.fn(async () => true),
+    repairStatus: vi.fn(async () => true),
+    finalizeChildAdmission: vi.fn(async () => {}),
+    updateMetrics: vi.fn(async () => true),
+  };
 
   const parentFetch = vi.fn(
     async (_sessionId: string, _path: string, _init?: RequestInit) =>
@@ -93,7 +90,7 @@ function harness(options: { session?: SessionRow | null; sessionIndex?: null } =
     repository as unknown as MessageRepository,
     artifactRepository,
     messenger,
-    sessionIndex as unknown as SessionIndexStore | null,
+    sessionIndex as unknown as SessionIndexStore,
     parentSessions
   );
 
@@ -117,7 +114,7 @@ describe("SessionStatusService.transition", () => {
     expect(await h.service.transition("active")).toBe(false);
 
     expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
-    expect(h.sessionIndex!.updateStatus).not.toHaveBeenCalled();
+    expect(h.sessionIndex.updateStatus).not.toHaveBeenCalled();
     expect(h.broadcast).not.toHaveBeenCalled();
   });
 
@@ -133,12 +130,12 @@ describe("SessionStatusService.transition", () => {
     );
     const updatedAt = h.repository.updateSessionStatus.mock.calls[0][2] as number;
     expect(updatedAt).toBeGreaterThan(2000);
-    expect(h.sessionIndex!.updateStatus).toHaveBeenCalledWith(
+    expect(h.sessionIndex.updateStatus).toHaveBeenCalledWith(
       "public-session-1",
       "active",
       updatedAt
     );
-    expect(h.sessionIndex!.finalizeChildAdmission).toHaveBeenCalledWith("public-session-1");
+    expect(h.sessionIndex.finalizeChildAdmission).toHaveBeenCalledWith("public-session-1");
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "active" });
   });
 
@@ -147,7 +144,7 @@ describe("SessionStatusService.transition", () => {
 
     expect(await h.service.transition("active")).toBe(false);
 
-    expect(h.sessionIndex!.updateStatus).toHaveBeenCalledWith("public-session-1", "active", 2000);
+    expect(h.sessionIndex.updateStatus).toHaveBeenCalledWith("public-session-1", "active", 2000);
     expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
     expect(h.broadcast).not.toHaveBeenCalled();
     expect(h.parentFetch).not.toHaveBeenCalled();
@@ -158,7 +155,7 @@ describe("SessionStatusService.transition", () => {
 
     await h.service.transition("completed");
 
-    expect(h.sessionIndex!.updateMetrics).toHaveBeenCalledWith("public-session-1", {
+    expect(h.sessionIndex.updateMetrics).toHaveBeenCalledWith("public-session-1", {
       totalCost: 2.5,
       activeDurationMs: 4500,
       messageCount: 3,
@@ -172,7 +169,7 @@ describe("SessionStatusService.transition", () => {
 
     expect(await h.service.transition("failed")).toBe(false);
 
-    expect(h.sessionIndex!.updateMetrics).toHaveBeenCalledWith(
+    expect(h.sessionIndex.updateMetrics).toHaveBeenCalledWith(
       "public-session-1",
       expect.any(Object)
     );
@@ -183,12 +180,12 @@ describe("SessionStatusService.transition", () => {
 
     await h.service.transition("active");
 
-    expect(h.sessionIndex!.updateMetrics).not.toHaveBeenCalled();
+    expect(h.sessionIndex.updateMetrics).not.toHaveBeenCalled();
   });
 
   it("logs index sync failures without throwing", async () => {
     const h = harness({ session: createSession({ status: "created" }) });
-    h.sessionIndex!.updateStatus.mockRejectedValue(new Error("d1 down"));
+    h.sessionIndex.updateStatus.mockRejectedValue(new Error("d1 down"));
 
     expect(await h.service.transition("active")).toBe(true);
 
@@ -201,15 +198,6 @@ describe("SessionStatusService.transition", () => {
       })
     );
     expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "active" });
-  });
-
-  it("skips index and metrics writes when no session index is bound", async () => {
-    const h = harness({ session: createSession({ status: "active" }), sessionIndex: null });
-
-    expect(await h.service.transition("completed")).toBe(true);
-
-    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
-    expect(h.backgroundTasks.submissions).toHaveLength(0);
   });
 
   it("submits the parent notification as a background job", async () => {
@@ -245,7 +233,7 @@ describe("SessionStatusService.cancel", () => {
   it("closes local status and unfinished messages before publishing projections", async () => {
     const h = harness({ session: createSession({ status: "active" }) });
     let releaseIndex!: () => void;
-    h.sessionIndex!.updateStatus.mockImplementation(
+    h.sessionIndex.updateStatus.mockImplementation(
       () => new Promise<boolean>((resolve) => (releaseIndex = () => resolve(true)))
     );
     const terminalize = vi.fn();
@@ -368,13 +356,13 @@ describe("SessionStatusService.repairIndexStatus", () => {
 
     await h.service.repairIndexStatus();
 
-    expect(h.sessionIndex!.repairStatus).toHaveBeenCalledWith("public-session-1", "completed");
+    expect(h.sessionIndex.repairStatus).toHaveBeenCalledWith("public-session-1", "completed");
   });
 
   it("logs and propagates repair failures", async () => {
     const h = harness({ session: createSession({ status: "completed" }) });
     const error = new Error("d1 down");
-    h.sessionIndex!.repairStatus.mockRejectedValue(error);
+    h.sessionIndex.repairStatus.mockRejectedValue(error);
 
     await expect(h.service.repairIndexStatus()).rejects.toThrow(error);
 

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -29,7 +29,7 @@ export class SessionStatusService {
     private readonly messageRepository: MessageRepository,
     private readonly artifactRepository: ArtifactRepository,
     private readonly messenger: SessionMessenger,
-    private readonly sessionIndex: SessionIndexStore | null,
+    private readonly sessionIndex: SessionIndexStore,
     /** Reaches the parent session's runtime for the child rollup. */
     private readonly sessions: SessionRuntimeClient
   ) {}
@@ -77,7 +77,7 @@ export class SessionStatusService {
    */
   async repairIndexStatus(): Promise<void> {
     const session = this.repository.getSession();
-    if (!session || !this.sessionIndex) return;
+    if (!session) return;
 
     const publicSessionId = this.getPublicSessionId(session);
     const repaired = await this.sessionIndex
@@ -247,7 +247,6 @@ export class SessionStatusService {
     status: SessionStatus,
     updatedAt: number
   ): Promise<void> {
-    if (!this.sessionIndex) return;
     const projected = await this.sessionIndex.updateStatus(sessionId, status, updatedAt);
     if (projected && status === "active") {
       await this.sessionIndex.finalizeChildAdmission(sessionId);
@@ -269,9 +268,6 @@ export class SessionStatusService {
   }
 
   private syncSessionMetrics(sessionId: string): void {
-    const sessionIndex = this.sessionIndex;
-    if (!sessionIndex) return;
-
     const session = this.repository.getSession();
     if (!session) return;
 
@@ -282,7 +278,7 @@ export class SessionStatusService {
 
     this.backgroundTasks.submit(
       () =>
-        sessionIndex.updateMetrics(sessionId, {
+        this.sessionIndex.updateMetrics(sessionId, {
           totalCost: session.total_cost ?? 0,
           activeDurationMs,
           messageCount,

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -21,6 +21,12 @@ import type { SessionMessenger } from "./messenger";
 import type { BackgroundTasks } from "../platform-ports";
 import { isSessionPromptable, isTurnSettled } from "@open-inspect/shared/types/session-activity";
 
+/** The index projections this service keeps consistent with the session row. */
+type SessionIndexProjections = Pick<
+  SessionIndexStore,
+  "updateStatus" | "repairStatus" | "finalizeChildAdmission" | "updateMetrics"
+>;
+
 export class SessionStatusService {
   constructor(
     private readonly backgroundTasks: BackgroundTasks,
@@ -29,7 +35,7 @@ export class SessionStatusService {
     private readonly messageRepository: MessageRepository,
     private readonly artifactRepository: ArtifactRepository,
     private readonly messenger: SessionMessenger,
-    private readonly sessionIndex: SessionIndexStore,
+    private readonly sessionIndex: SessionIndexProjections,
     /** Reaches the parent session's runtime for the child rollup. */
     private readonly sessions: SessionRuntimeClient
   ) {}

--- a/packages/control-plane/src/session/snapshot-reader.ts
+++ b/packages/control-plane/src/session/snapshot-reader.ts
@@ -35,8 +35,7 @@ export interface SessionSnapshotReaderDeps {
   messageService: MessageService;
   eventStream: SessionEventStream;
   sandboxDashboardSettings: SandboxDashboardSettings;
-  /** Null when the deployment has no D1 binding — environment names resolve null. */
-  db: SqlDatabase | null;
+  db: SqlDatabase;
   durableObjectId: string;
   /** DO storage transaction so the snapshot reads are a consistent cut. */
   transaction: <T>(closure: () => T) => T;
@@ -128,7 +127,7 @@ export class SessionSnapshotReader {
    * lookup failure resolves null rather than failing the whole state read.
    */
   private async resolveEnvironmentName(environmentId: string | null): Promise<string | null> {
-    if (!environmentId || !this.deps.db) {
+    if (!environmentId) {
       return null;
     }
     try {

--- a/packages/control-plane/src/session/terminal-message-projection.test.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.test.ts
@@ -61,7 +61,10 @@ function createProjection(
     current: vi.fn<() => Promise<number | null>>().mockResolvedValue(null),
   };
   const projection = new SessionTerminalMessageProjection({
-    sessionIndex: { recordLatestTerminalMessage } as unknown as SessionIndexStore,
+    sessionIndex: { recordLatestTerminalMessage } as Pick<
+      SessionIndexStore,
+      "recordLatestTerminalMessage"
+    >,
     getSessionId: () => "session-1",
     store: memory.store,
     alarmScheduler,

--- a/packages/control-plane/src/session/terminal-message-projection.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.ts
@@ -10,7 +10,7 @@ export interface TerminalMessageProjectionInput {
 }
 
 export interface SessionTerminalMessageProjectionDeps {
-  sessionIndex: SessionIndexStore | null;
+  sessionIndex: SessionIndexStore;
   getSessionId: () => string | null;
   store: TerminalMessageProjectionStore;
   alarmScheduler: AlarmScheduler;
@@ -37,7 +37,7 @@ export class SessionTerminalMessageProjection {
 
   async recordTerminalMessage(input: TerminalMessageProjectionInput): Promise<void> {
     const sessionId = this.deps.getSessionId();
-    if (!this.deps.sessionIndex || !sessionId) return;
+    if (!sessionId) return;
 
     const storeInput = { sessionId, ...input };
     try {
@@ -79,7 +79,7 @@ export class SessionTerminalMessageProjection {
       return;
     }
     const sessionId = this.deps.getSessionId();
-    if (!this.deps.sessionIndex || !sessionId) return;
+    if (!sessionId) return;
 
     const { messageId, messageCreatedAt, terminalMessageCompletedAt } = pending;
     try {

--- a/packages/control-plane/src/session/terminal-message-projection.ts
+++ b/packages/control-plane/src/session/terminal-message-projection.ts
@@ -10,7 +10,7 @@ export interface TerminalMessageProjectionInput {
 }
 
 export interface SessionTerminalMessageProjectionDeps {
-  sessionIndex: SessionIndexStore;
+  sessionIndex: Pick<SessionIndexStore, "recordLatestTerminalMessage">;
   getSessionId: () => string | null;
   store: TerminalMessageProjectionStore;
   alarmScheduler: AlarmScheduler;

--- a/packages/control-plane/src/session/title-service.test.ts
+++ b/packages/control-plane/src/session/title-service.test.ts
@@ -18,7 +18,7 @@ function sessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
   } as SessionRow;
 }
 
-function makeHarness(options: { session?: SessionRow | null; withoutIndexStore?: boolean } = {}) {
+function makeHarness(options: { session?: SessionRow | null } = {}) {
   const session = options.session === undefined ? sessionRow() : options.session;
   const repository = {
     getSession: vi.fn(() => session),
@@ -34,9 +34,7 @@ function makeHarness(options: { session?: SessionRow | null; withoutIndexStore?:
     messenger,
     statusService,
     backgroundTasks,
-    sessionIndexStore: options.withoutIndexStore
-      ? null
-      : ({ updateTitleIfNewer } as unknown as SessionIndexStore),
+    sessionIndexStore: { updateTitleIfNewer } as unknown as SessionIndexStore,
     durableObjectId: "do-hex-id",
     now: () => NOW,
   });
@@ -120,14 +118,5 @@ describe("SessionTitleService", () => {
       "public-name",
       { status: "active", title: "Child title" }
     );
-  });
-
-  it("skips the index sync when no D1 store is bound", () => {
-    const h = makeHarness({ withoutIndexStore: true });
-
-    const result = h.service.applySessionTitleUpdate("A title");
-
-    expect(result).toEqual({ ok: true, title: "A title" });
-    expect(h.backgroundTasks.submissions).toEqual([]);
   });
 });

--- a/packages/control-plane/src/session/title-service.test.ts
+++ b/packages/control-plane/src/session/title-service.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { createTestBackgroundTasks } from "../background-tasks.test-support";
-import type { SessionIndexStore } from "../db/session-index";
 import { SessionTitleService } from "./title-service";
 import type { SessionCoreRepository } from "./session-core-repository";
 import type { SessionRow } from "./types";
@@ -28,13 +27,13 @@ function makeHarness(options: { session?: SessionRow | null } = {}) {
   const messenger = { broadcast: vi.fn(), sendToSandbox: vi.fn(async () => {}) };
   const statusService = { notifyParentOfChildUpdate: vi.fn() };
   const backgroundTasks = createTestBackgroundTasks();
-  const updateTitleIfNewer = vi.fn(async () => {});
+  const updateTitleIfNewer = vi.fn(async () => true);
   const service = new SessionTitleService({
     sessionCoreRepository: repository as unknown as SessionCoreRepository,
     messenger,
     statusService,
     backgroundTasks,
-    sessionIndexStore: { updateTitleIfNewer } as unknown as SessionIndexStore,
+    sessionIndexStore: { updateTitleIfNewer },
     durableObjectId: "do-hex-id",
     now: () => NOW,
   });

--- a/packages/control-plane/src/session/title-service.ts
+++ b/packages/control-plane/src/session/title-service.ts
@@ -15,8 +15,7 @@ export interface SessionTitleServiceDeps {
   messenger: SessionMessenger;
   statusService: Pick<SessionStatusService, "notifyParentOfChildUpdate">;
   backgroundTasks: BackgroundTasks;
-  /** Null when the deployment has no D1 binding — the index sync is skipped. */
-  sessionIndexStore: SessionIndexStore | null;
+  sessionIndexStore: SessionIndexStore;
   durableObjectId: string;
   now: () => number;
 }
@@ -75,7 +74,6 @@ export class SessionTitleService {
 
   private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
     const { sessionIndexStore, backgroundTasks } = this.deps;
-    if (!sessionIndexStore) return;
     backgroundTasks.submit(
       () => sessionIndexStore.updateTitleIfNewer(sessionId, title, updatedAt),
       {

--- a/packages/control-plane/src/session/title-service.ts
+++ b/packages/control-plane/src/session/title-service.ts
@@ -15,7 +15,7 @@ export interface SessionTitleServiceDeps {
   messenger: SessionMessenger;
   statusService: Pick<SessionStatusService, "notifyParentOfChildUpdate">;
   backgroundTasks: BackgroundTasks;
-  sessionIndexStore: SessionIndexStore;
+  sessionIndexStore: Pick<SessionIndexStore, "updateTitleIfNewer">;
   durableObjectId: string;
   now: () => number;
 }

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -214,7 +214,6 @@ function makeHarness(
     session?: SessionRow | null;
     memberRows?: SessionRepositoryRow[];
     /** Model a deployment where the DB binding is missing. */
-    withoutDb?: boolean;
     /** Defaults to ENCRYPTION_KEY — the key is required in production. */
     encryptionKey?: string;
     /** Omit to model an unset SECRETS_CAP_ENFORCEMENT (fail-closed enforce). */
@@ -240,7 +239,7 @@ function makeHarness(
       ));
 
   const resolver = new UserEnvResolver({
-    db: options.withoutDb ? null : db,
+    db,
     sessionCoreRepository,
     resolveRepoId: (sessionForRepoId) => {
       resolveRepoIdCalls += 1;
@@ -285,14 +284,6 @@ describe("UserEnvResolver", () => {
 
       await expect(h.resolver.getProviderAuthenticationError("openai/gpt-5")).resolves.toBeNull();
     });
-  });
-
-  it("throws when a session exists but D1 is unavailable", async () => {
-    const h = makeHarness({ withoutDb: true });
-
-    await expect(h.resolver.getUserEnvVars()).rejects.toThrow(
-      "D1 is required to load session provider auth"
-    );
   });
 
   describe("with no stored secrets", () => {

--- a/packages/control-plane/src/session/user-env-resolver.test.ts
+++ b/packages/control-plane/src/session/user-env-resolver.test.ts
@@ -213,7 +213,6 @@ function makeHarness(
   options: {
     session?: SessionRow | null;
     memberRows?: SessionRepositoryRow[];
-    /** Model a deployment where the DB binding is missing. */
     /** Defaults to ENCRYPTION_KEY — the key is required in production. */
     encryptionKey?: string;
     /** Omit to model an unset SECRETS_CAP_ENFORCEMENT (fail-closed enforce). */

--- a/packages/control-plane/src/session/user-env-resolver.ts
+++ b/packages/control-plane/src/session/user-env-resolver.ts
@@ -36,7 +36,7 @@ import type { SessionRow } from "./types";
  * Dependencies injected into UserEnvResolver.
  */
 export interface UserEnvResolverDeps {
-  db: SqlDatabase | null;
+  db: SqlDatabase;
   sessionCoreRepository: SessionCoreRepository;
   /**
    * Resolves (and persists) the session's primary repo id for legacy rows
@@ -58,7 +58,7 @@ interface UserEnvContext {
 }
 
 export class UserEnvResolver {
-  private readonly db: SqlDatabase | null;
+  private readonly db: SqlDatabase;
   private readonly sessionCoreRepository: SessionCoreRepository;
   private readonly resolveRepoId: (session: SessionRow) => Promise<number>;
   private readonly durableObjectId: string;
@@ -115,7 +115,6 @@ export class UserEnvResolver {
     }
 
     const db = this.db;
-    if (!db) throw new Error("D1 is required to load session provider auth");
     const providerAuth = await new SessionIndexStore(db).getCompleteProviderAuth(
       resolvePublicSessionId(session, this.durableObjectId)
     );


### PR DESCRIPTION
Closes COL-127 (P-1b).

## Why

PR #1715 made the global store a required member of `SessionPlatform` (`db: SqlDatabase`), the Durable Object refuses to construct without the `DB` binding, and `session/components.ts` no longer has a null-store mode — the session index, the SCM-token store and `db` are all built unconditionally.

The collaborators they are handed to still declared nullable parameters from the old mode. They are only ever given non-null values, so the nullability was dead: it kept `if (store)` branches alive that no caller could reach, and their unit tests still exercised a mode production cannot enter.

## What changed

Parameters narrowed and the null branches deleted:

| File | Parameter |
|---|---|
| `session-status-service.ts` | `SessionIndexStore` |
| `title-service.ts` | `SessionIndexStore` |
| `terminal-message-projection.ts` | `SessionIndexStore` |
| `message-queue.ts` | `SessionIndexStore` |
| `participant-service.ts` | `UserScmTokenStore` |
| `user-env-resolver.ts` | `SqlDatabase` |
| `snapshot-reader.ts` | `SqlDatabase` |
| `scm-settings-resolution.ts` | `SqlDatabase` |

**Beyond the issue's list.** The same dead mode sits one type name away from the grep COL-127 specifies, so the pattern `Pick<SessionPullRequestStore, "upsert"> | null` was missed: `sessionPullRequests` in `pull-request-service.ts`, `pull-request-refresh.ts` and `pull-request-snapshot-apply.ts` is built at `components.ts:298` and passed unconditionally at both call sites (`:519`, `:654`). Included here since it is the same defect from the same cause; happy to split it out if you would rather keep the PR to the letter of the issue.

## Two things that are not simply mechanical

**`participant-service`'s local refresh path is not dead.** `refreshToken` branched on `this.userScmTokenStore && participant.scm_user_id`. Only the first half is unreachable — a participant with no `scm_user_id` has no row in the shared token store, so `refreshTokenLocal` stays, and the existing test "falls back to local when no scm_user_id even if store provided" still covers it. The doc comment on that method said "used as fallback when D1 is unavailable", which was already inaccurate; it now says what actually routes there.

**`message-queue`'s harness passed `null` for the session index**, which meant the queued-prompt index touch was never exercised by the suite at all. The harness now passes a stub, and one test covers that path. Red-tested: disabling the `backgroundTasks.submit` in `message-queue.ts` fails it.

## Verification

- The issue's grep returns nothing under `packages/control-plane/src`, tests included.
- `npm run typecheck` green across all four projects, `test/integration` included.
- Unit: 275 files, 4005 tests. Workerd integration: 100 files, 1178 passed / 1 skipped.
- eslint and prettier clean.

No behaviour change on Cloudflare — every deleted branch was unreachable from the composition root.

---

## Review round (`51245a29a`)

- **`writeSessionPullRequestRecord` still had `if (!store) return`.** Raised by both reviewers, and a real miss: the test this PR deleted — "skips the D1 write when no store is configured", which did `delete deps.sessionPullRequests` — was exercising exactly that branch, so I removed the coverage and left the code. Alias and guard gone; the try/catch stays, since an upsert *failure* is still best-effort.
- **The four `SessionIndexStore` consumers now take a `Pick` of what they call** — one method each for `message-queue`, `title-service` and `terminal-message-projection`, and a named `SessionIndexProjections` of four for `SessionStatusService`, in place of the whole 980-line, 29-method class. That removed three `as unknown as SessionIndexStore` casts outright, and the casts turned out to be hiding stub drift: `touchUpdatedAt` and `updateTitleIfNewer` return `Promise<boolean>` and two harness stubs returned `Promise<void>`. `terminal-message-projection` keeps one cast because fourteen call sites pass a bare `vi.fn()`, but it now targets the one-method capability. Pushed back on the same treatment for `UserScmTokenStore`: five methods, four of them used.
- A harness comment left dangling by the `withoutDb` deletion.

## Unrelated CI fix (`ebd614ad5`)

The unit lane failed on `src/node/session-runtime-registry.test.ts:814` — a file this branch does not touch — with "Test timed out in 5000ms". That test spawns a nested vitest run to get `--expose-gc` and gives the child 60s via `spawnSync`, but the `it()` carried no timeout, so vitest's 5s default governed: the two bounds disagreed by 12×, and the child was re-running all 35 tests in the file rather than the one it exists to run. Locally that is ~1.4s and passes; on a loaded runner it does not.

The child now runs only its own test (35 → 1), named from a shared constant so the `-t` filter cannot drift from the `it()`, and the outer test is held to `GC_CHILD_TIMEOUT_MS`. Happy to split this into its own PR if you would rather keep it separate — it is here because it was blocking this branch.
