### PR TITLE
fix(config): boot the compose stack from .env.example as shipped (COL-134)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,11 @@ AWS_SESSION_TOKEN=
 DEPLOYMENT_NAME=local
 # Display name in the UI, PR footers and User-Agent headers. Cloudflare: var.app_name
 APP_NAME=Open-Inspect
-# Required. The GitHub App's bot login, `<app-slug>[bot]`. Cloudflare: var.github_bot_username
-GITHUB_BOT_USERNAME=
+# Required. The GitHub App's bot login, `<app-slug>[bot]`. Only used to attribute
+# and filter the bot's own activity, so the placeholder below boots a local or
+# staging stack; set it to the real login before connecting a GitHub App.
+# Cloudflare: var.github_bot_username
+GITHUB_BOT_USERNAME=open-inspect[bot]
 # Public base URL of this control plane; sandboxes and image builds call back
 # to it, so it must be reachable from the sandbox provider. Cloudflare: local.control_plane_url
 WORKER_URL=http://localhost:8787

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".env.example"
       - ".github/workflows/ci.yml"
       - ".prettierignore"
       - ".prettierrc"
@@ -26,9 +27,13 @@ on:
       - "terraform/environments/production/**"
       - "vitest.workspace.ts"
       - "!**/*.md"
+      # Re-included after the exclusion above, which later patterns override: a
+      # unit test holds this document's quick start to the required variables.
+      - "docs/CONTROL_PLANE_CONTAINER.md"
   pull_request:
     branches: [main]
     paths:
+      - ".env.example"
       - ".github/workflows/ci.yml"
       - ".prettierignore"
       - ".prettierrc"
@@ -51,6 +56,9 @@ on:
       - "terraform/environments/production/**"
       - "vitest.workspace.ts"
       - "!**/*.md"
+      # Re-included after the exclusion above, which later patterns override: a
+      # unit test holds this document's quick start to the required variables.
+      - "docs/CONTROL_PLANE_CONTAINER.md"
 
 permissions:
   contents: read

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -32,10 +32,16 @@ Prerequisites: Docker with Compose v2, a GitHub App and OAuth app as in
    cp .env.example .env
    ```
 
-   Every variable is documented in place. The three encryption keys are generated with
-   `openssl rand -base64 32`. Generate a MinIO root password with `openssl rand -hex 16` and set it
-   as `MINIO_ROOT_PASSWORD`, `AWS_SECRET_ACCESS_KEY` and `LITESTREAM_SECRET_ACCESS_KEY`; the stack
-   refuses to start without it. The other MinIO and Litestream defaults work as they are.
+   Every variable is documented in place, and every value a boot cannot do without either ships with
+   a working default or is listed here. Generate the three encryption keys — `TOKEN_ENCRYPTION_KEY`,
+   `PROVIDER_ACCOUNTS_ENCRYPTION_KEY` and `REPO_SECRETS_ENCRYPTION_KEY` — with
+   `openssl rand -base64 32` each. Generate a MinIO root password with `openssl rand -hex 16` and
+   set it as `MINIO_ROOT_PASSWORD`, `AWS_SECRET_ACCESS_KEY` and `LITESTREAM_SECRET_ACCESS_KEY`; the
+   stack refuses to start without it. The other MinIO and Litestream defaults work as they are.
+
+   The rest of the file boots as shipped. A GitHub App, an OAuth app and a sandbox provider are what
+   the stack needs to do anything useful, but their variables are read at use rather than at boot,
+   so fill them in when you connect each one.
 
 2. Build and start:
 

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -15,6 +15,12 @@ const ENV_EXAMPLE_PATH = resolve(
   "../../../../.env.example"
 );
 
+/** The document whose quick start is the bring-up a clean checkout is expected to follow. */
+const CONTAINER_DOC_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../docs/CONTROL_PLANE_CONTAINER.md"
+);
+
 /** Variables docker-compose.yml and its sidecars read; the host never sees them. */
 const COMPOSE_VARIABLES = [
   "APP_BIND_ADDRESS",
@@ -34,6 +40,8 @@ interface DocumentedVariable {
   name: string;
   /** The comment lines directly above the assignment, up to the previous blank line. */
   comment: string[];
+  /** What the file ships as the value; empty means the operator has to supply one. */
+  value: string;
 }
 
 interface EnvExample {
@@ -55,15 +63,24 @@ function parseEnvExample(): EnvExample {
       comment.push(line);
       continue;
     }
-    const match = /^([A-Za-z_][A-Za-z0-9_]*)=/.exec(line);
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
     if (match) {
-      variables.push({ name: match[1], comment });
+      variables.push({ name: match[1], comment, value: match[2].trim() });
       comment = [];
     } else {
       malformed.push(line);
     }
   }
   return { variables, malformed };
+}
+
+/** The "## Quick start" section of the container document, and no other section. */
+function readQuickStart(): string {
+  const doc = readFileSync(CONTAINER_DOC_PATH, "utf8");
+  const start = doc.indexOf("\n## Quick start\n");
+  if (start === -1) throw new Error("CONTROL_PLANE_CONTAINER.md has no Quick start section");
+  const end = doc.indexOf("\n## ", start + 1);
+  return end === -1 ? doc.slice(start) : doc.slice(start, end);
 }
 
 describe(".env.example", () => {
@@ -90,5 +107,22 @@ describe(".env.example", () => {
       .filter((variable) => variable.comment[0]?.startsWith(REQUIRED_MARKER))
       .map((variable) => variable.name);
     expect(marked.sort()).toEqual([...REQUIRED_ENV_CONFIG_KEY_NAMES].sort());
+  });
+
+  /**
+   * A copy of this file plus the documented quick start has to produce a host that
+   * boots. A required key may therefore ship a working value, or be one the quick
+   * start names as an operator's to supply — the encryption keys, which cannot have
+   * a default. A key that is neither is a crash loop on a clean checkout, and the
+   * compose smoke cannot catch it: that script writes its own environment file.
+   */
+  it("gives every required key a value, or has the quick start ask for it", () => {
+    const required = new Set<string>(REQUIRED_ENV_CONFIG_KEY_NAMES);
+    const quickStart = readQuickStart();
+    const unsupplied = example.variables
+      .filter((variable) => required.has(variable.name))
+      .filter((variable) => variable.value === "" && !quickStart.includes(variable.name))
+      .map((variable) => variable.name);
+    expect(unsupplied).toEqual([]);
   });
 });

--- a/packages/control-plane/src/node/env-example.test.ts
+++ b/packages/control-plane/src/node/env-example.test.ts
@@ -15,6 +15,12 @@ const ENV_EXAMPLE_PATH = resolve(
   "../../../../.env.example"
 );
 
+/** The compose file, which has required variables of its own beyond the host's. */
+const COMPOSE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../docker-compose.yml"
+);
+
 /** The document whose quick start is the bring-up a clean checkout is expected to follow. */
 const CONTAINER_DOC_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -65,13 +71,32 @@ function parseEnvExample(): EnvExample {
     }
     const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
     if (match) {
-      variables.push({ name: match[1], comment, value: match[2].trim() });
+      variables.push({ name: match[1], comment, value: readEnvValue(match[2]) });
       comment = [];
     } else {
       malformed.push(line);
     }
   }
   return { variables, malformed };
+}
+
+/**
+ * The value dotenv would hand the process: an unquoted value ends at a comment,
+ * and a quoted one is its contents. `KEY=""` and `KEY= # unset` are both empty,
+ * and a check that read the raw text would take either for a supplied value.
+ */
+function readEnvValue(raw: string): string {
+  const quoted = /^\s*(["'])(.*?)\1\s*(?:#.*)?$/.exec(raw);
+  if (quoted) return quoted[2];
+  return raw.split("#")[0].trim();
+}
+
+/** The variables docker-compose.yml refuses to start without: `${NAME:?message}`. */
+function readComposeRequiredVariables(): string[] {
+  const compose = readFileSync(COMPOSE_PATH, "utf8");
+  const names = new Set<string>();
+  for (const match of compose.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*):\?/g)) names.add(match[1]);
+  return [...names];
 }
 
 /** The "## Quick start" section of the container document, and no other section. */
@@ -110,19 +135,30 @@ describe(".env.example", () => {
   });
 
   /**
-   * A copy of this file plus the documented quick start has to produce a host that
-   * boots. A required key may therefore ship a working value, or be one the quick
+   * A copy of this file plus the documented quick start has to produce a stack that
+   * comes up. A required key may therefore ship a working value, or be one the quick
    * start names as an operator's to supply — the encryption keys, which cannot have
    * a default. A key that is neither is a crash loop on a clean checkout, and the
    * compose smoke cannot catch it: that script writes its own environment file.
+   *
+   * "Required" spans both gates a bring-up passes through: `readEnvConfig`, which
+   * the host checks before it listens, and the `${NAME:?}` variables compose refuses
+   * to start without. Both sets are read from the artifacts that enforce them, so
+   * neither can drift from this test.
+   *
+   * The set is iterated, not the file, so deleting an assignment outright reads as
+   * the empty value it becomes rather than dropping out of the check.
    */
-  it("gives every required key a value, or has the quick start ask for it", () => {
-    const required = new Set<string>(REQUIRED_ENV_CONFIG_KEY_NAMES);
+  it("gives every required variable a value, or has the quick start ask for it", () => {
+    const required = new Set<string>([
+      ...REQUIRED_ENV_CONFIG_KEY_NAMES,
+      ...readComposeRequiredVariables(),
+    ]);
     const quickStart = readQuickStart();
-    const unsupplied = example.variables
-      .filter((variable) => required.has(variable.name))
-      .filter((variable) => variable.value === "" && !quickStart.includes(variable.name))
-      .map((variable) => variable.name);
+    const shipped = new Map(example.variables.map(({ name, value }) => [name, value]));
+    const unsupplied = [...required]
+      .filter((name) => (shipped.get(name) ?? "") === "" && !quickStart.includes(name))
+      .sort();
     expect(unsupplied).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes COL-134.

## The defect

A clean clone plus the quick start in `docs/CONTROL_PLANE_CONTAINER.md` — `cp .env.example .env`, fill the encryption keys and the MinIO password — produces a stack that crash-loops:

```
Missing required configuration: GITHUB_BOT_USERNAME
```

`GITHUB_BOT_USERNAME=` ships empty in `.env.example` and `readEnvConfig` has it in `REQUIRED_ENV_CONFIG_KEYS`. Verified against `main` before changing anything.

It reads worse than a missing value. `caddy` waits on `app` being `service_healthy`, the app never becomes healthy, so Caddy is never created and the operator sees "nothing on 443, no certificate" instead of a named variable. Found empirically on an EC2 instance during the AWS spike; it was the only blocker, and any non-empty string booted the host cleanly.

## The fix

`GITHUB_BOT_USERNAME=open-inspect[bot]`. The login is only used to attribute and filter the bot's own activity, so a placeholder is harmless for a local or staging bring-up and the comment says to set the real login before connecting a GitHub App.

## Audit of the rest of the required set

The required set is `DEPLOYMENT_NAME`, `GITHUB_BOT_USERNAME`, `TOKEN_ENCRYPTION_KEY`, `PROVIDER_ACCOUNTS_ENCRYPTION_KEY`, `REPO_SECRETS_ENCRYPTION_KEY`.

- `DEPLOYMENT_NAME` already ships `local`.
- The three encryption keys ship empty and must: a shared default would be a real hazard. They are the operator's to generate, and the quick start already asked for them — but as "the three encryption keys", never by name. It now names each one, so a reader can check off the list rather than infer which three.

No other required variable ships empty. Every remaining empty value in the file is read at use, not at boot.

## The regression test

`packages/control-plane/src/node/env-example.test.ts` already checks that `.env.example` names exactly the variables the host reads and marks exactly the required ones. It now also checks the property this bug violated: **every required key either ships a non-empty value or is named in the quick start's fill-in step.** That is the whole class, not just this instance.

Confirmed it fails on the original defect (blanking the value reports `[ 'GITHUB_BOT_USERNAME' ]`) and passes with the fix.

Worth noting why CI did not already catch this: `scripts/compose-smoke.sh` boots the stack on every PR, but it writes its own throwaway environment file rather than copying `.env.example`, so the shipped file was never on a boot path. A unit test on the file itself is the cheap place to close that.

## Not changed

`caddy`'s `depends_on: app: condition: service_healthy` is untouched. The issue raises it as a question and it is a deliberate trade — serving TLS in front of a dead app is not obviously better. Open question for a follow-up if the diagnosis cost is judged to outweigh that: whether a `service_started` dependency would surface app failures more usefully than a missing listener does.

`readEnvConfig` already names every missing required variable in one error, so the issue's third suggestion (a preflight that reports the whole gap at once) is satisfied today; the AWS spike looped because the encryption keys were being filled one at a time by hand, not because the reader reports one at a time.

## Verification

- `npm run typecheck` (after `npm run build -w @open-inspect/shared`) — clean
- `npm run lint` — clean
- `npm run test -w @open-inspect/control-plane` — 275 files, 4006 tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration guidance for container deployments, including boot-critical defaults and values that can be supplied when integrations are connected.
  * Added a usable placeholder for the GitHub bot login in the example environment configuration, with guidance to replace it before connecting a GitHub App.
* **Tests**
  * Added validation to ensure required environment variables have either working defaults or clear setup instructions, including variables required by container startup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->