### PR TITLE
fix(web): reconnect after a host restart closes the socket cleanly (COL-136)

### DIFF
--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -6,13 +6,13 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
+import { WS_CLOSE_SERVICE_RESTART } from "@open-inspect/shared/types/websocket";
 import type { SqlDatabase } from "../db/sql-database";
 import type { AlarmScheduleStore } from "../session/alarm/scheduler";
 import type { SessionRuntime } from "../session/components";
 import type { SessionPlatform, SessionStorage } from "../session/platform";
 import type { BackgroundTasks } from "../platform-ports";
 import {
-  SERVICE_RESTART_CLOSE_CODE,
   SessionRuntimeRegistry,
   type ManagedSessionRuntime,
   type SessionRuntimeRegistryOptions,
@@ -587,7 +587,7 @@ describe("SessionRuntimeRegistry", () => {
         await registry.shutdown();
 
         expect(await closed).toEqual({
-          code: SERVICE_RESTART_CLOSE_CODE,
+          code: WS_CLOSE_SERVICE_RESTART,
           reason: "Service restart",
         });
         expect(runtime.server.onClose).toHaveBeenCalledWith(server, 1012, "Service restart", true);
@@ -636,11 +636,45 @@ describe("SessionRuntimeRegistry", () => {
       await attached;
 
       await shutdown;
-      expect(await closed).toBe(SERVICE_RESTART_CLOSE_CODE);
+      expect(await closed).toBe(WS_CLOSE_SERVICE_RESTART);
       expect(registry.residentSessionIds()).toEqual([]);
       expect(log.warn).not.toHaveBeenCalled();
     } finally {
       client.terminate();
+      await new Promise<void>((done) => wss.close(() => done()));
+    }
+  });
+
+  it("shutdown's close reaches a spec-compliant client as a clean 1012", async () => {
+    // The browser only reconnects on codes it is told to reconnect on, and a
+    // proper close frame makes this a *clean* close (`wasClean: true`), not the
+    // 1006 an abrupt teardown would produce. The web transport's retry set has
+    // to contain this code for a deploy not to strand every open tab; see
+    // `use-session-transport.ts`.
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((done) => wss.once("listening", done));
+    // Node's global WebSocket implements the browser spec, close event included.
+    const client = new WebSocket(`ws://127.0.0.1:${(wss.address() as AddressInfo).port}`);
+    try {
+      const serverSide = new Promise<NodeWebSocket>((done) => wss.once("connection", done));
+      await new Promise<void>((done) => client.addEventListener("open", () => done()));
+      const server = await serverSide;
+      const closed = new Promise<{ code: number; wasClean: boolean }>((done) =>
+        client.addEventListener("close", (event) =>
+          done({ code: event.code, wasClean: event.wasClean })
+        )
+      );
+
+      const registry = makeRegistry();
+      await registry.withRuntime("s1", async (runtime) => {
+        runtime.platform.sockets.adopt(server, ["wsid:c1"]);
+      });
+
+      await registry.shutdown();
+
+      expect(await closed).toEqual({ code: WS_CLOSE_SERVICE_RESTART, wasClean: true });
+    } finally {
+      client.close();
       await new Promise<void>((done) => wss.close(() => done()));
     }
   });

--- a/packages/control-plane/src/node/session-runtime-registry.test.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.test.ts
@@ -568,8 +568,14 @@ describe("SessionRuntimeRegistry", () => {
       try {
         const registry = makeRegistry({ storeProvider: createFileSessionStoreProvider(dataDir) });
         const { server, client } = await connect();
-        const closed = new Promise<{ code: number; reason: string }>((done) =>
-          client.once("close", (code, reason) => done({ code, reason: reason.toString() }))
+        // The standards-style close event carries `wasClean`, which is what
+        // the browser decides on: a proper close frame makes this a clean
+        // close, so the web transport has to retry on the code rather than
+        // treat it as a deliberate teardown (`use-session-transport.ts`).
+        const closed = new Promise<{ code: number; reason: string; wasClean: boolean }>((done) =>
+          client.addEventListener("close", (event) =>
+            done({ code: event.code, reason: event.reason, wasClean: event.wasClean })
+          )
         );
         const runtime = await registry.withRuntime("s1", async (runtime) => {
           runtime.platform.sockets.adopt(server, ["wsid:c1"]);
@@ -589,6 +595,7 @@ describe("SessionRuntimeRegistry", () => {
         expect(await closed).toEqual({
           code: WS_CLOSE_SERVICE_RESTART,
           reason: "Service restart",
+          wasClean: true,
         });
         expect(runtime.server.onClose).toHaveBeenCalledWith(server, 1012, "Service restart", true);
         expect(deliveredAgainstOpenStore).toBe(true);
@@ -641,40 +648,6 @@ describe("SessionRuntimeRegistry", () => {
       expect(log.warn).not.toHaveBeenCalled();
     } finally {
       client.terminate();
-      await new Promise<void>((done) => wss.close(() => done()));
-    }
-  });
-
-  it("shutdown's close reaches a spec-compliant client as a clean 1012", async () => {
-    // The browser only reconnects on codes it is told to reconnect on, and a
-    // proper close frame makes this a *clean* close (`wasClean: true`), not the
-    // 1006 an abrupt teardown would produce. The web transport's retry set has
-    // to contain this code for a deploy not to strand every open tab; see
-    // `use-session-transport.ts`.
-    const wss = new WebSocketServer({ port: 0 });
-    await new Promise<void>((done) => wss.once("listening", done));
-    // Node's global WebSocket implements the browser spec, close event included.
-    const client = new WebSocket(`ws://127.0.0.1:${(wss.address() as AddressInfo).port}`);
-    try {
-      const serverSide = new Promise<NodeWebSocket>((done) => wss.once("connection", done));
-      await new Promise<void>((done) => client.addEventListener("open", () => done()));
-      const server = await serverSide;
-      const closed = new Promise<{ code: number; wasClean: boolean }>((done) =>
-        client.addEventListener("close", (event) =>
-          done({ code: event.code, wasClean: event.wasClean })
-        )
-      );
-
-      const registry = makeRegistry();
-      await registry.withRuntime("s1", async (runtime) => {
-        runtime.platform.sockets.adopt(server, ["wsid:c1"]);
-      });
-
-      await registry.shutdown();
-
-      expect(await closed).toEqual({ code: WS_CLOSE_SERVICE_RESTART, wasClean: true });
-    } finally {
-      client.close();
       await new Promise<void>((done) => wss.close(() => done()));
     }
   });

--- a/packages/control-plane/src/node/session-runtime-registry.ts
+++ b/packages/control-plane/src/node/session-runtime-registry.ts
@@ -33,6 +33,7 @@
  * explicit archive or delete route may.
  */
 
+import { WS_CLOSE_SERVICE_RESTART } from "@open-inspect/shared/types/websocket";
 import type { Logger } from "../logger";
 import type { SqlDatabase } from "../db/sql-database";
 import type { AlarmScheduleStore } from "../session/alarm/scheduler";
@@ -55,8 +56,6 @@ const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
 const DEFAULT_MAX_RESIDENT = 256;
 /** How long a shutdown waits for every runtime to quiesce before forcing it. */
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
-/** The close code sent to sockets a shutdown closes: the peer should reconnect. */
-export const SERVICE_RESTART_CLOSE_CODE = 1012;
 
 /**
  * What the registry drives on a runtime: the session server's socket entry
@@ -312,7 +311,7 @@ export class SessionRuntimeRegistry<Runtime extends ManagedSessionRuntime> {
   ): Promise<boolean> {
     for (;;) {
       for (const socket of session.sockets.sockets()) {
-        socket.close(SERVICE_RESTART_CLOSE_CODE, "Service restart");
+        socket.close(WS_CLOSE_SERVICE_RESTART, "Service restart");
       }
       const remainingMs = deadlineMs - Date.now();
       if (remainingMs <= 0) return this.isQuiescent(session);

--- a/packages/control-plane/src/node/socket-host.test.ts
+++ b/packages/control-plane/src/node/socket-host.test.ts
@@ -2,10 +2,10 @@ import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket, WebSocketServer } from "ws";
+import { WS_CLOSE_TRY_AGAIN_LATER } from "@open-inspect/shared/types/websocket";
 import type { Logger } from "../logger";
 import { isSocketOpen, type SessionWebSocket } from "../platform-ports";
 import {
-  BACKLOG_EXCEEDED_CLOSE_CODE,
   NodeWebSocketHost,
   type NodeSocketHostOptions,
   type SessionWebSocketEventSink,
@@ -310,7 +310,7 @@ describe("NodeWebSocketHost", () => {
     for (let i = 0; i < 4; i += 1) socket.emit("message", Buffer.from(`queued-${i}`), false);
 
     const [code, reason] = await once(client, "close");
-    expect(code).toBe(BACKLOG_EXCEEDED_CLOSE_CODE);
+    expect(code).toBe(WS_CLOSE_TRY_AGAIN_LATER);
     expect(String(reason)).toBe("Message backlog exceeded");
     expect(harness.log.warn).toHaveBeenCalledWith(
       "socket.backlog_exceeded",

--- a/packages/control-plane/src/node/socket-host.ts
+++ b/packages/control-plane/src/node/socket-host.ts
@@ -13,7 +13,7 @@
  * empties, so the peer's bytes wait in the kernel rather than on the heap;
  * only the frames `ws` had already decoded from the read in progress queue
  * behind an in-flight delivery, up to `maxPendingDeliveries`. A peer that
- * exceeds that bound is closed with 1013. A handler that never settles holds
+ * exceeds that bound is closed with `WS_CLOSE_TRY_AGAIN_LATER`. A handler that never settles holds
  * only its own socket; bounding handler time is the session executor's
  * concern, which is whatever `bindEventSink` receives.
  *
@@ -23,6 +23,7 @@
  */
 
 import { WebSocket as NodeWebSocket, type RawData } from "ws";
+import { WS_CLOSE_TRY_AGAIN_LATER } from "@open-inspect/shared/types/websocket";
 import type { Logger } from "../logger";
 import type { SessionWebSocket } from "../platform-ports";
 import type { SessionWebSocketHost } from "../session/platform";
@@ -49,9 +50,6 @@ export interface NodeSocketHostOptions {
 }
 
 const DEFAULT_MAX_PENDING_DELIVERIES = 4096;
-
-/** RFC 6455 "try again later": the server cannot keep up with this peer. */
-export const BACKLOG_EXCEEDED_CLOSE_CODE = 1013;
 
 interface Deliveries {
   queue: Array<() => Promise<void>>;
@@ -151,7 +149,7 @@ export class NodeWebSocketHost implements SessionWebSocketHost {
         pending: deliveries.queue.length,
       });
       deliveries.queue.length = 0;
-      socket.close(BACKLOG_EXCEEDED_CLOSE_CODE, "Message backlog exceeded");
+      socket.close(WS_CLOSE_TRY_AGAIN_LATER, "Message backlog exceeded");
       // The socket was paused for the in-flight delivery, which may never
       // settle; the closing handshake still has to read the peer's frame.
       socket.resume();

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -3,8 +3,17 @@ import { clientRequestIdSchema, webPromptPayloadSchema } from "./prompts";
 
 export { clientRequestIdSchema, MAX_UNFINISHED_PROMPTS, MAX_WEB_PROMPT_CHARS } from "./prompts";
 
+/** Standard close code for a peer that is shutting down or navigating away. */
+export const WS_CLOSE_GOING_AWAY = 1001;
+
 /** Standard close code for a transient server-side failure. */
 export const WS_CLOSE_INTERNAL_ERROR = 1011;
+
+/** Standard close code for a host that is restarting; the peer should reconnect. */
+export const WS_CLOSE_SERVICE_RESTART = 1012;
+
+/** Standard close code for a host that is temporarily overloaded; the peer should reconnect. */
+export const WS_CLOSE_TRY_AGAIN_LATER = 1013;
 
 /** Signals that the browser must discard its credential and reconnect fresh. */
 export const WS_CLOSE_AUTHORIZATION_REVOKED = 4010;

--- a/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
@@ -76,6 +76,7 @@ export default function SessionPage() {
   const {
     connected,
     connecting,
+    reconnecting,
     ready,
     presenceSynced,
     authError,
@@ -392,6 +393,7 @@ export default function SessionPage() {
         fallbackSessionInfo={fallbackSessionInfo}
         connected={connected && ready}
         connecting={connecting || (connected && !ready)}
+        reconnecting={reconnecting}
         isDetailsOpen={isDetailsOpen}
         isDesktopDetailsOpen={isDesktopDetailsOpen}
         showDesktopDetailsToggle={!resolvedDiff}

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -30,11 +30,15 @@ const FULL_CAPABILITIES: SessionCapabilities = {
 
 function SessionHeader({
   capabilities = FULL_CAPABILITIES,
+  reconnecting = false,
   ...props
-}: Omit<ComponentProps<typeof SessionHeaderComponent>, "capabilities"> & {
+}: Omit<ComponentProps<typeof SessionHeaderComponent>, "capabilities" | "reconnecting"> & {
   capabilities?: SessionCapabilities;
+  reconnecting?: boolean;
 }) {
-  return <SessionHeaderComponent {...props} capabilities={capabilities} />;
+  return (
+    <SessionHeaderComponent {...props} capabilities={capabilities} reconnecting={reconnecting} />
+  );
 }
 
 const actions: SessionActionProps = {
@@ -371,6 +375,28 @@ describe("SessionHeader", () => {
     rerender(<SessionHeader {...props} connected={false} connecting={false} />);
     expect(
       screen.getByRole("status", { name: "Connection status: Disconnected" })
+    ).toBeInTheDocument();
+  });
+
+  it("labels a pending reconnect distinctly from a first connection", () => {
+    const props = {
+      sessionState: createSessionState(),
+      fallbackSessionInfo: { repoOwner: "acme", repoName: "web", title: "Status icons" },
+      isDetailsOpen: false,
+      isDesktopDetailsOpen: true,
+      showDesktopDetailsToggle: true,
+      detailsButtonRef: createRef<HTMLButtonElement>(),
+      actionsButtonRef: createRef<HTMLButtonElement>(),
+      onToggleDetails: vi.fn(),
+      onToggleDesktopDetails: vi.fn(),
+      onOpenMobileDetails: vi.fn(),
+      actions,
+      renameSession: vi.fn(),
+    };
+    render(<SessionHeader {...props} connected={false} connecting={false} reconnecting />);
+
+    expect(
+      screen.getByRole("status", { name: "Connection status: Reconnecting..." })
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -90,6 +90,8 @@ export type SessionHeaderProps = {
   };
   connected: boolean;
   connecting: boolean;
+  /** A reconnect is scheduled and has not started yet. */
+  reconnecting: boolean;
   isDetailsOpen: boolean;
   isDesktopDetailsOpen: boolean;
   showDesktopDetailsToggle: boolean;
@@ -110,6 +112,7 @@ export function SessionHeader({
   fallbackSessionInfo,
   connected,
   connecting,
+  reconnecting,
   isDetailsOpen,
   isDesktopDetailsOpen,
   showDesktopDetailsToggle,
@@ -232,7 +235,11 @@ export function SessionHeader({
           />
           <div className="flex items-center gap-1">
             {capabilities.read && (
-              <ConnectionStatusIcon connected={connected} connecting={connecting} />
+              <ConnectionStatusIcon
+                connected={connected}
+                connecting={connecting}
+                reconnecting={reconnecting}
+              />
             )}
             <SandboxStatusIcon
               status={sessionState?.sandboxStatus}
@@ -267,12 +274,23 @@ export function SessionHeader({
 function ConnectionStatusIcon({
   connected,
   connecting,
+  reconnecting,
 }: {
   connected: boolean;
   connecting: boolean;
+  reconnecting: boolean;
 }) {
-  const label = connecting ? "Connecting..." : connected ? "Connected" : "Disconnected";
-  const color = connecting ? "bg-warning" : connected ? "bg-success" : "bg-destructive";
+  // A pending reconnect is a wait, not a dead connection: say so rather than
+  // showing "Disconnected" while the backoff timer runs.
+  const pending = connecting || reconnecting;
+  const label = reconnecting
+    ? "Reconnecting..."
+    : connecting
+      ? "Connecting..."
+      : connected
+        ? "Connected"
+        : "Disconnected";
+  const color = pending ? "bg-warning" : connected ? "bg-success" : "bg-destructive";
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -286,7 +304,7 @@ function ConnectionStatusIcon({
           >
             <span
               aria-hidden="true"
-              className={`h-2.5 w-2.5 rounded-full ${color}${connecting ? " animate-pulse motion-reduce:animate-none" : ""}`}
+              className={`h-2.5 w-2.5 rounded-full ${color}${pending ? " animate-pulse motion-reduce:animate-none" : ""}`}
             />
           </span>
         </TooltipTrigger>

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -42,6 +42,8 @@ const NO_MESSAGES: Message[] = [];
 interface UseSessionSocketReturn {
   connected: boolean;
   connecting: boolean;
+  /** A reconnect is scheduled and has not started yet. */
+  reconnecting: boolean;
   ready: boolean;
   presenceSynced: boolean;
   authError: string | null;
@@ -414,6 +416,7 @@ export function useSessionSocket(
   return {
     connected: transport.connected,
     connecting: transport.connecting,
+    reconnecting: transport.reconnecting,
     ready: state.ready,
     presenceSynced: state.presenceSynced,
     authError: transport.authError,

--- a/packages/web/src/hooks/use-session-transport.test.tsx
+++ b/packages/web/src/hooks/use-session-transport.test.tsx
@@ -244,6 +244,7 @@ describe("useSessionTransport", () => {
     // when that is discovered: the retry presents the stale token and is closed
     // 4001, which has to recover on its own rather than sit behind a banner.
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
     fetchMock
       .mockResolvedValueOnce(Response.json({ token: "stale-token" }))
       .mockResolvedValueOnce(Response.json({ token: "reissued-token" }));
@@ -256,7 +257,7 @@ describe("useSessionTransport", () => {
       FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true);
     });
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(5_000);
     });
     expect(FakeWebSocket.instances).toHaveLength(2);
     expect(FakeWebSocket.instances[1].sentMessages).toEqual([]);
@@ -330,6 +331,8 @@ describe("useSessionTransport", () => {
       original.open();
       original.serverClose(4010, true);
     });
+    // Every scheduled reconnect reports the wait, not just the backoff ones.
+    expect(rendered.result.current.reconnecting).toBe(true);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
@@ -367,25 +370,29 @@ describe("useSessionTransport", () => {
     rendered.unmount();
   });
 
-  // The host closes every adopted socket with WS_CLOSE_SERVICE_RESTART on
-  // shutdown, and a proper close frame makes it a *clean* close in the browser.
-  it.each([
-    ["a service restart", WS_CLOSE_SERVICE_RESTART],
-    ["a try-again-later close", WS_CLOSE_TRY_AGAIN_LATER],
-    ["the host going away", WS_CLOSE_GOING_AWAY],
-  ])("reconnects after %s, which the host reports as a clean close", async (_label, code) => {
+  it("reconnects after a service restart on a randomized RFC delay", async () => {
+    // The host closes every adopted socket with WS_CLOSE_SERVICE_RESTART on
+    // shutdown, and a proper close frame makes it a *clean* close in the
+    // browser. RFC 6455 registers 1012 with a randomized 5-30s reconnect: the
+    // restart hits every tab at once, and the host is not listening again a
+    // second later anyway.
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
     const rendered = renderTransport();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     act(() => {
       FakeWebSocket.instances[0].open();
-      FakeWebSocket.instances[0].serverClose(code, true);
+      FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true);
     });
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(4_999);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
     });
     expect(FakeWebSocket.instances).toHaveLength(2);
     // The credential outlives the host restart, so no second token fetch.
@@ -394,6 +401,78 @@ describe("useSessionTransport", () => {
 
     act(() => FakeWebSocket.instances[1].open());
     expect(rendered.result.current.connected).toBe(true);
+    rendered.unmount();
+  });
+
+  it("spreads service-restart reconnects across the whole randomized window", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(1);
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_999);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    rendered.unmount();
+  });
+
+  it("leaves an overloaded server alone and offers the user a reconnect", async () => {
+    // 1013 is registered as overload, and this codebase's only sender closes a
+    // peer for exhausting its own delivery backlog. Reconnecting on a timer
+    // would repeat exactly what the host just refused, so the registry asks for
+    // a reconnect on user action - which is what the banner's button is.
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      FakeWebSocket.instances[0].open();
+      FakeWebSocket.instances[0].serverClose(WS_CLOSE_TRY_AGAIN_LATER, true);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(rendered.result.current.reconnecting).toBe(false);
+    expect(rendered.result.current.connectionError).toBe(
+      "The server is too busy to accept the connection. Try reconnecting in a moment."
+    );
+
+    act(() => rendered.result.current.reconnect());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(rendered.result.current.connectionError).toBeNull();
+    rendered.unmount();
+  });
+
+  it("reconnects on the transient backoff when the host goes away", async () => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      FakeWebSocket.instances[0].open();
+      FakeWebSocket.instances[0].serverClose(WS_CLOSE_GOING_AWAY, true);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     rendered.unmount();
   });
 
@@ -406,7 +485,7 @@ describe("useSessionTransport", () => {
     act(() => FakeWebSocket.instances[0].open());
     expect(rendered.result.current.reconnecting).toBe(false);
 
-    act(() => FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true));
+    act(() => FakeWebSocket.instances[0].serverClose(WS_CLOSE_GOING_AWAY, true));
     expect(rendered.result.current.reconnecting).toBe(true);
     expect(rendered.result.current.connected).toBe(false);
 
@@ -418,7 +497,7 @@ describe("useSessionTransport", () => {
     rendered.unmount();
   });
 
-  it("retries on a backoff schedule that outlasts a host restart", async () => {
+  it("retries a transient close on a backoff schedule that outlasts an outage", async () => {
     vi.useFakeTimers();
     const rendered = renderTransport();
     await act(async () => {
@@ -435,7 +514,7 @@ describe("useSessionTransport", () => {
     );
 
     for (const [attempt, delayMs] of expectedDelaysMs.entries()) {
-      act(() => FakeWebSocket.instances[attempt].serverClose(WS_CLOSE_SERVICE_RESTART, true));
+      act(() => FakeWebSocket.instances[attempt].serverClose(WS_CLOSE_GOING_AWAY, true));
       await act(async () => {
         await vi.advanceTimersByTimeAsync(delayMs - 1);
       });
@@ -448,7 +527,7 @@ describe("useSessionTransport", () => {
     expect(rendered.result.current.connectionError).toBeNull();
 
     act(() =>
-      FakeWebSocket.instances[expectedDelaysMs.length].serverClose(WS_CLOSE_SERVICE_RESTART, true)
+      FakeWebSocket.instances[expectedDelaysMs.length].serverClose(WS_CLOSE_GOING_AWAY, true)
     );
     expect(rendered.result.current.connectionError).toBe(
       "Connection lost. Please check your network and try reconnecting."

--- a/packages/web/src/hooks/use-session-transport.test.tsx
+++ b/packages/web/src/hooks/use-session-transport.test.tsx
@@ -3,6 +3,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
+import {
+  WS_CLOSE_GOING_AWAY,
+  WS_CLOSE_SERVICE_RESTART,
+  WS_CLOSE_TRY_AGAIN_LATER,
+} from "@open-inspect/shared/types/websocket";
 import { useSessionTransport } from "./use-session-transport";
 
 class FakeWebSocket {
@@ -289,6 +294,96 @@ describe("useSessionTransport", () => {
     rendered.unmount();
   });
 
+  // The host closes every adopted socket with WS_CLOSE_SERVICE_RESTART on
+  // shutdown, and a proper close frame makes it a *clean* close in the browser.
+  it.each([
+    ["a service restart", WS_CLOSE_SERVICE_RESTART],
+    ["a try-again-later close", WS_CLOSE_TRY_AGAIN_LATER],
+    ["the host going away", WS_CLOSE_GOING_AWAY],
+  ])("reconnects after %s, which the host reports as a clean close", async (_label, code) => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      FakeWebSocket.instances[0].open();
+      FakeWebSocket.instances[0].serverClose(code, true);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    // The credential outlives the host restart, so no second token fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(rendered.result.current.connectionError).toBeNull();
+
+    act(() => FakeWebSocket.instances[1].open());
+    expect(rendered.result.current.connected).toBe(true);
+    rendered.unmount();
+  });
+
+  it("reports reconnecting while a scheduled retry is pending", async () => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => FakeWebSocket.instances[0].open());
+    expect(rendered.result.current.reconnecting).toBe(false);
+
+    act(() => FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true));
+    expect(rendered.result.current.reconnecting).toBe(true);
+    expect(rendered.result.current.connected).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(rendered.result.current.reconnecting).toBe(false);
+    rendered.unmount();
+  });
+
+  it("retries on a backoff schedule that outlasts a host restart", async () => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const expectedDelaysMs = [
+      1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000, 30_000, 30_000,
+    ];
+    // A restart of the Node host takes seconds to a minute; the budget has to
+    // outlast it, not the ~31s five attempts bought.
+    expect(expectedDelaysMs.reduce((total, delay) => total + delay, 0)).toBeGreaterThanOrEqual(
+      150_000
+    );
+
+    for (const [attempt, delayMs] of expectedDelaysMs.entries()) {
+      act(() => FakeWebSocket.instances[attempt].serverClose(WS_CLOSE_SERVICE_RESTART, true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delayMs - 1);
+      });
+      expect(FakeWebSocket.instances).toHaveLength(attempt + 1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(FakeWebSocket.instances).toHaveLength(attempt + 2);
+    }
+    expect(rendered.result.current.connectionError).toBeNull();
+
+    act(() =>
+      FakeWebSocket.instances[expectedDelaysMs.length].serverClose(WS_CLOSE_SERVICE_RESTART, true)
+    );
+    expect(rendered.result.current.connectionError).toBe(
+      "Connection lost. Please check your network and try reconnecting."
+    );
+    expect(rendered.result.current.reconnecting).toBe(false);
+    rendered.unmount();
+  });
+
   it("reconnects with backoff after an unclean close and reuses the cached token", async () => {
     vi.useFakeTimers();
     const rendered = renderTransport();
@@ -325,7 +420,7 @@ describe("useSessionTransport", () => {
     });
 
     // Never mark the sockets healthy, so repeated failures exhaust the budget.
-    for (let attempt = 0; attempt < 6; attempt++) {
+    for (let attempt = 0; attempt < 11; attempt++) {
       const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
       act(() => {
         socket.serverClose(1006);
@@ -335,7 +430,7 @@ describe("useSessionTransport", () => {
       });
     }
 
-    expect(FakeWebSocket.instances).toHaveLength(6);
+    expect(FakeWebSocket.instances).toHaveLength(11);
     expect(rendered.result.current.connectionError).toBe(
       "Connection lost. Please check your network and try reconnecting."
     );

--- a/packages/web/src/hooks/use-session-transport.test.tsx
+++ b/packages/web/src/hooks/use-session-transport.test.tsx
@@ -204,30 +204,103 @@ describe("useSessionTransport", () => {
     expect(result.current.connecting).toBe(false);
   });
 
-  it("sets an auth error on close code 4001 and fetches a fresh token on reconnect", async () => {
-    const { result, socket } = await openSocket();
-
-    act(() => {
-      socket.serverClose(4001);
+  it("refreshes a rejected credential once, then reports an auth error", async () => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
     });
 
-    await waitFor(() => {
-      expect(result.current.authError).toBe("Authentication failed. Please sign in again.");
-      expect(result.current.connected).toBe(false);
+    // One automatic refresh: the credential may simply be stale.
+    act(() => FakeWebSocket.instances[0].serverClose(4001, true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
     });
-    expect(onClose).toHaveBeenCalledTimes(1);
-    // No automatic reconnect on auth failure.
-    expect(FakeWebSocket.instances).toHaveLength(1);
-
-    act(() => {
-      result.current.reconnect();
-    });
-
-    await waitFor(() => {
-      expect(FakeWebSocket.instances).toHaveLength(2);
-    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.current.authError).toBeNull();
+    expect(rendered.result.current.authError).toBeNull();
+
+    // A freshly issued credential rejected too is a real auth failure.
+    act(() => FakeWebSocket.instances[1].serverClose(4001, true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(rendered.result.current.authError).toBe("Authentication failed. Please sign in again.");
+    expect(rendered.result.current.connected).toBe(false);
+
+    act(() => rendered.result.current.reconnect());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(rendered.result.current.authError).toBeNull();
+    rendered.unmount();
+  });
+
+  it("refreshes a credential another tab invalidated while the host was restarting", async () => {
+    // Only one WebSocket credential is stored per participant, so a second tab
+    // opening the session invalidates this tab's cached token. The restart is
+    // when that is discovered: the retry presents the stale token and is closed
+    // 4001, which has to recover on its own rather than sit behind a banner.
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(Response.json({ token: "stale-token" }))
+      .mockResolvedValueOnce(Response.json({ token: "reissued-token" }));
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      FakeWebSocket.instances[0].open();
+      FakeWebSocket.instances[0].serverClose(WS_CLOSE_SERVICE_RESTART, true);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].sentMessages).toEqual([]);
+
+    act(() => FakeWebSocket.instances[1].serverClose(4001, true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    act(() => FakeWebSocket.instances[2].open());
+    expect(FakeWebSocket.instances[2].sentMessages).toEqual([
+      expect.objectContaining({ token: "reissued-token" }),
+    ]);
+    expect(rendered.result.current.connected).toBe(true);
+    expect(rendered.result.current.authError).toBeNull();
+    rendered.unmount();
+  });
+
+  it("restores the credential-refresh budget once a connection synchronizes", async () => {
+    vi.useFakeTimers();
+    const rendered = renderTransport();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => FakeWebSocket.instances[0].serverClose(4001, true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    act(() => {
+      FakeWebSocket.instances[1].open();
+      rendered.result.current.markHealthy();
+      FakeWebSocket.instances[1].serverClose(4001, true);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The budget is spent per healthy connection, not once per page load.
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(rendered.result.current.authError).toBeNull();
+    rendered.unmount();
   });
 
   it("reports session expiry on close code 4002 without reconnecting", async () => {

--- a/packages/web/src/hooks/use-session-transport.ts
+++ b/packages/web/src/hooks/use-session-transport.ts
@@ -8,7 +8,10 @@ import {
 } from "@open-inspect/shared/types/server-messages";
 import {
   WS_CLOSE_AUTHORIZATION_REVOKED,
+  WS_CLOSE_GOING_AWAY,
   WS_CLOSE_INTERNAL_ERROR,
+  WS_CLOSE_SERVICE_RESTART,
+  WS_CLOSE_TRY_AGAIN_LATER,
 } from "@open-inspect/shared/types/websocket";
 
 function parseWsMessage(raw: unknown): ServerMessage | null {
@@ -24,7 +27,9 @@ const WS_CLOSE_AUTH_REQUIRED = 4001;
 const WS_CLOSE_SESSION_EXPIRED = 4002;
 const WS_CLOSE_INVALID_MESSAGE = 4004;
 
-const MAX_RECONNECT_ATTEMPTS = 5;
+// Ten attempts with the backoff below span ~3 minutes, so a host restart
+// (seconds to a minute of downtime) is ridden out rather than given up on.
+const MAX_RECONNECT_ATTEMPTS = 10;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30000;
 const PING_INTERVAL_MS = 30000;
@@ -59,7 +64,12 @@ function closeDirective(
   if (
     !event.wasClean ||
     event.code === WS_CLOSE_INVALID_MESSAGE ||
-    event.code === WS_CLOSE_INTERNAL_ERROR
+    event.code === WS_CLOSE_INTERNAL_ERROR ||
+    // A host that is restarting, overloaded, or going away closes cleanly and
+    // expects the client back: reconnect rather than strand the tab.
+    event.code === WS_CLOSE_GOING_AWAY ||
+    event.code === WS_CLOSE_SERVICE_RESTART ||
+    event.code === WS_CLOSE_TRY_AGAIN_LATER
   ) {
     return attemptsSoFar < MAX_RECONNECT_ATTEMPTS
       ? { action: "retry", delayMs: reconnectDelayMs(attemptsSoFar) }
@@ -78,6 +88,8 @@ export interface SessionTransportHandlers {
 export interface UseSessionTransportReturn {
   connected: boolean;
   connecting: boolean;
+  /** A reconnect is scheduled and has not started yet. */
+  reconnecting: boolean;
   authError: string | null;
   connectionError: string | null;
   /** Whether the socket is currently open. */
@@ -126,6 +138,7 @@ export function useSessionTransport(
 
   const [connected, setConnected] = useState(false);
   const [connecting, setConnecting] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
@@ -231,6 +244,8 @@ export function useSessionTransport(
     connectingEpochRef.current = null;
     setConnected(false);
     setConnecting(false);
+    // Every close ends any pending reconnect; only the retry branch re-arms it.
+    setReconnecting(false);
     wsRef.current = null;
     handlersRef.current.onClose?.();
 
@@ -275,6 +290,7 @@ export function useSessionTransport(
       case "retry":
         if (!mountedRef.current) return;
         reconnectAttempts.current++;
+        setReconnecting(true);
         console.log(
           `Reconnecting in ${directive.delayMs}ms (attempt ${reconnectAttempts.current})`
         );
@@ -314,6 +330,7 @@ export function useSessionTransport(
     const epoch = connectEpochRef.current;
     connectingEpochRef.current = epoch;
     setConnecting(true);
+    setReconnecting(false);
     setAuthError(null);
 
     const tokenReady = await ensureWsToken(epoch);
@@ -380,6 +397,7 @@ export function useSessionTransport(
     }
     reconnectAttempts.current = 0;
     wsTokenRef.current = null; // Clear token to fetch fresh one
+    setReconnecting(false);
     setAuthError(null);
     setConnectionError(null);
     connect();
@@ -419,6 +437,7 @@ export function useSessionTransport(
       reconnectAttempts.current = 0;
       setConnected(false);
       setConnecting(false);
+      setReconnecting(false);
       setAuthError(null);
       setConnectionError(null);
       if (hadActiveAttempt) handlersRef.current.onClose?.();
@@ -440,6 +459,7 @@ export function useSessionTransport(
   return {
     connected,
     connecting,
+    reconnecting,
     authError,
     connectionError,
     isOpen,

--- a/packages/web/src/hooks/use-session-transport.ts
+++ b/packages/web/src/hooks/use-session-transport.ts
@@ -27,12 +27,18 @@ const WS_CLOSE_AUTH_REQUIRED = 4001;
 const WS_CLOSE_SESSION_EXPIRED = 4002;
 const WS_CLOSE_INVALID_MESSAGE = 4004;
 
-// `MAX_RECONNECT_ATTEMPTS` on the backoff below spans ~3 minutes, so a host
-// restart (seconds to a minute of downtime) is ridden out rather than given
-// up on.
+// How long any *transient* cause may keep the socket down before the client
+// stops trying: `MAX_RECONNECT_ATTEMPTS` on the backoff below spans ~3
+// minutes, which covers a host restart, a redeploy behind a proxy, or a
+// network blip. The cause decides whether to retry; this decides for how long.
 const MAX_RECONNECT_ATTEMPTS = 10;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30000;
+// RFC 6455 registers 1012 with a randomized 5-30s reconnect. A restart closes
+// every tab at once, so the randomization spreads the return; and a host that
+// is restarting is not listening again a second later anyway.
+const RESTART_MIN_DELAY_MS = 5000;
+const RESTART_MAX_DELAY_MS = 30000;
 const PING_INTERVAL_MS = 30000;
 // Only one WebSocket credential is stored per participant, so another tab
 // opening the session invalidates this one's. A single automatic reissue per
@@ -44,6 +50,13 @@ function reconnectDelayMs(attemptsSoFar: number): number {
   return Math.min(RECONNECT_BASE_DELAY_MS * Math.pow(2, attemptsSoFar), MAX_RECONNECT_DELAY_MS);
 }
 
+function restartDelayMs(): number {
+  return RESTART_MIN_DELAY_MS + Math.random() * (RESTART_MAX_DELAY_MS - RESTART_MIN_DELAY_MS);
+}
+
+/** Where the transport is in its connection lifecycle; states are exclusive. */
+type ConnectionPhase = "idle" | "connecting" | "connected" | "reconnecting";
+
 /** What a close event calls for, decided as data; the caller applies effects. */
 type CloseDirective =
   | { action: "auth_required" }
@@ -52,6 +65,7 @@ type CloseDirective =
   | { action: "session_expired" }
   | { action: "authorization_revoked"; delayMs?: number }
   | { action: "retry"; delayMs: number }
+  | { action: "await_user"; message: string }
   | { action: "give_up" }
   | { action: "none" };
 
@@ -73,19 +87,30 @@ function closeDirective(
   if (event.code === WS_CLOSE_SESSION_EXPIRED) {
     return { action: "session_expired" };
   }
+  const budget = (delayMs: number): CloseDirective =>
+    attemptsSoFar < MAX_RECONNECT_ATTEMPTS ? { action: "retry", delayMs } : { action: "give_up" };
+
+  if (event.code === WS_CLOSE_SERVICE_RESTART) {
+    return budget(restartDelayMs());
+  }
+  if (event.code === WS_CLOSE_TRY_AGAIN_LATER) {
+    // Overload, and the only sender here closes a peer for exhausting its own
+    // delivery backlog. Coming back on a timer would repeat what the host just
+    // refused, so RFC 6455 asks for a reconnect on user action instead - the
+    // banner's button, which needs `connectionError` set to appear.
+    return {
+      action: "await_user",
+      message: "The server is too busy to accept the connection. Try reconnecting in a moment.",
+    };
+  }
   if (
+    // Transient: the peer expects the client back as soon as it can manage.
     !event.wasClean ||
     event.code === WS_CLOSE_INVALID_MESSAGE ||
     event.code === WS_CLOSE_INTERNAL_ERROR ||
-    // A host that is restarting, overloaded, or going away closes cleanly and
-    // expects the client back: reconnect rather than strand the tab.
-    event.code === WS_CLOSE_GOING_AWAY ||
-    event.code === WS_CLOSE_SERVICE_RESTART ||
-    event.code === WS_CLOSE_TRY_AGAIN_LATER
+    event.code === WS_CLOSE_GOING_AWAY
   ) {
-    return attemptsSoFar < MAX_RECONNECT_ATTEMPTS
-      ? { action: "retry", delayMs: reconnectDelayMs(attemptsSoFar) }
-      : { action: "give_up" };
+    return budget(reconnectDelayMs(attemptsSoFar));
   }
   return { action: "none" };
 }
@@ -150,9 +175,14 @@ export function useSessionTransport(
     handlersRef.current = { onMessage, onClose };
   }, [onMessage, onClose]);
 
-  const [connected, setConnected] = useState(false);
-  const [connecting, setConnecting] = useState(false);
-  const [reconnecting, setReconnecting] = useState(false);
+  // One phase, not three independent booleans: the socket is either down,
+  // being opened, open, or waiting out a scheduled reconnect. The three
+  // booleans below are views of it, kept because the session page composes
+  // `connecting` with protocol readiness before it reaches the header.
+  const [phase, setPhase] = useState<ConnectionPhase>("idle");
+  const connected = phase === "connected";
+  const connecting = phase === "connecting";
+  const reconnecting = phase === "reconnecting";
   const [authError, setAuthError] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
@@ -214,8 +244,7 @@ export function useSessionTransport(
     }
     console.log("WebSocket connected!");
     connectingEpochRef.current = null;
-    setConnected(true);
-    setConnecting(false);
+    setPhase("connected");
 
     ws.send(
       JSON.stringify({
@@ -243,98 +272,108 @@ export function useSessionTransport(
     }
   }, []);
 
-  /** `retry` is the connect function to schedule on an unclean close. */
-  const handleSocketClose = useCallback((ws: WebSocket, event: CloseEvent, retry: () => void) => {
-    // Browsers deliver close events asynchronously: a socket discarded by
-    // reconnect() or cleanup can close after its replacement exists. Only
-    // the current socket may mutate shared connection state.
-    if (wsRef.current !== ws) return;
-
-    console.log("WebSocket closed:", {
-      code: event.code,
-      reason: event.reason,
-      wasClean: event.wasClean,
-    });
-    connectingEpochRef.current = null;
-    setConnected(false);
-    setConnecting(false);
-    // Every close ends any pending reconnect; only the retry branch re-arms it.
-    setReconnecting(false);
-    wsRef.current = null;
-    handlersRef.current.onClose?.();
-
-    const directive = closeDirective(event, reconnectAttempts.current, credentialRefreshes.current);
-    switch (directive.action) {
-      case "auth_required":
-        setAuthError("Authentication failed. Please sign in again.");
-        // Clear the token so we fetch a new one on reconnect
-        wsTokenRef.current = null;
-        return;
-
-      case "refresh_credential":
-        if (!mountedRef.current) return;
-        credentialRefreshes.current++;
-        wsTokenRef.current = null;
-        setReconnecting(true);
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (mountedRef.current) retry();
-        }, 0);
-        return;
-
-      case "refresh_authorization":
-        if (!mountedRef.current) return;
-        wsTokenRef.current = null;
-        reconnectAttempts.current = 0;
-        setAuthError(null);
-        setConnectionError(null);
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (mountedRef.current) retry();
-        }, 0);
-        return;
-
-      case "session_expired":
-        // e.g. after server hibernation
-        setConnectionError("Session expired. Please reconnect.");
-        wsTokenRef.current = null;
-        return;
-
-      case "authorization_revoked":
-        wsTokenRef.current = null;
-        if (!mountedRef.current) return;
-        if (directive.delayMs === undefined) {
-          setConnectionError("Authorization could not be refreshed. Please try reconnecting.");
-          return;
-        }
-        reconnectAttempts.current++;
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (mountedRef.current) retry();
-        }, directive.delayMs);
-        return;
-
-      case "retry":
-        if (!mountedRef.current) return;
-        reconnectAttempts.current++;
-        setReconnecting(true);
-        console.log(
-          `Reconnecting in ${directive.delayMs}ms (attempt ${reconnectAttempts.current})`
-        );
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (mountedRef.current) {
-            retry();
-          }
-        }, directive.delayMs);
-        return;
-
-      case "give_up":
-        if (!mountedRef.current) return;
-        console.error(`WebSocket reconnection failed after ${MAX_RECONNECT_ATTEMPTS} attempts`);
-        setConnectionError("Connection lost. Please check your network and try reconnecting.");
-        return;
-
-      case "none":
-        return;
-    }
+  /**
+   * The single path back onto the wire: arms the timer and the phase together
+   * so no close branch can schedule a reconnect the UI does not report.
+   */
+  const scheduleReconnect = useCallback((delayMs: number, retry: () => void) => {
+    if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current);
+    setPhase("reconnecting");
+    reconnectTimeoutRef.current = setTimeout(() => {
+      if (mountedRef.current) retry();
+    }, delayMs);
   }, []);
+
+  /** `retry` is the connect function to schedule on an unclean close. */
+  const handleSocketClose = useCallback(
+    (ws: WebSocket, event: CloseEvent, retry: () => void) => {
+      // Browsers deliver close events asynchronously: a socket discarded by
+      // reconnect() or cleanup can close after its replacement exists. Only
+      // the current socket may mutate shared connection state.
+      if (wsRef.current !== ws) return;
+
+      console.log("WebSocket closed:", {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      });
+      connectingEpochRef.current = null;
+      // Every close ends any pending reconnect; a branch below re-arms it
+      // through scheduleReconnect, which owns the timer and the phase together.
+      setPhase("idle");
+      wsRef.current = null;
+      handlersRef.current.onClose?.();
+
+      const directive = closeDirective(
+        event,
+        reconnectAttempts.current,
+        credentialRefreshes.current
+      );
+      switch (directive.action) {
+        case "auth_required":
+          setAuthError("Authentication failed. Please sign in again.");
+          // Clear the token so we fetch a new one on reconnect
+          wsTokenRef.current = null;
+          return;
+
+        case "refresh_credential":
+          if (!mountedRef.current) return;
+          credentialRefreshes.current++;
+          wsTokenRef.current = null;
+          scheduleReconnect(0, retry);
+          return;
+
+        case "refresh_authorization":
+          if (!mountedRef.current) return;
+          wsTokenRef.current = null;
+          reconnectAttempts.current = 0;
+          setAuthError(null);
+          setConnectionError(null);
+          scheduleReconnect(0, retry);
+          return;
+
+        case "session_expired":
+          // e.g. after server hibernation
+          setConnectionError("Session expired. Please reconnect.");
+          wsTokenRef.current = null;
+          return;
+
+        case "authorization_revoked":
+          wsTokenRef.current = null;
+          if (!mountedRef.current) return;
+          if (directive.delayMs === undefined) {
+            setConnectionError("Authorization could not be refreshed. Please try reconnecting.");
+            return;
+          }
+          reconnectAttempts.current++;
+          scheduleReconnect(directive.delayMs, retry);
+          return;
+
+        case "retry":
+          if (!mountedRef.current) return;
+          reconnectAttempts.current++;
+          console.log(
+            `Reconnecting in ${directive.delayMs}ms (attempt ${reconnectAttempts.current})`
+          );
+          scheduleReconnect(directive.delayMs, retry);
+          return;
+
+        case "await_user":
+          setConnectionError(directive.message);
+          return;
+
+        case "give_up":
+          if (!mountedRef.current) return;
+          console.error(`WebSocket reconnection failed after ${MAX_RECONNECT_ATTEMPTS} attempts`);
+          setConnectionError("Connection lost. Please check your network and try reconnecting.");
+          return;
+
+        case "none":
+          return;
+      }
+    },
+    [scheduleReconnect]
+  );
 
   const connect = useCallback(async () => {
     // Use refs to avoid race conditions with React StrictMode
@@ -353,8 +392,7 @@ export function useSessionTransport(
 
     const epoch = connectEpochRef.current;
     connectingEpochRef.current = epoch;
-    setConnecting(true);
-    setReconnecting(false);
+    setPhase("connecting");
     setAuthError(null);
 
     const tokenReady = await ensureWsToken(epoch);
@@ -364,13 +402,13 @@ export function useSessionTransport(
       // owns it; a newer connect may hold it now.
       if (connectingEpochRef.current === epoch) {
         connectingEpochRef.current = null;
-        setConnecting(false);
+        setPhase("idle");
       }
       return;
     }
     if (!tokenReady) {
       connectingEpochRef.current = null;
-      setConnecting(false);
+      setPhase("idle");
       return;
     }
 
@@ -417,12 +455,11 @@ export function useSessionTransport(
       // The discarded socket's close event is ignored by the identity guard
       // (and may arrive late), so notify the protocol layer directly.
       handlersRef.current.onClose?.();
-      setConnected(false);
+      setPhase("idle");
     }
     reconnectAttempts.current = 0;
     credentialRefreshes.current = 0;
     wsTokenRef.current = null; // Clear token to fetch fresh one
-    setReconnecting(false);
     setAuthError(null);
     setConnectionError(null);
     connect();
@@ -462,9 +499,7 @@ export function useSessionTransport(
       wsTokenRef.current = null;
       reconnectAttempts.current = 0;
       credentialRefreshes.current = 0;
-      setConnected(false);
-      setConnecting(false);
-      setReconnecting(false);
+      setPhase("idle");
       setAuthError(null);
       setConnectionError(null);
       if (hadActiveAttempt) handlersRef.current.onClose?.();

--- a/packages/web/src/hooks/use-session-transport.ts
+++ b/packages/web/src/hooks/use-session-transport.ts
@@ -27,12 +27,18 @@ const WS_CLOSE_AUTH_REQUIRED = 4001;
 const WS_CLOSE_SESSION_EXPIRED = 4002;
 const WS_CLOSE_INVALID_MESSAGE = 4004;
 
-// Ten attempts with the backoff below span ~3 minutes, so a host restart
-// (seconds to a minute of downtime) is ridden out rather than given up on.
+// `MAX_RECONNECT_ATTEMPTS` on the backoff below spans ~3 minutes, so a host
+// restart (seconds to a minute of downtime) is ridden out rather than given
+// up on.
 const MAX_RECONNECT_ATTEMPTS = 10;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 30000;
 const PING_INTERVAL_MS = 30000;
+// Only one WebSocket credential is stored per participant, so another tab
+// opening the session invalidates this one's. A single automatic reissue per
+// healthy connection recovers from that without turning a genuine auth
+// failure into a refresh loop.
+const MAX_CREDENTIAL_REFRESHES = 1;
 
 function reconnectDelayMs(attemptsSoFar: number): number {
   return Math.min(RECONNECT_BASE_DELAY_MS * Math.pow(2, attemptsSoFar), MAX_RECONNECT_DELAY_MS);
@@ -41,6 +47,7 @@ function reconnectDelayMs(attemptsSoFar: number): number {
 /** What a close event calls for, decided as data; the caller applies effects. */
 type CloseDirective =
   | { action: "auth_required" }
+  | { action: "refresh_credential" }
   | { action: "refresh_authorization" }
   | { action: "session_expired" }
   | { action: "authorization_revoked"; delayMs?: number }
@@ -50,10 +57,15 @@ type CloseDirective =
 
 function closeDirective(
   event: Pick<CloseEvent, "code" | "wasClean">,
-  attemptsSoFar: number
+  attemptsSoFar: number,
+  refreshesSoFar: number
 ): CloseDirective {
   if (event.code === WS_CLOSE_AUTH_REQUIRED) {
-    return { action: "auth_required" };
+    // A rejected credential is more often stale than revoked: reissue once
+    // before telling a signed-in user to sign in again.
+    return refreshesSoFar < MAX_CREDENTIAL_REFRESHES
+      ? { action: "refresh_credential" }
+      : { action: "auth_required" };
   }
   if (event.code === WS_CLOSE_AUTHORIZATION_REVOKED) {
     return { action: "refresh_authorization" };
@@ -118,6 +130,8 @@ export function useSessionTransport(
   const wsTokenRef = useRef<string | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttempts = useRef(0);
+  // Automatic credential reissues spent since the last healthy connection.
+  const credentialRefreshes = useRef(0);
   // Monotonic id for connection attempts. reconnect() and unmount bump it so
   // a connect() that resumes after awaiting its token can tell it has been
   // superseded and must not open a socket.
@@ -249,12 +263,22 @@ export function useSessionTransport(
     wsRef.current = null;
     handlersRef.current.onClose?.();
 
-    const directive = closeDirective(event, reconnectAttempts.current);
+    const directive = closeDirective(event, reconnectAttempts.current, credentialRefreshes.current);
     switch (directive.action) {
       case "auth_required":
         setAuthError("Authentication failed. Please sign in again.");
         // Clear the token so we fetch a new one on reconnect
         wsTokenRef.current = null;
+        return;
+
+      case "refresh_credential":
+        if (!mountedRef.current) return;
+        credentialRefreshes.current++;
+        wsTokenRef.current = null;
+        setReconnecting(true);
+        reconnectTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) retry();
+        }, 0);
         return;
 
       case "refresh_authorization":
@@ -396,6 +420,7 @@ export function useSessionTransport(
       setConnected(false);
     }
     reconnectAttempts.current = 0;
+    credentialRefreshes.current = 0;
     wsTokenRef.current = null; // Clear token to fetch fresh one
     setReconnecting(false);
     setAuthError(null);
@@ -405,6 +430,7 @@ export function useSessionTransport(
 
   const markHealthy = useCallback(() => {
     reconnectAttempts.current = 0;
+    credentialRefreshes.current = 0;
   }, []);
 
   // Track the actual component lifetime separately from capability changes.
@@ -435,6 +461,7 @@ export function useSessionTransport(
       }
       wsTokenRef.current = null;
       reconnectAttempts.current = 0;
+      credentialRefreshes.current = 0;
       setConnected(false);
       setConnecting(false);
       setReconnecting(false);


### PR DESCRIPTION
Fixes [COL-136](https://linear.app/colemurray/issue/COL-136/n-01-web-client-never-reconnects-after-the-node-hosts-1012-service). P1 (N-01) from the 2026-09-05 Node-host systematic review.

## The bug

`SessionRuntimeRegistry.waitForQuiescence` closes every adopted socket with `1012 "Service restart"` and a proper close frame, so the browser sees `wasClean: true, code: 1012`.

The web transport's `closeDirective` retried only on `!wasClean`, `1011`, or its own 4xxx codes. `1012` fell through to `{action: "none"}`: no reconnect timer, and no `connectionError` — which is also what gates the manual **Reconnect** button in the session page. So the tab went quiet with no way back short of a page reload, and prompts typed meanwhile were dropped.

Ironically the *later* `terminate()` in `host.ts:311` (1006, unclean) **would** have triggered the retry path. The orderly close is the one that stranded the client.

On Cloudflare a deploy is a millisecond gap. On the Node host (one EC2, in-place restart) a deploy **is** a restart — 2–60 s for every open session.

## The fix

- **Retry on 1012, 1013 and 1001.** A host that is restarting, temporarily overloaded, or going away closes *cleanly* and expects the client back.
- **Budget that outlasts a restart.** 5 attempts ≈ 31 s was shorter than the outage it had to survive; now 10 attempts on the same backoff ≈ 3 minutes.
- **Say what is happening.** The transport exposes `reconnecting` (a retry is scheduled and has not started), and the header reads "Reconnecting..." with the pulsing warning dot instead of a flat "Disconnected" while the timer runs.
- **One definition of the close codes.** `WS_CLOSE_GOING_AWAY`/`SERVICE_RESTART`/`TRY_AGAIN_LATER` now live in `@open-inspect/shared/types/websocket`, imported by both the registry that sends 1012 and the browser that must retry on it, so the two ends cannot drift apart again.

## Verification (TDD — tests written first, all seven observed failing)

`packages/web/src/hooks/use-session-transport.test.tsx`

- `serverClose(1012 | 1013 | 1001, true)` reconnects, reusing the cached credential — the codes come from the shared module, not literals.
- `reconnecting` is `true` while the retry is pending and `false` once the attempt starts.
- The backoff schedule is pinned attempt by attempt (1s, 2s, 4s, 8s, 16s, then 30s × 5) and asserted to span ≥ 150 s before give-up.
- The existing unclean-close give-up test now exhausts the wider budget.

`packages/control-plane/src/node/session-runtime-registry.test.ts`

- A new drill connects Node's spec-compliant global `WebSocket` to a real registry runtime, calls `shutdown()`, and asserts the client observes `{code: 1012, wasClean: true}` — the exact event the web transport used to ignore. Mutation-checked (asserting `{1006, false}` fails with the real `{1012, true}`).

`packages/web/src/components/session-header.test.tsx`

- A pending reconnect is labelled distinctly from a first connection.

Full suites green: control-plane 4006 tests / 275 files, web 1467 tests / 190 files; `typecheck` clean for both packages (control-plane across all four tsconfigs); eslint and prettier clean.

## Review follow-up: the credential a second tab invalidated

Reviewers were right that restart recovery was still incomplete for multi-tab users, and the mechanism checks out: `participants.ws_auth_token` is a single column per participant and `updateParticipantWsToken` overwrites it, so opening the session in a second tab invalidates the first tab's cached token. A restart is when that gets discovered — the retry presents the stale token, `connection-authenticator.ts` closes `4001 "Invalid authentication token"`, and the old `auth_required` branch stopped dead, telling a perfectly signed-in user to sign in again.

The client now **reissues the credential once per healthy connection** and reconnects immediately; a freshly issued credential rejected too is a real auth failure and still raises the banner. The bound matters in both directions: it stops a genuine failure becoming a refresh loop, and stops two reconnecting tabs invalidating each other indefinitely. `markHealthy()` restores the budget, so it is spent per connection rather than once per page load. Three tests cover it (the reissue, the exhausted budget, and the budget reset).

The proper fix for the underlying constraint is concurrent valid tokens per participant, which is a schema change and belongs in its own PR.

Also addressed: the Node host's backlog close now uses the shared `WS_CLOSE_TRY_AGAIN_LATER` rather than its own `BACKLOG_EXCEEDED_CLOSE_CODE`, so the 1013 sender and the client that now retries on it share one definition; and the budget comment references `MAX_RECONNECT_ATTEMPTS` instead of repeating the literal, per AGENTS.md.

## Not in this PR

- **Concurrent WebSocket credentials per participant** — the schema change described above.
- **N-06** — the registry should not *rely* on peers honouring 1012; tracked separately.
- **Reconnect jitter.** Every tab retries at the same 1 s offset after a restart. Harmless at current scale (one cheap upgrade per tab) but worth revisiting if the Node host ever fronts many concurrent sessions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sessions now automatically refresh credentials once and reconnect when authentication expires.
  - Reconnection attempts use improved delays to help sessions recover during host restarts.
  - The session header displays “Reconnecting…” with a warning indicator while reconnection is scheduled.

- **Bug Fixes**
  - Clean WebSocket closures caused by service restarts now trigger reconnection instead of appearing disconnected.
  - Temporary connection closures now use standardized retry behavior.
  - Sessions closed because the server is temporarily unavailable now show a connection error instead of reconnecting automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->