### PR TITLE
test: cover managed provider-account env and a failed initial prompt

### DIFF
--- a/packages/control-plane/src/sandbox/managed-provider-env.test.ts
+++ b/packages/control-plane/src/sandbox/managed-provider-env.test.ts
@@ -51,6 +51,69 @@ describe("prepareLegacyManagedProviderEnv", () => {
       })
     ).toEqual({ USER_VALUE: "visible", OPENAI_OAUTH_MANAGED: "1" });
   });
+
+  it("makes provider-account mode override legacy OAuth and canonical API keys", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: {
+          OPENAI_API_KEY: "sk-openai",
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          OPENAI_OAUTH_MANAGED: "user-controlled",
+          XAI_API_KEY: "xai-key",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+          USER_VALUE: "visible",
+        },
+        brokerSecrets: {
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+        },
+        providerAuthModes: {
+          openai: "provider_account",
+          xai: "api_key",
+        },
+      })
+    ).toEqual({
+      OPENAI_OAUTH_MANAGED: "1",
+      XAI_API_KEY: "xai-key",
+      USER_VALUE: "visible",
+    });
+  });
+
+  it("retains canonical API keys and removes managed state in explicit API-key mode", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: {
+          OPENAI_API_KEY: "sk-openai",
+          OPENAI_OAUTH_ACCESS_TOKEN: "legacy-access",
+          OPENAI_OAUTH_MANAGED: "1",
+          XAI_API_KEY: "xai-key",
+          XAI_OAUTH_ACCESS_TOKEN: "legacy-access",
+          XAI_OAUTH_MANAGED: "1",
+        },
+        brokerSecrets: {
+          OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai",
+          XAI_OAUTH_REFRESH_TOKEN: "legacy-xai",
+        },
+        providerAuthModes: {
+          openai: "api_key",
+          xai: "api_key",
+        },
+      })
+    ).toEqual({ OPENAI_API_KEY: "sk-openai", XAI_API_KEY: "xai-key" });
+  });
+
+  it("uses scoped OAuth only when a legacy-bound provider has a compatible refresh token", () => {
+    expect(
+      prepareManagedProviderEnv({
+        exposedSecrets: { OPENAI_API_KEY: "sk-openai", XAI_API_KEY: "xai-key" },
+        brokerSecrets: { OPENAI_OAUTH_REFRESH_TOKEN: "legacy-openai" },
+        providerAuthModes: {
+          openai: "legacy_scoped_oauth",
+          xai: "legacy_scoped_oauth",
+        },
+      })
+    ).toEqual({ OPENAI_OAUTH_MANAGED: "1", XAI_API_KEY: "xai-key" });
+  });
 });
 
 describe("prepareManagedProviderEnv", () => {

--- a/packages/web/src/app/(app)/(sidebar)/page.test.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.test.tsx
@@ -709,4 +709,29 @@ describe("Home", () => {
 
     await screen.findByRole("button", { name: /docs/i });
   });
+
+  it("surfaces the error and stays put when the initial prompt fails", async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === "/api/sessions") {
+        return Response.json({ sessionId: "session-1", status: "created" });
+      }
+      if (url === "/api/sessions/session-1/prompt") {
+        return Response.json({ error: "Prompt rejected" }, { status: 500 });
+      }
+      return Response.json({ error: "unexpected request" }, { status: 500 });
+    });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.click(await screen.findByRole("button", { name: /background-agents/i }));
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", { name: /no repository/i })
+    );
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Investigate logs");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(await screen.findByText("Prompt rejected")).toBeInTheDocument();
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Two behaviours already in this repository had no test. Both tests exist in the production fork and were found by a tree-diff after a sync; this brings the coverage back where the code lives.

## `prepareManagedProviderEnv` — provider-account mode

`packages/control-plane/src/sandbox/managed-provider-env.ts` drops a provider's canonical API key and sets its managed marker when that provider is in `provider_account` mode, and keeps the canonical key in explicit `api_key` mode. Neither path was covered.

## Home — a rejected initial prompt

`packages/web/src/app/(app)/(sidebar)/page.tsx:337` does `setError(data.error || "Failed to send prompt")` and does not navigate when the first prompt fails after the session is created. The error path was untested, so a regression would have left the user on a silent screen.

## Verification

Both tests were confirmed to fail against a deliberately broken source rather than passing vacuously:

- Removing `delete env[config.apiKey]` from the `provider_account` branch fails `makes provider-account mode override legacy OAuth and canonical API keys`.
- Replacing the `setError` argument fails `surfaces the error and stays put when the initial prompt fails` with `Unable to find an element with the text: Prompt rejected`.

Additions only — no existing test or source line is changed. `npm run typecheck` and `npm run lint` clean; control-plane 275 files / 4009 tests and web 190 files / 1471 tests all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for managed provider authentication precedence, explicit API-key handling, and scoped OAuth fallback.
  - Added coverage confirming that prompt failures display an error message and prevent navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->