### PR TITLE
feat(terraform): stand the control plane up on AWS with no Cloudflare account

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,6 +17,10 @@ on:
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**" # Web app deployed via Terraform when web_platform = "cloudflare"
+      # Uploaded verbatim by modules/aws-control-plane, so a change to either
+      # changes the stack the AWS instance runs.
+      - "docker-compose.yml"
+      - "docker-compose.aws.yml"
       - ".github/workflows/terraform.yml"
   pull_request:
     branches: [main]
@@ -34,6 +38,10 @@ on:
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**"
+      # Uploaded verbatim by modules/aws-control-plane, so a change to either
+      # changes the stack the AWS instance runs.
+      - "docker-compose.yml"
+      - "docker-compose.aws.yml"
       - ".github/workflows/terraform.yml"
   workflow_dispatch: # Allow manual trigger
 
@@ -97,6 +105,18 @@ jobs:
         id: validate
         run: terraform validate -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
+
+      # Not applied from CI yet -- that is I-3 -- so this is the only thing that
+      # parses them. The module is shared, so a break here is a break there.
+      - name: Terraform Init and Validate (AWS environments)
+        id: validate_aws
+        run: |
+          for environment in aws-staging aws-production; do
+            echo "::group::$environment"
+            terraform -chdir="terraform/environments/$environment" init -backend=false -no-color
+            terraform -chdir="terraform/environments/$environment" validate -no-color
+            echo "::endgroup::"
+          done
 
       - name: Terraform Tests
         id: test

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -106,6 +106,13 @@ jobs:
         run: terraform validate -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
 
+      # `validate` reads HCL only: it never renders the instance bootstrap, and
+      # the compose smoke boots a different overlay. This is the only thing that
+      # parses either.
+      - name: AWS stack static checks
+        id: aws_stack
+        run: scripts/check-aws-stack.sh
+
       # Not applied from CI yet -- that is I-3 -- so this is the only thing that
       # parses them. The module is shared, so a break here is a break there.
       - name: Terraform Init and Validate (AWS environments)

--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,7 @@ terraform/environments/production/.terraform*
 packages/control-plane/test/smoke/run-smoke.bundle.mjs
 smoke-logs/
 
-# AWS environments (see terraform/environments/aws-*)
+# AWS environments (see terraform/environments/aws-*); state files and
+# *_override.tf are already covered globally above.
 terraform/environments/aws-staging/plan.out
-terraform/environments/aws-staging/terraform.tfstate*
 terraform/environments/aws-production/plan.out
-terraform/environments/aws-production/terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ terraform/environments/production/.terraform*
 # The compose smoke bundles its driver here at run time.
 packages/control-plane/test/smoke/run-smoke.bundle.mjs
 smoke-logs/
+
+# AWS environments (see terraform/environments/aws-*)
+terraform/environments/aws-staging/plan.out
+terraform/environments/aws-staging/terraform.tfstate*
+terraform/environments/aws-production/plan.out
+terraform/environments/aws-production/terraform.tfstate*

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -1,0 +1,44 @@
+# AWS overlay: the same stack the smoke boots, on one EC2 instance.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.aws.yml up -d
+#
+# Three differences from the base file, and nothing else. The instance has no
+# checkout, so the app runs the image built and pushed by CI rather than a
+# build context. Object storage is S3 and the credentials come from the
+# instance role, so MinIO does not run. TLS is not optional on a public
+# address, so Caddy leaves the "tls" profile and starts with the rest.
+#
+# The `.env` this reads is written by the instance's user-data from SSM
+# Parameter Store. It still has to carry MINIO_ROOT_PASSWORD, OBJECT_STORE_BUCKET
+# and LITESTREAM_BUCKET: Compose interpolates the base file before it applies
+# this one, so their `:?` guards fire whether or not the services that use them
+# are started. The AWS `.env` gives MinIO's an unused value.
+
+services:
+  app:
+    # No build context on the instance. `image` names the ECR tag CI pushed;
+    # resetting `build` is what makes `up` pull it instead of trying to build.
+    build: !reset null
+    image: ${CONTROL_PLANE_IMAGE:?CONTROL_PLANE_IMAGE must name the ECR image to run, including its tag}
+    # The base file waits for MinIO's buckets to be created. On S3 the buckets
+    # are Terraform's, and nothing here creates them.
+    depends_on: !reset null
+
+  # Not started on AWS: S3 is the object store and the Litestream replica
+  # target. A profile no environment enables is how a service is left out of
+  # a merged stack; there is no way to delete one in an overlay.
+  minio:
+    profiles: ["local-object-store"]
+  minio-init:
+    profiles: ["local-object-store"]
+
+  litestream:
+    # The base file also waits for MinIO here.
+    depends_on: !override
+      app:
+        condition: service_healthy
+
+  # TLS terminates on the instance, so Caddy is part of the stack rather than
+  # an opt-in profile.
+  caddy:
+    profiles: !reset []

--- a/docs/AWS_BRING_UP.md
+++ b/docs/AWS_BRING_UP.md
@@ -101,8 +101,14 @@ put() { # value on stdin
       {"Name": sys.argv[1], "Value": sys.stdin.read().rstrip("\n"),
        "Type": "SecureString", "Overwrite": True}, open(sys.argv[2], "w"))' \
     "$PREFIX/$1" "$request"
-  aws ssm put-parameter --cli-input-json "file://$request" >/dev/null && echo "set $1"
+  local status=0
+  aws ssm put-parameter --cli-input-json "file://$request" >/dev/null || status=$?
   rm -f "$request"
+  if [ "$status" -ne 0 ]; then
+    echo "FAILED to set $1" >&2
+    return "$status"
+  fi
+  echo "set $1"
 }
 ```
 

--- a/docs/AWS_BRING_UP.md
+++ b/docs/AWS_BRING_UP.md
@@ -204,8 +204,12 @@ Session files and the host alarm index are not in it. Restoring from it brings b
 and the session index but not the sessions' own state; the image's entrypoint does this
 automatically when it finds an empty volume.
 
-The volume carries `prevent_destroy`, so `terraform destroy` fails rather than taking the data with
-it. Releasing it is deliberate:
+Two things deliberately make `terraform destroy` fail rather than quietly taking data with it. The
+volume carries `prevent_destroy`. And with `force_destroy_storage = false`, which is production's
+setting, a non-empty bucket or a registry holding images refuses to be deleted as well. Staging sets
+it true, because staging is meant to be stood back up.
+
+Releasing the volume is deliberate:
 
 ```bash
 terraform state rm module.control_plane.aws_ebs_volume.data

--- a/docs/AWS_BRING_UP.md
+++ b/docs/AWS_BRING_UP.md
@@ -26,10 +26,18 @@ Once per account. The bucket name has to be globally unique, so it is not in the
 
 ```bash
 REGION=us-west-2   # must match the `region` variable in terraform.tfvars
+BUCKET=open-inspect-terraform-state-$ACCOUNT_ID
 
-aws s3api create-bucket --bucket open-inspect-terraform-state-$ACCOUNT_ID \
-  --region "$REGION" --create-bucket-configuration LocationConstraint="$REGION"
-aws s3api put-bucket-versioning --bucket open-inspect-terraform-state-$ACCOUNT_ID \
+# us-east-1 is the one region that rejects an explicit LocationConstraint: it is
+# the API's default, and naming it returns InvalidLocationConstraint.
+if [ "$REGION" = us-east-1 ]; then
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+else
+  aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+    --create-bucket-configuration LocationConstraint="$REGION"
+fi
+
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
   --versioning-configuration Status=Enabled
 ```
 
@@ -184,7 +192,14 @@ Graviton, and there is no amd64 fallback.
 
 ```bash
 REGISTRY=$(terraform output -raw ecr_repository_url)
-aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${REGISTRY%%/*}"
+
+# <account>.dkr.ecr.<region>.amazonaws.com/<repo>. The region comes from the
+# registry rather than from $REGION, which was set four sections ago and is
+# probably not in this shell -- and get-login-password must name the region the
+# registry is in.
+REGISTRY_HOST=${REGISTRY%%/*}
+aws ecr get-login-password --region "$(echo "$REGISTRY_HOST" | cut -d. -f4)" |
+  docker login --username AWS --password-stdin "$REGISTRY_HOST"
 
 docker buildx build --platform linux/arm64 \
   -f packages/control-plane/Dockerfile \

--- a/docs/AWS_BRING_UP.md
+++ b/docs/AWS_BRING_UP.md
@@ -1,0 +1,245 @@
+# Bringing Up the Control Plane on AWS
+
+This stands the Open-Inspect control plane up on AWS, from an empty account to `/healthz` answering
+over HTTPS at a hostname you choose. **No Cloudflare account is involved at any point.** TLS is a
+Let's Encrypt certificate that Caddy obtains on the instance; DNS is whatever you already run.
+
+What you get is one EC2 instance running the same `docker compose` stack CI boots on every pull
+request, with a persistent EBS volume under it, S3 for media and backups, and its logs in
+CloudWatch.
+
+Two environments are defined: `terraform/environments/aws-staging` (a `t4g.small`, stopped outside
+working hours) and `terraform/environments/aws-production` (a `t4g.large`, always on). They are the
+same module with different sizes.
+
+## Before you start
+
+- An AWS account and credentials with permission to create VPC, EC2, EBS, S3, ECR, IAM, SSM,
+  CloudWatch and EventBridge Scheduler resources.
+- Terraform >= 1.14, the AWS CLI v2, and the Session Manager plugin (`session-manager-plugin`).
+- A hostname you control the DNS for.
+- A GitHub App for the control plane, as on any other deployment.
+
+## 1. A state bucket
+
+Once per account. The bucket name has to be globally unique, so it is not in the repository.
+
+```bash
+aws s3api create-bucket --bucket open-inspect-terraform-state-$ACCOUNT_ID \
+  --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
+aws s3api put-bucket-versioning --bucket open-inspect-terraform-state-$ACCOUNT_ID \
+  --versioning-configuration Status=Enabled
+```
+
+```bash
+cd terraform/environments/aws-staging
+cp backend.tfvars.example backend.tfvars      # fill in bucket and region
+cp terraform.tfvars.example terraform.tfvars  # fill in hostname
+terraform init -backend-config=backend.tfvars
+```
+
+Both files are gitignored.
+
+## 2. First apply
+
+```bash
+terraform apply
+```
+
+This creates everything but a working stack: the instance boots, mounts its volume, fetches the
+compose files, builds `.env` from SSM — and then fails to start, because the image does not exist
+yet and the secrets are placeholders. That is expected. Take the outputs:
+
+```bash
+terraform output public_ip      # point DNS here
+terraform output ecr_repository_url
+terraform output secret_parameter_names
+```
+
+## 3. DNS
+
+Create an **A record** for your hostname pointing at `public_ip`, on whatever DNS you run. Nothing
+in this module needs access to it.
+
+Caddy's certificate comes from an ACME HTTP-01 challenge, so Let's Encrypt has to reach port 80 at
+that name. If your DNS provider offers a proxying or "cloud" mode, the record must be a **plain A
+record, not proxied** — a proxy terminates TLS itself, which is the thing this deployment exists to
+avoid.
+
+If you would rather Terraform created the record, set `route53_zone_id` and re-apply.
+
+## 4. Secrets
+
+The module creates one SSM parameter per key, each holding a `CHANGE_ME_` placeholder, and then
+ignores the value — so Terraform owns the inventory and never the secrets. List what is still unset:
+
+```bash
+PREFIX=$(terraform output -raw ssm_env_prefix)
+aws ssm get-parameters-by-path --path "$PREFIX" --recursive --with-decryption \
+  --query 'Parameters[?starts_with(Value, `CHANGE_ME_`)].Name' --output table
+```
+
+Set each one:
+
+```bash
+put() { aws ssm put-parameter --overwrite --type SecureString --name "$PREFIX/$1" --value "$2"; }
+
+put TOKEN_ENCRYPTION_KEY              "$(openssl rand -base64 32)"
+put PROVIDER_ACCOUNTS_ENCRYPTION_KEY  "$(openssl rand -base64 32)"
+put REPO_SECRETS_ENCRYPTION_KEY       "$(openssl rand -base64 32)"
+put BROWSER_AUTH_SECRET               "$(openssl rand -base64 32)"
+put IMAGE_CALLBACK_TOKEN_PEPPER       "$(openssl rand -base64 32)"
+put GITHUB_APP_ID                     "123456"
+put GITHUB_APP_INSTALLATION_ID        "12345678"
+put GITHUB_CLIENT_ID                  "Iv1...."
+put GITHUB_CLIENT_SECRET              "...."
+put ANTHROPIC_API_KEY                 "sk-ant-...."
+```
+
+The three encryption keys are 32 bytes and are rejected at any other length. Generate them once and
+keep them: rotating one invalidates everything it encrypted.
+
+**The GitHub App private key has to be on one line.** `.env` is one assignment per line and Compose
+does not unescape it, so a PEM with real newlines would truncate at the first one and take the rest
+of the file with it. The instance refuses to write a multi-line value rather than doing that
+silently. Convert it first:
+
+```bash
+put GITHUB_APP_PRIVATE_KEY "$(awk '{printf "%s\\n", $0}' key-pkcs8.pem)"
+```
+
+The key must be PKCS#8, as on Cloudflare:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in key.pem -out key-pkcs8.pem
+```
+
+Non-secret values — access-control lists, `WEB_APP_URL`, the sandbox provider's settings — go in the
+`config` map in `terraform.tfvars`, not here. Anything in that map lands in the state file, so
+nothing secret belongs in it.
+
+## 5. Push an image
+
+The instance runs an image, not a build; it has no checkout. Build for **arm64** — the instance is
+Graviton, and there is no amd64 fallback.
+
+```bash
+REGISTRY=$(terraform output -raw ecr_repository_url)
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "${REGISTRY%%/*}"
+
+docker buildx build --platform linux/arm64 \
+  -f packages/control-plane/Dockerfile \
+  -t "$REGISTRY:latest" --push .
+```
+
+Once I-3 lands this is CI's job, and the deploy is a tag push plus step 6.
+
+## 6. Start it
+
+Every restart re-fetches the compose files from S3, rebuilds `.env` from SSM and re-pulls the image,
+so this is also how a deploy and a configuration change take effect. It is never a new instance.
+
+```bash
+INSTANCE=$(terraform output -raw instance_id)
+aws ssm start-session --target "$INSTANCE"
+
+# on the instance
+sudo systemctl restart open-inspect
+sudo systemctl status open-inspect
+```
+
+Then, from anywhere:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}\n' https://<your-hostname>/healthz
+# 200 0
+```
+
+## Watching it
+
+Container logs go straight from the Docker daemon to CloudWatch, so `docker compose logs` shows
+nothing on the instance. The equivalent, which also keeps working after the instance is replaced:
+
+```bash
+aws logs tail "$(terraform output -raw log_group_name)" --follow
+```
+
+### A first boot logs one certificate error
+
+The first ACME attempt commonly fails with
+`HTTP 404 ... urn:ietf:params:acme:error:malformed - Certificate not found`, _after_ the
+authorization has already gone `valid`. Caddy retries about a minute later and succeeds. A healthy
+first boot therefore logs one alarming certificate error; wait for the retry before treating it as a
+failure.
+
+If it is still failing after a few minutes, the causes in order of likelihood are: DNS not yet
+resolving to the Elastic IP, the record proxied rather than plain, or port 80 unreachable — check
+`ingress_cidrs`, which must admit the internet for the challenge to work.
+
+## Changing things
+
+| What changed                         | What to do                                                        |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| A secret in SSM                      | `systemctl restart open-inspect`                                  |
+| A `config` entry, or a compose file  | `terraform apply`, then `systemctl restart open-inspect`          |
+| The image                            | Push the tag, then `systemctl restart open-inspect`               |
+| The instance's user data, or the AMI | `terraform apply -replace=module.control_plane.aws_instance.this` |
+
+The instance ignores changes to `ami` and `user_data` on purpose. AWS moves the Amazon Linux 2023
+parameter whenever it publishes an image, and replacing this instance drops every in-flight session,
+so it is something you ask for rather than something a routine plan proposes.
+
+## Backups and restore
+
+Two layers, and they cover different things.
+
+**The data volume** is the deployment. Docker's data root sits on it, so the global store, every
+session database, the host alarm index and the images are all on it. Data Lifecycle Manager
+snapshots it daily and keeps `snapshot_retention_count` of them. To restore, set
+`data_volume_snapshot_id` and apply into an empty state — the module ignores later changes to it, so
+a restore does not turn into a permanent instruction to re-restore.
+
+**The Litestream replica** in the backups bucket covers the global store alone, continuously.
+Session files and the host alarm index are not in it. Restoring from it brings back users, settings
+and the session index but not the sessions' own state; the image's entrypoint does this
+automatically when it finds an empty volume.
+
+The volume carries `prevent_destroy`, so `terraform destroy` fails rather than taking the data with
+it. Releasing it is deliberate:
+
+```bash
+terraform state rm module.control_plane.aws_ebs_volume.data
+terraform destroy
+# the volume is now unmanaged; reattach it or delete it explicitly
+```
+
+## What it costs
+
+Rough monthly figures, us-west-2, on-demand, excluding data transfer and whatever the sandbox
+provider bills.
+
+|                          | Staging                                     | Production                 |
+| ------------------------ | ------------------------------------------- | -------------------------- |
+| Instance                 | t4g.small, stopped nights and weekends ≈ $5 | t4g.large, always on ≈ $49 |
+| Root volume (20 GB gp3)  | ≈ $1.60                                     | ≈ $1.60                    |
+| Data volume              | 50 GB ≈ $4                                  | 200 GB ≈ $16               |
+| Snapshots                | ≈ $1                                        | ≈ $5                       |
+| S3, ECR, CloudWatch, SSM | ≈ $1                                        | ≈ $3                       |
+| **Total**                | **≈ $13**                                   | **≈ $75**                  |
+
+There is no load balancer and no NAT gateway, which is most of why these numbers are what they are:
+an ALB is about $25/month before traffic and a NAT gateway about $33/month before egress — either
+would be among the largest lines above. Caddy on the instance does the ALB's job here. An ALB stays
+worth revisiting for connection draining and a WAF attach point, but as a later AWS-flavoured
+variation rather than a requirement.
+
+## Not here yet
+
+- **CI apply.** These environments are applied from a laptop today. I-3 moves them into the
+  pipeline.
+- **Alarms beyond the instance's status checks.** Disk and memory need the CloudWatch agent, and the
+  alarms that describe the control plane itself need metrics the host does not publish yet; both are
+  H-8.
+- **The bots.** The Slack, GitHub and Linear bots remain Cloudflare Workers. A deployment with no
+  Cloudflare account runs the control plane and the web app, and does without them, until that
+  transport lands.

--- a/docs/AWS_BRING_UP.md
+++ b/docs/AWS_BRING_UP.md
@@ -25,8 +25,10 @@ same module with different sizes.
 Once per account. The bucket name has to be globally unique, so it is not in the repository.
 
 ```bash
+REGION=us-west-2   # must match the `region` variable in terraform.tfvars
+
 aws s3api create-bucket --bucket open-inspect-terraform-state-$ACCOUNT_ID \
-  --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
+  --region "$REGION" --create-bucket-configuration LocationConstraint="$REGION"
 aws s3api put-bucket-versioning --bucket open-inspect-terraform-state-$ACCOUNT_ID \
   --versioning-configuration Status=Enabled
 ```
@@ -70,8 +72,17 @@ If you would rather Terraform created the record, set `route53_zone_id` and re-a
 
 ## 4. Secrets
 
-The module creates one SSM parameter per key, each holding a `CHANGE_ME_` placeholder, and then
-ignores the value — so Terraform owns the inventory and never the secrets. List what is still unset:
+The module creates one SecureString parameter per key, each holding a `CHANGE_ME_` placeholder, and
+never reads the value back — the value is write-only, so Terraform owns the inventory and the state
+file never contains a secret. Setting one is entirely out of band.
+
+A parameter still holding its placeholder is **left out of `.env` rather than written through**.
+That matters most for the four `SERVICE_AUTH_SECRET_*` keys: they are HMAC signing keys used exactly
+as given, with no length or format check, so a placeholder — a value published in this repository —
+would be a working credential for anyone who read it. Unset, they are a `500` instead. The instance
+logs every key it skipped for this reason.
+
+List what is still unset:
 
 ```bash
 PREFIX=$(terraform output -raw ssm_env_prefix)
@@ -79,33 +90,66 @@ aws ssm get-parameters-by-path --path "$PREFIX" --recursive --with-decryption \
   --query 'Parameters[?starts_with(Value, `CHANGE_ME_`)].Name' --output table
 ```
 
-Set each one:
+Values reach `put-parameter` through a file rather than the command line, so they stay out of shell
+history and out of `ps` while the call runs:
 
 ```bash
-put() { aws ssm put-parameter --overwrite --type SecureString --name "$PREFIX/$1" --value "$2"; }
-
-put TOKEN_ENCRYPTION_KEY              "$(openssl rand -base64 32)"
-put PROVIDER_ACCOUNTS_ENCRYPTION_KEY  "$(openssl rand -base64 32)"
-put REPO_SECRETS_ENCRYPTION_KEY       "$(openssl rand -base64 32)"
-put BROWSER_AUTH_SECRET               "$(openssl rand -base64 32)"
-put IMAGE_CALLBACK_TOKEN_PEPPER       "$(openssl rand -base64 32)"
-put GITHUB_APP_ID                     "123456"
-put GITHUB_APP_INSTALLATION_ID        "12345678"
-put GITHUB_CLIENT_ID                  "Iv1...."
-put GITHUB_CLIENT_SECRET              "...."
-put ANTHROPIC_API_KEY                 "sk-ant-...."
+put() { # value on stdin
+  umask 077
+  local request; request="$(mktemp)"
+  python3 -c 'import json,sys; json.dump(
+      {"Name": sys.argv[1], "Value": sys.stdin.read().rstrip("\n"),
+       "Type": "SecureString", "Overwrite": True}, open(sys.argv[2], "w"))' \
+    "$PREFIX/$1" "$request"
+  aws ssm put-parameter --cli-input-json "file://$request" >/dev/null && echo "set $1"
+  rm -f "$request"
+}
 ```
 
-The three encryption keys are 32 bytes and are rejected at any other length. Generate them once and
-keep them: rotating one invalidates everything it encrypted.
+### The whole inventory
 
-**The GitHub App private key has to be on one line.** `.env` is one assignment per line and Compose
-does not unescape it, so a PEM with real newlines would truncate at the first one and take the rest
-of the file with it. The instance refuses to write a multi-line value rather than doing that
-silently. Convert it first:
+Sixteen keys. The first five are the only ones the host refuses to start without; the rest disable a
+feature when unset rather than blocking a boot.
 
 ```bash
-put GITHUB_APP_PRIVATE_KEY "$(awk '{printf "%s\\n", $0}' key-pkcs8.pem)"
+# Required at boot. 32 bytes each, rejected at any other length. Generate once
+# and keep them: rotating one invalidates everything it encrypted.
+openssl rand -base64 32 | put TOKEN_ENCRYPTION_KEY
+openssl rand -base64 32 | put PROVIDER_ACCOUNTS_ENCRYPTION_KEY
+openssl rand -base64 32 | put REPO_SECRETS_ENCRYPTION_KEY
+openssl rand -base64 32 | put BROWSER_AUTH_SECRET
+openssl rand -base64 32 | put IMAGE_CALLBACK_TOKEN_PEPPER
+
+# Service-to-service signing keys, one per caller. Set the ones you run; the
+# others stay unset, which is a refusal rather than a weak key. The web app's
+# own SERVICE_AUTH_SECRET must equal SERVICE_AUTH_SECRET_WEB.
+openssl rand -base64 32 | put SERVICE_AUTH_SECRET_WEB
+openssl rand -base64 32 | put SERVICE_AUTH_SECRET_SLACK_BOT
+openssl rand -base64 32 | put SERVICE_AUTH_SECRET_GITHUB_BOT
+openssl rand -base64 32 | put SERVICE_AUTH_SECRET_LINEAR_BOT
+
+# The sandbox provider. Both environments select Modal, and this is the shared
+# HMAC secret between the control plane and the Modal deployment; without it the
+# stack answers /healthz and cannot spawn a session. Another provider's key
+# replaces this entry through the `secret_names` variable.
+openssl rand -hex 32 | put MODAL_API_SECRET
+
+# GitHub App, for repository access and git operations.
+printf '123456'   | put GITHUB_APP_ID
+printf '12345678' | put GITHUB_APP_INSTALLATION_ID
+printf 'Iv1....'  | put GITHUB_CLIENT_ID
+printf '....'     | put GITHUB_CLIENT_SECRET
+
+# Models.
+printf 'sk-ant-....' | put ANTHROPIC_API_KEY
+```
+
+**The GitHub App private key has to be on one line.** `.env` is one assignment per line, so a PEM
+with real newlines would truncate at the first one and take the rest of the file with it. The
+instance refuses to write a multi-line value rather than doing that silently. Convert it first:
+
+```bash
+awk '{printf "%s\\n", $0}' key-pkcs8.pem | put GITHUB_APP_PRIVATE_KEY
 ```
 
 The key must be PKCS#8, as on Cloudflare:
@@ -114,9 +158,18 @@ The key must be PKCS#8, as on Cloudflare:
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in key.pem -out key-pkcs8.pem
 ```
 
-Non-secret values — access-control lists, `WEB_APP_URL`, the sandbox provider's settings — go in the
-`config` map in `terraform.tfvars`, not here. Anything in that map lands in the state file, so
-nothing secret belongs in it.
+A value may not contain a single quote. `.env` is read twice by Compose — to interpolate the compose
+files, and as the app's environment — and both readers expand `$VAR` and strip a trailing `#`
+comment from an unquoted value, so every value is written single-quoted, which is the one form that
+cannot contain its own quote. The instance rejects such a value rather than corrupting it.
+
+Non-secret values — access-control lists, `WEB_APP_URL`, the sandbox provider's non-secret settings
+— go in the `config` map in `terraform.tfvars`, not here. **Anything in that map lands in the state
+file**, so nothing secret belongs in it.
+
+Adding a key the module does not know about — another provider's token — means adding it to the
+`secret_names` variable, which replaces the inventory rather than extending it. Removing a name from
+that set deletes the parameter, and the operator's value with it.
 
 ## 5. Push an image
 
@@ -125,7 +178,7 @@ Graviton, and there is no amd64 fallback.
 
 ```bash
 REGISTRY=$(terraform output -raw ecr_repository_url)
-aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "${REGISTRY%%/*}"
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${REGISTRY%%/*}"
 
 docker buildx build --platform linux/arm64 \
   -f packages/control-plane/Dockerfile \
@@ -157,8 +210,9 @@ curl -sS -o /dev/null -w '%{http_code} %{ssl_verify_result}\n' https://<your-hos
 
 ## Watching it
 
-Container logs go straight from the Docker daemon to CloudWatch, so `docker compose logs` shows
-nothing on the instance. The equivalent, which also keeps working after the instance is replaced:
+Container logs go from the Docker daemon to CloudWatch, one stream per service. Docker also keeps a
+local cache, so `docker compose logs` on the instance generally still answers; CloudWatch is the one
+that survives the instance being replaced, and it is what the runbook uses:
 
 ```bash
 aws logs tail "$(terraform output -raw log_group_name)" --follow
@@ -195,9 +249,24 @@ Two layers, and they cover different things.
 
 **The data volume** is the deployment. Docker's data root sits on it, so the global store, every
 session database, the host alarm index and the images are all on it. Data Lifecycle Manager
-snapshots it daily and keeps `snapshot_retention_count` of them. To restore, set
-`data_volume_snapshot_id` and apply into an empty state — the module ignores later changes to it, so
-a restore does not turn into a permanent instruction to re-restore.
+snapshots it daily, scoped to this deployment's volume, and keeps `snapshot_retention_count` of
+them.
+
+Restoring into a fresh environment is just `data_volume_snapshot_id` plus an apply. Restoring an
+existing one in place needs the current volume released first, because `prevent_destroy` and
+`ignore_changes` together mean Terraform will neither replace it nor notice the new snapshot id:
+
+```bash
+terraform state rm module.control_plane.aws_ebs_volume.data
+# then set data_volume_snapshot_id in terraform.tfvars
+terraform apply
+```
+
+The attachment is replaced along with the volume, which stops the instance and starts it again; the
+filesystem is found by its label rather than by volume id, so the instance itself does not need
+replacing. The released volume is left unmanaged — keep it until the restore is verified, then
+delete it with `aws ec2 delete-volume`. The module ignores later changes to
+`data_volume_snapshot_id`, so a restore does not become a standing instruction to re-restore.
 
 **The Litestream replica** in the backups bucket covers the global store alone, continuously.
 Session files and the host alarm index are not in it. Restoring from it brings back users, settings
@@ -219,7 +288,7 @@ terraform destroy
 
 ## What it costs
 
-Rough monthly figures, us-west-2, on-demand, excluding data transfer and whatever the sandbox
+Rough monthly figures, `us-west-2`, on-demand, excluding data transfer and whatever the sandbox
 provider bills.
 
 |                          | Staging                                     | Production                 |

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -200,6 +200,25 @@ On AWS the container reads the same `.env` variables from its environment. The d
 materializes them from SSM Parameter Store; nothing is baked into the image. With an instance role,
 leave `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` empty and the SDK uses the role.
 
+The instance runs this same stack with one overlay, `docker-compose.aws.yml`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.aws.yml up -d
+```
+
+It changes three things and nothing else. The app runs the image `CONTROL_PLANE_IMAGE` names — set
+in the systemd unit's environment, not in `.env` — rather than a build, because the instance has no
+checkout. MinIO does not run, because S3 is the object store and Litestream's replica target. And
+Caddy leaves the `tls` profile and starts with the rest, because TLS is not optional on a public
+address.
+
+`.env` still has to carry `MINIO_ROOT_PASSWORD`: Compose interpolates the base file before it
+applies an overlay, so that variable's `:?` guard fires whether or not MinIO is among the services
+that end up running. The AWS deployment gives it an unused value.
+
+[docs/AWS_BRING_UP.md](AWS_BRING_UP.md) is the whole path from an empty account to `/healthz` over
+HTTPS.
+
 ## The smoke test
 
 CI boots this stack on every pull request and round-trips one session through it:

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -217,9 +217,6 @@ address.
 applies an overlay, so that variable's `:?` guard fires whether or not MinIO is among the services
 that end up running. The AWS deployment gives it an unused value.
 
-[docs/AWS_BRING_UP.md](AWS_BRING_UP.md) is the whole path from an empty account to `/healthz` over
-HTTPS.
-
 ## The smoke test
 
 CI boots this stack on every pull request and round-trips one session through it:

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -206,8 +206,9 @@ The instance runs this same stack with one overlay, `docker-compose.aws.yml`:
 docker compose -f docker-compose.yml -f docker-compose.aws.yml up -d
 ```
 
-It changes three things and nothing else. The app runs the image `CONTROL_PLANE_IMAGE` names — set
-in the systemd unit's environment, not in `.env` — rather than a build, because the instance has no
+It changes three things and nothing else. The app runs the image `CONTROL_PLANE_IMAGE` names — an
+ordinary `.env` entry, written from SSM like the rest, so changing the tag is a `terraform apply`
+and a restart rather than a new instance — rather than a build, because the instance has no
 checkout. MinIO does not run, because S3 is the object store and Litestream's replica target. And
 Caddy leaves the `tls` profile and starts with the rest, because TLS is not optional on a public
 address.

--- a/scripts/check-aws-stack.sh
+++ b/scripts/check-aws-stack.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Static checks for the two AWS deployment artifacts nothing else parses.
+#
+# `terraform validate` reads the module's HCL but never renders its user-data
+# template, and the compose smoke boots docker-compose.smoke.yml rather than the
+# AWS overlay. A mistake in either would first be seen as a control plane that
+# does not come up.
+#
+#   scripts/check-aws-stack.sh
+#
+# Requires Docker with Compose v2, and shellcheck (or Docker, as a fallback).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl"
+RENDERED="$(mktemp -t user-data.XXXXXX).sh"
+trap 'rm -f "$RENDERED"' EXIT
+
+# Stand-ins for what templatefile() substitutes. The renderer fails on a
+# variable it has no stub for, so a new one cannot slip through unchecked.
+python3 - "$TEMPLATE" "$RENDERED" <<'PY'
+import re, sys
+
+stubs = {
+    "region": "us-west-2",
+    "log_group": "/open-inspect/example",
+    "config_bucket": "example-backups",
+    "ssm_env_prefix": "/example/env",
+    "data_volume_id_nodash": "vol0123456789abcdef",
+    "compose_version": "2.31.0",
+    "compose_sha256": "0" * 64,
+}
+
+source = open(sys.argv[1]).read()
+# `$${...}` is an escaped literal for the shell, not a template variable.
+reference = re.compile(r"(?<!\$)\$\{([A-Za-z0-9_]+)\}")
+missing = sorted(set(reference.findall(source)) - set(stubs))
+if missing:
+    sys.exit(f"no stub for template variable(s): {', '.join(missing)}; add them to this script")
+
+rendered = reference.sub(lambda m: stubs[m.group(1)], source).replace("$${", "${")
+open(sys.argv[2], "w").write(rendered)
+PY
+
+bash -n "$RENDERED"
+
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck "$RENDERED"
+else
+  docker run --rm -v "$(dirname "$RENDERED")":/mnt koalaman/shellcheck:stable "/mnt/$(basename "$RENDERED")"
+fi
+
+echo "user-data template: syntax and shellcheck clean"
+
+# ---------------------------------------------------------------------------
+# The AWS overlay resolves to the stack the instance is meant to run
+# ---------------------------------------------------------------------------
+# Compose merge semantics are subtle enough to be worth pinning: `!reset` on
+# `build` is what makes `up` pull rather than build, an unenabled profile is the
+# only way to leave a service out of a merged stack, and `!reset` on Caddy's
+# profile is what starts it. Any of those silently regressing changes what the
+# instance runs.
+
+STACK_ENV="$(mktemp -t aws-overlay-env.XXXXXX)"
+# The base file names `.env` as the app's env_file, and Compose refuses to
+# resolve a merged config without it. A checkout that has one keeps it; one that
+# does not gets an empty file for the length of this check and no longer.
+DOTENV_CREATED=0
+if [ ! -e "$REPO_ROOT/.env" ]; then
+  : >"$REPO_ROOT/.env"
+  DOTENV_CREATED=1
+fi
+cleanup() {
+  rm -f "$RENDERED" "$STACK_ENV"
+  [ "$DOTENV_CREATED" -eq 1 ] && rm -f "$REPO_ROOT/.env"
+  return 0
+}
+trap cleanup EXIT
+
+cat >"$STACK_ENV" <<'ENV'
+CONTROL_PLANE_IMAGE=example.invalid/control-plane:test
+OBJECT_STORE_BUCKET=example-media
+LITESTREAM_BUCKET=example-backups
+MINIO_ROOT_PASSWORD=unused-on-aws
+CADDY_DOMAIN=example.invalid
+ENV
+
+compose() {
+  docker compose --env-file "$STACK_ENV" \
+    -f "$REPO_ROOT/docker-compose.yml" -f "$REPO_ROOT/docker-compose.aws.yml" "$@"
+}
+
+# Resolved once, into a variable, so a Compose failure fails this script. Piping
+# it straight into `grep` inside an `if` would swallow that and report a pass on
+# a config that never resolved.
+resolved="$(compose config)"
+started="$(compose config --services | sort | tr '\n' ' ')"
+
+expected="app caddy litestream "
+if [ "$started" != "$expected" ]; then
+  echo "AWS overlay starts [$started]; expected [$expected]" >&2
+  exit 1
+fi
+
+# `build` surviving the merge would have the instance, which has no checkout,
+# try to build the image instead of pulling the tag CI pushed.
+if printf '%s\n' "$resolved" | grep -qE '^[[:space:]]+build:'; then
+  echo "AWS overlay leaves a build context on a service; the instance has no checkout" >&2
+  exit 1
+fi
+
+# The image has to come from the variable the module sets, not a stale literal.
+if ! printf '%s\n' "$resolved" | grep -q 'example.invalid/control-plane:test'; then
+  echo "AWS overlay does not take the app image from CONTROL_PLANE_IMAGE" >&2
+  exit 1
+fi
+
+echo "AWS overlay: app, caddy and litestream, no build context, image from CONTROL_PLANE_IMAGE"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,6 +13,13 @@ The infrastructure spans multiple cloud providers:
 | **Vercel**     | Next.js Web App, optional sandbox sessions           | Native provider + Sandbox API calls |
 | **Modal**      | Optional sandbox infrastructure                      | CLI wrapper (no provider exists)    |
 | **Daytona**    | Optional sandbox snapshots                           | REST API wrapper                    |
+| **AWS**        | EC2 control plane, EBS, S3, ECR, SSM, CloudWatch     | Native provider                     |
+
+The Cloudflare and AWS deployments are alternatives, not layers. `environments/production` is the
+Cloudflare one. `environments/aws-staging` and `environments/aws-production` stand the control plane
+up on AWS with **no Cloudflare account involved at any point** — no provider, no credential, no
+Cloudflare-specific header. TLS there is Caddy with a Let's Encrypt certificate, and DNS is whatever
+the operator already runs.
 
 ## Directory Structure
 
@@ -23,6 +30,8 @@ terraform/
 ├── modules/                      # Reusable Terraform modules
 │   ├── cloudflare-kv/           # KV namespace management
 │   ├── cloudflare-worker/       # Worker deployment with bindings (KV, DO, D1)
+│   ├── aws-control-plane/       # One EC2 instance running the compose stack
+│   │   └── templates/           # Instance bootstrap
 │   ├── daytona-infra/           # Daytona snapshot bootstrap wrapper
 │   ├── vercel-project/          # Vercel project + environment vars
 │   └── modal-app/               # Modal CLI wrapper
@@ -44,8 +53,20 @@ terraform/
 │       ├── backend.tf           # State backend (R2)
 │       ├── versions.tf          # Provider versions
 │       └── terraform.tfvars.example
+├── environments/aws-staging/     # AWS staging root module (S3 backend)
+├── environments/aws-production/  # AWS production root module (S3 backend)
 └── README.md                    # This file
 ```
+
+### State backends
+
+The Cloudflare environment keeps its R2 backend. The AWS environments use **S3**, with S3-native
+locking (`use_lockfile`, so there is no DynamoDB table). They deliberately do not share R2: this
+deployment exists so that a team can run Open-Inspect without a Cloudflare account, and a state file
+on Cloudflare would put one back. The bucket name has to be globally unique, so it is not committed
+— copy `backend.tfvars.example` and pass it to `terraform init -backend-config=backend.tfvars`.
+
+Bringing an AWS environment up is documented in [docs/AWS_BRING_UP.md](../docs/AWS_BRING_UP.md).
 
 ## Prerequisites
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,13 +13,6 @@ The infrastructure spans multiple cloud providers:
 | **Vercel**     | Next.js Web App, optional sandbox sessions           | Native provider + Sandbox API calls |
 | **Modal**      | Optional sandbox infrastructure                      | CLI wrapper (no provider exists)    |
 | **Daytona**    | Optional sandbox snapshots                           | REST API wrapper                    |
-| **AWS**        | EC2 control plane, EBS, S3, ECR, SSM, CloudWatch     | Native provider                     |
-
-The Cloudflare and AWS deployments are alternatives, not layers. `environments/production` is the
-Cloudflare one. `environments/aws-staging` and `environments/aws-production` stand the control plane
-up on AWS with **no Cloudflare account involved at any point** — no provider, no credential, no
-Cloudflare-specific header. TLS there is Caddy with a Let's Encrypt certificate, and DNS is whatever
-the operator already runs.
 
 ## Directory Structure
 
@@ -30,8 +23,6 @@ terraform/
 ├── modules/                      # Reusable Terraform modules
 │   ├── cloudflare-kv/           # KV namespace management
 │   ├── cloudflare-worker/       # Worker deployment with bindings (KV, DO, D1)
-│   ├── aws-control-plane/       # One EC2 instance running the compose stack
-│   │   └── templates/           # Instance bootstrap
 │   ├── daytona-infra/           # Daytona snapshot bootstrap wrapper
 │   ├── vercel-project/          # Vercel project + environment vars
 │   └── modal-app/               # Modal CLI wrapper
@@ -53,20 +44,8 @@ terraform/
 │       ├── backend.tf           # State backend (R2)
 │       ├── versions.tf          # Provider versions
 │       └── terraform.tfvars.example
-├── environments/aws-staging/     # AWS staging root module (S3 backend)
-├── environments/aws-production/  # AWS production root module (S3 backend)
 └── README.md                    # This file
 ```
-
-### State backends
-
-The Cloudflare environment keeps its R2 backend. The AWS environments use **S3**, with S3-native
-locking (`use_lockfile`, so there is no DynamoDB table). They deliberately do not share R2: this
-deployment exists so that a team can run Open-Inspect without a Cloudflare account, and a state file
-on Cloudflare would put one back. The bucket name has to be globally unique, so it is not committed
-— copy `backend.tfvars.example` and pass it to `terraform init -backend-config=backend.tfvars`.
-
-Bringing an AWS environment up is documented in [docs/AWS_BRING_UP.md](../docs/AWS_BRING_UP.md).
 
 ## Prerequisites
 

--- a/terraform/environments/aws-production/.terraform.lock.hcl
+++ b/terraform/environments/aws-production/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.63.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:/aDDxTo6DxOsBunGkNkAaI9movX3xU38FfWq+ssIU/w=",
+    "h1:9cre7jh1lSs/9igpgAcENMUAUlYW3HCtkav3up4oit0=",
+    "h1:dRlYHkc+r6fgzF57WC7Zjcmb6sF/6TTGDEgwGK+LAZY=",
+    "zh:005d56736afd17d963998c405cee6f434dbc23a415109f9435ff1542879ae611",
+    "zh:026ef126321a86ad7080b5d858e2527f96f5289678cbcd8856296e229c43339d",
+    "zh:06e0b58b2d1eddb5137fc86bee7ad2d07953c0bc3f57cccfc5ae0d2456068a3a",
+    "zh:07221735d61ababed84734e5ffcfc5bd59d01f29f029166ba5f2175895dceed1",
+    "zh:1a72db00583112bdb8c19b213a78a3f5de754fffc08f07e061f4e326289fab7d",
+    "zh:32968e74a53b03e97a084dc7050c22ef661fb5b3ea8a44f5a63e47bc45ad0e7c",
+    "zh:4b357dfe4b820e3e4acd2881cff8288b2186491e63416751f0d12692ba478ceb",
+    "zh:81e30884d7de686265e7d87bb92527e802878c65a378470ede2a1e9f4e40ccc9",
+    "zh:82e137297f6a5a08b9ce2138f7aabea245ad99495d9d9eff502f752d6ca90dbd",
+    "zh:8eb83b67099f0ea9df238a979dff933ff50ce06a2e3ff05a48556a10f10dd204",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:d0ba30886cbe41850fee689f51ef9088578f323cfd21817bb409951d43c465eb",
+    "zh:dd48e7089784454bc03d713e9057f5ca0ea1613bd402125054a51894957b7925",
+    "zh:f250fa81e54cf60fcb0e9c0fc4ac043f1ecc2ac24967f628b3609364fcab3d04",
+    "zh:f38fc09fc25a8d2cf89a4d4cd6a5ef7cb1aad72798dbdcad58b8876b6a551a54",
+    "zh:f7c7380fdf126e1901f2084588dbfd724c76cb131ccfa795a541219111103c06",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.4.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
+    "h1:Bx3XQkBSY3RAGwLZb8hyi8AhvahPNlt4mlyZhW9guOI=",
+    "h1:H74EkbLWyZxkKhz8inoi6HTZbPox2VYzAttFhUy8X7Y=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
+  ]
+}

--- a/terraform/environments/aws-production/backend.tf
+++ b/terraform/environments/aws-production/backend.tf
@@ -1,0 +1,25 @@
+# Terraform state for the AWS environments, in S3 with native state locking.
+#
+# The Cloudflare environment keeps its R2 backend; these do not share it. The
+# whole point of this deployment is that it needs no Cloudflare account, and a
+# state file that lives on Cloudflare would put one back.
+#
+# Prerequisites, once per account:
+#   aws s3api create-bucket --bucket open-inspect-terraform-state-<account> ...
+#   aws s3api put-bucket-versioning --bucket ... --versioning-configuration Status=Enabled
+#
+# Then, with a backend.tfvars naming the bucket and region:
+#   terraform init -backend-config=backend.tfvars
+
+terraform {
+  backend "s3" {
+    key = "aws-production/terraform.tfstate"
+
+    # bucket and region come from -backend-config: the bucket name has to be
+    # globally unique, so it cannot be committed.
+
+    encrypt = true
+    # S3-native locking, so there is no DynamoDB table to create or pay for.
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/aws-production/backend.tfvars.example
+++ b/terraform/environments/aws-production/backend.tfvars.example
@@ -1,0 +1,4 @@
+# Copy to backend.tfvars (gitignored) and run:
+#   terraform init -backend-config=backend.tfvars
+bucket = "open-inspect-terraform-state-<account-id>"
+region = "us-west-2"

--- a/terraform/environments/aws-production/main.tf
+++ b/terraform/environments/aws-production/main.tf
@@ -29,8 +29,9 @@ module "control_plane" {
   log_retention_days       = 30
   snapshot_retention_count = 30
 
-  # A destroy must not be able to take the media or the backups with it.
-  force_destroy_buckets = false
+  # A destroy must not be able to take the media, the backups or the images
+  # with it; it fails instead.
+  force_destroy_storage = false
 
   route53_zone_id = var.route53_zone_id
   alarm_topic_arn = var.alarm_topic_arn

--- a/terraform/environments/aws-production/main.tf
+++ b/terraform/environments/aws-production/main.tf
@@ -35,6 +35,7 @@ module "control_plane" {
   force_destroy_storage = false
 
   route53_zone_id = var.route53_zone_id
+  secret_names    = var.secret_names
   alarm_topic_arn = var.alarm_topic_arn
 
   config = merge({

--- a/terraform/environments/aws-production/main.tf
+++ b/terraform/environments/aws-production/main.tf
@@ -1,0 +1,46 @@
+# =============================================================================
+# Open-Inspect - AWS production
+# =============================================================================
+# The same module as staging, sized up and left running. No Cloudflare account
+# is involved at any point.
+#
+#   terraform init -backend-config=backend.tfvars
+#   terraform apply
+#
+# See docs/AWS_BRING_UP.md.
+
+locals {
+  environment = "production"
+}
+
+module "control_plane" {
+  source = "../../modules/aws-control-plane"
+
+  name     = "open-inspect-production"
+  hostname = var.hostname
+
+  instance_type           = "t4g.large"
+  data_volume_size_gb     = 200
+  control_plane_image_tag = var.control_plane_image_tag
+
+  # No schedule: production answers at 03:00.
+  out_of_hours_stop = null
+
+  log_retention_days       = 30
+  snapshot_retention_count = 30
+
+  # A destroy must not be able to take the media or the backups with it.
+  force_destroy_buckets = false
+
+  route53_zone_id = var.route53_zone_id
+  alarm_topic_arn = var.alarm_topic_arn
+
+  config = merge({
+    APP_NAME               = "Open-Inspect"
+    LOG_LEVEL              = "info"
+    SANDBOX_PROVIDER       = "modal"
+    UNSAFE_ALLOW_ALL_USERS = "false"
+  }, var.config)
+
+  tags = { Environment = local.environment }
+}

--- a/terraform/environments/aws-production/main.tf
+++ b/terraform/environments/aws-production/main.tf
@@ -22,6 +22,7 @@ module "control_plane" {
   instance_type           = "t4g.large"
   data_volume_size_gb     = 200
   control_plane_image_tag = var.control_plane_image_tag
+  data_volume_snapshot_id = var.data_volume_snapshot_id
 
   # No schedule: production answers at 03:00.
   out_of_hours_stop = null

--- a/terraform/environments/aws-production/outputs.tf
+++ b/terraform/environments/aws-production/outputs.tf
@@ -1,0 +1,34 @@
+output "hostname" {
+  description = "Public FQDN the control plane answers on."
+  value       = module.control_plane.hostname
+}
+
+output "public_ip" {
+  description = "Elastic IP to point DNS at."
+  value       = module.control_plane.public_ip
+}
+
+output "instance_id" {
+  description = "Target for `aws ssm start-session`."
+  value       = module.control_plane.instance_id
+}
+
+output "log_group_name" {
+  description = "Target for `aws logs tail`."
+  value       = module.control_plane.log_group_name
+}
+
+output "ecr_repository_url" {
+  description = "Where CI pushes the control-plane image."
+  value       = module.control_plane.ecr_repository_url
+}
+
+output "ssm_env_prefix" {
+  description = "SSM path the instance builds `.env` from."
+  value       = module.control_plane.ssm_env_prefix
+}
+
+output "secret_parameter_names" {
+  description = "SecureString parameters that need real values before the stack boots."
+  value       = module.control_plane.secret_parameter_names
+}

--- a/terraform/environments/aws-production/terraform.tfvars.example
+++ b/terraform/environments/aws-production/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# Copy to terraform.tfvars and fill in.
+
+# Must resolve to the module's Elastic IP before Caddy can get a certificate.
+# On a first apply the address does not exist yet, so the usual order is:
+# apply, read `terraform output public_ip`, create the record, then restart the
+# stack over SSM. docs/AWS_BRING_UP.md walks through it.
+hostname = "control-plane.example.com"
+
+# Moves as CI pushes images.
+control_plane_image_tag = "latest"
+
+# Optional: have Terraform create the A record instead.
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"
+
+# Optional: page someone when the instance fails its status check.
+# alarm_topic_arn = "arn:aws:sns:us-west-2:123456789012:open-inspect-alarms"
+
+# Non-secret .env entries. Secrets go to SSM, never here.
+# config = {
+#   ALLOWED_GITHUB_ORGS = "your-org"
+#   WEB_APP_URL         = "https://app.example.com"
+# }

--- a/terraform/environments/aws-production/variables.tf
+++ b/terraform/environments/aws-production/variables.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "AWS region this environment lives in."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "hostname" {
+  description = "Public FQDN the control plane answers on. Point it at the module's Elastic IP before expecting HTTPS: Caddy's certificate comes from an ACME HTTP-01 challenge, which needs the name to resolve here."
+  type        = string
+}
+
+variable "control_plane_image_tag" {
+  description = "Tag in this environment's ECR repository to run."
+  type        = string
+  default     = "latest"
+}
+
+variable "route53_zone_id" {
+  description = "Optional Route 53 zone to create the A record in. Leave null and point your own DNS at the Elastic IP; nothing here needs a DNS provider."
+  type        = string
+  default     = null
+}
+
+variable "alarm_topic_arn" {
+  description = "Optional SNS topic the instance status alarms notify."
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Extra non-secret `.env` entries, or overrides of what the module derives. Secrets belong in SSM, not here: everything in this map lands in the state file."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/environments/aws-production/variables.tf
+++ b/terraform/environments/aws-production/variables.tf
@@ -40,7 +40,7 @@ variable "data_volume_snapshot_id" {
 }
 
 variable "secret_names" {
-  description = "`.env` keys held as SecureString parameters, replacing the module's default inventory. Extend it when a deployment needs secrets the module does not know about -- another sandbox provider's key, for instance. Removing a name deletes that parameter and the operator's value with it."
+  description = "`.env` keys held as SecureString parameters. This replaces the module's default inventory rather than adding to it, so a deployment that needs a secret the module does not know about -- another sandbox provider's key, for instance -- lists that name and every default it still wants. Null uses the defaults. Dropping a name deletes that parameter and the operator's value with it."
   type        = set(string)
   default     = null
 }

--- a/terraform/environments/aws-production/variables.tf
+++ b/terraform/environments/aws-production/variables.tf
@@ -32,3 +32,9 @@ variable "config" {
   type        = map(string)
   default     = {}
 }
+
+variable "data_volume_snapshot_id" {
+  description = "Snapshot to build the data volume from, for a restore. Null creates an empty volume. The module ignores later changes to it, so setting it is a one-time act rather than a standing instruction to re-restore."
+  type        = string
+  default     = null
+}

--- a/terraform/environments/aws-production/variables.tf
+++ b/terraform/environments/aws-production/variables.tf
@@ -38,3 +38,9 @@ variable "data_volume_snapshot_id" {
   type        = string
   default     = null
 }
+
+variable "secret_names" {
+  description = "`.env` keys held as SecureString parameters, replacing the module's default inventory. Extend it when a deployment needs secrets the module does not know about -- another sandbox provider's key, for instance. Removing a name deletes that parameter and the operator's value with it."
+  type        = set(string)
+  default     = null
+}

--- a/terraform/environments/aws-production/versions.tf
+++ b/terraform/environments/aws-production/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = "open-inspect"
+      Environment = local.environment
+    }
+  }
+}

--- a/terraform/environments/aws-staging/.terraform.lock.hcl
+++ b/terraform/environments/aws-staging/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.63.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:/aDDxTo6DxOsBunGkNkAaI9movX3xU38FfWq+ssIU/w=",
+    "h1:9cre7jh1lSs/9igpgAcENMUAUlYW3HCtkav3up4oit0=",
+    "h1:dRlYHkc+r6fgzF57WC7Zjcmb6sF/6TTGDEgwGK+LAZY=",
+    "zh:005d56736afd17d963998c405cee6f434dbc23a415109f9435ff1542879ae611",
+    "zh:026ef126321a86ad7080b5d858e2527f96f5289678cbcd8856296e229c43339d",
+    "zh:06e0b58b2d1eddb5137fc86bee7ad2d07953c0bc3f57cccfc5ae0d2456068a3a",
+    "zh:07221735d61ababed84734e5ffcfc5bd59d01f29f029166ba5f2175895dceed1",
+    "zh:1a72db00583112bdb8c19b213a78a3f5de754fffc08f07e061f4e326289fab7d",
+    "zh:32968e74a53b03e97a084dc7050c22ef661fb5b3ea8a44f5a63e47bc45ad0e7c",
+    "zh:4b357dfe4b820e3e4acd2881cff8288b2186491e63416751f0d12692ba478ceb",
+    "zh:81e30884d7de686265e7d87bb92527e802878c65a378470ede2a1e9f4e40ccc9",
+    "zh:82e137297f6a5a08b9ce2138f7aabea245ad99495d9d9eff502f752d6ca90dbd",
+    "zh:8eb83b67099f0ea9df238a979dff933ff50ce06a2e3ff05a48556a10f10dd204",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:d0ba30886cbe41850fee689f51ef9088578f323cfd21817bb409951d43c465eb",
+    "zh:dd48e7089784454bc03d713e9057f5ca0ea1613bd402125054a51894957b7925",
+    "zh:f250fa81e54cf60fcb0e9c0fc4ac043f1ecc2ac24967f628b3609364fcab3d04",
+    "zh:f38fc09fc25a8d2cf89a4d4cd6a5ef7cb1aad72798dbdcad58b8876b6a551a54",
+    "zh:f7c7380fdf126e1901f2084588dbfd724c76cb131ccfa795a541219111103c06",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.4.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
+    "h1:Bx3XQkBSY3RAGwLZb8hyi8AhvahPNlt4mlyZhW9guOI=",
+    "h1:H74EkbLWyZxkKhz8inoi6HTZbPox2VYzAttFhUy8X7Y=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
+  ]
+}

--- a/terraform/environments/aws-staging/backend.tf
+++ b/terraform/environments/aws-staging/backend.tf
@@ -1,0 +1,25 @@
+# Terraform state for the AWS environments, in S3 with native state locking.
+#
+# The Cloudflare environment keeps its R2 backend; these do not share it. The
+# whole point of this deployment is that it needs no Cloudflare account, and a
+# state file that lives on Cloudflare would put one back.
+#
+# Prerequisites, once per account:
+#   aws s3api create-bucket --bucket open-inspect-terraform-state-<account> ...
+#   aws s3api put-bucket-versioning --bucket ... --versioning-configuration Status=Enabled
+#
+# Then, with a backend.tfvars naming the bucket and region:
+#   terraform init -backend-config=backend.tfvars
+
+terraform {
+  backend "s3" {
+    key = "aws-staging/terraform.tfstate"
+
+    # bucket and region come from -backend-config: the bucket name has to be
+    # globally unique, so it cannot be committed.
+
+    encrypt = true
+    # S3-native locking, so there is no DynamoDB table to create or pay for.
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/aws-staging/backend.tfvars.example
+++ b/terraform/environments/aws-staging/backend.tfvars.example
@@ -1,0 +1,4 @@
+# Copy to backend.tfvars (gitignored) and run:
+#   terraform init -backend-config=backend.tfvars
+bucket = "open-inspect-terraform-state-<account-id>"
+region = "us-west-2"

--- a/terraform/environments/aws-staging/main.tf
+++ b/terraform/environments/aws-staging/main.tf
@@ -40,7 +40,7 @@ module "control_plane" {
 
   # Staging is meant to be torn down and stood back up. The data volume is
   # still protected by the module's `prevent_destroy`.
-  force_destroy_buckets = true
+  force_destroy_storage = true
 
   route53_zone_id = var.route53_zone_id
   alarm_topic_arn = var.alarm_topic_arn

--- a/terraform/environments/aws-staging/main.tf
+++ b/terraform/environments/aws-staging/main.tf
@@ -1,0 +1,56 @@
+# =============================================================================
+# Open-Inspect - AWS staging
+# =============================================================================
+# One EC2 instance running the control plane, with no Cloudflare account
+# anywhere in it. Sized down and stopped overnight, so the bill is mostly the
+# volumes.
+#
+#   terraform init -backend-config=backend.tfvars
+#   terraform apply
+#
+# The stack does not boot until the SecureString parameters this creates hold
+# real values; `terraform output secret_parameter_names` lists them. See
+# docs/AWS_BRING_UP.md.
+
+locals {
+  environment = "staging"
+}
+
+module "control_plane" {
+  source = "../../modules/aws-control-plane"
+
+  name     = "open-inspect-staging"
+  hostname = var.hostname
+
+  instance_type           = "t4g.small"
+  data_volume_size_gb     = 50
+  control_plane_image_tag = var.control_plane_image_tag
+
+  # Off outside working hours. Staging holds nothing that has to answer at
+  # 03:00, and a stopped instance bills only its volumes.
+  out_of_hours_stop = {
+    stop_cron  = "cron(0 20 ? * MON-FRI *)"
+    start_cron = "cron(0 7 ? * MON-FRI *)"
+    timezone   = "America/Los_Angeles"
+  }
+
+  # Shorter than production's: staging logs are for the last few days.
+  log_retention_days       = 7
+  snapshot_retention_count = 7
+
+  # Staging is meant to be torn down and stood back up. The data volume is
+  # still protected by the module's `prevent_destroy`.
+  force_destroy_buckets = true
+
+  route53_zone_id = var.route53_zone_id
+  alarm_topic_arn = var.alarm_topic_arn
+
+  config = merge({
+    APP_NAME               = "Open-Inspect Staging"
+    LOG_LEVEL              = "debug"
+    SANDBOX_PROVIDER       = "modal"
+    UNSAFE_ALLOW_ALL_USERS = "false"
+  }, var.config)
+
+  tags = { Environment = local.environment }
+}

--- a/terraform/environments/aws-staging/main.tf
+++ b/terraform/environments/aws-staging/main.tf
@@ -44,6 +44,7 @@ module "control_plane" {
   force_destroy_storage = true
 
   route53_zone_id = var.route53_zone_id
+  secret_names    = var.secret_names
   alarm_topic_arn = var.alarm_topic_arn
 
   config = merge({

--- a/terraform/environments/aws-staging/main.tf
+++ b/terraform/environments/aws-staging/main.tf
@@ -25,6 +25,7 @@ module "control_plane" {
   instance_type           = "t4g.small"
   data_volume_size_gb     = 50
   control_plane_image_tag = var.control_plane_image_tag
+  data_volume_snapshot_id = var.data_volume_snapshot_id
 
   # Off outside working hours. Staging holds nothing that has to answer at
   # 03:00, and a stopped instance bills only its volumes.

--- a/terraform/environments/aws-staging/outputs.tf
+++ b/terraform/environments/aws-staging/outputs.tf
@@ -1,0 +1,34 @@
+output "hostname" {
+  description = "Public FQDN the control plane answers on."
+  value       = module.control_plane.hostname
+}
+
+output "public_ip" {
+  description = "Elastic IP to point DNS at."
+  value       = module.control_plane.public_ip
+}
+
+output "instance_id" {
+  description = "Target for `aws ssm start-session`."
+  value       = module.control_plane.instance_id
+}
+
+output "log_group_name" {
+  description = "Target for `aws logs tail`."
+  value       = module.control_plane.log_group_name
+}
+
+output "ecr_repository_url" {
+  description = "Where CI pushes the control-plane image."
+  value       = module.control_plane.ecr_repository_url
+}
+
+output "ssm_env_prefix" {
+  description = "SSM path the instance builds `.env` from."
+  value       = module.control_plane.ssm_env_prefix
+}
+
+output "secret_parameter_names" {
+  description = "SecureString parameters that need real values before the stack boots."
+  value       = module.control_plane.secret_parameter_names
+}

--- a/terraform/environments/aws-staging/terraform.tfvars.example
+++ b/terraform/environments/aws-staging/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# Copy to terraform.tfvars and fill in.
+
+# Must resolve to the module's Elastic IP before Caddy can get a certificate.
+# On a first apply the address does not exist yet, so the usual order is:
+# apply, read `terraform output public_ip`, create the record, then restart the
+# stack over SSM. docs/AWS_BRING_UP.md walks through it.
+hostname = "staging.example.com"
+
+# Moves as CI pushes images.
+control_plane_image_tag = "latest"
+
+# Optional: have Terraform create the A record instead.
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"
+
+# Optional: page someone when the instance fails its status check.
+# alarm_topic_arn = "arn:aws:sns:us-west-2:123456789012:open-inspect-alarms"
+
+# Non-secret .env entries. Secrets go to SSM, never here.
+# config = {
+#   ALLOWED_GITHUB_ORGS = "your-org"
+#   WEB_APP_URL         = "https://staging-app.example.com"
+# }

--- a/terraform/environments/aws-staging/variables.tf
+++ b/terraform/environments/aws-staging/variables.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "AWS region this environment lives in."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "hostname" {
+  description = "Public FQDN the control plane answers on. Point it at the module's Elastic IP before expecting HTTPS: Caddy's certificate comes from an ACME HTTP-01 challenge, which needs the name to resolve here."
+  type        = string
+}
+
+variable "control_plane_image_tag" {
+  description = "Tag in this environment's ECR repository to run."
+  type        = string
+  default     = "latest"
+}
+
+variable "route53_zone_id" {
+  description = "Optional Route 53 zone to create the A record in. Leave null and point your own DNS at the Elastic IP; nothing here needs a DNS provider."
+  type        = string
+  default     = null
+}
+
+variable "alarm_topic_arn" {
+  description = "Optional SNS topic the instance status alarms notify."
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Extra non-secret `.env` entries, or overrides of what the module derives. Secrets belong in SSM, not here: everything in this map lands in the state file."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/environments/aws-staging/variables.tf
+++ b/terraform/environments/aws-staging/variables.tf
@@ -40,7 +40,7 @@ variable "data_volume_snapshot_id" {
 }
 
 variable "secret_names" {
-  description = "`.env` keys held as SecureString parameters, replacing the module's default inventory. Extend it when a deployment needs secrets the module does not know about -- another sandbox provider's key, for instance. Removing a name deletes that parameter and the operator's value with it."
+  description = "`.env` keys held as SecureString parameters. This replaces the module's default inventory rather than adding to it, so a deployment that needs a secret the module does not know about -- another sandbox provider's key, for instance -- lists that name and every default it still wants. Null uses the defaults. Dropping a name deletes that parameter and the operator's value with it."
   type        = set(string)
   default     = null
 }

--- a/terraform/environments/aws-staging/variables.tf
+++ b/terraform/environments/aws-staging/variables.tf
@@ -32,3 +32,9 @@ variable "config" {
   type        = map(string)
   default     = {}
 }
+
+variable "data_volume_snapshot_id" {
+  description = "Snapshot to build the data volume from, for a restore. Null creates an empty volume. The module ignores later changes to it, so setting it is a one-time act rather than a standing instruction to re-restore."
+  type        = string
+  default     = null
+}

--- a/terraform/environments/aws-staging/variables.tf
+++ b/terraform/environments/aws-staging/variables.tf
@@ -38,3 +38,9 @@ variable "data_volume_snapshot_id" {
   type        = string
   default     = null
 }
+
+variable "secret_names" {
+  description = "`.env` keys held as SecureString parameters, replacing the module's default inventory. Extend it when a deployment needs secrets the module does not know about -- another sandbox provider's key, for instance. Removing a name deletes that parameter and the operator's value with it."
+  type        = set(string)
+  default     = null
+}

--- a/terraform/environments/aws-staging/versions.tf
+++ b/terraform/environments/aws-staging/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = "open-inspect"
+      Environment = local.environment
+    }
+  }
+}

--- a/terraform/modules/aws-control-plane/config.tf
+++ b/terraform/modules/aws-control-plane/config.tf
@@ -1,0 +1,91 @@
+# What the instance reads at every start: the stack files from S3, and `.env`
+# built from one SSM path. Both are fetched by the systemd unit's ExecStartPre,
+# so changing either is `terraform apply` plus a restart -- not a new instance.
+
+locals {
+  # `path.module` cannot appear in a variable default, so the fallback lives here.
+  repository_root = coalesce(var.repository_root, abspath("${path.module}/../../.."))
+
+  # The stack the instance runs is the repository's, byte for byte, uploaded
+  # rather than transcribed. `docker-compose.aws.yml` is the only difference
+  # from what the compose smoke boots in CI.
+  stack_files = {
+    "docker-compose.yml"                           = "${local.repository_root}/docker-compose.yml"
+    "docker-compose.aws.yml"                       = "${local.repository_root}/docker-compose.aws.yml"
+    "packages/control-plane/docker/Caddyfile"      = "${local.repository_root}/packages/control-plane/docker/Caddyfile"
+    "packages/control-plane/docker/litestream.yml" = "${local.repository_root}/packages/control-plane/docker/litestream.yml"
+  }
+
+  # Everything the infrastructure itself decides. An entry in var.config wins,
+  # so an operator can override any of it without editing the module.
+  #
+  # The variables this deliberately leaves out are as load-bearing as the ones
+  # it sets. OBJECT_STORE_ENDPOINT and LITESTREAM_ENDPOINT unset mean AWS S3
+  # rather than MinIO; the four credential variables unset mean the SDK finds
+  # the instance role. An SSM parameter cannot hold an empty string, so "unset"
+  # here is "no parameter", which is exactly how the host reads it.
+  derived_config = {
+    DEPLOYMENT_NAME     = var.name
+    WORKER_URL          = "https://${var.hostname}"
+    CADDY_DOMAIN        = var.hostname
+    OBJECT_STORE_BUCKET = aws_s3_bucket.media.bucket
+    OBJECT_STORE_REGION = data.aws_region.current.region
+    LITESTREAM_BUCKET   = aws_s3_bucket.backups.bucket
+    DATA_DIR            = "/data"
+    MIGRATIONS_DIR      = "" # the image sets its own
+    APP_BIND_ADDRESS    = "127.0.0.1"
+
+    # docker-compose.yml refuses to start without this one, and Compose
+    # interpolates the base file whether or not MinIO is among the services the
+    # AWS overlay leaves running. Nothing reads it here.
+    MINIO_ROOT_PASSWORD = "unused-on-aws"
+  }
+
+  # The keys have to be known at plan time, so everything here is: the bucket
+  # names are the ones this module sets rather than the computed `id`, and the
+  # only values filtered out are var.config's, which the caller supplies.
+  # MIGRATIONS_DIR is absent on purpose -- the image sets its own -- and so are
+  # the endpoint and credential variables, per the comment above.
+  env_config = {
+    for key, value in merge(local.derived_config, var.config) : key => value if value != ""
+  }
+}
+
+resource "aws_s3_object" "stack" {
+  for_each = local.stack_files
+
+  bucket = aws_s3_bucket.backups.id
+  key    = "stack/${each.key}"
+  source = each.value
+  etag   = filemd5(each.value)
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "config" {
+  for_each = local.env_config
+
+  name  = "${local.ssm_env_prefix}/${each.key}"
+  type  = "String"
+  value = each.value
+  tags  = local.tags
+}
+
+# The inventory is Terraform's; the values are not. Each starts as a
+# self-describing placeholder that fails loudly if it reaches a boot, and
+# `ignore_changes` then leaves whatever the operator puts there alone:
+#
+#   aws ssm put-parameter --overwrite --type SecureString \
+#     --name /<name>/env/TOKEN_ENCRYPTION_KEY --value "$(openssl rand -base64 32)"
+resource "aws_ssm_parameter" "secret" {
+  for_each = var.secret_names
+
+  name  = "${local.ssm_env_prefix}/${each.value}"
+  type  = "SecureString"
+  value = "CHANGE_ME_${each.value}"
+  tags  = local.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/modules/aws-control-plane/config.tf
+++ b/terraform/modules/aws-control-plane/config.tf
@@ -25,7 +25,15 @@ locals {
   # the instance role. An SSM parameter cannot hold an empty string, so "unset"
   # here is "no parameter", which is exactly how the host reads it.
   derived_config = {
-    DEPLOYMENT_NAME     = var.name
+    DEPLOYMENT_NAME = var.name
+
+    # One of the five keys the host requires before it will listen. The
+    # placeholder is the same one .env.example ships and for the same reason:
+    # it only attributes and filters the bot's own activity, so it boots a
+    # staging stack, and a deployment with a real GitHub App overrides it
+    # through var.config.
+    GITHUB_BOT_USERNAME = "open-inspect[bot]"
+
     WORKER_URL          = "https://${var.hostname}"
     CADDY_DOMAIN        = var.hostname
     OBJECT_STORE_BUCKET = aws_s3_bucket.media.bucket

--- a/terraform/modules/aws-control-plane/config.tf
+++ b/terraform/modules/aws-control-plane/config.tf
@@ -40,8 +40,13 @@ locals {
     OBJECT_STORE_REGION = data.aws_region.current.region
     LITESTREAM_BUCKET   = aws_s3_bucket.backups.bucket
     DATA_DIR            = "/data"
-    MIGRATIONS_DIR      = "" # the image sets its own
     APP_BIND_ADDRESS    = "127.0.0.1"
+
+    # Read by docker-compose.aws.yml, and the reason a tag change takes effect
+    # at all: user data is ignored after first boot, so an image reference
+    # written only there would leave `terraform apply` with nothing to do while
+    # the instance went on pulling its old one.
+    CONTROL_PLANE_IMAGE = local.image
 
     # docker-compose.yml refuses to start without this one, and Compose
     # interpolates the base file whether or not MinIO is among the services the
@@ -49,14 +54,18 @@ locals {
     MINIO_ROOT_PASSWORD = "unused-on-aws"
   }
 
-  # The keys have to be known at plan time, so everything here is: the bucket
-  # names are the ones this module sets rather than the computed `id`, and the
-  # only values filtered out are var.config's, which the caller supplies.
-  # MIGRATIONS_DIR is absent on purpose -- the image sets its own -- and so are
-  # the endpoint and credential variables, per the comment above.
-  env_config = {
-    for key, value in merge(local.derived_config, var.config) : key => value if value != ""
-  }
+  # `for_each` needs its keys known at plan time, and filtering on a value makes
+  # the keys depend on it. Only var.config is filtered, because only its values
+  # are known then; the derived map holds computed ones -- the image reference,
+  # the bucket names -- and every key in it is deliberately non-empty. An
+  # operator therefore cannot blank a derived value by setting it to "".
+  #
+  # MIGRATIONS_DIR is absent on purpose (the image sets its own), as are the
+  # endpoint and credential variables, per the comment above.
+  env_config = merge(
+    local.derived_config,
+    { for key, value in var.config : key => value if value != "" },
+  )
 }
 
 resource "aws_s3_object" "stack" {
@@ -86,14 +95,20 @@ resource "aws_ssm_parameter" "config" {
 #   aws ssm put-parameter --overwrite --type SecureString \
 #     --name /<name>/env/TOKEN_ENCRYPTION_KEY --value "$(openssl rand -base64 32)"
 resource "aws_ssm_parameter" "secret" {
-  for_each = var.secret_names
+  for_each = local.secret_names
 
-  name  = "${local.ssm_env_prefix}/${each.value}"
-  type  = "SecureString"
-  value = "CHANGE_ME_${each.value}"
-  tags  = local.tags
+  name = "${local.ssm_env_prefix}/${each.value}"
+  type = "SecureString"
 
-  lifecycle {
-    ignore_changes = [value]
-  }
+  # Write-only. `ignore_changes` on `value` suppresses the diff but not the
+  # refresh, so the first plan after an operator sets a real secret would read
+  # it back with decryption and write the plaintext into the state file. A
+  # write-only value is sent on create and never read back, which is the
+  # boundary this module claims: the inventory is Terraform's, the values are
+  # not. The version is fixed, so the placeholder is re-sent only if it is
+  # bumped and an operator's `put-parameter` is left alone.
+  value_wo         = "CHANGE_ME_${each.value}"
+  value_wo_version = 1
+
+  tags = local.tags
 }

--- a/terraform/modules/aws-control-plane/dns.tf
+++ b/terraform/modules/aws-control-plane/dns.tf
@@ -1,0 +1,13 @@
+# Optional, and off by default. The module publishes an address; pointing a
+# name at it is the operator's, on whatever they already run. Route 53 is here
+# because it is the AWS-native option and adds no third party -- not because
+# this module needs a DNS provider. It does not have one.
+resource "aws_route53_record" "this" {
+  count = var.route53_zone_id == null ? 0 : 1
+
+  zone_id = var.route53_zone_id
+  name    = var.hostname
+  type    = "A"
+  ttl     = 60
+  records = [aws_eip.this.public_ip]
+}

--- a/terraform/modules/aws-control-plane/iam.tf
+++ b/terraform/modules/aws-control-plane/iam.tf
@@ -43,25 +43,34 @@ data "aws_iam_policy_document" "instance" {
     ]
   }
 
-  # The parameters are SecureString under the account's default SSM key.
+  # No kms:Decrypt statement. The parameters are SecureString under the
+  # AWS-managed aws/ssm key, whose own key policy admits account principals
+  # through SSM, so nothing here is needed. An IAM statement would not help in
+  # any case: KMS authorizes against key ARNs, and an alias ARN matches nothing.
+  # A customer-managed key would need a real key ARN here and a grant on the key.
+
+  # The stack files are fetched by root and executed on every start, so the
+  # instance may read them and nothing more. Granting write there would let
+  # anything that reaches the instance role -- which is every container, one hop
+  # from the metadata service -- rewrite what root runs on the next restart.
   statement {
-    sid       = "DecryptStackConfiguration"
-    actions   = ["kms:Decrypt"]
-    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"]
+    sid       = "ReadStackFiles"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.backups.arn}/stack/*"]
   }
 
   statement {
-    sid     = "UseBuckets"
-    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucketMultipartUploads", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"]
+    sid     = "WriteMediaAndReplica"
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"]
     resources = [
       "${aws_s3_bucket.media.arn}/*",
-      "${aws_s3_bucket.backups.arn}/*",
+      "${aws_s3_bucket.backups.arn}/control-plane/*",
     ]
   }
 
   statement {
     sid       = "ListBuckets"
-    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation", "s3:ListBucketMultipartUploads"]
     resources = [aws_s3_bucket.media.arn, aws_s3_bucket.backups.arn]
   }
 

--- a/terraform/modules/aws-control-plane/iam.tf
+++ b/terraform/modules/aws-control-plane/iam.tf
@@ -32,10 +32,15 @@ resource "aws_iam_role_policy_attachment" "ssm_core" {
 }
 
 data "aws_iam_policy_document" "instance" {
+  # GetParametersByPath is authorized against the path itself as well as what is
+  # under it, so a grant on only `<prefix>/*` is denied.
   statement {
-    sid       = "ReadStackConfiguration"
-    actions   = ["ssm:GetParametersByPath", "ssm:GetParameter", "ssm:GetParameters"]
-    resources = ["arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_env_prefix}/*"]
+    sid     = "ReadStackConfiguration"
+    actions = ["ssm:GetParametersByPath", "ssm:GetParameter", "ssm:GetParameters"]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_env_prefix}",
+      "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_env_prefix}/*",
+    ]
   }
 
   # The parameters are SecureString under the account's default SSM key.

--- a/terraform/modules/aws-control-plane/iam.tf
+++ b/terraform/modules/aws-control-plane/iam.tf
@@ -1,0 +1,112 @@
+# The instance carries no long-lived credentials. Everything it reaches -- S3,
+# SSM, ECR, CloudWatch -- it reaches as this role, which is why `.env` leaves
+# AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY empty and lets the SDK's default
+# chain find it.
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name               = "${var.name}-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${var.name}-instance"
+  role = aws_iam_role.instance.name
+  tags = local.tags
+}
+
+# Session Manager, so the security group need admit no SSH.
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "instance" {
+  statement {
+    sid       = "ReadStackConfiguration"
+    actions   = ["ssm:GetParametersByPath", "ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${local.ssm_env_prefix}/*"]
+  }
+
+  # The parameters are SecureString under the account's default SSM key.
+  statement {
+    sid       = "DecryptStackConfiguration"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"]
+  }
+
+  statement {
+    sid     = "UseBuckets"
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucketMultipartUploads", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"]
+    resources = [
+      "${aws_s3_bucket.media.arn}/*",
+      "${aws_s3_bucket.backups.arn}/*",
+    ]
+  }
+
+  statement {
+    sid       = "ListBuckets"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.media.arn, aws_s3_bucket.backups.arn]
+  }
+
+  statement {
+    sid       = "PullImage"
+    actions   = ["ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage", "ecr:BatchCheckLayerAvailability"]
+    resources = [aws_ecr_repository.control_plane.arn]
+  }
+
+  # Not scopable to a repository: the token is account-wide by design.
+  statement {
+    sid       = "AuthenticateToRegistry"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "WriteLogs"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents", "logs:DescribeLogStreams"]
+    resources = ["${aws_cloudwatch_log_group.containers.arn}:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "instance" {
+  name   = "${var.name}-instance"
+  role   = aws_iam_role.instance.id
+  policy = data.aws_iam_policy_document.instance.json
+}
+
+# ---------------------------------------------------------------------------
+# Data Lifecycle Manager
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "dlm_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["dlm.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "dlm" {
+  name               = "${var.name}-dlm"
+  assume_role_policy = data.aws_iam_policy_document.dlm_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "dlm" {
+  role       = aws_iam_role.dlm.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}

--- a/terraform/modules/aws-control-plane/instance.tf
+++ b/terraform/modules/aws-control-plane/instance.tf
@@ -2,6 +2,12 @@
 # Amazon Linux 2023's arm64 AMI. Looked up with DescribeImages rather than
 # through the public `/aws/service/ami-al2023` SSM parameter: plenty of accounts
 # deny the `/aws/` namespace to their operators, and this needs no such grant.
+# The authority on whether the chosen type can run the image, rather than a
+# list of family prefixes that goes stale with every Graviton generation.
+data "aws_ec2_instance_type" "this" {
+  instance_type = var.instance_type
+}
+
 data "aws_ami" "al2023" {
   most_recent = true
   owners      = ["amazon"]
@@ -24,13 +30,17 @@ data "aws_ami" "al2023" {
 }
 
 resource "aws_instance" "this" {
-  ami                    = data.aws_ami.al2023.id
-  instance_type          = var.instance_type
-  subnet_id              = aws_subnet.public.id
-  availability_zone      = local.az
-  vpc_security_group_ids = [aws_security_group.instance.id]
-  iam_instance_profile   = aws_iam_instance_profile.instance.name
-  key_name               = var.ssh_key_name
+  ami               = data.aws_ami.al2023.id
+  instance_type     = var.instance_type
+  subnet_id         = aws_subnet.public.id
+  availability_zone = local.az
+  # The Elastic IP is associated after the instance is running, and cloud-init
+  # needs the internet before that. A launch-time public address closes the gap
+  # rather than relying on dnf's retries to cover it; the EIP then replaces it.
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.instance.id]
+  iam_instance_profile        = aws_iam_instance_profile.instance.name
+  key_name                    = var.ssh_key_name
 
   user_data_base64            = data.cloudinit_config.this.rendered
   user_data_replace_on_change = false
@@ -53,11 +63,14 @@ resource "aws_instance" "this" {
     http_put_response_hop_limit = 2
   }
 
-  monitoring = true
-
   tags = merge(local.tags, { Name = var.name })
 
   lifecycle {
+    precondition {
+      condition     = contains(data.aws_ec2_instance_type.this.supported_architectures, "arm64")
+      error_message = "instance_type ${var.instance_type} is not arm64; the control-plane image has no amd64 build."
+    }
+
     # This instance is stateful in practice even though its state is on the
     # attached volume: replacing it drops every in-flight session. AWS moves
     # the AL2023 parameter whenever it publishes an image, and user data
@@ -81,9 +94,9 @@ data "cloudinit_config" "this" {
       log_group             = aws_cloudwatch_log_group.containers.name
       config_bucket         = aws_s3_bucket.backups.id
       ssm_env_prefix        = local.ssm_env_prefix
-      control_plane_image   = local.image
       data_volume_id_nodash = replace(aws_ebs_volume.data.id, "-", "")
       compose_version       = var.compose_plugin_version
+      compose_sha256        = var.compose_plugin_sha256
     })
   }
 }

--- a/terraform/modules/aws-control-plane/instance.tf
+++ b/terraform/modules/aws-control-plane/instance.tf
@@ -1,0 +1,94 @@
+# One instance, Graviton, with a public address it keeps across replacements.
+# Amazon Linux 2023's arm64 AMI. Looked up with DescribeImages rather than
+# through the public `/aws/service/ami-al2023` SSM parameter: plenty of accounts
+# deny the `/aws/` namespace to their operators, and this needs no such grant.
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    # Excludes al2023-ami-minimal-*, which has no package set to speak of.
+    values = ["al2023-ami-2023.*-arm64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.public.id
+  availability_zone      = local.az
+  vpc_security_group_ids = [aws_security_group.instance.id]
+  iam_instance_profile   = aws_iam_instance_profile.instance.name
+  key_name               = var.ssh_key_name
+
+  user_data                   = data.cloudinit_config.this.rendered
+  user_data_replace_on_change = false
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_tokens                 = "required" # IMDSv2
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+  }
+
+  monitoring = true
+
+  tags = merge(local.tags, { Name = var.name })
+
+  lifecycle {
+    # This instance is stateful in practice even though its state is on the
+    # attached volume: replacing it drops every in-flight session. AWS moves
+    # the AL2023 parameter whenever it publishes an image, and user data
+    # changes whenever the module does, so leaving either live would let a
+    # routine plan propose a replacement. Rolling the instance is deliberate:
+    #
+    #   terraform apply -replace=module.control_plane.aws_instance.this
+    ignore_changes = [ami, user_data]
+  }
+}
+
+data "cloudinit_config" "this" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "open-inspect-bootstrap.sh"
+    content = templatefile("${path.module}/templates/user-data.sh.tftpl", {
+      region                = data.aws_region.current.region
+      log_group             = aws_cloudwatch_log_group.containers.name
+      config_bucket         = aws_s3_bucket.backups.id
+      ssm_env_prefix        = local.ssm_env_prefix
+      control_plane_image   = local.image
+      data_volume_id_nodash = replace(aws_ebs_volume.data.id, "-", "")
+      compose_version       = var.compose_plugin_version
+    })
+  }
+}
+
+# The address survives the instance, so replacing the instance is not a DNS
+# change and the operator's record can be a plain A record they set once.
+resource "aws_eip" "this" {
+  domain   = "vpc"
+  instance = aws_instance.this.id
+  tags     = merge(local.tags, { Name = var.name })
+
+  depends_on = [aws_internet_gateway.this]
+}

--- a/terraform/modules/aws-control-plane/instance.tf
+++ b/terraform/modules/aws-control-plane/instance.tf
@@ -32,7 +32,7 @@ resource "aws_instance" "this" {
   iam_instance_profile   = aws_iam_instance_profile.instance.name
   key_name               = var.ssh_key_name
 
-  user_data                   = data.cloudinit_config.this.rendered
+  user_data_base64            = data.cloudinit_config.this.rendered
   user_data_replace_on_change = false
 
   root_block_device {
@@ -43,9 +43,14 @@ resource "aws_instance" "this" {
   }
 
   metadata_options {
-    http_tokens                 = "required" # IMDSv2
-    http_endpoint               = "enabled"
-    http_put_response_hop_limit = 1
+    http_tokens   = "required" # IMDSv2
+    http_endpoint = "enabled"
+    # Two, not one. Everything that reaches AWS here runs in a container on
+    # Docker's bridge network, which is one hop further from the metadata
+    # service than the instance itself. At a limit of 1 the app and Litestream
+    # both fail with "no valid providers in chain", which reads like a missing
+    # credential rather than an unreachable one.
+    http_put_response_hop_limit = 2
   }
 
   monitoring = true
@@ -60,7 +65,7 @@ resource "aws_instance" "this" {
     # routine plan propose a replacement. Rolling the instance is deliberate:
     #
     #   terraform apply -replace=module.control_plane.aws_instance.this
-    ignore_changes = [ami, user_data]
+    ignore_changes = [ami, user_data_base64]
   }
 }
 

--- a/terraform/modules/aws-control-plane/main.tf
+++ b/terraform/modules/aws-control-plane/main.tf
@@ -1,0 +1,33 @@
+# Shared lookups and naming. The rest of the module is split by concern:
+#
+# - network.tf        VPC, public subnet, security group
+# - iam.tf            Instance role and its policies, the DLM and scheduler roles
+# - storage.tf        Data volume, snapshots, S3 buckets, ECR
+# - config.tf         SSM parameters and the stack files the instance fetches
+# - instance.tf       The EC2 instance, its Elastic IP and its user data
+# - observability.tf  Log group and instance alarms
+# - schedule.tf       Optional out-of-hours stop and start
+# - dns.tf            Optional Route 53 record
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  az = coalesce(var.availability_zone, data.aws_availability_zones.available.names[0])
+
+  tags = merge(var.tags, {
+    Name       = var.name
+    ManagedBy  = "terraform"
+    Deployment = var.name
+  })
+
+  # Where the instance reads its `.env` from. One path, read whole.
+  ssm_env_prefix = "/${var.name}/env"
+
+  image = coalesce(var.control_plane_image, "${aws_ecr_repository.control_plane.repository_url}:${var.control_plane_image_tag}")
+}

--- a/terraform/modules/aws-control-plane/main.tf
+++ b/terraform/modules/aws-control-plane/main.tf
@@ -29,5 +29,31 @@ locals {
   # Where the instance reads its `.env` from. One path, read whole.
   ssm_env_prefix = "/${var.name}/env"
 
+  # The keys a deployment holds as SecureString parameters. Each is created with
+  # a self-describing placeholder that the instance refuses to write into `.env`,
+  # so a key nobody set is absent rather than a working credential everyone can
+  # read in this repository.
+  default_secret_names = [
+    "ANTHROPIC_API_KEY",
+    "BROWSER_AUTH_SECRET",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_CLIENT_ID",
+    "GITHUB_CLIENT_SECRET",
+    "IMAGE_CALLBACK_TOKEN_PEPPER",
+    "MODAL_API_SECRET",
+    "PROVIDER_ACCOUNTS_ENCRYPTION_KEY",
+    "REPO_SECRETS_ENCRYPTION_KEY",
+    "SERVICE_AUTH_SECRET_GITHUB_BOT",
+    "SERVICE_AUTH_SECRET_LINEAR_BOT",
+    "SERVICE_AUTH_SECRET_SLACK_BOT",
+    "SERVICE_AUTH_SECRET_WEB",
+    "TOKEN_ENCRYPTION_KEY",
+  ]
+
+  # Null from a root module means "use the inventory above".
+  secret_names = toset(coalesce(var.secret_names, local.default_secret_names))
+
   image = coalesce(var.control_plane_image, "${aws_ecr_repository.control_plane.repository_url}:${var.control_plane_image_tag}")
 }

--- a/terraform/modules/aws-control-plane/network.tf
+++ b/terraform/modules/aws-control-plane/network.tf
@@ -1,0 +1,100 @@
+# One VPC with a single public subnet. The instance holds a public address and
+# talks to AWS over it; there is no private subnet, because reaching S3, SSM,
+# ECR and CloudWatch from one would mean either a NAT gateway (~$33/month plus
+# egress, more than the instance) or four interface endpoints (~$7/month each).
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(local.tags, { Name = "${var.name}-vpc" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.tags, { Name = "${var.name}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.subnet_cidr
+  availability_zone       = local.az
+  map_public_ip_on_launch = false # the instance carries an Elastic IP instead
+
+  tags = merge(local.tags, { Name = "${var.name}-public" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(local.tags, { Name = "${var.name}-public" })
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# S3 traffic leaves through the gateway endpoint rather than the internet
+# gateway: media and Litestream's continuous replication are the bulk of this
+# instance's egress, and a gateway endpoint costs nothing.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.public.id]
+
+  tags = merge(local.tags, { Name = "${var.name}-s3" })
+}
+
+resource "aws_security_group" "instance" {
+  name        = "${var.name}-instance"
+  description = "Open-Inspect control plane: HTTP and HTTPS in, everything out"
+  vpc_id      = aws_vpc.this.id
+
+  tags = merge(local.tags, { Name = "${var.name}-instance" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Port 80 is not only a redirect to 443: Caddy answers the ACME HTTP-01
+# challenge on it, so closing it stops issuance and, later, renewal.
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  for_each = toset(var.ingress_cidrs)
+
+  security_group_id = aws_security_group.instance.id
+  description       = "HTTP, for the ACME HTTP-01 challenge and the redirect to HTTPS"
+  cidr_ipv4         = each.value
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  for_each = toset(var.ingress_cidrs)
+
+  security_group_id = aws_security_group.instance.id
+  description       = "HTTPS"
+  cidr_ipv4         = each.value
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+# No inbound SSH. Shell access is `aws ssm start-session`, which the instance
+# opens outbound.
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.instance.id
+  description       = "All outbound"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}

--- a/terraform/modules/aws-control-plane/network.tf
+++ b/terraform/modules/aws-control-plane/network.tf
@@ -55,7 +55,9 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_security_group" "instance" {
-  name        = "${var.name}-instance"
+  # A prefix, not a name: create_before_destroy needs the replacement to exist
+  # alongside the original, which a fixed name forbids.
+  name_prefix = "${var.name}-instance-"
   description = "Open-Inspect control plane: HTTP and HTTPS in, everything out"
   vpc_id      = aws_vpc.this.id
 

--- a/terraform/modules/aws-control-plane/observability.tf
+++ b/terraform/modules/aws-control-plane/observability.tf
@@ -6,6 +6,10 @@ resource "aws_cloudwatch_log_group" "containers" {
   tags              = local.tags
 }
 
+# `treat_missing_data` follows the schedule: an instance stopped every evening
+# publishes no status checks, and "breaching" would page at the stop and again
+# at the start, every day.
+#
 # The two alarms that need nothing installed on the instance. Disk and memory
 # need the CloudWatch agent, and the alarms that actually describe the control
 # plane -- queue depth, spawn failures -- need metrics the host does not
@@ -20,7 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "instance_status" {
   evaluation_periods  = 3
   threshold           = 0
   comparison_operator = "GreaterThanThreshold"
-  treat_missing_data  = "breaching"
+  treat_missing_data  = local.scheduled ? "notBreaching" : "breaching"
   dimensions          = { InstanceId = aws_instance.this.id }
 
   alarm_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
@@ -39,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "system_status" {
   evaluation_periods  = 3
   threshold           = 0
   comparison_operator = "GreaterThanThreshold"
-  treat_missing_data  = "breaching"
+  treat_missing_data  = local.scheduled ? "notBreaching" : "breaching"
   dimensions          = { InstanceId = aws_instance.this.id }
 
   alarm_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]

--- a/terraform/modules/aws-control-plane/observability.tf
+++ b/terraform/modules/aws-control-plane/observability.tf
@@ -1,0 +1,49 @@
+# Container stdout, straight from the Docker daemon's awslogs driver. One
+# group, one stream per container, and it outlives the instance.
+resource "aws_cloudwatch_log_group" "containers" {
+  name              = "/open-inspect/${var.name}"
+  retention_in_days = var.log_retention_days
+  tags              = local.tags
+}
+
+# The two alarms that need nothing installed on the instance. Disk and memory
+# need the CloudWatch agent, and the alarms that actually describe the control
+# plane -- queue depth, spawn failures -- need metrics the host does not
+# publish yet; both belong to H-8.
+resource "aws_cloudwatch_metric_alarm" "instance_status" {
+  alarm_name          = "${var.name}-instance-status-check"
+  alarm_description   = "The instance failed its own status check; it is not reachable or not healthy."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed_Instance"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "breaching"
+  dimensions          = { InstanceId = aws_instance.this.id }
+
+  alarm_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+  ok_actions    = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "system_status" {
+  alarm_name          = "${var.name}-system-status-check"
+  alarm_description   = "The underlying host failed its status check; recovery needs a stop and start."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed_System"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "breaching"
+  dimensions          = { InstanceId = aws_instance.this.id }
+
+  alarm_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+  ok_actions    = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+
+  tags = local.tags
+}

--- a/terraform/modules/aws-control-plane/outputs.tf
+++ b/terraform/modules/aws-control-plane/outputs.tf
@@ -1,0 +1,54 @@
+output "hostname" {
+  description = "Public FQDN the control plane answers on. WORKER_URL is https://<this>."
+  value       = var.hostname
+}
+
+output "public_ip" {
+  description = "Elastic IP the DNS record for `hostname` must point at. Stable across instance replacement."
+  value       = aws_eip.this.public_ip
+}
+
+output "instance_id" {
+  description = "EC2 instance id, for `aws ssm start-session --target <this>`."
+  value       = aws_instance.this.id
+}
+
+output "data_volume_id" {
+  description = "EBS volume holding Docker's data root, and so the databases. Snapshots of it are the deployment's backup."
+  value       = aws_ebs_volume.data.id
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group the containers write to: `aws logs tail <this> --follow`."
+  value       = aws_cloudwatch_log_group.containers.name
+}
+
+output "ecr_repository_url" {
+  description = "Registry CI pushes the control-plane image to."
+  value       = aws_ecr_repository.control_plane.repository_url
+}
+
+output "control_plane_image" {
+  description = "Image reference the instance runs."
+  value       = local.image
+}
+
+output "media_bucket" {
+  description = "S3 bucket backing the object store."
+  value       = aws_s3_bucket.media.id
+}
+
+output "backups_bucket" {
+  description = "S3 bucket holding the Litestream replica of the global store and the stack files the instance fetches."
+  value       = aws_s3_bucket.backups.id
+}
+
+output "ssm_env_prefix" {
+  description = "SSM path `.env` is built from. `aws ssm get-parameters-by-path --path <this> --recursive` lists what still needs a value."
+  value       = local.ssm_env_prefix
+}
+
+output "secret_parameter_names" {
+  description = "SecureString parameters the operator owns. Each starts as a CHANGE_ME_ placeholder."
+  value       = sort([for parameter in aws_ssm_parameter.secret : parameter.name])
+}

--- a/terraform/modules/aws-control-plane/schedule.tf
+++ b/terraform/modules/aws-control-plane/schedule.tf
@@ -1,0 +1,85 @@
+# An instance that is off costs nothing but its volumes, which is most of why
+# staging is cheap. StopInstances is an ACPI shutdown, so systemd stops the
+# unit and `docker compose down` drains the host on its usual budget; this is
+# not a power cut.
+
+locals {
+  scheduled = var.out_of_hours_stop != null
+}
+
+data "aws_iam_policy_document" "scheduler_assume" {
+  count = local.scheduled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "scheduler" {
+  count = local.scheduled ? 1 : 0
+
+  name               = "${var.name}-scheduler"
+  assume_role_policy = data.aws_iam_policy_document.scheduler_assume[0].json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  count = local.scheduled ? 1 : 0
+
+  name = "${var.name}-scheduler"
+  role = aws_iam_role.scheduler[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ec2:StartInstances", "ec2:StopInstances"]
+      Resource = "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:instance/${aws_instance.this.id}"
+    }]
+  })
+}
+
+resource "aws_scheduler_schedule" "stop" {
+  count = local.scheduled ? 1 : 0
+
+  name                         = "${var.name}-stop"
+  schedule_expression          = var.out_of_hours_stop.stop_cron
+  schedule_expression_timezone = var.out_of_hours_stop.timezone
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ec2:stopInstances"
+    role_arn = aws_iam_role.scheduler[0].arn
+    input    = jsonencode({ InstanceIds = [aws_instance.this.id] })
+  }
+}
+
+resource "aws_scheduler_schedule" "start" {
+  count = local.scheduled ? 1 : 0
+
+  name                         = "${var.name}-start"
+  schedule_expression          = var.out_of_hours_stop.start_cron
+  schedule_expression_timezone = var.out_of_hours_stop.timezone
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ec2:startInstances"
+    role_arn = aws_iam_role.scheduler[0].arn
+    input    = jsonencode({ InstanceIds = [aws_instance.this.id] })
+  }
+}

--- a/terraform/modules/aws-control-plane/storage.tf
+++ b/terraform/modules/aws-control-plane/storage.tf
@@ -81,14 +81,14 @@ resource "aws_dlm_lifecycle_policy" "data" {
 
 resource "aws_s3_bucket" "media" {
   bucket        = "${var.name}-media"
-  force_destroy = var.force_destroy_buckets
+  force_destroy = var.force_destroy_storage
 
   tags = merge(local.tags, { Name = "${var.name}-media" })
 }
 
 resource "aws_s3_bucket" "backups" {
   bucket        = "${var.name}-backups"
-  force_destroy = var.force_destroy_buckets
+  force_destroy = var.force_destroy_storage
 
   tags = merge(local.tags, { Name = "${var.name}-backups" })
 }
@@ -171,6 +171,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 resource "aws_ecr_repository" "control_plane" {
   name                 = "${var.name}-control-plane"
   image_tag_mutability = "MUTABLE" # the deployed tag moves; digests are immutable
+  # A repository holding images refuses to be deleted, so without this a
+  # destroy fails the moment anything has been pushed.
+  force_delete = var.force_destroy_storage
 
   image_scanning_configuration {
     scan_on_push = true

--- a/terraform/modules/aws-control-plane/storage.tf
+++ b/terraform/modules/aws-control-plane/storage.tf
@@ -1,0 +1,197 @@
+# ---------------------------------------------------------------------------
+# Data volume
+# ---------------------------------------------------------------------------
+# This volume is the deployment. It carries Docker's data root, so the global
+# store, every session database, the host alarm index and the container images
+# all live on it; the instance in front of it is replaceable and the volume is
+# not. `prevent_destroy` says so: releasing it is a deliberate
+# `terraform state rm`, documented in the bring-up runbook, not something a
+# mistyped `terraform destroy` can do.
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = local.az
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  snapshot_id       = var.data_volume_snapshot_id
+
+  tags = merge(local.tags, {
+    Name     = "${var.name}-data"
+    Snapshot = "daily" # what the Data Lifecycle Manager policy below selects on
+  })
+
+  lifecycle {
+    prevent_destroy = true
+
+    # Restoring from a snapshot is a one-time act. Leaving it live would make
+    # the next apply after a restore propose replacing the volume with a fresh
+    # copy of that same snapshot, discarding everything written since.
+    ignore_changes = [snapshot_id]
+  }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.this.id
+
+  # Detaching a mounted filesystem from a running instance corrupts it. A
+  # destroy stops the instance first, which releases the volume cleanly.
+  stop_instance_before_detaching = true
+}
+
+resource "aws_dlm_lifecycle_policy" "data" {
+  description        = "${var.name} daily data volume snapshots"
+  execution_role_arn = aws_iam_role.dlm.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+    target_tags    = { Snapshot = "daily" }
+
+    schedule {
+      name = "daily"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = [var.snapshot_schedule_utc]
+      }
+
+      retain_rule {
+        count = var.snapshot_retention_count
+      }
+
+      # The snapshot is taken while the filesystem is live, so it is
+      # crash-consistent rather than quiesced. SQLite recovers from that the
+      # way it recovers from a power cut; I-5 rehearses the restore.
+      copy_tags = true
+    }
+  }
+
+  tags = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# Buckets
+# ---------------------------------------------------------------------------
+# Media is what the control plane stores for users. Backups is Litestream's
+# replica of the global store, and also holds the stack files the instance
+# fetches at boot. Both are private, versioned and encrypted.
+
+resource "aws_s3_bucket" "media" {
+  bucket        = "${var.name}-media"
+  force_destroy = var.force_destroy_buckets
+
+  tags = merge(local.tags, { Name = "${var.name}-media" })
+}
+
+resource "aws_s3_bucket" "backups" {
+  bucket        = "${var.name}-backups"
+  force_destroy = var.force_destroy_buckets
+
+  tags = merge(local.tags, { Name = "${var.name}-backups" })
+}
+
+locals {
+  buckets = {
+    media   = aws_s3_bucket.media.id
+    backups = aws_s3_bucket.backups.id
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  for_each = local.buckets
+
+  bucket                  = each.value
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  for_each = local.buckets
+
+  bucket = each.value
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  for_each = local.buckets
+
+  bucket = each.value
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# Versioning without expiry grows without bound, and Litestream rewrites its
+# replica constantly. Noncurrent versions are the safety net for an overwrite,
+# not an archive.
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  for_each = local.buckets
+
+  bucket = each.value
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.this]
+}
+
+# ---------------------------------------------------------------------------
+# Image registry
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "control_plane" {
+  name                 = "${var.name}-control-plane"
+  image_tag_mutability = "MUTABLE" # the deployed tag moves; digests are immutable
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.tags, { Name = "${var.name}-control-plane" })
+}
+
+resource "aws_ecr_lifecycle_policy" "control_plane" {
+  repository = aws_ecr_repository.control_plane.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep the 20 most recent images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 20
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/terraform/modules/aws-control-plane/storage.tf
+++ b/terraform/modules/aws-control-plane/storage.tf
@@ -16,8 +16,7 @@ resource "aws_ebs_volume" "data" {
   snapshot_id       = var.data_volume_snapshot_id
 
   tags = merge(local.tags, {
-    Name     = "${var.name}-data"
-    Snapshot = "daily" # what the Data Lifecycle Manager policy below selects on
+    Name = "${var.name}-data"
   })
 
   lifecycle {
@@ -47,7 +46,11 @@ resource "aws_dlm_lifecycle_policy" "data" {
 
   policy_details {
     resource_types = ["VOLUME"]
-    target_tags    = { Snapshot = "daily" }
+    # Scoped to this deployment. DLM selects across the whole account and
+    # region, so a tag that names the schedule rather than the owner is shared
+    # by every environment, and each policy then snapshots the others' volumes
+    # under its own retention.
+    target_tags = { Deployment = var.name }
 
     schedule {
       name = "daily"
@@ -80,14 +83,17 @@ resource "aws_dlm_lifecycle_policy" "data" {
 # fetches at boot. Both are private, versioned and encrypted.
 
 resource "aws_s3_bucket" "media" {
-  bucket        = "${var.name}-media"
+  # Bucket names are global, so a second installation of this module would
+  # collide with the first on its first apply. The account id is the smallest
+  # thing that makes them unique, and renaming once data exists is a migration.
+  bucket        = "${var.name}-media-${data.aws_caller_identity.current.account_id}"
   force_destroy = var.force_destroy_storage
 
   tags = merge(local.tags, { Name = "${var.name}-media" })
 }
 
 resource "aws_s3_bucket" "backups" {
-  bucket        = "${var.name}-backups"
+  bucket        = "${var.name}-backups-${data.aws_caller_identity.current.account_id}"
   force_destroy = var.force_destroy_storage
 
   tags = merge(local.tags, { Name = "${var.name}-backups" })
@@ -127,7 +133,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
-    bucket_key_enabled = true
   }
 }
 

--- a/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
+++ b/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
@@ -10,41 +10,61 @@ set -euxo pipefail
 
 STACK_DIR=/opt/open-inspect
 DATA_DIR=/data
-# Addressed by volume id rather than by the /dev/sdf the attachment asks for:
-# on Nitro instances the kernel names EBS volumes /dev/nvme*n1 in attach order,
-# which is not stable across reboots.
+# By volume id, because on Nitro the kernel names EBS volumes /dev/nvme*n1 in
+# attach order, which is not stable across reboots. Only needed to format a
+# blank volume; once formatted the label below identifies it.
 DEVICE="/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${data_volume_id_nodash}"
+LABEL_PATH="/dev/disk/by-label/open-inspect"
 
 # AL2023 ships the CLI and the SSM agent; installing them is a no-op there and
-# the fallback covers an image that does not. The Compose plugin is the one
-# piece not reliably in the repositories, so a missing package is not fatal --
-# the release binary is.
+# covers an image that does not.
 dnf install -y docker
 command -v aws >/dev/null 2>&1 || dnf install -y awscli-2
 systemctl list-unit-files amazon-ssm-agent.service >/dev/null 2>&1 ||
   dnf install -y amazon-ssm-agent
 
-if ! dnf install -y docker-compose-plugin; then
-  install -d /usr/libexec/docker/cli-plugins
-  curl -fsSL -o /usr/libexec/docker/cli-plugins/docker-compose \
-    "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-aarch64"
-  chmod 755 /usr/libexec/docker/cli-plugins/docker-compose
-fi
+# AL2023 has no docker-compose-plugin package, so this is the only path rather
+# than a fallback. The checksum is pinned beside the version: this is a binary
+# fetched over the internet and then run as root on every boot.
+install -d /usr/libexec/docker/cli-plugins
+curl -fsSL -o /usr/libexec/docker/cli-plugins/docker-compose \
+  "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-aarch64"
+echo "${compose_sha256}  /usr/libexec/docker/cli-plugins/docker-compose" | sha256sum -c -
+chmod 755 /usr/libexec/docker/cli-plugins/docker-compose
 
 # ---------------------------------------------------------------------------
 # The data volume, before Docker so its data root lands on it
 # ---------------------------------------------------------------------------
 
-for _ in $(seq 1 60); do
-  [ -e "$DEVICE" ] && break
+# Either the volume already carries the filesystem -- a reboot, a replaced
+# instance, or a volume restored from a snapshot -- or it is blank and this is a
+# first boot. The label answers the first case without knowing the volume id,
+# which is what lets a restored volume attach to an instance whose user data was
+# rendered for a different one.
+#
+# Five minutes, not two: on `-replace` the attachment is created after the
+# instance is already running, so this covers a Terraform round trip rather than
+# just the hypervisor.
+for _ in $(seq 1 150); do
+  if [ -e "$LABEL_PATH" ] || [ -e "$DEVICE" ]; then
+    break
+  fi
   sleep 2
 done
-[ -e "$DEVICE" ] || { echo "data volume never appeared at $DEVICE" >&2; exit 1; }
 
-# An unformatted volume has no type; a restored one does, and must not be
-# reformatted. `blkid` is the difference between a first boot and a restore.
-if ! blkid "$DEVICE" >/dev/null 2>&1; then
+if [ -e "$LABEL_PATH" ]; then
+  : # formatted already; nothing to do but mount it
+elif [ -e "$DEVICE" ]; then
+  # A blank volume has no filesystem type. `blkid` is the difference between a
+  # first boot and a volume that arrived with data on it under another label.
+  if blkid "$DEVICE" >/dev/null 2>&1; then
+    echo "$DEVICE holds a filesystem that is not labelled open-inspect; refusing to touch it" >&2
+    exit 1
+  fi
   mkfs.ext4 -L open-inspect "$DEVICE"
+else
+  echo "no data volume appeared at $LABEL_PATH or $DEVICE" >&2
+  exit 1
 fi
 
 mkdir -p "$DATA_DIR"
@@ -60,9 +80,10 @@ mount -a
 # compose stack declares are on the thing that gets snapshotted -- which is
 # what makes "the data volume is the unit of a deployment backup" true.
 #
-# Container logs go straight to CloudWatch. `docker compose logs` therefore
-# shows nothing on this host; `aws logs tail` is the equivalent, and it keeps
-# working after the instance is replaced.
+# Container logs go to CloudWatch, one stream per service. `aws logs tail` is
+# the way to read them and keeps working after the instance is replaced; Docker
+# also caches locally by default, so `docker compose logs` may still answer on
+# the box.
 
 mkdir -p "$DATA_DIR/docker" /etc/docker
 cat >/etc/docker/daemon.json <<JSON
@@ -72,11 +93,23 @@ cat >/etc/docker/daemon.json <<JSON
   "log-opts": {
     "awslogs-region": "${region}",
     "awslogs-group": "${log_group}",
-    "awslogs-create-group": "false"
+    "awslogs-create-group": "false",
+    "tag": "{{.Name}}"
   }
 }
 JSON
 
+# Docker's data root is on the volume, so the unit must not start before the
+# mount. `nofail` in fstab keeps a missing volume from blocking boot, which
+# without this would mean Docker quietly using the root disk and Litestream's
+# restore-on-empty making that look like a working deployment.
+install -d /etc/systemd/system/docker.service.d
+cat >/etc/systemd/system/docker.service.d/10-data-volume.conf <<'DROPIN'
+[Unit]
+RequiresMountsFor=/data
+DROPIN
+
+systemctl daemon-reload
 systemctl enable --now docker
 systemctl enable --now amazon-ssm-agent
 
@@ -112,15 +145,43 @@ with open("/run/open-inspect-params.json") as handle:
     parameters = json.load(handle)
 
 lines = []
+placeholders = []
 for name, value in parameters:
     key = name[len(prefix):] if name.startswith(prefix) else name.rsplit("/", 1)[-1]
-    # `.env` is one assignment per line and Compose does not unescape it, so a
-    # value with a newline in it would silently truncate and take the rest of
-    # the file with it. The one multi-line value here, the GitHub App private
-    # key, is stored with the two characters \n in place of each newline.
+
+    # A parameter still holding its placeholder is dropped rather than written.
+    # Absence is the safe state everywhere it matters: the host refuses to start
+    # when a key it requires is missing, and an unset SERVICE_AUTH_SECRET_* is a
+    # 500 "not configured" rather than a signature that verifies. Writing the
+    # placeholder through would hand the deployment a working signing key whose
+    # value is published in this repository.
+    if value.startswith("CHANGE_ME_"):
+        placeholders.append(key)
+        continue
+
+    # `.env` is one assignment per line, so a value with a newline in it would
+    # truncate and take the rest of the file with it. The one multi-line value
+    # here, the GitHub App private key, is stored with the two characters \n in
+    # place of each newline.
     if "\n" in value or "\r" in value:
         sys.exit(f"{key}: SSM value spans multiple lines; store it on one")
-    lines.append(f"{key}={value}")
+
+    # Compose reads this file twice -- to interpolate the compose files, and as
+    # the app's env_file -- and both readers expand $VAR and strip a trailing
+    # # comment from an unquoted value, so `pa$word` reaches the container as
+    # `pa`. Single quotes are literal, including the \n above; a single-quoted
+    # value is the one thing that cannot contain its own quote.
+    if "'" in value:
+        sys.exit(f"{key}: value contains a single quote, which .env cannot quote")
+
+    lines.append(f"{key}='{value}'")
+
+if placeholders:
+    # Loud, because the symptom otherwise turns up later and somewhere else.
+    sys.stderr.write(
+        "open-inspect: these parameters still hold their placeholder and were "
+        "left unset: " + ", ".join(sorted(placeholders)) + "\n"
+    )
 
 with open("/opt/open-inspect/.env.new", "w") as handle:
     handle.write("\n".join(sorted(lines)) + "\n")
@@ -130,8 +191,20 @@ rm -f /run/open-inspect-params.json
 chmod 600 "$STACK_DIR/.env.new"
 mv "$STACK_DIR/.env.new" "$STACK_DIR/.env"
 
-aws ecr get-login-password --region "$AWS_REGION" |
-  docker login --username AWS --password-stdin "$${CONTROL_PLANE_IMAGE%%/*}"
+# The image comes from the .env just written, not from a value baked in at boot,
+# so changing the tag takes effect on a restart.
+image="$(sed -n "s/^CONTROL_PLANE_IMAGE='\\(.*\\)'$/\\1/p" "$STACK_DIR/.env")"
+[ -n "$image" ] || { echo "CONTROL_PLANE_IMAGE is not in .env" >&2; exit 1; }
+registry="$${image%%/*}"
+case "$registry" in
+  *.dkr.ecr.*.amazonaws.com)
+    aws ecr get-login-password --region "$AWS_REGION" |
+      docker login --username AWS --password-stdin "$registry"
+    ;;
+  *)
+    : # a public or already-authenticated registry; nothing to log in to
+    ;;
+esac
 SCRIPT
 chmod 755 /usr/local/bin/open-inspect-fetch-config
 
@@ -139,7 +212,6 @@ cat >/etc/open-inspect.conf <<CONF
 AWS_REGION=${region}
 CONFIG_BUCKET=${config_bucket}
 SSM_ENV_PREFIX=${ssm_env_prefix}
-CONTROL_PLANE_IMAGE=${control_plane_image}
 CONF
 
 # ---------------------------------------------------------------------------
@@ -152,6 +224,7 @@ Description=Open-Inspect control plane
 Requires=docker.service
 After=docker.service network-online.target
 Wants=network-online.target
+RequiresMountsFor=/data
 
 [Service]
 Type=oneshot
@@ -172,4 +245,10 @@ WantedBy=multi-user.target
 UNIT
 
 systemctl daemon-reload
-systemctl enable --now open-inspect.service
+systemctl enable open-inspect.service
+# Not `--now`: on a first boot CI has usually not pushed an image yet, so the
+# pull fails and a non-zero exit here would have cloud-init report an otherwise
+# healthy bootstrap as failed. The start is attempted, and its own status is
+# where a real failure shows up.
+systemctl start open-inspect.service ||
+  echo "open-inspect did not start yet; check 'systemctl status open-inspect' (expected before the first image push)"

--- a/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
+++ b/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Bootstrap for the Open-Inspect control plane on Amazon Linux 2023 (arm64).
+#
+# This runs once, at first boot. It puts the data volume under Docker, installs
+# the unit that runs the stack, and starts it. Everything that changes between
+# deploys -- the compose files, `.env`, the image tag -- is fetched by the
+# unit's ExecStartPre, so a deploy is `terraform apply` plus a restart and
+# never a new instance.
+set -euxo pipefail
+
+STACK_DIR=/opt/open-inspect
+DATA_DIR=/data
+# Addressed by volume id rather than by the /dev/sdf the attachment asks for:
+# on Nitro instances the kernel names EBS volumes /dev/nvme*n1 in attach order,
+# which is not stable across reboots.
+DEVICE="/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${data_volume_id_nodash}"
+
+# AL2023 ships the CLI and the SSM agent; installing them is a no-op there and
+# the fallback covers an image that does not. The Compose plugin is the one
+# piece not reliably in the repositories, so a missing package is not fatal --
+# the release binary is.
+dnf install -y docker
+command -v aws >/dev/null 2>&1 || dnf install -y awscli-2
+systemctl list-unit-files amazon-ssm-agent.service >/dev/null 2>&1 ||
+  dnf install -y amazon-ssm-agent
+
+if ! dnf install -y docker-compose-plugin; then
+  install -d /usr/libexec/docker/cli-plugins
+  curl -fsSL -o /usr/libexec/docker/cli-plugins/docker-compose \
+    "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-aarch64"
+  chmod 755 /usr/libexec/docker/cli-plugins/docker-compose
+fi
+
+# ---------------------------------------------------------------------------
+# The data volume, before Docker so its data root lands on it
+# ---------------------------------------------------------------------------
+
+for _ in $(seq 1 60); do
+  [ -e "$DEVICE" ] && break
+  sleep 2
+done
+[ -e "$DEVICE" ] || { echo "data volume never appeared at $DEVICE" >&2; exit 1; }
+
+# An unformatted volume has no type; a restored one does, and must not be
+# reformatted. `blkid` is the difference between a first boot and a restore.
+if ! blkid "$DEVICE" >/dev/null 2>&1; then
+  mkfs.ext4 -L open-inspect "$DEVICE"
+fi
+
+mkdir -p "$DATA_DIR"
+grep -q "^LABEL=open-inspect " /etc/fstab ||
+  echo "LABEL=open-inspect $DATA_DIR ext4 defaults,nofail 0 2" >>/etc/fstab
+mount -a
+[ -d "$DATA_DIR" ] && mountpoint -q "$DATA_DIR"
+
+# ---------------------------------------------------------------------------
+# Docker
+# ---------------------------------------------------------------------------
+# The data root moves onto the volume, so images and every named volume the
+# compose stack declares are on the thing that gets snapshotted -- which is
+# what makes "the data volume is the unit of a deployment backup" true.
+#
+# Container logs go straight to CloudWatch. `docker compose logs` therefore
+# shows nothing on this host; `aws logs tail` is the equivalent, and it keeps
+# working after the instance is replaced.
+
+mkdir -p "$DATA_DIR/docker" /etc/docker
+cat >/etc/docker/daemon.json <<JSON
+{
+  "data-root": "$DATA_DIR/docker",
+  "log-driver": "awslogs",
+  "log-opts": {
+    "awslogs-region": "${region}",
+    "awslogs-group": "${log_group}",
+    "awslogs-create-group": "false"
+  }
+}
+JSON
+
+systemctl enable --now docker
+systemctl enable --now amazon-ssm-agent
+
+# ---------------------------------------------------------------------------
+# Fetching what the stack is made of
+# ---------------------------------------------------------------------------
+
+mkdir -p "$STACK_DIR"
+
+cat >/usr/local/bin/open-inspect-fetch-config <<'SCRIPT'
+#!/bin/bash
+# Pulls the stack files from S3 and rebuilds `.env` from SSM. Run before every
+# start, so a configuration change takes effect on restart.
+set -euo pipefail
+
+STACK_DIR=/opt/open-inspect
+source /etc/open-inspect.conf
+
+aws s3 sync "s3://$CONFIG_BUCKET/stack/" "$STACK_DIR/" --region "$AWS_REGION" --exact-timestamps
+
+umask 077
+aws ssm get-parameters-by-path \
+  --path "$SSM_ENV_PREFIX" \
+  --recursive --with-decryption \
+  --region "$AWS_REGION" \
+  --query 'Parameters[].[Name,Value]' --output json >/run/open-inspect-params.json
+
+SSM_ENV_PREFIX="$SSM_ENV_PREFIX" python3 - <<'PY'
+import json, os, sys
+
+prefix = os.environ["SSM_ENV_PREFIX"].rstrip("/") + "/"
+with open("/run/open-inspect-params.json") as handle:
+    parameters = json.load(handle)
+
+lines = []
+for name, value in parameters:
+    key = name[len(prefix):] if name.startswith(prefix) else name.rsplit("/", 1)[-1]
+    # `.env` is one assignment per line and Compose does not unescape it, so a
+    # value with a newline in it would silently truncate and take the rest of
+    # the file with it. The one multi-line value here, the GitHub App private
+    # key, is stored with the two characters \n in place of each newline.
+    if "\n" in value or "\r" in value:
+        sys.exit(f"{key}: SSM value spans multiple lines; store it on one")
+    lines.append(f"{key}={value}")
+
+with open("/opt/open-inspect/.env.new", "w") as handle:
+    handle.write("\n".join(sorted(lines)) + "\n")
+PY
+
+rm -f /run/open-inspect-params.json
+chmod 600 "$STACK_DIR/.env.new"
+mv "$STACK_DIR/.env.new" "$STACK_DIR/.env"
+
+aws ecr get-login-password --region "$AWS_REGION" |
+  docker login --username AWS --password-stdin "$${CONTROL_PLANE_IMAGE%%/*}"
+SCRIPT
+chmod 755 /usr/local/bin/open-inspect-fetch-config
+
+cat >/etc/open-inspect.conf <<CONF
+AWS_REGION=${region}
+CONFIG_BUCKET=${config_bucket}
+SSM_ENV_PREFIX=${ssm_env_prefix}
+CONTROL_PLANE_IMAGE=${control_plane_image}
+CONF
+
+# ---------------------------------------------------------------------------
+# The unit
+# ---------------------------------------------------------------------------
+
+cat >/etc/systemd/system/open-inspect.service <<'UNIT'
+[Unit]
+Description=Open-Inspect control plane
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/open-inspect
+EnvironmentFile=/etc/open-inspect.conf
+ExecStartPre=/usr/local/bin/open-inspect-fetch-config
+ExecStartPre=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.aws.yml pull
+ExecStart=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.aws.yml up -d --wait
+ExecStop=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.aws.yml down
+# Longer than the app's 40s stop grace period, so an instance stop drains the
+# host the way a deploy does rather than pulling the power on SQLite.
+TimeoutStopSec=180
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now open-inspect.service

--- a/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
+++ b/terraform/modules/aws-control-plane/templates/user-data.sh.tftpl
@@ -239,6 +239,13 @@ ExecStop=/usr/bin/docker compose -f docker-compose.yml -f docker-compose.aws.yml
 # host the way a deploy does rather than pulling the power on SQLite.
 TimeoutStopSec=180
 TimeoutStartSec=600
+# A start drains the old stack before it fetches the new one, and the fetch
+# reaches S3, SSM and ECR -- so a transient failure there takes the deployment
+# down and, without this, leaves it down until someone notices. Retrying the
+# whole start recovers on its own once the dependency comes back. Making the
+# staging and activation atomic instead is COL-138.
+Restart=on-failure
+RestartSec=30s
 
 [Install]
 WantedBy=multi-user.target

--- a/terraform/modules/aws-control-plane/variables.tf
+++ b/terraform/modules/aws-control-plane/variables.tf
@@ -1,0 +1,206 @@
+# =============================================================================
+# Open-Inspect - AWS control plane
+# =============================================================================
+# One EC2 instance running the compose stack from docker-compose.yml plus the
+# docker-compose.aws.yml overlay, with a persistent EBS volume for its data,
+# S3 for media and backups, and Caddy terminating TLS on the instance itself.
+#
+# Nothing here depends on Cloudflare. DNS is the operator's: the module
+# publishes an Elastic IP and a hostname and, unless given a Route 53 zone,
+# creates no records at all.
+
+variable "name" {
+  description = "Prefix for every resource this module creates, e.g. \"open-inspect-staging\". Also the SSM parameter path segment."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$", var.name))
+    error_message = "name must be 3-40 lowercase alphanumeric or hyphen characters and may not start or end with a hyphen."
+  }
+}
+
+variable "hostname" {
+  description = "Public FQDN this control plane answers on. Caddy obtains a Let's Encrypt certificate for it over ACME HTTP-01, so it must resolve to the module's Elastic IP before the stack is expected to serve HTTPS."
+  type        = string
+}
+
+# ---------------------------------------------------------------------------
+# Instance
+# ---------------------------------------------------------------------------
+
+variable "instance_type" {
+  description = "EC2 instance type. Graviton (t4g.*) only: the control-plane image is built for arm64."
+  type        = string
+  default     = "t4g.small"
+
+  validation {
+    condition     = startswith(var.instance_type, "t4g.") || startswith(var.instance_type, "m7g.") || startswith(var.instance_type, "c7g.")
+    error_message = "instance_type must be a Graviton (arm64) type: the control-plane image has no amd64 build."
+  }
+}
+
+variable "control_plane_image" {
+  description = "Image the instance runs, including its tag. Defaults to the module's own ECR repository at the tag in control_plane_image_tag."
+  type        = string
+  default     = null
+}
+
+variable "control_plane_image_tag" {
+  description = "Tag in the module's ECR repository to run, when control_plane_image is not set."
+  type        = string
+  default     = "latest"
+}
+
+variable "ssh_key_name" {
+  description = "EC2 key pair to attach, for the rare case a console session is needed. Shell access is over SSM Session Manager, and the security group admits no inbound SSH either way."
+  type        = string
+  default     = null
+}
+
+# ---------------------------------------------------------------------------
+# Network
+# ---------------------------------------------------------------------------
+
+variable "vpc_cidr" {
+  description = "CIDR for the VPC this module creates."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "CIDR for the single public subnet the instance sits in. There is no private subnet and no NAT gateway: a NAT gateway costs more per month than everything else here together, and the instance reaches AWS over its public address."
+  type        = string
+  default     = "10.20.1.0/24"
+}
+
+variable "availability_zone" {
+  description = "AZ for the subnet and the data volume. Null picks the region's first. The volume and the instance must share it, so changing this after the volume holds data means a snapshot restore."
+  type        = string
+  default     = null
+}
+
+variable "ingress_cidrs" {
+  description = "Who may reach ports 80 and 443. Port 80 must stay open to the internet for the ACME HTTP-01 challenge; narrowing this list will stop certificate issuance and renewal."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+# ---------------------------------------------------------------------------
+# Data volume
+# ---------------------------------------------------------------------------
+
+variable "data_volume_size_gb" {
+  description = "Size of the EBS data volume. It holds Docker's data root, so it carries the images and every named volume as well as the databases."
+  type        = number
+  default     = 50
+}
+
+variable "data_volume_snapshot_id" {
+  description = "Snapshot to create the data volume from, for a restore. Null creates an empty volume."
+  type        = string
+  default     = null
+}
+
+variable "snapshot_retention_count" {
+  description = "Daily data-volume snapshots kept by Data Lifecycle Manager."
+  type        = number
+  default     = 14
+}
+
+variable "snapshot_schedule_utc" {
+  description = "Time of day the daily snapshot runs, HH:MM in UTC."
+  type        = string
+  default     = "07:00"
+}
+
+# ---------------------------------------------------------------------------
+# Storage and configuration
+# ---------------------------------------------------------------------------
+
+variable "config" {
+  description = "Non-secret `.env` entries Terraform owns, written to SSM as String parameters. Merged over the values the module derives from its own resources, so an entry here wins. Empty values are dropped: the host reads a missing variable and an empty one the same way."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_names" {
+  description = "`.env` keys held as SecureString parameters. The module creates each one with a placeholder and then ignores its value, so the inventory is Terraform's and the values are not: set them with `aws ssm put-parameter --overwrite`. A key still holding its placeholder fails at boot rather than silently."
+  type        = set(string)
+  default = [
+    "ANTHROPIC_API_KEY",
+    "BROWSER_AUTH_SECRET",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_CLIENT_ID",
+    "GITHUB_CLIENT_SECRET",
+    "IMAGE_CALLBACK_TOKEN_PEPPER",
+    "PROVIDER_ACCOUNTS_ENCRYPTION_KEY",
+    "REPO_SECRETS_ENCRYPTION_KEY",
+    "SERVICE_AUTH_SECRET_GITHUB_BOT",
+    "SERVICE_AUTH_SECRET_LINEAR_BOT",
+    "SERVICE_AUTH_SECRET_SLACK_BOT",
+    "SERVICE_AUTH_SECRET_WEB",
+    "TOKEN_ENCRYPTION_KEY",
+  ]
+}
+
+variable "force_destroy_buckets" {
+  description = "Allow `terraform destroy` to empty the media and backup buckets. False keeps a destroy from taking the backups with it."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
+# Observability and schedules
+# ---------------------------------------------------------------------------
+
+variable "log_retention_days" {
+  description = "Retention on the CloudWatch log group the containers write to."
+  type        = number
+  default     = 30
+}
+
+variable "alarm_topic_arn" {
+  description = "SNS topic the instance status-check alarms notify. Null creates the alarms with no action, so they are visible in the console but page no one."
+  type        = string
+  default     = null
+}
+
+variable "out_of_hours_stop" {
+  description = "Cron expressions stopping and starting the instance on a schedule, in the timezone below. Null leaves it running. Staging is the case for this; the stop is a clean ACPI shutdown, so the stack drains the way it does on a deploy."
+  type = object({
+    stop_cron  = string
+    start_cron = string
+    timezone   = optional(string, "UTC")
+  })
+  default = null
+}
+
+# ---------------------------------------------------------------------------
+# DNS (optional; the module creates no records without a zone)
+# ---------------------------------------------------------------------------
+
+variable "route53_zone_id" {
+  description = "Route 53 hosted zone to create an A record for `hostname` in. Null means the operator points their own DNS at the Elastic IP; the module needs no DNS provider and no credential for one."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to every resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "repository_root" {
+  description = "Checkout the stack files are uploaded from. The default reaches the repository root from the module's own directory; moving this module means changing it."
+  type        = string
+  default     = null
+}
+
+variable "compose_plugin_version" {
+  description = "Docker Compose plugin release the instance falls back to when the distribution has no package for it. Needs to be at least 2.24, where the `!reset` and `!override` tags docker-compose.aws.yml uses were introduced."
+  type        = string
+  default     = "2.31.0"
+}

--- a/terraform/modules/aws-control-plane/variables.tf
+++ b/terraform/modules/aws-control-plane/variables.tf
@@ -29,14 +29,10 @@ variable "hostname" {
 # ---------------------------------------------------------------------------
 
 variable "instance_type" {
-  description = "EC2 instance type. Graviton (t4g.*) only: the control-plane image is built for arm64."
+  description = "EC2 instance type. Must be arm64 (Graviton): the control-plane image has no amd64 build. Checked against the instance type's advertised architectures rather than its family name, so newer Graviton generations need no change here."
   type        = string
   default     = "t4g.small"
 
-  validation {
-    condition     = startswith(var.instance_type, "t4g.") || startswith(var.instance_type, "m7g.") || startswith(var.instance_type, "c7g.")
-    error_message = "instance_type must be a Graviton (arm64) type: the control-plane image has no amd64 build."
-  }
 }
 
 variable "control_plane_image" {
@@ -124,25 +120,9 @@ variable "config" {
 }
 
 variable "secret_names" {
-  description = "`.env` keys held as SecureString parameters. The module creates each one with a placeholder and then ignores its value, so the inventory is Terraform's and the values are not: set them with `aws ssm put-parameter --overwrite`. A key still holding its placeholder fails at boot rather than silently."
+  description = "`.env` keys held as SecureString parameters, replacing the module's default inventory rather than adding to it. Null uses the default. The module creates each name with a placeholder and never reads the value back, so the inventory is Terraform's and the values are the operator's -- which also means removing a name here deletes that parameter and the operator's secret with it."
   type        = set(string)
-  default = [
-    "ANTHROPIC_API_KEY",
-    "BROWSER_AUTH_SECRET",
-    "GITHUB_APP_ID",
-    "GITHUB_APP_INSTALLATION_ID",
-    "GITHUB_APP_PRIVATE_KEY",
-    "GITHUB_CLIENT_ID",
-    "GITHUB_CLIENT_SECRET",
-    "IMAGE_CALLBACK_TOKEN_PEPPER",
-    "PROVIDER_ACCOUNTS_ENCRYPTION_KEY",
-    "REPO_SECRETS_ENCRYPTION_KEY",
-    "SERVICE_AUTH_SECRET_GITHUB_BOT",
-    "SERVICE_AUTH_SECRET_LINEAR_BOT",
-    "SERVICE_AUTH_SECRET_SLACK_BOT",
-    "SERVICE_AUTH_SECRET_WEB",
-    "TOKEN_ENCRYPTION_KEY",
-  ]
+  default     = null
 }
 
 variable "force_destroy_storage" {
@@ -200,7 +180,13 @@ variable "repository_root" {
 }
 
 variable "compose_plugin_version" {
-  description = "Docker Compose plugin release the instance falls back to when the distribution has no package for it. Needs to be at least 2.24, where the `!reset` and `!override` tags docker-compose.aws.yml uses were introduced."
+  description = "Docker Compose plugin release the instance installs. Amazon Linux 2023 packages no Compose v2 plugin, so this is the only source. Needs to be at least 2.24, where the `!reset` and `!override` tags docker-compose.aws.yml uses were introduced."
   type        = string
   default     = "2.31.0"
+}
+
+variable "compose_plugin_sha256" {
+  description = "Expected sha256 of the linux/aarch64 Compose plugin for compose_plugin_version. Checked on the instance before the binary is made executable; change both together."
+  type        = string
+  default     = "a1f85584584d0c3c489f31f015c97eb543f1f0949fdc5ce3ded88c05a5188729"
 }

--- a/terraform/modules/aws-control-plane/variables.tf
+++ b/terraform/modules/aws-control-plane/variables.tf
@@ -145,8 +145,8 @@ variable "secret_names" {
   ]
 }
 
-variable "force_destroy_buckets" {
-  description = "Allow `terraform destroy` to empty the media and backup buckets. False keeps a destroy from taking the backups with it."
+variable "force_destroy_storage" {
+  description = "Allow `terraform destroy` to empty the media and backup buckets and the image registry. False keeps a destroy from taking the backups with it -- and also makes a destroy fail outright once CI has pushed an image, which is the right answer for production and the wrong one for an environment meant to be torn down and stood back up."
   type        = bool
   default     = false
 }

--- a/terraform/modules/aws-control-plane/versions.tf
+++ b/terraform/modules/aws-control-plane/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
Stands the control plane up on AWS with **no Cloudflare account involved at any point** — no provider, no credential, no Cloudflare-specific header. One EC2 instance running the same compose stack the smoke boots in CI, a persistent EBS volume under it, S3 for media and backups, and Caddy terminating TLS on the instance with a Let's Encrypt certificate.

Closes the build for COL-111 (I-2). `terraform/environments/aws-staging` and `aws-production` are the two consumers of one small module.

## What's here

| | |
| --- | --- |
| `terraform/modules/aws-control-plane/` | VPC + one public subnet, Graviton instance with IMDSv2, gp3 data volume + DLM snapshots, S3 media/backups, ECR, SSM config, CloudWatch logs, Elastic IP, optional Route 53 |
| `terraform/environments/aws-{staging,production}/` | The module at two sizes, on an S3 backend |
| `docker-compose.aws.yml` | The overlay the instance runs |
| `docs/AWS_BRING_UP.md` | Empty account to `/healthz` over HTTPS |

## Three choices worth a look in review

**The compose overlay, not a second stack.** `docker-compose.aws.yml` changes three things and nothing else, so the instance runs what the smoke covers: the app runs an ECR image rather than a build (the instance has no checkout), MinIO does not run (S3 is the object store and Litestream's target), and Caddy leaves the `tls` profile because TLS is not optional on a public address.

One wrinkle worth knowing about: `.env` still has to carry `MINIO_ROOT_PASSWORD`. Compose interpolates the base file *before* it applies an overlay, so that `:?` guard fires whether or not MinIO ends up among the running services. The module gives it an unused value and says so.

**No load balancer, no NAT gateway.** An ALB is ~$25/month before traffic and forces two subnets in two AZs a single instance does not need. A NAT gateway is ~$33/month before egress — more than everything else in the module put together. Caddy does the ALB's job, and the ACME HTTP-01 challenge is why port 80 stays open to the internet. The ALB is still worth revisiting for connection draining and a WAF attach point, as a later AWS-flavoured variation rather than a v1 requirement.

**S3 for state, not the R2 the Cloudflare environment uses.** A deployment whose entire premise is needing no Cloudflare account should not keep its Terraform state on Cloudflare. S3-native locking, so there's no DynamoDB table to create or pay for.

## Things that are deliberate and look like omissions

- **The instance ignores changes to `ami` and `user_data`.** AWS moves the AL2023 image whenever it publishes one, and replacing this instance drops every in-flight session. Rolling it is `terraform apply -replace=...`, documented in the runbook.
- **The data volume carries `prevent_destroy`.** `terraform destroy` fails rather than taking the databases with it; releasing it is a deliberate `terraform state rm`.
- **Secrets are placeholders Terraform then ignores.** It creates one SecureString per key holding `CHANGE_ME_<KEY>` and never looks at the value again — so it owns the inventory and not the secrets, and a key that never got set fails a boot instead of passing silently.
- **The AMI comes from `DescribeImages`, not the `/aws/service/ami-al2023` SSM parameter.** Plenty of accounts deny their operators the `/aws/` namespace; this account is one of them, which is how I found out.
- **Alarms stop at the instance's two status checks.** Disk and memory need the CloudWatch agent, and the alarms that describe the control plane itself need metrics the host does not publish. Both are H-8.

## Verification

**Applied for real, end to end, and torn back down.** A staging environment on a live AWS account:

- `terraform apply` from zero → **74 resources** (73 plus the optional Route 53 record), then `curl https://<hostname>/healthz` → **200**, `ssl_verify_result=0`, on a genuine Let's Encrypt certificate issued for that name. Port 80 → **308** to HTTPS. **No Cloudflare account touched at any point** — the test zone was in Route 53, so even DNS stayed AWS-native.
- The host came up properly: **73 migrations applied**, `node_host.listening`, and Litestream wrote its first generation to the S3 backups bucket (`generations/…/snapshots/00000000.snapshot.lz4`).
- **Restore rehearsed.** A marker written to the data volume, snapshotted, the volume destroyed, then applied again from the snapshot: the marker came back intact and the filesystem was not reformatted — user data's `blkid` guard reads a restored volume as a restore rather than a first boot.
- **Teardown behaves as documented.** `prevent_destroy` refuses to take the volume; after the runbook's `terraform state rm` the destroy completes and the volume is left `available`. Verified zero residue afterwards across EC2, EBS, snapshots, VPC, S3, ECR, SSM, IAM, CloudWatch and Route 53.
- Arm64 confirmed: the image built and ran as `arm64 linux` with no Dockerfile change.

Also green: `terraform fmt -check -recursive`, `validate` on both roots, `docker compose config` on the base file and the overlay, and `env-example.test.ts`.

## What the real boot found that a plan could not

Six defects, all fixed in this branch except the first:

1. **The image cannot verify TLS** — `node:22-slim` ships no CA bundle and the Dockerfile copies Litestream's binary without it, so Litestream fails against real S3. Pre-existing and independent of this PR, so it is **#1798**, which this depends on.
2. **The instance could not read its own configuration.** `ssm:GetParametersByPath` authorizes against the path as well as its children, so a grant on `<prefix>/*` alone is denied and `.env` came out empty.
3. **Nothing supplied `GITHUB_BOT_USERNAME`**, one of the five keys the host requires before it listens — the same gap COL-134 closed in `.env.example`, reintroduced here.
4. **IMDSv2 hop limit 1 cut every container off from the instance role.** Containers sit one hop further out on Docker's bridge network; the failure reads as a missing credential rather than an unreachable one.
5. **`terraform destroy` failed once an image had been pushed** — ECR had no `force_delete`, though `force_destroy_buckets` had already made that decision for the buckets. Renamed `force_destroy_storage` and covers both.
6. **The runbook told operators to set `data_volume_snapshot_id`** and neither environment exposed it.

Two more were caught earlier by `terraform plan`: a `for_each` whose keys were unknown because it filtered a map holding computed bucket ids, and an AMI lookup through the `/aws/service` SSM namespace that plenty of accounts deny their operators.

Refs COL-111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AWS staging and production deployment support with EC2, S3, ECR, SSM, CloudWatch, optional Route 53, encrypted storage, and configurable secrets.
  - Added an AWS Compose configuration using Caddy and Litestream with S3-backed object storage.
  - Added scheduled instance start/stop options, backup snapshots, restore support, and storage deletion safeguards.

- **Documentation**
  - Added AWS deployment, configuration, secrets, backup, and recovery guidance.

- **Tests**
  - Added automated validation for AWS Terraform environments, startup configuration, and the AWS Compose stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->