### PR TITLE
fix(control-plane): give the image a CA bundle so Litestream can reach real S3

### DIFF
--- a/packages/control-plane/Dockerfile
+++ b/packages/control-plane/Dockerfile
@@ -34,12 +34,24 @@ ENV NODE_ENV=production \
 # The bundle and the migrations sit where they sit in the repository, so the
 # host's default migrations path resolves without MIGRATIONS_DIR being set.
 WORKDIR /app
+# node:22-slim carries no CA bundle, and Node does not need one: it verifies
+# against the roots compiled into it. Litestream is a Go binary and uses the
+# system store, so without this it cannot verify any TLS endpoint -- which
+# means the restore-on-empty-volume path fails against real S3 and works only
+# against a plain-http MinIO, the one case the compose stack and the smoke
+# cover.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream
 COPY --from=build /app/packages/control-plane/dist/node/main.js packages/control-plane/dist/node/main.js
 COPY terraform/d1/migrations/ terraform/d1/migrations/
 COPY --chmod=755 packages/control-plane/docker/entrypoint.sh /app/entrypoint.sh
 COPY packages/control-plane/docker/litestream.yml /etc/litestream.yml
 RUN mkdir -p /data && chown node:node /data && chmod 700 /data
+# The failure this guards against is silent until a deployment points
+# Litestream at an https endpoint, so it is caught here instead.
+RUN test -f /etc/ssl/certs/ca-certificates.crt
 USER node
 VOLUME ["/data"]
 EXPOSE 8787

--- a/packages/control-plane/Dockerfile
+++ b/packages/control-plane/Dockerfile
@@ -26,6 +26,14 @@ RUN npm run build -w @open-inspect/shared \
 
 FROM litestream/litestream:0.3.13 AS litestream
 
+# Debian's trust store, built here so the runtime image gets the bundle without
+# the toolchain that generates it: ca-certificates pulls in openssl and libssl3,
+# which nothing at runtime uses.
+FROM node:22-slim AS certs
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 FROM node:22-slim
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
@@ -39,19 +47,15 @@ WORKDIR /app
 # system store, so without this it cannot verify any TLS endpoint -- which
 # means the restore-on-empty-volume path fails against real S3 and works only
 # against a plain-http MinIO, the one case the compose stack and the smoke
-# cover.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# cover. Taken from the stage above rather than from the litestream image,
+# whose own bundle is frozen at that pinned tag.
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream
 COPY --from=build /app/packages/control-plane/dist/node/main.js packages/control-plane/dist/node/main.js
 COPY terraform/d1/migrations/ terraform/d1/migrations/
 COPY --chmod=755 packages/control-plane/docker/entrypoint.sh /app/entrypoint.sh
 COPY packages/control-plane/docker/litestream.yml /etc/litestream.yml
 RUN mkdir -p /data && chown node:node /data && chmod 700 /data
-# The failure this guards against is silent until a deployment points
-# Litestream at an https endpoint, so it is caught here instead.
-RUN test -f /etc/ssl/certs/ca-certificates.crt
 USER node
 VOLUME ["/data"]
 EXPOSE 8787


### PR DESCRIPTION
The container image cannot verify TLS, so Litestream fails against real S3.

`node:22-slim` ships no CA certificates. The image copies Litestream's binary out of `litestream/litestream` but not the bundle sitting beside it in that image. Node is fine — it verifies against roots compiled into it — but Litestream is a Go binary and uses the system store:

```
cannot fetch generations: cannot lookup bucket region: RequestError: send request failed
caused by: Get "https://s3.amazonaws.com/<bucket>?location=":
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The entrypoint's restore-on-empty-volume then fails and the container crash-loops. This happens on exactly the configuration `.env.example` documents for AWS — an empty `LITESTREAM_ENDPOINT`, which means real S3 over https.

## Why nothing caught it

Both places this image gets exercised point Litestream at a plain-http MinIO: the compose stack (`LITESTREAM_ENDPOINT=http://minio:9000`) and `scripts/compose-smoke.sh`, which writes the same. The TLS path has never run in CI, and no unit test can see it.

So the build now asserts the bundle is there:

```dockerfile
RUN test -f /etc/ssl/certs/ca-certificates.crt
```

A missing file is cheap to check at build time, and the alternative is learning about it from a crash-looping container in a deployment.

## How it was found

Bringing the control plane up on EC2 for the first time (COL-111). It is the difference between a stack that boots and one that does not; with this fix the same image applied 73 migrations, came up healthy, and Litestream wrote its first generation to S3.

Verified on an arm64 build: before, `/etc/ssl/certs/ca-certificates.crt` is absent and `/usr/share/ca-certificates` does not exist; after, Litestream replicates to a real bucket.

Blocks #1797.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Container images now include the required CA certificate bundle, improving reliable validation of secure HTTPS connections.
  - Updated certificate handling ensures the runtime image receives the certificate bundle consistently during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->