### PR TITLE
ci: support Actions variables for non-secret deployment config

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_TEAM_ID || secrets.VERCEL_TEAM_ID }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID || secrets.VERCEL_PROJECT_ID }}
 
 jobs:
   deploy:
@@ -26,11 +26,11 @@ jobs:
         id: check-secrets
         run: |
           # Skip if web_platform is set to something other than vercel
-          WEB_PLATFORM="${{ secrets.WEB_PLATFORM }}"
+          WEB_PLATFORM="${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM }}"
           if [ -n "$WEB_PLATFORM" ] && [ "$WEB_PLATFORM" != "vercel" ]; then
             echo "Skipping Vercel deployment - web_platform is '${WEB_PLATFORM}'"
             echo "configured=false" >> $GITHUB_OUTPUT
-          elif [ -z "${{ secrets.VERCEL_API_TOKEN }}" ] || [ -z "${{ secrets.VERCEL_PROJECT_ID }}" ]; then
+          elif [ -z "${{ secrets.VERCEL_API_TOKEN }}" ] || [ -z "${{ vars.VERCEL_PROJECT_ID || secrets.VERCEL_PROJECT_ID }}" ]; then
             echo "Skipping deployment - Vercel secrets not configured"
             echo "configured=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -24,13 +24,15 @@ jobs:
     steps:
       - name: Check if secrets are configured
         id: check-secrets
+        env:
+          WEB_PLATFORM: ${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM }}
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
         run: |
           # Skip if web_platform is set to something other than vercel
-          WEB_PLATFORM="${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM }}"
           if [ -n "$WEB_PLATFORM" ] && [ "$WEB_PLATFORM" != "vercel" ]; then
             echo "Skipping Vercel deployment - web_platform is '${WEB_PLATFORM}'"
             echo "configured=false" >> $GITHUB_OUTPUT
-          elif [ -z "${{ secrets.VERCEL_API_TOKEN }}" ] || [ -z "${{ vars.VERCEL_PROJECT_ID || secrets.VERCEL_PROJECT_ID }}" ]; then
+          elif [ -z "$VERCEL_API_TOKEN" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
             echo "Skipping deployment - Vercel secrets not configured"
             echo "configured=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -203,11 +203,13 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           terraform init \
             -backend-config="access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
             -backend-config="secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
-            -backend-config='endpoints={s3="https://${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
+            -backend-config="endpoints={s3=\"https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com\"}"
         working-directory: ${{ env.TF_WORKING_DIR }}
 
       - name: Stage SchedulerDO deletion migration
@@ -382,11 +384,13 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           terraform init \
             -backend-config="access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
             -backend-config="secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
-            -backend-config='endpoints={s3="https://${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
+            -backend-config="endpoints={s3=\"https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com\"}"
         working-directory: ${{ env.TF_WORKING_DIR }}
 
       - name: Stage SchedulerDO deletion migration

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -207,7 +207,7 @@ jobs:
           terraform init \
             -backend-config="access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
             -backend-config="secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
-            -backend-config='endpoints={s3="https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
+            -backend-config='endpoints={s3="https://${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
         working-directory: ${{ env.TF_WORKING_DIR }}
 
       - name: Stage SchedulerDO deletion migration
@@ -235,23 +235,23 @@ jobs:
         continue-on-error: true
         env:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          TF_VAR_cloudflare_worker_subdomain: ${{ secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
+          TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TF_VAR_cloudflare_worker_subdomain: ${{ vars.CLOUDFLARE_WORKER_SUBDOMAIN || secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
           TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || '000000000000000000000000' }}"
-          TF_VAR_vercel_team_id: "${{ secrets.VERCEL_TEAM_ID || 'unused' }}"
+          TF_VAR_vercel_team_id: "${{ vars.VERCEL_TEAM_ID || secrets.VERCEL_TEAM_ID || 'unused' }}"
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
-          TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
-          TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
-          TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
-          TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          TF_VAR_modal_workspace: ${{ vars.MODAL_WORKSPACE || secrets.MODAL_WORKSPACE }}
+          TF_VAR_modal_environment: "${{ vars.MODAL_ENVIRONMENT || secrets.MODAL_ENVIRONMENT || 'main' }}"
+          TF_VAR_modal_environment_web_suffix: ${{ vars.MODAL_ENVIRONMENT_WEB_SUFFIX || secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
+          TF_VAR_github_client_id: ${{ vars.GH_OAUTH_CLIENT_ID || secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
-          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_id: ${{ vars.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID }}
           TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
+          TF_VAR_github_app_id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
-          TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
+          TF_VAR_github_app_installation_id: ${{ vars.GH_APP_INSTALLATION_ID || secrets.GH_APP_INSTALLATION_ID }}
+          TF_VAR_enable_slack_bot: "${{ vars.ENABLE_SLACK_BOT || secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -262,48 +262,48 @@ jobs:
           TF_VAR_provider_accounts_encryption_key: ${{ secrets.PROVIDER_ACCOUNTS_ENCRYPTION_KEY }}
           TF_VAR_nextauth_secret: ${{ secrets.NEXTAUTH_SECRET }}
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
-          TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
-          TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
-          TF_VAR_allowed_emails: ${{ secrets.ALLOWED_EMAILS }}
-          TF_VAR_allowed_github_orgs: ${{ secrets.ALLOWED_GITHUB_ORGS }}
-          TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
-          TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
+          TF_VAR_allowed_users: ${{ vars.ALLOWED_USERS || secrets.ALLOWED_USERS }}
+          TF_VAR_allowed_email_domains: ${{ vars.ALLOWED_EMAIL_DOMAINS || secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_allowed_emails: ${{ vars.ALLOWED_EMAILS || secrets.ALLOWED_EMAILS }}
+          TF_VAR_allowed_github_orgs: ${{ vars.ALLOWED_GITHUB_ORGS || secrets.ALLOWED_GITHUB_ORGS }}
+          TF_VAR_deployment_name: ${{ vars.DEPLOYMENT_NAME || secrets.DEPLOYMENT_NAME }}
+          TF_VAR_enable_github_bot: "${{ vars.ENABLE_GITHUB_BOT || secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
-          TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
-          TF_VAR_app_name: "${{ secrets.APP_NAME || 'Open-Inspect' }}"
-          TF_VAR_app_icon_url: ${{ secrets.APP_ICON_URL }}
-          TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
-          TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
+          TF_VAR_github_bot_username: ${{ vars.GH_BOT_USERNAME || secrets.GH_BOT_USERNAME }}
+          TF_VAR_app_name: "${{ vars.APP_NAME || secrets.APP_NAME || 'Open-Inspect' }}"
+          TF_VAR_app_icon_url: ${{ vars.APP_ICON_URL || secrets.APP_ICON_URL }}
+          TF_VAR_enable_linear_bot: "${{ vars.ENABLE_LINEAR_BOT || secrets.ENABLE_LINEAR_BOT || 'false' }}"
+          TF_VAR_linear_client_id: ${{ vars.LINEAR_CLIENT_ID || secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
-          TF_VAR_web_platform: "${{ secrets.WEB_PLATFORM || 'vercel' }}"
-          TF_VAR_enable_durable_object_bindings: "${{ secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
-          TF_VAR_sandbox_provider: "${{ secrets.SANDBOX_PROVIDER || 'modal' }}"
-          TF_VAR_daytona_api_url: ${{ secrets.DAYTONA_API_URL }}
+          TF_VAR_web_platform: "${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM || 'vercel' }}"
+          TF_VAR_enable_durable_object_bindings: "${{ vars.ENABLE_DURABLE_OBJECT_BINDINGS || secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
+          TF_VAR_sandbox_provider: "${{ vars.SANDBOX_PROVIDER || secrets.SANDBOX_PROVIDER || 'modal' }}"
+          TF_VAR_daytona_api_url: ${{ vars.DAYTONA_API_URL || secrets.DAYTONA_API_URL }}
           TF_VAR_daytona_api_key: ${{ secrets.DAYTONA_API_KEY }}
-          TF_VAR_daytona_base_snapshot: ${{ secrets.DAYTONA_BASE_SNAPSHOT }}
-          TF_VAR_daytona_target: ${{ secrets.DAYTONA_TARGET }}
+          TF_VAR_daytona_base_snapshot: ${{ vars.DAYTONA_BASE_SNAPSHOT || secrets.DAYTONA_BASE_SNAPSHOT }}
+          TF_VAR_daytona_target: ${{ vars.DAYTONA_TARGET || secrets.DAYTONA_TARGET }}
           TF_VAR_vercel_sandbox_token: ${{ secrets.VERCEL_SANDBOX_TOKEN }}
-          TF_VAR_vercel_sandbox_project_id: ${{ secrets.VERCEL_SANDBOX_PROJECT_ID }}
-          TF_VAR_vercel_sandbox_team_id: ${{ secrets.VERCEL_SANDBOX_TEAM_ID }}
-          TF_VAR_vercel_sandbox_api_base_url: ${{ secrets.VERCEL_SANDBOX_API_BASE_URL }}
-          TF_VAR_vercel_base_snapshot_id: ${{ secrets.VERCEL_BASE_SNAPSHOT_ID }}
-          TF_VAR_vercel_sandbox_runtime: "${{ secrets.VERCEL_SANDBOX_RUNTIME || 'node24' }}"
-          TF_VAR_vercel_snapshot_expiration_ms: "${{ secrets.VERCEL_SNAPSHOT_EXPIRATION_MS || '0' }}"
+          TF_VAR_vercel_sandbox_project_id: ${{ vars.VERCEL_SANDBOX_PROJECT_ID || secrets.VERCEL_SANDBOX_PROJECT_ID }}
+          TF_VAR_vercel_sandbox_team_id: ${{ vars.VERCEL_SANDBOX_TEAM_ID || secrets.VERCEL_SANDBOX_TEAM_ID }}
+          TF_VAR_vercel_sandbox_api_base_url: ${{ vars.VERCEL_SANDBOX_API_BASE_URL || secrets.VERCEL_SANDBOX_API_BASE_URL }}
+          TF_VAR_vercel_base_snapshot_id: ${{ vars.VERCEL_BASE_SNAPSHOT_ID || secrets.VERCEL_BASE_SNAPSHOT_ID }}
+          TF_VAR_vercel_sandbox_runtime: "${{ vars.VERCEL_SANDBOX_RUNTIME || secrets.VERCEL_SANDBOX_RUNTIME || 'node24' }}"
+          TF_VAR_vercel_snapshot_expiration_ms: "${{ vars.VERCEL_SNAPSHOT_EXPIRATION_MS || secrets.VERCEL_SNAPSHOT_EXPIRATION_MS || '0' }}"
           # Sandbox provider: OpenComputer. Inert while sandbox_provider defaults to "modal";
           # when set to "opencomputer", Terraform builds the managed base snapshot during apply.
-          TF_VAR_opencomputer_api_url: ${{ secrets.OPENCOMPUTER_API_URL }}
+          TF_VAR_opencomputer_api_url: ${{ vars.OPENCOMPUTER_API_URL || secrets.OPENCOMPUTER_API_URL }}
           TF_VAR_opencomputer_api_key: ${{ secrets.OPENCOMPUTER_API_KEY }}
-          TF_VAR_opencomputer_template: ${{ secrets.OPENCOMPUTER_TEMPLATE }}
-          TF_VAR_opencomputer_project_id: ${{ secrets.OPENCOMPUTER_PROJECT_ID }}
-          TF_VAR_opencomputer_target: ${{ secrets.OPENCOMPUTER_TARGET }}
+          TF_VAR_opencomputer_template: ${{ vars.OPENCOMPUTER_TEMPLATE || secrets.OPENCOMPUTER_TEMPLATE }}
+          TF_VAR_opencomputer_project_id: ${{ vars.OPENCOMPUTER_PROJECT_ID || secrets.OPENCOMPUTER_PROJECT_ID }}
+          TF_VAR_opencomputer_target: ${{ vars.OPENCOMPUTER_TARGET || secrets.OPENCOMPUTER_TARGET }}
           TF_VAR_e2b_api_key: ${{ secrets.E2B_API_KEY }}
-          TF_VAR_e2b_template_id: ${{ secrets.E2B_TEMPLATE_ID }}
-          TF_VAR_e2b_api_url: "${{ secrets.E2B_API_URL || 'https://api.e2b.app' }}"
-          TF_VAR_e2b_sandbox_timeout_seconds: "${{ secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
-          TF_VAR_e2b_auto_pause: "${{ secrets.E2B_AUTO_PAUSE || 'true' }}"
-          TF_VAR_e2b_template_cpu: "${{ secrets.E2B_TEMPLATE_CPU || '2' }}"
-          TF_VAR_e2b_template_memory_mb: "${{ secrets.E2B_TEMPLATE_MEMORY_MB || '4096' }}"
+          TF_VAR_e2b_template_id: ${{ vars.E2B_TEMPLATE_ID || secrets.E2B_TEMPLATE_ID }}
+          TF_VAR_e2b_api_url: "${{ vars.E2B_API_URL || secrets.E2B_API_URL || 'https://api.e2b.app' }}"
+          TF_VAR_e2b_sandbox_timeout_seconds: "${{ vars.E2B_SANDBOX_TIMEOUT_SECONDS || secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
+          TF_VAR_e2b_auto_pause: "${{ vars.E2B_AUTO_PAUSE || secrets.E2B_AUTO_PAUSE || 'true' }}"
+          TF_VAR_e2b_template_cpu: "${{ vars.E2B_TEMPLATE_CPU || secrets.E2B_TEMPLATE_CPU || '2' }}"
+          TF_VAR_e2b_template_memory_mb: "${{ vars.E2B_TEMPLATE_MEMORY_MB || secrets.E2B_TEMPLATE_MEMORY_MB || '4096' }}"
 
       - name: Post Plan Results
         uses: actions/github-script@v8
@@ -386,7 +386,7 @@ jobs:
           terraform init \
             -backend-config="access_key=${{ secrets.R2_ACCESS_KEY_ID }}" \
             -backend-config="secret_key=${{ secrets.R2_SECRET_ACCESS_KEY }}" \
-            -backend-config='endpoints={s3="https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
+            -backend-config='endpoints={s3="https://${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"}'
         working-directory: ${{ env.TF_WORKING_DIR }}
 
       - name: Stage SchedulerDO deletion migration
@@ -408,23 +408,23 @@ jobs:
         working-directory: ${{ env.TF_WORKING_DIR }}
         env:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          TF_VAR_cloudflare_worker_subdomain: ${{ secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
+          TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TF_VAR_cloudflare_worker_subdomain: ${{ vars.CLOUDFLARE_WORKER_SUBDOMAIN || secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
           TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || '000000000000000000000000' }}"
-          TF_VAR_vercel_team_id: "${{ secrets.VERCEL_TEAM_ID || 'unused' }}"
+          TF_VAR_vercel_team_id: "${{ vars.VERCEL_TEAM_ID || secrets.VERCEL_TEAM_ID || 'unused' }}"
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
-          TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
-          TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
-          TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
-          TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          TF_VAR_modal_workspace: ${{ vars.MODAL_WORKSPACE || secrets.MODAL_WORKSPACE }}
+          TF_VAR_modal_environment: "${{ vars.MODAL_ENVIRONMENT || secrets.MODAL_ENVIRONMENT || 'main' }}"
+          TF_VAR_modal_environment_web_suffix: ${{ vars.MODAL_ENVIRONMENT_WEB_SUFFIX || secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
+          TF_VAR_github_client_id: ${{ vars.GH_OAUTH_CLIENT_ID || secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
-          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_id: ${{ vars.GOOGLE_CLIENT_ID || secrets.GOOGLE_CLIENT_ID }}
           TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
+          TF_VAR_github_app_id: ${{ vars.GH_APP_ID || secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
-          TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
+          TF_VAR_github_app_installation_id: ${{ vars.GH_APP_INSTALLATION_ID || secrets.GH_APP_INSTALLATION_ID }}
+          TF_VAR_enable_slack_bot: "${{ vars.ENABLE_SLACK_BOT || secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -435,48 +435,48 @@ jobs:
           TF_VAR_provider_accounts_encryption_key: ${{ secrets.PROVIDER_ACCOUNTS_ENCRYPTION_KEY }}
           TF_VAR_nextauth_secret: ${{ secrets.NEXTAUTH_SECRET }}
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
-          TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
-          TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
-          TF_VAR_allowed_emails: ${{ secrets.ALLOWED_EMAILS }}
-          TF_VAR_allowed_github_orgs: ${{ secrets.ALLOWED_GITHUB_ORGS }}
-          TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
-          TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
+          TF_VAR_allowed_users: ${{ vars.ALLOWED_USERS || secrets.ALLOWED_USERS }}
+          TF_VAR_allowed_email_domains: ${{ vars.ALLOWED_EMAIL_DOMAINS || secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_allowed_emails: ${{ vars.ALLOWED_EMAILS || secrets.ALLOWED_EMAILS }}
+          TF_VAR_allowed_github_orgs: ${{ vars.ALLOWED_GITHUB_ORGS || secrets.ALLOWED_GITHUB_ORGS }}
+          TF_VAR_deployment_name: ${{ vars.DEPLOYMENT_NAME || secrets.DEPLOYMENT_NAME }}
+          TF_VAR_enable_github_bot: "${{ vars.ENABLE_GITHUB_BOT || secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
-          TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
-          TF_VAR_app_name: "${{ secrets.APP_NAME || 'Open-Inspect' }}"
-          TF_VAR_app_icon_url: ${{ secrets.APP_ICON_URL }}
-          TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
-          TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
+          TF_VAR_github_bot_username: ${{ vars.GH_BOT_USERNAME || secrets.GH_BOT_USERNAME }}
+          TF_VAR_app_name: "${{ vars.APP_NAME || secrets.APP_NAME || 'Open-Inspect' }}"
+          TF_VAR_app_icon_url: ${{ vars.APP_ICON_URL || secrets.APP_ICON_URL }}
+          TF_VAR_enable_linear_bot: "${{ vars.ENABLE_LINEAR_BOT || secrets.ENABLE_LINEAR_BOT || 'false' }}"
+          TF_VAR_linear_client_id: ${{ vars.LINEAR_CLIENT_ID || secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
-          TF_VAR_web_platform: "${{ secrets.WEB_PLATFORM || 'vercel' }}"
-          TF_VAR_enable_durable_object_bindings: "${{ secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
-          TF_VAR_sandbox_provider: "${{ secrets.SANDBOX_PROVIDER || 'modal' }}"
-          TF_VAR_daytona_api_url: ${{ secrets.DAYTONA_API_URL }}
+          TF_VAR_web_platform: "${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM || 'vercel' }}"
+          TF_VAR_enable_durable_object_bindings: "${{ vars.ENABLE_DURABLE_OBJECT_BINDINGS || secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
+          TF_VAR_sandbox_provider: "${{ vars.SANDBOX_PROVIDER || secrets.SANDBOX_PROVIDER || 'modal' }}"
+          TF_VAR_daytona_api_url: ${{ vars.DAYTONA_API_URL || secrets.DAYTONA_API_URL }}
           TF_VAR_daytona_api_key: ${{ secrets.DAYTONA_API_KEY }}
-          TF_VAR_daytona_base_snapshot: ${{ secrets.DAYTONA_BASE_SNAPSHOT }}
-          TF_VAR_daytona_target: ${{ secrets.DAYTONA_TARGET }}
+          TF_VAR_daytona_base_snapshot: ${{ vars.DAYTONA_BASE_SNAPSHOT || secrets.DAYTONA_BASE_SNAPSHOT }}
+          TF_VAR_daytona_target: ${{ vars.DAYTONA_TARGET || secrets.DAYTONA_TARGET }}
           TF_VAR_vercel_sandbox_token: ${{ secrets.VERCEL_SANDBOX_TOKEN }}
-          TF_VAR_vercel_sandbox_project_id: ${{ secrets.VERCEL_SANDBOX_PROJECT_ID }}
-          TF_VAR_vercel_sandbox_team_id: ${{ secrets.VERCEL_SANDBOX_TEAM_ID }}
-          TF_VAR_vercel_sandbox_api_base_url: ${{ secrets.VERCEL_SANDBOX_API_BASE_URL }}
-          TF_VAR_vercel_base_snapshot_id: ${{ secrets.VERCEL_BASE_SNAPSHOT_ID }}
-          TF_VAR_vercel_sandbox_runtime: "${{ secrets.VERCEL_SANDBOX_RUNTIME || 'node24' }}"
-          TF_VAR_vercel_snapshot_expiration_ms: "${{ secrets.VERCEL_SNAPSHOT_EXPIRATION_MS || '0' }}"
+          TF_VAR_vercel_sandbox_project_id: ${{ vars.VERCEL_SANDBOX_PROJECT_ID || secrets.VERCEL_SANDBOX_PROJECT_ID }}
+          TF_VAR_vercel_sandbox_team_id: ${{ vars.VERCEL_SANDBOX_TEAM_ID || secrets.VERCEL_SANDBOX_TEAM_ID }}
+          TF_VAR_vercel_sandbox_api_base_url: ${{ vars.VERCEL_SANDBOX_API_BASE_URL || secrets.VERCEL_SANDBOX_API_BASE_URL }}
+          TF_VAR_vercel_base_snapshot_id: ${{ vars.VERCEL_BASE_SNAPSHOT_ID || secrets.VERCEL_BASE_SNAPSHOT_ID }}
+          TF_VAR_vercel_sandbox_runtime: "${{ vars.VERCEL_SANDBOX_RUNTIME || secrets.VERCEL_SANDBOX_RUNTIME || 'node24' }}"
+          TF_VAR_vercel_snapshot_expiration_ms: "${{ vars.VERCEL_SNAPSHOT_EXPIRATION_MS || secrets.VERCEL_SNAPSHOT_EXPIRATION_MS || '0' }}"
           # Sandbox provider: OpenComputer. Inert while sandbox_provider defaults to "modal";
           # when set to "opencomputer", Terraform builds the managed base snapshot during apply.
-          TF_VAR_opencomputer_api_url: ${{ secrets.OPENCOMPUTER_API_URL }}
+          TF_VAR_opencomputer_api_url: ${{ vars.OPENCOMPUTER_API_URL || secrets.OPENCOMPUTER_API_URL }}
           TF_VAR_opencomputer_api_key: ${{ secrets.OPENCOMPUTER_API_KEY }}
-          TF_VAR_opencomputer_template: ${{ secrets.OPENCOMPUTER_TEMPLATE }}
-          TF_VAR_opencomputer_project_id: ${{ secrets.OPENCOMPUTER_PROJECT_ID }}
-          TF_VAR_opencomputer_target: ${{ secrets.OPENCOMPUTER_TARGET }}
+          TF_VAR_opencomputer_template: ${{ vars.OPENCOMPUTER_TEMPLATE || secrets.OPENCOMPUTER_TEMPLATE }}
+          TF_VAR_opencomputer_project_id: ${{ vars.OPENCOMPUTER_PROJECT_ID || secrets.OPENCOMPUTER_PROJECT_ID }}
+          TF_VAR_opencomputer_target: ${{ vars.OPENCOMPUTER_TARGET || secrets.OPENCOMPUTER_TARGET }}
           TF_VAR_e2b_api_key: ${{ secrets.E2B_API_KEY }}
-          TF_VAR_e2b_template_id: ${{ secrets.E2B_TEMPLATE_ID }}
-          TF_VAR_e2b_api_url: "${{ secrets.E2B_API_URL || 'https://api.e2b.app' }}"
-          TF_VAR_e2b_sandbox_timeout_seconds: "${{ secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
-          TF_VAR_e2b_auto_pause: "${{ secrets.E2B_AUTO_PAUSE || 'true' }}"
-          TF_VAR_e2b_template_cpu: "${{ secrets.E2B_TEMPLATE_CPU || '2' }}"
-          TF_VAR_e2b_template_memory_mb: "${{ secrets.E2B_TEMPLATE_MEMORY_MB || '4096' }}"
+          TF_VAR_e2b_template_id: ${{ vars.E2B_TEMPLATE_ID || secrets.E2B_TEMPLATE_ID }}
+          TF_VAR_e2b_api_url: "${{ vars.E2B_API_URL || secrets.E2B_API_URL || 'https://api.e2b.app' }}"
+          TF_VAR_e2b_sandbox_timeout_seconds: "${{ vars.E2B_SANDBOX_TIMEOUT_SECONDS || secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
+          TF_VAR_e2b_auto_pause: "${{ vars.E2B_AUTO_PAUSE || secrets.E2B_AUTO_PAUSE || 'true' }}"
+          TF_VAR_e2b_template_cpu: "${{ vars.E2B_TEMPLATE_CPU || secrets.E2B_TEMPLATE_CPU || '2' }}"
+          TF_VAR_e2b_template_memory_mb: "${{ vars.E2B_TEMPLATE_MEMORY_MB || secrets.E2B_TEMPLATE_MEMORY_MB || '4096' }}"
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1001,11 +1001,90 @@ curl -I "$(terraform output -raw web_app_url)"
 
 ## Step 10: Set Up CI/CD (Optional)
 
-Enable automatic deployments when you push to main by adding GitHub Secrets.
+Enable automatic deployments when you push to main by configuring GitHub Actions secrets and
+variables under your fork's **Settings → Secrets and variables → Actions**.
 
-Go to your fork's Settings → Secrets and variables → Actions, and add:
+Use the **Variables** tab for the following non-secret settings (only configure the providers and
+features you use):
 
-| Secret Name                        | Value                                                                                       |
+```text
+# Deployment and Cloudflare
+DEPLOYMENT_NAME
+WEB_PLATFORM
+SANDBOX_PROVIDER
+CLOUDFLARE_ACCOUNT_ID
+CLOUDFLARE_WORKER_SUBDOMAIN
+ENABLE_DURABLE_OBJECT_BINDINGS
+
+# Vercel web app
+VERCEL_TEAM_ID
+VERCEL_PROJECT_ID
+
+# Modal
+MODAL_WORKSPACE
+MODAL_ENVIRONMENT
+MODAL_ENVIRONMENT_WEB_SUFFIX
+
+# Application IDs and bot configuration
+GH_OAUTH_CLIENT_ID
+GOOGLE_CLIENT_ID
+GH_APP_ID
+GH_APP_INSTALLATION_ID
+ENABLE_SLACK_BOT
+ENABLE_GITHUB_BOT
+GH_BOT_USERNAME
+ENABLE_LINEAR_BOT
+LINEAR_CLIENT_ID
+
+# Access control and branding
+ALLOWED_USERS
+ALLOWED_EMAIL_DOMAINS
+ALLOWED_EMAILS
+ALLOWED_GITHUB_ORGS
+APP_NAME
+APP_ICON_URL
+
+# Daytona
+DAYTONA_API_URL
+DAYTONA_BASE_SNAPSHOT
+DAYTONA_TARGET
+
+# Vercel Sandbox
+VERCEL_SANDBOX_PROJECT_ID
+VERCEL_SANDBOX_TEAM_ID
+VERCEL_SANDBOX_API_BASE_URL
+VERCEL_BASE_SNAPSHOT_ID
+VERCEL_SANDBOX_RUNTIME
+VERCEL_SNAPSHOT_EXPIRATION_MS
+
+# OpenComputer
+OPENCOMPUTER_API_URL
+OPENCOMPUTER_TEMPLATE
+OPENCOMPUTER_PROJECT_ID
+OPENCOMPUTER_TARGET
+
+# E2B
+E2B_TEMPLATE_ID
+E2B_API_URL
+E2B_SANDBOX_TIMEOUT_SECONDS
+E2B_AUTO_PAUSE
+E2B_TEMPLATE_CPU
+E2B_TEMPLATE_MEMORY_MB
+```
+
+These settings resolve as **non-empty variable → same-named secret → existing default**, where a
+workflow default exists. Existing secret-only deployments need no migration. If both are set, the
+variable wins; delete it to return to the secret. An empty variable does not clear an existing
+secret. Values such as `false` and `0` are strings in Actions variables and are preserved.
+
+Keep credentials in the **Secrets** tab: API tokens/keys, OAuth client secrets, signing secrets,
+private keys, encryption keys, and both `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`. Allowlist values
+may contain personal information; leave them in secrets if you prefer masking in workflow logs.
+
+The table below describes deployment settings and credentials; use Variables for the names above and
+Secrets for credentials:
+
+| Setting Name                       | Value                                                                                       |
 | ---------------------------------- | ------------------------------------------------------------------------------------------- |
 | `CLOUDFLARE_API_TOKEN`             | Your Cloudflare API token                                                                   |
 | `CLOUDFLARE_ACCOUNT_ID`            | Your Cloudflare account ID                                                                  |
@@ -1080,13 +1159,22 @@ application in **Linear Settings → API → Applications**. This provider-side 
 by Terraform. Existing eligible single-workspace installations transition on their next request
 without uninstalling or reinstalling the app.
 
-**Bulk upload secrets with `gh` CLI:**
+**Bulk upload with `gh` CLI:**
 
-Instead of adding secrets one by one, create a `.secrets` file (don't commit this!):
+For non-secret settings, create a `.variables` file:
+
+```dotenv
+CLOUDFLARE_ACCOUNT_ID=your-account-id
+DEPLOYMENT_NAME=my-deployment
+WEB_PLATFORM=cloudflare
+ENABLE_SLACK_BOT=false
+```
+
+Upload it with `gh variable set -f .variables`. For credentials, create a `.secrets` file (don't
+commit this!):
 
 ```
 CLOUDFLARE_API_TOKEN=your-token
-CLOUDFLARE_ACCOUNT_ID=your-account-id
 ANTHROPIC_API_KEY=sk-ant-...
 DEEPSEEK_API_KEY=sk-...
 # ... add all secrets

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -193,7 +193,16 @@ The GitHub Actions workflow (`.github/workflows/terraform.yml`) automates:
 | Pull Request  | `terraform plan` with PR comment |
 | Merge to main | `terraform apply` (auto-approve) |
 
-### Required GitHub Secrets
+### GitHub Actions Secrets and Variables
+
+Keep credentials in Actions **Secrets**. Non-secret configuration (account/application IDs, provider
+settings, feature flags, allowlists, and branding) can use Actions **Variables** instead. The
+workflows prefer a non-empty variable, then the same-named secret, then the existing default where
+one exists. Existing secret-only deployments continue to work; an empty variable falls back to the
+secret rather than clearing it. `CLASSIFICATION_MODEL` remains variable-only.
+
+See [the CI/CD setup guide](../docs/GETTING_STARTED.md#step-10-set-up-cicd-optional) for the
+complete variable list and bulk upload examples using `gh variable set` and `gh secret set`.
 
 Add these secrets to your repository settings:
 


### PR DESCRIPTION
## Summary

Allow existing non-secret deployment settings to live in GitHub Actions **Variables**, while keeping credentials in **Secrets** and preserving existing secret-only deployments.

Today most deployment settings—including account IDs, feature flags, provider configuration, and branding—must be stored as secrets. That makes ordinary configuration write-only in the GitHub UI and masks it in deployment logs. The workflows already use `vars.CLASSIFICATION_MODEL`; this extends that distinction to the other existing non-secret settings.

## Changes

- Resolve 45 existing configuration names as `vars.NAME || secrets.NAME`, preserving each existing default where present.
- Apply the same resolution to Terraform plan and apply, R2 backend account selection, and the Vercel deployment gate/environment.
- Pass configuration consumed by shell commands through environment bindings rather than interpolating variable values into shell source.
- Document which settings can use Variables, how to bulk-upload them with `gh variable set`, and how fallback/migration works.

## Compatibility and scope

- Existing secret-only deployments require no changes.
- A non-empty variable takes precedence over the same-named secret. An empty variable falls back to the secret; it does not clear it.
- `false` and `0` are non-empty strings in Actions variables and retain their intended values.
- API credentials, OAuth client secrets, signing/private/encryption keys, R2 credentials, and both Modal token fields remain secret-only.
- Allowlists may still be kept in secrets when operators prefer masking personal information in logs.
- `CLASSIFICATION_MODEL` retains its existing variable-only behavior.
- No new Terraform inputs, provider behavior, branding assets, or sandbox image changes.

## Validation

- [x] `actionlint -shellcheck= .github/workflows/terraform.yml .github/workflows/deploy-web.yml`
- [x] Prettier check for both workflows and both documentation files
- [x] `git diff --check`
- [x] Local verification using `@actions/expressions`: 744 checks across all updated expression occurrences, covering variable precedence, secret fallback, empty/missing values, defaults, `false`, `0`, whitespace, and shell-like strings
- [x] Parsed-YAML checks for plan/apply environment parity, documented variable coverage, and credential isolation
- [x] Executed the Vercel gate with six configuration cases and both R2 initialization commands against a stub Terraform executable

The expression and shell checks were run from a temporary validation harness; no new runtime dependencies were added. Full application suites and a live deployment were not run for this workflow/documentation-only PR. GitHub CI will provide the repository checks.

Compare: https://github.com/ColeMurray/background-agents/compare/main...csaroff:background-agents:feat-actions-config-variables?expand=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CI/CD setup guidance to distinguish non-sensitive configuration variables from credential secrets.
  - Documented configuration precedence: repository or organization variable, same-named secret, then existing default.
  - Added instructions for bulk-uploading variables with the GitHub CLI.
  - Clarified that secret-only deployments remain supported.
  - Updated Terraform documentation with the new Actions Secrets and Variables configuration model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->