### PR TITLE
feat: bound per-prompt spending independently of sandbox lifetime

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_budget.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_budget.py
@@ -29,8 +29,8 @@ class PromptLimits:
     @classmethod
     def from_env(cls) -> PromptLimits:
         return cls(
-            turns=int(_env_limit("BRIDGE_MAX_PROMPT_TURNS", DEFAULT_MAX_PROMPT_TURNS)),
-            tokens=int(_env_limit("BRIDGE_MAX_PROMPT_TOKENS", DEFAULT_MAX_PROMPT_TOKENS)),
+            turns=math.ceil(_env_limit("BRIDGE_MAX_PROMPT_TURNS", DEFAULT_MAX_PROMPT_TURNS)),
+            tokens=math.ceil(_env_limit("BRIDGE_MAX_PROMPT_TOKENS", DEFAULT_MAX_PROMPT_TOKENS)),
             cost_usd=_env_limit("BRIDGE_MAX_PROMPT_COST_USD", DEFAULT_MAX_PROMPT_COST_USD),
         )
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_budget.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_budget.py
@@ -1,0 +1,77 @@
+"""Per-prompt spending limits, separate from the sandbox's snapshot deadline."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_MAX_PROMPT_TURNS = 80
+DEFAULT_MAX_PROMPT_TOKENS = 6_000_000
+DEFAULT_MAX_PROMPT_COST_USD = 0.0
+
+
+def _env_limit(name: str, default: float) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return value if math.isfinite(value) and value >= 0 else default
+
+
+@dataclass(frozen=True)
+class PromptLimits:
+    turns: int = DEFAULT_MAX_PROMPT_TURNS
+    tokens: int = DEFAULT_MAX_PROMPT_TOKENS
+    cost_usd: float = DEFAULT_MAX_PROMPT_COST_USD
+
+    @classmethod
+    def from_env(cls) -> PromptLimits:
+        return cls(
+            turns=int(_env_limit("BRIDGE_MAX_PROMPT_TURNS", DEFAULT_MAX_PROMPT_TURNS)),
+            tokens=int(_env_limit("BRIDGE_MAX_PROMPT_TOKENS", DEFAULT_MAX_PROMPT_TOKENS)),
+            cost_usd=_env_limit("BRIDGE_MAX_PROMPT_COST_USD", DEFAULT_MAX_PROMPT_COST_USD),
+        )
+
+
+def _nonnegative_number(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return float(value) if math.isfinite(value) and value >= 0 else 0
+
+
+class PromptBudgetExceeded(Exception):
+    """A completed authorized step reached a configured spending limit."""
+
+
+@dataclass
+class PromptBudget:
+    limits: PromptLimits
+    turns: int = 0
+    tokens: int = 0
+    cost_usd: float = 0.0
+    seen: set[tuple[str, str]] = field(default_factory=set)
+
+    def record(self, part: dict[str, Any]) -> None:
+        # Called only after parent/child attribution accepts the part. An unrelated
+        # session on the same SSE connection cannot spend this prompt's budget.
+        key = (str(part.get("sessionID", "")), str(part.get("id", "")))
+        if not key[1] or key in self.seen:
+            return
+        self.seen.add(key)
+        self.turns += 1
+        tokens = part.get("tokens")
+        if isinstance(tokens, dict):
+            self.tokens += sum(
+                int(_nonnegative_number(tokens.get(name)))
+                for name in ("input", "output", "reasoning")
+            )
+        self.cost_usd += _nonnegative_number(part.get("cost"))
+        for name, used, limit in (
+            ("turns", self.turns, self.limits.turns),
+            ("tokens", self.tokens, self.limits.tokens),
+            ("cost_usd", self.cost_usd, self.limits.cost_usd),
+        ):
+            if limit and used >= limit:
+                raise PromptBudgetExceeded(name)

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -26,6 +26,7 @@ from .opencode_client import (
     SSEStreamDisconnectedError,
 )
 from .opencode_identifier import OpenCodeIdentifier
+from .prompt_budget import PromptBudget, PromptBudgetExceeded, PromptLimits
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -61,6 +62,7 @@ class _PromptState:
     message_id: str
     opencode_message_id: str
     start_time: float
+    budget: PromptBudget = field(default_factory=lambda: PromptBudget(PromptLimits.from_env()))
     cumulative_text: dict[str, str] = field(default_factory=dict)
     emitted_tool_states: set[str] = field(default_factory=set)
     attribution: MessageAttribution = field(init=False)
@@ -230,6 +232,26 @@ class OpenCodePromptStream:
 
                 for event in self._flush_unassociated_child_activity(state):
                     yield event
+
+        except PromptBudgetExceeded as error:
+            reason = f"prompt_max_{error}"
+            self._log.error(
+                "bridge.prompt_limit_exceeded",
+                limit=reason,
+                turns=state.budget.turns,
+                tokens=state.budget.tokens,
+                cost_usd=state.budget.cost_usd,
+                message_id=message_id,
+            )
+            # Keep stop and final-state retrieval inside the snapshot cleanup reserve.
+            try:
+                async with asyncio.timeout(self._prompt_cleanup_timeout_seconds):
+                    await self._client.request_stop(opencode_session_id, reason=reason)
+                    async for final_event in self._fetch_final_message_state(state):
+                        yield final_event
+            except TimeoutError:
+                self._log.error("bridge.prompt_budget_cleanup_timeout", message_id=message_id)
+            raise RuntimeError(f"Prompt exceeded configured {error} budget.") from error
 
         except _PromptMaxDurationTimeout:
             elapsed = time.time() - state.start_time
@@ -649,6 +671,7 @@ class OpenCodePromptStream:
             )
 
         elif part_type == "step-finish":
+            state.budget.record(part)
             events.append(
                 {
                     "type": "step_finish",

--- a/packages/sandbox-runtime/tests/test_prompt_budget.py
+++ b/packages/sandbox-runtime/tests/test_prompt_budget.py
@@ -118,3 +118,11 @@ async def test_stream_aborts_opencode_and_fails_on_budget(monkeypatch):
             emitted.append(event)
     stream._client.request_stop.assert_awaited_once_with("parent", reason="prompt_max_turns")
     assert emitted == [{"type": "token", "content": "final state"}]
+
+
+def test_fractional_positive_limits_cannot_disable_guard(monkeypatch):
+    monkeypatch.setenv("BRIDGE_MAX_PROMPT_TURNS", "0.5")
+    monkeypatch.setenv("BRIDGE_MAX_PROMPT_TOKENS", "0.1")
+    limits = PromptLimits.from_env()
+    assert limits.turns == 1
+    assert limits.tokens == 1

--- a/packages/sandbox-runtime/tests/test_prompt_budget.py
+++ b/packages/sandbox-runtime/tests/test_prompt_budget.py
@@ -1,0 +1,120 @@
+"""Spending controls survive duplicate events, child sessions and prompt resets."""
+
+import pytest
+
+from sandbox_runtime.prompt_budget import PromptBudget, PromptBudgetExceeded, PromptLimits
+
+
+def part(part_id="step1", session="parent", **kwargs):
+    return {"id": part_id, "sessionID": session, **kwargs}
+
+
+def test_counts_once_per_session_part():
+    budget = PromptBudget(PromptLimits(turns=3))
+    budget.record(part(tokens={"input": 20, "output": 2, "reasoning": 3}))
+    budget.record(part(tokens={"input": 20}))
+    assert budget.turns == 1
+    assert budget.tokens == 25
+    budget.record(part(session="child"))
+    assert budget.turns == 2
+    with pytest.raises(PromptBudgetExceeded, match="turns"):
+        budget.record(part("step2"))
+
+
+def test_cumulative_token_limit_and_fresh_prompt():
+    limits = PromptLimits(tokens=30)
+    budget = PromptBudget(limits)
+    budget.record(part(tokens={"input": 20}))
+    with pytest.raises(PromptBudgetExceeded, match="tokens"):
+        budget.record(part("step2", tokens={"input": 5, "output": 5}))
+    fresh = PromptBudget(limits)
+    fresh.record(part(tokens={"input": 20}))
+    assert fresh.tokens == 20
+
+
+def test_cost_cap_and_invalid_usage():
+    budget = PromptBudget(PromptLimits(cost_usd=1))
+    budget.record(part(cost=float("nan"), tokens={"input": -2, "output": "oops"}))
+    assert budget.tokens == 0
+    assert budget.cost_usd == 0
+    with pytest.raises(PromptBudgetExceeded, match="cost_usd"):
+        budget.record(part("step2", cost=1))
+
+
+def test_zero_disables_guard():
+    budget = PromptBudget(PromptLimits(turns=0, tokens=0, cost_usd=0))
+    budget.record(part(tokens={"input": 9_000_000}, cost=1000))
+    assert budget.tokens == 9_000_000
+
+
+@pytest.mark.parametrize("invalid", ["oops", "nan", "inf", "-1"])
+def test_invalid_environment_keeps_default(monkeypatch, invalid):
+    monkeypatch.setenv("BRIDGE_MAX_PROMPT_TURNS", invalid)
+    assert PromptLimits.from_env().turns == 80
+
+
+def test_unrelated_session_does_not_consume_budget(monkeypatch):
+    from tests.test_prompt_stream import make_state, make_stream, sse
+
+    monkeypatch.setenv("BRIDGE_MAX_PROMPT_TURNS", "1")
+    state = make_state()
+    stream = make_stream()
+    stream._apply_sse_event(
+        state,
+        sse(
+            "message.part.updated",
+            {"part": part(session="unrelated", type="step-finish", messageID="other")},
+        ),
+    )
+    assert state.budget.turns == 0
+    state.attribution.allow_assistant("assistant")
+    with pytest.raises(PromptBudgetExceeded):
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": part(
+                        session=state.opencode_session_id, type="step-finish", messageID="assistant"
+                    )
+                },
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_aborts_opencode_and_fails_on_budget(monkeypatch):
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock
+
+    from tests.test_prompt_stream import make_stream
+
+    monkeypatch.setenv("BRIDGE_MAX_PROMPT_TURNS", "1")
+    stream = make_stream()
+
+    @asynccontextmanager
+    async def events(**kwargs):
+        async def iterator():
+            yield {"type": "test"}
+
+        yield iterator()
+
+    def apply(state, event):
+        state.budget.record(part())
+
+    async def final_state(state):
+        yield {"type": "token", "content": "final state"}
+
+    stream._client.events = events
+    stream._client.post_prompt = AsyncMock()
+    stream._client.request_stop = AsyncMock()
+    stream._apply_sse_event = apply
+    stream._fetch_final_message_state = final_state
+    emitted = []
+    with pytest.raises(RuntimeError, match="turns budget"):
+        async for event in stream.stream_prompt(
+            opencode_session_id="parent", message_id="message", content="test"
+        ):
+            emitted.append(event)
+    stream._client.request_stop.assert_awaited_once_with("parent", reason="prompt_max_turns")
+    assert emitted == [{"type": "token", "content": "final state"}]


### PR DESCRIPTION
Long-running prompts can exhaust a metered model budget before reaching the sandbox deadline. This adds independent per-prompt turn, token and optional cost limits while preserving the existing deadline and snapshot reserve.

Usage is counted once per authorized `(sessionID, partID)`, including tracked child sessions. Reaching a cap requests a bounded stop, persists final state and fails the prompt. Each new prompt starts a fresh budget. Defaults are 80 steps, 6M uncached input/output/reasoning tokens and no dollar cap; environment overrides are `BRIDGE_MAX_PROMPT_TURNS`, `BRIDGE_MAX_PROMPT_TOKENS`, and `BRIDGE_MAX_PROMPT_COST_USD`. Zero disables an individual limit. Positive fractional counts round up.

Validation: 104 focused runtime tests passed before the fractional-limit test was added; all 11 budget tests pass afterward. Full sandbox-runtime tests, Python lint and typecheck also passed in the deployment mirror's CI. Independently reviewed with Claude Sonnet; checked per-step usage against OpenCode v1.18.29's processor source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable prompt spending limits for turns, token usage, and USD cost.
  * Added support for setting limits through environment variables with validation and defaults.
  * Prompts now stop when a configured budget is reached and report final usage and state.

* **Bug Fixes**
  * Prevented duplicate usage events from being counted more than once.
  * Improved handling of invalid usage data and unrelated session activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->