### PR TITLE
fix: retry webhook deliveries that failed to enqueue Autofix

### DIFF
--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -73,6 +73,11 @@ app.post("/webhooks/github", async (c) => {
         event_type: event,
         dedupe_status: existing,
       });
+      // A processing lease is not proof of durable delivery. Retry after it
+      // completes or expires, including when failed-delivery cleanup lost KV.
+      if (existing === DELIVERY_STATUS_PROCESSING) {
+        return c.json({ error: "Delivery still processing" }, 503);
+      }
       return c.json({ ok: true, duplicate: true });
     }
 
@@ -118,7 +123,16 @@ app.post("/webhooks/github", async (c) => {
       });
       // Acknowledging this delivery would mark it processed with no queued revision.
       // Release the receipt so the sender can retry the same delivery identity.
-      if (dedupeKey) await cacheStore.delete(dedupeKey);
+      if (dedupeKey) {
+        try {
+          await cacheStore.delete(dedupeKey);
+        } catch (deleteErr) {
+          log.warn("webhook.dedupe_clear_failed", {
+            delivery_id: deliveryId,
+            error: deleteErr instanceof Error ? deleteErr : new Error(String(deleteErr)),
+          });
+        }
+      }
       return c.json({ error: "Autofix queue unavailable" }, 503);
     }
   }

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -116,6 +116,10 @@ app.post("/webhooks/github", async (c) => {
         delivery_id: deliveryId,
         error: err instanceof Error ? err : new Error(String(err)),
       });
+      // Acknowledging this delivery would mark it processed with no queued revision.
+      // Release the receipt so the sender can retry the same delivery identity.
+      if (dedupeKey) await cacheStore.delete(dedupeKey);
+      return c.json({ error: "Autofix queue unavailable" }, 503);
     }
   }
 

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -286,58 +286,80 @@ describe("POST /webhooks/github", () => {
     expect(env.AUTOFIX_QUEUE.send).not.toHaveBeenCalled();
   });
 
-  it("rejects an unqueued delivery and releases it for retry", async () => {
-    const body = JSON.stringify({
-      action: "created",
-      issue: {
-        number: 42,
-        title: "Handle nullable input",
-        pull_request: {
-          url: "https://api.github.com/repos/test/repo/pulls/42",
+  it.each([false, true])(
+    "rejects an unqueued delivery (KV cleanup failure: %s)",
+    async (cleanupFails) => {
+      const body = JSON.stringify({
+        action: "created",
+        issue: {
+          number: 42,
+          title: "Handle nullable input",
+          pull_request: {
+            url: "https://api.github.com/repos/test/repo/pulls/42",
+          },
         },
-      },
-      comment: {
-        id: 1236,
-        body: "Please handle the null case.",
-        user: { login: "alice" },
-      },
-      repository: {
-        id: 99,
-        name: "repo",
-        private: false,
-        owner: { login: "test" },
-      },
-      sender: {
-        id: 7,
-        login: "alice",
-        type: "User",
-        avatar_url: "https://example.com/alice.png",
-      },
-    });
-    const signature = await sign(SECRET, body);
-    const env = makeEnv();
-    const ctx = makeCtx();
-    env.AUTOFIX_QUEUE.send.mockRejectedValueOnce(new Error("queue unavailable"));
-
-    const res = await app.fetch(
-      new Request("http://localhost/webhooks/github", {
-        method: "POST",
-        body,
-        headers: {
-          "X-Hub-Signature-256": signature,
-          "X-GitHub-Event": "issue_comment",
-          "X-GitHub-Delivery": "delivery-comment-1236",
+        comment: {
+          id: 1236,
+          body: "Please handle the null case.",
+          user: { login: "alice" },
         },
-      }),
-      env,
-      ctx
-    );
+        repository: {
+          id: 99,
+          name: "repo",
+          private: false,
+          owner: { login: "test" },
+        },
+        sender: {
+          id: 7,
+          login: "alice",
+          type: "User",
+          avatar_url: "https://example.com/alice.png",
+        },
+      });
+      const signature = await sign(SECRET, body);
+      const env = makeEnv();
+      const ctx = makeCtx();
+      env.AUTOFIX_QUEUE.send.mockRejectedValueOnce(new Error("queue unavailable"));
+      if (cleanupFails)
+        vi.mocked(env.GITHUB_KV.delete).mockRejectedValueOnce(new Error("KV unavailable"));
 
-    expect(res.status).toBe(503);
-    expect(ctx.waitUntil).not.toHaveBeenCalled();
-    expect(env.CONTROL_PLANE.fetch).not.toHaveBeenCalled();
-    expect(env.GITHUB_KV.delete).toHaveBeenCalledWith("delivery:delivery-comment-1236");
-  });
+      const res = await app.fetch(
+        new Request("http://localhost/webhooks/github", {
+          method: "POST",
+          body,
+          headers: {
+            "X-Hub-Signature-256": signature,
+            "X-GitHub-Event": "issue_comment",
+            "X-GitHub-Delivery": "delivery-comment-1236",
+          },
+        }),
+        env,
+        ctx
+      );
+
+      expect(res.status).toBe(503);
+      expect(ctx.waitUntil).not.toHaveBeenCalled();
+      expect(env.CONTROL_PLANE.fetch).not.toHaveBeenCalled();
+      expect(env.GITHUB_KV.delete).toHaveBeenCalledWith("delivery:delivery-comment-1236");
+      if (cleanupFails) {
+        const retry = await app.fetch(
+          new Request("http://localhost/webhooks/github", {
+            method: "POST",
+            body,
+            headers: {
+              "X-Hub-Signature-256": signature,
+              "X-GitHub-Event": "issue_comment",
+              "X-GitHub-Delivery": "delivery-comment-1236",
+            },
+          }),
+          env,
+          ctx
+        );
+        expect(retry.status).toBe(503);
+        expect(env.AUTOFIX_QUEUE.send).toHaveBeenCalledTimes(1);
+      }
+    }
+  );
 
   it("returns 401 for invalid signature", async () => {
     const body = '{"action":"created"}';

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -286,7 +286,7 @@ describe("POST /webhooks/github", () => {
     expect(env.AUTOFIX_QUEUE.send).not.toHaveBeenCalled();
   });
 
-  it("continues normal webhook handling when Autofix queueing fails", async () => {
+  it("rejects an unqueued delivery and releases it for retry", async () => {
     const body = JSON.stringify({
       action: "created",
       issue: {
@@ -333,14 +333,10 @@ describe("POST /webhooks/github", () => {
       ctx
     );
 
-    expect(res.status).toBe(200);
-    expect(ctx.waitUntil).toHaveBeenCalledOnce();
-    await flushWaitUntil(ctx);
-    expect(env.CONTROL_PLANE.fetch).toHaveBeenCalledWith(
-      "https://internal/internal/github-event",
-      expect.any(Object)
-    );
-    expect(env.GITHUB_KV.delete).not.toHaveBeenCalled();
+    expect(res.status).toBe(503);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(env.CONTROL_PLANE.fetch).not.toHaveBeenCalled();
+    expect(env.GITHUB_KV.delete).toHaveBeenCalledWith("delivery:delivery-comment-1236");
   });
 
   it("returns 401 for invalid signature", async () => {


### PR DESCRIPTION
When `AUTOFIX_QUEUE.send` fails, the webhook previously returned 200 and finalized its delivery marker despite never enqueueing the revision. Return 503 and clear the receipt so the sender can retry. If KV cleanup also fails, keep the processing lease retryable (503) until it expires, instead of acknowledging it as completed.

Successfully processed duplicates still return 200. Other handling is intentionally deferred on an enqueue failure so the retry can process the complete delivery.

Validation: all 147 GitHub-bot tests pass, including queue failure with successful and failed KV cleanup. Independently reviewed with Claude Sonnet 5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Webhook deliveries that are still being processed now return a retryable error instead of being acknowledged as duplicates.
  - Failed autofix queueing now allows the same delivery to be retried safely.
  - Failed deliveries return HTTP 503 and avoid forwarding incomplete events.

- **Tests**
  - Added coverage for queueing failures, retry behavior, and cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->