### PR TITLE
refactor: consolidate GitHub session launch workflows

### DIFF
--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,10 +1,5 @@
 import { encodeRepositoryPathSegments } from "@open-inspect/shared/types/repositories";
-import {
-  createSessionResponseSchema,
-  sendPromptResponseSchema,
-} from "@open-inspect/shared/types/session-api";
 import { resolveAppName } from "@open-inspect/shared/app-name";
-import { signedControlPlaneFetch } from "./internal-auth";
 import type {
   Env,
   PullRequestOpenedPayload,
@@ -15,88 +10,17 @@ import type {
 import type { Logger } from "./logger";
 import { generateInstallationToken, postReaction, checkSenderPermission } from "./github-auth";
 import { buildCodeReviewPrompt, buildCommentActionPrompt } from "./prompts";
-import { resolveSessionTarget, type SessionTargetFields } from "./session-target";
+import { launchSession, type SessionLaunchResult } from "./session-launch";
 import { getGitHubConfig, type ResolvedGitHubConfig } from "./utils/integration-config";
 import { requestedReviewerPayloadSchema } from "./payload-schemas";
 import { containsBotMention, stripBotMention } from "./github-mention";
 
-export type HandlerResult =
-  | { outcome: "processed"; session_id: string; message_id: string; handler_action: string }
-  | { outcome: "skipped"; skip_reason: string };
+export type HandlerResult = SessionLaunchResult | { outcome: "skipped"; skip_reason: string };
 
 export function isReviewRequestedForBot(payload: unknown, botUsername: string): boolean {
   const parsed = requestedReviewerPayloadSchema.safeParse(payload);
   if (!parsed.success) return false;
   return parsed.data.requested_reviewer?.login === botUsername;
-}
-
-async function createSession(
-  env: Env,
-  traceId: string,
-  params: {
-    target: SessionTargetFields;
-    title: string;
-    model: string;
-    reasoningEffort?: string | null;
-    scmLogin: string;
-    scmUserId: string;
-    scmAvatarUrl: string;
-  }
-): Promise<string> {
-  const body: Record<string, unknown> = {
-    ...params.target,
-    title: params.title,
-    model: params.model,
-    scmLogin: params.scmLogin,
-    scmAvatarUrl: params.scmAvatarUrl,
-  };
-  if (params.reasoningEffort) {
-    body.reasoningEffort = params.reasoningEffort;
-  }
-  const url = "https://internal/sessions";
-  const bodyText = JSON.stringify(body);
-  const response = await signedControlPlaneFetch(env, {
-    method: "POST",
-    url,
-    body: bodyText,
-    actor: `github:${params.scmUserId}`,
-    traceId,
-  });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Session creation failed: ${response.status} ${body}`);
-  }
-  const result = createSessionResponseSchema.safeParse(await response.json());
-  if (!result.success) {
-    throw new Error("Session creation failed: invalid response");
-  }
-  return result.data.sessionId;
-}
-
-async function sendPrompt(
-  env: Env,
-  traceId: string,
-  sessionId: string,
-  params: { content: string; authorId: string }
-): Promise<string> {
-  const url = `https://internal/sessions/${sessionId}/prompt`;
-  const bodyText = JSON.stringify({ content: params.content, source: "github" });
-  const response = await signedControlPlaneFetch(env, {
-    method: "POST",
-    url,
-    body: bodyText,
-    actor: params.authorId.startsWith("github:") ? params.authorId : undefined,
-    traceId,
-  });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Prompt delivery failed: ${response.status} ${body}`);
-  }
-  const result = sendPromptResponseSchema.safeParse(await response.json());
-  if (!result.success) {
-    throw new Error("Prompt delivery failed: invalid response");
-  }
-  return result.data.messageId;
 }
 
 async function withReaction<T>(
@@ -225,58 +149,31 @@ export async function handleReviewRequested(
     `https://api.github.com/repos/${repositoryPath}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
-    async () => {
-      const target = await resolveSessionTarget(env, log, {
+    () =>
+      launchSession(env, log, {
         owner,
         repoName,
-        senderLogin: sender.login,
+        sender,
         config,
         ghToken,
         traceId,
-      });
-      const sessionId = await createSession(env, traceId, {
-        target,
+        pullNumber: pr.number,
         title: `GitHub: Review PR #${pr.number}`,
-        model: config.model,
-        reasoningEffort: config.reasoningEffort,
-        scmLogin: sender.login,
-        scmUserId: String(sender.id),
-        scmAvatarUrl: sender.avatar_url,
-      });
-      log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
-
-      const prompt = buildCodeReviewPrompt({
-        owner,
-        repo: repoName,
-        number: pr.number,
-        title: pr.title,
-        body: pr.body,
-        author: pr.user.login,
-        base: pr.base.ref,
-        head: pr.head.ref,
-        isPublic: !repo.private,
-        codeReviewInstructions: config.codeReviewInstructions,
-      });
-
-      const messageId = await sendPrompt(env, traceId, sessionId, {
-        content: prompt,
-        authorId: `github:${payload.sender.id}`,
-      });
-      log.info("prompt.sent", {
-        ...meta,
-        session_id: sessionId,
-        message_id: messageId,
-        source: "github",
-        content_length: prompt.length,
-      });
-
-      return {
-        outcome: "processed",
-        session_id: sessionId,
-        message_id: messageId,
-        handler_action: "review",
-      };
-    }
+        action: "review",
+        buildPrompt: () =>
+          buildCodeReviewPrompt({
+            owner,
+            repo: repoName,
+            number: pr.number,
+            title: pr.title,
+            body: pr.body,
+            author: pr.user.login,
+            base: pr.base.ref,
+            head: pr.head.ref,
+            isPublic: !repo.private,
+            codeReviewInstructions: config.codeReviewInstructions,
+          }),
+      })
   );
 }
 
@@ -329,59 +226,32 @@ export async function handlePullRequestOpened(
     `https://api.github.com/repos/${repositoryPath}/issues/${pr.number}/reactions`,
     resolveAppName(env),
     meta,
-    async () => {
-      const target = await resolveSessionTarget(env, log, {
+    () =>
+      launchSession(env, log, {
         owner,
         repoName,
-        senderLogin: sender.login,
+        sender,
         config,
         ghToken,
         traceId,
-      });
-      const sessionId = await createSession(env, traceId, {
-        target,
+        pullNumber: pr.number,
         title: `GitHub: Review PR #${pr.number}`,
-        model: config.model,
-        reasoningEffort: config.reasoningEffort,
-        scmLogin: sender.login,
-        scmUserId: String(sender.id),
-        scmAvatarUrl: sender.avatar_url,
-      });
-      log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
-
-      const prompt = buildCodeReviewPrompt({
-        owner,
-        repo: repoName,
-        number: pr.number,
-        title: pr.title,
-        body: pr.body,
-        author: pr.user.login,
-        base: pr.base.ref,
-        head: pr.head.ref,
-        isPublic: !repo.private,
-        codeReviewInstructions: config.codeReviewInstructions,
-        isSelfReview: pr.user.login.toLowerCase() === env.GITHUB_BOT_USERNAME.toLowerCase(),
-      });
-
-      const messageId = await sendPrompt(env, traceId, sessionId, {
-        content: prompt,
-        authorId: `github:${sender.id}`,
-      });
-      log.info("prompt.sent", {
-        ...meta,
-        session_id: sessionId,
-        message_id: messageId,
-        source: "github",
-        content_length: prompt.length,
-      });
-
-      return {
-        outcome: "processed",
-        session_id: sessionId,
-        message_id: messageId,
-        handler_action: "auto_review",
-      };
-    }
+        action: "auto_review",
+        buildPrompt: () =>
+          buildCodeReviewPrompt({
+            owner,
+            repo: repoName,
+            number: pr.number,
+            title: pr.title,
+            body: pr.body,
+            author: pr.user.login,
+            base: pr.base.ref,
+            head: pr.head.ref,
+            isPublic: !repo.private,
+            codeReviewInstructions: config.codeReviewInstructions,
+            isSelfReview: pr.user.login.toLowerCase() === env.GITHUB_BOT_USERNAME.toLowerCase(),
+          }),
+      })
   );
 }
 
@@ -445,56 +315,29 @@ export async function handleIssueComment(
     `https://api.github.com/repos/${repositoryPath}/issues/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
-    async () => {
-      const target = await resolveSessionTarget(env, log, {
+    () =>
+      launchSession(env, log, {
         owner,
         repoName,
-        senderLogin: sender.login,
+        sender,
         config,
         ghToken,
         traceId,
-      });
-      const sessionId = await createSession(env, traceId, {
-        target,
+        pullNumber: issue.number,
         title: `GitHub: PR #${issue.number} comment`,
-        model: config.model,
-        reasoningEffort: config.reasoningEffort,
-        scmLogin: sender.login,
-        scmUserId: String(sender.id),
-        scmAvatarUrl: sender.avatar_url,
-      });
-      log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
-
-      const prompt = buildCommentActionPrompt({
-        owner,
-        repo: repoName,
-        number: issue.number,
-        title: issue.title,
-        commentBody,
-        commenter: sender.login,
-        isPublic: !repo.private,
-        commentActionInstructions: config.commentActionInstructions,
-      });
-
-      const messageId = await sendPrompt(env, traceId, sessionId, {
-        content: prompt,
-        authorId: `github:${sender.id}`,
-      });
-      log.info("prompt.sent", {
-        ...meta,
-        session_id: sessionId,
-        message_id: messageId,
-        source: "github",
-        content_length: prompt.length,
-      });
-
-      return {
-        outcome: "processed",
-        session_id: sessionId,
-        message_id: messageId,
-        handler_action: "comment",
-      };
-    }
+        action: "comment",
+        buildPrompt: () =>
+          buildCommentActionPrompt({
+            owner,
+            repo: repoName,
+            number: issue.number,
+            title: issue.title,
+            commentBody,
+            commenter: sender.login,
+            isPublic: !repo.private,
+            commentActionInstructions: config.commentActionInstructions,
+          }),
+      })
   );
 }
 
@@ -553,60 +396,33 @@ export async function handleReviewComment(
     `https://api.github.com/repos/${repositoryPath}/pulls/comments/${comment.id}/reactions`,
     resolveAppName(env),
     meta,
-    async () => {
-      const target = await resolveSessionTarget(env, log, {
+    () =>
+      launchSession(env, log, {
         owner,
         repoName,
-        senderLogin: sender.login,
+        sender,
         config,
         ghToken,
         traceId,
-      });
-      const sessionId = await createSession(env, traceId, {
-        target,
+        pullNumber: pr.number,
         title: `GitHub: PR #${pr.number} review comment`,
-        model: config.model,
-        reasoningEffort: config.reasoningEffort,
-        scmLogin: sender.login,
-        scmUserId: String(sender.id),
-        scmAvatarUrl: sender.avatar_url,
-      });
-      log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
-
-      const prompt = buildCommentActionPrompt({
-        owner,
-        repo: repoName,
-        number: pr.number,
-        title: pr.title,
-        base: pr.base.ref,
-        head: pr.head.ref,
-        commentBody,
-        commenter: sender.login,
-        isPublic: !repo.private,
-        filePath: comment.path,
-        diffHunk: comment.diff_hunk,
-        commentId: comment.id,
-        commentActionInstructions: config.commentActionInstructions,
-      });
-
-      const messageId = await sendPrompt(env, traceId, sessionId, {
-        content: prompt,
-        authorId: `github:${sender.id}`,
-      });
-      log.info("prompt.sent", {
-        ...meta,
-        session_id: sessionId,
-        message_id: messageId,
-        source: "github",
-        content_length: prompt.length,
-      });
-
-      return {
-        outcome: "processed",
-        session_id: sessionId,
-        message_id: messageId,
-        handler_action: "review_comment",
-      };
-    }
+        action: "review_comment",
+        buildPrompt: () =>
+          buildCommentActionPrompt({
+            owner,
+            repo: repoName,
+            number: pr.number,
+            title: pr.title,
+            base: pr.base.ref,
+            head: pr.head.ref,
+            commentBody,
+            commenter: sender.login,
+            isPublic: !repo.private,
+            filePath: comment.path,
+            diffHunk: comment.diff_hunk,
+            commentId: comment.id,
+            commentActionInstructions: config.commentActionInstructions,
+          }),
+      })
   );
 }

--- a/packages/github-bot/src/session-launch.ts
+++ b/packages/github-bot/src/session-launch.ts
@@ -1,0 +1,121 @@
+import {
+  createSessionResponseSchema,
+  sendPromptResponseSchema,
+} from "@open-inspect/shared/types/session-api";
+import { signedControlPlaneFetch } from "./internal-auth";
+import type { Logger } from "./logger";
+import { resolveSessionTarget } from "./session-target";
+import type { Env, ReviewRequestedPayload } from "./types";
+import type { ResolvedGitHubConfig } from "./utils/integration-config";
+
+export type SessionLaunchResult = {
+  outcome: "processed";
+  session_id: string;
+  message_id: string;
+  handler_action: string;
+};
+
+export async function launchSession(
+  env: Env,
+  log: Logger,
+  params: {
+    owner: string;
+    repoName: string;
+    sender: ReviewRequestedPayload["sender"];
+    config: ResolvedGitHubConfig;
+    ghToken: string;
+    traceId: string;
+    pullNumber: number;
+    title: string;
+    action: string;
+    buildPrompt: () => string;
+  }
+): Promise<SessionLaunchResult> {
+  const {
+    owner,
+    repoName,
+    sender,
+    config,
+    ghToken,
+    traceId,
+    pullNumber,
+    title,
+    action,
+    buildPrompt,
+  } = params;
+  const meta = {
+    trace_id: traceId,
+    repo: `${owner}/${repoName}`.toLowerCase(),
+    pull_number: pullNumber,
+  };
+  const target = await resolveSessionTarget(env, log, {
+    owner,
+    repoName,
+    senderLogin: sender.login,
+    config,
+    ghToken,
+    traceId,
+  });
+  const actor = `github:${sender.id}`;
+  const body: Record<string, unknown> = {
+    ...target,
+    title,
+    model: config.model,
+    scmLogin: sender.login,
+    scmAvatarUrl: sender.avatar_url,
+  };
+  if (config.reasoningEffort) {
+    body.reasoningEffort = config.reasoningEffort;
+  }
+  const sessionResponse = await signedControlPlaneFetch(env, {
+    method: "POST",
+    url: "https://internal/sessions",
+    body: JSON.stringify(body),
+    actor,
+    traceId,
+  });
+  if (!sessionResponse.ok) {
+    throw new Error(
+      `Session creation failed: ${sessionResponse.status} ${await sessionResponse.text()}`
+    );
+  }
+  const sessionResult = createSessionResponseSchema.safeParse(await sessionResponse.json());
+  if (!sessionResult.success) {
+    throw new Error("Session creation failed: invalid response");
+  }
+  const sessionId = sessionResult.data.sessionId;
+  log.info("session.created", { ...meta, session_id: sessionId, action });
+
+  const prompt = buildPrompt();
+  const promptResponse = await signedControlPlaneFetch(env, {
+    method: "POST",
+    url: `https://internal/sessions/${sessionId}/prompt`,
+    body: JSON.stringify({ content: prompt, source: "github" }),
+    actor,
+    traceId,
+  });
+  if (!promptResponse.ok) {
+    throw new Error(
+      `Prompt delivery failed: ${promptResponse.status} ${await promptResponse.text()}`
+    );
+  }
+  const promptResult = sendPromptResponseSchema.safeParse(await promptResponse.json());
+  if (!promptResult.success) {
+    throw new Error("Prompt delivery failed: invalid response");
+  }
+  const messageId = promptResult.data.messageId;
+  log.info("prompt.sent", {
+    ...meta,
+    session_id: sessionId,
+    message_id: messageId,
+    source: "github",
+    content_length: prompt.length,
+  });
+
+  return {
+    outcome: "processed",
+    session_id: sessionId,
+    message_id: messageId,
+    handler_action: action,
+  };
+}

--- a/packages/github-bot/src/session-launch.ts
+++ b/packages/github-bot/src/session-launch.ts
@@ -1,11 +1,13 @@
 import {
   createSessionResponseSchema,
   sendPromptResponseSchema,
+  type CreateSessionInput,
+  type SendPromptRequest,
 } from "@open-inspect/shared/types/session-api";
 import { signedControlPlaneFetch } from "./internal-auth";
 import type { Logger } from "./logger";
 import { resolveSessionTarget } from "./session-target";
-import type { Env, ReviewRequestedPayload } from "./types";
+import type { Env } from "./types";
 import type { ResolvedGitHubConfig } from "./utils/integration-config";
 
 export type SessionLaunchResult = {
@@ -21,7 +23,7 @@ export async function launchSession(
   params: {
     owner: string;
     repoName: string;
-    sender: ReviewRequestedPayload["sender"];
+    sender: { login: string; id: number; avatar_url: string };
     config: ResolvedGitHubConfig;
     ghToken: string;
     traceId: string;
@@ -57,16 +59,14 @@ export async function launchSession(
     traceId,
   });
   const actor = `github:${sender.id}`;
-  const body: Record<string, unknown> = {
+  const body = {
     ...target,
     title,
     model: config.model,
     scmLogin: sender.login,
-    scmAvatarUrl: sender.avatar_url,
-  };
-  if (config.reasoningEffort) {
-    body.reasoningEffort = config.reasoningEffort;
-  }
+    actorAvatarUrl: sender.avatar_url,
+    ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
+  } satisfies CreateSessionInput;
   const sessionResponse = await signedControlPlaneFetch(env, {
     method: "POST",
     url: "https://internal/sessions",
@@ -90,7 +90,7 @@ export async function launchSession(
   const promptResponse = await signedControlPlaneFetch(env, {
     method: "POST",
     url: `https://internal/sessions/${sessionId}/prompt`,
-    body: JSON.stringify({ content: prompt, source: "github" }),
+    body: JSON.stringify({ content: prompt, source: "github" } satisfies SendPromptRequest),
     actor,
     traceId,
   });

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -218,7 +218,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
-    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
+    expect(sessionBody.actorAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
     // Identity travels via the signed actor assertion, never the body.
     expect(sessionBody).not.toHaveProperty("scmUserId");
     expect(sessionBody).not.toHaveProperty("spawnSource");
@@ -430,7 +430,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
-    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
+    expect(sessionBody.actorAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
     // Identity travels via the signed actor assertion, never the body.
     expect(sessionBody).not.toHaveProperty("scmUserId");
     expect(sessionBody).not.toHaveProperty("spawnSource");
@@ -547,7 +547,7 @@ describe("handleIssueComment", () => {
 
     const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.scmLogin).toBe("bob");
-    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1002");
+    expect(sessionBody.actorAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1002");
     // Identity travels via the signed actor assertion, never the body.
     expect(sessionBody).not.toHaveProperty("scmUserId");
     expect(sessionBody).not.toHaveProperty("spawnSource");
@@ -663,7 +663,7 @@ describe("handleReviewComment", () => {
 
     const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.scmLogin).toBe("carol");
-    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1003");
+    expect(sessionBody.actorAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1003");
     // Identity travels via the signed actor assertion, never the body.
     expect(sessionBody).not.toHaveProperty("scmUserId");
     expect(sessionBody).not.toHaveProperty("spawnSource");

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -234,29 +234,6 @@ describe("handlePullRequestOpened", () => {
     );
   });
 
-  it("rejects a malformed session creation response before sending a prompt", async () => {
-    const env = createMockEnv();
-    const cpFetch = getControlPlaneFetch(env);
-    cpFetch.mockImplementation((url: string) => {
-      if (url === "https://internal/sessions") {
-        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
-      }
-      if (/\/sessions\/.+\/prompt$/.test(url)) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ messageId: "msg-456" }), { status: 200 })
-        );
-      }
-      return Promise.resolve(new Response("Not found", { status: 404 }));
-    });
-    const log = createMockLogger();
-
-    await expect(
-      handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-0")
-    ).rejects.toThrow("Session creation failed: invalid response");
-
-    expect(cpFetch).toHaveBeenCalledTimes(2);
-  });
-
   it("returns early for draft PRs", async () => {
     const env = createMockEnv();
     const log = createMockLogger();

--- a/packages/github-bot/test/session-launch.test.ts
+++ b/packages/github-bot/test/session-launch.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSessionInputSchema,
+  sendPromptRequestSchema,
+} from "@open-inspect/shared/types/session-api";
 import { signedControlPlaneFetch } from "../src/internal-auth";
 import { launchSession } from "../src/session-launch";
 import { resolveSessionTarget } from "../src/session-target";
@@ -113,18 +117,22 @@ describe("launchSession", () => {
           body: expect.any(String),
         },
       ]);
-      expect(JSON.parse(requests[0].body!)).toEqual({
+      const sessionBody = JSON.parse(requests[0].body!);
+      expect(sessionBody).toEqual({
         ...target,
         title: params.title,
         model: params.config.model,
         reasoningEffort: "high",
         scmLogin: "alice",
-        scmAvatarUrl: params.sender.avatar_url,
+        actorAvatarUrl: params.sender.avatar_url,
       });
-      expect(JSON.parse(requests[1].body!)).toEqual({
+      expect(createSessionInputSchema.parse(sessionBody)).toEqual(sessionBody);
+      const promptBody = JSON.parse(requests[1].body!);
+      expect(promptBody).toEqual({
         content: "Review this PR",
         source: "github",
       });
+      expect(sendPromptRequestSchema.parse(promptBody)).toEqual(promptBody);
       const meta = {
         trace_id: params.traceId,
         repo: "acme/widgets",

--- a/packages/github-bot/test/session-launch.test.ts
+++ b/packages/github-bot/test/session-launch.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signedControlPlaneFetch } from "../src/internal-auth";
+import { launchSession } from "../src/session-launch";
+import { resolveSessionTarget } from "../src/session-target";
+import type { Logger } from "../src/logger";
+import type { Env } from "../src/types";
+
+vi.mock("../src/internal-auth", () => ({ signedControlPlaneFetch: vi.fn() }));
+vi.mock("../src/session-target", () => ({ resolveSessionTarget: vi.fn() }));
+
+const env = {} as Env;
+const log: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+};
+const params = {
+  owner: "Acme",
+  repoName: "Widgets",
+  sender: { login: "alice", id: 1001, avatar_url: "https://example.com/alice.png" },
+  config: {
+    model: "openai/gpt-5",
+    reasoningEffort: "high",
+    autoReviewOnOpen: true,
+    enabledRepos: null,
+    allowedTriggerUsers: null,
+    codeReviewInstructions: null,
+    commentActionInstructions: null,
+  },
+  ghToken: "installation-token",
+  traceId: "trace-launch",
+  pullNumber: 42,
+  title: "GitHub: Review PR #42",
+  action: "review",
+  buildPrompt: vi.fn(() => "Review this PR"),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  params.buildPrompt.mockReturnValue("Review this PR");
+  vi.mocked(resolveSessionTarget).mockResolvedValue({ repoOwner: "Acme", repoName: "Widgets" });
+  vi.mocked(signedControlPlaneFetch).mockImplementation(async (_env, request) =>
+    Response.json(
+      request.url === "https://internal/sessions"
+        ? { sessionId: "session-123", status: "created" }
+        : { messageId: "msg-456" }
+    )
+  );
+});
+
+describe("launchSession", () => {
+  it.each([{ repoOwner: "Acme", repoName: "Widgets" }, { environmentId: "env-123" }])(
+    "launches the resolved target %j in order with actor and config mapping",
+    async (target) => {
+      const steps: string[] = [];
+      vi.mocked(resolveSessionTarget).mockImplementation(async () => {
+        steps.push("resolve");
+        return target;
+      });
+      vi.mocked(signedControlPlaneFetch).mockImplementation(async (_env, request) => {
+        const creating = request.url === "https://internal/sessions";
+        steps.push(creating ? "create" : "send");
+        return Response.json(
+          creating ? { sessionId: "session-123", status: "created" } : { messageId: "msg-456" }
+        );
+      });
+      vi.mocked(log.info).mockImplementation((event) => {
+        steps.push(event);
+      });
+      params.buildPrompt.mockImplementation(() => {
+        steps.push("build");
+        return "Review this PR";
+      });
+
+      await expect(launchSession(env, log, params)).resolves.toEqual({
+        outcome: "processed",
+        session_id: "session-123",
+        message_id: "msg-456",
+        handler_action: "review",
+      });
+      expect(steps).toEqual([
+        "resolve",
+        "create",
+        "session.created",
+        "build",
+        "send",
+        "prompt.sent",
+      ]);
+      expect(resolveSessionTarget).toHaveBeenCalledWith(env, log, {
+        owner: params.owner,
+        repoName: params.repoName,
+        senderLogin: "alice",
+        config: params.config,
+        ghToken: params.ghToken,
+        traceId: params.traceId,
+      });
+      const requests = vi.mocked(signedControlPlaneFetch).mock.calls.map(([, request]) => request);
+      expect(requests).toEqual([
+        {
+          method: "POST",
+          url: "https://internal/sessions",
+          actor: "github:1001",
+          traceId: params.traceId,
+          body: expect.any(String),
+        },
+        {
+          method: "POST",
+          url: "https://internal/sessions/session-123/prompt",
+          actor: "github:1001",
+          traceId: params.traceId,
+          body: expect.any(String),
+        },
+      ]);
+      expect(JSON.parse(requests[0].body!)).toEqual({
+        ...target,
+        title: params.title,
+        model: params.config.model,
+        reasoningEffort: "high",
+        scmLogin: "alice",
+        scmAvatarUrl: params.sender.avatar_url,
+      });
+      expect(JSON.parse(requests[1].body!)).toEqual({
+        content: "Review this PR",
+        source: "github",
+      });
+      const meta = {
+        trace_id: params.traceId,
+        repo: "acme/widgets",
+        pull_number: 42,
+        session_id: "session-123",
+      };
+      expect(log.info).toHaveBeenNthCalledWith(1, "session.created", { ...meta, action: "review" });
+      expect(log.info).toHaveBeenNthCalledWith(2, "prompt.sent", {
+        ...meta,
+        message_id: "msg-456",
+        source: "github",
+        content_length: "Review this PR".length,
+      });
+    }
+  );
+
+  it("omits an unset reasoning effort", async () => {
+    await launchSession(env, log, {
+      ...params,
+      config: { ...params.config, reasoningEffort: null },
+    });
+    const request = vi.mocked(signedControlPlaneFetch).mock.calls[0][1];
+    expect(JSON.parse(request.body!)).not.toHaveProperty("reasoningEffort");
+  });
+
+  it("stops if target resolution rejects", async () => {
+    vi.mocked(resolveSessionTarget).mockRejectedValue(new Error("target failed"));
+    await expect(launchSession(env, log, params)).rejects.toThrow("target failed");
+    expect(signedControlPlaneFetch).not.toHaveBeenCalled();
+    expect(params.buildPrompt).not.toHaveBeenCalled();
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it.each(["create", "send"])(
+    "propagates %s failures without advancing or retrying",
+    async (stage) => {
+      const error = new Error("network failed");
+      vi.mocked(signedControlPlaneFetch).mockImplementation(async (_env, request) => {
+        if (stage === "create" || request.url.endsWith("/prompt")) throw error;
+        return Response.json({ sessionId: "session-123", status: "created" });
+      });
+      await expect(launchSession(env, log, params)).rejects.toBe(error);
+      expect(signedControlPlaneFetch).toHaveBeenCalledTimes(stage === "create" ? 1 : 2);
+      expect(params.buildPrompt).toHaveBeenCalledTimes(stage === "create" ? 0 : 1);
+      expect(log.info).toHaveBeenCalledTimes(stage === "create" ? 0 : 1);
+    }
+  );
+
+  it.each([
+    ["create", "http", "Session creation failed: 500 unavailable"],
+    ["create", "schema", "Session creation failed: invalid response"],
+    ["create", "json", ""],
+    ["send", "http", "Prompt delivery failed: 500 unavailable"],
+    ["send", "schema", "Prompt delivery failed: invalid response"],
+    ["send", "json", ""],
+  ])("rejects %s %s errors", async (stage, failure, message) => {
+    vi.mocked(signedControlPlaneFetch).mockImplementation(async (_env, request) => {
+      if (stage === "send" && request.url === "https://internal/sessions") {
+        return Response.json({ sessionId: "session-123", status: "created" });
+      }
+      if (failure === "http") return new Response("unavailable", { status: 500 });
+      if (failure === "json") return new Response("not json");
+      return Response.json({});
+    });
+    await expect(launchSession(env, log, params)).rejects.toThrow(
+      failure === "json" ? SyntaxError : message
+    );
+    expect(signedControlPlaneFetch).toHaveBeenCalledTimes(stage === "create" ? 1 : 2);
+    expect(params.buildPrompt).toHaveBeenCalledTimes(stage === "create" ? 0 : 1);
+    expect(log.info).toHaveBeenCalledTimes(stage === "create" ? 0 : 1);
+  });
+
+  it("does not deliver a prompt if its builder throws", async () => {
+    params.buildPrompt.mockImplementation(() => {
+      throw new Error("prompt failed");
+    });
+    await expect(launchSession(env, log, params)).rejects.toThrow("prompt failed");
+    expect(signedControlPlaneFetch).toHaveBeenCalledTimes(1);
+    expect(log.info).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract a GitHub-local `launchSession` module used by review-requested, PR-opened, issue-comment, and review-comment handlers.
- Centralize target resolution, session creation, actor/model mapping, prompt delivery, logging, and processed-result construction.
- Keep event gating, reactions, and event-specific prompt construction in the adapters, preserving the existing launch order and failure behavior.
- Add shared contract tests for repository/environment targets, ordering, request mapping, and target/create/build/send failures. Retain event-specific handler coverage and move malformed-response coverage to the shared suite.

## Validation
- `npm test -w @open-inspect/github-bot`: 158 tests passed across 9 files
- `npm run typecheck -w @open-inspect/github-bot`
- `npm run lint -w @open-inspect/github-bot`
- `npm run build -w @open-inspect/github-bot`
- Prettier checks and `git diff --check`
- Independent code review found no regressions

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1bb1be7be55934794902892cd3721885)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - GitHub review requests now use a consistent session-launch flow across supported event handlers.
  - Session targets are resolved before prompts are delivered, including repository- and environment-based targets.
  - Errors during session creation, target resolution, or prompt delivery are surfaced more consistently.
  - Session and prompt activity is recorded for improved operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->