### PR TITLE
refactor: move Slack delivery mechanics out of the scheduler

### DIFF
--- a/packages/control-plane/src/scheduler/scheduler.test.ts
+++ b/packages/control-plane/src/scheduler/scheduler.test.ts
@@ -15,6 +15,7 @@ import { fakeSessionRuntimeDispatch } from "../router.test-support";
 import type { Logger } from "../logger";
 import type { InvocationRunAggregate } from "../db/automation-store";
 import type { SlackAutomationEvent } from "@open-inspect/shared/triggers";
+import { SlackDelivery } from "./slack-delivery";
 
 const mockCheckRepositoryAccess = vi.hoisted(() => vi.fn());
 const mockResolveSessionProviderAuth = vi.hoisted(() =>
@@ -2251,18 +2252,26 @@ describe("Scheduler", () => {
       });
 
       it("does not request context when admission is skipped for concurrency", async () => {
-        mockGetSlackAutomationsForChannel.mockResolvedValue([sampleSlackAutomation]);
+        mockGetSlackAutomationsForChannel.mockResolvedValue([
+          sampleSlackAutomation,
+          { ...sampleSlackAutomation, id: "auto-slack-2" },
+        ]);
         mockStore.getLatestSteerableRunForThread.mockResolvedValue(null);
         mockStore.getActiveRunForKey.mockResolvedValue(sampleRunRow({ id: "busy" }));
         const { slackFetch, env } = threadContextEnv();
 
         expect(await createScheduler(env).event(makeSlackEvent())).toEqual({
           triggered: 0,
-          skipped: 1,
+          skipped: 2,
           steered: 0,
         });
 
         expect(threadContextCalls(slackFetch)).toHaveLength(0);
+        // A shared event gets one notice, not one per skipped automation.
+        expect(slackFetch).toHaveBeenCalledExactlyOnceWith(
+          "https://internal/callbacks/automation-skip",
+          expect.any(Object)
+        );
       });
 
       it("does not request context when the invocation is deduplicated", async () => {
@@ -2280,6 +2289,7 @@ describe("Scheduler", () => {
         });
 
         expect(threadContextCalls(slackFetch)).toHaveLength(0);
+        expect(slackFetch).not.toHaveBeenCalled();
       });
 
       it("requests context once for an admitted run and splices it into the prompt", async () => {
@@ -2375,51 +2385,24 @@ describe("Scheduler", () => {
         expect(String(prompt.content)).not.toContain("<thread_context>");
       });
 
-      it("launches without history when the context request is aborted", async () => {
-        mockGetSlackAutomationsForChannel.mockResolvedValue([sampleSlackAutomation]);
-        mockStore.getLatestSteerableRunForThread.mockResolvedValue(null);
-        // What a timed-out binding fetch looks like to the caller.
-        const slackFetch = vi.fn(async () => {
-          throw Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" });
-        });
-        const stub = createMockSessionStub();
-        const env = createEnv(
-          {
-            SLACK_BOT: { fetch: slackFetch } as FetchClient,
-            SERVICE_AUTH_SECRET_SLACK_BOT: "test-secret",
-          } as Partial<Env>,
-          stub
-        );
-
-        expect(await createScheduler(env).event(makeSlackEvent())).toEqual({
-          triggered: 1,
-          skipped: 0,
-          steered: 0,
-        });
-
-        // The run still launches — a slow Slack read must not strand children.
-        const prompt = await getPromptBody(vi.mocked(stub.fetch));
-        expect(String(prompt.content)).toContain("A message was posted in #ops.");
-        expect(String(prompt.content)).not.toContain("<thread_context>");
-      });
-
       it("uses the baseline prompt when lazy prompt construction rejects", async () => {
         mockGetSlackAutomationsForChannel.mockResolvedValue([sampleSlackAutomation]);
         mockStore.getLatestSteerableRunForThread.mockResolvedValue(null);
         const { env, stub } = threadContextEnv();
         const scheduler = createScheduler(env);
-        const promptBuilder = scheduler as unknown as {
-          buildSlackContextWithThread: () => Promise<string>;
-        };
-        vi.spyOn(promptBuilder, "buildSlackContextWithThread").mockRejectedValue(
-          new Error("prompt provider failed")
-        );
+        const promptBuilder = vi
+          .spyOn(SlackDelivery.prototype, "buildSlackContextWithThread")
+          .mockRejectedValueOnce(new Error("prompt provider failed"));
 
-        expect(await scheduler.event(makeSlackEvent())).toEqual({
-          triggered: 1,
-          skipped: 0,
-          steered: 0,
-        });
+        try {
+          expect(await scheduler.event(makeSlackEvent())).toEqual({
+            triggered: 1,
+            skipped: 0,
+            steered: 0,
+          });
+        } finally {
+          promptBuilder.mockRestore();
+        }
 
         const prompt = await getPromptBody(vi.mocked(stub.fetch));
         expect(String(prompt.content)).toContain("A message was posted in #ops.");

--- a/packages/control-plane/src/scheduler/scheduler.ts
+++ b/packages/control-plane/src/scheduler/scheduler.ts
@@ -11,8 +11,6 @@
 import {
   matchesConditions,
   conditionRegistry,
-  buildSlackContextBlock,
-  slackChannelLabel,
   type AutomationEvent,
   type SlackAutomationEvent,
   type TriggerConfig,
@@ -26,9 +24,6 @@ import type {
   AutomationCallbackContext,
   SlackCallbackContext,
 } from "@open-inspect/shared/types/session-api";
-import { computeHmacHex } from "@open-inspect/shared/auth";
-import { z } from "zod";
-import { callbackSigningSecret } from "../auth/service/callback-signing";
 import {
   AutomationStore,
   toAutomationRun,
@@ -46,13 +41,8 @@ import {
 } from "../db/automation-model-provider-auth";
 import { SlackChannelStore } from "../db/slack-channel-store";
 import { IntegrationSettingsStore } from "../db/integration-settings";
-import {
-  buildSlackCompletionNotification,
-  buildSlackSkipNotification,
-  parseSlackTriggerMetadata,
-  type SlackRunMetadata,
-  type SlackCompletionContext,
-} from "./slack-completion";
+import { parseSlackTriggerMetadata, type SlackRunMetadata } from "./slack-completion";
+import { SlackDelivery } from "./slack-delivery";
 import { UserStore } from "../db/user-store";
 import { createRequestMetrics } from "../db/instrumented-sql-database";
 import { generateId } from "../auth/crypto";
@@ -77,7 +67,6 @@ import {
   isPrincipalAuthorized,
 } from "../automation/authorization-guard";
 import type { RequestContext } from "../routes/shared";
-import { deliverWithRetry } from "../session/callback-delivery";
 import type { GitHubEnrichment } from "../session/identity";
 
 /** Max automations to process per tick (backpressure). */
@@ -125,15 +114,6 @@ const INVOCATION_SWEEP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const SLACK_THREAD_CONTINUITY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Bound on the thread-context request. It sits between admission and launch, so
- * a slow Slack read would hold every child in `starting` until the orphan sweep
- * repairs them. Matches the callback-delivery attempt timeout; on expiry the run
- * launches with no thread history, which is the same fallback as any other
- * failure.
- */
-const SLACK_THREAD_CONTEXT_TIMEOUT_MS = 10_000;
-
-/**
  * Repository label for user-facing surfaces (Slack), read from the run's
  * firing-time snapshot — the automation row's selection may have been edited
  * since this run started.
@@ -157,10 +137,6 @@ async function getSlackSessionInstructions(db: SqlDatabase): Promise<string | un
 function appendSlackSessionInstructions(prompt: string, instructions: string | undefined): string {
   return instructions ? `${prompt}\n\n## Additional Instructions\n\n${instructions}` : prompt;
 }
-
-const slackThreadContextResponseSchema = z.object({
-  threadContext: z.string(),
-});
 
 export interface AutomationRunCompletion {
   automationId: string;
@@ -288,6 +264,7 @@ export function composeAutomationPrompt(contextBlock: string, instructions: stri
 /** Coordinates authorized automation scheduling, dispatch, and completion handling. */
 export class Scheduler {
   private readonly log: Logger;
+  private readonly slackDelivery: SlackDelivery;
 
   constructor(
     private readonly db: SqlDatabase,
@@ -295,6 +272,7 @@ export class Scheduler {
     private readonly backgroundJobs: BackgroundTasks
   ) {
     this.log = createLogger("scheduler", {}, parseLogLevel(env.LOG_LEVEL));
+    this.slackDelivery = new SlackDelivery(env, this.log);
   }
 
   /**
@@ -991,7 +969,7 @@ export class Scheduler {
     // same channel; they must not each re-read the thread.
     let slackContextPromise: Promise<string> | undefined;
     const slackContextBlock = (slackEvent: SlackAutomationEvent): Promise<string> => {
-      slackContextPromise ??= this.buildSlackContextWithThread(slackEvent);
+      slackContextPromise ??= this.slackDelivery.buildSlackContextWithThread(slackEvent);
       return slackContextPromise;
     };
     let slackSteeringActorPromise: Promise<string | null> | undefined;
@@ -1135,7 +1113,7 @@ export class Scheduler {
     }
 
     if (event.source === "slack" && concurrencySkipped) {
-      await this.notifySlackConcurrencySkip(event);
+      await this.slackDelivery.notifySlackConcurrencySkip(event);
     }
 
     this.log.info("Event processed", {
@@ -1280,7 +1258,7 @@ export class Scheduler {
     const slackMeta = parseSlackTriggerMetadata(invocation?.trigger_metadata ?? null);
     if (slackMeta) {
       const automation = await store.getById(body.automationId);
-      await this.notifySlackCompletion(run, slackMeta, {
+      await this.slackDelivery.notifySlackCompletion(run, slackMeta, {
         sessionId: body.sessionId,
         messageId: body.messageId,
         success: body.success,
@@ -1288,154 +1266,6 @@ export class Scheduler {
         repoFullName: formatRunRepositoryLabel(run),
         model: automation?.model ?? "",
         reasoningEffort: automation?.reasoning_effort ?? undefined,
-      });
-    }
-  }
-
-  /**
-   * Tell the slack-bot to post a slack-triggered run's result into the triggering
-   * message's thread and clear the `eyes` reaction, via its
-   * `/callbacks/automation-complete` endpoint. Signs the body with the
-   * slack-bot's own service secret (in-body HMAC, matching the bot's other
-   * callbacks). No-ops when the run has no triggering message, when
-   * `SLACK_BOT` is unbound, or when the secret is unset — all best-effort.
-   */
-  private async notifySlackCompletion(
-    run: AutomationRunRow,
-    meta: SlackRunMetadata,
-    ctx: SlackCompletionContext
-  ): Promise<void> {
-    const binding = this.env.SLACK_BOT;
-    const secret = callbackSigningSecret(this.env, "slack-bot");
-    if (!binding || !secret) return;
-
-    const body = buildSlackCompletionNotification(meta, ctx);
-    if (!body) return;
-
-    const signature = await computeHmacHex(JSON.stringify(body), secret);
-    await deliverWithRetry(
-      (signal) =>
-        binding.fetch("https://internal/callbacks/automation-complete", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...body, signature }),
-          signal,
-        }),
-      (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
-      ({ attempt, response, error }) => {
-        this.log.warn("Slack completion callback failed", {
-          event: "scheduler.slack_complete_failed",
-          automation_id: run.automation_id,
-          run_id: run.id,
-          attempt,
-          ...(response ? { http_status: response.status } : {}),
-          ...(error !== undefined
-            ? { error: error instanceof Error ? error : new Error(String(error)) }
-            : {}),
-        });
-      }
-    );
-  }
-
-  /**
-   * Rebuild a Slack event's context block with the thread the message was posted
-   * in, asking slack-bot to fetch and render it.
-   *
-   * Called only after an invocation has been admitted, so the read is paid for
-   * exactly when a run will consume it. The bot owns the Slack token and
-   * display-name resolution; the scheduler only splices the rendered block into
-   * the same layout the ingress path used.
-   *
-   * Every failure path returns the original context block: thread history is an
-   * enhancement and must never prevent a run from starting.
-   */
-  private async buildSlackContextWithThread(event: SlackAutomationEvent): Promise<string> {
-    if (!event.threadTs) return event.contextBlock;
-
-    const binding = this.env.SLACK_BOT;
-    const secret = callbackSigningSecret(this.env, "slack-bot");
-    if (!binding || !secret) return event.contextBlock;
-
-    try {
-      const body = {
-        channel: event.channelId,
-        threadTs: event.threadTs,
-        ts: event.ts,
-      };
-      const signature = await computeHmacHex(JSON.stringify(body), secret);
-      const response = await binding.fetch("https://internal/internal/thread-context", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...body, signature }),
-        signal: AbortSignal.timeout(SLACK_THREAD_CONTEXT_TIMEOUT_MS),
-      });
-      if (!response.ok) {
-        this.log.warn("Slack thread context request failed", {
-          event: "scheduler.slack_thread_context_failed",
-          channel: event.channelId,
-          http_status: response.status,
-        });
-        return event.contextBlock;
-      }
-
-      const parsed = slackThreadContextResponseSchema.safeParse(await response.json());
-      const threadContext = parsed.success ? parsed.data.threadContext : "";
-      if (!threadContext) return event.contextBlock;
-
-      return buildSlackContextBlock({
-        channelLabel: slackChannelLabel(event.channelId, event.channelName),
-        actorUserId: event.actorUserId,
-        permalink: event.permalink,
-        text: event.text,
-        threadContext,
-      });
-    } catch (error) {
-      this.log.warn("Slack thread context request threw", {
-        event: "scheduler.slack_thread_context_failed",
-        channel: event.channelId,
-        error: error instanceof Error ? error : new Error(String(error)),
-      });
-      return event.contextBlock;
-    }
-  }
-
-  /**
-   * Post a best-effort ephemeral "a run is already active for this thread"
-   * notice to the message author when a slack event is dropped by the
-   * per-thread concurrency guard. No-ops without a binding/secret/actor.
-   */
-  private async notifySlackConcurrencySkip(event: SlackAutomationEvent): Promise<void> {
-    const binding = this.env.SLACK_BOT;
-    const secret = callbackSigningSecret(this.env, "slack-bot");
-    if (!binding || !secret) return;
-
-    const body = buildSlackSkipNotification({
-      channelId: event.channelId,
-      actorUserId: event.actorUserId,
-      threadTs: event.threadTs,
-      ts: event.ts,
-    });
-    if (!body) return;
-
-    try {
-      const signature = await computeHmacHex(JSON.stringify(body), secret);
-      const response = await binding.fetch("https://internal/callbacks/automation-skip", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...body, signature }),
-      });
-      if (!response.ok) {
-        this.log.warn("Slack skip callback failed", {
-          event: "scheduler.slack_skip_failed",
-          channel: event.channelId,
-          http_status: response.status,
-        });
-      }
-    } catch (e) {
-      this.log.warn("Slack skip callback errored", {
-        event: "scheduler.slack_skip_failed",
-        channel: event.channelId,
-        error: e instanceof Error ? e : new Error(String(e)),
       });
     }
   }

--- a/packages/control-plane/src/scheduler/slack-completion.ts
+++ b/packages/control-plane/src/scheduler/slack-completion.ts
@@ -1,7 +1,7 @@
 /**
  * Pure builders for the scheduler → slack-bot notifications (run completion and
  * concurrency-skip). Kept free of Durable Object state so they can be unit
- * tested directly; the scheduler signs the result (HMAC over the JSON
+ * tested directly; SlackDelivery signs the result (HMAC over the JSON
  * body) and POSTs it via the optional `SLACK_BOT` Fetcher.
  *
  * Returning `null` from either builder is the explicit signal to skip the bot
@@ -42,8 +42,8 @@ export function parseSlackTriggerMetadata(raw: string | null | undefined): Slack
 /**
  * Run result fields the bot needs to post the agent's final response into the
  * triggering message's thread. The scheduler sources `sessionId`/`messageId`
- * (and success/error) from the run-complete callback and repo/model from the
- * automation row.
+ * (and success/error) from the run-complete callback, repo from the run's
+ * firing-time snapshot, and model/reasoning effort from the automation row.
  */
 export interface SlackCompletionContext {
   sessionId: string;

--- a/packages/control-plane/src/scheduler/slack-delivery.test.ts
+++ b/packages/control-plane/src/scheduler/slack-delivery.test.ts
@@ -1,0 +1,258 @@
+import { createHmac } from "node:crypto";
+import type { SlackAutomationEvent } from "@open-inspect/shared/triggers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import type { Env } from "../types";
+import { SlackDelivery } from "./slack-delivery";
+
+const secret = "slack-delivery-test-secret";
+const run = { automation_id: "automation-1", id: "run-1" };
+const meta = { channel: "C1", messageTs: "1700000000.000002" };
+const context = {
+  sessionId: "session-1",
+  messageId: "message-1",
+  success: false,
+  error: "Run failed",
+  repoFullName: "acme/web",
+  model: "openai/gpt-5",
+  reasoningEffort: "high",
+};
+const event: SlackAutomationEvent = {
+  source: "slack",
+  eventType: "message.posted",
+  triggerKey: "slack:msg:C1:1700000000.000002",
+  concurrencyKey: "slack:thread:C1:1700000000.000001",
+  channelId: "C1",
+  channelName: "engineering",
+  actorUserId: "U1",
+  ts: meta.messageTs,
+  threadTs: "1700000000.000001",
+  permalink: "https://slack.example/message",
+  text: "Please investigate",
+  contextBlock: "Original context",
+  meta: {},
+};
+
+function setup(overrides: Partial<Pick<Env, "SLACK_BOT" | "SERVICE_AUTH_SECRET_SLACK_BOT">> = {}) {
+  const fetch = vi.fn<NonNullable<Env["SLACK_BOT"]>["fetch"]>();
+  fetch.mockResolvedValue(new Response(null, { status: 200 }));
+  const log: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => log),
+  };
+  const delivery = new SlackDelivery(
+    {
+      SLACK_BOT: { fetch } as NonNullable<Env["SLACK_BOT"]>,
+      SERVICE_AUTH_SECRET_SLACK_BOT: secret,
+      ...overrides,
+    },
+    log
+  );
+  return { delivery, fetch, log };
+}
+
+function signedBody(body: Record<string, unknown>) {
+  return JSON.stringify({
+    ...body,
+    signature: createHmac("sha256", secret).update(JSON.stringify(body)).digest("hex"),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("SlackDelivery", () => {
+  it("posts the complete result with a real HMAC and stops on success", async () => {
+    const { delivery, fetch, log } = setup();
+    await delivery.notifySlackCompletion(run, meta, context);
+    expect(fetch).toHaveBeenCalledExactlyOnceWith(
+      "https://internal/callbacks/automation-complete",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: signedBody({ channel: meta.channel, reactionMessageTs: meta.messageTs, ...context }),
+        signal: expect.any(AbortSignal),
+      }
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it.each(["binding", "secret", "empty secret"])(
+    "no-ops all methods without %s",
+    async (missing) => {
+      const { delivery, fetch, log } = setup(
+        missing === "binding"
+          ? { SLACK_BOT: undefined }
+          : { SERVICE_AUTH_SECRET_SLACK_BOT: missing === "secret" ? undefined : "" }
+      );
+      await delivery.notifySlackCompletion(run, meta, context);
+      await delivery.notifySlackConcurrencySkip(event);
+      await expect(delivery.buildSlackContextWithThread(event)).resolves.toBe(event.contextBlock);
+      expect(fetch).not.toHaveBeenCalled();
+      expect(log.warn).not.toHaveBeenCalled();
+    }
+  );
+
+  it("no-ops without the triggering message, skip actor, or context thread", async () => {
+    const { delivery, fetch } = setup();
+    await delivery.notifySlackCompletion(run, { ...meta, messageTs: "" }, context);
+    await delivery.notifySlackConcurrencySkip({ ...event, actorUserId: "" });
+    await expect(
+      delivery.buildSlackContextWithThread({ ...event, threadTs: undefined })
+    ).resolves.toBe(event.contextBlock);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["non-OK", true],
+    ["thrown fetch", true],
+    ["non-OK", false],
+    ["thrown fetch", false],
+  ] as const)(
+    "retries completion after %s (recovery: %s) with bounded exhaustion",
+    async (kind, recovers) => {
+      vi.useFakeTimers();
+      const { delivery, fetch, log } = setup();
+      const error = new Error("Network unavailable");
+      if (kind === "non-OK") fetch.mockResolvedValue(new Response(null, { status: 503 }));
+      else fetch.mockRejectedValue(error);
+
+      const pending = delivery.notifySlackCompletion(run, meta, context);
+      // HMAC uses real WebCrypto; wait for it before advancing the retry sleep.
+      await vi.waitFor(() => expect(log.warn).toHaveBeenCalledTimes(1));
+      expect(fetch).toHaveBeenCalledTimes(1);
+      if (recovers) fetch.mockResolvedValue(new Response(null, { status: 200 }));
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch.mock.calls[1][0]).toBe(fetch.mock.calls[0][0]);
+      expect(fetch.mock.calls[1][1]?.body).toBe(fetch.mock.calls[0][1]?.body);
+      expect(log.warn).toHaveBeenCalledTimes(recovers ? 1 : 2);
+      for (let attempt = 1; attempt <= (recovers ? 1 : 2); attempt++) {
+        expect(log.warn).toHaveBeenNthCalledWith(attempt, "Slack completion callback failed", {
+          event: "scheduler.slack_complete_failed",
+          automation_id: run.automation_id,
+          run_id: run.id,
+          attempt,
+          ...(kind === "non-OK" ? { http_status: 503 } : { error }),
+        });
+      }
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it.each([event.threadTs, undefined])(
+    "signs skip notices using thread anchor %s",
+    async (threadTs) => {
+      const { delivery, fetch } = setup();
+      await delivery.notifySlackConcurrencySkip({ ...event, threadTs });
+      expect(fetch).toHaveBeenCalledExactlyOnceWith("https://internal/callbacks/automation-skip", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: signedBody({ channel: "C1", user: "U1", threadTs: threadTs ?? event.ts }),
+      });
+    }
+  );
+
+  it.each(["non-OK", "thrown fetch"])(
+    "treats skip %s as best effort without retries",
+    async (kind) => {
+      vi.useFakeTimers();
+      const { delivery, fetch, log } = setup();
+      if (kind === "non-OK") fetch.mockResolvedValue(new Response(null, { status: 503 }));
+      else fetch.mockRejectedValue("offline");
+      await expect(delivery.notifySlackConcurrencySkip(event)).resolves.toBeUndefined();
+      await vi.runAllTimersAsync();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+        kind === "non-OK" ? "Slack skip callback failed" : "Slack skip callback errored",
+        {
+          event: "scheduler.slack_skip_failed",
+          channel: "C1",
+          ...(kind === "non-OK" ? { http_status: 503 } : { error: new Error("offline") }),
+        }
+      );
+    }
+  );
+
+  it.each(["engineering", undefined])(
+    "signs the thread request and renders ordered context (%s)",
+    async (channelName) => {
+      const { delivery, fetch, log } = setup();
+      fetch.mockResolvedValue(
+        Response.json({ threadContext: "Alice: Earlier message\nBob: Reply" })
+      );
+      const timeout = vi.spyOn(AbortSignal, "timeout");
+      await expect(delivery.buildSlackContextWithThread({ ...event, channelName })).resolves.toBe(
+        [
+          `A message was posted in Slack channel ${channelName ? "#engineering" : "C1"} by user U1.`,
+          `Permalink: ${event.permalink}`,
+          "",
+          "Alice: Earlier message",
+          "Bob: Reply",
+          "",
+          "<user_content>",
+          event.text,
+          "</user_content>",
+        ].join("\n")
+      );
+      expect(timeout).toHaveBeenCalledExactlyOnceWith(10_000);
+      expect(fetch).toHaveBeenCalledExactlyOnceWith("https://internal/internal/thread-context", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: signedBody({ channel: "C1", threadTs: event.threadTs, ts: event.ts }),
+        signal: timeout.mock.results[0].value,
+      });
+      expect(log.warn).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ["non-OK", "{}", 503],
+    ["invalid JSON", "{", 200],
+    ["missing field", "{}", 200],
+    ["invalid field type", '{"threadContext":42}', 200],
+    ["null schema", "null", 200],
+    ["empty thread", '{"threadContext":""}', 200],
+  ])("keeps original context for %s", async (_name, body, status) => {
+    const { delivery, fetch } = setup();
+    fetch.mockResolvedValue(new Response(body, { status }));
+    await expect(delivery.buildSlackContextWithThread(event)).resolves.toBe(event.contextBlock);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back when the thread request times out", async () => {
+    vi.useFakeTimers();
+    const { delivery, fetch, log } = setup();
+    const error = new DOMException("Thread request timed out", "TimeoutError");
+    const controller = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      setTimeout(() => controller.abort(error), ms);
+      return controller.signal;
+    });
+    fetch.mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        })
+    );
+    const pending = delivery.buildSlackContextWithThread(event);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    await vi.runAllTimersAsync();
+    await expect(pending).resolves.toBe(event.contextBlock);
+    expect(AbortSignal.timeout).toHaveBeenCalledExactlyOnceWith(10_000);
+    expect(log.warn).toHaveBeenCalledExactlyOnceWith("Slack thread context request threw", {
+      event: "scheduler.slack_thread_context_failed",
+      channel: "C1",
+      error,
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/control-plane/src/scheduler/slack-delivery.ts
+++ b/packages/control-plane/src/scheduler/slack-delivery.ts
@@ -1,0 +1,185 @@
+import { computeHmacHex } from "@open-inspect/shared/auth";
+import {
+  buildSlackContextBlock,
+  slackChannelLabel,
+  type SlackAutomationEvent,
+} from "@open-inspect/shared/triggers";
+import { z } from "zod";
+import { callbackSigningSecret } from "../auth/service/callback-signing";
+import type { Logger } from "../logger";
+import { deliverWithRetry } from "../session/callback-delivery";
+import type { Env } from "../types";
+import {
+  buildSlackCompletionNotification,
+  buildSlackSkipNotification,
+  type SlackRunMetadata,
+  type SlackCompletionContext,
+} from "./slack-completion";
+
+/**
+ * Bound on the thread-context request. It sits between admission and launch, so
+ * a slow Slack read would hold every child in `starting` until the orphan sweep
+ * repairs them. Matches the callback-delivery attempt timeout; on expiry the run
+ * launches with no thread history, which is the same fallback as any other
+ * failure.
+ */
+const SLACK_THREAD_CONTEXT_TIMEOUT_MS = 10_000;
+
+const slackThreadContextResponseSchema = z.object({
+  threadContext: z.string(),
+});
+
+export class SlackDelivery {
+  constructor(
+    private readonly env: Pick<Env, "SLACK_BOT" | "SERVICE_AUTH_SECRET_SLACK_BOT">,
+    private readonly log: Logger
+  ) {}
+
+  /**
+   * Tell the slack-bot to post a slack-triggered run's result into the triggering
+   * message's thread and clear the `eyes` reaction, via its
+   * `/callbacks/automation-complete` endpoint. Signs the body with the
+   * slack-bot's own service secret (in-body HMAC, matching the bot's other
+   * callbacks). No-ops when the run has no triggering message, when
+   * `SLACK_BOT` is unbound, or when the secret is unset - all best-effort.
+   */
+  async notifySlackCompletion(
+    run: { automation_id: string; id: string },
+    meta: SlackRunMetadata,
+    ctx: SlackCompletionContext
+  ): Promise<void> {
+    const binding = this.env.SLACK_BOT;
+    const secret = callbackSigningSecret(this.env, "slack-bot");
+    if (!binding || !secret) return;
+
+    const body = buildSlackCompletionNotification(meta, ctx);
+    if (!body) return;
+
+    const signature = await computeHmacHex(JSON.stringify(body), secret);
+    await deliverWithRetry(
+      (signal) =>
+        binding.fetch("https://internal/callbacks/automation-complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...body, signature }),
+          signal,
+        }),
+      (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+      ({ attempt, response, error }) => {
+        this.log.warn("Slack completion callback failed", {
+          event: "scheduler.slack_complete_failed",
+          automation_id: run.automation_id,
+          run_id: run.id,
+          attempt,
+          ...(response ? { http_status: response.status } : {}),
+          ...(error !== undefined
+            ? { error: error instanceof Error ? error : new Error(String(error)) }
+            : {}),
+        });
+      }
+    );
+  }
+
+  /**
+   * Rebuild a Slack event's context block with the thread the message was posted
+   * in, asking slack-bot to fetch and render it.
+   *
+   * Called only after an invocation has been admitted, so the read is paid for
+   * exactly when a run will consume it. The bot owns the Slack token and
+   * display-name resolution; SlackDelivery only splices the rendered block into
+   * the same layout the ingress path used.
+   *
+   * Every failure path returns the original context block: thread history is an
+   * enhancement and must never prevent a run from starting.
+   */
+  async buildSlackContextWithThread(event: SlackAutomationEvent): Promise<string> {
+    if (!event.threadTs) return event.contextBlock;
+
+    const binding = this.env.SLACK_BOT;
+    const secret = callbackSigningSecret(this.env, "slack-bot");
+    if (!binding || !secret) return event.contextBlock;
+
+    try {
+      const body = {
+        channel: event.channelId,
+        threadTs: event.threadTs,
+        ts: event.ts,
+      };
+      const signature = await computeHmacHex(JSON.stringify(body), secret);
+      const response = await binding.fetch("https://internal/internal/thread-context", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...body, signature }),
+        signal: AbortSignal.timeout(SLACK_THREAD_CONTEXT_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        this.log.warn("Slack thread context request failed", {
+          event: "scheduler.slack_thread_context_failed",
+          channel: event.channelId,
+          http_status: response.status,
+        });
+        return event.contextBlock;
+      }
+
+      const parsed = slackThreadContextResponseSchema.safeParse(await response.json());
+      const threadContext = parsed.success ? parsed.data.threadContext : "";
+      if (!threadContext) return event.contextBlock;
+
+      return buildSlackContextBlock({
+        channelLabel: slackChannelLabel(event.channelId, event.channelName),
+        actorUserId: event.actorUserId,
+        permalink: event.permalink,
+        text: event.text,
+        threadContext,
+      });
+    } catch (error) {
+      this.log.warn("Slack thread context request threw", {
+        event: "scheduler.slack_thread_context_failed",
+        channel: event.channelId,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      return event.contextBlock;
+    }
+  }
+
+  /**
+   * Post a best-effort ephemeral "a run is already active for this thread"
+   * notice to the message author when a slack event is dropped by the
+   * per-thread concurrency guard. No-ops without a binding/secret/actor.
+   */
+  async notifySlackConcurrencySkip(event: SlackAutomationEvent): Promise<void> {
+    const binding = this.env.SLACK_BOT;
+    const secret = callbackSigningSecret(this.env, "slack-bot");
+    if (!binding || !secret) return;
+
+    const body = buildSlackSkipNotification({
+      channelId: event.channelId,
+      actorUserId: event.actorUserId,
+      threadTs: event.threadTs,
+      ts: event.ts,
+    });
+    if (!body) return;
+
+    try {
+      const signature = await computeHmacHex(JSON.stringify(body), secret);
+      const response = await binding.fetch("https://internal/callbacks/automation-skip", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...body, signature }),
+      });
+      if (!response.ok) {
+        this.log.warn("Slack skip callback failed", {
+          event: "scheduler.slack_skip_failed",
+          channel: event.channelId,
+          http_status: response.status,
+        });
+      }
+    } catch (e) {
+      this.log.warn("Slack skip callback errored", {
+        event: "scheduler.slack_skip_failed",
+        channel: event.channelId,
+        error: e instanceof Error ? e : new Error(String(e)),
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Extract a concrete `SlackDelivery` class that owns Slack callback signing, endpoint URLs, completion retries, thread-context decoding/rendering, and transport fallback behavior.
- Keep admission, authorization, invocation accounting, per-event context reuse, and notification timing in `Scheduler`, preserving existing payloads, logs, and delivery policies.
- Replace the scheduler private-method test spy with the delivery class's public seam. Add 22 independent transport tests and strengthen scheduler assertions for one skip notice per event and no notification on deduplication.

## Validation
- Scheduler unit tests: 115 passed across 4 files.
- Scheduler and automation-invocations integration tests: 49 passed.
- Control-plane typecheck passed, including Node, test, and integration configurations.
- Targeted ESLint, Prettier, and git diff checks passed.
- Full control-plane unit suite: 4,029 passed, 1 failed. The unchanged `src/node/host.test.ts` test `waits for a request in flight before closing the stores, and answers it` fails at line 191, with an accompanying `ECONNRESET` rejection; it also fails on a targeted rerun. No Node-host files are changed in this PR.

## Review
The extraction preserves the existing transport behavior and introduces no generic transport framework or new scheduler policy. Code review found no issues in the scoped changes.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ab051b77095e96e44456c088c00a17ad)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Slack-based automation updates, including signed completion notifications and concurrency-skip notices.
  * Added richer Slack thread context when available for automation runs.

* **Bug Fixes**
  * Slack notifications now fall back gracefully when thread context cannot be retrieved.
  * Improved delivery reliability with bounded retries for completion updates.
  * Prevented duplicate Slack notifications when multiple automations are skipped concurrently.

* **Refactor**
  * Improved separation of Slack delivery handling for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->