### PR TITLE
perf: reduce session replay and query latency

### DIFF
--- a/docs/plans/session-latency-improvements.md
+++ b/docs/plans/session-latency-improvements.md
@@ -102,5 +102,6 @@ npm run typecheck -w @open-inspect/web
 
 Performance tests use real storage metadata rather than timing assertions. Smaller tests cover UTF-8
 accounting, oversized/malformed rows, contiguous paging, HTTP/WS equality, current-prompt fallback
-removal, and retaining the admitted identity for browser and bot prompts. Boundary schema
-validation, authorization, callback rules, and the synchronous subscription handoff remain intact.
+behavior (including removal when the original message loads), and retaining the admitted identity
+for browser and bot prompts. Boundary schema validation, authorization, callback rules, and the
+synchronous subscription handoff remain intact.

--- a/docs/plans/session-latency-improvements.md
+++ b/docs/plans/session-latency-improvements.md
@@ -70,7 +70,25 @@ The committed real-workerd regression fixture checks work rather than wall time:
 
 ## Reproduce regression validation
 
-From the repository root, after installing dependencies:
+The commands below validate only the committed regression suites. They do **not** reproduce the
+latency timing table above: those samples were collected with a separate local-only benchmark
+harness that is not included in this PR.
+
+From the repository root, install the lockfile dependencies and build the shared package. The
+integration configuration creates local workerd/D1 bindings, applies the checked-in migrations,
+generates test encryption keys, supplies fixture service/browser credentials, and mocks Modal. The
+tests seed their own synthetic data; no production credentials, deployed D1 database, or real Modal
+sandbox are required.
+
+To run just the committed storage-read and bounded-replay integration fixtures:
+
+```bash
+npm ci
+npm run build -w @open-inspect/shared
+npm run test:integration -w @open-inspect/control-plane -- test/integration/session-query-work.test.ts test/integration/session-snapshot.test.ts
+```
+
+For the complete regression validation after that setup:
 
 ```bash
 npm run build -w @open-inspect/shared

--- a/docs/plans/session-latency-improvements.md
+++ b/docs/plans/session-latency-improvements.md
@@ -10,8 +10,9 @@
    UTF-8 stored-event budget. Existing count limits, response schemas, and cursor formats remain.
    One oversized storage row is allowed so pagination progresses. Malformed rows still advance the
    cursor even when they do not yield a visible event. HTTP snapshots and WS subscriptions use the
-   same synchronous projection. The web timeline displays the current prompt from the existing queue
-   when its original event is outside the window, without inventing event identity or attribution.
+   same synchronous projection. A separate canonical active-prompt projection preserves attachments,
+   attribution, and PR-feedback origin outside the window without changing the paginated suffix. An
+   explicit load-older control keeps empty or non-renderable pages traversable without scrolling.
 3. **Event cursor seeks:** use `(created_at, timeline_sequence)` tuple comparison and a matching
    index. Preserve the old timestamp/id cursor branches and index for compatibility. `initSchema`
    creates indexes after migrations, so both fresh sessions and existing sessions receive the new

--- a/docs/plans/session-latency-improvements.md
+++ b/docs/plans/session-latency-improvements.md
@@ -2,10 +2,10 @@
 
 ## Selected changes
 
-1. **Creator-filtered inbox query:** materialize `eligible_sessions` only for a nonempty creator
-   filter. This lets SQLite index parent links during recursive rerooting instead of repeatedly
-   scanning the creator's sessions. Snapshot and category pages share the fix. Global queries retain
-   their existing plan; unconditional materialization regressed them in the experiment.
+1. **Creator-filtered inbox query:** materialize only `(id, parent_session_id)` links in the
+   recursive child traversal. Seed detection and the full eligible projection remain inline, so
+   dense all-visible lineages do not build the temporary relation. Snapshot and category pages share
+   the fix. The hint remains limited to nonempty creator filters.
 2. **Replay and history payloads:** retain a contiguous newest suffix under an estimated 256 KiB
    UTF-8 stored-event budget. Existing count limits, response schemas, and cursor formats remain.
    One oversized storage row is allowed so pagination progresses. Malformed rows still advance the
@@ -26,7 +26,8 @@
 
 Base: `265a5997cf5d2a929344bdecd671ce9972349b36`. Local workerd, real D1 and DO SQLite, generated
 credentials and synthetic data, mocked Modal. Thirty sequential warm samples after five warmups. The
-candidate measurements below use the actual production sources, with no experiment transforms.
+candidate measurements below used production sources at `69945bf61`, before review follow-ups, with
+no experiment transforms. They have not been remeasured with the active-prompt projection.
 
 | Operation                                               | Baseline p50 / p95 | Candidate p50 / p95 |
 | ------------------------------------------------------- | -----------------: | ------------------: |
@@ -40,14 +41,31 @@ confirms one removed user lookup; the original generic-cache experiment's three-
 **not** claimed for this implementation. Injection is a sensitivity test, not a measurement of
 regional D1 latency.
 
-The preceding filtered-inbox experiment at 100k sessions measured a 60.9-second baseline probe (only
+The original filtered-inbox experiment at 100k sessions measured a 60.9-second baseline probe (only
 one, deliberately bounded) versus a 253 ms candidate median over 30 samples, with identical results.
+That wide-materialization candidate was superseded after review reproduced a dense-case regression.
+The final query materializes only links, and only when recursive traversal runs. A schema-migrated
+Node SQLite comparison (one warmup, five warm samples, identical snapshot/list results) verified
+both dense all-owned sessions with visible parents and sparse sessions with hidden parents. Dense
+queries remain near the original inline plan, while sparse traversal retains its improvement. These
+timings come from a separate local-only comparison harness, not the committed regression suites.
+
+| Fixture / operation | Original inline p50 | Final narrow-links p50 |
+| ------------------- | ------------------: | ---------------------: |
+| Dense 100k snapshot |           194.51 ms |              193.48 ms |
+| Dense 100k list     |           126.05 ms |              126.86 ms |
+| Sparse 4k snapshot  |            52.74 ms |                7.31 ms |
+| Sparse 4k list      |            49.67 ms |                5.94 ms |
+
 The committed real-workerd regression fixture checks work rather than wall time:
 
 - A 50-event deep page over 10k rows read 5,402 rows before the fix; now required to read fewer
   than 200.
-- A 4k creator-filtered inbox fixture read 384,806 rows before the fix; now required to read fewer
-  than 160,000. It includes hidden parents and checks snapshot/category cursor disjointness.
+- Dense and sparse 4k creator-filtered inbox fixtures require fewer than 160,000 rows read for both
+  snapshot and category pagination. The original sparse fixture read 384,806 rows before the fix.
+  Both backends share wide synthetic rows and check snapshot/category cursor disjointness.
+- Node adapter tests use all production migrations and verify identical snapshot/category results,
+  hidden-parent rerooting, and query plans that index narrow links without materializing wide rows.
 - Existing inbox integration tests cover rerooting, unread classification, automation visibility,
   tied timestamps, and repository/PR decoration. Additional tests constrain the hint to nonempty
   creator filters, preserve legacy schema initialization, and reconstruct heavy replay over HTTP/WS.

--- a/docs/plans/session-latency-improvements.md
+++ b/docs/plans/session-latency-improvements.md
@@ -1,0 +1,88 @@
+# OpenInspect session latency improvements
+
+## Selected changes
+
+1. **Creator-filtered inbox query:** materialize `eligible_sessions` only for a nonempty creator
+   filter. This lets SQLite index parent links during recursive rerooting instead of repeatedly
+   scanning the creator's sessions. Snapshot and category pages share the fix. Global queries retain
+   their existing plan; unconditional materialization regressed them in the experiment.
+2. **Replay and history payloads:** retain a contiguous newest suffix under an estimated 256 KiB
+   UTF-8 stored-event budget. Existing count limits, response schemas, and cursor formats remain.
+   One oversized storage row is allowed so pagination progresses. Malformed rows still advance the
+   cursor even when they do not yield a visible event. HTTP snapshots and WS subscriptions use the
+   same synchronous projection. The web timeline displays the current prompt from the existing queue
+   when its original event is outside the window, without inventing event identity or attribution.
+3. **Event cursor seeks:** use `(created_at, timeline_sequence)` tuple comparison and a matching
+   index. Preserve the old timestamp/id cursor branches and index for compatibility. `initSchema`
+   creates indexes after migrations, so both fresh sessions and existing sessions receive the new
+   index after any legacy sequence backfill; no new D1 migration or binding is needed.
+4. **Prompt identity:** enrich with the canonical user ID already resolved and authorized during
+   admission. Remove the second user/actor lookup; do not change Better Auth account/token refresh,
+   permission checks, or service-actor admission. Attribution cannot switch users due to an actor
+   relink after admission.
+
+## Production-code verification
+
+Base: `265a5997cf5d2a929344bdecd671ce9972349b36`. Local workerd, real D1 and DO SQLite, generated
+credentials and synthetic data, mocked Modal. Thirty sequential warm samples after five warmups. The
+candidate measurements below use the actual production sources, with no experiment transforms.
+
+| Operation                                               | Baseline p50 / p95 | Candidate p50 / p95 |
+| ------------------------------------------------------- | -----------------: | ------------------: |
+| Heavy HTTP session snapshot                             |   54.98 / 64.92 ms |     7.57 / 10.27 ms |
+| Heavy WS token + subscription                           |   44.34 / 56.14 ms |     9.07 / 11.14 ms |
+| Short HTTP snapshot                                     |     5.63 / 8.47 ms |      4.74 / 6.08 ms |
+| Prompt acknowledgement, 20 ms injected per D1 operation | 222.44 / 226.53 ms |  200.44 / 203.51 ms |
+
+Heavy snapshot bytes: **8,319,852 → 250,422**. Short snapshot bytes are unchanged. D1 tracing
+confirms one removed user lookup; the original generic-cache experiment's three-read saving is
+**not** claimed for this implementation. Injection is a sensitivity test, not a measurement of
+regional D1 latency.
+
+The preceding filtered-inbox experiment at 100k sessions measured a 60.9-second baseline probe (only
+one, deliberately bounded) versus a 253 ms candidate median over 30 samples, with identical results.
+The committed real-workerd regression fixture checks work rather than wall time:
+
+- A 50-event deep page over 10k rows read 5,402 rows before the fix; now required to read fewer
+  than 200.
+- A 4k creator-filtered inbox fixture read 384,806 rows before the fix; now required to read fewer
+  than 160,000. It includes hidden parents and checks snapshot/category cursor disjointness.
+- Existing inbox integration tests cover rerooting, unread classification, automation visibility,
+  tied timestamps, and repository/PR decoration. Additional tests constrain the hint to nonempty
+  creator filters, preserve legacy schema initialization, and reconstruct heavy replay over HTTP/WS.
+
+## Deferred experiments and limits
+
+- **Generic request-local SQL caching:** the larger measured saving crosses Better Auth's separate
+  session/account API contexts. Successful SCM refresh/account-profile flows were not measured by
+  the credential-less fixture. Keep that redesign separate from admitted-ID reuse.
+- **Snapshot digest/delta protocol:** roughly halves unchanged transfer but still reads and hashes
+  the timeline, with a short-session regression. Insert sequence numbers are not revision
+  watermarks; updated/deleted events need a complete protocol design.
+- **Session-list keyset API:** promising deep-page results, but requires deterministic tie ordering,
+  cursor/client changes, and explicit semantics under concurrent updates. No offset API change here.
+- The byte budget trims an already-read SQL page. It reduces parsing/validation/serialization work,
+  not the bytes read from SQLite. The response can exceed the estimate for one oversized event or
+  non-timeline fields. This is not a strict wire-size cap.
+- These are synthetic loopback observations, not production SLOs. No actual browser hydration/WAN
+  latency, compressed transfer, cold-start distribution, or real model/sandbox startup was measured.
+  The current prompt fallback is covered by DOM tests, not a timed browser benchmark.
+
+## Reproduce regression validation
+
+From the repository root, after installing dependencies:
+
+```bash
+npm run build -w @open-inspect/shared
+npm test -w @open-inspect/control-plane
+npm run test:integration -w @open-inspect/control-plane
+npm run typecheck -w @open-inspect/control-plane
+npm run build -w @open-inspect/control-plane
+npm test -w @open-inspect/web
+npm run typecheck -w @open-inspect/web
+```
+
+Performance tests use real storage metadata rather than timing assertions. Smaller tests cover UTF-8
+accounting, oversized/malformed rows, contiguous paging, HTTP/WS equality, current-prompt fallback
+removal, and retaining the admitted identity for browser and bot prompts. Boundary schema
+validation, authorization, callback rules, and the synchronous subscription handoff remain intact.

--- a/packages/control-plane/src/db/session-inbox-store.test.ts
+++ b/packages/control-plane/src/db/session-inbox-store.test.ts
@@ -1,0 +1,83 @@
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createNodeSqlDatabase, type NodeSqlDatabase } from "../node/sqlite-database";
+import { applyMigrations } from "../node/migrate";
+import { seedSessionInboxWork } from "../../test/fixtures/session-inbox-work";
+import { SessionInboxStore } from "./session-inbox-store";
+
+describe("session inbox query shape on the Node adapter", () => {
+  let sqlite: DatabaseSync;
+  let db: NodeSqlDatabase;
+  beforeEach(() => {
+    sqlite = new DatabaseSync(":memory:");
+    sqlite.exec("PRAGMA foreign_keys = ON");
+    applyMigrations(
+      sqlite,
+      fileURLToPath(new URL("../../../../terraform/d1/migrations/", import.meta.url))
+    );
+    db = createNodeSqlDatabase(sqlite);
+  });
+  afterEach(() => db.close());
+
+  it.each(["dense", "sparse"] as const)(
+    "keeps %s snapshot and list results aligned without materializing wide rows",
+    async (shape) => {
+      await seedSessionInboxWork(db, 4000, shape);
+      const queries: string[] = [];
+      const store = new SessionInboxStore({
+        prepare(query) {
+          queries.push(query);
+          return db.prepare(query);
+        },
+        batch: db.batch.bind(db),
+      });
+      const options = {
+        viewerUserId: "query-viewer",
+        createdByUserIds: ["query-viewer"],
+        limit: 20,
+      };
+      const snapshot = await store.snapshot(options);
+      const snapshotQuery = queries[0];
+      queries.length = 0;
+      const firstPage = await store.list({ ...options, category: "finished", cursor: null });
+      const listQuery = queries[0];
+      expect(firstPage).toEqual(snapshot.finished);
+      expect(firstPage.items).toHaveLength(20);
+      expect(firstPage.items[0].rootSession.id).toBe("work-1");
+      expect(firstPage.items[0].descendantSessions.map((session) => session.id)).toEqual([
+        "work-2",
+      ]);
+      expect(firstPage.items.some((item) => item.rootSession.id === "work-22")).toBe(
+        shape === "sparse"
+      );
+      expect(snapshot.in_progress.items).toEqual([]);
+      expect(snapshot.needs_attention.items).toEqual([]);
+      const secondPage = await store.list({
+        ...options,
+        category: "finished",
+        cursor: firstPage.nextCursor,
+      });
+      expect(secondPage.items).toHaveLength(20);
+      const firstIds = new Set(firstPage.items.map((item) => item.rootSession.id));
+      expect(secondPage.items.every((item) => !firstIds.has(item.rootSession.id))).toBe(true);
+      for (const [query, params] of [
+        [snapshotQuery, ["query-viewer", "query-viewer", 21]],
+        [listQuery, ["query-viewer", "query-viewer", "finished", 21]],
+      ] as const) {
+        const plan = sqlite
+          .prepare("EXPLAIN QUERY PLAN " + query)
+          .all(...params)
+          .map((row) => row.detail)
+          .join("\n");
+        expect(plan).not.toContain("MATERIALIZE eligible_sessions");
+        expect(plan).toContain("MATERIALIZE eligible_session_links");
+        expect(plan).toMatch(/SEARCH child USING AUTOMATIC .*INDEX \(parent_session_id=\?\)/);
+        // The narrow table belongs only to the recursive arm, not seed detection.
+        expect(query).toContain("FROM eligible_sessions eligible");
+        expect(query).toContain("FROM eligible_sessions parent");
+        expect(query).toContain("JOIN eligible_session_links child");
+      }
+    }
+  );
+});

--- a/packages/control-plane/src/db/session-inbox-store.ts
+++ b/packages/control-plane/src/db/session-inbox-store.ts
@@ -194,12 +194,12 @@ export class SessionInboxStore {
     >
   ): { sql: string; params: unknown[] } {
     const { conditions, params } = this.eligibility(options);
-    // With a creator filter, inlining this CTE can repeatedly scan all of that
-    // creator's sessions in the recursive child join. Materialization lets SQLite
-    // index the eligible parent links. Leave the faster unfiltered plan alone.
+    // Only recursive child traversal needs transient parent-link indexes. Keep
+    // the seed and full projection inline so dense, all-visible lineages never
+    // build a temporary table. Unfiltered links retain their existing plan.
     const materialization = options.createdByUserIds?.length ? "MATERIALIZED " : "";
     return {
-      sql: `WITH RECURSIVE eligible_sessions AS ${materialization}(
+      sql: `WITH RECURSIVE eligible_sessions AS (
               SELECT sessions.*, ${unreadSql("sessions")} AS unread
               FROM sessions
               LEFT JOIN users viewer ON viewer.id = ?
@@ -207,6 +207,9 @@ export class SessionInboxStore {
                 ON read_state.session_id = sessions.id
                AND read_state.user_id = viewer.id
               WHERE ${conditions.join(" AND ")}
+            ),
+            eligible_session_links AS ${materialization}(
+              SELECT id, parent_session_id FROM eligible_sessions
             ),
             -- Filtering can hide an ancestor. Re-root each resulting visible subtree
             -- while retaining the persisted root for uninterrupted lineages.
@@ -221,7 +224,7 @@ export class SessionInboxStore {
               UNION
               SELECT child.id, rerooted_sessions.effective_root_session_id
               FROM rerooted_sessions
-              JOIN eligible_sessions child ON child.parent_session_id = rerooted_sessions.id
+              JOIN eligible_session_links child ON child.parent_session_id = rerooted_sessions.id
             ),
             effective_sessions AS (
               SELECT eligible_sessions.*,

--- a/packages/control-plane/src/db/session-inbox-store.ts
+++ b/packages/control-plane/src/db/session-inbox-store.ts
@@ -194,8 +194,12 @@ export class SessionInboxStore {
     >
   ): { sql: string; params: unknown[] } {
     const { conditions, params } = this.eligibility(options);
+    // With a creator filter, inlining this CTE can repeatedly scan all of that
+    // creator's sessions in the recursive child join. Materialization lets SQLite
+    // index the eligible parent links. Leave the faster unfiltered plan alone.
+    const materialization = options.createdByUserIds?.length ? "MATERIALIZED " : "";
     return {
-      sql: `WITH RECURSIVE eligible_sessions AS (
+      sql: `WITH RECURSIVE eligible_sessions AS ${materialization}(
               SELECT sessions.*, ${unreadSql("sessions")} AS unread
               FROM sessions
               LEFT JOIN users viewer ON viewer.id = ?

--- a/packages/control-plane/src/router.session-prompt.test.ts
+++ b/packages/control-plane/src/router.session-prompt.test.ts
@@ -91,9 +91,10 @@ describe("session prompt identity enrichment", () => {
   });
 
   it("enriches a web prompt from the canonical linked GitHub identity", async () => {
+    const getUserById = vi.fn(async () => ({ id: "relinked-user", displayName: "Other User" }));
     vi.mocked(UserStore).mockImplementation(function () {
       return {
-        getUserById: async () => ({ id: "user-1", displayName: "Trusted Ada" }),
+        getUserById,
       } as never;
     });
     vi.mocked(resolveGitHubEnrichmentForRequest).mockResolvedValue({
@@ -106,6 +107,7 @@ describe("session prompt identity enrichment", () => {
       const body = (await request.json()) as Record<string, unknown>;
       expect(body).toMatchObject({
         authorId: "user-1",
+        canonicalUserId: "user-1",
         scmEnrichment: {
           userId: "1001",
           login: "ada",
@@ -126,16 +128,18 @@ describe("session prompt identity enrichment", () => {
 
     expect(response.status).toBe(200);
     expect(sessionFetch).toHaveBeenCalledOnce();
+    expect(getUserById).not.toHaveBeenCalled();
+    expect(resolveGitHubEnrichmentForRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      "user-1",
+      expect.anything()
+    );
   });
 
   it("preserves stored enrichment when the GitHub identity lookup is unavailable", async () => {
-    vi.mocked(UserStore).mockImplementation(function () {
-      return {
-        getUserById: async () => {
-          throw new Error("D1 unavailable");
-        },
-      } as never;
-    });
+    vi.mocked(resolveGitHubEnrichmentForRequest).mockRejectedValue(new Error("D1 unavailable"));
     const sessionFetch = vi.fn(async (request: Request) => {
       const body = (await request.json()) as Record<string, unknown>;
       expect(body.authorId).toBe("user-1");
@@ -153,11 +157,6 @@ describe("session prompt identity enrichment", () => {
   });
 
   it("leaves stored enrichment unchanged when no linked GitHub identity exists", async () => {
-    vi.mocked(UserStore).mockImplementation(function () {
-      return {
-        getUserById: async () => ({ id: "user-1", displayName: "Unlinked User" }),
-      } as never;
-    });
     vi.mocked(resolveGitHubEnrichmentForRequest).mockResolvedValue(null);
     const sessionFetch = vi.fn(async (request: Request) => {
       const body = (await request.json()) as Record<string, unknown>;
@@ -187,6 +186,64 @@ describe("session prompt identity enrichment", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Field 'authorId' is not accepted from verified callers",
     });
+    expect(sessionFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["slack-bot", "slack:U123"],
+    ["github-bot", "github:123"],
+    ["linear-bot", "linear:actor-123"],
+  ] as const)(
+    "keeps the admitted %s actor when a later identity lookup would relink it",
+    async (service, actor) => {
+      const getIdentity = vi
+        .fn()
+        .mockResolvedValueOnce({ userId: "user-1" })
+        .mockResolvedValue({ userId: "relinked-user" });
+      vi.mocked(UserStore).mockImplementation(function () {
+        return { getIdentity } as never;
+      });
+      vi.mocked(resolveGitHubEnrichmentForRequest).mockResolvedValue(null);
+      const sessionFetch = vi.fn(async (request: Request) => {
+        expect(await request.json()).toMatchObject({ authorId: actor, canonicalUserId: "user-1" });
+        return Response.json({ status: "queued" });
+      });
+      const response = await handleRequest(
+        await signedServiceRequest("https://test.local/sessions/session-1/prompt", {
+          method: "POST",
+          service,
+          actor,
+          body: JSON.stringify({ content: "Continue" }),
+        }),
+        createEnv(sessionFetch) as never,
+        TEST_BACKGROUND_TASK_CONTEXT
+      );
+      expect(response.status).toBe(200);
+      expect(getIdentity).toHaveBeenCalledOnce();
+      expect(resolveGitHubEnrichmentForRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        "user-1",
+        expect.anything()
+      );
+      expect(sessionFetch).toHaveBeenCalledOnce();
+    }
+  );
+
+  it("continues rejecting actorless bot prompts before credential enrichment", async () => {
+    const sessionFetch = vi.fn(async () => Response.json({ status: "queued" }));
+    const response = await handleRequest(
+      await signedServiceRequest("https://test.local/sessions/session-1/prompt", {
+        method: "POST",
+        service: "github-bot",
+        body: JSON.stringify({ content: "Continue" }),
+      }),
+      createEnv(sessionFetch) as never,
+      TEST_BACKGROUND_TASK_CONTEXT
+    );
+    expect(response.status).toBe(403);
+    expect(resolveGitHubEnrichmentForRequest).not.toHaveBeenCalled();
     expect(sessionFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -21,11 +21,7 @@ import { UserStore } from "../db/user-store";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
 import type { EnqueuePromptRequest } from "../session/enqueue-prompt-contract";
-import {
-  parseAuthorId,
-  resolveGitHubEnrichmentForRequest,
-  type GitHubEnrichment,
-} from "../session/identity";
+import { resolveGitHubEnrichmentForRequest, type GitHubEnrichment } from "../session/identity";
 import type { Env } from "../types";
 import { error, GITHUB_USER_OR_SERVICE_ROUTE, requirePermission } from "./shared";
 import { parseJsonBody } from "./body";
@@ -85,7 +81,7 @@ export async function handleSessionPrompt(
   // anonymous. callbackContext is a completion notification channel — only
   // the bots that own callbacks may attach one.
   const authorId = enforcement.enforced.participantUserId ?? "anonymous";
-  let canonicalUserId = enforcement.enforced.canonicalUserId ?? undefined;
+  const canonicalUserId = enforcement.enforced.canonicalUserId ?? undefined;
   if (callbackContext === undefined && body.callbackContext !== undefined) {
     logger.warn("Dropped callbackContext from unauthorized principal", {
       event: "identity.callback_context_dropped",
@@ -95,28 +91,19 @@ export async function handleSessionPrompt(
   }
 
   let enrichment: GitHubEnrichment | undefined;
-  const parsed = parseAuthorId(authorId);
-  if (authorId !== "anonymous") {
+  if (canonicalUserId) {
     try {
       const userStore = new UserStore(ctx.db);
-      let userId: string | undefined;
-      if (parsed) {
-        const identity = await userStore.getIdentity(parsed.provider, parsed.providerUserId);
-        userId = identity?.userId;
-      } else {
-        userId = (await userStore.getUserById(authorId))?.id;
-      }
-      if (userId) {
-        canonicalUserId = userId;
-        enrichment =
-          (await resolveGitHubEnrichmentForRequest(
-            env,
-            ctx.db,
-            userStore,
-            userId,
-            await resolveGitHubCredentialAuthority(ctx, request.headers)
-          )) ?? undefined;
-      }
+      // Admission already resolved and authorized this identity. Re-resolving an
+      // actor here costs a read and could switch users after an identity relink.
+      enrichment =
+        (await resolveGitHubEnrichmentForRequest(
+          env,
+          ctx.db,
+          userStore,
+          canonicalUserId,
+          await resolveGitHubCredentialAuthority(ctx, request.headers)
+        )) ?? undefined;
     } catch (e) {
       logger.warn("Failed to enrich prompt with GitHub identity", {
         error: e instanceof Error ? e : String(e),

--- a/packages/control-plane/src/session/event-cursor.ts
+++ b/packages/control-plane/src/session/event-cursor.ts
@@ -19,13 +19,16 @@ export type ParseEventCursorResult<TCursor> =
   | { ok: false; error: string };
 
 export function eventTimelineCursorFromRow(
-  event: Pick<EventRow, "created_at" | "id" | "timeline_sequence">
+  event: Pick<EventRow, "created_at" | "id" | "timeline_sequence">,
+  tieBreaker: "id" | "timeline_sequence" = "timeline_sequence"
 ): EventTimelineCursor {
   return {
     kind: "timeline",
     createdAt: event.created_at,
     id: event.id,
-    ...(event.timeline_sequence === undefined ? {} : { sequence: event.timeline_sequence }),
+    ...(tieBreaker === "id" || event.timeline_sequence === undefined
+      ? {}
+      : { sequence: event.timeline_sequence }),
   };
 }
 

--- a/packages/control-plane/src/session/event-repository.ts
+++ b/packages/control-plane/src/session/event-repository.ts
@@ -181,7 +181,9 @@ export class EventRepository {
     const rows = this.sql.exec(query, ...params).toArray() as EventRow[];
     const hasMore = rows.length > options.limit;
     const events = hasMore ? rows.slice(0, options.limit) : rows;
-    const nextCursor = events.length ? eventTimelineCursorFromRow(events[events.length - 1]) : null;
+    const nextCursor = events.length
+      ? eventTimelineCursorFromRow(events[events.length - 1], tieBreaker)
+      : null;
     return { events, hasMore, nextCursor };
   }
 }

--- a/packages/control-plane/src/session/event-repository.ts
+++ b/packages/control-plane/src/session/event-repository.ts
@@ -160,8 +160,8 @@ export class EventRepository {
     const cursor = options.cursor;
     if (cursor?.kind === "timeline") {
       if (cursor.sequence !== undefined) {
-        conditions.push(`((created_at < ?) OR (created_at = ? AND timeline_sequence < ?))`);
-        params.push(cursor.createdAt, cursor.createdAt, cursor.sequence);
+        conditions.push(`(created_at, timeline_sequence) < (?, ?)`);
+        params.push(cursor.createdAt, cursor.sequence);
       } else {
         conditions.push(`((created_at < ?) OR (created_at = ? AND id < ?))`);
         params.push(cursor.createdAt, cursor.createdAt, cursor.id);

--- a/packages/control-plane/src/session/event-repository.ts
+++ b/packages/control-plane/src/session/event-repository.ts
@@ -134,6 +134,11 @@ export class EventRepository {
     return this.queryEventPage(options);
   }
 
+  getEventById(id: string): EventRow | null {
+    const rows = this.sql.exec("SELECT * FROM events WHERE id = ?", id).toArray() as EventRow[];
+    return rows[0] ?? null;
+  }
+
   getEventTimelinePage(options: ListEventTimelinePageOptions): EventPage {
     const page = this.queryEventPage(options);
     return { ...page, events: [...page.events].reverse() };

--- a/packages/control-plane/src/session/event-stream-storage.test.ts
+++ b/packages/control-plane/src/session/event-stream-storage.test.ts
@@ -4,6 +4,7 @@ import { createNodeSqlStorage } from "../node/sqlite-storage";
 import { EventRepository } from "./event-repository";
 import { SessionEventStream, type EventStreamCursor } from "./event-stream";
 import { initSchema } from "./schema";
+import { parseEventListCursor } from "./event-cursor";
 
 describe("bounded timeline replay over SQLite", () => {
   let db: DatabaseSync;
@@ -83,6 +84,56 @@ describe("bounded timeline replay over SQLite", () => {
     seed(10, "😀".repeat(16384));
     expect(stream.getReplay().events).toHaveLength(3);
   });
+
+  it.each([5, 150000])(
+    "preserves legacy ID order across history and event-list pages (payload length %i)",
+    (contentLength) => {
+      const content = "x".repeat(contentLength);
+      for (const id of ["y", "a", "w", "x"]) {
+        repository.createEvent({
+          id,
+          type: "token",
+          messageId: "message-1",
+          createdAt: 1000,
+          data: JSON.stringify({
+            type: "token",
+            content,
+            messageId: "message-1",
+            sandboxId: "s",
+            timestamp: 1000,
+          }),
+        });
+      }
+      let cursor: EventStreamCursor | null = { timestamp: 1000, id: "z" };
+      const historyIds: string[] = [];
+      for (let remaining = 4; cursor && remaining > 0; remaining--) {
+        const page = stream.getHistoryPage({ cursor, limit: 2 });
+        historyIds.unshift(...page.items.map((item) => item.eventId));
+        expect(page.cursor).not.toHaveProperty("sequence");
+        cursor = page.hasMore ? page.cursor : null;
+      }
+      expect(cursor).toBeNull();
+      expect(historyIds).toEqual(["a", "w", "x", "y"]);
+
+      let rawCursor: string | undefined = "1000:z";
+      const listIds: string[] = [];
+      for (let remaining = 4; rawCursor && remaining > 0; remaining--) {
+        const parsed = parseEventListCursor(rawCursor);
+        if (!parsed.ok) throw new Error(parsed.error);
+        const page = stream.listEvents({
+          cursor: parsed.cursor,
+          limit: 2,
+          type: null,
+          messageId: null,
+        });
+        listIds.push(...page.events.map((event) => event.id));
+        expect(page.cursor).toMatch(/^1000:[a-z]$/);
+        rawCursor = page.hasMore ? page.cursor : undefined;
+      }
+      expect(rawCursor).toBeUndefined();
+      expect(listIds).toEqual(["y", "x", "w", "a"]);
+    }
+  );
 
   it("advances past oversized malformed storage rows even when the visible page is empty", () => {
     seed(2, "small");

--- a/packages/control-plane/src/session/event-stream-storage.test.ts
+++ b/packages/control-plane/src/session/event-stream-storage.test.ts
@@ -152,4 +152,16 @@ describe("bounded timeline replay over SQLite", () => {
     expect(page.items).toHaveLength(2);
     expect(page.hasMore).toBe(false);
   });
+
+  it("does not synthesize active prompts from missing or malformed events", () => {
+    expect(stream.getActivePrompt("missing")).toBeNull();
+    repository.createEvent({
+      id: "user_message:bad",
+      type: "user_message",
+      data: "{",
+      messageId: "bad",
+      createdAt: 1,
+    });
+    expect(stream.getActivePrompt("bad")).toBeNull();
+  });
 });

--- a/packages/control-plane/src/session/event-stream-storage.test.ts
+++ b/packages/control-plane/src/session/event-stream-storage.test.ts
@@ -1,0 +1,104 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createNodeSqlStorage } from "../node/sqlite-storage";
+import { EventRepository } from "./event-repository";
+import { SessionEventStream, type EventStreamCursor } from "./event-stream";
+import { initSchema } from "./schema";
+
+describe("bounded timeline replay over SQLite", () => {
+  let db: DatabaseSync;
+  let repository: EventRepository;
+  let stream: SessionEventStream;
+  beforeEach(() => {
+    db = new DatabaseSync(":memory:");
+    const storage = createNodeSqlStorage(db);
+    initSchema(storage.sql);
+    repository = new EventRepository(storage.sql, storage.transactionSync);
+    stream = new SessionEventStream(repository);
+  });
+  afterEach(() => db.close());
+
+  function seed(count: number, content: string) {
+    for (let i = 0; i < count; i++)
+      repository.createEvent({
+        id: `event-${i}`,
+        type: "token",
+        messageId: "message-1",
+        createdAt: 1000,
+        data: JSON.stringify({
+          type: "token",
+          content,
+          messageId: "message-1",
+          sandboxId: "sandbox-1",
+          timestamp: 1,
+        }),
+      });
+  }
+
+  it("bounds heavy replay and every history page without losing tied-timestamp events", () => {
+    seed(40, "x".repeat(32768));
+    const replay = stream.getReplay();
+    expect(replay.events.length).toBeLessThan(10);
+    expect(replay.events.at(-1)?.eventId).toBe("event-39");
+    let cursor = replay.cursor;
+    let hasMore = replay.hasMore;
+    const ids = replay.events.map((row) => row.eventId);
+    while (hasMore) {
+      const page = stream.getHistoryPage({ cursor: cursor!, limit: 200 });
+      expect(page.items.length).toBeGreaterThan(0);
+      expect(page.items.length).toBeLessThan(10);
+      ids.unshift(...page.items.map((row) => row.eventId));
+      cursor = page.cursor;
+      hasMore = page.hasMore;
+    }
+    expect(ids).toEqual(Array.from({ length: 40 }, (_, i) => `event-${i}`));
+  });
+
+  it("preserves small pages and permits one oversized event so history progresses", () => {
+    seed(2, "small");
+    expect(stream.getReplay().events).toHaveLength(2);
+    expect(stream.getReplay().hasMore).toBe(false);
+    repository.createEvent({
+      id: 'oversized:"😀',
+      type: "token",
+      messageId: "message-1",
+      createdAt: 2000,
+      data: JSON.stringify({
+        type: "token",
+        content: "😀".repeat(100000),
+        messageId: "message-1",
+        sandboxId: "s",
+        timestamp: 2,
+      }),
+    });
+    const replay = stream.getReplay();
+    expect(replay.events.map((row) => row.eventId)).toEqual(['oversized:"😀']);
+    expect(replay.hasMore).toBe(true);
+    const page = stream.getHistoryPage({ cursor: replay.cursor! });
+    expect(page.items.map((row) => row.eventId)).toEqual(["event-0", "event-1"]);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it("budgets UTF-8 bytes rather than JavaScript string length", () => {
+    seed(10, "😀".repeat(16384));
+    expect(stream.getReplay().events).toHaveLength(3);
+  });
+
+  it("advances past oversized malformed storage rows even when the visible page is empty", () => {
+    seed(2, "small");
+    repository.createEvent({
+      id: "bad",
+      type: "token",
+      data: "{".repeat(300000),
+      messageId: null,
+      createdAt: 2000,
+    });
+    const replay = stream.getReplay();
+    expect(replay.events).toEqual([]);
+    expect(replay.hasMore).toBe(true);
+    expect(replay.cursor).toMatchObject({ id: "bad", timestamp: 2000 });
+    const page = stream.getHistoryPage({ cursor: replay.cursor as EventStreamCursor });
+    expect(page.items).toHaveLength(2);
+    expect(page.hasMore).toBe(false);
+  });
+});

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -119,7 +119,10 @@ function boundTimelinePage(page: EventPage): EventPage {
     events,
     hasMore: true,
     // Storage order, not parsed events: even malformed rows must advance history.
-    nextCursor: eventTimelineCursorFromRow(events[0]),
+    nextCursor: eventTimelineCursorFromRow(
+      events[0],
+      page.nextCursor?.sequence === undefined ? "id" : "timeline_sequence"
+    ),
   };
 }
 

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -46,6 +46,13 @@ export interface SessionEventListRequest {
 export class SessionEventStream {
   constructor(private readonly repository: EventRepository) {}
 
+  /** Read the persisted prompt without inserting it into the paginated suffix. */
+  getActivePrompt(messageId: string) {
+    const row = this.repository.getEventById(`user_message:${messageId}`);
+    const event = row ? parseSessionTimelineEvents([row])[0]?.event : undefined;
+    return event?.type === "user_message" && event.messageId === messageId ? event : null;
+  }
+
   getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionTimeline {
     const page = boundTimelinePage(
       this.repository.getEventTimelinePage({

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -6,11 +6,12 @@ import {
 } from "@open-inspect/shared/types/sandbox-events";
 import {
   encodeEventTimelineCursor,
+  eventTimelineCursorFromRow,
   type EventListCursor,
   type EventTimelineCursor,
 } from "./event-cursor";
 import type { EventRow } from "./types";
-import type { EventRepository } from "./event-repository";
+import type { EventPage, EventRepository } from "./event-repository";
 import {
   sessionTimelineEventSchema,
   type ServerMessage,
@@ -18,6 +19,10 @@ import {
 } from "@open-inspect/shared/types/server-messages";
 
 export const DEFAULT_REPLAY_LIMIT = 500;
+// Estimated UTF-8 stored-event payload, not a strict final response-size limit.
+// A single oversized event is allowed so history always makes progress.
+const MAX_TIMELINE_PAGE_BYTES = 256 * 1024;
+const EVENT_ENVELOPE_ESTIMATE_BYTES = 100;
 const DEFAULT_HISTORY_LIMIT = 200;
 const MIN_HISTORY_LIMIT = 1;
 const MAX_HISTORY_LIMIT = 500;
@@ -42,10 +47,12 @@ export class SessionEventStream {
   constructor(private readonly repository: EventRepository) {}
 
   getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionTimeline {
-    const page = this.repository.getEventTimelinePage({
-      excludeTypes: HISTORY_EXCLUDED_TYPES,
-      limit,
-    });
+    const page = boundTimelinePage(
+      this.repository.getEventTimelinePage({
+        excludeTypes: HISTORY_EXCLUDED_TYPES,
+        limit,
+      })
+    );
 
     return {
       events: parseSessionTimelineEvents(page.events),
@@ -55,16 +62,18 @@ export class SessionEventStream {
   }
 
   getHistoryPage(input: { cursor: EventStreamCursor; limit?: number }): SessionHistoryPage {
-    const page = this.repository.getEventTimelinePage({
-      cursor: {
-        kind: "timeline",
-        createdAt: input.cursor.timestamp,
-        id: input.cursor.id,
-        sequence: input.cursor.sequence,
-      },
-      excludeTypes: HISTORY_EXCLUDED_TYPES,
-      limit: clampHistoryLimit(input.limit),
-    });
+    const page = boundTimelinePage(
+      this.repository.getEventTimelinePage({
+        cursor: {
+          kind: "timeline",
+          createdAt: input.cursor.timestamp,
+          id: input.cursor.id,
+          sequence: input.cursor.sequence,
+        },
+        excludeTypes: HISTORY_EXCLUDED_TYPES,
+        limit: clampHistoryLimit(input.limit),
+      })
+    );
 
     return {
       items: parseSessionTimelineEvents(page.events),
@@ -87,6 +96,31 @@ export class SessionEventStream {
       hasMore: page.hasMore,
     };
   }
+}
+
+/** Keep a contiguous newest suffix; older rows remain reachable through the cursor. */
+function boundTimelinePage(page: EventPage): EventPage {
+  const encoder = new TextEncoder();
+  let bytes = 0;
+  let first = page.events.length;
+  while (first > 0) {
+    const row = page.events[first - 1];
+    const size =
+      encoder.encode(row.data).byteLength +
+      encoder.encode(JSON.stringify(row.id)).byteLength +
+      EVENT_ENVELOPE_ESTIMATE_BYTES;
+    if (first < page.events.length && bytes + size > MAX_TIMELINE_PAGE_BYTES) break;
+    bytes += size;
+    first--;
+  }
+  if (first === 0) return page;
+  const events = page.events.slice(first);
+  return {
+    events,
+    hasMore: true,
+    // Storage order, not parsed events: even malformed rows must advance history.
+    nextCursor: eventTimelineCursorFromRow(events[0]),
+  };
 }
 
 function parseSessionTimelineEvents(rows: EventRow[]): SessionTimelineEvent[] {

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -397,6 +397,30 @@ describe("applyMigrations", () => {
     }
   });
 
+  it("indexes timeline seeks after backfilling legacy event sequences", () => {
+    const db = new DatabaseSync(":memory:");
+    const sql = createDatabaseSql(db);
+    try {
+      db.exec(`CREATE TABLE events (
+        id TEXT PRIMARY KEY, type TEXT NOT NULL, data TEXT NOT NULL,
+        message_id TEXT, created_at INTEGER NOT NULL
+      ); INSERT INTO events VALUES ('legacy', 'token', '{}', NULL, 1000)`);
+      initSchema(sql);
+      initSchema(sql);
+      expect(db.prepare("SELECT id,timeline_sequence FROM events").all()).toEqual([
+        { id: "legacy", timeline_sequence: 1 },
+      ]);
+      expect(
+        db
+          .prepare("PRAGMA index_info(idx_events_created_sequence)")
+          .all()
+          .map((row) => row.name)
+      ).toEqual(["created_at", "timeline_sequence"]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("initializes a legacy messages table before creating indexes for new columns", () => {
     expect(SCHEMA_SQL).not.toMatch(/\bCREATE (?:UNIQUE )?INDEX\b/);
 

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -239,6 +239,7 @@ ON messages(autofix_pr_key, created_at) WHERE autofix_pr_key IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_events_message ON events(message_id);
 CREATE INDEX IF NOT EXISTS idx_events_type ON events(type);
 CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at, id);
+CREATE INDEX IF NOT EXISTS idx_events_created_sequence ON events(created_at, timeline_sequence);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_events_timeline_sequence ON events(timeline_sequence);
 CREATE INDEX IF NOT EXISTS idx_participants_user ON participants(user_id);
 `;

--- a/packages/control-plane/src/session/snapshot-reader.ts
+++ b/packages/control-plane/src/session/snapshot-reader.ts
@@ -70,11 +70,16 @@ export class SessionSnapshotReader {
     return this.deps.transaction(() => {
       const local = this.readSessionState(enrichment);
       if (!local) return null;
+      const promptQueue = this.deps.messageRepository.listPromptQueue();
+      const processing = promptQueue.find((item) => item.status === "processing");
       return {
         session: local.session,
         artifacts: this.deps.messageService.listArtifacts().artifacts,
         timeline: this.deps.eventStream.getReplay(),
-        promptQueue: this.deps.messageRepository.listPromptQueue(),
+        promptQueue,
+        activePrompt: processing
+          ? this.deps.eventStream.getActivePrompt(processing.messageId)
+          : null,
         spawnError: local.sandbox?.last_spawn_error ?? null,
       };
     });

--- a/packages/control-plane/test/fixtures/session-inbox-work.ts
+++ b/packages/control-plane/test/fixtures/session-inbox-work.ts
@@ -1,0 +1,30 @@
+import type { SqlDatabase } from "../../src/db/sql-database";
+
+/** Same wide, schema-backed inbox fixture for Node SQLite and Workerd/D1. */
+export async function seedSessionInboxWork(
+  db: SqlDatabase,
+  count: number,
+  shape: "dense" | "sparse"
+) {
+  await db
+    .prepare(
+      `INSERT INTO users(id,display_name,created_at,updated_at)
+    VALUES ('query-viewer','Viewer',1,1),('query-other','Other',1,1)`
+    )
+    .run();
+  await db
+    .prepare(
+      `WITH RECURSIVE n(x) AS (
+    SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?
+  ) INSERT INTO sessions(id,title,repo_owner,repo_name,model,status,user_id,
+      parent_session_id,root_session_id,spawn_source,spawn_depth,created_at,updated_at)
+    SELECT 'work-'||x,printf('%0256d',x),'acme','lab','model','completed',
+      CASE WHEN ?='sparse' AND x%3=0 THEN 'query-other' ELSE 'query-viewer' END,
+      CASE WHEN x%10=2 THEN 'work-'||(x-1) ELSE NULL END,
+      'work-'||(CASE WHEN x%10=2 THEN x-1 ELSE x END),
+      CASE WHEN x%10=2 THEN 'agent' ELSE 'user' END,
+      CASE WHEN x%10=2 THEN 1 ELSE 0 END,1000,1000000-x FROM n`
+    )
+    .bind(count, shape)
+    .run();
+}

--- a/packages/control-plane/test/integration/session-query-work.test.ts
+++ b/packages/control-plane/test/integration/session-query-work.test.ts
@@ -1,0 +1,120 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createRequestMetrics,
+  instrumentSqlDatabase,
+} from "../../src/db/instrumented-sql-database";
+import { SessionInboxStore } from "../../src/db/session-inbox-store";
+import { EventRepository } from "../../src/session/event-repository";
+import { cleanD1Tables } from "./cleanup";
+import { initSession, seedActiveUser, sqlDatabase } from "./helpers";
+import { runInSessionDO } from "./session-do-access";
+
+describe("session query work bounds", () => {
+  beforeEach(cleanD1Tables);
+
+  it.each([
+    [undefined, false],
+    [[], false],
+    [["viewer"], true],
+    [["viewer", "other"], true],
+  ] as const)(
+    "only materializes eligible sessions for a nonempty creator filter (%j)",
+    async (createdByUserIds, materialized) => {
+      const queries: string[] = [];
+      const db = sqlDatabase(env.DB);
+      const store = new SessionInboxStore({
+        prepare(sql) {
+          queries.push(sql);
+          return db.prepare(sql);
+        },
+        batch: db.batch.bind(db),
+      });
+      await store.snapshot({ viewerUserId: "viewer", createdByUserIds, limit: 20 });
+      expect(queries[0].includes("eligible_sessions AS MATERIALIZED (")).toBe(materialized);
+      queries.length = 0;
+      await store.list({
+        viewerUserId: "viewer",
+        createdByUserIds,
+        limit: 20,
+        category: "finished",
+        cursor: null,
+      });
+      expect(queries[0].includes("eligible_sessions AS MATERIALIZED (")).toBe(materialized);
+    }
+  );
+
+  it("seeks deep timeline pages without scanning or sorting the remaining history", async () => {
+    const { stub } = await initSession();
+    await runInSessionDO(stub, (_instance, state) => {
+      state.storage.sql.exec(`WITH RECURSIVE n(x) AS (
+        SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<10000
+      ) INSERT INTO events(id,type,data,created_at,timeline_sequence)
+        SELECT 'seek-'||x,'token','{}',x/300,x FROM n`);
+      let rowsRead = 0;
+      const repository = new EventRepository(
+        {
+          exec(query, ...params) {
+            const result = state.storage.sql.exec(query, ...params);
+            const rows = result.toArray();
+            rowsRead += result.rowsRead;
+            return { toArray: () => rows, one: () => rows[0] };
+          },
+        },
+        (fn) => fn()
+      );
+      const page = repository.getEventTimelinePage({
+        cursor: { kind: "timeline", createdAt: 16, sequence: 5000, id: "seek-5000" },
+        limit: 50,
+      });
+      expect(page.events.map((row) => row.id)).toEqual(
+        Array.from({ length: 50 }, (_, i) => `seek-${4950 + i}`)
+      );
+      expect(page.hasMore).toBe(true);
+      // An indexed seek visits the requested page, not thousands of older rows.
+      expect(rowsRead).toBeLessThan(200);
+    });
+  });
+
+  it("keeps creator-filtered inbox work linear when hidden parents split lineages", async () => {
+    const viewer = "query-viewer";
+    const other = "query-other";
+    await seedActiveUser(viewer);
+    await seedActiveUser(other);
+    const count = 4000;
+    await env.DB.prepare(
+      `WITH RECURSIVE n(x) AS (
+      SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?
+    ) INSERT INTO sessions(id,title,repo_owner,repo_name,model,status,user_id,
+        parent_session_id,root_session_id,spawn_source,spawn_depth,created_at,updated_at)
+      SELECT 'work-'||x,'Session','acme','lab','model','completed',
+        CASE WHEN x%3=0 THEN ? ELSE ? END,
+        CASE WHEN x%10=2 THEN 'work-'||(x-1) ELSE NULL END,
+        'work-'||(CASE WHEN x%10=2 THEN x-1 ELSE x END),
+        CASE WHEN x%10=2 THEN 'agent' ELSE 'user' END,
+        CASE WHEN x%10=2 THEN 1 ELSE 0 END,1000,100000-x
+      FROM n`
+    )
+      .bind(count, other, viewer)
+      .run();
+    const metrics = createRequestMetrics();
+    const store = new SessionInboxStore(instrumentSqlDatabase(env.DB, metrics));
+    const options = { viewerUserId: viewer, createdByUserIds: [viewer], limit: 20 };
+    const snapshot = await store.snapshot(options);
+    expect(snapshot.finished.items).toHaveLength(20);
+    expect(snapshot.finished.items[0].rootSession.id).toBe("work-1");
+    expect(snapshot.finished.items[0].descendantSessions.map((row) => row.id)).toEqual(["work-2"]);
+    expect(snapshot.in_progress.items).toEqual([]);
+    expect(snapshot.needs_attention.items).toEqual([]);
+    expect(metrics.sqlQueries[0].rows_read).toBeGreaterThan(0);
+    expect(metrics.sqlQueries[0].rows_read).toBeLessThan(count * 40);
+    const page = await store.list({
+      ...options,
+      category: "finished",
+      cursor: snapshot.finished.nextCursor,
+    });
+    expect(page.items).toHaveLength(20);
+    const firstIds = new Set(snapshot.finished.items.map((item) => item.rootSession.id));
+    expect(page.items.every((item) => !firstIds.has(item.rootSession.id))).toBe(true);
+  });
+});

--- a/packages/control-plane/test/integration/session-query-work.test.ts
+++ b/packages/control-plane/test/integration/session-query-work.test.ts
@@ -7,7 +7,8 @@ import {
 import { SessionInboxStore } from "../../src/db/session-inbox-store";
 import { EventRepository } from "../../src/session/event-repository";
 import { cleanD1Tables } from "./cleanup";
-import { initSession, seedActiveUser, sqlDatabase } from "./helpers";
+import { initSession, sqlDatabase } from "./helpers";
+import { seedSessionInboxWork } from "../fixtures/session-inbox-work";
 import { runInSessionDO } from "./session-do-access";
 
 describe("session query work bounds", () => {
@@ -19,7 +20,7 @@ describe("session query work bounds", () => {
     [["viewer"], true],
     [["viewer", "other"], true],
   ] as const)(
-    "only materializes eligible sessions for a nonempty creator filter (%j)",
+    "only materializes parent links for a nonempty creator filter (%j)",
     async (createdByUserIds, materialized) => {
       const queries: string[] = [];
       const db = sqlDatabase(env.DB);
@@ -31,7 +32,8 @@ describe("session query work bounds", () => {
         batch: db.batch.bind(db),
       });
       await store.snapshot({ viewerUserId: "viewer", createdByUserIds, limit: 20 });
-      expect(queries[0].includes("eligible_sessions AS MATERIALIZED (")).toBe(materialized);
+      expect(queries[0]).not.toContain("eligible_sessions AS MATERIALIZED (");
+      expect(queries[0].includes("eligible_session_links AS MATERIALIZED (")).toBe(materialized);
       queries.length = 0;
       await store.list({
         viewerUserId: "viewer",
@@ -40,7 +42,8 @@ describe("session query work bounds", () => {
         category: "finished",
         cursor: null,
       });
-      expect(queries[0].includes("eligible_sessions AS MATERIALIZED (")).toBe(materialized);
+      expect(queries[0]).not.toContain("eligible_sessions AS MATERIALIZED (");
+      expect(queries[0].includes("eligible_session_links AS MATERIALIZED (")).toBe(materialized);
     }
   );
 
@@ -76,45 +79,36 @@ describe("session query work bounds", () => {
     });
   });
 
-  it("keeps creator-filtered inbox work linear when hidden parents split lineages", async () => {
-    const viewer = "query-viewer";
-    const other = "query-other";
-    await seedActiveUser(viewer);
-    await seedActiveUser(other);
-    const count = 4000;
-    await env.DB.prepare(
-      `WITH RECURSIVE n(x) AS (
-      SELECT 1 UNION ALL SELECT x+1 FROM n WHERE x<?
-    ) INSERT INTO sessions(id,title,repo_owner,repo_name,model,status,user_id,
-        parent_session_id,root_session_id,spawn_source,spawn_depth,created_at,updated_at)
-      SELECT 'work-'||x,'Session','acme','lab','model','completed',
-        CASE WHEN x%3=0 THEN ? ELSE ? END,
-        CASE WHEN x%10=2 THEN 'work-'||(x-1) ELSE NULL END,
-        'work-'||(CASE WHEN x%10=2 THEN x-1 ELSE x END),
-        CASE WHEN x%10=2 THEN 'agent' ELSE 'user' END,
-        CASE WHEN x%10=2 THEN 1 ELSE 0 END,1000,100000-x
-      FROM n`
-    )
-      .bind(count, other, viewer)
-      .run();
-    const metrics = createRequestMetrics();
-    const store = new SessionInboxStore(instrumentSqlDatabase(env.DB, metrics));
-    const options = { viewerUserId: viewer, createdByUserIds: [viewer], limit: 20 };
-    const snapshot = await store.snapshot(options);
-    expect(snapshot.finished.items).toHaveLength(20);
-    expect(snapshot.finished.items[0].rootSession.id).toBe("work-1");
-    expect(snapshot.finished.items[0].descendantSessions.map((row) => row.id)).toEqual(["work-2"]);
-    expect(snapshot.in_progress.items).toEqual([]);
-    expect(snapshot.needs_attention.items).toEqual([]);
-    expect(metrics.sqlQueries[0].rows_read).toBeGreaterThan(0);
-    expect(metrics.sqlQueries[0].rows_read).toBeLessThan(count * 40);
-    const page = await store.list({
-      ...options,
-      category: "finished",
-      cursor: snapshot.finished.nextCursor,
-    });
-    expect(page.items).toHaveLength(20);
-    const firstIds = new Set(snapshot.finished.items.map((item) => item.rootSession.id));
-    expect(page.items.every((item) => !firstIds.has(item.rootSession.id))).toBe(true);
-  });
+  it.each(["dense", "sparse"] as const)(
+    "keeps %s creator-filtered inbox work bounded",
+    async (shape) => {
+      const viewer = "query-viewer";
+      const count = 4000;
+      await seedSessionInboxWork(sqlDatabase(env.DB), count, shape);
+      const metrics = createRequestMetrics();
+      const store = new SessionInboxStore(instrumentSqlDatabase(env.DB, metrics));
+      const options = { viewerUserId: viewer, createdByUserIds: [viewer], limit: 20 };
+      const snapshot = await store.snapshot(options);
+      expect(snapshot.finished.items).toHaveLength(20);
+      expect(snapshot.finished.items[0].rootSession.id).toBe("work-1");
+      expect(snapshot.finished.items[0].descendantSessions.map((row) => row.id)).toEqual([
+        "work-2",
+      ]);
+      expect(snapshot.in_progress.items).toEqual([]);
+      expect(snapshot.needs_attention.items).toEqual([]);
+      expect(metrics.sqlQueries[0].rows_read).toBeGreaterThan(0);
+      expect(metrics.sqlQueries[0].rows_read).toBeLessThan(count * 40);
+      metrics.sqlQueries.length = 0;
+      const page = await store.list({
+        ...options,
+        category: "finished",
+        cursor: snapshot.finished.nextCursor,
+      });
+      expect(page.items).toHaveLength(20);
+      const firstIds = new Set(snapshot.finished.items.map((item) => item.rootSession.id));
+      expect(page.items.every((item) => !firstIds.has(item.rootSession.id))).toBe(true);
+      expect(metrics.sqlQueries[0].rows_read).toBeGreaterThan(0);
+      expect(metrics.sqlQueries[0].rows_read).toBeLessThan(count * 40);
+    }
+  );
 });

--- a/packages/control-plane/test/integration/session-snapshot.test.ts
+++ b/packages/control-plane/test/integration/session-snapshot.test.ts
@@ -134,6 +134,30 @@ describe("session snapshot synchronization", () => {
     const { stub } = await initNamedSession(name);
     await waitForSandboxStatus(stub, "failed");
     const createdAt = Date.now();
+    const activePrompt = {
+      type: "user_message" as const,
+      content: "",
+      messageId: "active-message",
+      timestamp: createdAt / 1000,
+      author: { participantId: "author-1", userId: "user-1", name: "Prompt author" },
+      attachments: [
+        { attachmentId: "image-1", name: "design.png", mimeType: "image/png" as const },
+      ],
+      origin: {
+        kind: "review" as const,
+        authorType: "bot" as const,
+        feedbackUrl: "https://github.com/acme/widgets/pull/42#pullrequestreview-5678",
+      },
+    };
+    await seedEvents(stub, [
+      {
+        id: "user_message:active-message",
+        type: "user_message",
+        messageId: "active-message",
+        createdAt,
+        data: JSON.stringify(activePrompt),
+      },
+    ]);
     await seedEvents(
       stub,
       Array.from({ length: 30 }, (_, i) => ({
@@ -153,22 +177,25 @@ describe("session snapshot synchronization", () => {
     await queryDO(
       stub,
       `INSERT INTO messages(id,author_id,content,source,status,created_at)
-      SELECT 'active-message',id,'Active prompt','web','processing',? FROM participants LIMIT 1`,
+      SELECT 'active-message',id,'','web','processing',? FROM participants LIMIT 1`,
       createdAt
     );
     const response = await stub.fetch("http://internal/internal/snapshot");
     const snapshot = sessionSnapshotSchema.parse(await response.json());
     expect(snapshot.timeline.events.length).toBeLessThan(10);
     expect(snapshot.timeline.hasMore).toBe(true);
+    expect(snapshot.activePrompt).toEqual(activePrompt);
+    expect(snapshot.timeline.events.some((row) => row.event.type === "user_message")).toBe(false);
     expect(snapshot.promptQueue).toContainEqual({
       messageId: "active-message",
-      content: "Active prompt",
+      content: "",
       status: "processing",
     });
     const { ws, messages } = await openClientWs(name, { subscribe: true });
     try {
       expect(messages![0].timeline).toEqual(snapshot.timeline);
       expect(messages![0].promptQueue).toEqual(snapshot.promptQueue);
+      expect(messages![0].activePrompt).toEqual(snapshot.activePrompt);
       const ids = snapshot.timeline.events.map((row) => row.eventId);
       let { cursor, hasMore } = snapshot.timeline;
       while (hasMore) {
@@ -191,6 +218,10 @@ describe("session snapshot synchronization", () => {
       expect(ids.filter((id) => id.startsWith("heavy-"))).toEqual(
         Array.from({ length: 30 }, (_, i) => `heavy-${i}`)
       );
+      expect(ids.filter((id) => id === "user_message:active-message")).toHaveLength(1);
+      await queryDO(stub, "UPDATE messages SET status = 'completed' WHERE id = 'active-message'");
+      const completed = await stub.fetch("http://internal/internal/snapshot");
+      expect(sessionSnapshotSchema.parse(await completed.json()).activePrompt).toBeNull();
     } finally {
       ws.close();
     }

--- a/packages/control-plane/test/integration/session-snapshot.test.ts
+++ b/packages/control-plane/test/integration/session-snapshot.test.ts
@@ -1,9 +1,14 @@
 import { env } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { encryptToken } from "../../src/auth/crypto";
+import {
+  sessionSnapshotSchema,
+  type ServerMessage,
+} from "@open-inspect/shared/types/server-messages";
 import { cleanD1Tables } from "./cleanup";
 import {
   initNamedSession,
+  collectMessages,
   openClientWs,
   queryDO,
   seedEvents,
@@ -120,5 +125,72 @@ describe("session snapshot synchronization", () => {
     );
 
     await expect(closed).resolves.toEqual({ code: 4003, reason: "Already subscribed" });
+  });
+
+  it("shares a bounded replay across HTTP and subscription and retrieves the omitted history", async () => {
+    const name = `snapshot-bounded-${crypto.randomUUID()}`;
+    const { stub } = await initNamedSession(name);
+    await waitForSandboxStatus(stub, "failed");
+    const createdAt = Date.now();
+    await seedEvents(
+      stub,
+      Array.from({ length: 30 }, (_, i) => ({
+        id: `heavy-${i}`,
+        type: "token",
+        messageId: "active-message",
+        createdAt,
+        data: JSON.stringify({
+          type: "token",
+          content: "x".repeat(32768),
+          messageId: "active-message",
+          sandboxId: "sandbox-1",
+          timestamp: createdAt,
+        }),
+      }))
+    );
+    await queryDO(
+      stub,
+      `INSERT INTO messages(id,author_id,content,source,status,created_at)
+      SELECT 'active-message',id,'Active prompt','web','processing',? FROM participants LIMIT 1`,
+      createdAt
+    );
+    const response = await stub.fetch("http://internal/internal/snapshot");
+    const snapshot = sessionSnapshotSchema.parse(await response.json());
+    expect(snapshot.timeline.events.length).toBeLessThan(10);
+    expect(snapshot.timeline.hasMore).toBe(true);
+    expect(snapshot.promptQueue).toContainEqual({
+      messageId: "active-message",
+      content: "Active prompt",
+      status: "processing",
+    });
+    const { ws, messages } = await openClientWs(name, { subscribe: true });
+    try {
+      expect(messages![0].timeline).toEqual(snapshot.timeline);
+      expect(messages![0].promptQueue).toEqual(snapshot.promptQueue);
+      const ids = snapshot.timeline.events.map((row) => row.eventId);
+      let { cursor, hasMore } = snapshot.timeline;
+      while (hasMore) {
+        await new Promise((resolve) => setTimeout(resolve, 210));
+        const pending = collectMessages(ws, {
+          until: (message) => message.type === "history_page",
+        });
+        ws.send(JSON.stringify({ type: "fetch_history", cursor, limit: 200 }));
+        const replies = await pending;
+        const page = replies.find((message) => message.type === "history_page") as
+          | Extract<ServerMessage, { type: "history_page" }>
+          | undefined;
+        expect(page).toBeDefined();
+        expect(page!.items.length).toBeGreaterThan(0);
+        expect(page!.items.length).toBeLessThan(10);
+        ids.unshift(...page!.items.map((row) => row.eventId));
+        cursor = page!.cursor;
+        hasMore = page!.hasMore;
+      }
+      expect(ids.filter((id) => id.startsWith("heavy-"))).toEqual(
+        Array.from({ length: 30 }, (_, i) => `heavy-${i}`)
+      );
+    } finally {
+      ws.close();
+    }
   });
 });

--- a/packages/control-plane/test/integration/session-snapshot.test.ts
+++ b/packages/control-plane/test/integration/session-snapshot.test.ts
@@ -15,6 +15,8 @@ import {
   waitForSandboxStatus,
 } from "./helpers";
 
+const HISTORY_PAGE_REQUEST_DELAY_MS = 210;
+
 describe("session snapshot synchronization", () => {
   beforeEach(cleanD1Tables);
 
@@ -170,7 +172,7 @@ describe("session snapshot synchronization", () => {
       const ids = snapshot.timeline.events.map((row) => row.eventId);
       let { cursor, hasMore } = snapshot.timeline;
       while (hasMore) {
-        await new Promise((resolve) => setTimeout(resolve, 210));
+        await new Promise((resolve) => setTimeout(resolve, HISTORY_PAGE_REQUEST_DELAY_MS));
         const pending = collectMessages(ws, {
           until: (message) => message.type === "history_page",
         });

--- a/packages/shared/src/types/sandbox-events.ts
+++ b/packages/shared/src/types/sandbox-events.ts
@@ -4,6 +4,24 @@ import { resolvedSessionAttachmentsSchema } from "./session-attachments";
 import { githubAutofixOriginSchema } from "./github-autofix";
 
 const recordSchema = z.record(z.string(), z.unknown());
+export const userMessageEventSchema = z.object({
+  type: z.literal("user_message"),
+  content: z.string(),
+  messageId: z.string(),
+  timestamp: z.number(),
+  ackId: z.string().optional(),
+  author: z
+    .object({
+      participantId: z.string(),
+      userId: z.string().optional(),
+      name: z.string(),
+      avatar: z.string().optional(),
+    })
+    .optional(),
+  // References only; attachment content is served separately.
+  attachments: resolvedSessionAttachmentsSchema.optional(),
+  origin: githubAutofixOriginSchema.optional(),
+});
 const gitSyncStatusSchema = z.enum(["pending", "in_progress", "completed", "failed"]);
 export type GitSyncStatus = z.infer<typeof gitSyncStatusSchema>;
 
@@ -166,25 +184,7 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
     type: z.literal("session_title"),
     title: z.string(),
   }),
-  z.object({
-    type: z.literal("user_message"),
-    content: z.string(),
-    messageId: z.string(),
-    timestamp: z.number(),
-    ackId: z.string().optional(),
-    author: z
-      .object({
-        participantId: z.string(),
-        userId: z.string().optional(),
-        name: z.string(),
-        avatar: z.string().optional(),
-      })
-      .optional(),
-    // Attachment metadata only — never inline content, which would bloat the
-    // events table and every broadcast. attachmentId lets clients stream attachments.
-    attachments: resolvedSessionAttachmentsSchema.optional(),
-    origin: githubAutofixOriginSchema.optional(),
-  }),
+  userMessageEventSchema,
 ]);
 
 export type SandboxEvent = z.infer<typeof sandboxEventSchema>;

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { sessionArtifactSchema } from "./artifacts";
 import { sessionRepositoryStateSchema } from "./repositories";
-import { sandboxEventSchema } from "./sandbox-events";
+import { sandboxEventSchema, userMessageEventSchema } from "./sandbox-events";
 import { sandboxStatusSchema, sessionStatusSchema } from "./sessions";
 import { clientRequestIdSchema } from "./prompts";
 
@@ -113,6 +113,9 @@ export const sessionSnapshotSchema = z.object({
   session: sessionSnapshotStateSchema,
   artifacts: z.array(sessionArtifactSchema),
   timeline: sessionTimelineSchema,
+  // Display-only projection, outside the contiguous paginated timeline. Optional
+  // for compatibility with servers predating bounded replay.
+  activePrompt: userMessageEventSchema.nullable().optional(),
   spawnError: z.string().nullable().optional(),
   promptQueue: z.array(promptQueueItemSchema),
 });

--- a/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
@@ -89,6 +89,7 @@ export default function SessionPage() {
     currentParticipantId,
     isProcessing,
     promptQueue,
+    hasMoreHistory,
     loadingHistory,
     sendPrompt,
     cancelPrompt,
@@ -320,6 +321,7 @@ export default function SessionPage() {
               participantProfiles={profiles}
               isProcessing={isProcessing}
               promptQueue={promptQueue}
+              hasMoreHistory={hasMoreHistory}
               loadingHistory={loadingHistory}
               showSkeleton={false}
               onLoadOlder={loadOlderEvents}

--- a/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/session/[id]/page.tsx
@@ -89,6 +89,7 @@ export default function SessionPage() {
     currentParticipantId,
     isProcessing,
     promptQueue,
+    activePrompt,
     hasMoreHistory,
     loadingHistory,
     sendPrompt,
@@ -321,6 +322,7 @@ export default function SessionPage() {
               participantProfiles={profiles}
               isProcessing={isProcessing}
               promptQueue={promptQueue}
+              activePrompt={activePrompt}
               hasMoreHistory={hasMoreHistory}
               loadingHistory={loadingHistory}
               showSkeleton={false}

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -227,28 +227,47 @@ const baseTimelineProps = {
 } as const;
 
 describe("prompt queue status", () => {
-  it("keeps an out-of-window running prompt visible until its original event is loaded", () => {
-    const props = {
-      ...baseTimelineProps,
-      promptQueue: [
-        { messageId: "running", content: "Current task", status: "processing" as const },
-      ],
-    };
-    const { rerender } = render(<SessionTimeline {...props} events={[]} />);
-    expect(screen.getByRole("region", { name: "Current prompt" })).toHaveTextContent(
-      "Current task"
-    );
-    rerender(
-      <SessionTimeline
-        {...props}
-        events={[{ ...event(), messageId: "running", content: "Current task" }]}
-      />
-    );
-    expect(screen.queryByRole("region", { name: "Current prompt" })).not.toBeInTheDocument();
-    expect(screen.getAllByText("Current task")).toHaveLength(1);
-    rerender(<SessionTimeline {...baseTimelineProps} events={[]} />);
-    expect(screen.queryByText("Current task")).not.toBeInTheDocument();
-  });
+  it.each(["", "Current task"])(
+    "preserves canonical out-of-window prompt presentation for content %j",
+    (content) => {
+      const activePrompt = {
+        ...event(),
+        messageId: "running",
+        content,
+        attachments: [
+          { attachmentId: "image-1", name: "design.png", mimeType: "image/png" as const },
+        ],
+        origin: {
+          kind: "review" as const,
+          authorType: "bot" as const,
+          feedbackUrl: "https://github.com/acme/widgets/pull/42#pullrequestreview-5678",
+        },
+      };
+      const props = {
+        ...baseTimelineProps,
+        activePrompt,
+        promptQueue: [{ messageId: "running", content, status: "processing" as const }],
+      };
+      const { rerender } = render(<SessionTimeline {...props} events={[]} />);
+      expect(screen.getByRole("region", { name: "Current prompt" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "design.png" })).toHaveAttribute(
+        "src",
+        "/api/sessions/session-1/attachments/image-1"
+      );
+      expect(screen.getByText("Historical Name")).toBeInTheDocument();
+      expect(screen.getByText("Resumed by PR feedback")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Open feedback" })).toHaveAttribute(
+        "href",
+        activePrompt.origin.feedbackUrl
+      );
+      rerender(<SessionTimeline {...props} events={[activePrompt]} />);
+      expect(screen.queryByRole("region", { name: "Current prompt" })).not.toBeInTheDocument();
+      expect(screen.getAllByRole("img", { name: "design.png" })).toHaveLength(1);
+      rerender(<SessionTimeline {...props} promptQueue={[]} events={[]} />);
+      expect(screen.queryByRole("region", { name: "Current prompt" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("img", { name: "design.png" })).not.toBeInTheDocument();
+    }
+  );
 
   it("hides pending messages and leaves the running message undecorated", () => {
     const events: SandboxEvent[] = [

--- a/packages/web/src/components/session-timeline.test.tsx
+++ b/packages/web/src/components/session-timeline.test.tsx
@@ -227,6 +227,29 @@ const baseTimelineProps = {
 } as const;
 
 describe("prompt queue status", () => {
+  it("keeps an out-of-window running prompt visible until its original event is loaded", () => {
+    const props = {
+      ...baseTimelineProps,
+      promptQueue: [
+        { messageId: "running", content: "Current task", status: "processing" as const },
+      ],
+    };
+    const { rerender } = render(<SessionTimeline {...props} events={[]} />);
+    expect(screen.getByRole("region", { name: "Current prompt" })).toHaveTextContent(
+      "Current task"
+    );
+    rerender(
+      <SessionTimeline
+        {...props}
+        events={[{ ...event(), messageId: "running", content: "Current task" }]}
+      />
+    );
+    expect(screen.queryByRole("region", { name: "Current prompt" })).not.toBeInTheDocument();
+    expect(screen.getAllByText("Current task")).toHaveLength(1);
+    rerender(<SessionTimeline {...baseTimelineProps} events={[]} />);
+    expect(screen.queryByText("Current task")).not.toBeInTheDocument();
+  });
+
   it("hides pending messages and leaves the running message undecorated", () => {
     const events: SandboxEvent[] = [
       { ...event(), messageId: "running", content: "First" },

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -49,6 +49,7 @@ export function SessionTimeline({
   participantProfiles,
   isProcessing,
   promptQueue = EMPTY_PROMPT_QUEUE,
+  hasMoreHistory = false,
   loadingHistory,
   showSkeleton,
   onLoadOlder,
@@ -60,6 +61,7 @@ export function SessionTimeline({
   participantProfiles: Record<string, SessionParticipantProfile>;
   isProcessing: boolean;
   promptQueue?: PromptQueueItem[];
+  hasMoreHistory?: boolean;
   loadingHistory: boolean;
   showSkeleton: boolean;
   onLoadOlder: () => void;
@@ -300,6 +302,18 @@ export function SessionTimeline({
     >
       <div className="relative w-full min-w-0 max-w-3xl mx-auto">
         <div ref={topSentinelRef} className="absolute left-0 top-0 h-1 w-full" />
+        {!showSkeleton && hasMoreHistory && (
+          <div className="pb-3 text-center">
+            <button
+              type="button"
+              className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+              disabled={loadingHistory}
+              onClick={onLoadOlder}
+            >
+              {loadingHistory ? "Loading older messages..." : "Load older messages"}
+            </button>
+          </div>
+        )}
         {showSkeleton ? (
           <TimelineSkeleton />
         ) : (

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -50,7 +50,7 @@ export function SessionTimeline({
   isProcessing,
   promptQueue = EMPTY_PROMPT_QUEUE,
   activePrompt,
-  hasMoreHistory = false,
+  hasMoreHistory,
   loadingHistory,
   showSkeleton,
   onLoadOlder,

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -76,6 +76,16 @@ export function SessionTimeline({
     () => buildSessionTimelineItems(events, pendingMessageIds),
     [events, pendingMessageIds]
   );
+  // A bounded replay may start after the running user_message. Keep its text
+  // available without fabricating an event, timestamp, or author attribution.
+  const currentPrompt = promptQueue.find((item) => item.status === "processing");
+  const omittedCurrentPrompt =
+    currentPrompt &&
+    !events.some(
+      (event) => event.type === "user_message" && event.messageId === currentPrompt.messageId
+    )
+      ? currentPrompt
+      : undefined;
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
   const [expandedWorkGroups, setExpandedWorkGroups] = useState<Set<string>>(new Set());
@@ -90,8 +100,9 @@ export function SessionTimeline({
         items: timelineItems,
         loadingHistory,
         isProcessing,
+        currentPrompt: omittedCurrentPrompt,
       }),
-    [isProcessing, loadingHistory, timelineItems]
+    [isProcessing, loadingHistory, timelineItems, omittedCurrentPrompt]
   );
   const getVirtualRowKey = useCallback(
     (index: number) => virtualRows[index]?.id ?? index,
@@ -264,6 +275,16 @@ export function SessionTimeline({
         return <ThinkingIndicator />;
       case "item":
         return renderTimelineItem(row.item);
+      case "current_prompt":
+        return (
+          <section
+            aria-label="Current prompt"
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <div className="mb-2 text-xs text-muted-foreground">Current prompt</div>
+            <div className="whitespace-pre-wrap break-words text-sm">{row.content}</div>
+          </section>
+        );
     }
   };
 

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -49,6 +49,7 @@ export function SessionTimeline({
   participantProfiles,
   isProcessing,
   promptQueue = EMPTY_PROMPT_QUEUE,
+  activePrompt,
   hasMoreHistory = false,
   loadingHistory,
   showSkeleton,
@@ -61,6 +62,7 @@ export function SessionTimeline({
   participantProfiles: Record<string, SessionParticipantProfile>;
   isProcessing: boolean;
   promptQueue?: PromptQueueItem[];
+  activePrompt?: Extract<SandboxEvent, { type: "user_message" }> | null;
   hasMoreHistory?: boolean;
   loadingHistory: boolean;
   showSkeleton: boolean;
@@ -78,15 +80,16 @@ export function SessionTimeline({
     () => buildSessionTimelineItems(events, pendingMessageIds),
     [events, pendingMessageIds]
   );
-  // A bounded replay may start after the running user_message. Keep its text
-  // available without fabricating an event, timestamp, or author attribution.
-  const currentPrompt = promptQueue.find((item) => item.status === "processing");
+  // Use the canonical event projection without changing history pagination.
   const omittedCurrentPrompt =
-    currentPrompt &&
+    activePrompt &&
+    promptQueue.some(
+      (item) => item.status === "processing" && item.messageId === activePrompt.messageId
+    ) &&
     !events.some(
-      (event) => event.type === "user_message" && event.messageId === currentPrompt.messageId
+      (event) => event.type === "user_message" && event.messageId === activePrompt.messageId
     )
-      ? currentPrompt
+      ? activePrompt
       : undefined;
   const [expandedToolGroups, setExpandedToolGroups] = useState<Set<string>>(new Set());
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
@@ -279,12 +282,14 @@ export function SessionTimeline({
         return renderTimelineItem(row.item);
       case "current_prompt":
         return (
-          <section
-            aria-label="Current prompt"
-            className="rounded-lg border border-border bg-card p-4"
-          >
-            <div className="mb-2 text-xs text-muted-foreground">Current prompt</div>
-            <div className="whitespace-pre-wrap break-words text-sm">{row.content}</div>
+          <section aria-label="Current prompt">
+            <EventItem
+              event={row.event}
+              sessionId={sessionId}
+              currentParticipantId={currentParticipantId}
+              participantProfiles={participantProfiles}
+              onOpenMedia={onOpenMedia}
+            />
           </section>
         );
     }

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -179,7 +179,7 @@ describe("useSessionSocket", () => {
                 {
                   eventId: "hidden",
                   timelineSequence: 3,
-                  event: { type: "heartbeat", sandboxId: "sandbox-1", timestamp: 3 },
+                  event: { type: "ready", sandboxId: "sandbox-1", timestamp: 3 },
                 },
               ],
         hasMore: true,

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -255,6 +255,13 @@ describe("useSessionSocket", () => {
     const fetchMock = vi.mocked(fetch);
     const snapshot = createSnapshot();
     snapshot.session.title = "Read-only snapshot";
+    snapshot.activePrompt = {
+      type: "user_message",
+      content: "",
+      messageId: "active",
+      timestamp: 1,
+      attachments: [{ attachmentId: "image-1", name: "design.png", mimeType: "image/png" }],
+    };
 
     const { result } = renderHook(() =>
       useSessionSocket("session-1", snapshot, {
@@ -268,7 +275,16 @@ describe("useSessionSocket", () => {
     await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
 
     expect(result.current.sessionState?.title).toBe("Read-only snapshot");
+    expect(result.current.activePrompt).toEqual(snapshot.activePrompt);
     expect(result.current.connected).toBe(false);
+    act(() => {
+      FakeWebSocket.instances[0].open();
+      FakeWebSocket.instances[0].receive({
+        ...createSubscribedMessage(),
+        activePrompt: snapshot.activePrompt,
+      });
+    });
+    expect(result.current.activePrompt).toEqual(snapshot.activePrompt);
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/sessions/session-1/ws-token",
       expect.objectContaining({ method: "POST" })

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -2,7 +2,16 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SessionTimeline } from "@/components/session-timeline";
 import type { SessionArtifact } from "@open-inspect/shared/types/artifacts";
 import type {
   ServerMessage,
@@ -144,8 +153,103 @@ describe("useSessionSocket", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
+
+  it.each(["empty", "non-renderable"])(
+    "loads older history without scrolling from a %s replay through empty pages",
+    async (replayKind) => {
+      vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(800);
+      vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(800);
+      vi.stubGlobal(
+        "IntersectionObserver",
+        class {
+          observe() {}
+          disconnect() {}
+        }
+      );
+      const snapshot = createSnapshot();
+      snapshot.timeline = {
+        events:
+          replayKind === "empty"
+            ? []
+            : [
+                {
+                  eventId: "hidden",
+                  timelineSequence: 3,
+                  event: { type: "heartbeat", sandboxId: "sandbox-1", timestamp: 3 },
+                },
+              ],
+        hasMore: true,
+        cursor: { timestamp: 3, id: "hidden", sequence: 3 },
+      };
+      function HistoryView() {
+        const state = useSessionSocket("session-1", snapshot, FULL_CAPABILITIES);
+        return (
+          <SessionTimeline
+            events={state.events}
+            sessionId="session-1"
+            currentParticipantId={state.currentParticipantId}
+            participantProfiles={{}}
+            isProcessing={state.isProcessing}
+            hasMoreHistory={state.hasMoreHistory}
+            loadingHistory={state.loadingHistory}
+            showSkeleton={false}
+            onLoadOlder={state.loadOlderEvents}
+            onOpenMedia={() => {}}
+          />
+        );
+      }
+      render(<HistoryView />);
+      await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+      const socket = FakeWebSocket.instances[0];
+      act(() => {
+        socket.open();
+        socket.receive({ ...createSubscribedMessage(), timeline: snapshot.timeline });
+      });
+      // No scroll event or intersection callback: the viewport cannot scroll.
+      fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
+      expect(socket.sentMessages.at(-1)).toMatchObject({
+        type: "fetch_history",
+        cursor: snapshot.timeline.cursor,
+      });
+      expect(
+        screen.getByRole("button", { name: "Loading older messages..." }).hasAttribute("disabled")
+      ).toBe(true);
+      const nextCursor = { timestamp: 2, id: "malformed", sequence: 2 };
+      act(() =>
+        socket.receive({ type: "history_page", items: [], hasMore: true, cursor: nextCursor })
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
+      expect(socket.sentMessages.at(-1)).toMatchObject({
+        type: "fetch_history",
+        cursor: nextCursor,
+      });
+      act(() =>
+        socket.receive({
+          type: "history_page",
+          items: [
+            {
+              eventId: "old-prompt",
+              timelineSequence: 1,
+              event: {
+                type: "user_message",
+                content: "Reachable older prompt",
+                messageId: "message-old",
+                timestamp: 1,
+              },
+            },
+          ],
+          hasMore: false,
+          cursor: null,
+        })
+      );
+      expect(screen.getByText("Reachable older prompt")).toBeDefined();
+      expect(screen.queryByRole("button", { name: "Load older messages" })).toBeNull();
+    }
+  );
 
   it("keeps read synchronization available without collaboration or sandbox access", async () => {
     const fetchMock = vi.mocked(fetch);

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -58,6 +58,7 @@ interface UseSessionSocketReturn {
   currentParticipantId: string | null;
   isProcessing: boolean;
   promptQueue: PromptQueueItem[];
+  activePrompt: SessionSnapshot["activePrompt"];
   hasMoreHistory: boolean;
   loadingHistory: boolean;
   sendPrompt: (
@@ -430,6 +431,7 @@ export function useSessionSocket(
     currentParticipantId: state.currentParticipantId,
     isProcessing,
     promptQueue: state.promptQueue,
+    activePrompt: state.activePrompt,
     hasMoreHistory,
     loadingHistory,
     sendPrompt,

--- a/packages/web/src/lib/session-socket/reducer.ts
+++ b/packages/web/src/lib/session-socket/reducer.ts
@@ -33,6 +33,7 @@ export interface SessionSocketState {
   loadingHistory: boolean;
   cursor: HistoryCursor | null;
   promptQueue: PromptQueueItem[];
+  activePrompt: SessionSnapshot["activePrompt"];
   /**
    * Why the sandbox last failed, as reported by the control plane — the
    * provider's own message (quota, rate limit, bad config), not a status label.
@@ -55,6 +56,7 @@ export const initialSessionSocketState: SessionSocketState = {
   loadingHistory: false,
   cursor: null,
   promptQueue: [],
+  activePrompt: null,
   sandboxError: null,
 };
 
@@ -102,6 +104,7 @@ export function createSessionSocketState(snapshot: SessionSnapshot): SessionSock
     hasMoreHistory: snapshot.timeline.hasMore,
     cursor: snapshot.timeline.cursor,
     promptQueue: snapshot.promptQueue,
+    activePrompt: snapshot.activePrompt ?? null,
     sandboxError: snapshot.spawnError ?? null,
   };
 }
@@ -197,6 +200,7 @@ function reduceServerMessage(
         // stuck true and block loadOlderEvents after the reconnect.
         loadingHistory: false,
         promptQueue: message.promptQueue,
+        activePrompt: message.activePrompt ?? null,
         sandboxError: message.spawnError ?? null,
       };
     }

--- a/packages/web/src/lib/timeline-virtual-rows.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.ts
@@ -2,6 +2,7 @@ import type { SessionTimelineItem } from "./timeline-items";
 
 export type TimelineVirtualRow =
   | { type: "item"; id: string; item: SessionTimelineItem }
+  | { type: "current_prompt"; id: string; content: string }
   | { type: "loading"; id: string }
   | { type: "thinking"; id: string };
 
@@ -29,19 +30,28 @@ export function buildTimelineVirtualRows({
   items,
   loadingHistory,
   isProcessing,
+  currentPrompt,
 }: {
   items: SessionTimelineItem[];
   loadingHistory: boolean;
   isProcessing: boolean;
+  currentPrompt?: { messageId: string; content: string };
 }): TimelineVirtualRow[] {
   const rows: TimelineVirtualRow[] = [];
   if (loadingHistory) rows.push({ type: "loading", id: "history-loading" });
+  if (currentPrompt)
+    rows.push({
+      type: "current_prompt",
+      id: `current-prompt:${currentPrompt.messageId}`,
+      content: currentPrompt.content,
+    });
   for (const item of items) rows.push({ type: "item", id: `item:${item.id}`, item });
   if (isProcessing) rows.push({ type: "thinking", id: "thinking" });
   return rows;
 }
 
 export function estimateTimelineRowSize(row: TimelineVirtualRow): number {
+  if (row.type === "current_prompt") return TIMELINE_ROW_SIZE_ESTIMATES.userMessage;
   if (row.type === "loading" || row.type === "thinking") {
     return TIMELINE_ROW_SIZE_ESTIMATES.status;
   }

--- a/packages/web/src/lib/timeline-virtual-rows.ts
+++ b/packages/web/src/lib/timeline-virtual-rows.ts
@@ -1,8 +1,9 @@
 import type { SessionTimelineItem } from "./timeline-items";
+import type { SandboxEvent } from "@/types/session";
 
 export type TimelineVirtualRow =
   | { type: "item"; id: string; item: SessionTimelineItem }
-  | { type: "current_prompt"; id: string; content: string }
+  | { type: "current_prompt"; id: string; event: Extract<SandboxEvent, { type: "user_message" }> }
   | { type: "loading"; id: string }
   | { type: "thinking"; id: string };
 
@@ -35,7 +36,7 @@ export function buildTimelineVirtualRows({
   items: SessionTimelineItem[];
   loadingHistory: boolean;
   isProcessing: boolean;
-  currentPrompt?: { messageId: string; content: string };
+  currentPrompt?: Extract<SandboxEvent, { type: "user_message" }>;
 }): TimelineVirtualRow[] {
   const rows: TimelineVirtualRow[] = [];
   if (loadingHistory) rows.push({ type: "loading", id: "history-loading" });
@@ -43,7 +44,7 @@ export function buildTimelineVirtualRows({
     rows.push({
       type: "current_prompt",
       id: `current-prompt:${currentPrompt.messageId}`,
-      content: currentPrompt.content,
+      event: currentPrompt,
     });
   for (const item of items) rows.push({ type: "item", id: `item:${item.id}`, item });
   if (isProcessing) rows.push({ type: "thinking", id: "thinking" });


### PR DESCRIPTION
## Summary

Turns the successful local workerd/D1 experiments into focused production changes:

- Materialize only narrow parent links in recursive creator-filtered inbox traversal. Seed detection and full session projections stay inline, avoiding the dense all-owned regression.
- Bound replay and WS history to an estimated 256 KiB of stored event payload while retaining a contiguous suffix. Explicit load-older controls keep empty/non-renderable pages traversable.
- Preserve the canonical active user-message outside the timeline window through a separate snapshot projection and the existing renderer, including attachments, attribution, timestamp, and PR-feedback origin.
- Add a `(created_at, timeline_sequence)` index and tuple seek. Legacy sequence-less cursors remain ID-ordered throughout pagination, including byte-trimmed pages.
- Reuse the prompt's admitted canonical user ID instead of resolving it again; Better Auth credential refresh and authorization remain unchanged.

No generic SQL cache, snapshot-delta protocol, new dependency, or session-list API change is included.

## Evidence

Original production-source measurements at `69945bf61`, before review follow-ups: local workerd + D1 + DO SQLite, synthetic fixtures, mocked Modal; 30 measured samples after five warmups. These have not been remeasured with the active-prompt projection.

| Operation | Baseline median | Original candidate median |
| --- | ---: | ---: |
| Heavy HTTP session load | 54.98 ms | 7.57 ms |
| Heavy WS token + subscription | 44.34 ms | 9.07 ms |
| Prompt ack with 20 ms injected per D1 operation | 222.44 ms | 200.44 ms |

Original heavy snapshot payload: **8,319,852 → 250,422 bytes**. The prompt change removes **one lookup**, not the experimental generic cache's three-read saving.

Review reproduced a dense-case regression in wide inbox materialization, which has been replaced. Fresh final-production-query measurements using the schema-migrated Node adapter (one warmup, five measured samples, identical results):

| Fixture / operation | Original inline median | Final narrow-links median |
| --- | ---: | ---: |
| Dense 100k snapshot | 194.51 ms | 193.48 ms |
| Dense 100k list | 126.05 ms | 126.86 ms |
| Sparse 4k snapshot | 52.74 ms | 7.31 ms |
| Sparse 4k list | 49.67 ms | 5.94 ms |

Committed regression checks bound storage work rather than wall time: fewer than 200 rows read for a deep 50-event page, and fewer than 160,000 rows for dense/sparse 4k inbox snapshot and category queries. Node query-plan checks prevent wide-row materialization.

See `docs/plans/session-latency-improvements.md` for rationale, tradeoffs, and exact regression commands. Timing harnesses are local-only, not included in this PR.

## Validation

- [x] Control-plane unit tests: 4,023 passed
- [x] Full control-plane Workerd integration: 1,194 passed, 1 skipped
- [x] Web tests: 1,475 passed with `--maxWorkers=2`
- [x] Shared tests: 806 passed
- [x] Control-plane and web typechecks
- [x] Control-plane Worker and Node builds
- [x] Changed-file ESLint, Prettier, and diff whitespace checks
- [x] Regression coverage for UTF-8/oversized/malformed replay; complete legacy cursor traversal; UI-to-socket pagination without scrolling; HTTP/WS equality; canonical attachment-only/PR-feedback prompts; old schema initialization; dense/sparse inbox semantics on both adapters; browser/bot admitted identity

The first fully concurrent web run timed out in one unchanged Slack settings test; that exact file passed on rerun, followed by a passing full web suite with lower concurrency.

## Limits / rollout considerations

The byte budget trims an already-read page; it reduces parsing/serialization/transfer, not SQLite read bytes. A single oversized event and non-timeline state may exceed the estimate. Existing sessions incur a one-time index build on schema initialization. Measurements are synthetic loopback sensitivity tests, not production SLOs; no real browser/WAN/compression/model-startup latency was measured. The subscription handoff stays synchronous and boundary validation remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved session loading and filtering, especially for creator-filtered queries and deep timeline pages.
  * Reduced initial timeline payloads while preserving access to older history.

* **User Experience**
  * Added a visible “Current prompt” section when an active prompt is outside the loaded timeline.
  * Added an option to load older messages when more history is available.

* **Reliability**
  * Improved handling of large, malformed, and legacy timeline events.
  * Preserved prompt identity, event ordering, and compatibility with existing timeline cursors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
