### PR TITLE
refactor: separate Git push execution from bridge transport

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -15,13 +15,11 @@ import contextlib
 import json
 import math
 import os
-import re
 import tempfile
 import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any
 
 import websockets
 from websockets import ClientConnection, State
@@ -46,7 +44,8 @@ from .git_signing import GitSigningError, GitSigningRuntime
 from .log_config import configure_logging, get_logger
 from .opencode_client import OpenCodeClient
 from .prompt_stream import OpenCodePromptStream
-from .repo_config import find_repo_entry, load_repo_manifest
+from .push_operation import PushOperation
+from .repo_config import load_repo_manifest
 from .types import GitUser
 
 configure_logging()
@@ -74,71 +73,6 @@ def parse_prompt_git_author(author_data: object) -> GitUser | None:
     if not isinstance(email, str) or not email.strip():
         raise GitSigningError("Invalid prompt Git identity")
     return GitUser(name=name.strip(), email=email.strip())
-
-
-@dataclass(frozen=True)
-class PushRequest:
-    """The provider-generated push spec, normalized for execution.
-
-    Absent fields normalize to ""/False; _validate_push_request decides
-    which of those are fatal.
-    """
-
-    branch_name: str
-    repo_owner: str
-    repo_name: str
-    refspec: str
-    push_url: str
-    redacted_push_url: str
-    force: bool
-
-    @classmethod
-    def from_push_spec(cls, push_spec: dict[str, Any] | None) -> "PushRequest":
-        """Normalize the raw spec; missing fields become ""/False, never errors."""
-        spec = push_spec or {}
-
-        def field(key: str) -> str:
-            return str(spec.get(key, "")).strip()
-
-        return cls(
-            branch_name=field("targetBranch"),
-            repo_owner=field("repoOwner"),
-            repo_name=field("repoName"),
-            refspec=field("refspec"),
-            push_url=field("remoteUrl"),
-            redacted_push_url=field("redactedRemoteUrl"),
-            force=bool(spec.get("force", False)),
-        )
-
-    @property
-    def has_repo_identity(self) -> bool:
-        """True when the spec names its target repository.
-
-        Owner and name always travel together — _validate_push_request
-        rejects partial identity before anything consults this.
-        """
-        return bool(self.repo_owner and self.repo_name)
-
-    @property
-    def repo_full_name(self) -> str:
-        return f"{self.repo_owner}/{self.repo_name}"
-
-    def repo_fields(self) -> dict[str, Any]:
-        """Repo identity echoed on push events when the spec carried it."""
-        fields: dict[str, Any] = {}
-        if self.repo_owner:
-            fields["repoOwner"] = self.repo_owner
-        if self.repo_name:
-            fields["repoName"] = self.repo_name
-        return fields
-
-
-class PushRejected(Exception):
-    """A push that cannot proceed; str(exc) is the user-facing error message.
-
-    Raise sites log their own specific event first — this exception only
-    carries the message to the single push_error emitter in _handle_push.
-    """
 
 
 class SessionTerminatedError(Exception):
@@ -170,8 +104,6 @@ class AgentBridge:
     SSE_INACTIVITY_TIMEOUT = 120.0
     SSE_INACTIVITY_TIMEOUT_MIN = 5.0
     SSE_INACTIVITY_TIMEOUT_MAX = 3600.0
-    GIT_PUSH_TIMEOUT_SECONDS = 300.0
-    GIT_PUSH_TERMINATE_GRACE_SECONDS = 5.0
     DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 
     def __init__(
@@ -307,15 +239,6 @@ class AgentBridge:
                 if repository.base_sha
             ],
         }
-
-    @staticmethod
-    def _redact_git_stderr(stderr_text: str, push_url: str, redacted_push_url: str) -> str:
-        """Redact credential-bearing URLs from git stderr."""
-        redacted_stderr = stderr_text
-        if push_url and redacted_push_url:
-            redacted_stderr = redacted_stderr.replace(push_url, redacted_push_url)
-
-        return re.sub(r"(https?://)([^/\s@]+)@", r"\1***@", redacted_stderr)
 
     async def run(self) -> None:
         """Main bridge loop with reconnection handling.
@@ -842,210 +765,19 @@ class AgentBridge:
         self.shutdown_event.set()
 
     async def _handle_push(self, cmd: dict[str, Any]) -> None:
-        """Handle push command using provider-generated push spec.
-
-        Pipeline: parse → validate → resolve checkout → run git push. Every
-        failure raises PushRejected (logged at the raise site) and lands in
-        the single push_error emitter below.
-        """
-        push_spec = cmd.get("pushSpec") if isinstance(cmd.get("pushSpec"), dict) else None
-        request = PushRequest.from_push_spec(push_spec)
-
-        self.log.info(
-            "git.push_start",
-            branch_name=request.branch_name,
-            repo_owner=request.repo_owner,
-            repo_name=request.repo_name,
-            mode="push_spec",
-        )
-
-        try:
-            self._validate_push_request(request, spec_present=push_spec is not None)
-            repo_dir = self._resolve_push_checkout(request)
-            await self._run_git_push(request, repo_dir)
-        except PushRejected as rejection:
-            await self._send_push_error(str(rejection), request)
-            return
-        except Exception as e:
-            self.log.error("git.push_error", exc=e, branch_name=request.branch_name)
-            await self._send_push_error(str(e), request)
-            return
-
-        self.log.info(
-            "git.push_complete",
-            branch_name=request.branch_name,
-            repo_owner=request.repo_owner,
-            repo_name=request.repo_name,
-        )
+        """Execute locally, then emit exactly one timestamped result event."""
+        result = await PushOperation(
+            repo_path=self.repo_path,
+            manifest_path=self.repo_manifest_path,
+            logger=self.log,
+        ).execute(cmd.get("pushSpec"))
         await self._send_event(
             {
-                "type": "push_complete",
-                "branchName": request.branch_name,
-                **request.repo_fields(),
-                "timestamp": time.time(),
-            }
-        )
-
-    def _reject_push(self, *, reason: str, message: str, **log_fields: Any) -> NoReturn:
-        """Log a push rejection and raise it toward _handle_push's emitter."""
-        self.log.warn("git.push_error", reason=reason, **log_fields)
-        raise PushRejected(message)
-
-    def _validate_push_request(self, request: PushRequest, *, spec_present: bool) -> None:
-        """Reject structurally unusable specs before touching the workspace."""
-        if not spec_present:
-            self._reject_push(
-                reason="missing_push_spec",
-                message="Push failed - missing push specification",
-            )
-        if bool(request.repo_owner) != bool(request.repo_name):
-            self._reject_push(
-                reason="partial_repo_identity",
-                message="Push failed - pushSpec must carry both repoOwner and repoName",
-                repo_owner=request.repo_owner,
-                repo_name=request.repo_name,
-            )
-        if not request.branch_name:
-            self._reject_push(
-                reason="missing_target_branch",
-                message="Push failed - missing target branch",
-            )
-        if not request.refspec or not request.push_url:
-            self._reject_push(
-                reason="invalid_push_spec",
-                message="Push failed - invalid push specification",
-            )
-
-    def _resolve_push_checkout(self, request: PushRequest) -> Path:
-        """Pick the git checkout the push runs in."""
-        if request.has_repo_identity:
-            return self._member_checkout(request)
-        return self._sole_workspace_checkout()
-
-    def _member_checkout(self, request: PushRequest) -> Path:
-        """Checkout of the session member the spec names.
-
-        The identity is matched against the supervisor-written manifest and
-        the matched entry's path is used verbatim — spec-supplied strings
-        never become filesystem paths, so a crafted name cannot select a
-        checkout outside the session.
-        """
-        member = find_repo_entry(
-            load_repo_manifest(self.repo_manifest_path),
-            request.repo_owner,
-            request.repo_name,
-        )
-        if member is None:
-            self._reject_push(
-                reason="repo_not_session_member",
-                message=f"Repository {request.repo_full_name} is not part of this session",
-                repo_owner=request.repo_owner,
-                repo_name=request.repo_name,
-            )
-        if not (member.path / ".git").exists():
-            self._reject_push(
-                reason="repo_not_in_workspace",
-                message=f"Repository {request.repo_full_name} not found in workspace",
-                repo_owner=request.repo_owner,
-                repo_name=request.repo_name,
-            )
-        return member.path
-
-    def _sole_workspace_checkout(self) -> Path:
-        """Checkout for a spec that names no repository (legacy control
-        planes, single-repo sessions): the one clone directly under
-        /workspace. Sorted only to be deterministic if that invariant is
-        ever violated."""
-        repo_dirs = sorted(self.repo_path.glob("*/.git"))
-        if not repo_dirs:
-            self._reject_push(reason="no_repo_configured", message="No repository found")
-        return repo_dirs[0].parent
-
-    async def _run_git_push(self, request: PushRequest, repo_dir: Path) -> None:
-        """Run git push in repo_dir; raises PushRejected on failure or timeout."""
-        self.log.info(
-            "git.push_command",
-            branch_name=request.branch_name,
-            refspec=request.refspec,
-            force=request.force,
-            remote_url=request.redacted_push_url,
-        )
-
-        process = await asyncio.create_subprocess_exec(
-            "git",
-            "push",
-            request.push_url,
-            request.refspec,
-            *(["-f"] if request.force else []),
-            cwd=repo_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-        try:
-            _stdout, stderr = await asyncio.wait_for(
-                process.communicate(),
-                timeout=self.GIT_PUSH_TIMEOUT_SECONDS,
-            )
-        except TimeoutError:
-            self.log.warn(
-                "git.push_timeout",
-                branch_name=request.branch_name,
-                timeout_ms=int(self.GIT_PUSH_TIMEOUT_SECONDS * 1000),
-            )
-            await self._terminate_push_process(process, request.branch_name)
-            raise PushRejected(
-                f"Push failed - git push timed out after {int(self.GIT_PUSH_TIMEOUT_SECONDS)}s"
-            ) from None
-
-        if process.returncode != 0:
-            stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
-            redacted_stderr_text = self._redact_git_stderr(
-                stderr_text,
-                request.push_url,
-                request.redacted_push_url,
-            )
-            self.log.warn(
-                "git.push_failed",
-                branch_name=request.branch_name,
-                stderr=redacted_stderr_text,
-            )
-            raise PushRejected(
-                f"Push failed: {redacted_stderr_text}"
-                if redacted_stderr_text
-                else "Push failed - unknown error"
-            )
-
-    async def _terminate_push_process(
-        self, process: asyncio.subprocess.Process, branch_name: str
-    ) -> None:
-        """Terminate a hung git push, escalating to kill after a grace period."""
-        with contextlib.suppress(ProcessLookupError):
-            process.terminate()
-        try:
-            await asyncio.wait_for(
-                process.wait(),
-                timeout=self.GIT_PUSH_TERMINATE_GRACE_SECONDS,
-            )
-        except TimeoutError:
-            self.log.warn(
-                "git.push_kill",
-                branch_name=branch_name,
-                timeout_ms=int(self.GIT_PUSH_TERMINATE_GRACE_SECONDS * 1000),
-            )
-            with contextlib.suppress(ProcessLookupError):
-                process.kill()
-            await process.wait()
-
-    async def _send_push_error(self, error: str, request: PushRequest) -> None:
-        """Emit push_error. branchName is included even when empty so the
-        control plane can resolve its pending push instead of leaking it."""
-        await self._send_event(
-            {
-                "type": "push_error",
-                "error": error,
-                "branchName": request.branch_name,
-                **request.repo_fields(),
+                "type": "push_error" if result.error is not None else "push_complete",
+                **({"error": result.error} if result.error is not None else {}),
+                # Even an empty branch resolves the control plane's pending push.
+                "branchName": result.request.branch_name,
+                **result.request.repo_fields(),
                 "timestamp": time.time(),
             }
         )

--- a/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
@@ -18,29 +18,48 @@ async def terminate_owned_subprocess(
     process: asyncio.subprocess.Process,
     *,
     kill_process_group: Callable[[int, int], None] = os.killpg,
+    terminate_grace_seconds: float = 0,
 ) -> None:
     """Kill a child-owned process group and reap its leader."""
-    if process.returncode is None:
-        process_id = getattr(process, "pid", None)
-        if isinstance(process_id, int):
-            with contextlib.suppress(ProcessLookupError):
-                kill_process_group(process_id, signal.SIGKILL)
-        else:
-            process.kill()
-    await asyncio.shield(process.wait())
+    process_id = getattr(process, "pid", None)
+
+    def send_signal(sig: int) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            if isinstance(process_id, int):
+                kill_process_group(process_id, sig)
+            elif process.returncode is None:
+                if sig == signal.SIGTERM:
+                    process.terminate()
+                else:
+                    process.kill()
+
+    try:
+        if terminate_grace_seconds > 0:
+            send_signal(signal.SIGTERM)
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(process.wait(), timeout=terminate_grace_seconds)
+    finally:
+        # The leader may have exited while descendants still hold its output pipes.
+        send_signal(signal.SIGKILL)
+        await asyncio.shield(process.wait())
 
 
 async def communicate_owned_subprocess(
     process: asyncio.subprocess.Process,
     *,
     kill_process_group: Callable[[int, int], None] = os.killpg,
+    terminate_grace_seconds: float = 0,
 ) -> tuple[bytes, bytes]:
-    """Communicate with a child and terminate its process group if cancelled."""
+    """Communicate with a child, cleaning up its process group on failure."""
     try:
         stdout, stderr = await process.communicate()
         return stdout or b"", stderr or b""
-    except asyncio.CancelledError:
-        await terminate_owned_subprocess(process, kill_process_group=kill_process_group)
+    except (asyncio.CancelledError, Exception):
+        await terminate_owned_subprocess(
+            process,
+            kill_process_group=kill_process_group,
+            terminate_grace_seconds=terminate_grace_seconds,
+        )
         raise
 
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
@@ -1,13 +1,13 @@
 """Local Git push execution, independent of control-plane transport."""
 
 import asyncio
-import contextlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NoReturn
 
 from .log_config import StructuredLogger
+from .process_output import communicate_owned_subprocess
 from .repo_config import find_repo_entry, load_repo_manifest
 
 GIT_PUSH_TIMEOUT_SECONDS = 300.0
@@ -16,7 +16,7 @@ GIT_PUSH_TERMINATE_GRACE_SECONDS = 5.0
 
 @dataclass(frozen=True)
 class PushRequest:
-    """Provider-generated push spec with absent fields normalized to empty values."""
+    """Validated provider-generated push spec, or correlation data for a rejection."""
 
     branch_name: str
     repo_owner: str
@@ -31,17 +31,36 @@ class PushRequest:
         spec = push_spec if isinstance(push_spec, dict) else {}
 
         def field(key: str) -> str:
-            return str(spec.get(key, "")).strip()
+            value = spec.get(key)
+            return value.strip() if isinstance(value, str) else ""
 
-        return cls(
+        force = spec.get("force")
+        request = cls(
             branch_name=field("targetBranch"),
             repo_owner=field("repoOwner"),
             repo_name=field("repoName"),
             refspec=field("refspec"),
             push_url=field("remoteUrl"),
             redacted_push_url=field("redactedRemoteUrl"),
-            force=bool(spec.get("force", False)),
+            force=force if isinstance(force, bool) else False,
         )
+        error = None
+        if not isinstance(push_spec, dict):
+            error = "missing push specification"
+        elif ("repoOwner" in spec or "repoName" in spec) and not request.has_repo_identity:
+            error = "pushSpec must carry both repoOwner and repoName"
+        elif not request.branch_name:
+            error = "missing target branch"
+        elif (
+            not request.refspec
+            or not request.push_url
+            or not request.redacted_push_url
+            or not isinstance(force, bool)
+        ):
+            error = "invalid push specification"
+        if error:
+            raise PushRejected(f"Push failed - {error}", request)
+        return request
 
     @property
     def has_repo_identity(self) -> bool:
@@ -68,7 +87,11 @@ class PushResult:
 
 
 class PushRejected(Exception):
-    """A user-facing rejection, already logged at the raise site."""
+    """A user-facing rejection with optional parsed correlation metadata."""
+
+    def __init__(self, message: str, request: PushRequest | None = None):
+        super().__init__(message)
+        self.request = request
 
 
 class PushOperation:
@@ -78,7 +101,12 @@ class PushOperation:
         self.log = logger
 
     async def execute(self, push_spec: object) -> PushResult:
-        request = PushRequest.from_push_spec(push_spec)
+        try:
+            request = PushRequest.from_push_spec(push_spec)
+        except PushRejected as rejection:
+            assert rejection.request is not None
+            self.log.warn("git.push_error", reason="invalid_push_spec")
+            return PushResult(rejection.request, str(rejection))
         self.log.info(
             "git.push_start",
             branch_name=request.branch_name,
@@ -87,7 +115,6 @@ class PushOperation:
             mode="push_spec",
         )
         try:
-            self._validate_push_request(request, spec_present=isinstance(push_spec, dict))
             repo_dir = self._resolve_push_checkout(request)
             await self._run_git_push(request, repo_dir)
         except PushRejected as rejection:
@@ -107,30 +134,6 @@ class PushOperation:
     def _reject_push(self, *, reason: str, message: str, **log_fields: Any) -> NoReturn:
         self.log.warn("git.push_error", reason=reason, **log_fields)
         raise PushRejected(message)
-
-    def _validate_push_request(self, request: PushRequest, *, spec_present: bool) -> None:
-        if not spec_present:
-            self._reject_push(
-                reason="missing_push_spec",
-                message="Push failed - missing push specification",
-            )
-        if bool(request.repo_owner) != bool(request.repo_name):
-            self._reject_push(
-                reason="partial_repo_identity",
-                message="Push failed - pushSpec must carry both repoOwner and repoName",
-                repo_owner=request.repo_owner,
-                repo_name=request.repo_name,
-            )
-        if not request.branch_name:
-            self._reject_push(
-                reason="missing_target_branch",
-                message="Push failed - missing target branch",
-            )
-        if not request.refspec or not request.push_url:
-            self._reject_push(
-                reason="invalid_push_spec",
-                message="Push failed - invalid push specification",
-            )
 
     def _resolve_push_checkout(self, request: PushRequest) -> Path:
         if request.has_repo_identity:
@@ -185,10 +188,14 @@ class PushOperation:
             cwd=repo_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             _stdout, stderr = await asyncio.wait_for(
-                process.communicate(), timeout=GIT_PUSH_TIMEOUT_SECONDS
+                communicate_owned_subprocess(
+                    process, terminate_grace_seconds=GIT_PUSH_TERMINATE_GRACE_SECONDS
+                ),
+                timeout=GIT_PUSH_TIMEOUT_SECONDS,
             )
         except TimeoutError:
             self.log.warn(
@@ -196,7 +203,6 @@ class PushOperation:
                 branch_name=request.branch_name,
                 timeout_ms=int(GIT_PUSH_TIMEOUT_SECONDS * 1000),
             )
-            await self._terminate_push_process(process, request.branch_name)
             raise PushRejected(
                 f"Push failed - git push timed out after {int(GIT_PUSH_TIMEOUT_SECONDS)}s"
             ) from None
@@ -214,23 +220,6 @@ class PushOperation:
                 if redacted_stderr_text
                 else "Push failed - unknown error"
             )
-
-    async def _terminate_push_process(
-        self, process: asyncio.subprocess.Process, branch_name: str
-    ) -> None:
-        with contextlib.suppress(ProcessLookupError):
-            process.terminate()
-        try:
-            await asyncio.wait_for(process.wait(), timeout=GIT_PUSH_TERMINATE_GRACE_SECONDS)
-        except TimeoutError:
-            self.log.warn(
-                "git.push_kill",
-                branch_name=branch_name,
-                timeout_ms=int(GIT_PUSH_TERMINATE_GRACE_SECONDS * 1000),
-            )
-            with contextlib.suppress(ProcessLookupError):
-                process.kill()
-            await process.wait()
 
     @staticmethod
     def _redact_git_stderr(stderr_text: str, push_url: str, redacted_push_url: str) -> str:

--- a/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
@@ -1,0 +1,240 @@
+"""Local Git push execution, independent of control-plane transport."""
+
+import asyncio
+import contextlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn
+
+from .log_config import StructuredLogger
+from .repo_config import find_repo_entry, load_repo_manifest
+
+GIT_PUSH_TIMEOUT_SECONDS = 300.0
+GIT_PUSH_TERMINATE_GRACE_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class PushRequest:
+    """Provider-generated push spec with absent fields normalized to empty values."""
+
+    branch_name: str
+    repo_owner: str
+    repo_name: str
+    refspec: str
+    push_url: str
+    redacted_push_url: str
+    force: bool
+
+    @classmethod
+    def from_push_spec(cls, push_spec: object) -> "PushRequest":
+        spec = push_spec if isinstance(push_spec, dict) else {}
+
+        def field(key: str) -> str:
+            return str(spec.get(key, "")).strip()
+
+        return cls(
+            branch_name=field("targetBranch"),
+            repo_owner=field("repoOwner"),
+            repo_name=field("repoName"),
+            refspec=field("refspec"),
+            push_url=field("remoteUrl"),
+            redacted_push_url=field("redactedRemoteUrl"),
+            force=bool(spec.get("force", False)),
+        )
+
+    @property
+    def has_repo_identity(self) -> bool:
+        return bool(self.repo_owner and self.repo_name)
+
+    @property
+    def repo_full_name(self) -> str:
+        return f"{self.repo_owner}/{self.repo_name}"
+
+    def repo_fields(self) -> dict[str, Any]:
+        """Include partial identity too, so rejected requests retain their metadata."""
+        fields: dict[str, Any] = {}
+        if self.repo_owner:
+            fields["repoOwner"] = self.repo_owner
+        if self.repo_name:
+            fields["repoName"] = self.repo_name
+        return fields
+
+
+@dataclass(frozen=True)
+class PushResult:
+    request: PushRequest
+    error: str | None = None
+
+
+class PushRejected(Exception):
+    """A user-facing rejection, already logged at the raise site."""
+
+
+class PushOperation:
+    def __init__(self, *, repo_path: Path, manifest_path: Path, logger: StructuredLogger):
+        self.repo_path = repo_path
+        self.manifest_path = manifest_path
+        self.log = logger
+
+    async def execute(self, push_spec: object) -> PushResult:
+        request = PushRequest.from_push_spec(push_spec)
+        self.log.info(
+            "git.push_start",
+            branch_name=request.branch_name,
+            repo_owner=request.repo_owner,
+            repo_name=request.repo_name,
+            mode="push_spec",
+        )
+        try:
+            self._validate_push_request(request, spec_present=isinstance(push_spec, dict))
+            repo_dir = self._resolve_push_checkout(request)
+            await self._run_git_push(request, repo_dir)
+        except PushRejected as rejection:
+            return PushResult(request, str(rejection))
+        except Exception as e:
+            self.log.error("git.push_error", exc=e, branch_name=request.branch_name)
+            return PushResult(request, str(e))
+
+        self.log.info(
+            "git.push_complete",
+            branch_name=request.branch_name,
+            repo_owner=request.repo_owner,
+            repo_name=request.repo_name,
+        )
+        return PushResult(request)
+
+    def _reject_push(self, *, reason: str, message: str, **log_fields: Any) -> NoReturn:
+        self.log.warn("git.push_error", reason=reason, **log_fields)
+        raise PushRejected(message)
+
+    def _validate_push_request(self, request: PushRequest, *, spec_present: bool) -> None:
+        if not spec_present:
+            self._reject_push(
+                reason="missing_push_spec",
+                message="Push failed - missing push specification",
+            )
+        if bool(request.repo_owner) != bool(request.repo_name):
+            self._reject_push(
+                reason="partial_repo_identity",
+                message="Push failed - pushSpec must carry both repoOwner and repoName",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
+            )
+        if not request.branch_name:
+            self._reject_push(
+                reason="missing_target_branch",
+                message="Push failed - missing target branch",
+            )
+        if not request.refspec or not request.push_url:
+            self._reject_push(
+                reason="invalid_push_spec",
+                message="Push failed - invalid push specification",
+            )
+
+    def _resolve_push_checkout(self, request: PushRequest) -> Path:
+        if request.has_repo_identity:
+            return self._member_checkout(request)
+        return self._sole_workspace_checkout()
+
+    def _member_checkout(self, request: PushRequest) -> Path:
+        # Only canonical manifest paths select checkouts, never spec-supplied paths.
+        member = find_repo_entry(
+            load_repo_manifest(self.manifest_path),
+            request.repo_owner,
+            request.repo_name,
+        )
+        if member is None:
+            self._reject_push(
+                reason="repo_not_session_member",
+                message=f"Repository {request.repo_full_name} is not part of this session",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
+            )
+        if not (member.path / ".git").exists():
+            self._reject_push(
+                reason="repo_not_in_workspace",
+                message=f"Repository {request.repo_full_name} not found in workspace",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
+            )
+        return member.path
+
+    def _sole_workspace_checkout(self) -> Path:
+        """Legacy identity-free fallback, sorted for deterministic selection."""
+        repo_dirs = sorted(self.repo_path.glob("*/.git"))
+        if not repo_dirs:
+            self._reject_push(reason="no_repo_configured", message="No repository found")
+        return repo_dirs[0].parent
+
+    async def _run_git_push(self, request: PushRequest, repo_dir: Path) -> None:
+        self.log.info(
+            "git.push_command",
+            branch_name=request.branch_name,
+            refspec=request.refspec,
+            force=request.force,
+            remote_url=request.redacted_push_url,
+        )
+        process = await asyncio.create_subprocess_exec(
+            "git",
+            "push",
+            request.push_url,
+            request.refspec,
+            *(["-f"] if request.force else []),
+            cwd=repo_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _stdout, stderr = await asyncio.wait_for(
+                process.communicate(), timeout=GIT_PUSH_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            self.log.warn(
+                "git.push_timeout",
+                branch_name=request.branch_name,
+                timeout_ms=int(GIT_PUSH_TIMEOUT_SECONDS * 1000),
+            )
+            await self._terminate_push_process(process, request.branch_name)
+            raise PushRejected(
+                f"Push failed - git push timed out after {int(GIT_PUSH_TIMEOUT_SECONDS)}s"
+            ) from None
+
+        if process.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            redacted_stderr_text = self._redact_git_stderr(
+                stderr_text, request.push_url, request.redacted_push_url
+            )
+            self.log.warn(
+                "git.push_failed", branch_name=request.branch_name, stderr=redacted_stderr_text
+            )
+            raise PushRejected(
+                f"Push failed: {redacted_stderr_text}"
+                if redacted_stderr_text
+                else "Push failed - unknown error"
+            )
+
+    async def _terminate_push_process(
+        self, process: asyncio.subprocess.Process, branch_name: str
+    ) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=GIT_PUSH_TERMINATE_GRACE_SECONDS)
+        except TimeoutError:
+            self.log.warn(
+                "git.push_kill",
+                branch_name=branch_name,
+                timeout_ms=int(GIT_PUSH_TERMINATE_GRACE_SECONDS * 1000),
+            )
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+
+    @staticmethod
+    def _redact_git_stderr(stderr_text: str, push_url: str, redacted_push_url: str) -> str:
+        """Redact credential-bearing URLs from git stderr."""
+        redacted_stderr = stderr_text
+        if push_url and redacted_push_url:
+            redacted_stderr = redacted_stderr.replace(push_url, redacted_push_url)
+        return re.sub(r"(https?://)([^/\s@]+)@", r"\1***@", redacted_stderr)

--- a/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/push_operation.py
@@ -94,7 +94,7 @@ class PushOperation:
             return PushResult(request, str(rejection))
         except Exception as e:
             self.log.error("git.push_error", exc=e, branch_name=request.branch_name)
-            return PushResult(request, str(e))
+            return PushResult(request, str(e) or "Push failed - unknown error")
 
         self.log.info(
             "git.push_complete",
@@ -178,9 +178,10 @@ class PushOperation:
         process = await asyncio.create_subprocess_exec(
             "git",
             "push",
+            *(["-f"] if request.force else []),
+            "--",
             request.push_url,
             request.refspec,
-            *(["-f"] if request.force else []),
             cwd=repo_dir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/packages/sandbox-runtime/tests/test_bridge_push.py
+++ b/packages/sandbox-runtime/tests/test_bridge_push.py
@@ -1,362 +1,62 @@
-"""Tests for bridge git push handling."""
+"""Transport contract for local push results."""
 
-import asyncio
-import json
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
+from sandbox_runtime.push_operation import PushRequest, PushResult
 
 
-def _create_bridge(tmp_path: Path) -> AgentBridge:
-    bridge = AgentBridge(
-        sandbox_id="test-sandbox",
-        session_id="test-session",
-        control_plane_url="http://localhost:8787",
-        auth_token="test-token",
-    )
-    bridge.repo_path = tmp_path
-    # Point at a per-test manifest (absent until a test writes one) so the
-    # real /tmp manifest never leaks in.
-    bridge.repo_manifest_path = tmp_path / "manifest.json"
-    repo_dir = tmp_path / "repo"
-    (repo_dir / ".git").mkdir(parents=True)
-    return bridge
-
-
-def _write_manifest(bridge: AgentBridge, tmp_path: Path, members: list[tuple[str, str]]) -> None:
-    """Write the supervisor-style repo manifest for the given (owner, name) members."""
-    bridge.repo_manifest_path.write_text(
-        json.dumps(
-            {
-                "repositories": [
-                    {
-                        "owner": owner,
-                        "name": name,
-                        "branch": "main",
-                        "path": str(tmp_path / name),
-                    }
-                    for owner, name in members
-                ]
-            }
-        )
-    )
-
-
-def _push_command() -> dict:
-    return {
-        "type": "push",
-        "pushSpec": {
-            "targetBranch": "feature/test",
-            "refspec": "HEAD:refs/heads/feature/test",
-            "remoteUrl": "https://token@github.com/open-inspect/repo.git",
-            "redactedRemoteUrl": "https://***@github.com/open-inspect/repo.git",
-            "force": False,
-        },
-    }
-
-
-def _fake_process(returncode: int | None, communicate_result: tuple[bytes, bytes] = (b"", b"")):
-    process = MagicMock()
-    process.returncode = returncode
-    process.communicate = AsyncMock(return_value=communicate_result)
-    process.wait = AsyncMock(return_value=None)
-    process.terminate = MagicMock()
-    process.kill = MagicMock()
-    return process
-
-
-@pytest.mark.asyncio
-async def test_handle_push_sends_push_complete_on_success(tmp_path: Path):
-    bridge = _create_bridge(tmp_path)
+@pytest.mark.parametrize(
+    "metadata,error",
+    [
+        ({"targetBranch": "feature/test"}, None),
+        ({"targetBranch": "feature/test", "repoOwner": "group/sub", "repoName": "repo"}, None),
+        ({"targetBranch": "feature/test", "repoOwner": "group/sub", "repoName": "repo"}, "failed"),
+        ({"targetBranch": "", "repoOwner": "group/sub"}, "missing branch"),
+        ({"repoName": "repo"}, "partial identity"),
+        ({}, ""),
+    ],
+)
+async def test_push_dispatch_emits_one_result(metadata, error):
+    bridge = AgentBridge("sandbox", "session", "http://localhost:8787", "token")
     bridge._send_event = AsyncMock()
-    process = _fake_process(returncode=0)
-
-    with patch(
-        "sandbox_runtime.bridge.asyncio.create_subprocess_exec", AsyncMock(return_value=process)
-    ):
-        await bridge._handle_push(_push_command())
-
-    bridge._send_event.assert_awaited_once()
-    await_args = bridge._send_event.await_args
-    assert await_args is not None
-    event = await_args.args[0]
-    assert event["type"] == "push_complete"
-    assert event["branchName"] == "feature/test"
-    assert isinstance(event["timestamp"], float)
-    process.terminate.assert_not_called()
-    process.kill.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_handle_push_sends_redacted_stderr_on_nonzero_exit(tmp_path: Path):
-    bridge = _create_bridge(tmp_path)
-    bridge._send_event = AsyncMock()
-    process = _fake_process(
-        returncode=1,
-        communicate_result=(
-            b"",
-            b"fatal: Authentication failed for 'https://token@github.com/open-inspect/repo.git'",
-        ),
-    )
-
-    with patch(
-        "sandbox_runtime.bridge.asyncio.create_subprocess_exec", AsyncMock(return_value=process)
-    ):
-        await bridge._handle_push(_push_command())
-
-    bridge._send_event.assert_awaited_once()
-    await_args = bridge._send_event.await_args
-    assert await_args is not None
-    event = await_args.args[0]
-    assert event["type"] == "push_error"
-    assert (
-        event["error"]
-        == "Push failed: fatal: Authentication failed for 'https://***@github.com/open-inspect/repo.git'"
-    )
-    assert event["branchName"] == "feature/test"
-    assert isinstance(event["timestamp"], float)
-    process.terminate.assert_not_called()
-    process.kill.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_handle_push_sends_unknown_error_when_stderr_is_empty(tmp_path: Path):
-    bridge = _create_bridge(tmp_path)
-    bridge._send_event = AsyncMock()
-    process = _fake_process(returncode=1)
-
-    with patch(
-        "sandbox_runtime.bridge.asyncio.create_subprocess_exec", AsyncMock(return_value=process)
-    ):
-        await bridge._handle_push(_push_command())
-
-    bridge._send_event.assert_awaited_once()
-    await_args = bridge._send_event.await_args
-    assert await_args is not None
-    event = await_args.args[0]
-    assert event["type"] == "push_error"
-    assert event["error"] == "Push failed - unknown error"
-    assert event["branchName"] == "feature/test"
-    assert isinstance(event["timestamp"], float)
-
-
-@pytest.mark.asyncio
-async def test_handle_push_timeout_terminates_process_and_sends_error(tmp_path: Path):
-    bridge = _create_bridge(tmp_path)
-    bridge._send_event = AsyncMock()
-    bridge.GIT_PUSH_TIMEOUT_SECONDS = 42.0
-    bridge.GIT_PUSH_TERMINATE_GRACE_SECONDS = 3.0
-
-    process = _fake_process(returncode=None)
-    wait_for_calls: list[float | None] = []
-    original_wait_for = asyncio.wait_for
-
-    async def timeout_first_wait_for(coro, timeout=None):
-        wait_for_calls.append(timeout)
-        if len(wait_for_calls) == 1:
-            if hasattr(coro, "close"):
-                coro.close()
-            raise TimeoutError
-        return await original_wait_for(coro, timeout=timeout)
+    raw_spec = {"opaque": "passed unchanged"}
+    result = PushResult(PushRequest.from_push_spec(metadata), error)
 
     with (
-        patch(
-            "sandbox_runtime.bridge.asyncio.create_subprocess_exec", AsyncMock(return_value=process)
-        ),
-        patch("sandbox_runtime.bridge.asyncio.wait_for", side_effect=timeout_first_wait_for),
+        patch("sandbox_runtime.bridge.PushOperation") as operation,
+        patch("sandbox_runtime.bridge.time.time", return_value=123.5) as clock,
     ):
-        await bridge._handle_push(_push_command())
+        operation.return_value.execute = AsyncMock(return_value=result)
+        await bridge._handle_command({"type": "push", "pushSpec": raw_spec})
 
-    assert wait_for_calls == [42.0, 3.0]
-    process.terminate.assert_called_once()
-    process.wait.assert_awaited_once()
-    process.kill.assert_not_called()
-    bridge._send_event.assert_awaited_once()
-    await_args = bridge._send_event.await_args
-    assert await_args is not None
-    event = await_args.args[0]
-    assert event["type"] == "push_error"
-    assert event["error"] == "Push failed - git push timed out after 42s"
-    assert event["branchName"] == "feature/test"
-    assert isinstance(event["timestamp"], float)
-
-
-def _multi_repo_push_command() -> dict:
-    cmd = _push_command()
-    cmd["pushSpec"]["repoOwner"] = "open-inspect"
-    cmd["pushSpec"]["repoName"] = "backend"
-    return cmd
-
-
-@pytest.mark.asyncio
-async def test_handle_push_targets_member_from_spec(tmp_path: Path):
-    """A spec carrying repo identity pushes from that member's checkout."""
-    bridge = _create_bridge(tmp_path)  # creates tmp_path/repo/.git
-    _write_manifest(bridge, tmp_path, [("open-inspect", "frontend"), ("open-inspect", "backend")])
-    (tmp_path / "backend" / ".git").mkdir(parents=True)
-    bridge._send_event = AsyncMock()
-    process = _fake_process(returncode=0)
-    captured: dict = {}
-
-    async def fake_exec(*args, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-        return process
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
-        await bridge._handle_push(_multi_repo_push_command())
-
-    assert captured["cwd"] == tmp_path / "backend"
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_complete"
-    assert event["branchName"] == "feature/test"
-    assert event["repoOwner"] == "open-inspect"
-    assert event["repoName"] == "backend"
-
-
-@pytest.mark.asyncio
-async def test_handle_push_matches_member_case_insensitively(tmp_path: Path):
-    """Identity matching is case-insensitive but the canonical path is used."""
-    bridge = _create_bridge(tmp_path)
-    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
-    (tmp_path / "backend" / ".git").mkdir(parents=True)
-    bridge._send_event = AsyncMock()
-    process = _fake_process(returncode=0)
-    captured: dict = {}
-
-    async def fake_exec(*args, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-        return process
-
-    cmd = _multi_repo_push_command()
-    cmd["pushSpec"]["repoOwner"] = "Open-Inspect"
-    cmd["pushSpec"]["repoName"] = "Backend"
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
-        await bridge._handle_push(cmd)
-
-    assert captured["cwd"] == tmp_path / "backend"
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_complete"
-
-
-@pytest.mark.asyncio
-async def test_handle_push_non_member_errors_without_pushing(tmp_path: Path):
-    """Identity not in the manifest never touches the filesystem."""
-    bridge = _create_bridge(tmp_path)
-    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
-    bridge._send_event = AsyncMock()
-    cmd = _multi_repo_push_command()
-    cmd["pushSpec"]["repoName"] = "missing"
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
-        await bridge._handle_push(cmd)
-
-    mock_exec.assert_not_called()
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_error"
-    assert "not part of this session" in event["error"]
-    assert event["branchName"] == "feature/test"
-    assert event["repoName"] == "missing"
-
-
-@pytest.mark.asyncio
-async def test_handle_push_traversal_repo_name_errors_without_pushing(tmp_path: Path):
-    """A crafted path-segment identity cannot select a checkout outside the manifest."""
-    bridge = _create_bridge(tmp_path)
-    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
-    outside = tmp_path / "outside"
-    (outside / ".git").mkdir(parents=True)
-    bridge._send_event = AsyncMock()
-    cmd = _multi_repo_push_command()
-    cmd["pushSpec"]["repoName"] = "../outside"
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
-        await bridge._handle_push(cmd)
-
-    mock_exec.assert_not_called()
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_error"
-    assert "not part of this session" in event["error"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("dropped_field", ["repoOwner", "repoName"])
-async def test_handle_push_partial_identity_errors(tmp_path: Path, dropped_field: str):
-    """Owner and name must travel together — no silent fallback for half a spec."""
-    bridge = _create_bridge(tmp_path)
-    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
-    bridge._send_event = AsyncMock()
-    cmd = _multi_repo_push_command()
-    del cmd["pushSpec"][dropped_field]
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
-        await bridge._handle_push(cmd)
-
-    mock_exec.assert_not_called()
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_error"
-    assert "both repoOwner and repoName" in event["error"]
-    assert event["branchName"] == "feature/test"
-
-
-@pytest.mark.asyncio
-async def test_handle_push_member_without_checkout_errors(tmp_path: Path):
-    """A manifest member whose checkout is missing on disk fails cleanly."""
-    bridge = _create_bridge(tmp_path)
-    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
-    bridge._send_event = AsyncMock()
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
-        await bridge._handle_push(_multi_repo_push_command())
-
-    mock_exec.assert_not_called()
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_error"
-    assert "not found in workspace" in event["error"]
-    assert event["repoName"] == "backend"
-
-
-@pytest.mark.asyncio
-async def test_handle_push_without_identity_keeps_legacy_behavior(tmp_path: Path):
-    """Specs without repo identity push from the sole clone, no repo fields."""
-    bridge = _create_bridge(tmp_path)
-    bridge._send_event = AsyncMock()
-    process = _fake_process(returncode=0)
-    captured: dict = {}
-
-    async def fake_exec(*args, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-        return process
-
-    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
-        await bridge._handle_push(_push_command())
-
-    assert captured["cwd"] == tmp_path / "repo"
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_complete"
-    assert "repoOwner" not in event
-    assert "repoName" not in event
-
-
-@pytest.mark.asyncio
-async def test_handle_push_no_repo_error_includes_branch(tmp_path: Path):
-    """The no-repository error must carry branchName so the control plane can
-    resolve its pending push instead of leaking it for 360s."""
-    bridge = AgentBridge(
-        sandbox_id="test-sandbox",
-        session_id="test-session",
-        control_plane_url="http://localhost:8787",
-        auth_token="test-token",
+    operation.assert_called_once_with(
+        repo_path=bridge.repo_path, manifest_path=bridge.repo_manifest_path, logger=bridge.log
     )
-    bridge.repo_path = tmp_path  # no clones at all
+    operation.return_value.execute.assert_awaited_once_with(raw_spec)
+    assert operation.return_value.execute.await_args.args[0] is raw_spec
+    clock.assert_called_once_with()
+    bridge._send_event.assert_awaited_once_with(
+        {
+            "type": "push_complete" if error is None else "push_error",
+            "branchName": metadata.get("targetBranch", ""),
+            **{key: metadata[key] for key in ("repoOwner", "repoName") if key in metadata},
+            **({"error": error} if error is not None else {}),
+            "timestamp": 123.5,
+        }
+    )
+
+
+@pytest.mark.parametrize("cmd", [{"type": "push"}, {"type": "push", "pushSpec": ["invalid"]}])
+async def test_push_passes_missing_or_invalid_spec_to_operation(cmd):
+    bridge = AgentBridge("sandbox", "session", "http://localhost:8787", "token")
     bridge._send_event = AsyncMock()
-
-    await bridge._handle_push(_push_command())
-
-    event = bridge._send_event.await_args.args[0]
-    assert event["type"] == "push_error"
-    assert event["error"] == "No repository found"
-    assert event["branchName"] == "feature/test"
+    with patch("sandbox_runtime.bridge.PushOperation") as operation:
+        operation.return_value.execute = AsyncMock(
+            return_value=PushResult(PushRequest.from_push_spec(None), "missing spec")
+        )
+        await bridge._handle_command(cmd)
+    operation.return_value.execute.assert_awaited_once_with(cmd.get("pushSpec"))
+    bridge._send_event.assert_awaited_once()

--- a/packages/sandbox-runtime/tests/test_bridge_push.py
+++ b/packages/sandbox-runtime/tests/test_bridge_push.py
@@ -23,7 +23,18 @@ async def test_push_dispatch_emits_one_result(metadata, error):
     bridge = AgentBridge("sandbox", "session", "http://localhost:8787", "token")
     bridge._send_event = AsyncMock()
     raw_spec = {"opaque": "passed unchanged"}
-    result = PushResult(PushRequest.from_push_spec(metadata), error)
+    result = PushResult(
+        PushRequest(
+            metadata.get("targetBranch", ""),
+            metadata.get("repoOwner", ""),
+            metadata.get("repoName", ""),
+            "",
+            "",
+            "",
+            False,
+        ),
+        error,
+    )
 
     with (
         patch("sandbox_runtime.bridge.PushOperation") as operation,
@@ -55,7 +66,7 @@ async def test_push_passes_missing_or_invalid_spec_to_operation(cmd):
     bridge._send_event = AsyncMock()
     with patch("sandbox_runtime.bridge.PushOperation") as operation:
         operation.return_value.execute = AsyncMock(
-            return_value=PushResult(PushRequest.from_push_spec(None), "missing spec")
+            return_value=PushResult(PushRequest("", "", "", "", "", "", False), "missing spec")
         )
         await bridge._handle_command(cmd)
     operation.return_value.execute.assert_awaited_once_with(cmd.get("pushSpec"))

--- a/packages/sandbox-runtime/tests/test_process_output.py
+++ b/packages/sandbox-runtime/tests/test_process_output.py
@@ -1,0 +1,80 @@
+"""Owned subprocess cleanup without network or Git operations."""
+
+import asyncio
+import signal
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sandbox_runtime.process_output import communicate_owned_subprocess, terminate_owned_subprocess
+
+
+@pytest.mark.parametrize("returncode", [None, 0])
+@pytest.mark.parametrize("missing_group", [False, True])
+async def test_communication_error_kills_group_and_reaps(returncode, missing_group):
+    error = OSError("read failed")
+    process = MagicMock(pid=123, returncode=returncode)
+    process.communicate = AsyncMock(side_effect=error)
+    process.wait = AsyncMock()
+    group_signal = MagicMock(side_effect=ProcessLookupError if missing_group else None)
+
+    with pytest.raises(OSError, match="read failed") as caught:
+        await communicate_owned_subprocess(process, kill_process_group=group_signal)
+
+    assert caught.value is error
+    group_signal.assert_called_once_with(123, signal.SIGKILL)
+    process.wait.assert_awaited_once()
+
+
+@pytest.mark.parametrize("grace_seconds", [0, 0.1])
+async def test_local_process_cancellation_reaps_before_propagating(grace_seconds):
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; print('ready', flush=True); time.sleep(60)",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    task = asyncio.create_task(
+        communicate_owned_subprocess(process, terminate_grace_seconds=grace_seconds)
+    )
+    try:
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=2)
+        assert process.returncode in (-signal.SIGTERM, -signal.SIGKILL)
+        assert await process.wait() == process.returncode
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+
+async def test_cancellation_during_grace_still_kills_and_reaps():
+    waiting = asyncio.Event()
+    process = MagicMock(pid=123, returncode=None)
+    group_signal = MagicMock()
+
+    async def wait():
+        if process.wait.await_count == 1:
+            waiting.set()
+            await asyncio.Future()
+
+    process.wait = AsyncMock(side_effect=wait)
+    task = asyncio.create_task(
+        terminate_owned_subprocess(
+            process, kill_process_group=group_signal, terminate_grace_seconds=5
+        )
+    )
+    await waiting.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert [call.args for call in group_signal.call_args_list] == [
+        (123, signal.SIGTERM),
+        (123, signal.SIGKILL),
+    ]
+    assert process.wait.await_count == 2

--- a/packages/sandbox-runtime/tests/test_push_operation.py
+++ b/packages/sandbox-runtime/tests/test_push_operation.py
@@ -2,11 +2,14 @@
 
 import asyncio
 import json
+import signal
+from functools import partial
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from sandbox_runtime.process_output import communicate_owned_subprocess
 from sandbox_runtime.push_operation import PushOperation, PushRequest
 
 
@@ -74,6 +77,7 @@ async def test_success_uses_legacy_checkout(operation):
         cwd=operation.repo_path / "repo",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
     )
     process.terminate.assert_not_called()
     process.kill.assert_not_called()
@@ -116,38 +120,97 @@ async def test_nonzero_exit_redacts_stderr(operation, stderr, expected):
 @pytest.mark.parametrize("escalate", [False, True])
 @pytest.mark.parametrize("already_exited", [False, True])
 async def test_timeout_terminates_then_kills_if_needed(operation, escalate, already_exited):
-    process = _fake_process(None)
-    if already_exited:
-        process.terminate.side_effect = ProcessLookupError
-        process.kill.side_effect = ProcessLookupError
-    timeouts = []
+    process = _fake_process(0 if already_exited else None)
+    process.pid = 123
+    group_signal = MagicMock()
+    reaped = asyncio.Event()
 
-    async def wait_for(coro, timeout):
-        timeouts.append(timeout)
-        if len(timeouts) == 1 or escalate:
-            coro.close()
-            raise TimeoutError
-        return await coro
+    async def communicate():
+        await asyncio.Future()
+
+    async def wait():
+        if escalate and process.wait.await_count == 1:
+            await asyncio.Future()
+        reaped.set()
+
+    process.communicate.side_effect = communicate
+    process.wait.side_effect = wait
 
     with (
         patch(
             "sandbox_runtime.push_operation.asyncio.create_subprocess_exec", return_value=process
         ),
-        patch("sandbox_runtime.push_operation.asyncio.wait_for", side_effect=wait_for),
-        patch("sandbox_runtime.push_operation.GIT_PUSH_TIMEOUT_SECONDS", 42.0),
-        patch("sandbox_runtime.push_operation.GIT_PUSH_TERMINATE_GRACE_SECONDS", 3.0),
+        patch(
+            "sandbox_runtime.push_operation.communicate_owned_subprocess",
+            partial(communicate_owned_subprocess, kill_process_group=group_signal),
+        ),
+        patch("sandbox_runtime.push_operation.GIT_PUSH_TIMEOUT_SECONDS", 0.01),
+        patch("sandbox_runtime.push_operation.GIT_PUSH_TERMINATE_GRACE_SECONDS", 0.01),
     ):
         result = await operation.execute(_push_spec())
-    assert timeouts == [42.0, 3.0]
-    assert result.error == "Push failed - git push timed out after 42s"
+    assert result.error == "Push failed - git push timed out after 0s"
     assert result.request.branch_name == "feature/test"
-    process.terminate.assert_called_once_with()
-    if escalate:
-        process.kill.assert_called_once_with()
-        assert process.wait.call_count == 2
-    else:
-        process.kill.assert_not_called()
-    process.wait.assert_awaited_once()
+    assert [call.args for call in group_signal.call_args_list] == [
+        (123, signal.SIGTERM),
+        (123, signal.SIGKILL),
+    ]
+    assert reaped.is_set()
+    assert process.wait.await_count == 2
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+@pytest.mark.parametrize("already_exited", [False, True])
+async def test_failure_waits_for_group_cleanup_and_reap(operation, cancel, already_exited):
+    process = _fake_process(0 if already_exited else None)
+    process.pid = 123
+    communicating = asyncio.Event()
+    cleaning = asyncio.Event()
+    release = asyncio.Event()
+    group_signal = MagicMock()
+
+    async def communicate():
+        communicating.set()
+        if cancel:
+            await asyncio.Future()
+        raise OSError("communication failed")
+
+    async def wait():
+        if process.wait.await_count == 2:
+            cleaning.set()
+            await release.wait()
+
+    process.communicate.side_effect = communicate
+    process.wait.side_effect = wait
+    with (
+        patch(
+            "sandbox_runtime.push_operation.asyncio.create_subprocess_exec", return_value=process
+        ),
+        patch(
+            "sandbox_runtime.push_operation.communicate_owned_subprocess",
+            partial(communicate_owned_subprocess, kill_process_group=group_signal),
+        ),
+    ):
+        task = asyncio.create_task(operation.execute(_push_spec()))
+        await communicating.wait()
+        if cancel:
+            task.cancel()
+        await cleaning.wait()
+        assert not task.done()
+        assert [call.args for call in group_signal.call_args_list] == [
+            (123, signal.SIGTERM),
+            (123, signal.SIGKILL),
+        ]
+        release.set()
+        if cancel:
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            assert (await task).error == "communication failed"
+    assert [call.args for call in group_signal.call_args_list] == [
+        (123, signal.SIGTERM),
+        (123, signal.SIGKILL),
+    ]
+    assert process.wait.await_count == 2
 
 
 @pytest.mark.parametrize("owner,name", [("open-inspect", "backend"), ("Open-Inspect", "Backend")])
@@ -234,6 +297,7 @@ async def test_provider_url_refspec_and_force_pass_through(operation, force):
         cwd=operation.repo_path / "repo",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
     )
 
 
@@ -262,17 +326,47 @@ async def test_invalid_fields(operation, spec, error):
         result = await operation.execute(spec)
     launch.assert_not_called()
     assert result.error == f"Push failed - {error}"
-    assert result.request == PushRequest.from_push_spec(spec)
+    assert result.request.branch_name == spec.get("targetBranch", "").strip()
 
 
-def test_normalization_preserves_existing_string_and_bool_coercion():
-    request = PushRequest.from_push_spec(
-        _push_spec(targetBranch=123, refspec=None, force="false", repoOwner=" owner ")
-    )
-    assert request.branch_name == "123"
-    assert request.refspec == "None"
-    assert request.force is True
-    assert request.repo_owner == "owner"
+@pytest.mark.parametrize(
+    "field", ["targetBranch", "refspec", "remoteUrl", "redactedRemoteUrl", "repoOwner", "repoName"]
+)
+@pytest.mark.parametrize("value", [None, [], {}, False, True, 0, 1, 123, "", "  "])
+async def test_invalid_strings_rejected_without_launch(operation, field, value):
+    spec = _push_spec(**{"repoOwner": " owner ", "repoName": " repo ", field: value})
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(spec)
+    launch.assert_not_called()
+    assert result.error
+    assert result.request.branch_name == ("" if field == "targetBranch" else "feature/test")
+    assert result.request.repo_fields() == {
+        key: val for key, val in {"repoOwner": "owner", "repoName": "repo"}.items() if key != field
+    }
+
+
+@pytest.mark.parametrize("value", [None, [], {}, "false", "true", "", 0, 1])
+async def test_invalid_force_rejected_without_launch(operation, value):
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(
+            _push_spec(force=value, repoOwner="owner", repoName="repo")
+        )
+    launch.assert_not_called()
+    assert result.error
+    assert result.request.branch_name == "feature/test"
+    assert result.request.repo_fields() == {"repoOwner": "owner", "repoName": "repo"}
+
+
+@pytest.mark.parametrize(
+    "field", ["targetBranch", "refspec", "remoteUrl", "redactedRemoteUrl", "force"]
+)
+async def test_missing_required_field_rejected(operation, field):
+    spec = _push_spec()
+    del spec[field]
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(spec)
+    launch.assert_not_called()
+    assert result.error
 
 
 @pytest.mark.parametrize(

--- a/packages/sandbox-runtime/tests/test_push_operation.py
+++ b/packages/sandbox-runtime/tests/test_push_operation.py
@@ -1,0 +1,286 @@
+"""Local push execution coverage without WebSocket or bridge dependencies."""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandbox_runtime.push_operation import PushOperation, PushRequest
+
+
+@pytest.fixture
+def operation(tmp_path: Path) -> PushOperation:
+    (tmp_path / "repo" / ".git").mkdir(parents=True)
+    return PushOperation(
+        repo_path=tmp_path, manifest_path=tmp_path / "manifest.json", logger=MagicMock()
+    )
+
+
+def _write_manifest(operation: PushOperation, members: list[tuple[str, str]]) -> None:
+    operation.manifest_path.write_text(
+        json.dumps(
+            {
+                "repositories": [
+                    {
+                        "owner": owner,
+                        "name": name,
+                        "branch": "main",
+                        "path": str(operation.repo_path / name),
+                    }
+                    for owner, name in members
+                ]
+            }
+        )
+    )
+
+
+def _push_spec(**fields) -> dict:
+    return {
+        "targetBranch": "feature/test",
+        "refspec": "HEAD:refs/heads/feature/test",
+        "remoteUrl": "https://token@github.com/open-inspect/repo.git",
+        "redactedRemoteUrl": "https://***@github.com/open-inspect/repo.git",
+        "force": False,
+        **fields,
+    }
+
+
+def _fake_process(returncode=0, stderr=b""):
+    process = MagicMock()
+    process.returncode = returncode
+    process.communicate = AsyncMock(return_value=(b"", stderr))
+    process.wait = AsyncMock()
+    return process
+
+
+async def test_success_uses_legacy_checkout(operation):
+    process = _fake_process()
+    spec = _push_spec()
+    with patch(
+        "sandbox_runtime.push_operation.asyncio.create_subprocess_exec", return_value=process
+    ) as launch:
+        result = await operation.execute(spec)
+    assert result.error is None
+    assert result.request == PushRequest.from_push_spec(spec)
+    assert result.request.repo_fields() == {}
+    launch.assert_awaited_once_with(
+        "git",
+        "push",
+        spec["remoteUrl"],
+        spec["refspec"],
+        cwd=operation.repo_path / "repo",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "stderr,expected",
+    [
+        (
+            b"fatal: Authentication failed for 'https://token@github.com/open-inspect/repo.git'",
+            "Push failed: fatal: Authentication failed for 'https://***@github.com/open-inspect/repo.git'",
+        ),
+        (b"", "Push failed - unknown error"),
+        (b" \n ", "Push failed - unknown error"),
+        (
+            b"\xff https://user:secret@other.example/repo http://secret@host/repo\n",
+            "Push failed: \ufffd https://***@other.example/repo http://***@host/repo",
+        ),
+    ],
+)
+async def test_nonzero_exit_redacts_stderr(operation, stderr, expected):
+    process = _fake_process(1, stderr)
+    with patch(
+        "sandbox_runtime.push_operation.asyncio.create_subprocess_exec", return_value=process
+    ):
+        result = await operation.execute(_push_spec())
+    assert result.error == expected
+    assert result.request.branch_name == "feature/test"
+    operation.log.warn.assert_called_once_with(
+        "git.push_failed",
+        branch_name="feature/test",
+        stderr=expected.removeprefix("Push failed: ")
+        if expected != "Push failed - unknown error"
+        else "",
+    )
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+
+
+@pytest.mark.parametrize("escalate", [False, True])
+@pytest.mark.parametrize("already_exited", [False, True])
+async def test_timeout_terminates_then_kills_if_needed(operation, escalate, already_exited):
+    process = _fake_process(None)
+    if already_exited:
+        process.terminate.side_effect = ProcessLookupError
+        process.kill.side_effect = ProcessLookupError
+    timeouts = []
+
+    async def wait_for(coro, timeout):
+        timeouts.append(timeout)
+        if len(timeouts) == 1 or escalate:
+            coro.close()
+            raise TimeoutError
+        return await coro
+
+    with (
+        patch(
+            "sandbox_runtime.push_operation.asyncio.create_subprocess_exec", return_value=process
+        ),
+        patch("sandbox_runtime.push_operation.asyncio.wait_for", side_effect=wait_for),
+        patch("sandbox_runtime.push_operation.GIT_PUSH_TIMEOUT_SECONDS", 42.0),
+        patch("sandbox_runtime.push_operation.GIT_PUSH_TERMINATE_GRACE_SECONDS", 3.0),
+    ):
+        result = await operation.execute(_push_spec())
+    assert timeouts == [42.0, 3.0]
+    assert result.error == "Push failed - git push timed out after 42s"
+    assert result.request.branch_name == "feature/test"
+    process.terminate.assert_called_once_with()
+    if escalate:
+        process.kill.assert_called_once_with()
+        assert process.wait.call_count == 2
+    else:
+        process.kill.assert_not_called()
+    process.wait.assert_awaited_once()
+
+
+@pytest.mark.parametrize("owner,name", [("open-inspect", "backend"), ("Open-Inspect", "Backend")])
+async def test_targets_manifest_member_case_insensitively(operation, owner, name):
+    _write_manifest(operation, [("open-inspect", "frontend"), ("open-inspect", "backend")])
+    (operation.repo_path / "backend" / ".git").mkdir(parents=True)
+    with patch(
+        "sandbox_runtime.push_operation.asyncio.create_subprocess_exec",
+        return_value=_fake_process(),
+    ) as launch:
+        result = await operation.execute(_push_spec(repoOwner=owner, repoName=name))
+    assert result.error is None
+    assert launch.call_args.kwargs["cwd"] == operation.repo_path / "backend"
+    assert result.request.repo_fields() == {"repoOwner": owner, "repoName": name}
+
+
+@pytest.mark.parametrize("name", ["missing", "../outside"])
+async def test_non_member_rejected_without_pushing(operation, name):
+    _write_manifest(operation, [("open-inspect", "backend")])
+    (operation.repo_path / "outside" / ".git").mkdir(parents=True)
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(_push_spec(repoOwner="open-inspect", repoName=name))
+    launch.assert_not_called()
+    assert result.error == f"Repository open-inspect/{name} is not part of this session"
+    assert result.request.repo_name == name
+
+
+async def test_member_without_checkout(operation):
+    _write_manifest(operation, [("open-inspect", "backend")])
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(_push_spec(repoOwner="open-inspect", repoName="backend"))
+    launch.assert_not_called()
+    assert result.error == "Repository open-inspect/backend not found in workspace"
+    assert result.request.repo_name == "backend"
+
+
+async def test_no_repository(tmp_path):
+    operation = PushOperation(
+        repo_path=tmp_path, manifest_path=tmp_path / "absent", logger=MagicMock()
+    )
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(_push_spec())
+    launch.assert_not_called()
+    assert result.error == "No repository found"
+    assert result.request.branch_name == "feature/test"
+
+
+async def test_identity_free_fallback_ignores_manifest_and_sorts_clones(operation):
+    _write_manifest(operation, [("open-inspect", "repo")])
+    (operation.repo_path / "aaa" / ".git").mkdir(parents=True)
+    with patch(
+        "sandbox_runtime.push_operation.asyncio.create_subprocess_exec",
+        return_value=_fake_process(),
+    ) as launch:
+        result = await operation.execute(_push_spec())
+    assert result.error is None
+    assert launch.call_args.kwargs["cwd"] == operation.repo_path / "aaa"
+
+
+@pytest.mark.parametrize("force", [False, True])
+async def test_provider_url_refspec_and_force_pass_through(operation, force):
+    _write_manifest(operation, [("group/subgroup", "repo")])
+    spec = _push_spec(
+        repoOwner="group/subgroup",
+        repoName="repo",
+        force=force,
+        remoteUrl="https://oauth2:token@gitlab.example/group/subgroup/repo.git",
+        redactedRemoteUrl="https://***@gitlab.example/group/subgroup/repo.git",
+        refspec="local-branch:refs/heads/provider-target",
+    )
+    with patch(
+        "sandbox_runtime.push_operation.asyncio.create_subprocess_exec",
+        return_value=_fake_process(),
+    ) as launch:
+        result = await operation.execute(spec)
+    assert result.error is None
+    launch.assert_awaited_once_with(
+        "git",
+        "push",
+        spec["remoteUrl"],
+        spec["refspec"],
+        *(["-f"] if force else []),
+        cwd=operation.repo_path / "repo",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+
+@pytest.mark.parametrize("spec", [None, False, 42, "invalid", [], ["invalid"]])
+async def test_invalid_spec(operation, spec):
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(spec)
+    launch.assert_not_called()
+    assert result.error == "Push failed - missing push specification"
+    assert result.request.branch_name == ""
+
+
+@pytest.mark.parametrize(
+    "spec,error",
+    [
+        ({}, "missing target branch"),
+        (_push_spec(targetBranch="  "), "missing target branch"),
+        (_push_spec(refspec=""), "invalid push specification"),
+        (_push_spec(remoteUrl="  "), "invalid push specification"),
+        (_push_spec(repoOwner="owner"), "pushSpec must carry both repoOwner and repoName"),
+        (_push_spec(repoName="repo"), "pushSpec must carry both repoOwner and repoName"),
+    ],
+)
+async def test_invalid_fields(operation, spec, error):
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec") as launch:
+        result = await operation.execute(spec)
+    launch.assert_not_called()
+    assert result.error == f"Push failed - {error}"
+    assert result.request == PushRequest.from_push_spec(spec)
+
+
+def test_normalization_preserves_existing_string_and_bool_coercion():
+    request = PushRequest.from_push_spec(
+        _push_spec(targetBranch=123, refspec=None, force="false", repoOwner=" owner ")
+    )
+    assert request.branch_name == "123"
+    assert request.refspec == "None"
+    assert request.force is True
+    assert request.repo_owner == "owner"
+
+
+@pytest.mark.parametrize(
+    "error", [OSError("git unavailable"), RuntimeError("launch failed"), RuntimeError("")]
+)
+async def test_launch_exception_becomes_result(operation, error):
+    with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec", side_effect=error):
+        result = await operation.execute(_push_spec())
+    assert result.error == str(error)
+    assert result.request.branch_name == "feature/test"
+    operation.log.error.assert_called_once_with(
+        "git.push_error", exc=error, branch_name="feature/test"
+    )

--- a/packages/sandbox-runtime/tests/test_push_operation.py
+++ b/packages/sandbox-runtime/tests/test_push_operation.py
@@ -68,6 +68,7 @@ async def test_success_uses_legacy_checkout(operation):
     launch.assert_awaited_once_with(
         "git",
         "push",
+        "--",
         spec["remoteUrl"],
         spec["refspec"],
         cwd=operation.repo_path / "repo",
@@ -226,9 +227,10 @@ async def test_provider_url_refspec_and_force_pass_through(operation, force):
     launch.assert_awaited_once_with(
         "git",
         "push",
+        *(["-f"] if force else []),
+        "--",
         spec["remoteUrl"],
         spec["refspec"],
-        *(["-f"] if force else []),
         cwd=operation.repo_path / "repo",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -274,12 +276,17 @@ def test_normalization_preserves_existing_string_and_bool_coercion():
 
 
 @pytest.mark.parametrize(
-    "error", [OSError("git unavailable"), RuntimeError("launch failed"), RuntimeError("")]
+    "error,expected",
+    [
+        (OSError("git unavailable"), "git unavailable"),
+        (RuntimeError("launch failed"), "launch failed"),
+        (RuntimeError(""), "Push failed - unknown error"),
+    ],
 )
-async def test_launch_exception_becomes_result(operation, error):
+async def test_launch_exception_becomes_result(operation, error, expected):
     with patch("sandbox_runtime.push_operation.asyncio.create_subprocess_exec", side_effect=error):
         result = await operation.execute(_push_spec())
-    assert result.error == str(error)
+    assert result.error == expected
     assert result.request.branch_name == "feature/test"
     operation.log.error.assert_called_once_with(
         "git.push_error", exc=error, branch_name="feature/test"

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -174,6 +174,7 @@ class TestSetupScriptTimeout:
         _create_setup_script(sup.repo_path)
         fake_proc = _fake_process(returncode=None)
         fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
+        fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
         fake_proc.stdout = MagicMock()
         fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
 

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -1,6 +1,7 @@
 """Tests for RepositoryHooks.run_setup() and its integration in RepositoryBoot.boot()."""
 
 import asyncio
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sandbox_runtime.repository_boot import RepositoryBoot
@@ -169,22 +170,25 @@ class TestSetupScriptFailure:
 class TestSetupScriptTimeout:
     """Timeout handling for the setup script."""
 
-    async def test_timeout_kills_process(self, tmp_path):
+    async def test_timeout_kills_process_group(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(sup.repo_path)
         fake_proc = _fake_process(returncode=None)
+        fake_proc.pid = 123
         fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
         fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
         fake_proc.stdout = MagicMock()
         fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
 
-        with patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
         ):
             result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
 
         assert result is False
-        fake_proc.kill.assert_called_once()
+        kill_process_group.assert_called_once_with(fake_proc.pid, signal.SIGKILL)
+        fake_proc.kill.assert_not_called()
         fake_proc.wait.assert_awaited_once()
 
     async def test_build_timeout_log_omits_hook_output(self, tmp_path):

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -1,6 +1,7 @@
 """Tests for RepositoryHooks.run_start() and strict repository boot integration."""
 
 import asyncio
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -155,22 +156,25 @@ class TestStartScriptFailure:
 class TestStartScriptTimeout:
     """Timeout handling for the start script."""
 
-    async def test_timeout_kills_process(self, tmp_path):
+    async def test_timeout_kills_process_group(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_start_script(sup.repo_path)
         fake_proc = _fake_process(returncode=None)
+        fake_proc.pid = 123
         fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
         fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
         fake_proc.stdout = MagicMock()
         fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
 
-        with patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
         ):
             result = await sup.hooks.run_start(sup.repositories[0], BootMode.FRESH)
 
         assert result is False
-        fake_proc.kill.assert_called_once()
+        kill_process_group.assert_called_once_with(fake_proc.pid, signal.SIGKILL)
+        fake_proc.kill.assert_not_called()
         fake_proc.wait.assert_awaited_once()
 
     async def test_default_timeout_120(self, tmp_path):

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -160,6 +160,7 @@ class TestStartScriptTimeout:
         _create_start_script(sup.repo_path)
         fake_proc = _fake_process(returncode=None)
         fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
+        fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
         fake_proc.stdout = MagicMock()
         fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
 


### PR DESCRIPTION
## Summary
- Extract a local `PushOperation` owning push-spec parsing, validation, checkout selection, Git subprocess execution, timeout escalation, redaction, and error-to-result conversion.
- Keep command dispatch and timestamped `push_complete` / `push_error` Session Event Stream emission in the bridge.
- Preserve provider-generated URLs/refspecs/force, manifest-based repository selection, identity-free fallback, existing redaction, and branch/repository event metadata.
- Move execution tests out of the bridge suite and retain boundary-mocked transport contract tests. Add coverage for nested GitLab owners, force/refspec passthrough, kill escalation, malformed specs/stderr, and launch failures.

## Verification
- Focused push and bridge tests: 192 passed.
- Full sandbox-runtime suite with ambient credential environment cleared: 820 passed, 3 skipped, 1 unrelated failure.
- Remaining failure: `test_git_invokes_custom_ssh_signer_with_literal_public_key` expects Git to pass `-U` to the SSH signer; installed Git 2.39.5 does not. This test exercises untouched signing code.
- Ruff lint and formatting checks passed for all changed files.
- Commit hooks and `git diff --check` passed.

Addresses issue 7, Separate Git push execution from WebSocket transport.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ee6a9a84a0c39f3f517282a948b03485)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git push handling with clearer success and error reporting, including branch and repository details.
  * Added validation for incomplete or invalid push requests.
  * Improved checkout selection, repository-specific workspace support, and identity-free fallback behavior.
  * Improved timeout and cancellation cleanup for push operations.
  * Added safer redaction of sensitive Git error details and clearer handling of unexpected failures.

* **Tests**
  * Expanded coverage for push success, failures, validation, workspace selection, timeouts, cancellation, and process cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->