### PR TITLE
fix(web): preserve launch choices when prerequisites fail

### DIFF
--- a/packages/web/src/app/(app)/(sidebar)/page.test.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.test.tsx
@@ -13,6 +13,7 @@ import {
 import Home from "./page";
 import { isSessionInboxKey } from "@/lib/session-inbox-api";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
+import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
 
 expect.extend(matchers);
 
@@ -29,6 +30,8 @@ const mocks = vi.hoisted(() => ({
     defaultBranch: string;
   }>,
   loadingReposValue: false,
+  reposError: undefined as Error | undefined,
+  environmentsError: undefined as Error | undefined,
   environmentsLoadingValue: false,
   environmentsValue: [] as Array<{
     id: string;
@@ -64,6 +67,7 @@ const mocks = vi.hoisted(() => ({
     archivedAt: null;
   }>,
   providerAccountsLoadingValue: false,
+  providerAccountsError: undefined as Error | undefined,
   skillPreview: {
     skills: [
       {
@@ -120,6 +124,11 @@ vi.mock("@/hooks/use-environments", () => ({
   useEnvironments: () => ({
     environments: mocks.environmentsValue,
     loading: mocks.environmentsLoadingValue,
+    status: getPrerequisiteStatus(
+      mocks.environmentsValue,
+      mocks.environmentsLoadingValue,
+      mocks.environmentsError
+    ),
   }),
 }));
 
@@ -136,7 +145,11 @@ vi.mock("@/components/model-reasoning-selector", () => ({
 }));
 
 vi.mock("@/hooks/use-repos", () => ({
-  useRepos: () => ({ repos: mocks.reposValue, loading: mocks.loadingReposValue }),
+  useRepos: () => ({
+    repos: mocks.reposValue,
+    loading: mocks.loadingReposValue,
+    status: getPrerequisiteStatus(mocks.reposValue, mocks.loadingReposValue, mocks.reposError),
+  }),
 }));
 
 vi.mock("@/hooks/use-branches", () => ({
@@ -170,7 +183,12 @@ vi.mock("@/hooks/use-provider-accounts", () => ({
     accounts: mocks.providerAccountsValue,
     defaults: [],
     loading: mocks.providerAccountsLoadingValue,
-    error: undefined,
+    accountsStatus: getPrerequisiteStatus(
+      mocks.providerAccountsValue,
+      mocks.providerAccountsLoadingValue,
+      mocks.providerAccountsError
+    ),
+    error: mocks.providerAccountsError,
     refresh: vi.fn(),
   }),
 }));
@@ -192,6 +210,9 @@ beforeAll(() => {
 beforeEach(() => {
   mocks.reposValue = [repo];
   mocks.loadingReposValue = false;
+  mocks.reposError = undefined;
+  mocks.environmentsError = undefined;
+  mocks.providerAccountsError = undefined;
   mocks.environmentsLoadingValue = false;
   mocks.environmentsValue = [];
   mocks.enabledModelsValue = [DEFAULT_MODEL];
@@ -642,6 +663,75 @@ describe("Home", () => {
 
     await waitFor(() => expect(sessionCreateBody()).toMatchObject({ providerSelections: {} }));
     expect(localStorage.getItem("open-inspect-last-provider-selections:v1")).toBe("{}");
+  });
+
+  it.each([true, false])(
+    "preserves provider choices during failure and reconciles recovery (account exists: %s)",
+    async (exists) => {
+      const accountId = "a".repeat(32);
+      const selection = { openai: { mode: "provider_account", accountId } };
+      const stored = JSON.stringify(selection);
+      localStorage.setItem("open-inspect-last-provider-selections:v1", stored);
+      mocks.providerAccountsError = new Error("Service unavailable");
+      const view = render(<Home />);
+
+      expect(localStorage.getItem("open-inspect-last-provider-selections:v1")).toBe(stored);
+
+      mocks.providerAccountsError = undefined;
+      mocks.providerAccountsValue = exists ? [activeOpenAiAccount(accountId)] : [];
+      view.rerender(<Home />);
+      expect(localStorage.getItem("open-inspect-last-provider-selections:v1")).toBe(
+        exists ? stored : "{}"
+      );
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText("What do you want to build?"), "Continue work");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+      await waitFor(() =>
+        expect(sessionCreateBody()).toMatchObject({
+          providerSelections: exists ? selection : {},
+        })
+      );
+    }
+  );
+
+  it.each([true, false])(
+    "preserves a stored environment during failure and restores after recovery (exists: %s)",
+    async (exists) => {
+      localStorage.setItem("open-inspect-last-selected-repo", "env:env-1");
+      mocks.environmentsError = new Error("Service unavailable");
+      const view = render(<Home />);
+
+      expect(screen.getByRole("button", { name: /select repo/i })).toBeInTheDocument();
+      expect(localStorage.getItem("open-inspect-last-selected-repo")).toBe("env:env-1");
+      fireEvent.change(screen.getByPlaceholderText("What do you want to build?"), {
+        target: { value: "Continue work" },
+      });
+      expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
+      expect(fetch).not.toHaveBeenCalled();
+
+      mocks.environmentsError = undefined;
+      mocks.environmentsValue = exists ? [environment] : [];
+      view.rerender(<Home />);
+      await screen.findByRole("button", { name: exists ? /full-stack/i : /background-agents/i });
+      expect(localStorage.getItem("open-inspect-last-selected-repo")).toBe(
+        exists ? "env:env-1" : repo.fullName
+      );
+    }
+  );
+
+  it("restores a saved repository after a failed repository request recovers", async () => {
+    localStorage.setItem("open-inspect-last-selected-repo", repo.fullName);
+    mocks.reposValue = [];
+    mocks.reposError = new Error("Service unavailable");
+    const view = render(<Home />);
+
+    expect(screen.getByRole("button", { name: /select repo/i })).toBeInTheDocument();
+    expect(localStorage.getItem("open-inspect-last-selected-repo")).toBe(repo.fullName);
+
+    mocks.reposError = undefined;
+    mocks.reposValue = [repo];
+    view.rerender(<Home />);
+    await screen.findByRole("button", { name: /background-agents/i });
   });
 
   it("waits for environments to load before restoring a stored environment", async () => {

--- a/packages/web/src/app/(app)/(sidebar)/page.test.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.test.tsx
@@ -475,47 +475,57 @@ describe("Home", () => {
     expect(body).not.toHaveProperty("branch");
   });
 
-  it("launches an ad-hoc set sending only repositories, seeded from the selected repo", async () => {
-    mocks.reposValue = [
-      repo,
-      {
-        id: 2,
-        fullName: "open-inspect/docs",
-        owner: "open-inspect",
-        name: "docs",
-        description: null,
-        private: false,
-        defaultBranch: "main",
-      },
-    ];
-    const user = userEvent.setup();
-    render(<Home />);
+  it.each(["ready", "unavailable"] as const)(
+    "edits and launches an ad-hoc set with cached repositories (status: %s)",
+    async (status) => {
+      mocks.reposValue = [
+        repo,
+        {
+          id: 2,
+          fullName: "open-inspect/docs",
+          owner: "open-inspect",
+          name: "docs",
+          description: null,
+          private: false,
+          defaultBranch: "main",
+        },
+      ];
+      const user = userEvent.setup();
+      const view = render(<Home />);
 
-    await screen.findByRole("button", { name: /background-agents/i });
-    await user.click(screen.getByRole("button", { name: /background-agents/i }));
-    const listbox = screen.getByRole("listbox");
-    await user.click(within(listbox).getByRole("option", { name: /multiple repositories/i }));
+      await screen.findByRole("button", { name: /background-agents/i });
+      await user.click(screen.getByRole("button", { name: /background-agents/i }));
+      const listbox = screen.getByRole("listbox");
+      await user.click(within(listbox).getByRole("option", { name: /multiple repositories/i }));
 
-    // The multi-select opens seeded with the previously selected repo; add docs.
-    await user.click(screen.getByRole("button", { name: /repository selection/i }));
-    await user.click(screen.getByRole("checkbox", { name: /open-inspect\/docs/i }));
-    await user.click(screen.getByRole("button", { name: /done/i }));
+      mocks.reposStatus = "loading";
+      view.rerender(<Home />);
+      expect(screen.getByRole("button", { name: /repository selection/i })).toBeDisabled();
+      mocks.reposStatus = status;
+      view.rerender(<Home />);
+      expect(screen.getByRole("button", { name: /repository selection/i })).toBeEnabled();
 
-    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Sync the docs");
-    await user.click(screen.getByRole("button", { name: /send/i }));
+      // The multi-select opens seeded with the previously selected repo; add docs.
+      await user.click(screen.getByRole("button", { name: /repository selection/i }));
+      await user.click(screen.getByRole("checkbox", { name: /open-inspect\/docs/i }));
+      await user.click(screen.getByRole("button", { name: /done/i }));
 
-    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
-    const body = sessionCreateBody();
-    expect(body).toMatchObject({
-      repositories: [
-        { repoOwner: "open-inspect", repoName: "background-agents" },
-        { repoOwner: "open-inspect", repoName: "docs" },
-      ],
-    });
-    expect(body).not.toHaveProperty("repoOwner");
-    expect(body).not.toHaveProperty("environmentId");
-    expect(body).not.toHaveProperty("branch");
-  });
+      await user.type(screen.getByPlaceholderText("What do you want to build?"), "Sync the docs");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+      const body = sessionCreateBody();
+      expect(body).toMatchObject({
+        repositories: [
+          { repoOwner: "open-inspect", repoName: "background-agents" },
+          { repoOwner: "open-inspect", repoName: "docs" },
+        ],
+      });
+      expect(body).not.toHaveProperty("repoOwner");
+      expect(body).not.toHaveProperty("environmentId");
+      expect(body).not.toHaveProperty("branch");
+    }
+  );
 
   const environment = {
     id: "env-1",

--- a/packages/web/src/app/(app)/(sidebar)/page.test.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.test.tsx
@@ -13,7 +13,7 @@ import {
 import Home from "./page";
 import { isSessionInboxKey } from "@/lib/session-inbox-api";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
-import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
+import type { PrerequisiteStatus } from "@/lib/prerequisite-status";
 
 expect.extend(matchers);
 
@@ -29,10 +29,8 @@ const mocks = vi.hoisted(() => ({
     private: boolean;
     defaultBranch: string;
   }>,
-  loadingReposValue: false,
-  reposError: undefined as Error | undefined,
-  environmentsError: undefined as Error | undefined,
-  environmentsLoadingValue: false,
+  reposStatus: "ready" as PrerequisiteStatus,
+  environmentsStatus: "ready" as PrerequisiteStatus,
   environmentsValue: [] as Array<{
     id: string;
     name: string;
@@ -66,8 +64,7 @@ const mocks = vi.hoisted(() => ({
     updatedAt: number;
     archivedAt: null;
   }>,
-  providerAccountsLoadingValue: false,
-  providerAccountsError: undefined as Error | undefined,
+  providerAccountsStatus: "ready" as PrerequisiteStatus,
   skillPreview: {
     skills: [
       {
@@ -123,12 +120,7 @@ vi.mock("@/hooks/use-environments", () => ({
   ENVIRONMENTS_KEY: "/api/environments",
   useEnvironments: () => ({
     environments: mocks.environmentsValue,
-    loading: mocks.environmentsLoadingValue,
-    status: getPrerequisiteStatus(
-      mocks.environmentsValue,
-      mocks.environmentsLoadingValue,
-      mocks.environmentsError
-    ),
+    status: mocks.environmentsStatus,
   }),
 }));
 
@@ -147,8 +139,7 @@ vi.mock("@/components/model-reasoning-selector", () => ({
 vi.mock("@/hooks/use-repos", () => ({
   useRepos: () => ({
     repos: mocks.reposValue,
-    loading: mocks.loadingReposValue,
-    status: getPrerequisiteStatus(mocks.reposValue, mocks.loadingReposValue, mocks.reposError),
+    status: mocks.reposStatus,
   }),
 }));
 
@@ -182,13 +173,8 @@ vi.mock("@/hooks/use-provider-accounts", () => ({
     providers: [],
     accounts: mocks.providerAccountsValue,
     defaults: [],
-    loading: mocks.providerAccountsLoadingValue,
-    accountsStatus: getPrerequisiteStatus(
-      mocks.providerAccountsValue,
-      mocks.providerAccountsLoadingValue,
-      mocks.providerAccountsError
-    ),
-    error: mocks.providerAccountsError,
+    loading: mocks.providerAccountsStatus === "loading",
+    accountsStatus: mocks.providerAccountsStatus,
     refresh: vi.fn(),
   }),
 }));
@@ -209,11 +195,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   mocks.reposValue = [repo];
-  mocks.loadingReposValue = false;
-  mocks.reposError = undefined;
-  mocks.environmentsError = undefined;
-  mocks.providerAccountsError = undefined;
-  mocks.environmentsLoadingValue = false;
+  mocks.reposStatus = "ready";
+  mocks.environmentsStatus = "ready";
   mocks.environmentsValue = [];
   mocks.enabledModelsValue = [DEFAULT_MODEL];
   mocks.enabledModelOptionsValue = [
@@ -223,7 +206,7 @@ beforeEach(() => {
     },
   ];
   mocks.providerAccountsValue = [];
-  mocks.providerAccountsLoadingValue = false;
+  mocks.providerAccountsStatus = "ready";
   mocks.keyboardShortcuts = DEFAULT_KEYBOARD_SHORTCUTS;
   mocks.canCreateSession = true;
   mocks.routerPush.mockReset();
@@ -423,6 +406,22 @@ describe("Home", () => {
     });
     expect(sessionCreateBody()).not.toHaveProperty("branch");
   });
+
+  it.each(["loading", "unavailable", "ready"] as const)(
+    "only shows an authoritative repository empty state when ready (status: %s)",
+    (status) => {
+      mocks.reposValue = [];
+      mocks.reposStatus = status;
+      render(<Home />);
+
+      const emptyMessage = screen.queryByText(/No repositories found/);
+      if (status === "ready") {
+        expect(emptyMessage).toBeInTheDocument();
+      } else {
+        expect(emptyMessage).not.toBeInTheDocument();
+      }
+    }
+  );
 
   it("defaults to a no-repository session target when no repositories are available", async () => {
     mocks.reposValue = [];
@@ -646,7 +645,7 @@ describe("Home", () => {
       "open-inspect-last-provider-selections:v1",
       JSON.stringify({ xai: { mode: "provider_account", accountId: staleAccountId } })
     );
-    mocks.providerAccountsLoadingValue = true;
+    mocks.providerAccountsStatus = "loading";
     const user = userEvent.setup();
     const view = render(<Home />);
 
@@ -657,7 +656,7 @@ describe("Home", () => {
     expect(vi.mocked(fetch)).not.toHaveBeenCalledWith("/api/sessions", expect.anything());
     expect(screen.queryByText("Failed to create session")).not.toBeInTheDocument();
 
-    mocks.providerAccountsLoadingValue = false;
+    mocks.providerAccountsStatus = "ready";
     view.rerender(<Home />);
     await user.click(screen.getByRole("button", { name: /send/i }));
 
@@ -672,12 +671,12 @@ describe("Home", () => {
       const selection = { openai: { mode: "provider_account", accountId } };
       const stored = JSON.stringify(selection);
       localStorage.setItem("open-inspect-last-provider-selections:v1", stored);
-      mocks.providerAccountsError = new Error("Service unavailable");
+      mocks.providerAccountsStatus = "unavailable";
       const view = render(<Home />);
 
       expect(localStorage.getItem("open-inspect-last-provider-selections:v1")).toBe(stored);
 
-      mocks.providerAccountsError = undefined;
+      mocks.providerAccountsStatus = "ready";
       mocks.providerAccountsValue = exists ? [activeOpenAiAccount(accountId)] : [];
       view.rerender(<Home />);
       expect(localStorage.getItem("open-inspect-last-provider-selections:v1")).toBe(
@@ -698,7 +697,7 @@ describe("Home", () => {
     "preserves a stored environment during failure and restores after recovery (exists: %s)",
     async (exists) => {
       localStorage.setItem("open-inspect-last-selected-repo", "env:env-1");
-      mocks.environmentsError = new Error("Service unavailable");
+      mocks.environmentsStatus = "unavailable";
       const view = render(<Home />);
 
       expect(screen.getByRole("button", { name: /select repo/i })).toBeInTheDocument();
@@ -709,7 +708,7 @@ describe("Home", () => {
       expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
       expect(fetch).not.toHaveBeenCalled();
 
-      mocks.environmentsError = undefined;
+      mocks.environmentsStatus = "ready";
       mocks.environmentsValue = exists ? [environment] : [];
       view.rerender(<Home />);
       await screen.findByRole("button", { name: exists ? /full-stack/i : /background-agents/i });
@@ -722,13 +721,14 @@ describe("Home", () => {
   it("restores a saved repository after a failed repository request recovers", async () => {
     localStorage.setItem("open-inspect-last-selected-repo", repo.fullName);
     mocks.reposValue = [];
-    mocks.reposError = new Error("Service unavailable");
+    mocks.reposStatus = "unavailable";
     const view = render(<Home />);
 
     expect(screen.getByRole("button", { name: /select repo/i })).toBeInTheDocument();
     expect(localStorage.getItem("open-inspect-last-selected-repo")).toBe(repo.fullName);
+    expect(screen.queryByText(/No repositories found/)).not.toBeInTheDocument();
 
-    mocks.reposError = undefined;
+    mocks.reposStatus = "ready";
     mocks.reposValue = [repo];
     view.rerender(<Home />);
     await screen.findByRole("button", { name: /background-agents/i });
@@ -736,14 +736,14 @@ describe("Home", () => {
 
   it("waits for environments to load before restoring a stored environment", async () => {
     localStorage.setItem("open-inspect-last-selected-repo", "env:env-1");
-    mocks.environmentsLoadingValue = true;
+    mocks.environmentsStatus = "loading";
     const { rerender } = render(<Home />);
 
     // Must not commit the repo default while the stored environment is pending.
     await screen.findByRole("button", { name: /select repo/i });
     expect(screen.queryByRole("button", { name: /background-agents/i })).not.toBeInTheDocument();
 
-    mocks.environmentsLoadingValue = false;
+    mocks.environmentsStatus = "ready";
     mocks.environmentsValue = [environment];
     rerender(<Home />);
     await screen.findByRole("button", { name: /full-stack/i });

--- a/packages/web/src/app/(app)/(sidebar)/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.tsx
@@ -156,14 +156,15 @@ export default function Home() {
     hasHydratedModelPreferencesRef.current = true;
   }, []);
 
-  const availableProviderSelections = providerAccounts.loading
-    ? providerSelections
-    : reconcileProviderSelections(providerSelections, providerAccounts.accounts);
+  const availableProviderSelections =
+    providerAccounts.accountsStatus === "ready"
+      ? reconcileProviderSelections(providerSelections, providerAccounts.accounts)
+      : providerSelections;
 
   useEffect(() => {
     if (
       !providerSelectionsHydrated ||
-      providerAccounts.loading ||
+      providerAccounts.accountsStatus !== "ready" ||
       availableProviderSelections === providerSelections
     ) {
       return;
@@ -176,7 +177,7 @@ export default function Home() {
     );
   }, [
     availableProviderSelections,
-    providerAccounts.loading,
+    providerAccounts.accountsStatus,
     providerSelections,
     providerSelectionsHydrated,
   ]);

--- a/packages/web/src/app/(app)/(sidebar)/page.tsx
+++ b/packages/web/src/app/(app)/(sidebar)/page.tsx
@@ -458,7 +458,7 @@ function HomeContent({
     handleDragOver,
     handleDragLeave,
   } = useAttachmentDropZone({ locked: attachmentsLocked, onAdd: attachments.onAdd });
-  const { sessionTarget, selectedRepo, repos, loadingRepos, isLaunchable } = picker;
+  const { sessionTarget, selectedRepo, repos, reposStatus, isLaunchable } = picker;
   const selectedProvider = getSubscriptionProviderForModel(selectedModel);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -653,7 +653,7 @@ function HomeContent({
                 </div>
               )}
 
-              {repos.length === 0 && !loadingRepos && (
+              {repos.length === 0 && reposStatus === "ready" && (
                 <p className="mt-3 text-sm text-muted-foreground text-center">
                   No repositories found. You can start without a repository or grant repository
                   access in settings.

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -58,7 +58,7 @@ export function SessionTargetPicker({
           loadingRepos={loadingRepos}
           selected={sessionTarget.repoFullNames}
           onChange={onMultiSelectionChange}
-          disabled={disabled || reposStatus !== "ready"}
+          disabled={disabled || loadingRepos}
           triggerLabel={
             sessionTarget.repoFullNames.length === 0
               ? "Choose repositories"

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -22,9 +22,10 @@ export function SessionTargetPicker({
   branches,
   loadingBranches,
   repos,
-  loadingRepos,
+  reposStatus,
   disabled,
 }: SessionTargetPickerProps & { disabled: boolean }) {
+  const loadingRepos = reposStatus === "loading";
   return (
     <>
       {/* Target selector */}
@@ -57,7 +58,7 @@ export function SessionTargetPicker({
           loadingRepos={loadingRepos}
           selected={sessionTarget.repoFullNames}
           onChange={onMultiSelectionChange}
-          disabled={disabled || loadingRepos}
+          disabled={disabled || reposStatus !== "ready"}
           triggerLabel={
             sessionTarget.repoFullNames.length === 0
               ? "Choose repositories"

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -19,17 +19,16 @@ export function useEnvironments(): {
   const { data, isLoading, error } = useSWR<ListEnvironmentsResponse>(
     session ? ENVIRONMENTS_KEY : null
   );
+  const resourceStatus = getPrerequisiteStatus(
+    session ? data : undefined,
+    status === "loading" || isLoading,
+    error
+  );
 
   return {
     environments: data?.environments ?? [],
-    status: getPrerequisiteStatus(
-      session ? data : undefined,
-      status === "loading" || isLoading,
-      error
-    ),
-    // The fetch is gated on the auth session, so the list is still loading
-    // while the session itself resolves — don't report an authoritative [].
-    loading: status === "loading" || isLoading,
+    status: resourceStatus,
+    loading: resourceStatus === "loading",
     error,
   };
 }

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -1,5 +1,5 @@
-import useSWR from "swr";
-import { getPrerequisiteStatus, type PrerequisiteStatus } from "@/lib/prerequisite-status";
+import { usePrerequisiteResource } from "@/hooks/use-prerequisite-resource";
+import type { PrerequisiteStatus } from "@/lib/prerequisite-status";
 import { useAuthSession } from "@/lib/auth-session";
 import type {
   Environment,
@@ -16,14 +16,12 @@ export function useEnvironments(): {
 } {
   const { data: session, status } = useAuthSession();
 
-  const { data, isLoading, error } = useSWR<ListEnvironmentsResponse>(
-    session ? ENVIRONMENTS_KEY : null
-  );
-  const resourceStatus = getPrerequisiteStatus(
-    session ? data : undefined,
-    status === "loading" || isLoading,
-    error
-  );
+  const {
+    data,
+    status: requestStatus,
+    error,
+  } = usePrerequisiteResource<ListEnvironmentsResponse>(session ? ENVIRONMENTS_KEY : null);
+  const resourceStatus = status === "loading" ? "loading" : requestStatus;
 
   return {
     environments: data?.environments ?? [],

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -1,4 +1,5 @@
 import useSWR from "swr";
+import { getPrerequisiteStatus, type PrerequisiteStatus } from "@/lib/prerequisite-status";
 import { useAuthSession } from "@/lib/auth-session";
 import type {
   Environment,
@@ -10,6 +11,7 @@ export const ENVIRONMENTS_KEY = "/api/environments";
 export function useEnvironments(): {
   environments: Environment[];
   loading: boolean;
+  status: PrerequisiteStatus;
   error: unknown;
 } {
   const { data: session, status } = useAuthSession();
@@ -20,6 +22,11 @@ export function useEnvironments(): {
 
   return {
     environments: data?.environments ?? [],
+    status: getPrerequisiteStatus(
+      session ? data : undefined,
+      status === "loading" || isLoading,
+      error
+    ),
     // The fetch is gated on the auth session, so the list is still loading
     // while the session itself resolves — don't report an authoritative [].
     loading: status === "loading" || isLoading,

--- a/packages/web/src/hooks/use-prerequisite-hooks.test.tsx
+++ b/packages/web/src/hooks/use-prerequisite-hooks.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { SWRConfig, useSWRConfig } from "swr";
+import { SWRConfig, useSWRConfig, type Cache } from "swr";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Environment } from "@open-inspect/shared/types/environments";
 import { useEnvironments } from "./use-environments";
@@ -44,12 +44,13 @@ describe.each([
   const emptyResponse = field === "repos" ? { repos: [] } : { environments: [], total: 0 };
   const populatedResponse = { [field]: items, ...(field === "environments" ? { total: 1 } : {}) };
   let fetcher: ReturnType<typeof vi.fn<(key: string) => Promise<unknown>>>;
+  let cache: Cache;
 
   function wrapper({ children }: { children: ReactNode }) {
     return (
       <SWRConfig
         value={{
-          provider: () => new Map(),
+          provider: () => cache,
           fetcher,
           dedupingInterval: 0,
           shouldRetryOnError: false,
@@ -65,6 +66,7 @@ describe.each([
   beforeEach(() => {
     mocks.useAuthSession.mockReturnValue({ data: { user: {} }, status: "authenticated" });
     fetcher = vi.fn().mockResolvedValue(emptyResponse);
+    cache = new Map();
   });
   afterEach(cleanup);
 
@@ -147,6 +149,48 @@ describe.each([
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it("does not authorize cached data on remount until revalidation succeeds", async () => {
+    const first = renderHook(() => useHook(), { wrapper });
+    await waitFor(() => expect(first.result.current.status).toBe("ready"));
+    first.unmount();
+
+    let reject!: (error: Error) => void;
+    fetcher.mockReturnValueOnce(
+      new Promise((_, fail) => {
+        reject = fail;
+      })
+    );
+    const statuses: string[] = [];
+    const { result } = renderHook(
+      () => {
+        const value = useHook();
+        statuses.push(value.status);
+        return { value, mutate: useSWRConfig().mutate };
+      },
+      { wrapper }
+    );
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(result.current.value.status).toBe("loading");
+    expect(statuses).not.toContain("ready");
+
+    const error = new Error("Remount revalidation failed");
+    await act(async () => reject(error));
+    await waitFor(() => expect(result.current.value.status).toBe("unavailable"));
+    expect(statuses).not.toContain("ready");
+
+    fetcher.mockResolvedValueOnce(populatedResponse);
+    await act(async () => {
+      await result.current.mutate(key);
+    });
+    expect(result.current.value).toEqual({
+      [field]: items,
+      status: "ready",
+      loading: false,
+      error: undefined,
+    });
+  });
+
   it("retains cached data but becomes unavailable when revalidation fails", async () => {
     fetcher.mockResolvedValueOnce(populatedResponse);
     const { result } = renderHook(() => ({ value: useHook(), mutate: useSWRConfig().mutate }), {
@@ -162,9 +206,20 @@ describe.each([
     );
 
     const error = new Error("Revalidation failed");
-    fetcher.mockRejectedValueOnce(error);
+    let reject!: (error: Error) => void;
+    fetcher.mockReturnValueOnce(
+      new Promise((_, fail) => {
+        reject = fail;
+      })
+    );
+    let refresh!: Promise<unknown>;
+    act(() => {
+      refresh = result.current.mutate(key);
+    });
+    expect(result.current.value.status).toBe("loading");
     await act(async () => {
-      await result.current.mutate(key);
+      reject(error);
+      await refresh;
     });
     await waitFor(() =>
       expect(result.current.value).toEqual({

--- a/packages/web/src/hooks/use-prerequisite-hooks.test.tsx
+++ b/packages/web/src/hooks/use-prerequisite-hooks.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig, useSWRConfig } from "swr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import { useEnvironments } from "./use-environments";
+import { useRepos, type Repo } from "./use-repos";
+
+const mocks = vi.hoisted(() => ({ useAuthSession: vi.fn() }));
+
+vi.mock("@/lib/auth-session", () => ({ useAuthSession: mocks.useAuthSession }));
+
+const repo: Repo = {
+  id: 1,
+  fullName: "owner/repo",
+  owner: "owner",
+  name: "repo",
+  description: null,
+  private: false,
+  defaultBranch: "main",
+};
+const environment: Environment = {
+  id: "env_test",
+  name: "Test",
+  description: null,
+  prebuildEnabled: false,
+  createdAt: 0,
+  updatedAt: 0,
+  repositories: [{ repoOwner: "owner", repoName: "repo", repoId: 1, baseBranch: "main" }],
+};
+
+describe.each([
+  { name: "useRepos", useHook: useRepos, key: "/api/repos", field: "repos", items: [repo] },
+  {
+    name: "useEnvironments",
+    useHook: useEnvironments,
+    key: "/api/environments",
+    field: "environments",
+    items: [environment],
+  },
+])("$name SWR wiring", ({ useHook, key, field, items }) => {
+  const emptyResponse = field === "repos" ? { repos: [] } : { environments: [], total: 0 };
+  const populatedResponse = { [field]: items, ...(field === "environments" ? { total: 1 } : {}) };
+  let fetcher: ReturnType<typeof vi.fn<(key: string) => Promise<unknown>>>;
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fetcher,
+          dedupingInterval: 0,
+          shouldRetryOnError: false,
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        {children}
+      </SWRConfig>
+    );
+  }
+
+  beforeEach(() => {
+    mocks.useAuthSession.mockReturnValue({ data: { user: {} }, status: "authenticated" });
+    fetcher = vi.fn().mockResolvedValue(emptyResponse);
+  });
+  afterEach(cleanup);
+
+  it("waits for auth, then reports fetch loading before accepting an empty response", async () => {
+    mocks.useAuthSession.mockReturnValue({ data: null, status: "loading" });
+    let resolve!: (value: typeof emptyResponse) => void;
+    fetcher.mockReturnValue(new Promise<typeof emptyResponse>((done) => (resolve = done)));
+    const { result, rerender } = renderHook(() => useHook(), { wrapper });
+
+    expect(result.current).toEqual({
+      [field]: [],
+      status: "loading",
+      loading: true,
+      error: undefined,
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+
+    mocks.useAuthSession.mockReturnValue({ data: { user: {} }, status: "authenticated" });
+    rerender();
+    expect(fetcher).toHaveBeenCalledExactlyOnceWith(key);
+    expect(result.current).toEqual({
+      [field]: [],
+      status: "loading",
+      loading: true,
+      error: undefined,
+    });
+
+    await act(async () => resolve(emptyResponse));
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        [field]: [],
+        status: "ready",
+        loading: false,
+        error: undefined,
+      })
+    );
+  });
+
+  it("does not fetch without an authenticated session", () => {
+    mocks.useAuthSession.mockReturnValue({ data: null, status: "unauthenticated" });
+    const { result } = renderHook(() => useHook(), { wrapper });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current).toEqual({
+      [field]: [],
+      status: "unavailable",
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it("reports an initial failure and recovers after successful revalidation", async () => {
+    const error = new Error("Initial request failed");
+    fetcher.mockRejectedValueOnce(error);
+    const { result } = renderHook(() => ({ value: useHook(), mutate: useSWRConfig().mutate }), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(result.current.value).toEqual({
+        [field]: [],
+        status: "unavailable",
+        loading: false,
+        error,
+      })
+    );
+    expect(fetcher).toHaveBeenCalledExactlyOnceWith(key);
+
+    await act(async () => {
+      await result.current.mutate(key);
+    });
+    await waitFor(() =>
+      expect(result.current.value).toEqual({
+        [field]: [],
+        status: "ready",
+        loading: false,
+        error: undefined,
+      })
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains cached data but becomes unavailable when revalidation fails", async () => {
+    fetcher.mockResolvedValueOnce(populatedResponse);
+    const { result } = renderHook(() => ({ value: useHook(), mutate: useSWRConfig().mutate }), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(result.current.value).toEqual({
+        [field]: items,
+        status: "ready",
+        loading: false,
+        error: undefined,
+      })
+    );
+
+    const error = new Error("Revalidation failed");
+    fetcher.mockRejectedValueOnce(error);
+    await act(async () => {
+      await result.current.mutate(key);
+    });
+    await waitFor(() =>
+      expect(result.current.value).toEqual({
+        [field]: items,
+        status: "unavailable",
+        loading: false,
+        error,
+      })
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/hooks/use-prerequisite-resource.ts
+++ b/packages/web/src/hooks/use-prerequisite-resource.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import useSWR, { type BareFetcher } from "swr";
+import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
+
+/** Own the mount refresh so cached data cannot become authoritative before it starts. */
+export function usePrerequisiteResource<T>(key: string | null, fetcher?: BareFetcher<T>) {
+  const resource = useSWR<T>(key, { ...(fetcher ? { fetcher } : {}), revalidateOnMount: false });
+  const { mutate } = resource;
+  const [validatedKey, setValidatedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setValidatedKey(null);
+    if (key) {
+      void mutate()
+        .catch(() => undefined)
+        .then(() => {
+          if (active) setValidatedKey(key);
+        });
+    }
+    return () => {
+      active = false;
+    };
+  }, [key, mutate]);
+
+  return {
+    ...resource,
+    status: getPrerequisiteStatus(
+      key ? resource.data : undefined,
+      !!key && (validatedKey !== key || resource.isLoading || resource.isValidating),
+      resource.error
+    ),
+  };
+}

--- a/packages/web/src/hooks/use-provider-accounts.test.tsx
+++ b/packages/web/src/hooks/use-provider-accounts.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
@@ -109,7 +109,12 @@ describe("useProviderAccounts", () => {
     );
 
     expect(browserApiFetch).not.toHaveBeenCalled();
-    expect(result.current.accounts).toMatchObject({ accounts: [], defaults: [], loading: false });
+    expect(result.current.accounts).toMatchObject({
+      accounts: [],
+      defaults: [],
+      loading: false,
+      accountsStatus: "unavailable",
+    });
     expect(result.current.legacy).toMatchObject({ legacyKeys: [], loading: false });
   });
 
@@ -136,12 +141,52 @@ describe("useProviderAccounts", () => {
     const { result } = renderHook(() => useProviderAccounts(), { wrapper });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.accountsStatus).toBe("ready");
     expect(result.current.providers).toEqual([
       { provider: "openai", displayName: "OpenAI", subscriptionName: "ChatGPT" },
       { provider: "xai", displayName: "xAI", subscriptionName: "SuperGrok" },
     ]);
     expect(browserApiFetch).toHaveBeenCalledTimes(2);
     expect(browserApiFetch).not.toHaveBeenCalledWith("/api/model-subscription-providers");
+  });
+
+  it("marks failed account loads unavailable and becomes ready after recovery", async () => {
+    let failed = true;
+    vi.mocked(browserApiFetch).mockImplementation(async (path) => {
+      if (path === "/api/model-provider-account-defaults") return Response.json({ defaults: [] });
+      return failed
+        ? Response.json({ error: "Service unavailable" }, { status: 503 })
+        : Response.json({ accounts: [account] });
+    });
+    const { result } = renderHook(() => useProviderAccounts(), { wrapper });
+    expect(result.current.accountsStatus).toBe("loading");
+    await waitFor(() => expect(result.current.accountsStatus).toBe("unavailable"));
+    expect(result.current.accounts).toEqual([]);
+
+    failed = false;
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.accountsStatus).toBe("ready");
+    expect(result.current.accounts).toEqual([account]);
+
+    failed = true;
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.accountsStatus).toBe("unavailable");
+    expect(result.current.accounts).toEqual([account]);
+  });
+
+  it("keeps successful accounts authoritative when only defaults fail", async () => {
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      path === "/api/model-provider-account-defaults"
+        ? Response.json({ error: "Service unavailable" }, { status: 503 })
+        : Response.json({ accounts: [] })
+    );
+    const { result } = renderHook(() => useProviderAccounts(), { wrapper });
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.accountsStatus).toBe("ready");
   });
 });
 

--- a/packages/web/src/hooks/use-provider-accounts.test.tsx
+++ b/packages/web/src/hooks/use-provider-accounts.test.tsx
@@ -119,9 +119,11 @@ describe("useProviderAccounts", () => {
   });
 
   it("clears provider resources when read permission is revoked", async () => {
-    vi.mocked(browserApiFetch)
-      .mockResolvedValueOnce(Response.json({ accounts: [account] }))
-      .mockResolvedValueOnce(Response.json({ defaults: [] }));
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      Response.json(
+        path === "/api/model-provider-account-defaults" ? { defaults: [] } : { accounts: [account] }
+      )
+    );
 
     const { result, rerender } = renderHook(() => useProviderAccounts(), { wrapper });
     await waitFor(() => expect(result.current.accounts).toEqual([account]));
@@ -134,9 +136,11 @@ describe("useProviderAccounts", () => {
   });
 
   it("uses the shared static provider catalog without fetching it", async () => {
-    vi.mocked(browserApiFetch)
-      .mockResolvedValueOnce(Response.json({ accounts: [] }))
-      .mockResolvedValueOnce(Response.json({ defaults: [] }));
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      Response.json(
+        path === "/api/model-provider-account-defaults" ? { defaults: [] } : { accounts: [] }
+      )
+    );
 
     const { result } = renderHook(() => useProviderAccounts(), { wrapper });
 
@@ -186,6 +190,68 @@ describe("useProviderAccounts", () => {
     );
     const { result } = renderHook(() => useProviderAccounts(), { wrapper });
     await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.accountsStatus).toBe("ready");
+  });
+
+  it("does not authorize cached accounts on remount until revalidation succeeds", async () => {
+    const cache = new Map();
+    const cachedWrapper = ({ children }: { children: ReactNode }) => (
+      <SWRConfig value={{ provider: () => cache, dedupingInterval: 0, shouldRetryOnError: false }}>
+        {children}
+      </SWRConfig>
+    );
+    let accountResponse = Promise.resolve(Response.json({ accounts: [] }));
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      path === "/api/model-provider-account-defaults"
+        ? Response.json({ defaults: [] })
+        : accountResponse
+    );
+    const first = renderHook(() => useProviderAccounts(), { wrapper: cachedWrapper });
+    await waitFor(() => expect(first.result.current.accountsStatus).toBe("ready"));
+    first.unmount();
+
+    let resolve!: (response: Response) => void;
+    accountResponse = new Promise((done) => {
+      resolve = done;
+    });
+    const statuses: string[] = [];
+    const { result } = renderHook(
+      () => {
+        const value = useProviderAccounts();
+        statuses.push(value.accountsStatus);
+        return value;
+      },
+      { wrapper: cachedWrapper }
+    );
+    await waitFor(() => expect(browserApiFetch).toHaveBeenCalledTimes(4));
+    expect(result.current.accountsStatus).toBe("loading");
+    expect(statuses).not.toContain("ready");
+
+    await act(async () =>
+      resolve(Response.json({ error: "Service unavailable" }, { status: 503 }))
+    );
+    await waitFor(() => expect(result.current.accountsStatus).toBe("unavailable"));
+    expect(statuses).not.toContain("ready");
+
+    accountResponse = Promise.resolve(Response.json({ accounts: [account] }));
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.accountsStatus).toBe("ready");
+    expect(result.current.accounts).toEqual([account]);
+
+    accountResponse = new Promise((done) => {
+      resolve = done;
+    });
+    let refresh!: ReturnType<typeof result.current.refresh>;
+    act(() => {
+      refresh = result.current.refresh();
+    });
+    expect(result.current.accountsStatus).toBe("loading");
+    await act(async () => {
+      resolve(Response.json({ accounts: [account] }));
+      await refresh;
+    });
     expect(result.current.accountsStatus).toBe("ready");
   });
 });
@@ -246,9 +312,11 @@ describe("provider account API response boundaries", () => {
   });
 
   it("uses the same status policy for query resources", async () => {
-    vi.mocked(browserApiFetch)
-      .mockResolvedValueOnce(Response.json({ error: "Accounts unavailable" }, { status: 503 }))
-      .mockResolvedValueOnce(Response.json({ defaults: [] }));
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      path === "/api/model-provider-account-defaults"
+        ? Response.json({ defaults: [] })
+        : Response.json({ error: "Accounts unavailable" }, { status: 503 })
+    );
 
     const { result } = renderHook(() => useProviderAccounts(), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -260,11 +328,11 @@ describe("provider account API response boundaries", () => {
   });
 
   it("falls back when the error response body is malformed", async () => {
-    vi.mocked(browserApiFetch)
-      .mockResolvedValueOnce(
-        Response.json({ error: "Untrusted error", retryable: "no" }, { status: 502 })
-      )
-      .mockResolvedValueOnce(Response.json({ defaults: [] }));
+    vi.mocked(browserApiFetch).mockImplementation(async (path) =>
+      path === "/api/model-provider-account-defaults"
+        ? Response.json({ defaults: [] })
+        : Response.json({ error: "Untrusted error", retryable: "no" }, { status: 502 })
+    );
 
     const { result } = renderHook(() => useProviderAccounts(), { wrapper });
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/packages/web/src/hooks/use-provider-accounts.ts
+++ b/packages/web/src/hooks/use-provider-accounts.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
+import { usePrerequisiteResource } from "@/hooks/use-prerequisite-resource";
 import { z, type ZodType } from "zod";
 import { useCurrentUserAuthorization } from "@/hooks/use-current-user-authorization";
 import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
@@ -92,7 +92,7 @@ async function requestProviderResourceWithoutContent(
 export function useProviderAccounts() {
   const { hasPermission } = useCurrentUserAuthorization();
   const canRead = hasPermission("provider_accounts.read");
-  const accounts = useSWR(canRead ? ACCOUNTS_KEY : null, async (path) => {
+  const accounts = usePrerequisiteResource(canRead ? ACCOUNTS_KEY : null, async (path) => {
     return (await requestProviderResource(path, modelProviderAccountsResponseSchema)).accounts;
   });
   const defaults = useSWR(canRead ? DEFAULTS_KEY : null, async (path) => {
@@ -107,12 +107,8 @@ export function useProviderAccounts() {
     })),
     accounts: (accounts.data ?? []) as ModelProviderAccount[],
     defaults: (defaults.data ?? []) as ModelProviderAccountDefault[],
-    loading: accounts.isLoading || defaults.isLoading,
-    accountsStatus: getPrerequisiteStatus(
-      canRead ? accounts.data : undefined,
-      accounts.isLoading,
-      accounts.error
-    ),
+    loading: accounts.status === "loading" || defaults.isLoading,
+    accountsStatus: accounts.status,
     error: accounts.error ?? defaults.error,
     refresh: async () => Promise.all([accounts.mutate(), defaults.mutate()]),
   };

--- a/packages/web/src/hooks/use-provider-accounts.ts
+++ b/packages/web/src/hooks/use-provider-accounts.ts
@@ -1,4 +1,5 @@
 import useSWR from "swr";
+import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
 import { z, type ZodType } from "zod";
 import { useCurrentUserAuthorization } from "@/hooks/use-current-user-authorization";
 import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
@@ -107,6 +108,11 @@ export function useProviderAccounts() {
     accounts: (accounts.data ?? []) as ModelProviderAccount[],
     defaults: (defaults.data ?? []) as ModelProviderAccountDefault[],
     loading: accounts.isLoading || defaults.isLoading,
+    accountsStatus: getPrerequisiteStatus(
+      canRead ? accounts.data : undefined,
+      accounts.isLoading,
+      accounts.error
+    ),
     error: accounts.error ?? defaults.error,
     refresh: async () => Promise.all([accounts.mutate(), defaults.mutate()]),
   };

--- a/packages/web/src/hooks/use-repos.test.tsx
+++ b/packages/web/src/hooks/use-repos.test.tsx
@@ -1,31 +1,49 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useRepos } from "./use-repos";
 
-const mocks = vi.hoisted(() => ({ useSWR: vi.fn() }));
-
-vi.mock("swr", () => ({ default: mocks.useSWR }));
 vi.mock("@/lib/auth-session", () => ({
   useAuthSession: () => ({ data: { user: {} }, status: "authenticated" }),
 }));
 
 describe("useRepos", () => {
-  beforeEach(() => {
-    mocks.useSWR.mockReset();
-    mocks.useSWR.mockReturnValue({ data: undefined, isLoading: false, error: undefined });
-  });
+  afterEach(cleanup);
 
-  it("does not request repositories when the caller is unauthorized", () => {
-    renderHook(() => useRepos(false));
+  it("only requests repositories after the caller is authorized", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ repos: [] });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fetcher,
+          dedupingInterval: 0,
+          shouldRetryOnError: false,
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        {children}
+      </SWRConfig>
+    );
+    const { result, rerender } = renderHook(({ enabled }) => useRepos(enabled), {
+      initialProps: { enabled: false },
+      wrapper,
+    });
 
-    expect(mocks.useSWR).toHaveBeenCalledWith(null);
-  });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current).toEqual({
+      repos: [],
+      status: "unavailable",
+      loading: false,
+      error: undefined,
+    });
 
-  it("requests repositories when enabled", () => {
-    renderHook(() => useRepos());
-
-    expect(mocks.useSWR).toHaveBeenCalledWith("/api/repos");
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(fetcher).toHaveBeenCalledExactlyOnceWith("/api/repos");
   });
 });

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -25,17 +25,16 @@ export function useRepos(enabled = true) {
   const { data, isLoading, error } = useSWR<ReposResponse>(
     enabled && session ? "/api/repos" : null
   );
+  const resourceStatus = getPrerequisiteStatus(
+    enabled && session ? data : undefined,
+    enabled && (status === "loading" || isLoading),
+    error
+  );
 
   return {
     repos: data?.repos ?? [],
-    status: getPrerequisiteStatus(
-      enabled && session ? data : undefined,
-      enabled && (status === "loading" || isLoading),
-      error
-    ),
-    // The fetch is gated on the auth session, so the list is still loading
-    // while the session itself resolves — don't report an authoritative [].
-    loading: enabled && (status === "loading" || isLoading),
+    status: resourceStatus,
+    loading: resourceStatus === "loading",
     error,
   };
 }

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -1,5 +1,4 @@
-import useSWR from "swr";
-import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
+import { usePrerequisiteResource } from "@/hooks/use-prerequisite-resource";
 import { useAuthSession } from "@/lib/auth-session";
 
 export interface Repo {
@@ -22,14 +21,12 @@ interface ReposResponse {
 export function useRepos(enabled = true) {
   const { data: session, status } = useAuthSession();
 
-  const { data, isLoading, error } = useSWR<ReposResponse>(
-    enabled && session ? "/api/repos" : null
-  );
-  const resourceStatus = getPrerequisiteStatus(
-    enabled && session ? data : undefined,
-    enabled && (status === "loading" || isLoading),
-    error
-  );
+  const {
+    data,
+    status: requestStatus,
+    error,
+  } = usePrerequisiteResource<ReposResponse>(enabled && session ? "/api/repos" : null);
+  const resourceStatus = enabled && status === "loading" ? "loading" : requestStatus;
 
   return {
     repos: data?.repos ?? [],

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -1,4 +1,5 @@
 import useSWR from "swr";
+import { getPrerequisiteStatus } from "@/lib/prerequisite-status";
 import { useAuthSession } from "@/lib/auth-session";
 
 export interface Repo {
@@ -27,6 +28,11 @@ export function useRepos(enabled = true) {
 
   return {
     repos: data?.repos ?? [],
+    status: getPrerequisiteStatus(
+      enabled && session ? data : undefined,
+      enabled && (status === "loading" || isLoading),
+      error
+    ),
     // The fetch is gated on the auth session, so the list is still loading
     // while the session itself resolves — don't report an authoritative [].
     loading: enabled && (status === "loading" || isLoading),

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -134,8 +134,8 @@ export interface SessionTargetSelection {
  * via `pickerProps`; the page keeps model, prompt, and warming.
  */
 export function useSessionTargetPicker(): SessionTargetSelection {
-  const { repos, loading: loadingRepos } = useRepos();
-  const { environments, loading: loadingEnvironments } = useEnvironments();
+  const { repos, loading: loadingRepos, status: reposStatus } = useRepos();
+  const { environments, status: environmentsStatus } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string>("");
 
@@ -165,7 +165,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
   // Restore the last-selected target once data loads. This effect commits a
   // target exactly once (the guard blocks any later correction), so a stored
   // environment must not fall through to the repo default while environments
-  // are still loading — wait for the fetch to settle before deciding.
+  // are loading or unavailable — wait for a successful response before deciding.
   useEffect(() => {
     if (sessionTarget) return;
 
@@ -173,13 +173,15 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     const storedTarget = storedValue ? parseTargetSelectValue(storedValue, null) : null;
 
     if (storedTarget?.kind === "environment") {
-      if (loadingEnvironments) return;
+      if (environmentsStatus !== "ready") return;
       if (environments.some((environment) => environment.id === storedTarget.environmentId)) {
         setSessionTarget(storedTarget);
         return;
       }
       // The stored environment was deleted — fall through to the repo default.
     }
+
+    if (reposStatus !== "ready") return;
 
     if (repos.length > 0) {
       // A stored `env:<id>` value never matches a fullName, so a deleted
@@ -192,10 +194,8 @@ export function useSessionTargetPicker(): SessionTargetSelection {
       return;
     }
 
-    if (!loadingRepos) {
-      setSessionTarget({ kind: "none" });
-    }
-  }, [loadingRepos, repos, loadingEnvironments, environments, sessionTarget]);
+    setSessionTarget({ kind: "none" });
+  }, [reposStatus, repos, environmentsStatus, environments, sessionTarget]);
 
   // Persist launchable, restorable selections: repos and environments. Ad-hoc
   // lists and "no repository" keep whatever was stored before them.

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -15,6 +15,7 @@ import {
   repoImageBuildScopeId,
 } from "@/lib/image-builds";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
+import type { PrerequisiteStatus } from "@/lib/prerequisite-status";
 import { useImageBuilds } from "@/hooks/use-image-builds";
 import {
   type SessionTarget,
@@ -107,7 +108,7 @@ export interface SessionTargetPickerProps {
   branches: { name: string }[];
   loadingBranches: boolean;
   repos: Repo[];
-  loadingRepos: boolean;
+  reposStatus: PrerequisiteStatus;
 }
 
 /** Launch-facing selection state for the page: warming identity and request construction. */
@@ -115,7 +116,7 @@ export interface SessionTargetSelection {
   sessionTarget: SessionTarget | null;
   selectedBranch: string;
   repos: Repo[];
-  loadingRepos: boolean;
+  reposStatus: PrerequisiteStatus;
   /** The selected repository's metadata when the target is a single repo. */
   selectedRepo: Repo | undefined;
   isLaunchable: boolean;
@@ -134,7 +135,7 @@ export interface SessionTargetSelection {
  * via `pickerProps`; the page keeps model, prompt, and warming.
  */
 export function useSessionTargetPicker(): SessionTargetSelection {
-  const { repos, loading: loadingRepos, status: reposStatus } = useRepos();
+  const { repos, status: reposStatus } = useRepos();
   const { environments, status: environmentsStatus } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string>("");
@@ -290,7 +291,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     sessionTarget,
     selectedBranch,
     repos,
-    loadingRepos,
+    reposStatus,
     selectedRepo,
     isLaunchable: isSessionTargetLaunchable(sessionTarget),
     configKey: getTargetConfigKey(sessionTarget),
@@ -307,7 +308,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
       branches,
       loadingBranches,
       repos,
-      loadingRepos,
+      reposStatus,
     },
   };
 }

--- a/packages/web/src/lib/prerequisite-status.test.ts
+++ b/packages/web/src/lib/prerequisite-status.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { getPrerequisiteStatus } from "./prerequisite-status";
+
+describe("getPrerequisiteStatus", () => {
+  it("distinguishes pending, unavailable, and successful empty responses", () => {
+    expect(getPrerequisiteStatus(undefined, true, undefined)).toBe("loading");
+    expect(getPrerequisiteStatus(undefined, false, undefined)).toBe("unavailable");
+    expect(getPrerequisiteStatus([], false, undefined)).toBe("ready");
+  });
+
+  it("does not treat errors or failed revalidation as authoritative data", () => {
+    const error = new Error("Service unavailable");
+    expect(getPrerequisiteStatus(undefined, false, error)).toBe("unavailable");
+    expect(getPrerequisiteStatus([], false, error)).toBe("unavailable");
+    expect(getPrerequisiteStatus([], true, error)).toBe("unavailable");
+  });
+});

--- a/packages/web/src/lib/prerequisite-status.ts
+++ b/packages/web/src/lib/prerequisite-status.ts
@@ -1,0 +1,12 @@
+export type PrerequisiteStatus = "loading" | "ready" | "unavailable";
+
+/** Failed revalidation is not authoritative, even when cached data is available. */
+export function getPrerequisiteStatus(
+  data: unknown,
+  loading: boolean,
+  error: unknown
+): PrerequisiteStatus {
+  if (error) return "unavailable";
+  if (loading) return "loading";
+  return data === undefined ? "unavailable" : "ready";
+}


### PR DESCRIPTION
## Summary
- Add explicit loading, ready, and unavailable prerequisite states for provider accounts, repositories, and environments.
- Reconcile saved provider selections only against successful account responses, independently of the defaults request. Errors, failed revalidation, and unavailable requests no longer erase saved account choices.
- Wait for successful environment/repository data before automatically restoring or falling back from a saved target. Successful empty responses retain the existing stale-selection fallback behavior.
- Keep existing launch policy and manual selection behavior unchanged.

## Tests
- Add page regressions covering provider and environment failures, recovery with existing selections, recovery with genuinely empty responses, and repository-load recovery.
- Add real SWR coverage for account failure/recovery, failed revalidation with cached data, and defaults-only failure.
- Add prerequisite-state unit coverage.
- `npm test -w @open-inspect/web -- --maxWorkers=4`: 191 files, 1,480 tests passed.
- `npm run typecheck -w @open-inspect/web`: passed.
- ESLint and Prettier on changed files: passed.

The initial unrestricted full-suite run hit two 5-second timeouts in unrelated authentication-boundary ESLint tests. The complete suite passed with four workers.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e94848fff46ff7f78cf9c56a0de6b149)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of loading, unavailable, recovery, and empty-data states for repositories, environments, and provider accounts.
  * Preserved valid provider, environment, and repository selections during temporary request failures.
  * Restored selections after requests recover and prevented fallback choices before data is ready.
  * Disabled repository editing until repository data is available.

* **Tests**
  * Added coverage for authentication-gated requests, failed revalidation, recovery, cached data, and provider-account loading outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->