### PR TITLE
fix(web): automatically save model settings toggles

### DIFF
--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -30,7 +30,8 @@ const { useSWRMock, mutateMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
 }));
 
-vi.mock("swr", () => ({
+vi.mock(import("swr"), async (importOriginal) => ({
+  ...(await importOriginal()),
   default: useSWRMock,
   mutate: mutateMock,
 }));

--- a/packages/web/src/components/settings/models-settings.test.tsx
+++ b/packages/web/src/components/settings/models-settings.test.tsx
@@ -2,6 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState, type ReactNode } from "react";
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
@@ -26,7 +27,22 @@ function CachedModels() {
   return <span data-testid="cached-models">{JSON.stringify(enabledModels)}</span>;
 }
 
-function renderSettings(enabledModels = ["openai/gpt-5.4"]) {
+function NavigableSettings() {
+  const [showModels, setShowModels] = useState(true);
+  return (
+    <>
+      <button onClick={() => setShowModels(!showModels)}>
+        {showModels ? "Other settings" : "Models"}
+      </button>
+      {showModels && <ModelsSettings />}
+    </>
+  );
+}
+
+function renderSettings(
+  enabledModels = ["openai/gpt-5.4"],
+  children: ReactNode = <ModelsSettings />
+) {
   return render(
     <SWRConfig
       value={{
@@ -39,7 +55,7 @@ function renderSettings(enabledModels = ["openai/gpt-5.4"]) {
         revalidateIfStale: false,
       }}
     >
-      <ModelsSettings />
+      {children}
       <CachedModels />
     </SWRConfig>
   );
@@ -156,6 +172,53 @@ describe("ModelsSettings", () => {
       await waitFor(() => expect(toggle).toBeEnabled());
       expect(toggle).toBeChecked();
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it.each([true, false])(
+    "preserves the pending selection and lock across navigation (success: %s)",
+    async (ok) => {
+      let resolve!: (response: { ok: boolean; json: () => Promise<{ error: string }> }) => void;
+      const fetchMock = vi
+        .fn()
+        .mockReturnValueOnce(
+          new Promise((done) => {
+            resolve = done;
+          })
+        )
+        .mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+      const user = userEvent.setup();
+      renderSettings(undefined, <NavigableSettings />);
+
+      await user.click(screen.getByRole("switch", { name: /Claude Haiku 4.5/ }));
+      await user.click(screen.getByRole("button", { name: "Other settings" }));
+      expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Models" }));
+
+      expect(screen.getByRole("switch", { name: /Claude Haiku 4.5/ })).toBeChecked();
+      expect(screen.getByRole("status")).toHaveTextContent("Saving...");
+      for (const control of screen.getAllByRole("switch")) {
+        expect(control).toBeDisabled();
+      }
+      await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => resolve({ ok, json: async () => ({ error: "Save denied" }) }));
+      expect(screen.getByRole("status")).toBeEmptyDOMElement();
+      const haiku = screen.getByRole("switch", { name: /Claude Haiku 4.5/ });
+      expect(haiku).toBeEnabled();
+      expect(haiku).toHaveAttribute("aria-checked", String(ok));
+
+      await user.click(screen.getByRole("switch", { name: /Claude Sonnet 4.6/ }));
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
+        enabledModels: [
+          "openai/gpt-5.4",
+          ...(ok ? ["anthropic/claude-haiku-4-5"] : []),
+          "anthropic/claude-sonnet-4-6",
+        ],
+      });
     }
   );
 });

--- a/packages/web/src/components/settings/models-settings.test.tsx
+++ b/packages/web/src/components/settings/models-settings.test.tsx
@@ -2,11 +2,13 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig } from "swr";
-import { MODEL_PREFERENCES_KEY } from "@/hooks/use-enabled-models";
+import { toast } from "sonner";
+import { MODEL_OPTIONS } from "@open-inspect/shared/models";
+import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
 import { ModelsSettings } from "./models-settings";
 
 expect.extend(matchers);
@@ -16,35 +18,144 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
+function CachedModels() {
+  const { enabledModels } = useEnabledModels();
+  return <span data-testid="cached-models">{JSON.stringify(enabledModels)}</span>;
+}
+
+function renderSettings(enabledModels = ["openai/gpt-5.4"]) {
+  return render(
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        fallback: {
+          [MODEL_PREFERENCES_KEY]: {
+            enabledModels,
+          },
+        },
+        revalidateIfStale: false,
+      }}
+    >
+      <ModelsSettings />
+      <CachedModels />
+    </SWRConfig>
+  );
+}
+
 describe("ModelsSettings", () => {
-  it("does not count or submit removed models from stored preferences", async () => {
+  it("automatically saves toggles and updates other model selectors", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal("fetch", fetchMock);
     const user = userEvent.setup();
-    render(
-      <SWRConfig
-        value={{
-          provider: () => new Map(),
-          fallback: {
-            [MODEL_PREFERENCES_KEY]: {
-              enabledModels: ["openai/gpt-5.2", "openai/gpt-5.4"],
-            },
-          },
-          revalidateIfStale: false,
-        }}
-      >
-        <ModelsSettings />
-      </SWRConfig>
+    renderSettings(["openai/gpt-5.2", "openai/gpt-5.4"]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("switch", { name: /Claude Haiku 4.5/ }));
+    await waitFor(() => expect(screen.getByRole("status")).toBeEmptyDOMElement());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/model-preferences",
+      expect.objectContaining({ method: "PUT" })
     );
-
-    await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
-    await user.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+      enabledModels: ["openai/gpt-5.4", "anthropic/claude-haiku-4-5"],
+    });
+    expect(JSON.parse(screen.getByTestId("cached-models").textContent!)).toEqual([
+      "openai/gpt-5.4",
+      "anthropic/claude-haiku-4-5",
+    ]);
+    await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
+      enabledModels: ["anthropic/claude-haiku-4-5"],
+    });
+  });
+
+  it("automatically saves category actions", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    renderSettings();
+    const category = within(screen.getByRole("heading", { name: "Anthropic" }).parentElement!);
+    await user.click(category.getByRole("button", { name: "Enable all" }));
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+      enabledModels: ["openai/gpt-5.4", ...MODEL_OPTIONS[0].models.map((model) => model.id)],
+    });
+    await user.click(category.getByRole("button", { name: "Disable all" }));
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
       enabledModels: ["openai/gpt-5.4"],
     });
   });
+
+  it("does not save when disabling the last model or last category", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    const { unmount } = renderSettings(["openai/gpt-5.2", "openai/gpt-5.4"]);
+    await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
+    expect(screen.getByRole("switch", { name: /GPT 5.4/ })).toBeChecked();
+    expect(fetchMock).not.toHaveBeenCalled();
+    unmount();
+    renderSettings(MODEL_OPTIONS[0].models.map((model) => model.id));
+    await user.click(screen.getByRole("button", { name: "Disable all" }));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("switch", { name: /Claude Haiku 4.5/ })).toBeChecked();
+  });
+
+  it("prevents overlapping saves while showing the new selection immediately", async () => {
+    let resolve!: (response: { ok: boolean }) => void;
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByRole("switch", { name: /Claude Haiku 4.5/ }));
+    expect(screen.getByRole("switch", { name: /Claude Haiku 4.5/ })).toBeChecked();
+    expect(screen.getByRole("status")).toHaveTextContent("Saving...");
+    for (const control of [...screen.getAllByRole("switch"), ...screen.getAllByRole("button")]) {
+      expect(control).toBeDisabled();
+    }
+    await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(async () => resolve({ ok: true }));
+    expect(screen.getByRole("switch", { name: /GPT 5.4/ })).toBeEnabled();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+  });
+
+  it.each(["server", "network"])(
+    "restores the previous selection after a %s failure and allows retry",
+    async (failure) => {
+      const fetchMock = vi.fn();
+      if (failure === "server") {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ error: "Save denied" }),
+        });
+      } else {
+        fetchMock.mockRejectedValueOnce(new Error("Network unavailable"));
+      }
+      fetchMock.mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+      const user = userEvent.setup();
+      renderSettings();
+      const toggle = screen.getByRole("switch", { name: /Claude Haiku 4.5/ });
+      await user.click(toggle);
+      await waitFor(() => expect(toggle).toBeEnabled());
+      expect(toggle).not.toBeChecked();
+      expect(screen.getByTestId("cached-models")).toHaveTextContent('["openai/gpt-5.4"]');
+      expect(toast.error).toHaveBeenCalledWith(
+        failure === "server" ? "Save denied" : "Network unavailable"
+      );
+      await user.click(toggle);
+      await waitFor(() => expect(toggle).toBeEnabled());
+      expect(toggle).toBeChecked();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    }
+  );
 });

--- a/packages/web/src/components/settings/models-settings.test.tsx
+++ b/packages/web/src/components/settings/models-settings.test.tsx
@@ -6,7 +6,7 @@ import { useState, type ReactNode } from "react";
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { SWRConfig } from "swr";
+import { SWRConfig, useSWRConfig } from "swr";
 import { toast } from "sonner";
 import { MODEL_OPTIONS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
@@ -21,6 +21,10 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
+
+async function saveResponse(_url: unknown, init: RequestInit) {
+  return { ok: true, json: async () => JSON.parse(init.body as string) };
+}
 
 function CachedModels() {
   const { enabledModels } = useEnabledModels();
@@ -63,7 +67,7 @@ function renderSettings(
 
 describe("ModelsSettings", () => {
   it("automatically saves toggles and updates other model selectors", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = vi.fn(saveResponse);
     vi.stubGlobal("fetch", fetchMock);
     const user = userEvent.setup();
     renderSettings(["openai/gpt-5.2", "openai/gpt-5.4"]);
@@ -91,7 +95,7 @@ describe("ModelsSettings", () => {
   });
 
   it("automatically saves category actions", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = vi.fn(saveResponse);
     vi.stubGlobal("fetch", fetchMock);
     const user = userEvent.setup();
     renderSettings();
@@ -122,7 +126,7 @@ describe("ModelsSettings", () => {
   });
 
   it("prevents overlapping saves while showing the new selection immediately", async () => {
-    let resolve!: (response: { ok: boolean }) => void;
+    let resolve!: (response: { ok: boolean; json: () => Promise<unknown> }) => void;
     const fetchMock = vi.fn().mockReturnValue(
       new Promise((done) => {
         resolve = done;
@@ -133,13 +137,19 @@ describe("ModelsSettings", () => {
     renderSettings();
     await user.click(screen.getByRole("switch", { name: /Claude Haiku 4.5/ }));
     expect(screen.getByRole("switch", { name: /Claude Haiku 4.5/ })).toBeChecked();
+    expect(screen.getByTestId("cached-models")).toHaveTextContent("anthropic/claude-haiku-4-5");
     expect(screen.getByRole("status")).toHaveTextContent("Saving...");
     for (const control of [...screen.getAllByRole("switch"), ...screen.getAllByRole("button")]) {
       expect(control).toBeDisabled();
     }
     await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    await act(async () => resolve({ ok: true }));
+    await act(async () =>
+      resolve({
+        ok: true,
+        json: async () => ({ enabledModels: ["openai/gpt-5.4", "anthropic/claude-haiku-4-5"] }),
+      })
+    );
     expect(screen.getByRole("switch", { name: /GPT 5.4/ })).toBeEnabled();
     expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
@@ -156,7 +166,7 @@ describe("ModelsSettings", () => {
       } else {
         fetchMock.mockRejectedValueOnce(new Error("Network unavailable"));
       }
-      fetchMock.mockResolvedValue({ ok: true });
+      fetchMock.mockImplementation(saveResponse);
       vi.stubGlobal("fetch", fetchMock);
       const user = userEvent.setup();
       renderSettings();
@@ -178,7 +188,7 @@ describe("ModelsSettings", () => {
   it.each([true, false])(
     "preserves the pending selection and lock across navigation (success: %s)",
     async (ok) => {
-      let resolve!: (response: { ok: boolean; json: () => Promise<{ error: string }> }) => void;
+      let resolve!: (response: { ok: boolean; json: () => Promise<unknown> }) => void;
       const fetchMock = vi
         .fn()
         .mockReturnValueOnce(
@@ -186,7 +196,7 @@ describe("ModelsSettings", () => {
             resolve = done;
           })
         )
-        .mockResolvedValue({ ok: true });
+        .mockImplementation(saveResponse);
       vi.stubGlobal("fetch", fetchMock);
       const user = userEvent.setup();
       renderSettings(undefined, <NavigableSettings />);
@@ -204,7 +214,15 @@ describe("ModelsSettings", () => {
       await user.click(screen.getByRole("switch", { name: /GPT 5.4/ }));
       expect(fetchMock).toHaveBeenCalledTimes(1);
 
-      await act(async () => resolve({ ok, json: async () => ({ error: "Save denied" }) }));
+      await act(async () =>
+        resolve({
+          ok,
+          json: async () =>
+            ok
+              ? { enabledModels: ["openai/gpt-5.4", "anthropic/claude-haiku-4-5"] }
+              : { error: "Save denied" },
+        })
+      );
       expect(screen.getByRole("status")).toBeEmptyDOMElement();
       const haiku = screen.getByRole("switch", { name: /Claude Haiku 4.5/ });
       expect(haiku).toBeEnabled();
@@ -221,4 +239,45 @@ describe("ModelsSettings", () => {
       });
     }
   );
+
+  it("uses external cache updates for both the switches and the next save", async () => {
+    let updateCache!: ReturnType<typeof useSWRConfig>["mutate"];
+    function CacheAccess() {
+      updateCache = useSWRConfig().mutate;
+      return <ModelsSettings />;
+    }
+    const fetchMock = vi.fn(saveResponse);
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+    renderSettings(undefined, <CacheAccess />);
+    await act(async () => {
+      await updateCache(
+        MODEL_PREFERENCES_KEY,
+        {
+          enabledModels: ["anthropic/claude-sonnet-4-6"],
+        },
+        { revalidate: false }
+      );
+    });
+    expect(screen.getByRole("switch", { name: /GPT 5.4/ })).not.toBeChecked();
+    expect(screen.getByRole("switch", { name: /Claude Sonnet 4.6/ })).toBeChecked();
+    await user.click(screen.getByRole("switch", { name: /Claude Haiku 4.5/ }));
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+      enabledModels: ["anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"],
+    });
+  });
+
+  it("does not offer writable defaults after an initial read failure", async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error("Unavailable"));
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <SWRConfig value={{ provider: () => new Map(), fetcher, shouldRetryOnError: false }}>
+        <ModelsSettings />
+      </SWRConfig>
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load model preferences");
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -1,28 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { useSWRConfig } from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { toast } from "sonner";
-import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
+import { MODEL_OPTIONS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 
-export function ModelsSettings() {
-  const { mutate } = useSWRConfig();
-  const { enabledModels: storedEnabledModels, loading } = useEnabledModels();
-  const [enabledModels, setEnabledModels] = useState<Set<string>>(
-    () => new Set(DEFAULT_ENABLED_MODELS)
-  );
-  const [initialized, setInitialized] = useState(false);
-  const [saving, setSaving] = useState(false);
+const PENDING_MODELS_KEY = "model-preferences:pending";
 
-  // Sync SWR data into local state once on initial load
-  if (!loading && !initialized) {
-    setEnabledModels(new Set(storedEnabledModels));
-    setInitialized(true);
-  }
+export function ModelsSettings() {
+  const { cache, mutate } = useSWRConfig();
+  const { enabledModels: storedEnabledModels, loading } = useEnabledModels();
+  // Keep the selection and write lock across settings-panel unmounts.
+  const { data: pendingModels, mutate: setPendingModels } = useSWR<string[] | null>(
+    PENDING_MODELS_KEY,
+    null
+  );
+  const enabledModels = new Set(pendingModels ?? storedEnabledModels);
+  const saving = !!pendingModels;
 
   const toggleModel = (modelId: string) => {
     const next = new Set(enabledModels);
@@ -49,10 +46,8 @@ export function ModelsSettings() {
   };
 
   const savePreferences = async (next: Set<string>) => {
-    if (saving) return;
-    const previous = enabledModels;
-    setEnabledModels(next);
-    setSaving(true);
+    if (cache.get(PENDING_MODELS_KEY)?.data) return;
+    await setPendingModels(Array.from(next), { revalidate: false });
 
     try {
       const res = await browserApiFetch("/api/model-preferences", {
@@ -72,10 +67,9 @@ export function ModelsSettings() {
         throw new Error(data.error || "Failed to save preferences");
       }
     } catch (error) {
-      setEnabledModels(previous);
       toast.error(error instanceof Error ? error.message : "Failed to save preferences");
     } finally {
-      setSaving(false);
+      await setPendingModels(null, { revalidate: false });
     }
   };
 

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -1,25 +1,20 @@
 "use client";
 
-import useSWR, { useSWRConfig } from "swr";
 import { toast } from "sonner";
 import { MODEL_OPTIONS } from "@open-inspect/shared/models";
-import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
+import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
-
-const PENDING_MODELS_KEY = "model-preferences:pending";
 
 export function ModelsSettings() {
-  const { cache, mutate } = useSWRConfig();
-  const { enabledModels: storedEnabledModels, loading } = useEnabledModels();
-  // Keep the selection and write lock across settings-panel unmounts.
-  const { data: pendingModels, mutate: setPendingModels } = useSWR<string[] | null>(
-    PENDING_MODELS_KEY,
-    null
-  );
-  const enabledModels = new Set(pendingModels ?? storedEnabledModels);
-  const saving = !!pendingModels;
+  const {
+    enabledModels: storedEnabledModels,
+    loading,
+    error,
+    saving,
+    saveEnabledModels,
+  } = useEnabledModels();
+  const enabledModels = new Set(storedEnabledModels);
 
   const toggleModel = (modelId: string) => {
     const next = new Set(enabledModels);
@@ -46,30 +41,10 @@ export function ModelsSettings() {
   };
 
   const savePreferences = async (next: Set<string>) => {
-    if (cache.get(PENDING_MODELS_KEY)?.data) return;
-    await setPendingModels(Array.from(next), { revalidate: false });
-
     try {
-      const res = await browserApiFetch("/api/model-preferences", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabledModels: Array.from(next) }),
-      });
-
-      if (res.ok) {
-        await mutate(
-          MODEL_PREFERENCES_KEY,
-          { enabledModels: Array.from(next) },
-          { revalidate: false }
-        );
-      } else {
-        const data = await res.json();
-        throw new Error(data.error || "Failed to save preferences");
-      }
+      await saveEnabledModels(Array.from(next));
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to save preferences");
-    } finally {
-      await setPendingModels(null, { revalidate: false });
     }
   };
 
@@ -79,6 +54,14 @@ export function ModelsSettings() {
         <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
         Loading model preferences...
       </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        Unable to load model preferences. Please reload to try again.
+      </p>
     );
   }
 

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 import { toast } from "sonner";
 import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
@@ -10,13 +10,13 @@ import { Switch } from "@/components/ui/switch";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export function ModelsSettings() {
+  const { mutate } = useSWRConfig();
   const { enabledModels: storedEnabledModels, loading } = useEnabledModels();
   const [enabledModels, setEnabledModels] = useState<Set<string>>(
     () => new Set(DEFAULT_ENABLED_MODELS)
   );
   const [initialized, setInitialized] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [dirty, setDirty] = useState(false);
 
   // Sync SWR data into local state once on initial load
   if (!loading && !initialized) {
@@ -25,55 +25,55 @@ export function ModelsSettings() {
   }
 
   const toggleModel = (modelId: string) => {
-    setEnabledModels((prev) => {
-      const next = new Set(prev);
-      if (next.has(modelId)) {
-        if (next.size <= 1) return prev;
-        next.delete(modelId);
-      } else {
-        next.add(modelId);
-      }
-      return next;
-    });
-    setDirty(true);
+    const next = new Set(enabledModels);
+    if (next.has(modelId)) {
+      if (next.size <= 1) return;
+      next.delete(modelId);
+    } else {
+      next.add(modelId);
+    }
+    void savePreferences(next);
   };
 
   const toggleCategory = (category: (typeof MODEL_OPTIONS)[number], enable: boolean) => {
-    setEnabledModels((prev) => {
-      const next = new Set(prev);
-      for (const model of category.models) {
-        if (enable) {
-          next.add(model.id);
-        } else {
-          next.delete(model.id);
-        }
+    const next = new Set(enabledModels);
+    for (const model of category.models) {
+      if (enable) {
+        next.add(model.id);
+      } else {
+        next.delete(model.id);
       }
-      if (next.size === 0) return prev;
-      return next;
-    });
-    setDirty(true);
+    }
+    if (next.size === 0) return;
+    void savePreferences(next);
   };
 
-  const handleSave = async () => {
+  const savePreferences = async (next: Set<string>) => {
+    if (saving) return;
+    const previous = enabledModels;
+    setEnabledModels(next);
     setSaving(true);
 
     try {
       const res = await browserApiFetch("/api/model-preferences", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabledModels: Array.from(enabledModels) }),
+        body: JSON.stringify({ enabledModels: Array.from(next) }),
       });
 
       if (res.ok) {
-        mutate(MODEL_PREFERENCES_KEY);
-        toast.success("Model preferences saved.");
-        setDirty(false);
+        await mutate(
+          MODEL_PREFERENCES_KEY,
+          { enabledModels: Array.from(next) },
+          { revalidate: false }
+        );
       } else {
         const data = await res.json();
-        toast.error(data.error || "Failed to save preferences");
+        throw new Error(data.error || "Failed to save preferences");
       }
-    } catch {
-      toast.error("Failed to save preferences");
+    } catch (error) {
+      setEnabledModels(previous);
+      toast.error(error instanceof Error ? error.message : "Failed to save preferences");
     } finally {
       setSaving(false);
     }
@@ -92,7 +92,8 @@ export function ModelsSettings() {
     <div>
       <h2 className="text-xl font-semibold text-foreground mb-1">Enabled Models</h2>
       <p className="text-sm text-muted-foreground mb-6">
-        Choose which models appear in the model selector across the web UI and Slack bot.
+        Choose which models appear in the model selector across the web UI and Slack bot. Changes
+        are saved automatically.
       </p>
 
       <div className="space-y-6">
@@ -109,6 +110,7 @@ export function ModelsSettings() {
                   type="button"
                   variant="subtle"
                   size="xs"
+                  disabled={saving}
                   onClick={() => toggleCategory(group, !allEnabled)}
                   className="text-accent hover:text-accent/80"
                 >
@@ -133,6 +135,7 @@ export function ModelsSettings() {
                       <Switch
                         id={`model-toggle-${model.id}`}
                         checked={isEnabled}
+                        disabled={saving}
                         onCheckedChange={() => toggleModel(model.id)}
                       />
                     </label>
@@ -144,11 +147,9 @@ export function ModelsSettings() {
         })}
       </div>
 
-      <div className="mt-6">
-        <Button onClick={handleSave} disabled={saving || !dirty}>
-          {saving ? "Saving..." : "Save"}
-        </Button>
-      </div>
+      <p role="status" className="mt-6 text-sm text-muted-foreground">
+        {saving ? "Saving..." : ""}
+      </p>
     </div>
   );
 }

--- a/packages/web/src/hooks/use-enabled-models.test.tsx
+++ b/packages/web/src/hooks/use-enabled-models.test.tsx
@@ -1,11 +1,16 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "./use-enabled-models";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 function wrapper(enabledModels: unknown) {
   return function TestWrapper({ children }: { children: ReactNode }) {
@@ -38,5 +43,66 @@ describe("useEnabledModels", () => {
     });
 
     expect(result.current.enabledModels).toEqual(DEFAULT_ENABLED_MODELS);
+  });
+
+  it("stores the authoritative PUT response instead of the submitted selection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "updated", enabledModels: ["anthropic/claude-sonnet-4-6"] }),
+      })
+    );
+    const { result } = renderHook(() => useEnabledModels(), {
+      wrapper: wrapper(["openai/gpt-5.4"]),
+    });
+    await act(async () => {
+      await result.current.saveEnabledModels(["openai/gpt-5.4", "anthropic/claude-haiku-4-5"]);
+    });
+    expect(result.current.enabledModels).toEqual(["anthropic/claude-sonnet-4-6"]);
+    expect(result.current.saving).toBe(false);
+  });
+
+  it.each([null, {}, { enabledModels: [] }, { enabledModels: [42] }])(
+    "rejects an invalid PUT response and rolls back: %j",
+    async (response) => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => response }));
+      const { result } = renderHook(() => useEnabledModels(), {
+        wrapper: wrapper(["openai/gpt-5.4"]),
+      });
+      await act(async () => {
+        await expect(
+          result.current.saveEnabledModels(["anthropic/claude-haiku-4-5"])
+        ).rejects.toThrow("Invalid model preferences response");
+      });
+      expect(result.current.enabledModels).toEqual(["openai/gpt-5.4"]);
+      expect(result.current.saving).toBe(false);
+    }
+  );
+
+  it("exposes read errors and rejects writes before preferences have loaded", async () => {
+    const readError = new Error("Read failed");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useEnabledModels(), {
+      wrapper: ({ children }) => (
+        <SWRConfig
+          value={{
+            provider: () => new Map(),
+            fetcher: async () => {
+              throw readError;
+            },
+            shouldRetryOnError: false,
+          }}
+        >
+          {children}
+        </SWRConfig>
+      ),
+    });
+    await waitFor(() => expect(result.current.error).toBe(readError));
+    await expect(result.current.saveEnabledModels(["openai/gpt-5.4"])).rejects.toThrow(
+      "Model preferences must load before saving"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/hooks/use-enabled-models.ts
+++ b/packages/web/src/hooks/use-enabled-models.ts
@@ -1,20 +1,58 @@
 import { useMemo } from "react";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
+import { z } from "zod";
 import {
   MODEL_OPTIONS,
   DEFAULT_ENABLED_MODELS,
   normalizeValidModels,
   type ModelCategory,
 } from "@open-inspect/shared/models";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export const MODEL_PREFERENCES_KEY = "/api/model-preferences";
+const MODEL_PREFERENCES_SAVING_KEY = "model-preferences:saving";
 
-interface ModelPreferencesResponse {
-  enabledModels: string[];
-}
+const modelPreferencesSchema = z.object({ enabledModels: z.array(z.string()).nonempty() });
+type ModelPreferencesResponse = z.infer<typeof modelPreferencesSchema>;
 
 export function useEnabledModels() {
-  const { data, isLoading } = useSWR<ModelPreferencesResponse>(MODEL_PREFERENCES_KEY);
+  const { cache } = useSWRConfig();
+  const { data, error, isLoading, mutate } =
+    useSWR<ModelPreferencesResponse>(MODEL_PREFERENCES_KEY);
+  // Share the write lock across consumers and settings-panel remounts.
+  const { data: saving = false, mutate: setSaving } = useSWR<boolean>(
+    MODEL_PREFERENCES_SAVING_KEY,
+    null
+  );
+
+  const saveEnabledModels = async (next: string[]) => {
+    if (cache.get(MODEL_PREFERENCES_SAVING_KEY)?.data) return;
+    if (isLoading || error) throw new Error("Model preferences must load before saving");
+    await setSaving(true, { revalidate: false });
+    try {
+      await mutate(
+        async () => {
+          const res = await browserApiFetch(MODEL_PREFERENCES_KEY, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabledModels: next }),
+          });
+          const response = await res.json();
+          if (!res.ok) throw new Error(response?.error || "Failed to save preferences");
+          const parsed = modelPreferencesSchema.safeParse(response);
+          if (!parsed.success) throw new Error("Invalid model preferences response");
+          return parsed.data;
+        },
+        {
+          optimisticData: { enabledModels: next },
+          rollbackOnError: true,
+          revalidate: false,
+        }
+      );
+    } finally {
+      await setSaving(false, { revalidate: false });
+    }
+  };
 
   const enabledModels = useMemo<string[]>(() => {
     if (isLoading) return [];
@@ -32,5 +70,12 @@ export function useEnabledModels() {
     })).filter((group) => group.models.length > 0);
   }, [enabledModels]);
 
-  return { enabledModels, enabledModelOptions, loading: isLoading };
+  return {
+    enabledModels,
+    enabledModelOptions,
+    loading: isLoading,
+    error,
+    saving,
+    saveEnabledModels,
+  };
 }


### PR DESCRIPTION
## Summary
Users can currently toggle available models and leave settings without pressing Save, unintentionally losing their changes. Save each change immediately instead.

- Autosave individual model switches and category Enable all / Disable all actions.
- Remove the Save button and explain that changes save automatically.
- Show the updated selection immediately and a Saving... status while persisting; temporarily disable controls to prevent overlapping full-list writes.
- Restore the previous selection and show an error when saving fails, allowing retry.
- Update the active SWR cache after successful saves so other model selectors reflect the change.
- Preserve the requirement that at least one model remains enabled, and never save initial/default state just from rendering.

## Verification
- All 1,476 web tests pass across 190 files: `npm test -w @open-inspect/web -- --maxWorkers=4`.
- New component coverage includes individual/category autosave, shared-cache updates, removed-model filtering, last-model protection, pending-write protection, and server/network failures with retry.
- Shared build, web typecheck, ESLint on changed files, formatting, and `git diff --check` pass.
- The default-concurrency full-suite run hit two authentication-lint test timeouts; the four-worker run passed without test or timeout configuration changes.
- Browser visual verification was not performed: the workspace lacks local web authentication/backend configuration, and settings requires authenticated access.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5fb0a64c707818b0d24d6290ee14ccc9)*