### PR TITLE
fix(scripts): verify the D1 migration ledger after applying, and parse Wrangler's progress output in owner bootstrap

### DIFF
--- a/scripts/bootstrap-workspace-owner.test.ts
+++ b/scripts/bootstrap-workspace-owner.test.ts
@@ -382,6 +382,38 @@ describe("Owner bootstrap orchestration", () => {
     assert.equal(calls, 2);
   });
 
+  it("accepts Wrangler progress output before the execution JSON", async () => {
+    let calls = 0;
+    await run(
+      { database: "workspace", userId: USER_ID, execute: true },
+      {
+        randomUUID: () => "audit-exact",
+        now: () => 123,
+        runWrangler: (_database, operation) => {
+          calls += 1;
+          const report =
+            operation[0] === "--command"
+              ? { report: "preflight", status: "ready" }
+              : { report: "postcondition", status: "executed", audit_written: 1 };
+          const output = JSON.stringify([{ success: true, results: [report] }]);
+          return operation[0] === "--file" ? `├ Checking remote database...\n${output}` : output;
+        },
+      }
+    );
+
+    assert.equal(calls, 2);
+  });
+
+  it("rejects progress output that carries no JSON payload", async () => {
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: false },
+        { runWrangler: () => "├ Checking remote database...\n" }
+      ),
+      /no JSON output/
+    );
+  });
+
   it("reports a concurrent winner instead of claiming this invocation completed", async () => {
     await assert.rejects(
       run(

--- a/scripts/bootstrap-workspace-owner.ts
+++ b/scripts/bootstrap-workspace-owner.ts
@@ -222,8 +222,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// Wrangler prints human-readable progress lines ("├ Checking remote database...")
+// ahead of the JSON array for remote `--file` execution even with `--json` set, so
+// stdout is not itself the payload. Slice out the documented array — first
+// line-anchored "[" through the last "]" — so a progress line can never be read as
+// a result row. Anything without such an array is still handed to JSON.parse whole,
+// so a well-formed payload of the wrong shape reaches the shape check below instead
+// of being reported as missing output.
+function parseWranglerJson(stdout: string): unknown {
+  const start = stdout.search(/^[ \t]*\[/m);
+  const end = stdout.lastIndexOf("]");
+  if (start >= 0 && end > start) return JSON.parse(stdout.slice(start, end + 1));
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    throw new Error("Wrangler returned no JSON output");
+  }
+}
+
 function parseWranglerResults(stdout: string): WranglerResult[] {
-  const parsed: unknown = JSON.parse(stdout);
+  const parsed: unknown = parseWranglerJson(stdout);
   if (!Array.isArray(parsed)) throw new Error("Wrangler returned a malformed JSON result");
 
   return parsed.map((result) => {

--- a/scripts/d1-migrate.sh
+++ b/scripts/d1-migrate.sh
@@ -104,3 +104,42 @@ for file in "$MIGRATIONS_DIR"/*.sql; do
 done
 
 echo "Done. Applied $COUNT migration(s)."
+
+# 4. Postcondition: the ledger must record exactly the migration files on disk.
+# Steps 1-3 can leave the schema silently incomplete — a lost wrangler response,
+# a provider that reports success on a partial batch, or any future early return
+# — and callers (Terraform's null_resource) then record a successful deploy over
+# a half-migrated database. Re-read the ledger from the database and compare it
+# to the files, so divergence fails the deploy instead of shipping it.
+EXPECTED_LEDGER_FILE="$MIGRATION_BATCH_DIR/ledger-expected"
+FINAL_LEDGER_FILE="$MIGRATION_BATCH_DIR/ledger-final"
+
+for file in "$MIGRATIONS_DIR"/*.sql; do
+  [ -f "$file" ] || continue
+  BASE=$(basename "$file")
+  printf '%s\t%s\n' "$(printf '%s' "$BASE" | grep -oE '^[0-9]+')" "$BASE"
+done | sort >"$EXPECTED_LEDGER_FILE"
+
+FINAL_JSON=$(
+  $WRANGLER d1 execute "$DATABASE_NAME" --remote \
+    --command "SELECT version, name FROM _schema_migrations" \
+    --json
+)
+# Prove the response is readable before diffing it. An empty or truncated
+# payload otherwise reads as "the database recorded nothing" and the report
+# below blames the ledger for what is really a lost wrangler response.
+printf '%s' "$FINAL_JSON" |
+  jq -e '.[0].results | type == "array"' >/dev/null
+printf '%s' "$FINAL_JSON" |
+  jq -r '.[0].results[]? | [.version, .name] | @tsv' | sort >"$FINAL_LEDGER_FILE"
+
+if ! cmp -s "$EXPECTED_LEDGER_FILE" "$FINAL_LEDGER_FILE"; then
+  echo "ERROR: migration ledger does not match $MIGRATIONS_DIR after applying." >&2
+  echo "Missing from the database (expected but not recorded):" >&2
+  comm -23 "$EXPECTED_LEDGER_FILE" "$FINAL_LEDGER_FILE" | sed 's/^/  /' >&2
+  echo "Unexpected in the database (recorded but no such file):" >&2
+  comm -13 "$EXPECTED_LEDGER_FILE" "$FINAL_LEDGER_FILE" | sed 's/^/  /' >&2
+  exit 1
+fi
+
+echo "Verified: ledger matches all $(wc -l <"$EXPECTED_LEDGER_FILE" | tr -d ' ') migration file(s)."


### PR DESCRIPTION
Two independent robustness fixes in the deploy scripts. Both are about the same class of bug: a script trusting output it should be verifying.

## 1. `scripts/d1-migrate.sh` — fail the run when the ledger diverges from the migration files

The runner decides what to apply from `_schema_migrations`, then reports success based on nothing but the absence of a nonzero exit from each `wrangler d1 execute`. Steps 1-3 can therefore finish "successfully" with the schema incomplete:

- a lost or truncated wrangler response for one file,
- a provider that reports success on a partially applied batch,
- any future early `continue`/`return` added to the apply loop.

The caller is Terraform's `null_resource` in `terraform/environments/production/d1.tf`, so a zero exit records a successful deploy over a half-migrated database, and the next `terraform apply` sees no change to make. The failure surfaces later as a runtime error against a missing column.

This adds a postcondition after the apply loop: re-read `version, name` from the ledger and compare it, in both directions, against the `*.sql` files in the migrations directory. Divergence prints the two difference sets and exits nonzero.

The existing step 0 (duplicate-prefix / missing-prefix validation) and the step 3 `RECORDED_NAME` check both run *before* any SQL is submitted and only inspect the ledger snapshot taken up front. They cannot catch a write that silently did not land. This check reads the database again afterwards, so it is the only thing here that observes the post-apply state.

Behaviour note: the "recorded but no such file" direction now fails a run against a database whose ledger holds rows for migrations that are not in the directory being applied — a deleted or renamed already-applied migration, for instance. That is a state worth failing on, since the schema then contains something the repository no longer describes, and both in-tree callers (`d1.tf` and the default in the script itself) point at `terraform/d1/migrations` exclusively.

The database name still comes from `$1`; nothing deployment-specific is introduced.

## 2. `scripts/bootstrap-workspace-owner.ts` — parse Wrangler's output instead of assuming it is pure JSON

`reportRows` ran `JSON.parse(stdout)` on the whole of wrangler's stdout. For remote `--file` execution wrangler prints human-readable progress lines (`├ Checking remote database...`) ahead of the JSON array even with `--json` set, so the parse throws and the bootstrap fails on output that is actually a success. Loose recovery is worse than the throw: reading a progress line as a result would let the script accept a row it never received.

This slices out the documented JSON payload — first line-anchored `[` through the last `]` — and parses only that, throwing a clear `Wrangler returned no JSON output` when there is no array at all. The audit-ID binding that gates which execution response this invocation will accept is untouched.

## Gates run locally

- `npm run test:rbac-bootstrap-owner` (the script's own `node --test` target): **tests 14, pass 14, fail 0**.
- Same target with `reportRows` reverted to the bare `JSON.parse(stdout)`: **pass 13, fail 1**, the failure being `accepts Wrangler progress output before the execution JSON`. The new test bites.
- `bash -n scripts/d1-migrate.sh`: clean.
- `shellcheck 0.11.0 scripts/d1-migrate.sh`: two `SC2001` style notes, at lines 40 and 79. Both are pre-existing — `shellcheck` on `main`'s copy of the file reports the identical two. The added lines introduce no new findings.
- Migration postcondition, exercised against a throwaway stub standing in for `npx wrangler d1 execute` (no remote D1 needed), on three scenarios:
  - both migrations recorded: exits 0, prints `Verified: ledger matches all 2 migration file(s).`
  - the second apply returns success without recording its ledger row: exits 1 and names `0002 0002_b.sql` under "Missing from the database". `main`'s copy of the script, same stub, same scenario, prints `Done. Applied 2 migration(s).` and exits **0** with only `0001` in the ledger — the bug this fixes.
  - ledger holds a row with no corresponding file: exits 1 and names it under "Unexpected in the database".

No repo-wide lint or unrelated package suites were run: `scripts/` is outside every workspace `tsconfig`, so no package typecheck covers these files, and no application package or Terraform config is touched.

## Upstream adaptation

Both changes applied to the current `scripts/` layout without conflict. No upstream structure was moved and no existing test or assertion was removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace owner setup to handle command output with progress messages before the expected data.
  - Added clearer errors when setup output lacks valid results.

- **Reliability**
  - Migration deployments now verify that the database migration ledger matches available migration files.
  - Deployments report missing or unexpected entries and fail when inconsistencies are detected.
  - Successful deployments report the verified migration count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->