### PR TITLE
terraform: make each bot's default model a variable instead of a tracked literal

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -255,6 +255,7 @@ jobs:
           TF_VAR_enable_slack_bot: "${{ vars.ENABLE_SLACK_BOT || secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          TF_VAR_slack_bot_default_model: "${{ vars.SLACK_BOT_DEFAULT_MODEL || secrets.SLACK_BOT_DEFAULT_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
           TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
@@ -271,12 +272,14 @@ jobs:
           TF_VAR_enable_github_bot: "${{ vars.ENABLE_GITHUB_BOT || secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ vars.GH_BOT_USERNAME || secrets.GH_BOT_USERNAME }}
+          TF_VAR_github_bot_default_model: "${{ vars.GH_BOT_DEFAULT_MODEL || secrets.GH_BOT_DEFAULT_MODEL || 'anthropic/claude-haiku-4-5' }}"
           TF_VAR_app_name: "${{ vars.APP_NAME || secrets.APP_NAME || 'Open-Inspect' }}"
           TF_VAR_app_icon_url: ${{ vars.APP_ICON_URL || secrets.APP_ICON_URL }}
           TF_VAR_enable_linear_bot: "${{ vars.ENABLE_LINEAR_BOT || secrets.ENABLE_LINEAR_BOT || 'false' }}"
           TF_VAR_linear_client_id: ${{ vars.LINEAR_CLIENT_ID || secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
+          TF_VAR_linear_bot_default_model: "${{ vars.LINEAR_BOT_DEFAULT_MODEL || secrets.LINEAR_BOT_DEFAULT_MODEL || 'claude-sonnet-4-6' }}"
           TF_VAR_web_platform: "${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM || 'vercel' }}"
           TF_VAR_enable_durable_object_bindings: "${{ vars.ENABLE_DURABLE_OBJECT_BINDINGS || secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
           TF_VAR_sandbox_provider: "${{ vars.SANDBOX_PROVIDER || secrets.SANDBOX_PROVIDER || 'modal' }}"
@@ -430,6 +433,7 @@ jobs:
           TF_VAR_enable_slack_bot: "${{ vars.ENABLE_SLACK_BOT || secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          TF_VAR_slack_bot_default_model: "${{ vars.SLACK_BOT_DEFAULT_MODEL || secrets.SLACK_BOT_DEFAULT_MODEL || 'claude-haiku-4-5' }}"
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           TF_VAR_classification_openai_api_key: ${{ secrets.CLASSIFICATION_OPENAI_API_KEY }}
           TF_VAR_classification_model: "${{ vars.CLASSIFICATION_MODEL || 'claude-haiku-4-5' }}"
@@ -446,12 +450,14 @@ jobs:
           TF_VAR_enable_github_bot: "${{ vars.ENABLE_GITHUB_BOT || secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ vars.GH_BOT_USERNAME || secrets.GH_BOT_USERNAME }}
+          TF_VAR_github_bot_default_model: "${{ vars.GH_BOT_DEFAULT_MODEL || secrets.GH_BOT_DEFAULT_MODEL || 'anthropic/claude-haiku-4-5' }}"
           TF_VAR_app_name: "${{ vars.APP_NAME || secrets.APP_NAME || 'Open-Inspect' }}"
           TF_VAR_app_icon_url: ${{ vars.APP_ICON_URL || secrets.APP_ICON_URL }}
           TF_VAR_enable_linear_bot: "${{ vars.ENABLE_LINEAR_BOT || secrets.ENABLE_LINEAR_BOT || 'false' }}"
           TF_VAR_linear_client_id: ${{ vars.LINEAR_CLIENT_ID || secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
+          TF_VAR_linear_bot_default_model: "${{ vars.LINEAR_BOT_DEFAULT_MODEL || secrets.LINEAR_BOT_DEFAULT_MODEL || 'claude-sonnet-4-6' }}"
           TF_VAR_web_platform: "${{ vars.WEB_PLATFORM || secrets.WEB_PLATFORM || 'vercel' }}"
           TF_VAR_enable_durable_object_bindings: "${{ vars.ENABLE_DURABLE_OBJECT_BINDINGS || secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
           TF_VAR_sandbox_provider: "${{ vars.SANDBOX_PROVIDER || secrets.SANDBOX_PROVIDER || 'modal' }}"

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -169,6 +169,11 @@ github_webhook_secret = ""
 # The webhook handler uses this to detect @mentions of the bot in PRs/issues.
 github_bot_username = ""
 
+# Model the GitHub bot uses for a repository that does not pin one in its own
+# integration config. Accepts a canonical "provider/model" id or a bare
+# "claude-"/"gpt-" id. Commented out means the default below.
+# github_bot_default_model = "anthropic/claude-haiku-4-5"
+
 # =============================================================================
 # Google OAuth Credentials (Optional)
 # =============================================================================
@@ -194,6 +199,10 @@ enable_slack_bot = false
 slack_bot_token = ""       # e.g., "xoxb-..."
 slack_signing_secret = ""
 
+# Model the Slack bot uses for a user who has not picked one from the model
+# menu. Accepts a canonical "provider/model" id or a bare "claude-"/"gpt-" id.
+# slack_bot_default_model = "claude-haiku-4-5"
+
 # Linear Agent (Optional)
 # Create an OAuth Application at: https://linear.app/settings/api/applications/new
 # - Enable webhooks, select "Agent session events" + "Issues" + "Comments"
@@ -213,6 +222,11 @@ enable_linear_bot = false
 linear_client_id = ""        # OAuth Application Client ID
 linear_client_secret = ""    # OAuth Application Client Secret
 linear_webhook_secret = ""   # Webhook Signing Secret from the application config
+
+# Model the Linear bot uses when no repository config, user preference, or
+# "model:" issue label selects one. Accepts a canonical "provider/model" id or a
+# bare "claude-"/"gpt-" id.
+# linear_bot_default_model = "claude-sonnet-4-6"
 
 # =============================================================================
 # API Keys

--- a/terraform/environments/production/tests/bot_default_model.tftest.hcl
+++ b/terraform/environments/production/tests/bot_default_model.tftest.hcl
@@ -1,0 +1,228 @@
+mock_provider "cloudflare" {}
+mock_provider "external" {
+  mock_data "external" {
+    defaults = {
+      result = {
+        hash = "test-source-hash"
+      }
+    }
+  }
+}
+mock_provider "local" {}
+mock_provider "null" {}
+mock_provider "random" {}
+mock_provider "vercel" {}
+
+variables {
+  cloudflare_api_token        = "test-cloudflare-token"
+  cloudflare_account_id       = "test-account"
+  cloudflare_worker_subdomain = "test-account"
+  github_app_id               = "1"
+  github_app_private_key      = "test-private-key"
+  github_app_installation_id  = "1"
+  anthropic_api_key           = "test-anthropic-key"
+  token_encryption_key        = "test-token-key"
+  repo_secrets_encryption_key = "test-repo-key"
+  nextauth_secret             = "test-browser-auth-secret-with-32-characters"
+  deployment_name             = "bot-default-model-test"
+
+  modal_token_id     = "test-modal-token-id"
+  modal_token_secret = "test-modal-token-secret"
+  modal_workspace    = "test-workspace"
+  modal_api_secret   = "test-modal-api-secret"
+
+  web_platform = "cloudflare"
+  project_root = "../../../"
+
+  # All three bots are deployed so every DEFAULT_MODEL binding can be asserted.
+  enable_github_bot     = true
+  github_webhook_secret = "test-github-webhook-secret"
+  github_bot_username   = "test-bot[bot]"
+
+  enable_slack_bot     = true
+  slack_bot_token      = "xoxb-test"
+  slack_signing_secret = "test-signing-secret"
+
+  enable_linear_bot     = true
+  linear_client_id      = "test-linear-client-id"
+  linear_client_secret  = "test-linear-client-secret"
+  linear_webhook_secret = "test-linear-webhook-secret"
+  linear_api_key        = "test-linear-api-key"
+
+  github_client_id     = "github-id"
+  github_client_secret = "github-secret"
+  allowed_users        = "octocat"
+}
+
+# The defaults must reproduce the values these bindings carried while they were
+# hardcoded, so making them configurable changes no existing deployment. Each
+# bot keeps its own default deliberately: they are not required to agree.
+run "defaults_preserve_the_previously_hardcoded_models" {
+  command = plan
+
+  assert {
+    condition     = module.github_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "anthropic/claude-haiku-4-5"
+    error_message = "The GitHub bot's default model binding must stay anthropic/claude-haiku-4-5."
+  }
+
+  assert {
+    condition     = module.slack_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "claude-haiku-4-5"
+    error_message = "The Slack bot's default model binding must stay claude-haiku-4-5."
+  }
+
+  assert {
+    condition     = module.linear_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "claude-sonnet-4-6"
+    error_message = "The Linear bot's default model binding must stay claude-sonnet-4-6."
+  }
+}
+
+# The point of the variables: a deployment picks its models in tfvars, and the
+# choice reaches the workers instead of requiring an edit to tracked .tf files.
+run "overrides_reach_each_bot_binding" {
+  command = plan
+
+  variables {
+    github_bot_default_model = "anthropic/claude-opus-4-5"
+    slack_bot_default_model  = "openai/gpt-5.4"
+    linear_bot_default_model = "claude-sonnet-5"
+  }
+
+  assert {
+    condition     = module.github_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "anthropic/claude-opus-4-5"
+    error_message = "An overridden github_bot_default_model must reach the GitHub bot's DEFAULT_MODEL binding."
+  }
+
+  assert {
+    condition     = module.slack_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "openai/gpt-5.4"
+    error_message = "An overridden slack_bot_default_model must reach the Slack bot's DEFAULT_MODEL binding."
+  }
+
+  assert {
+    condition     = module.linear_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] == "claude-sonnet-5"
+    error_message = "An overridden linear_bot_default_model must reach the Linear bot's DEFAULT_MODEL binding."
+  }
+
+  # One bot's override must not leak into another's binding.
+  assert {
+    condition = (
+      module.github_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] !=
+      module.slack_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] &&
+      module.slack_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"] !=
+      module.linear_bot_worker[0].plain_text_bindings["DEFAULT_MODEL"]
+    )
+    error_message = "Each bot's default model must be sourced from its own variable."
+  }
+}
+
+# An unset CI variable renders as an empty string. Treating that as "use the
+# default" would silently deploy whichever model the configuration last shipped,
+# so a blank override must fail at plan time instead.
+run "rejects_a_blank_github_model" {
+  command = plan
+
+  variables {
+    github_bot_default_model = "  "
+  }
+
+  expect_failures = [var.github_bot_default_model]
+}
+
+run "rejects_a_blank_slack_model" {
+  command = plan
+
+  variables {
+    slack_bot_default_model = ""
+  }
+
+  expect_failures = [var.slack_bot_default_model]
+}
+
+run "rejects_a_blank_linear_model" {
+  command = plan
+
+  variables {
+    linear_bot_default_model = ""
+  }
+
+  expect_failures = [var.linear_bot_default_model]
+}
+
+# A provider namespace with no model after it satisfies a prefix check but names
+# nothing, and the bots would forward it to the provider verbatim.
+run "rejects_a_bare_provider_namespace" {
+  command = plan
+
+  variables {
+    slack_bot_default_model = "anthropic/"
+  }
+
+  expect_failures = [var.slack_bot_default_model]
+}
+
+run "rejects_a_bare_model_prefix" {
+  command = plan
+
+  variables {
+    linear_bot_default_model = "claude-"
+  }
+
+  expect_failures = [var.linear_bot_default_model]
+}
+
+# A bare id with no recognized prefix names no provider — the bots cannot
+# normalize it, and it would reach session creation unresolvable.
+run "rejects_an_unprefixed_bare_id" {
+  command = plan
+
+  variables {
+    github_bot_default_model = "haiku-4-5"
+  }
+
+  expect_failures = [var.github_bot_default_model]
+}
+
+# Whitespace inside the id is not cosmetic: the value reaches each worker's
+# DEFAULT_MODEL binding verbatim, so a stray space produces a model id no
+# provider resolves. Each shape a hand-edited tfvars or a CI variable can
+# introduce must fail at plan time.
+run "rejects_whitespace_after_the_provider_namespace" {
+  command = plan
+
+  variables {
+    github_bot_default_model = "anthropic/ claude-haiku-4-5"
+  }
+
+  expect_failures = [var.github_bot_default_model]
+}
+
+run "rejects_a_trailing_space_on_a_bare_id" {
+  command = plan
+
+  variables {
+    slack_bot_default_model = "claude-haiku-4-5 "
+  }
+
+  expect_failures = [var.slack_bot_default_model]
+}
+
+run "rejects_a_leading_space_before_the_provider" {
+  command = plan
+
+  variables {
+    linear_bot_default_model = " anthropic/claude-sonnet-4-6"
+  }
+
+  expect_failures = [var.linear_bot_default_model]
+}
+
+# A canonical id names exactly one provider and one model. More segments than
+# that is not a namespace the bots can normalize, however the id begins.
+run "rejects_more_than_one_slash" {
+  command = plan
+
+  variables {
+    github_bot_default_model = "claude-haiku/4-5/beta"
+  }
+
+  expect_failures = [var.github_bot_default_model]
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -206,6 +206,28 @@ variable "github_bot_username" {
   default     = ""
 }
 
+variable "github_bot_default_model" {
+  description = "Model the GitHub bot starts a session with when the repository's integration config does not pin one. A canonical \"provider/model\" id, or a bare \"claude-\"/\"gpt-\" id the bots normalize into that provider's namespace."
+  type        = string
+  default     = "anthropic/claude-haiku-4-5"
+  nullable    = false
+
+  # Each side of the id must name something, and name it without whitespace:
+  # "anthropic/", "claude-" and "/x" all pass a naive prefix or slash check
+  # while naming no model, and "anthropic/ claude-haiku-4-5" survives a
+  # trimspace check with the space still in the value. Either shape reaches the
+  # model provider verbatim. The same rule rejects a blank value, so an unset
+  # CI variable fails at plan time instead of deploying a bot that cannot start
+  # a session.
+  validation {
+    condition = can(regex(
+      "^(?:[^/[:space:]]+/[^/[:space:]]+|(?:claude-|gpt-)[^/[:space:]]+)$",
+      var.github_bot_default_model
+    ))
+    error_message = "github_bot_default_model must be a canonical \"provider/model\" id such as \"anthropic/claude-haiku-4-5\", or a bare \"claude-\"/\"gpt-\" id, naming a model with no whitespace on each side of any slash."
+  }
+}
+
 # =============================================================================
 # Slack App Credentials
 # =============================================================================
@@ -233,6 +255,24 @@ variable "slack_signing_secret" {
   type        = string
   sensitive   = true
   default     = ""
+}
+
+variable "slack_bot_default_model" {
+  description = "Model the Slack bot starts a session with when the requesting user has no saved model preference. A canonical \"provider/model\" id, or a bare \"claude-\"/\"gpt-\" id the bots normalize into that provider's namespace."
+  type        = string
+  default     = "claude-haiku-4-5"
+  nullable    = false
+
+  # See github_bot_default_model: a prefix or slash with nothing after it names
+  # no model, whitespace anywhere in the id reaches the provider verbatim, and a
+  # blank value must fail at plan time rather than deploy.
+  validation {
+    condition = can(regex(
+      "^(?:[^/[:space:]]+/[^/[:space:]]+|(?:claude-|gpt-)[^/[:space:]]+)$",
+      var.slack_bot_default_model
+    ))
+    error_message = "slack_bot_default_model must be a canonical \"provider/model\" id such as \"anthropic/claude-haiku-4-5\", or a bare \"claude-\"/\"gpt-\" id, naming a model with no whitespace on each side of any slash."
+  }
 }
 
 # =============================================================================
@@ -279,6 +319,24 @@ variable "linear_api_key" {
   type        = string
   default     = ""
   sensitive   = true
+}
+
+variable "linear_bot_default_model" {
+  description = "Model the Linear bot starts a session with when neither the repository's integration config, the requesting user's preference, nor a model label selects one. A canonical \"provider/model\" id, or a bare \"claude-\"/\"gpt-\" id the bots normalize into that provider's namespace."
+  type        = string
+  default     = "claude-sonnet-4-6"
+  nullable    = false
+
+  # See github_bot_default_model: a prefix or slash with nothing after it names
+  # no model, whitespace anywhere in the id reaches the provider verbatim, and a
+  # blank value must fail at plan time rather than deploy.
+  validation {
+    condition = can(regex(
+      "^(?:[^/[:space:]]+/[^/[:space:]]+|(?:claude-|gpt-)[^/[:space:]]+)$",
+      var.linear_bot_default_model
+    ))
+    error_message = "linear_bot_default_model must be a canonical \"provider/model\" id such as \"anthropic/claude-haiku-4-5\", or a bare \"claude-\"/\"gpt-\" id, naming a model with no whitespace on each side of any slash."
+  }
 }
 
 # =============================================================================

--- a/terraform/environments/production/workers-github.tf
+++ b/terraform/environments/production/workers-github.tf
@@ -65,7 +65,7 @@ module "github_bot_worker" {
   plain_text_bindings = [
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
-    { name = "DEFAULT_MODEL", value = "anthropic/claude-haiku-4-5" },
+    { name = "DEFAULT_MODEL", value = var.github_bot_default_model },
     { name = "GITHUB_BOT_USERNAME", value = var.github_bot_username },
   ]
 

--- a/terraform/environments/production/workers-linear.tf
+++ b/terraform/environments/production/workers-linear.tf
@@ -46,7 +46,7 @@ module "linear_bot_worker" {
     { name = "WEB_APP_URL", value = local.web_app_url },
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
-    { name = "DEFAULT_MODEL", value = "claude-sonnet-4-6" },
+    { name = "DEFAULT_MODEL", value = var.linear_bot_default_model },
     { name = "CLASSIFICATION_MODEL", value = var.classification_model },
     { name = "LINEAR_CLIENT_ID", value = var.linear_client_id },
     { name = "WORKER_URL", value = "https://open-inspect-linear-bot-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev" },

--- a/terraform/environments/production/workers-slack.tf
+++ b/terraform/environments/production/workers-slack.tf
@@ -69,7 +69,7 @@ module "slack_bot_worker" {
     { name = "WEB_APP_URL", value = local.web_app_url },
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
     { name = "APP_NAME", value = var.app_name },
-    { name = "DEFAULT_MODEL", value = "claude-haiku-4-5" },
+    { name = "DEFAULT_MODEL", value = var.slack_bot_default_model },
     { name = "CLASSIFICATION_MODEL", value = var.classification_model },
   ]
 

--- a/terraform/modules/cloudflare-worker/outputs.tf
+++ b/terraform/modules/cloudflare-worker/outputs.tf
@@ -33,6 +33,11 @@ output "plain_text_binding_names" {
   value       = [for binding in var.plain_text_bindings : binding.name]
 }
 
+output "plain_text_bindings" {
+  description = "Configured plain-text bindings as a name => value map, so a configuration test can assert the value a binding actually carries."
+  value       = { for binding in var.plain_text_bindings : binding.name => binding.value }
+}
+
 output "secret_binding_names" {
   description = "Names of configured secret bindings; secret values are not exposed."
   value       = nonsensitive([for binding in var.secrets : binding.name])


### PR DESCRIPTION
## What this changes

Each bot worker receives a `DEFAULT_MODEL` plain-text binding, and today the value is a literal inside tracked Terraform:

- `workers-github.tf`: `"anthropic/claude-haiku-4-5"`
- `workers-slack.tf`: `"claude-haiku-4-5"`
- `workers-linear.tf`: `"claude-sonnet-4-6"`

So a deployment that wants its bots on a different model has no configuration path. It has to edit those three tracked `.tf` files and keep carrying the edit — every `git pull` is a potential conflict, and the choice is invisible to anyone reading `terraform.tfvars`. Every other deployment-shaped decision in this environment (`classification_model`, `app_name`, `sandbox_provider`, `enable_durable_object_bindings`) is already a variable.

This adds one variable per bot and binds it:

- `github_bot_default_model`, default `anthropic/claude-haiku-4-5`
- `slack_bot_default_model`, default `claude-haiku-4-5`
- `linear_bot_default_model`, default `claude-sonnet-4-6`

Each default is exactly the literal the binding already carried, so no existing deployment changes behaviour and nobody has to set anything. The three defaults deliberately stay different from one another — this is a refactor of where the value lives, not a decision to unify the bots' models.

One variable per bot rather than one shared variable, because the bots consume `DEFAULT_MODEL` at different decision points and a deployment can reasonably want them to differ: the GitHub bot falls back to it when a repository's integration config pins no model (`packages/github-bot/src/utils/integration-config.ts`), the Slack bot when the requesting user has no saved preference (`packages/slack-bot/src/user-preferences.ts`), and the Linear bot when neither repo config, user preference, nor a `model:` issue label selects one (`packages/linear-bot/src/model-resolution.ts`).

No bot TypeScript changes: the binding name and its meaning are unchanged.

## Validation

Modelled on the existing `classification_model` variable, including its "a prefix with nothing after it names no model" reasoning. Accepted shapes match what `normalizeModelId` in `packages/shared/src/models.ts` actually resolves — a canonical `provider/model` id, or a bare `claude-`/`gpt-` id that the bots normalize into `anthropic/`/`openai/`. A value with an empty side (`anthropic/`, `claude-`, `/x`) is rejected, as is a bare id with no recognized prefix (`haiku-4-5`).

That rule also rejects blank, which matters for CI: an unset Actions variable renders as an empty string, and treating that as "use the default" would silently deploy whichever model the configuration last shipped. It now fails at plan time instead.

Unlike `classification_model`, the accepted namespace is not restricted to Anthropic and OpenAI — `MODEL_CATALOG` also ships `xai/`, `opencode/`, `deepseek/` and `zai-coding-plan/` ids, and a `DEFAULT_MODEL` is a session model, not a classifier model with a provider-specific credential requirement.

## CI

`TF_VAR_github_bot_default_model`, `TF_VAR_slack_bot_default_model` and `TF_VAR_linear_bot_default_model` are threaded through both the `plan` and `apply` jobs of `.github/workflows/terraform.yml`, using the existing `${{ vars.X || secrets.X || 'default' }}` precedence with an explicit fallback so an unset variable does not render as a blank that fails validation. The GitHub one is named `GH_BOT_DEFAULT_MODEL` because Actions reserves the `GITHUB_` prefix, matching the existing `GH_BOT_USERNAME`.

## Upstream-structure adaptation

`terraform/modules/cloudflare-worker/outputs.tf` gains a `plain_text_bindings` `name => value` map output. The module previously exposed only `plain_text_binding_names`, which lets a test assert that a binding exists but not what it carries — so "the default still reaches `DEFAULT_MODEL`" was not assertable. The new output sits next to the existing name-list outputs and exposes nothing sensitive (plain-text bindings are non-secret by construction; `secrets` remains name-only).

## Gates run locally

In `terraform/environments/production`, Terraform v1.15.3:

- `terraform validate` — `Success! The configuration is valid.`
- `terraform fmt -check -recursive` on `terraform/environments/production` and `terraform/modules/cloudflare-worker` — clean, no reformatting of untouched files.
- `terraform test` — `Success! 42 passed, 0 failed.` (34 pre-existing + 8 new)

The new `tests/bot_default_model.tftest.hcl` enables all three bots and covers:

- `defaults_preserve_the_previously_hardcoded_models` — each bot's `DEFAULT_MODEL` binding still carries the exact literal it carried before this change.
- `overrides_reach_each_bot_binding` — an override of each variable reaches that bot's binding, and no bot's override leaks into another's.
- six validation cases — blank on each of the three variables, a bare provider namespace, a bare model prefix, and an unprefixed bare id.

Falsification check that the new test actually bites: repointing the Slack worker's binding at `var.linear_bot_default_model` fails three assertions across both plan runs (`6 passed, 2 failed`); reverted before commit.

PRs from a fork land as `action_required` here — upstream CI awaits maintainer approval — so the above are local runs rather than a green check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable default model settings for the GitHub, Slack, and Linear bots.
  * Supports provider/model identifiers and approved shorthand model IDs.
  * Existing default model selections remain unchanged unless overridden.

* **Documentation**
  * Added example configuration entries describing each bot’s default model setting.

* **Bug Fixes**
  * Invalid, blank, or incomplete model identifiers are now rejected during configuration validation.
  * Invalid whitespace and multi-provider model identifiers are also rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->