### PR TITLE
fix(control-plane): widen the sandbox connect watchdog and tie the spawn staleness bound to it

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -17,6 +17,7 @@ import {
   isSandboxReconnectBlockedStatus,
   isSnapshotRuntimeCompatible,
   DEFAULT_CONNECTING_TIMEOUT_CONFIG,
+  DEFAULT_SPAWN_CONFIG,
   DEFAULT_EXECUTION_TIMEOUT_MS,
   type CircuitBreakerState,
   type CircuitBreakerConfig,
@@ -911,6 +912,44 @@ describe("evaluateConnectingTimeout", () => {
       const result = evaluateConnectingTimeout(status, old, config, now);
       expect(result.isTimedOut).toBe(false);
     }
+  });
+});
+
+describe("connect watchdog and spawn staleness defaults", () => {
+  it("does not spawn a replacement while a sandbox is still inside the connect watchdog window", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "connecting",
+      createdAt: now - (DEFAULT_CONNECTING_TIMEOUT_CONFIG.timeoutMs - 1),
+      snapshotImageId: null,
+      snapshotRuntimeVersion: null,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, DEFAULT_SPAWN_CONFIG, now, false);
+
+    expect(decision.action).toBe("skip");
+  });
+
+  it("spawns a replacement once the connect watchdog has failed the sandbox", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "connecting",
+      createdAt: now - DEFAULT_CONNECTING_TIMEOUT_CONFIG.timeoutMs,
+      snapshotImageId: null,
+      snapshotRuntimeVersion: null,
+      hasActiveWebSocket: false,
+    };
+
+    expect(
+      evaluateConnectingTimeout(
+        "connecting",
+        state.createdAt,
+        DEFAULT_CONNECTING_TIMEOUT_CONFIG,
+        now
+      ).isTimedOut
+    ).toBe(true);
+    expect(evaluateSpawnDecision(state, DEFAULT_SPAWN_CONFIG, now, false).action).toBe("spawn");
   });
 });
 

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -855,22 +855,24 @@ describe("evaluateConnectingTimeout", () => {
 
   it("returns not timed out when within timeout window", () => {
     const now = Date.now();
-    const createdAt = now - 60_000; // 60s ago, well within 120s timeout
+    const elapsed = config.timeoutMs / 2; // comfortably inside the window
+    const createdAt = now - elapsed;
 
     const result = evaluateConnectingTimeout("connecting", createdAt, config, now);
 
     expect(result.isTimedOut).toBe(false);
-    expect(result.elapsedMs).toBe(60_000);
+    expect(result.elapsedMs).toBe(elapsed);
   });
 
   it("returns timed out when past timeout", () => {
     const now = Date.now();
-    const createdAt = now - 130_000; // 130s ago, past 120s timeout
+    const elapsed = config.timeoutMs + 10_000; // past the window
+    const createdAt = now - elapsed;
 
     const result = evaluateConnectingTimeout("connecting", createdAt, config, now);
 
     expect(result.isTimedOut).toBe(true);
-    expect(result.elapsedMs).toBe(130_000);
+    expect(result.elapsedMs).toBe(elapsed);
   });
 
   it("returns timed out at exact boundary (>=)", () => {
@@ -885,12 +887,13 @@ describe("evaluateConnectingTimeout", () => {
 
   it("returns timed out when stuck in spawning past timeout (interrupted spawn)", () => {
     const now = Date.now();
-    const createdAt = now - 130_000; // 130s ago, past 120s timeout
+    const elapsed = config.timeoutMs + 10_000; // past the window
+    const createdAt = now - elapsed;
 
     const result = evaluateConnectingTimeout("spawning", createdAt, config, now);
 
     expect(result.isTimedOut).toBe(true);
-    expect(result.elapsedMs).toBe(130_000);
+    expect(result.elapsedMs).toBe(elapsed);
   });
 
   it("returns not timed out for spawning within timeout window", () => {

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -170,7 +170,8 @@ export interface SpawnConfig {
   readyWaitMs: number;
   /**
    * Max time a sandbox may remain in "spawning"/"connecting" before it is
-   * treated as dead and a fresh spawn is allowed (default: 120s).
+   * treated as dead and a fresh spawn is allowed. Defaults to
+   * CONNECT_WATCHDOG_MS — see the note there on why the two must agree.
    *
    * Guards against spawns interrupted before the sandbox connects (provider
    * crash, redeploy, cancelled provider call). Such a spawn can leave the
@@ -182,12 +183,33 @@ export interface SpawnConfig {
 }
 
 /**
+ * How long a sandbox may sit in "spawning"/"connecting" before it is treated as dead.
+ *
+ * Single source of truth for two decisions that must agree: the initial-connect watchdog
+ * (DEFAULT_CONNECTING_TIMEOUT_CONFIG) that fails a sandbox, and the staleness bound
+ * (DEFAULT_SPAWN_CONFIG.spawningTimeoutMs) that lets a replacement spawn. If the staleness bound
+ * were the shorter of the two, a healthy sandbox still inside the watchdog window would be judged
+ * dead and a second sandbox spawned alongside it.
+ *
+ * The boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically takes
+ * 30–90 seconds, but large repos with real setup scripts land close to the previous two-minute
+ * limit. Overrunning it is not a soft failure: `clearSandboxAccessState` locks out the sandbox that
+ * does eventually come up, the queued prompt is never re-driven, and the documented recovery ("it
+ * will be retried on your next message") cannot fire for bot-triggered sessions, which only ever
+ * send one prompt. Sessions were being stranded by boots that overran by under five seconds.
+ *
+ * Widened to give slow boots real headroom. This is a mitigation, not the fix — see
+ * ColeMurray/background-agents#1363 for the underlying recovery gap.
+ */
+const CONNECT_WATCHDOG_MS = 240_000;
+
+/**
  * Default spawn configuration.
  */
 export const DEFAULT_SPAWN_CONFIG: SpawnConfig = {
   cooldownMs: 30000, // 30 seconds
   readyWaitMs: 60000, // 60 seconds
-  spawningTimeoutMs: 120000, // 2 minutes — matches the connecting-timeout watchdog
+  spawningTimeoutMs: CONNECT_WATCHDOG_MS,
 };
 
 /**
@@ -548,19 +570,10 @@ export interface ConnectingTimeoutConfig {
 
 /**
  * Default connecting timeout for the initial-connect watchdog.
- *
- * The boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically takes
- * 30–90 seconds, but large repos with real setup scripts land close to the previous two-minute
- * limit. Overrunning it is not a soft failure: `clearSandboxAccessState` locks out the sandbox that
- * does eventually come up, the queued prompt is never re-driven, and the documented recovery ("it
- * will be retried on your next message") cannot fire for bot-triggered sessions, which only ever
- * send one prompt. Sessions were being stranded by boots that overran by under five seconds.
- *
- * Widened to give slow boots real headroom. This is a mitigation, not the fix — see
- * ColeMurray/background-agents#1363 for the underlying recovery gap.
+ * Shares CONNECT_WATCHDOG_MS with DEFAULT_SPAWN_CONFIG.spawningTimeoutMs; see the rationale there.
  */
 export const DEFAULT_CONNECTING_TIMEOUT_CONFIG: ConnectingTimeoutConfig = {
-  timeoutMs: 240_000,
+  timeoutMs: CONNECT_WATCHDOG_MS,
 };
 
 /**

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -547,12 +547,20 @@ export interface ConnectingTimeoutConfig {
 }
 
 /**
- * Default connecting timeout: 2 minutes.
- * Boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically
- * takes 30–90 seconds. Two minutes provides margin without leaving users waiting too long.
+ * Default connecting timeout for the initial-connect watchdog.
+ *
+ * The boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically takes
+ * 30–90 seconds, but large repos with real setup scripts land close to the previous two-minute
+ * limit. Overrunning it is not a soft failure: `clearSandboxAccessState` locks out the sandbox that
+ * does eventually come up, the queued prompt is never re-driven, and the documented recovery ("it
+ * will be retried on your next message") cannot fire for bot-triggered sessions, which only ever
+ * send one prompt. Sessions were being stranded by boots that overran by under five seconds.
+ *
+ * Widened to give slow boots real headroom. This is a mitigation, not the fix — see
+ * ColeMurray/background-agents#1363 for the underlying recovery gap.
  */
 export const DEFAULT_CONNECTING_TIMEOUT_CONFIG: ConnectingTimeoutConfig = {
-  timeoutMs: 120_000,
+  timeoutMs: 240_000,
 };
 
 /**

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -186,20 +186,22 @@ export interface SpawnConfig {
  * How long a sandbox may sit in "spawning"/"connecting" before it is treated as dead.
  *
  * Single source of truth for two decisions that must agree: the initial-connect watchdog
- * (DEFAULT_CONNECTING_TIMEOUT_CONFIG) that fails a sandbox, and the staleness bound
- * (DEFAULT_SPAWN_CONFIG.spawningTimeoutMs) that lets a replacement spawn. If the staleness bound
- * were the shorter of the two, a healthy sandbox still inside the watchdog window would be judged
- * dead and a second sandbox spawned alongside it.
+ * (DEFAULT_CONNECTING_TIMEOUT_CONFIG) that fails the sandbox, and the staleness bound
+ * (DEFAULT_SPAWN_CONFIG.spawningTimeoutMs) that lets a replacement spawn. Stating the bound
+ * independently is what let them drift: whenever the staleness bound is the shorter of the two, a
+ * healthy sandbox still inside the watchdog window is judged dead and a second sandbox is spawned
+ * alongside it.
  *
  * The boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically takes
- * 30–90 seconds, but large repos with real setup scripts land close to the previous two-minute
- * limit. Overrunning it is not a soft failure: `clearSandboxAccessState` locks out the sandbox that
- * does eventually come up, the queued prompt is never re-driven, and the documented recovery ("it
- * will be retried on your next message") cannot fire for bot-triggered sessions, which only ever
- * send one prompt. Sessions were being stranded by boots that overran by under five seconds.
+ * 30–90 seconds, but large repos with real setup scripts run far longer, and overrunning the
+ * watchdog is not a soft failure: `clearSandboxAccessState` locks out the sandbox that does
+ * eventually come up, the queued prompt is never re-driven, and the documented recovery ("it will
+ * be retried on your next message") cannot fire for bot-triggered sessions, which only ever send
+ * one prompt. Boots that overran by a few seconds were stranding their sessions permanently, so
+ * the bound sits well clear of the observed boot spread rather than at its edge.
  *
- * Widened to give slow boots real headroom. This is a mitigation, not the fix — see
- * ColeMurray/background-agents#1363 for the underlying recovery gap.
+ * Widening it is a mitigation, not the fix — see ColeMurray/background-agents#1363 for the
+ * underlying recovery gap.
  */
 const CONNECT_WATCHDOG_MS = 240_000;
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -2309,7 +2309,7 @@ describe("SandboxLifecycleManager", () => {
       const now = Date.now();
       const sandbox = createMockSandbox({
         status: "connecting" as SandboxStatus,
-        created_at: now - 130_000, // 130s ago, past 120s timeout
+        created_at: now - (DEFAULT_LIFECYCLE_CONFIG.connectingTimeout.timeoutMs + 10_000),
         last_heartbeat: null,
       });
       const storage = createMockStorage(createMockSession(), sandbox);

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -2349,7 +2349,7 @@ describe("SandboxLifecycleManager", () => {
       const now = Date.now();
       const sandbox = createMockSandbox({
         status: "connecting" as SandboxStatus,
-        created_at: now - 30_000, // 30s ago, well within 120s timeout
+        created_at: now - DEFAULT_LIFECYCLE_CONFIG.connectingTimeout.timeoutMs / 2,
         last_heartbeat: null,
       });
       const storage = createMockStorage(createMockSession(), sandbox);


### PR DESCRIPTION
Two related reliability defects in sandbox spawn/connect handling.

## 1. The initial-connect watchdog was too tight

`DEFAULT_CONNECTING_TIMEOUT_CONFIG.timeoutMs` gave a sandbox two minutes to report connected. The boot sequence (git clone, setup.sh, start.sh, opencode, bridge connect) is 30-90 seconds for a small repo, but a large repo with a real setup script lands right at that limit.

Overrunning it is not a soft failure. `handleAlarm` marks the sandbox failed and calls `clearSandboxAccessState`, which locks out the sandbox that does eventually come up; the queued prompt is never re-driven; and the documented recovery ("it will be retried on your next message") cannot fire for bot-triggered sessions, which only ever send one prompt. So a boot that overran by a few seconds stranded its session permanently and lost the review with no signal on the PR.

This widens the bound to four minutes so slow-but-healthy boots have real headroom. It is a mitigation of the symptom, not a fix for the underlying recovery gap, which is #1363 - a session that trips the watchdog should be recoverable rather than terminal, and that is a bigger change than this.

## 2. The staleness bound and the watchdog could disagree

`DEFAULT_SPAWN_CONFIG.spawningTimeoutMs` decides when a sandbox sitting in `spawning`/`connecting` is stale enough that `evaluateSpawnDecision` stops skipping and lets a replacement spawn. Its comment said it matched the connecting-timeout watchdog, but the value was restated independently as a second literal.

That made the two silently separable, and widening the watchdog in (1) alone would have opened a two-minute window in which a healthy sandbox still inside the watchdog window is judged dead and a second sandbox is spawned alongside it - a duplicate provider sandbox per slow boot.

Both now derive from a single `CONNECT_WATCHDOG_MS`, so the invariant holds by construction rather than by comment, and the rationale for the value lives in one place.

## Why this is generally useful

Neither part is deployment-specific: no new configuration, no new environment variable, no provider-specific behavior. The first is a defaults change that only affects how much slack a slow boot gets before it is declared dead; the second removes a duplicated constant whose two copies had already drifted in meaning, which is the kind of coupling that reappears the next time either number is touched.

## Tests

`evaluateConnectingTimeout` tests that hardcoded offsets against the old two-minute value now derive them from `config.timeoutMs`, and the same in `manager.test.ts`, so they assert the behavior rather than the constant. Two new tests in `decisions.test.ts` (`connect watchdog and spawn staleness defaults`) exercise the shipped defaults together: a sandbox one millisecond inside the watchdog window must not get a replacement spawn, and once the watchdog has failed it, it must. Falsified by reintroducing the old independent literal `spawningTimeoutMs: 120_000`, which fails the first of the two (`expected 'spawn' to be 'skip'`); restored, both pass.

## Gates run locally

Run in a clean worktree off `main` at `265a5997`:

- `npm run build -w @open-inspect/shared` - exit 0
- `npm run typecheck -w @open-inspect/control-plane` (all four TS projects: default, `tsconfig.node.json`, `tsconfig.test.json`, `test/integration`) - exit 0
- `npm test -w @open-inspect/control-plane` - 275 test files passed, 4011 tests passed, exit 0
- `npm run test:integration -w @open-inspect/control-plane` - 102 test files passed, 1186 tests passed, 1 skipped, exit 0

No other package is touched, so package-scoped gates only.

## Adaptation to current main

The change was originally written against an older revision of this file. One test it edited, `calls onSandboxTerminating callback on connecting timeout` in `manager.test.ts`, no longer exists on `main` - that area is now the `terminateUnresponsiveSandbox` describe block - so only the surviving `detects connecting timeout and sets failed` case needed the derived offset. Nothing upstream was reverted and no upstream test or assertion was removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the sandbox connection and startup watchdog window to four minutes.
  * Sandboxes still within the connection window are now skipped, while replacements are spawned after the watchdog expires.
  * Updated timeout handling to use the configured watchdog duration consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->