### PR TITLE
perf: reuse installed MCP packages during sandbox startup

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -301,6 +301,36 @@ from a prebuild-enabled environment, the environment's whole repository set):
 
 If `start.sh` exists and fails, startup fails fast instead of continuing with a broken runtime.
 
+#### Preinstalling local MCP dependencies
+
+OpenInspect checks the global npm installation before preparing local `npx` MCP servers. An exact
+package version already installed with intact executable links is reused, including after a snapshot
+restore. Only missing or mismatched packages are installed. Failed or interrupted installs are
+marked for retry rather than treated as cache hits.
+
+To remove the installation from first-session startup, pin the same package version in the MCP
+command and the repository's `.openinspect/setup.sh` (or the setup hook used by its environment):
+
+```bash
+# .openinspect/setup.sh — replace this example package/version with your MCP dependency
+npm install --global @example/mcp-server@1.2.3
+```
+
+Configure the matching MCP command as `["npx", "-y", "@example/mcp-server@1.2.3"]` and rebuild the
+prebuilt image. This uses the existing setup/prebuild lifecycle; MCP settings are not automatically
+baked into images. Changing a pinned version causes an install until the image is rebuilt with it.
+
+Unversioned packages and tags such as `latest` are refreshed once per sandbox boot. Successful
+installs are reused across OpenCode process restarts within that boot, but not across snapshot
+restores. Remote MCP servers are unaffected, and server commands, arguments, and credentials are
+passed through unchanged. Unsupported `npx` option forms are left to `npx` without eager
+installation.
+
+The `mcp.package_cache` event reports hit/miss counts and lookup time; `mcp.packages_installed`
+reports preparation time on misses. This optimization removes redundant **global installation**, not
+all MCP startup work: `npx` may still resolve registry metadata or populate its own execution cache,
+particularly with explicit `--package` commands.
+
 ### When Snapshots Are Taken
 
 - **After successful prompt completion**: Preserves the workspace state

--- a/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
@@ -114,10 +114,10 @@ class McpPackageInstaller:
             version = manifest.get("version")
             if not isinstance(version, str) or not _EXACT_VERSION_RE.fullmatch(version):
                 return None
-            bins = manifest.get("bin", {})
+            bins = manifest.get("bin")
             if isinstance(bins, str):
                 bins = {name.rsplit("/", 1)[-1]: bins}
-            if not isinstance(bins, dict):
+            if not isinstance(bins, dict) or not bins:
                 return None
             # npm's Unix global layout is {prefix}/lib/node_modules and {prefix}/bin.
             for binary, relative_path in bins.items():

--- a/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
@@ -1,0 +1,235 @@
+"""Reuse installed MCP dependencies without freezing floating npm versions across boots."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import time
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .process_output import communicate_owned_subprocess
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+NPM_PACKAGE_RE = re.compile(r"(?P<name>(?:@[\w.-]+/)?[\w][\w.-]*)(?:@(?P<version>[\w.+-]+))?$")
+_EXACT_VERSION_RE = re.compile(r"\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$")
+MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS = 180
+_NPM_ROOT_TIMEOUT_SECONDS = 5
+_INCOMPLETE_INSTALL_FILE = ".openinspect-mcp-installing.json"
+
+
+def _write_incomplete(marker: Path, names: set[str]) -> None:
+    # Publish before starting npm without truncating an earlier failed-install record.
+    temporary = marker.with_suffix(".tmp")
+    temporary.write_text(json.dumps(sorted(names)))
+    temporary.replace(marker)
+
+
+def _packages(servers: list[Mapping[str, Any]]) -> list[str]:
+    """Recognize simple npx commands; leave other npm options to npx itself.
+
+    Stop at the executable: its arguments (including -p) are not npx options.
+    """
+    packages: list[str] = []
+    for server in servers:
+        command = server.get("command") or ()
+        if server.get("type") == "remote" or not command or command[0] != "npx":
+            continue
+        selected: list[str] = []
+        index = 1
+        while index < len(command):
+            part = command[index]
+            if not isinstance(part, str):
+                selected = []
+                break
+            if part in ("-y", "--yes"):
+                index += 1
+                continue
+            if part in ("-p", "--package") and index + 1 < len(command):
+                selected.append(command[index + 1])
+                index += 2
+                continue
+            if part.startswith("--package="):
+                selected.append(part.removeprefix("--package="))
+                index += 1
+                continue
+            if part == "--" and index + 1 < len(command):
+                part = command[index + 1]
+            elif part.startswith("-"):
+                selected = []
+                break
+            if not selected:
+                selected.append(part)
+            break
+        packages.extend(
+            package
+            for package in selected
+            if isinstance(package, str) and NPM_PACKAGE_RE.fullmatch(package)
+        )
+    return list(dict.fromkeys(packages))
+
+
+class McpPackageInstaller:
+    def __init__(self, log: Any) -> None:
+        self.log = log
+        self._root: Path | None = None
+        # Only this supervisor lifetime: a restored sandbox refreshes floating specs.
+        self._resolved_this_boot: dict[str, str] = {}
+
+    async def _global_root(self) -> Path | None:
+        if self._root is not None:
+            return self._root
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "npm",
+                "root",
+                "--global",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            stdout, _ = await asyncio.wait_for(
+                communicate_owned_subprocess(process), timeout=_NPM_ROOT_TIMEOUT_SECONDS
+            )
+            path = stdout.decode().strip()
+            if process.returncode == 0 and "\n" not in path and Path(path).is_absolute():
+                self._root = Path(path)
+        except (OSError, ValueError, TimeoutError) as error:
+            self.log.warn("mcp.cache_lookup_failed", error=str(error))
+        return self._root
+
+    def _installed_version(self, name: str) -> str | None:
+        if self._root is None:
+            return None
+        package_dir = self._root / name
+        try:
+            manifest = json.loads((package_dir / "package.json").read_text())
+            if not isinstance(manifest, dict) or manifest.get("name") != name:
+                return None
+            version = manifest.get("version")
+            if not isinstance(version, str) or not _EXACT_VERSION_RE.fullmatch(version):
+                return None
+            bins = manifest.get("bin", {})
+            if isinstance(bins, str):
+                bins = {name.rsplit("/", 1)[-1]: bins}
+            if not isinstance(bins, dict):
+                return None
+            # npm's Unix global layout is {prefix}/lib/node_modules and {prefix}/bin.
+            for binary, relative_path in bins.items():
+                if not isinstance(binary, str) or not isinstance(relative_path, str):
+                    return None
+                target = package_dir / relative_path
+                link = self._root.parent.parent / "bin" / binary
+                if not os.access(target, os.X_OK) or not link.samefile(target):
+                    return None
+            return version
+        except (OSError, ValueError):
+            return None
+
+    async def install(self, servers: list[Mapping[str, Any]]) -> None:
+        packages = _packages(servers)
+        if not packages:
+            return
+        started_at = time.monotonic()
+        root = await self._global_root()
+        marker = root / _INCOMPLETE_INSTALL_FILE if root else None
+        specs = {
+            package: (match["name"], match["version"] or "")
+            for package in packages
+            if (match := NPM_PACKAGE_RE.fullmatch(package))
+        }
+        incomplete: set[str] = set()
+        if marker is not None:
+            try:
+                pending = json.loads(marker.read_text())
+                if not isinstance(pending, list) or not all(isinstance(p, str) for p in pending):
+                    raise ValueError("invalid incomplete-install marker")
+                incomplete.update(pending)
+            except FileNotFoundError:
+                pass
+            except (OSError, ValueError):
+                # A damaged marker cannot certify any existing installation.
+                incomplete.update(name for name, _ in specs.values())
+        counts = Counter(name for name, _ in specs.values())
+        missing: list[str] = []
+        for package, (name, requested) in specs.items():
+            expected = (
+                requested
+                if _EXACT_VERSION_RE.fullmatch(requested)
+                else self._resolved_this_boot.get(package)
+            )
+            if (
+                name in incomplete
+                or counts[name] > 1
+                or not expected
+                or self._installed_version(name) != expected
+            ):
+                missing.append(package)
+
+        self.log.info(
+            "mcp.package_cache",
+            hits=len(packages) - len(missing),
+            misses=len(missing),
+            duration_ms=round((time.monotonic() - started_at) * 1000),
+        )
+        if not missing:
+            return
+        for package in missing:
+            self._resolved_this_boot.pop(package, None)
+        if marker is not None:
+            try:
+                marker.parent.mkdir(parents=True, exist_ok=True)
+                # Persist before npm runs: a killed/failed install must be retried after restore.
+                _write_incomplete(marker, incomplete | {specs[p][0] for p in missing})
+            except OSError as error:
+                self.log.warn("mcp.cache_marker_failed", error=str(error))
+                marker = None
+        try:
+            self.log.info("mcp.install_packages", packages=missing)
+            process = await asyncio.create_subprocess_exec(
+                "npm",
+                "install",
+                "-g",
+                *missing,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            _, stderr = await asyncio.wait_for(
+                communicate_owned_subprocess(process), timeout=MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS
+            )
+            if process.returncode != 0:
+                self.log.warn(
+                    "mcp.packages_install_failed",
+                    packages=missing,
+                    stderr=stderr.decode(errors="replace")[:500],
+                )
+                return
+            for package in missing:
+                version = self._installed_version(specs[package][0])
+                if version:
+                    self._resolved_this_boot[package] = version
+            if marker is not None:
+                remaining = incomplete - {specs[p][0] for p in missing}
+                if remaining:
+                    _write_incomplete(marker, remaining)
+                else:
+                    marker.unlink(missing_ok=True)
+            self.log.info(
+                "mcp.packages_installed",
+                packages=missing,
+                duration_ms=round((time.monotonic() - started_at) * 1000),
+            )
+        except TimeoutError:
+            self.log.warn(
+                "mcp.packages_install_timeout",
+                packages=missing,
+                timeout_seconds=MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS,
+            )
+        except Exception as error:
+            self.log.warn("mcp.packages_install_error", packages=missing, exc=str(error))

--- a/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/mcp_packages.py
@@ -132,6 +132,21 @@ class McpPackageInstaller:
             return None
 
     async def install(self, servers: list[Mapping[str, Any]]) -> None:
+        """Best-effort preinstall packages from supported local npx server commands.
+
+        Reuse exact version pins only when the installed manifest and executable
+        links validate. Floating specs (including unversioned packages) must be
+        installed once per installer lifetime before they can be reused, so a
+        new supervisor refreshes them even when restoring a sandbox snapshot.
+
+        Install only cache misses, recording their package names on disk before
+        invoking npm. Failed or interrupted installs leave that marker behind
+        so a later call retries them instead of trusting partial installations.
+
+        Installation errors are logged and do not abort server startup; npx
+        remains responsible for launching the server. Cancellation propagates
+        after the owned npm process is cleaned up.
+        """
         packages = _packages(servers)
         if not packages:
             return
@@ -155,6 +170,8 @@ class McpPackageInstaller:
             except (OSError, ValueError):
                 # A damaged marker cannot certify any existing installation.
                 incomplete.update(name for name, _ in specs.values())
+        # Keep conflicting specs in request order: filtering one out could change
+        # which version wins when npm installs several specs for the same name.
         counts = Counter(name for name, _ in specs.values())
         missing: list[str] = []
         for package, (name, requested) in specs.items():
@@ -179,6 +196,8 @@ class McpPackageInstaller:
         )
         if not missing:
             return
+        # Forget prior floating resolutions before retrying: failed npm work may
+        # mutate the installed package even if it exits unsuccessfully.
         for package in missing:
             self._resolved_this_boot.pop(package, None)
         if marker is not None:
@@ -210,6 +229,7 @@ class McpPackageInstaller:
                     stderr=stderr.decode(errors="replace")[:500],
                 )
                 return
+            # Remember only validated results for reuse within this supervisor.
             for package in missing:
                 version = self._installed_version(specs[package][0])
                 if version:

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
@@ -5,7 +5,6 @@ import contextlib
 import filecmp
 import json
 import os
-import re
 import shutil
 import time
 from pathlib import Path
@@ -19,6 +18,7 @@ from .constants import (
     OPENCODE_PORT,
 )
 from .git_excludes import install_runtime_git_excludes
+from .mcp_packages import McpPackageInstaller
 from .process_output import iter_process_lines
 
 if TYPE_CHECKING:
@@ -44,8 +44,6 @@ def resolve_opencode_global_config_dir() -> Path:
 
 class OpenCodeServer:
     HEALTH_CHECK_TIMEOUT = 30.0
-    MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS = 180
-    _NPM_PKG_RE = re.compile(r"^(@[\w.-]+/)?[\w][\w.-]*(@[\w.-]+)?$")
 
     def __init__(
         self,
@@ -62,6 +60,7 @@ class OpenCodeServer:
         self.provider = config.provider
         self.model = config.model
         self.mcp_servers = config.mcp_servers
+        self._mcp_packages = McpPackageInstaller(log)
         self._opencode_process: asyncio.subprocess.Process | None = None
 
     def _assemble_workspace_opencode(self, repositories: Sequence[RepoEntry]) -> None:
@@ -387,72 +386,7 @@ class OpenCodeServer:
         return list(self.mcp_servers)
 
     async def _install_mcp_packages(self, servers: list[Mapping[str, Any]]) -> None:
-        """Pre-install npm packages for local MCP servers that use npx."""
-        packages: list[str] = []
-        for server in servers:
-            if server.get("type") == "remote":
-                continue
-            cmd = server.get("command", [])
-            if not cmd:
-                continue
-            parts = [c for c in cmd if isinstance(c, str)]
-            if not parts or parts[0] != "npx":
-                continue
-            # Extract package name: prefer -p/--package flag, else first non-flag arg
-            pkg: str | None = None
-            for i, part in enumerate(parts):
-                if part in ("-p", "--package") and i + 1 < len(parts):
-                    pkg = parts[i + 1]
-                    break
-            if pkg is None:
-                non_flags = [p for p in parts[1:] if not p.startswith("-")]
-                pkg = non_flags[0] if non_flags else None
-
-            if pkg:
-                if self._NPM_PKG_RE.match(pkg):
-                    packages.append(pkg)
-                else:
-                    self.log.warn(
-                        "mcp.invalid_package_name",
-                        package=pkg,
-                        note="package skipped — npx will attempt download at runtime",
-                    )
-
-        packages = list(dict.fromkeys(packages))  # deduplicate, preserve order
-        if not packages:
-            return
-
-        self.log.info("mcp.install_packages", packages=packages)
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "npm",
-                "install",
-                "-g",
-                *packages,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            _stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS
-            )
-            if proc.returncode == 0:
-                self.log.info("mcp.packages_installed", packages=packages)
-            else:
-                self.log.warn(
-                    "mcp.packages_install_failed",
-                    packages=packages,
-                    stderr=(stderr or b"").decode()[:500],
-                )
-        except TimeoutError:
-            self.log.warn(
-                "mcp.packages_install_timeout",
-                packages=packages,
-                timeout_seconds=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS,
-            )
-            proc.kill()
-            await proc.wait()
-        except Exception as e:
-            self.log.warn("mcp.packages_install_error", packages=packages, exc=str(e))
+        await self._mcp_packages.install(servers)
 
     def _build_mcp_config(self, servers: list[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
         """Convert MCP server list to OpenCode mcp config format."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "v62-gpt6-astra",
-  "generation": 62,
+  "runtimeVersion": "v63-mcp-package-cache",
+  "generation": 63,
   "minimumCompatibleGeneration": 62,
-  "minimumRebuildGeneration": 62
+  "minimumRebuildGeneration": 63
 }

--- a/packages/sandbox-runtime/tests/test_mcp.py
+++ b/packages/sandbox-runtime/tests/test_mcp.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from sandbox_runtime.mcp_packages import NPM_PACKAGE_RE, McpPackageInstaller
 from tests.runtime_helpers import make_opencode_server
 
 
@@ -49,6 +50,14 @@ class TestResolveMcpServers:
 
 
 class TestInstallMcpPackages:
+    @pytest.fixture(autouse=True)
+    def global_root(self, tmp_path, monkeypatch):
+        async def resolve_root(installer):
+            installer._root = tmp_path
+            return tmp_path
+
+        monkeypatch.setattr(McpPackageInstaller, "_global_root", resolve_root)
+
     def _mock_proc(self, returncode=0):
         """Create a mock async subprocess with the given return code."""
         proc = AsyncMock()
@@ -209,8 +218,7 @@ class TestNpmPackageRegex:
 
     @pytest.fixture
     def regex(self):
-        sup = _make_supervisor()
-        return sup._NPM_PKG_RE
+        return NPM_PACKAGE_RE
 
     @pytest.mark.parametrize(
         "pkg",

--- a/packages/sandbox-runtime/tests/test_mcp_package_cache.py
+++ b/packages/sandbox-runtime/tests/test_mcp_package_cache.py
@@ -49,12 +49,35 @@ def process(returncode=0):
     return result
 
 
-async def test_prebuilt_pinned_package_needs_no_npm_process(installer):
-    installed(installer._root)
+@pytest.mark.parametrize("bins", [{"mcp": "cli.js"}, "cli.js"])
+async def test_prebuilt_pinned_package_needs_no_npm_process(installer, bins):
+    package = installed(installer._root)
+    manifest_path = package / "package.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["bin"] = bins
+    manifest_path.write_text(json.dumps(manifest))
     with patch("asyncio.create_subprocess_exec") as spawn:
         await installer.install(servers("@scope/mcp@1.2.3"))
     spawn.assert_not_called()
     assert not (installer._root / ".openinspect-mcp-installing.json").exists()
+
+
+@pytest.mark.parametrize("missing_bin", [True, False], ids=["missing-bin", "empty-bin"])
+async def test_missing_executable_metadata_is_reinstalled(installer, missing_bin):
+    package = installed(installer._root)
+    manifest_path = package / "package.json"
+    manifest = json.loads(manifest_path.read_text())
+    if missing_bin:
+        del manifest["bin"]
+    else:
+        manifest["bin"] = {}
+    manifest_path.write_text(json.dumps(manifest))
+
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3"))
+
+    spawn.assert_called_once()
+    assert spawn.call_args.args == ("npm", "install", "-g", "@scope/mcp@1.2.3")
 
 
 @pytest.mark.parametrize("damage", ["version", "manifest", "binary", "link", "executable"])

--- a/packages/sandbox-runtime/tests/test_mcp_package_cache.py
+++ b/packages/sandbox-runtime/tests/test_mcp_package_cache.py
@@ -1,0 +1,220 @@
+"""Behavioral checks for prebuilt, restored, restarted, and incomplete MCP installs."""
+
+import asyncio
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandbox_runtime.mcp_packages import McpPackageInstaller, _packages
+
+
+def servers(*packages):
+    return [{"type": "local", "command": ["npx", "-y", package]} for package in packages]
+
+
+def installed(root, name="@scope/mcp", version="1.2.3"):
+    package = root / name
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "package.json").write_text(
+        json.dumps({"name": name, "version": version, "bin": {"mcp": "cli.js"}})
+    )
+    cli = package / "cli.js"
+    cli.write_text("#!/usr/bin/env node\nconsole.log('ready');\n")
+    cli.chmod(0o755)
+    binary = root.parent.parent / "bin" / "mcp"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    binary.unlink(missing_ok=True)
+    binary.symlink_to(cli)
+    return package
+
+
+@pytest.fixture
+def installer(tmp_path):
+    result = McpPackageInstaller(MagicMock())
+    result._root = tmp_path / "prefix/lib/node_modules"
+    result._root.mkdir(parents=True)
+    return result
+
+
+def process(returncode=0):
+    result = MagicMock()
+    result.returncode = returncode
+    result.communicate = AsyncMock(return_value=(b"", b""))
+    result.wait = AsyncMock()
+    return result
+
+
+async def test_prebuilt_pinned_package_needs_no_npm_process(installer):
+    installed(installer._root)
+    with patch("asyncio.create_subprocess_exec") as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3"))
+    spawn.assert_not_called()
+    assert not (installer._root / ".openinspect-mcp-installing.json").exists()
+
+
+@pytest.mark.parametrize("damage", ["version", "manifest", "binary", "link", "executable"])
+async def test_missing_or_changed_package_is_reinstalled(installer, damage):
+    package = installed(installer._root)
+    if damage == "version":
+        installed(installer._root, version="1.2.2")
+    elif damage == "manifest":
+        (package / "package.json").write_text("not json")
+    elif damage == "binary":
+        (package / "cli.js").unlink()
+    elif damage == "link":
+        (installer._root.parent.parent / "bin/mcp").unlink()
+    else:
+        (package / "cli.js").chmod(0o644)
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3"))
+    assert spawn.call_args.args == ("npm", "install", "-g", "@scope/mcp@1.2.3")
+
+
+async def test_installs_only_misses_in_mixed_configuration(installer):
+    installed(installer._root)
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3", "another@2.0.0"))
+    assert spawn.call_args.args == ("npm", "install", "-g", "another@2.0.0")
+
+
+@pytest.mark.parametrize("spec", ["@scope/mcp", "@scope/mcp@latest", "@scope/mcp@next"])
+async def test_floating_versions_reuse_only_successful_installs_in_this_boot(installer, spec):
+    installed(installer._root)
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers(spec))
+        await installer.install(servers(spec))
+        assert spawn.call_count == 1
+        restored = McpPackageInstaller(MagicMock())
+        restored._root = installer._root
+        await restored.install(servers(spec))
+        assert spawn.call_count == 2
+
+
+async def test_restart_rechecks_installed_version_for_floating_spec(installer):
+    installed(installer._root)
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp"))
+        installed(installer._root, version="9.0.0")
+        await installer.install(servers("@scope/mcp"))
+    assert spawn.call_count == 2
+
+
+async def test_conflicting_versions_are_not_reordered_by_cache_hits(installer):
+    installed(installer._root)
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.2", "@scope/mcp@1.2.3"))
+    assert spawn.call_args.args == ("npm", "install", "-g", "@scope/mcp@1.2.2", "@scope/mcp@1.2.3")
+
+
+async def test_failed_install_is_not_cached_after_supervisor_recreation(installer):
+    async def incomplete_install(*_args, **_kwargs):
+        installed(installer._root)
+        return process(returncode=1)
+
+    with patch("asyncio.create_subprocess_exec", side_effect=incomplete_install):
+        await installer.install(servers("@scope/mcp@1.2.3"))
+    marker = installer._root / ".openinspect-mcp-installing.json"
+    assert json.loads(marker.read_text()) == ["@scope/mcp"]
+    restored = McpPackageInstaller(MagicMock())
+    restored._root = installer._root
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await restored.install(servers("@scope/mcp@1.2.3"))
+        await restored.install(servers("@scope/mcp@1.2.3"))
+    assert spawn.call_count == 1
+    assert not marker.exists()
+
+
+async def test_corrupt_marker_requires_install(installer):
+    installed(installer._root)
+    (installer._root / ".openinspect-mcp-installing.json").write_text("[")
+    with patch("asyncio.create_subprocess_exec", return_value=process()) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3"))
+    assert spawn.call_count == 1
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_interrupted_installs_reap_process_and_remain_uncached(
+    installer, monkeypatch, cancel
+):
+    monkeypatch.setattr("sandbox_runtime.mcp_packages.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS", 0.01)
+    child = process(returncode=None)
+    child.pid = None
+    started = asyncio.Event()
+
+    async def hang():
+        installed(installer._root)
+        started.set()
+        await asyncio.Event().wait()
+
+    child.communicate.side_effect = hang
+    with patch("asyncio.create_subprocess_exec", return_value=child):
+        task = asyncio.create_task(installer.install(servers("@scope/mcp@1.2.3")))
+        await started.wait()
+        if cancel:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            await task
+    child.kill.assert_called_once()
+    child.wait.assert_awaited_once()
+    assert (installer._root / ".openinspect-mcp-installing.json").exists()
+
+
+async def test_root_lookup_failure_falls_back_to_install():
+    installer = McpPackageInstaller(MagicMock())
+    with patch("asyncio.create_subprocess_exec", side_effect=[process(1), process()]) as spawn:
+        await installer.install(servers("@scope/mcp@1.2.3"))
+    assert spawn.call_count == 2
+    assert spawn.call_args.args == ("npm", "install", "-g", "@scope/mcp@1.2.3")
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (["npx", "-y", "@scope/mcp@1.2.3", "-p", "server-option"], ["@scope/mcp@1.2.3"]),
+        (["npx", "-p", "one@1.0.0", "--package=two@2.0.0", "binary"], ["one@1.0.0", "two@2.0.0"]),
+        (["npx", "--registry", "https://registry.example", "pkg"], []),
+        (["npx", "--", "pkg@1.2.3+build.1"], ["pkg@1.2.3+build.1"]),
+        (["npx", "pkg\n"], []),
+        (["npx", "-p"], []),
+    ],
+)
+def test_package_options_do_not_consume_server_arguments(command, expected):
+    assert _packages([{"type": "local", "command": command}]) == expected
+
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm required for offline integration")
+async def test_real_npm_prebuild_install_is_reused_without_registry(tmp_path, monkeypatch):
+    """Real npm layout and binaries, an offline tarball, no host global writes."""
+    archive = tmp_path / "fixture.tgz"
+    manifest = {"name": "oi-mcp-cache-fixture", "version": "1.0.0", "bin": {"oi-cache": "cli.js"}}
+    with tarfile.open(archive, "w:gz") as tar:
+        for filename, body, mode in [
+            ("package.json", json.dumps(manifest), 0o644),
+            ("cli.js", "#!/usr/bin/env node\nconsole.log('ready');\n", 0o755),
+        ]:
+            data = body.encode()
+            info = tarfile.TarInfo(f"package/{filename}")
+            info.size, info.mode = len(data), mode
+            tar.addfile(info, io.BytesIO(data))
+    prefix = tmp_path / "prefix"
+    monkeypatch.setenv("NPM_CONFIG_PREFIX", str(prefix))
+    monkeypatch.setenv("NPM_CONFIG_CACHE", str(tmp_path / "npm-cache"))
+    monkeypatch.setenv("NPM_CONFIG_OFFLINE", "true")
+    subprocess.run(
+        ["npm", "install", "-g", "--ignore-scripts", "--no-audit", "--no-fund", str(archive)],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    assert subprocess.check_output([str(prefix / "bin/oi-cache")], text=True).strip() == "ready"
+    with patch("asyncio.create_subprocess_exec", wraps=asyncio.create_subprocess_exec) as spawn:
+        for _ in range(2):
+            await McpPackageInstaller(MagicMock()).install(servers("oi-mcp-cache-fixture@1.0.0"))
+    assert [call.args for call in spawn.call_args_list] == [("npm", "root", "--global")] * 2


### PR DESCRIPTION
## Summary

Reduce redundant global npm installation on the sandbox's MCP startup path.

- Reuse exact pinned versions already installed globally, checking package metadata and executable links. This covers packages baked by existing setup/prebuild hooks and retained in filesystem snapshots.
- Install only cache misses. Reuse successful floating-version installs during OpenCode process restarts, but refresh unversioned packages and tags on each new sandbox boot.
- Persist an incomplete-install marker before invoking npm; failed, timed-out, or cancelled installs are retried. Publish the marker atomically and terminate/reap the owned npm process group on interruption.
- Keep commands, server arguments, and credentials unchanged. Recognize common npx package options without interpreting server arguments as npm flags, and preserve ordering for conflicting versions of the same package.
- Add cache hit/miss and preparation-duration logs. Keep the policy in a dedicated runtime module.
- Advance runtime/rebuild generation to 63 while retaining compatibility floor 62, so existing snapshots remain valid.

## Scope and rollout

This uses the existing prebuild lifecycle, not a new automatic MCP image-building pipeline. To eliminate the install from first-session startup, pin matching versions in the MCP command and `.openinspect/setup.sh`, then rebuild the image. Documentation includes the pattern.

Floating versions retain their cross-boot refresh behavior. This removes redundant global installation; npx can still resolve registry metadata or populate its own execution cache, especially with explicit `--package` commands. No production latency reduction is claimed without measurement, and no deployment is included.

## Validation

- Sandbox runtime suite: 816 passed, 3 skipped.
- Final focused MCP tests: 56 passed, including a real offline npm tarball installation under a temporary prefix and reuse by newly constructed installers without another install.
- Supervisor/MCP regression subset after cache bookkeeping cleanup: 63 passed.
- Modal infrastructure suite: 219 passed.
- Control-plane runtime manifest, prebuilt image selection, and rebuild-policy tests: 14 passed.
- Shared TypeScript build, Ruff lint/format, Prettier checks, and mypy for the new cache module passed.
- Regression coverage includes mixed hits/misses, pinned version changes, damaged manifests/binaries/links, floating-version refresh, conflicting package versions, failed installs across supervisor recreation, timeout/cancellation cleanup, and npm-root lookup fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP server packages now load faster across sandbox restarts by reusing verified installations when available.
  - Failed or interrupted package installations are retried automatically.
  - Unversioned packages are refreshed as needed to ensure current versions are used.
  - Invalid or incomplete package installations are detected and repaired.
  - Installation and cache activity now provides clearer metrics and status reporting.

- **Documentation**
  - Added guidance covering package preinstallation, image setup, snapshots, supported options, remote servers, and command or credential forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->