### PR TITLE
ci: skip Compose smoke for unrelated changes

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -2,8 +2,8 @@
 # deployment does and round-trip one session through it.
 #
 # Keep the workflow unfiltered so this check can be required for merge without
-# leaving documentation-only pull requests pending. Those changes still report
-# success, but skip the dependency install, image build and container smoke.
+# leaving unrelated pull requests pending. Changes outside this stack still
+# report success, but skip the dependency install, image build and smoke.
 name: Compose smoke
 
 on:
@@ -36,20 +36,73 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for changes beyond documentation
+      - name: Check for changes affecting Compose smoke
         id: changes
         env:
           # PRs compare from the merge base; pushes compare the complete push.
           DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('{0}..{1}', github.event.before, github.sha) }}
         run: |
-          # Only exclude prose outside runtime packages. A new/unknown path,
-          # or an unavailable comparison (for example a force push), runs smoke.
-          if git diff --quiet --no-renames "$DIFF_RANGE" -- . \
-            ':(exclude,glob)*.md' \
-            ':(exclude,glob)docs/**/*.md' \
-            ':(exclude,glob)docs/**/*.html'; then
+          # Protect inputs inside otherwise unrelated directories first.
+          # npm ci installs all workspaces; the image copies sandbox JSON and
+          # migrations, and the driver/fake Modal live under test/smoke.
+          required_inputs=(
+            ':(glob)packages/*/package.json'
+            ':(glob)packages/*/package-lock.json'
+            ':(glob)packages/*/npm-shrinkwrap.json'
+            ':(glob)packages/*/.npmrc'
+            ':(glob)packages/sandbox-runtime/src/sandbox_runtime/*.json'
+            terraform/d1/migrations
+            packages/control-plane/test/smoke
+          )
+          # These are not built or executed by this smoke. Keep this list in
+          # sync with Dockerfile COPYs, .dockerignore and compose-smoke.sh.
+          # Do not exclude all tests: shared test-support is compiled by tsc.
+          unrelated_paths=(
+            ':(exclude,glob)*.md'
+            ':(exclude,glob)docs/**/*.md'
+            ':(exclude,glob)docs/**/*.html'
+            ':(exclude)packages/web'
+            ':(exclude)packages/slack-bot'
+            ':(exclude)packages/github-bot'
+            ':(exclude)packages/linear-bot'
+            ':(exclude)packages/modal-infra'
+            ':(exclude)packages/daytona-infra'
+            ':(exclude)packages/e2b-infra'
+            ':(exclude)packages/opencomputer-infra'
+            ':(exclude)packages/sandbox-runtime'
+            ':(exclude)terraform'
+            ':(exclude,glob)packages/control-plane/src/**/*.test.ts'
+            ':(exclude,glob)packages/shared/src/**/*.test.ts'
+            ':(exclude)packages/control-plane/test'
+            ':(exclude,glob)packages/control-plane/vitest*.ts'
+            ':(exclude)packages/shared/vitest.config.ts'
+            ':(exclude)packages/control-plane/tsconfig.test.json'
+            ':(exclude)packages/shared/tsconfig.test.json'
+            ':(exclude).github/workflows/ci.yml'
+            ':(exclude).github/workflows/ci-python.yml'
+            ':(exclude).github/workflows/deploy-web.yml'
+            ':(exclude).github/workflows/terraform.yml'
+            ':(exclude)eslint.config.js'
+            ':(exclude)knip.json'
+            ':(exclude)ruff.toml'
+            ':(exclude).prettierrc'
+            ':(exclude).prettierignore'
+            ':(exclude)vitest.workspace.ts'
+            ':(exclude,glob)scripts/lint-*.mjs'
+            ':(exclude)scripts/sql-portability-baseline.json'
+            ':(exclude,glob)scripts/bootstrap-workspace-owner*.ts'
+            ':(exclude,glob)scripts/merge-split-users*.ts'
+            ':(exclude)scripts/cf-logs.ts'
+            ':(exclude)scripts/check-aws-stack.sh'
+            ':(exclude)scripts/d1-migrate.sh'
+            ':(exclude)scripts/wrangler-secrets.sh'
+          )
+          # Unknown paths and unavailable comparisons run smoke. No rename
+          # detection: moving an input into an unrelated directory must run it.
+          if git diff --quiet --no-renames "$DIFF_RANGE" -- "${required_inputs[@]}" &&
+            git diff --quiet --no-renames "$DIFF_RANGE" -- . "${unrelated_paths[@]}"; then
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Documentation-only change: container smoke is not needed." >> "$GITHUB_STEP_SUMMARY"
+            echo "No Compose smoke inputs changed: skipping container smoke." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
@@ -64,6 +117,10 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
         run: npm ci
+
+      - name: Test smoke change detection
+        if: steps.changes.outputs.run == 'true'
+        run: node --test scripts/compose-smoke-paths.test.mjs
 
       - name: Build shared package
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -1,11 +1,9 @@
 # The container's deployment gate: boot the control-plane image the way a
 # deployment does and round-trip one session through it.
 #
-# Deliberately unfiltered by path, unlike CI (TypeScript). This check is meant
-# to be required for merge, and a required check that a path filter can skip
-# leaves those pull requests pending forever. Every pull request pays about
-# two and a half minutes for a check that is always present and always means
-# the same thing.
+# Keep the workflow unfiltered so this check can be required for merge without
+# leaving documentation-only pull requests pending. Those changes still report
+# success, but skip the dependency install, image build and container smoke.
 name: Compose smoke
 
 on:
@@ -35,20 +33,44 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes beyond documentation
+        id: changes
+        env:
+          # PRs compare from the merge base; pushes compare the complete push.
+          DIFF_RANGE: ${{ github.event_name == 'pull_request' && format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('{0}..{1}', github.event.before, github.sha) }}
+        run: |
+          # Only exclude prose outside runtime packages. A new/unknown path,
+          # or an unavailable comparison (for example a force push), runs smoke.
+          if git diff --quiet --no-renames "$DIFF_RANGE" -- . \
+            ':(exclude,glob)*.md' \
+            ':(exclude,glob)docs/**/*.md' \
+            ':(exclude,glob)docs/**/*.html'; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Documentation-only change: container smoke is not needed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node.js
+        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
         run: npm ci
 
       - name: Build shared package
+        if: steps.changes.outputs.run == 'true'
         run: npm run build -w @open-inspect/shared
 
       - name: Boot the container and round-trip a session
+        if: steps.changes.outputs.run == 'true'
         run: scripts/compose-smoke.sh
 
       - name: Upload container logs

--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check for changes affecting Compose smoke

--- a/scripts/compose-smoke-paths.test.mjs
+++ b/scripts/compose-smoke-paths.test.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/compose-smoke.yml", import.meta.url),
+  "utf8"
+);
+// Execute the workflow's script, not a second implementation of the policy.
+const changesStep = workflow.match(
+  / {6}- name: Check for changes affecting Compose smoke\n([\s\S]*?)(?=\n {6}- name:)/
+)[1];
+const script = changesStep
+  .split("        run: |\n")[1]
+  .split("\n")
+  .map((line) => line.slice(10))
+  .join("\n");
+
+const unrelated = [
+  "README.md",
+  "provider-accounts.md",
+  "docs/ramp-inspect-agent.md",
+  "docs/plans/walkthrough.html",
+  "packages/web/src/app/page.tsx",
+  "packages/web/public/logo.svg",
+  "packages/web/src/app/page.test.tsx",
+  "packages/web/src/space and\nnewline.tsx",
+  "packages/slack-bot/src/index.ts",
+  "packages/github-bot/test/handlers.test.ts",
+  "packages/linear-bot/src/webhook-handler.ts",
+  "packages/modal-infra/src/web_api.py",
+  "packages/daytona-infra/src/toolchain.py",
+  "packages/e2b-infra/pyproject.toml",
+  "packages/opencomputer-infra/src/build-template.ts",
+  "packages/sandbox-runtime/src/sandbox_runtime/bridge.py",
+  "packages/sandbox-runtime/src/sandbox_runtime/skills/example/SKILL.md",
+  "packages/sandbox-runtime/src/sandbox_runtime/tools/slack-notify.js",
+  "terraform/environments/production/main.tf",
+  "terraform/modules/aws-control-plane/templates/user-data.sh.tftpl",
+  "terraform/README.md",
+  "packages/control-plane/src/node/host.test.ts",
+  "packages/control-plane/src/index.test.ts",
+  "packages/shared/src/auth.test.ts",
+  "packages/shared/src/types/skills.test.ts",
+  "packages/control-plane/test/integration/session.test.ts",
+  "packages/control-plane/test/integration/fixtures/requests.json",
+  "packages/control-plane/vitest.config.ts",
+  "packages/control-plane/vitest.integration.config.ts",
+  "packages/shared/vitest.config.ts",
+  "packages/control-plane/tsconfig.test.json",
+  "packages/shared/tsconfig.test.json",
+  ".github/workflows/ci.yml",
+  ".github/workflows/ci-python.yml",
+  ".github/workflows/deploy-web.yml",
+  ".github/workflows/terraform.yml",
+  "eslint.config.js",
+  "knip.json",
+  "ruff.toml",
+  ".prettierrc",
+  ".prettierignore",
+  "vitest.workspace.ts",
+  "scripts/lint-complexity.mjs",
+  "scripts/lint-sql-portability.test.mjs",
+  "scripts/sql-portability-baseline.json",
+  "scripts/bootstrap-workspace-owner.ts",
+  "scripts/merge-split-users.test.ts",
+  "scripts/cf-logs.ts",
+  "scripts/check-aws-stack.sh",
+  "scripts/d1-migrate.sh",
+  "scripts/wrangler-secrets.sh",
+];
+
+const required = [
+  "packages/control-plane/src/node/main.ts",
+  "packages/control-plane/src/session/message-queue.ts",
+  "packages/shared/src/service-auth.ts",
+  "packages/shared/src/triggers/testing.ts",
+  "packages/shared/src/helper.test-support.ts",
+  "packages/shared/tsconfig.json",
+  "packages/control-plane/tsconfig.json",
+  "packages/control-plane/Dockerfile",
+  "packages/control-plane/docker/entrypoint.sh",
+  "packages/control-plane/docker/litestream.yml",
+  "packages/control-plane/docker/Caddyfile",
+  "docker-compose.yml",
+  "docker-compose.smoke.yml",
+  "docker-compose.aws.yml",
+  ".dockerignore",
+  ".env.example",
+  "package.json",
+  "package-lock.json",
+  ".npmrc",
+  "packages/web/package.json",
+  "packages/web/package-lock.json",
+  "packages/web/npm-shrinkwrap.json",
+  "packages/web/.npmrc",
+  "packages/slack-bot/package.json",
+  "packages/github-bot/package.json",
+  "packages/linear-bot/package.json",
+  "packages/opencomputer-infra/package.json",
+  "packages/control-plane/package.json",
+  "packages/shared/package.json",
+  "packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json",
+  "packages/sandbox-runtime/src/sandbox_runtime/image_build_callback_env.json",
+  "packages/sandbox-runtime/src/sandbox_runtime/new_contract.json",
+  "terraform/d1/migrations/0080_example.sql",
+  "packages/control-plane/test/smoke/run-smoke.mjs",
+  "packages/control-plane/test/smoke/fake-modal-host.mjs",
+  "packages/control-plane/test/smoke/new-fixture.json",
+  "scripts/compose-smoke.sh",
+  "scripts/compose-smoke-paths.test.mjs",
+  ".github/workflows/compose-smoke.yml",
+  ".github/workflows/new-workflow.yml",
+  "packages/new-package/src/index.ts",
+  "scripts/new-build-input.sh",
+  "unknown.config",
+];
+
+test("Compose smoke selects real inputs and keeps unknown changes covered", async (t) => {
+  const scratch = mkdtempSync(join(tmpdir(), "compose-paths-"));
+  t.after(() => rmSync(scratch, { recursive: true, force: true }));
+  const repo = join(scratch, "repo");
+  mkdirSync(repo);
+  const env = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" };
+  const git = (...args) => execFileSync("git", args, { cwd: repo, env, encoding: "utf8" }).trim();
+  git("init", "--quiet", "--initial-branch=main");
+  git("config", "user.name", "Smoke filter test");
+  git("config", "user.email", "smoke-filter@example.test");
+  git("commit", "--quiet", "--allow-empty", "-m", "base");
+  let revision = 0;
+  function write(file) {
+    mkdirSync(dirname(join(repo, file)), { recursive: true });
+    writeFileSync(join(repo, file), `fixture ${++revision}\n`);
+  }
+  function commit() {
+    git("add", "--all");
+    git("commit", "--quiet", "-m", "fixture change");
+    return git("rev-parse", "HEAD");
+  }
+  function expectRun(range, expected) {
+    const output = join(scratch, "output");
+    const summary = join(scratch, "summary");
+    writeFileSync(output, "");
+    writeFileSync(summary, "");
+    const result = spawnSync("bash", ["-e", "-o", "pipefail"], {
+      cwd: repo,
+      input: script,
+      encoding: "utf8",
+      env: { ...env, DIFF_RANGE: range, GITHUB_OUTPUT: output, GITHUB_STEP_SUMMARY: summary },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(output, "utf8"), `run=${expected}\n`, result.stderr);
+  }
+
+  for (const [expected, paths] of [
+    [false, unrelated],
+    [true, required],
+  ]) {
+    for (const file of paths) {
+      await t.test(`${expected ? "run" : "skip"}: ${JSON.stringify(file)}`, () => {
+        const before = git("rev-parse", "HEAD");
+        write(file);
+        expectRun(`${before}..${commit()}`, expected);
+      });
+    }
+  }
+
+  await t.test("mixed edits and the full multi-commit push run smoke", () => {
+    const before = git("rev-parse", "HEAD");
+    write("packages/control-plane/src/node/main.ts");
+    write("packages/web/src/app/page.tsx");
+    const code = commit();
+    write("README.md");
+    const docs = commit();
+    expectRun(`${before}..${docs}`, true);
+    expectRun(`${code}..${docs}`, false);
+  });
+
+  for (const [from, to] of [
+    ["packages/control-plane/src/node/main.ts", "docs/moved.md"],
+    ["packages/web/package.json", "docs/old-package.md"],
+    ["docs/moved.md", "packages/control-plane/src/node/moved.ts"],
+  ]) {
+    await t.test(`rename ${from} to ${to} runs smoke`, () => {
+      const before = git("rev-parse", "HEAD");
+      mkdirSync(dirname(join(repo, to)), { recursive: true });
+      git("mv", from, to);
+      expectRun(`${before}..${commit()}`, true);
+    });
+  }
+
+  for (const [file, expected] of [
+    ["docs/ramp-inspect-agent.md", false],
+    ["terraform/environments/production/main.tf", false],
+    ["terraform/d1/migrations/0080_example.sql", true],
+    ["packages/control-plane/test/smoke/run-smoke.mjs", true],
+  ]) {
+    await t.test(`deletion of ${file}`, () => {
+      const before = git("rev-parse", "HEAD");
+      git("rm", "--quiet", file);
+      expectRun(`${before}..${commit()}`, expected);
+    });
+  }
+
+  await t.test("behind-base docs PR excludes changes made only on main", () => {
+    git("switch", "--quiet", "-c", "docs-pr");
+    write("README.md");
+    const head = commit();
+    git("switch", "--quiet", "main");
+    write("packages/control-plane/src/node/main.ts");
+    const base = commit();
+    expectRun(`${base}...${head}`, false);
+  });
+
+  await t.test("empty comparisons skip; missing comparisons run", () => {
+    expectRun("HEAD..HEAD", false);
+    expectRun(`${"0".repeat(40)}..HEAD`, true);
+    expectRun("missing-base...HEAD", true);
+  });
+});


### PR DESCRIPTION
## Summary

Keep the `Compose smoke (container)` check present on every main-branch PR and push, but skip expensive work when all changed paths are outside the stack this test builds and exercises.

The smoke runs the Node control-plane image, MinIO, Litestream, and a fake Modal/sandbox service. It does not build the web app, run the real bots or Python sandbox, or apply Terraform.

### Skip known unrelated changes

- Root Markdown and Markdown/HTML documentation under `docs/`.
- Web and Slack/GitHub/Linear bot implementation, assets, and tests.
- Modal/Daytona/E2B/OpenComputer infrastructure and sandbox-runtime implementation, except the JSON contracts below.
- Terraform configuration, except D1 migrations.
- Ordinary control-plane/shared `.test.ts` files, non-smoke control-plane test suites, and their test-only configuration. Shared test-support source remains covered because the shared build compiles it.
- The other existing CI/deployment workflows and explicitly listed linting/operator scripts and configuration.

### Preserve real inputs and conservative fallback

- Check workspace package manifests, lockfiles, and npm configuration before applying directory exclusions: the workflow runs monorepo-wide `npm ci`.
- Always cover `terraform/d1/migrations/`, the sandbox-runtime JSON files copied into the image, and `packages/control-plane/test/smoke/`.
- Control-plane/shared production code and build configuration, Docker/Compose inputs, entrypoint/replication configuration, and this workflow and smoke scripts remain covered.
- Unknown paths outside the explicitly excluded areas and unavailable Git comparisons run the full smoke.

PRs compare from the merge base; pushes compare the complete before/after range. `--no-renames` ensures moving a real input into an excluded directory still runs smoke. The check identity and workflow events remain unchanged, avoiding pending required checks on skipped changes.

## Validation

- Added `scripts/compose-smoke-paths.test.mjs`, which executes the actual workflow Bash against temporary Git histories; the workflow runs it on the full-smoke path.
- All 104 scenarios passed (105 Node test results including the parent): unrelated and required path families, dependency and migration exceptions, mixed edits, source/manifest renames, documentation and runtime-input deletions, a behind-base PR, a multi-commit push, and missing comparisons.
- Actionlint, ESLint, and Prettier passed; `git diff --check` passed.
- The workflow/test change itself selects full smoke in hosted CI. No application or infrastructure behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated validation for pull requests and pushes with more precise change detection.
  - Documentation-only and other unrelated changes can skip application setup and container smoke checks.
  - Changes to required application inputs continue to run the complete smoke validation workflow.

- **Tests**
  - Added coverage for multi-commit updates, pull requests, renames, deletions, empty ranges, and missing-base scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->