### PR TITLE
docs: deduplicate provider model catalogs

### DIFF
--- a/docs/GROK_MODELS.md
+++ b/docs/GROK_MODELS.md
@@ -10,13 +10,8 @@ the durable OAuth refresh token and gives each sandbox only a short-lived access
 
 ## Supported Models
 
-| Model ID             | Display name   | Reasoning efforts | Default effort |
-| -------------------- | -------------- | ----------------- | -------------- |
-| `xai/grok-4.5`       | Grok 4.5       | low, medium, high | high           |
-| `xai/grok-4.6`       | Grok 4.6       | low, medium, high | high           |
-| `xai/grok-build-0.1` | Grok Build 0.1 | Not configurable  | N/A            |
-
-Grok Build performs reasoning internally but does not accept a configurable reasoning effort.
+See [Available Models — xAI / SuperGrok](AVAILABLE_MODELS.md#xai--supergrok) for supported model
+IDs, reasoning effort options, and defaults.
 
 The **xAI / SuperGrok** group is disabled by default. An administrator must enable it under
 **Settings > Models** before it appears in session and integration model selectors.

--- a/docs/OPENAI_MODELS.md
+++ b/docs/OPENAI_MODELS.md
@@ -10,18 +10,8 @@ can use the installation default, select a specific account, or explicitly use A
 
 ## Supported Models
 
-For the full model list, including Claude Fable 5 and other Anthropic models, see
-[Available Models](AVAILABLE_MODELS.md).
-
-| Model               | Description               |
-| ------------------- | ------------------------- |
-| GPT 5.4             | Flagship model            |
-| GPT 5.5             | Latest flagship model     |
-| GPT 5.3 Codex       | Latest codex variant      |
-| GPT 5.3 Codex Spark | Lightweight Codex variant |
-
-OpenAI models support reasoning effort levels: none, low, medium, high, and extra high (default:
-high for Codex models).
+See [Available Models — OpenAI](AVAILABLE_MODELS.md#openai) for supported model IDs, reasoning
+effort options, and defaults.
 
 ---
 


### PR DESCRIPTION
## Summary

- Address the remaining model-table duplication finding in the September 2 debt audit, section 4.1.
- Replace the incomplete OpenAI table and duplicated Grok table with direct links to the corresponding sections of `docs/AVAILABLE_MODELS.md`.
- Keep model IDs, reasoning options, and defaults in the central catalog. Preserve both setup guides, existing headings, and all authentication, rollout, and troubleshooting guidance.

Two documentation files only: 4 additions, 19 deletions. No runtime, dependency, configuration, or model-availability changes.

## Validation

- Prettier check passed for both changed files.
- Verified both catalog links and section anchors.
- Programmatically verified introductions and all content from Setup onward are unchanged.
- `git diff --check` passed.
- Reviewed the complete diff; no blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Grok and OpenAI model guides to reference the centralized available-models documentation.
  - Removed duplicated inline model listings and reasoning-effort details from these guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->