### PR TITLE
refactor: remove unused scoped route requirement

### DIFF
--- a/packages/control-plane/src/router.policy.test.ts
+++ b/packages/control-plane/src/router.policy.test.ts
@@ -8,7 +8,6 @@ import {
   TEST_SERVICE_SECRETS,
 } from "./router.test-support";
 import { serviceAllowsPermission } from "./authorization/service-permissions";
-import { SCOPED_PERMISSION_PAIRS } from "@open-inspect/shared/rbac";
 
 function routeFor(method: string, path: string) {
   return matchRoute(routes, method, path)?.route;
@@ -166,10 +165,6 @@ describe("route policy table", () => {
             expect(
               serviceAllowsPermission(grant.service, requirement.permission),
               `${grant.service} must allow ${requirement.permission} for ${route.method} ${route.path}`
-            ).toBe(true);
-          } else if (requirement.kind === "scoped-permission") {
-            expect(
-              serviceAllowsPermission(grant.service, SCOPED_PERMISSION_PAIRS[requirement.stem].own)
             ).toBe(true);
           }
         }

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -7,7 +7,7 @@ import type { RequestContext } from "../http/request-context";
 import { HttpError } from "../http/responses";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
-import type { PermissionId, ScopedPermissionStem } from "@open-inspect/shared/rbac";
+import type { PermissionId } from "@open-inspect/shared/rbac";
 import type { ServiceName } from "@open-inspect/shared/service-auth";
 import {
   createSourceControlProviderFromEnv,
@@ -39,7 +39,6 @@ export type ServiceActorClaimsResult =
 /** One permission or resource-admission requirement for an active user. */
 export type RouteAuthorizationRequirement =
   | { kind: "permission"; permission: PermissionId }
-  | { kind: "scoped-permission"; stem: ScopedPermissionStem }
   | {
       kind: "automation";
       operation: "manage" | "trigger";
@@ -162,19 +161,6 @@ export function requirePermission(
       options?.service === "deny"
         ? { kind: "deny" }
         : { kind: "actor", actorlessGrants: options?.actorlessGrants },
-  };
-}
-
-/** Require an active user with at least one permission under a scoped stem. */
-export function requireScopedPermission(
-  stem: ScopedPermissionStem,
-  options?: { service?: "actor" }
-): RouteAuthorization {
-  return {
-    kind: "active-user",
-    allOf: [{ kind: "scoped-permission", stem }],
-    auditAllowed: true,
-    service: options?.service === "actor" ? { kind: "actor" } : { kind: "deny" },
   };
 }
 

--- a/packages/control-plane/src/routing/route-admission.ts
+++ b/packages/control-plane/src/routing/route-admission.ts
@@ -327,12 +327,7 @@ function enforceStaticServicePermissionCeiling(
   if (policy.authorization.kind !== "active-user") return null;
 
   for (const requirement of policy.authorization.allOf) {
-    const permission =
-      requirement.kind === "permission"
-        ? requirement.permission
-        : requirement.kind === "scoped-permission"
-          ? SCOPED_PERMISSION_PAIRS[requirement.stem].own
-          : null;
+    const permission = requirement.kind === "permission" ? requirement.permission : null;
     if (permission && !serviceAllowsPermission(principal.service, permission)) {
       return authorizationDenial(
         json({ error: "Forbidden", code: "service_capability_required" }, 403),
@@ -520,48 +515,6 @@ async function enforcePermissionRequirement(
   );
 }
 
-async function enforceScopedPermissionRequirement(
-  requirement: Extract<RouteAuthorizationRequirement, { kind: "scoped-permission" }>,
-  ctx: RequestContext,
-  evidence: AuthorizationEvidence
-): Promise<AuthorizationFailure | null> {
-  const pair = SCOPED_PERMISSION_PAIRS[requirement.stem];
-  if (
-    ctx.principal?.kind === "service" &&
-    !serviceAllowsPermission(ctx.principal.service, pair.own)
-  ) {
-    return authorizationDenial(
-      json({ error: "Forbidden", code: "service_capability_required" }, 403),
-      evidence,
-      requirement,
-      "service_capability_required",
-      "Forbidden",
-      pair.own
-    );
-  }
-  const userId = authorizationUserId(ctx);
-  if (!userId) {
-    evidence.requirements.push(requirement);
-    return null;
-  }
-  const scope = ctx.authorization
-    ? resolveScopedPermission(requirement.stem, ctx.authorization.permissions)
-    : null;
-  if (scope) {
-    evidence.requirements.push(requirement);
-    evidence.effectivePermissions.push(pair[scope]);
-    return null;
-  }
-  return authorizationDenial(
-    json({ error: "Forbidden", code: "permission_required", permission: pair.own }, 403),
-    evidence,
-    requirement,
-    "permission_required",
-    "Forbidden",
-    pair.own
-  );
-}
-
 async function enforceAutomationRequirement(
   requirement: Extract<RouteAuthorizationRequirement, { kind: "automation" }>,
   params: RouteParams,
@@ -683,9 +636,6 @@ async function enforceRouteAuthorization(
       switch (requirement.kind) {
         case "permission":
           failure = await enforcePermissionRequirement(requirement, ctx, evidence);
-          break;
-        case "scoped-permission":
-          failure = await enforceScopedPermissionRequirement(requirement, ctx, evidence);
           break;
         case "automation":
           failure = await enforceAutomationRequirement(requirement, params, ctx, evidence);


### PR DESCRIPTION
## Summary

- Remove the unused `requireScopedPermission` constructor and `scoped-permission` member of the internal route authorization requirement union.
- Remove its unreachable enforcement branch, service-ceiling mapping, and matching test conditional.
- Preserve the shared scoped-permission definitions and resolver used by live automation ownership checks.

## Why this is safe

Repository searches found no callers of the constructor and no route declarations constructing this requirement directly. Documentation and Linear review found no use case tied to this unused helper. No route declarations, permission definitions, endpoints, or automation ownership behavior change.

The change is intentionally limited to three files; it does not remove the active `automation` requirement or any other debt candidate.

## Validation

- Shared build and control-plane Worker/Node builds
- Control-plane typecheck (production, Node, unit-test, and integration-test configurations)
- Full control-plane unit suite: 4,114 tests passed across 281 files
- Real Worker/D1 integration: 62 tests passed across route catalog conformance, route admission matrix, automation authorization, service authentication, and audit events routes
- Existing 172-route catalog and admission snapshots unchanged
- ESLint and Prettier checks for the three changed files; `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed support for scoped-permission authorization requirements in route configuration.
  - Routes using scoped-permission requirements no longer receive scoped-permission enforcement and should be updated to use supported permission or automation requirements.
  - Updated authorization validation to focus on supported permission-based requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->