### PR TITLE
fix: unblock Modal image builds and function deployment

### DIFF
--- a/packages/modal-infra/src/app.py
+++ b/packages/modal-infra/src/app.py
@@ -37,7 +37,7 @@ function_image = (
         "PyJWT[crypto]",  # For GitHub App token generation
     )
     # Bundle sandbox_runtime so modal-infra shims can import from it at runtime
-    .add_local_dir(str(_SANDBOX_RUNTIME_DIR), remote_path="/root/sandbox_runtime")
+    .add_local_dir(str(_SANDBOX_RUNTIME_DIR), remote_path="/root/sandbox_runtime", copy=True)
     .env(deployed_image_environment())
 )
 

--- a/packages/modal-infra/tests/test_deploy.py
+++ b/packages/modal-infra/tests/test_deploy.py
@@ -185,6 +185,12 @@ def test_modal_deploy_script_builds_sandbox_image_before_app_deploy(tmp_path: Pa
     ]
 
 
+def test_function_image_copies_runtime_before_later_build_steps() -> None:
+    source = (Path(__file__).parents[1] / "src/app.py").read_text()
+    add_runtime = source.index(".add_local_dir(")
+    assert "copy=True" in source[add_runtime : source.index(".env(", add_runtime)]
+
+
 def test_modal_deploy_script_stops_when_eager_build_fails(tmp_path: Path) -> None:
     result, uv_calls = _run_deploy_script(tmp_path, fail_eager_build=True)
 

--- a/packages/sandbox-images/install/os/debian.sh
+++ b/packages/sandbox-images/install/os/debian.sh
@@ -5,6 +5,7 @@ case "$ID" in debian|ubuntu) ;; *) echo "Unsupported Debian target: $ID" >&2; ex
 export DEBIAN_FRONTEND=noninteractive
 audio_library=libasound2
 if [[ "$ID" == ubuntu && "$VERSION_ID" == 24.04 ]]; then audio_library=libasound2t64; fi
+install -d -m 1777 /tmp
 apt-get update
 apt-get install -y --no-install-recommends git curl build-essential ca-certificates gnupg openssh-client jq unzip \
   passwd adduser sysvinit-utils procps util-linux xz-utils ffmpeg xvfb fluxbox x11vnc \

--- a/packages/sandbox-images/tests/test_bundle.py
+++ b/packages/sandbox-images/tests/test_bundle.py
@@ -50,6 +50,11 @@ def test_debian_installs_disable_recommended_packages():
     assert all("--no-install-recommends" in command for command in install_commands)
 
 
+def test_debian_restores_shared_tmp_before_using_apt():
+    script = (REPO_ROOT / "packages/sandbox-images/install/os/debian.sh").read_text()
+    assert script.index("install -d -m 1777 /tmp") < script.index("apt-get update")
+
+
 @pytest.mark.parametrize("provider", PROVIDERS)
 def test_pack_rejects_stale_locks_before_creating_context(checkout, tmp_path, provider):
     path = checkout / "packages/sandbox-images/locks/runtime.txt"


### PR DESCRIPTION
## Summary

Port the two Modal deployment fixes validated in production after the shared sandbox-image consolidation (#1816):

- Restore `/tmp` to mode `1777` before Debian/Ubuntu APT operations. The staged Modal image can leave it owned by root with mode `0755`, preventing APT's unprivileged `_apt` user from creating temporary files and causing misleading repository-signature errors.
- Set `copy=True` when adding `sandbox_runtime` to the Modal function image. This bakes the source into the image so the subsequent `.env(...)` build step is valid; Modal rejects build steps after a runtime-only `add_local_dir` mount.
- Include the regression guards from production for both image contracts.

No provider selection, deployment configuration, credentials, or unrelated production changes are included.

## Validation

- Full sandbox-images test suite.
- Full Modal infrastructure test suite.
- Ruff lint and format checks on changed Python files.
- Bash syntax check for the Debian installer and `git diff --check`.

These same runtime changes were previously verified through a successful production Modal image build, fresh-sandbox smoke verification, and function deployment. This public port does not trigger a new manual production deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime files are now copied into built images, ensuring builds use a fresh bundled copy.
  * Debian and Ubuntu sandbox images now restore `/tmp` with shared, secure permissions before package installation.

* **Tests**
  * Added coverage verifying runtime copying and `/tmp` setup occur in the correct build order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->