### PR TITLE
refactor: remove unused session index title write

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -50,7 +50,6 @@ const QUERY_PATTERNS = {
   SELECT_LIST: /^SELECT \* FROM sessions\b.*ORDER BY updated_at DESC LIMIT/,
   UPDATE_STATUS: /^UPDATE sessions SET status = \?/,
   UPDATE_UPDATED_AT: /^UPDATE sessions SET updated_at = \?/,
-  UPDATE_TITLE: /^UPDATE sessions SET title = \?/,
   UPDATE_TITLE_IF_NEWER:
     /^UPDATE sessions SET title = \?, updated_at = \? WHERE id = \? AND updated_at <= \?$/,
   UPDATE_METRICS: /^UPDATE sessions SET total_cost = \?/,
@@ -285,17 +284,6 @@ class FakeD1Database {
       const [title, updatedAt, id, maxUpdatedAt] = args as [string, number, string, number];
       const row = this.rows.get(id);
       if (row && row.updated_at <= maxUpdatedAt) {
-        row.title = title;
-        row.updated_at = updatedAt;
-        return { meta: { changes: 1 } };
-      }
-      return { meta: { changes: 0 } };
-    }
-
-    if (QUERY_PATTERNS.UPDATE_TITLE.test(normalized)) {
-      const [title, updatedAt, id] = args as [string, number, string];
-      const row = this.rows.get(id);
-      if (row) {
         row.title = title;
         row.updated_at = updatedAt;
         return { meta: { changes: 1 } };
@@ -821,22 +809,6 @@ describe("SessionIndexStore", () => {
       const session = await store.get("test-id");
       expect(session?.status).toBe("completed");
       expect(session?.updatedAt).toBe(2000);
-    });
-  });
-
-  describe("updateTitle", () => {
-    it("updates the title of an existing session", async () => {
-      await store.create(makeSession());
-      const updated = await store.updateTitle("test-id", "New Title");
-      expect(updated).toBe(true);
-
-      const session = await store.get("test-id");
-      expect(session?.title).toBe("New Title");
-    });
-
-    it("returns false when session not found", async () => {
-      const updated = await store.updateTitle("nonexistent", "New Title");
-      expect(updated).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -725,15 +725,6 @@ export class SessionIndexStore {
     return row ? readStateFromRow(row) : null;
   }
 
-  async updateTitle(id: string, title: string): Promise<boolean> {
-    const result = await this.db
-      .prepare("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
-      .bind(title, Date.now(), id)
-      .run();
-
-    return (result.meta.changes ?? 0) > 0;
-  }
-
   async updateTitleIfNewer(id: string, title: string, updatedAt: number): Promise<boolean> {
     const result = await this.db
       .prepare("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ? AND updated_at <= ?")


### PR DESCRIPTION
## Summary

- Remove the unused `SessionIndexStore.updateTitle` method, its two self-tests, and its now-unused SQL handling in the unit-test fake.
- Keep `updateTitleIfNewer`, including its current-write and stale-write regression tests.

## Why

The old method unconditionally updated the D1 session title using `Date.now()`. Repository-wide reference checks found only its declaration and two self-tests; there are no production or fixture callers.

Manual renames and generated titles both flow through `SessionTitleService`, which synchronizes D1 through `updateTitleIfNewer` with the authoritative update timestamp. The same-named lifecycle HTTP handler is a different method and remains unchanged, as do the title endpoints, event handling, broadcasts, and ownership/authorization checks.

Documentation and Linear review found no planned use for this store method. The rename-related issue found in Linear concerns the live lifecycle handler, not this unused persistence helper.

This is a focused subset of the dead-store-method audit finding: two files, 37 deleted lines, no replacement abstraction, and no database migration. Other store helpers now used by integration tests are intentionally out of scope.

## Validation

- Shared build
- Control-plane typecheck (production, Node, unit-test, and integration-test configurations)
- 145 unit tests across session index, title service, lifecycle handler, sandbox event processor, and runtime proxy
- 69 real Worker/D1 integration tests across session index, session lifecycle, and sandbox events
- ESLint, Prettier, and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session title updates now reject stale writes when a newer update already exists.
  - Unconditional title updates are no longer supported, helping prevent newer session titles from being overwritten by outdated changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->