### PR TITLE
Fix session budget section spacing

### DIFF
--- a/packages/web/src/components/session-right-sidebar.test.tsx
+++ b/packages/web/src/components/session-right-sidebar.test.tsx
@@ -112,6 +112,24 @@ describe("SessionRightSidebar", () => {
     expect(screen.getByRole("button", { name: "Edit limit" })).toBeInTheDocument();
   });
 
+  it("does not render budget spacing when the budget section is hidden", () => {
+    const { container } = render(
+      <SessionRightSidebar
+        sessionId="session-1"
+        sessionState={{ ...sessionState, totalCost: 0, maxSessionCostUsd: null }}
+        participants={[]}
+        presenceSynced={false}
+        events={[]}
+        artifacts={[]}
+        onOpenMedia={vi.fn()}
+        capabilities={FULL_CAPABILITIES}
+      />
+    );
+
+    expect(screen.queryByText(/Session cost|No session cost limit/)).not.toBeInTheDocument();
+    expect(container.querySelector(".mt-4")).not.toBeInTheDocument();
+  });
+
   it("forwards budget management to the mobile overlay", () => {
     render(
       <SessionDetailsOverlay

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -133,12 +133,14 @@ export function SessionRightSidebarContent({
           parentSessionId={sessionState.parentSessionId}
           canManageLifecycle={capabilities.lifecycle}
         />
-        <BudgetSection
-          sessionId={sessionId}
-          totalCost={sessionState.totalCost ?? 0}
-          maxSessionCostUsd={sessionState.maxSessionCostUsd}
-          canManageBudget={canManageBudget}
-        />
+        <div className="mt-4">
+          <BudgetSection
+            sessionId={sessionId}
+            totalCost={sessionState.totalCost ?? 0}
+            maxSessionCostUsd={sessionState.maxSessionCostUsd}
+            canManageBudget={canManageBudget}
+          />
+        </div>
       </div>
 
       {/* Code Server */}

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -115,7 +115,7 @@ export function SessionRightSidebarContent({
       </div>
 
       {/* Metadata */}
-      <div className="px-4 py-4 border-b border-border-muted">
+      <div className="space-y-4 px-4 py-4 border-b border-border-muted">
         <MetadataSection
           sessionId={sessionId}
           createdAt={sessionState.createdAt}
@@ -133,14 +133,12 @@ export function SessionRightSidebarContent({
           parentSessionId={sessionState.parentSessionId}
           canManageLifecycle={capabilities.lifecycle}
         />
-        <div className="mt-4">
-          <BudgetSection
-            sessionId={sessionId}
-            totalCost={sessionState.totalCost ?? 0}
-            maxSessionCostUsd={sessionState.maxSessionCostUsd}
-            canManageBudget={canManageBudget}
-          />
-        </div>
+        <BudgetSection
+          sessionId={sessionId}
+          totalCost={sessionState.totalCost ?? 0}
+          maxSessionCostUsd={sessionState.maxSessionCostUsd}
+          canManageBudget={canManageBudget}
+        />
       </div>
 
       {/* Code Server */}


### PR DESCRIPTION
## Summary

- add vertical separation between session metadata and the budget/spend-limit section in the right sidebar

## Verification

- `npm test -w @open-inspect/web -- session-right-sidebar.test.tsx`
- `npm run lint -w @open-inspect/web -- --quiet`

## Visual verification

The local app was captured at 1512x982, but authentication prevented reaching a populated session sidebar. The component change is covered by the targeted sidebar test.

Artifact: `287c3d647a098b0a32404001b286c47b`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/500a799f4e892af979ab623125ed18d3)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary empty space in the session sidebar when no budget information is available.
  * Budget-related content now appears with consistent spacing when applicable.

* **Style**
  * Improved the sidebar layout for sessions without cost limits or budget data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->