### PR TITLE
fix: clear predecessor heartbeat when replacing a sandbox

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -196,6 +196,7 @@ function createMockStorage(
         sandbox.created_at = data.createdAt;
         sandbox.auth_token_hash = "";
         sandbox.auth_token = null;
+        sandbox.last_heartbeat = null;
         sandbox.modal_sandbox_id = data.modalSandboxId;
         sandbox.runtime_version = null;
         if (!data.preserveProviderObjectId) sandbox.modal_object_id = null;
@@ -1990,6 +1991,56 @@ describe("SandboxLifecycleManager", () => {
   });
 
   describe("handleAlarm", () => {
+    it.each(["spawn", "restore"] as const)(
+      "%s does not inherit a stopped sandbox's heartbeat when an alarm fires during startup",
+      async (kind) => {
+        const sandbox = createMockSandbox({
+          status: "stopped",
+          created_at: Date.now() - 4_000_000,
+          last_heartbeat: Date.now() - 4_000_000,
+          snapshot_image_id: kind === "restore" ? "snapshot-old" : null,
+          snapshot_runtime_version: COMPATIBLE_RUNTIME_VERSION,
+        });
+        const storage = createMockStorage(createMockSession(), sandbox);
+        const wsManager = createMockWebSocketManager(false);
+        const checkStartup = async () => {
+          expect(sandbox.status).toBe("spawning");
+          expect(await manager.handleAlarm()).toBe("no_action");
+          expect(sandbox.status).toBe("spawning");
+        };
+        const provider = createMockProvider({
+          createSandbox: vi.fn(async (config) => {
+            await checkStartup();
+            return { sandboxId: config.sandboxId, status: "connecting", createdAt: Date.now() };
+          }),
+          restoreFromSnapshot: vi.fn(async (config) => {
+            await checkStartup();
+            return { success: true, sandboxId: config.sandboxId };
+          }),
+        });
+        const manager = new SandboxLifecycleManager(
+          provider,
+          storage,
+          storage,
+          createMockBroadcaster(),
+          wsManager,
+          createMockAlarmScheduler(),
+          createMockIdGenerator(),
+          createTestConfig()
+        );
+
+        await manager.spawnSandbox();
+
+        expect(
+          kind === "restore" ? provider.restoreFromSnapshot : provider.createSandbox
+        ).toHaveBeenCalledOnce();
+        expect(sandbox.status).toBe("connecting");
+        expect(sandbox.last_heartbeat).toBeNull();
+        expect(wsManager.detachSandboxWebSocket).not.toHaveBeenCalled();
+        expect(provider.takeSnapshot).not.toHaveBeenCalled();
+      }
+    );
+
     it("detects heartbeat timeout and sets stale", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({

--- a/packages/control-plane/src/session/sandbox-repository.ts
+++ b/packages/control-plane/src/session/sandbox-repository.ts
@@ -147,12 +147,15 @@ export class SandboxRepository {
    * Phase 1 of the two-phase spawn write (#1589): the reservation itself
    * invalidates credentials — no token can match the emptied hash — until
    * `updateSandboxAuthTokenHash` publishes the new one.
+   * A replacement has not sent a heartbeat yet; retaining the predecessor's
+   * timestamp lets an alarm declare the new generation stale during startup.
    */
   updateSandboxForSpawn(data: SpawnSandboxData): void {
     this.sql.exec(
       `UPDATE sandbox SET
          status = ?,
          created_at = ?,
+         last_heartbeat = NULL,
          auth_token_hash = '',
          auth_token = NULL,
          modal_sandbox_id = ?,

--- a/packages/control-plane/test/conformance/session-core-conformance.ts
+++ b/packages/control-plane/test/conformance/session-core-conformance.ts
@@ -469,7 +469,7 @@ export const STORAGE_CONTRACTS: Record<
 
           sql.exec(
             `UPDATE sandbox SET modal_object_id = 'provider-1', code_server_url = 'old',
-           vnc_url = 'old', tunnel_urls = '{}', ttyd_url = 'old'`
+           vnc_url = 'old', tunnel_urls = '{}', ttyd_url = 'old', last_heartbeat = 200`
           );
           repository.updateSandboxForSpawn({
             status: "connecting",
@@ -480,6 +480,7 @@ export const STORAGE_CONTRACTS: Record<
             status: "connecting",
             modal_object_id: null,
             modal_sandbox_id: "sandbox-provider-id",
+            last_heartbeat: null,
             code_server_url: null,
             vnc_url: null,
             tunnel_urls: null,


### PR DESCRIPTION
## Summary

Clear `last_heartbeat` atomically when reserving a replacement sandbox generation. A new sandbox has not sent a heartbeat yet and must not inherit the predecessor's liveness timestamp.

## Validated root cause

Correlated Modal and control-plane logs for production session `f5674775558d2ab1aedf5e614939ea66` show this sequence on 2026-09-08 (UTC):

- 04:10:04.501: snapshot restore begins.
- 04:10:11.079: the replacement is still `spawning`.
- 04:10:11.753: an alarm reports `sandbox.heartbeat_stale`, age 3,914,472 ms, threshold 90,000 ms; the row becomes `stale`.
- 04:10:15.243: Modal restore succeeds.
- 04:10:17.059: sandbox token verification returns 410 because the sandbox is `stale`; route admission translates this into a 401 for `/sandbox-skills`.
- The restored supervisor exits with `ManagedSkillsError` before connecting its bridge.

The heartbeat belongs to the previous sandbox, not the seven-second-old restore. `updateSandboxForSpawn()` retained it, unlike `updateSandboxForResume()`, which already clears it. Shared session alarms can fire during provider startup. Startup finalization correctly refuses to overwrite a terminal lifecycle transition, so the incorrect `stale` classification persists.

The runtime's subsequent `/sandbox-error` response of 200 acknowledges and ignores a report from a stale sandbox; it does not recover the session.

## History

This is a longstanding defect, not a recent regression. It is present in the root public commit `31b6df7e` (Initial open source release, 2026-01-24): restore reused the sandbox row without clearing `last_heartbeat`, and the alarm evaluated that field for `spawning` rows. Later lifecycle and repository extractions preserved the behavior.

Managed skills, introduced in `97f6aeb8`, made this occurrence fail immediately at the first authenticated HTTP request. It did not introduce the invalid stale transition.

## Fix choice

- Reset the generation-owned heartbeat alongside the new identity and credentials, before any provider work.
- Keep heartbeat timeouts, connecting watchdogs, dead-sandbox authentication rejection, and conditional generation/status transitions unchanged.
- Do not add retries, relax authentication, or overwrite genuinely stopped/superseded attempts on late provider completion.
- Leave the broader restore-success logging semantics unchanged in this focused repair.

## Regression validation

- Added spawn/restore interleaving tests: seed a stopped sandbox with an expired heartbeat, run an alarm inside the provider call, and require the replacement to remain spawning and finish connecting without shutdown or snapshot side effects.
- Extended the shared storage conformance test to verify that an actual stored heartbeat is cleared. This runs on Node SQLite (memory and file) and real Durable Object SQLite.
- Before the fix: both lifecycle cases became stale, and both Node storage variants retained the old heartbeat.
- After the fix: existing heartbeat-expiry, connecting-timeout, authentication, and generation-fencing cases remain green.

Checks:

- Shared build passed.
- 317 focused control-plane tests passed across lifecycle manager/decisions, sandbox repository, sandbox handler, and Node storage conformance.
- 15 Workerd storage conformance tests passed.
- Control-plane typecheck passed.
- ESLint, Prettier, and `git diff --check` passed.

No production state changes or deployment were performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected sandbox startup so replaced or restored sandboxes no longer retain stale heartbeat information from a previous instance.
  - Improved startup state handling during replacement, keeping the sandbox in the appropriate connecting state without unnecessary websocket detachment or snapshot creation.
  - Added coverage to verify heartbeat reset behavior across spawn and restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->