### PR TITLE
feat: add Claude Fable 5.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## September 9, 2026
+
+**Claude Fable 5.1.** Adds `claude-fable-5-1` to the model picker and integrations, with adaptive
+thinking controls from low through max.
+
 ## September 1, 2026
 
 **Workspace audit log.** Owners, Administrators, and authorized custom roles can review paginated

--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider         | Models                                                               |
-| ---------------- | -------------------------------------------------------------------- |
-| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5  |
-| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                         |
-| xAI / SuperGrok  | Grok models (opt-in)                                                 |
-| OpenCode Zen     | Kimi K2.5/K2.6/K3, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1/5.2 (opt-in) |
-| Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                 |
+| Provider         | Models                                                                  |
+| ---------------- | ----------------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6/5, Opus 4.5/4.6/4.7/4.8/5, Fable 5/5.1 |
+| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                            |
+| xAI / SuperGrok  | Grok models (opt-in)                                                    |
+| OpenCode Zen     | Kimi K2.5/K2.6/K3, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1/5.2 (opt-in)    |
+| Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                    |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -13,18 +13,19 @@ unattended mode.
 
 ## Anthropic
 
-| Model ID                      | Display name      | Description                        | Reasoning efforts             | Default effort |
-| ----------------------------- | ----------------- | ---------------------------------- | ----------------------------- | -------------- |
-| `anthropic/claude-haiku-4-5`  | Claude Haiku 4.5  | Fast and efficient                 | high, max                     | max            |
-| `anthropic/claude-sonnet-4-5` | Claude Sonnet 4.5 | Balanced performance               | high, max                     | max            |
-| `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 | Balanced, fast coding              | low, medium, high, max        | high           |
-| `anthropic/claude-sonnet-5`   | Claude Sonnet 5   | Latest Sonnet, adaptive thinking   | low, medium, high, xhigh, max | high           |
-| `anthropic/claude-opus-4-5`   | Claude Opus 4.5   | Most capable                       | high, max                     | max            |
-| `anthropic/claude-opus-4-6`   | Claude Opus 4.6   | Most capable, adaptive thinking    | low, medium, high, max        | high           |
-| `anthropic/claude-opus-4-7`   | Claude Opus 4.7   | Most capable, adaptive thinking    | low, medium, high, xhigh, max | high           |
-| `anthropic/claude-opus-4-8`   | Claude Opus 4.8   | Most capable, adaptive thinking    | low, medium, high, xhigh, max | high           |
-| `anthropic/claude-opus-5`     | Claude Opus 5     | Latest Opus, adaptive thinking     | low, medium, high, xhigh, max | high           |
-| `anthropic/claude-fable-5`    | Claude Fable 5    | Most powerful, new tier above Opus | low, medium, high, xhigh, max | high           |
+| Model ID                      | Display name      | Description                                       | Reasoning efforts             | Default effort |
+| ----------------------------- | ----------------- | ------------------------------------------------- | ----------------------------- | -------------- |
+| `anthropic/claude-haiku-4-5`  | Claude Haiku 4.5  | Fast and efficient                                | high, max                     | max            |
+| `anthropic/claude-sonnet-4-5` | Claude Sonnet 4.5 | Balanced performance                              | high, max                     | max            |
+| `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 | Balanced, fast coding                             | low, medium, high, max        | high           |
+| `anthropic/claude-sonnet-5`   | Claude Sonnet 5   | Latest Sonnet, adaptive thinking                  | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-opus-4-5`   | Claude Opus 4.5   | Most capable                                      | high, max                     | max            |
+| `anthropic/claude-opus-4-6`   | Claude Opus 4.6   | Most capable, adaptive thinking                   | low, medium, high, max        | high           |
+| `anthropic/claude-opus-4-7`   | Claude Opus 4.7   | Most capable, adaptive thinking                   | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-opus-4-8`   | Claude Opus 4.8   | Most capable, adaptive thinking                   | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-opus-5`     | Claude Opus 5     | Latest Opus, adaptive thinking                    | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-fable-5`    | Claude Fable 5    | Most powerful, new tier above Opus                | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-fable-5-1`  | Claude Fable 5.1  | Demanding reasoning and long-horizon agentic work | low, medium, high, xhigh, max | high           |
 
 ## OpenAI
 

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -162,7 +162,8 @@ On any Linear issue:
 - Assign the issue to `OpenInspect` → agent picks it up
 - Agent status is visible directly in Linear (thinking, working, done)
 - Add a `model:<name>` label to override the model (e.g., `model:opus`, `model:sonnet`,
-  `model:opus-5`, `model:sonnet-5`, `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
+  `model:opus-5`, `model:sonnet-5`, `model:fable-5-1`, `model:haiku`, `model:gpt-5.4`,
+  `model:gpt-5.3-codex`)
 
 ## Repo Resolution
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -124,6 +124,12 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:sonnet-5" }])).toBe("anthropic/claude-sonnet-5");
   });
 
+  it("returns Fable 5.1 for model:fable-5-1 label", () => {
+    expect(extractModelFromLabels([{ name: "model:fable-5-1" }])).toBe(
+      "anthropic/claude-fable-5-1"
+    );
+  });
+
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();
   });

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -85,7 +85,7 @@ describe("extractModelFromLabels", () => {
     ["haiku", "anthropic/claude-haiku-4-5"],
     ["sonnet", "anthropic/claude-sonnet-4-5"],
     ["opus", "anthropic/claude-opus-4-5"],
-    ["fable", "anthropic/claude-fable-5"],
+    ["fable", "anthropic/claude-fable-5-1"],
   ])("returns the configured model for the model:%s alias", (alias, expected) => {
     expect(extractModelFromLabels([{ name: `model:${alias}` }])).toBe(expected);
   });

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -108,6 +108,15 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: `model:${label}` }])).toBe(expected);
   });
 
+  it.each(["claude-fable-5-1", "anthropic/claude-fable-5-1"])(
+    "preserves the canonical model ID in model:%s",
+    (model) => {
+      expect(extractModelFromLabels([{ name: `model:${model}` }])).toBe(
+        "anthropic/claude-fable-5-1"
+      );
+    }
+  );
+
   it.each(["gpt-5.2", "gpt-5.2-codex", "opus-6"])(
     "returns null for unsupported model:%s label",
     (model) => {

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { VALID_MODELS } from "@open-inspect/shared/models";
 import {
   extractModelFromLabels,
   resolveSessionModelSettings,
@@ -80,55 +81,39 @@ describe("matchExplicitRepo", () => {
 // ─── extractModelFromLabels ──────────────────────────────────────────────────
 
 describe("extractModelFromLabels", () => {
-  it("returns model for a valid label", () => {
-    expect(extractModelFromLabels([{ name: "model:opus" }])).toBe("anthropic/claude-opus-4-5");
+  it.each([
+    ["haiku", "anthropic/claude-haiku-4-5"],
+    ["sonnet", "anthropic/claude-sonnet-4-5"],
+    ["opus", "anthropic/claude-opus-4-5"],
+    ["fable", "anthropic/claude-fable-5"],
+  ])("returns the configured model for the model:%s alias", (alias, expected) => {
+    expect(extractModelFromLabels([{ name: `model:${alias}` }])).toBe(expected);
   });
 
   it("returns model for case-insensitive label", () => {
     expect(extractModelFromLabels([{ name: "Model:Sonnet" }])).toBe("anthropic/claude-sonnet-4-5");
   });
 
-  it("returns GPT 5.4 for model:gpt-5.4 label", () => {
-    expect(extractModelFromLabels([{ name: "model:gpt-5.4" }])).toBe("openai/gpt-5.4");
+  const versionedModelLabels = VALID_MODELS.flatMap((model) => {
+    if (model.startsWith("anthropic/claude-")) {
+      return [[model.replace("anthropic/claude-", ""), model] as const];
+    }
+    if (model.startsWith("openai/gpt-")) {
+      return [[model.replace("openai/", ""), model] as const];
+    }
+    return [];
   });
 
-  it("returns GPT-6 Astra for model:gpt-6-astra label", () => {
-    expect(extractModelFromLabels([{ name: "model:gpt-6-astra" }])).toBe("openai/gpt-6-astra");
+  it.each(versionedModelLabels)("derives model:%s from the shared catalog", (label, expected) => {
+    expect(extractModelFromLabels([{ name: `model:${label}` }])).toBe(expected);
   });
 
-  it("returns GPT 5.5 for model:gpt-5.5 label", () => {
-    expect(extractModelFromLabels([{ name: "model:gpt-5.5" }])).toBe("openai/gpt-5.5");
-  });
-
-  it.each(["gpt-5.2", "gpt-5.2-codex"])("returns null for unsupported model:%s label", (model) => {
-    expect(extractModelFromLabels([{ name: `model:${model}` }])).toBeNull();
-  });
-
-  it.each([
-    ["sol", "openai/gpt-5.6-sol"],
-    ["terra", "openai/gpt-5.6-terra"],
-    ["luna", "openai/gpt-5.6-luna"],
-  ])("returns GPT 5.6 %s for its model label", (variant, expected) => {
-    expect(extractModelFromLabels([{ name: `model:gpt-5.6-${variant}` }])).toBe(expected);
-  });
-
-  it("returns Opus 4.7 for model:opus-4-7 label", () => {
-    expect(extractModelFromLabels([{ name: "model:opus-4-7" }])).toBe("anthropic/claude-opus-4-7");
-  });
-
-  it("returns Opus 5 for model:opus-5 label", () => {
-    expect(extractModelFromLabels([{ name: "model:opus-5" }])).toBe("anthropic/claude-opus-5");
-  });
-
-  it("returns Sonnet 5 for model:sonnet-5 label", () => {
-    expect(extractModelFromLabels([{ name: "model:sonnet-5" }])).toBe("anthropic/claude-sonnet-5");
-  });
-
-  it("returns Fable 5.1 for model:fable-5-1 label", () => {
-    expect(extractModelFromLabels([{ name: "model:fable-5-1" }])).toBe(
-      "anthropic/claude-fable-5-1"
-    );
-  });
+  it.each(["gpt-5.2", "gpt-5.2-codex", "opus-6"])(
+    "returns null for unsupported model:%s label",
+    (model) => {
+      expect(extractModelFromLabels([{ name: `model:${model}` }])).toBeNull();
+    }
+  );
 
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -41,6 +41,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "sonnet-5": "anthropic/claude-sonnet-5",
   fable: "anthropic/claude-fable-5",
   "fable-5": "anthropic/claude-fable-5",
+  "fable-5-1": "anthropic/claude-fable-5-1",
   "gpt-5.4": "openai/gpt-5.4",
   "gpt-5.5": "openai/gpt-5.5",
   "gpt-5.6-sol": "openai/gpt-5.6-sol",

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -51,7 +51,11 @@ export function extractModelFromLabels(labels: Array<{ name: string }>): ValidMo
       const alias = MODEL_LABEL_ALIASES[key as keyof typeof MODEL_LABEL_ALIASES];
       if (alias) return alias;
 
-      const normalized = normalizeModelId(key.startsWith("gpt-") ? key : `claude-${key}`);
+      const candidate =
+        key.startsWith("gpt-") || key.startsWith("claude-") || key.includes("/")
+          ? key
+          : `claude-${key}`;
+      const normalized = normalizeModelId(candidate);
       if (isValidModel(normalized)) return normalized;
     }
   }

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -6,7 +6,10 @@ import type { TeamRepoMapping, StaticTargetConfig } from "./types";
 import {
   getDefaultReasoningEffort,
   getValidModelOrDefault,
+  isValidModel,
   isValidReasoningEffort,
+  normalizeModelId,
+  type ValidModel,
 } from "@open-inspect/shared/models";
 
 /**
@@ -30,36 +33,26 @@ export function resolveStaticTarget(
   );
 }
 
-const MODEL_LABEL_MAP: Record<string, string> = {
+const MODEL_LABEL_ALIASES = {
   haiku: "anthropic/claude-haiku-4-5",
   sonnet: "anthropic/claude-sonnet-4-5",
   opus: "anthropic/claude-opus-4-5",
-  "opus-4-6": "anthropic/claude-opus-4-6",
-  "opus-4-7": "anthropic/claude-opus-4-7",
-  "opus-4-8": "anthropic/claude-opus-4-8",
-  "opus-5": "anthropic/claude-opus-5",
-  "sonnet-5": "anthropic/claude-sonnet-5",
   fable: "anthropic/claude-fable-5",
-  "fable-5": "anthropic/claude-fable-5",
-  "fable-5-1": "anthropic/claude-fable-5-1",
-  "gpt-5.4": "openai/gpt-5.4",
-  "gpt-5.5": "openai/gpt-5.5",
-  "gpt-5.6-sol": "openai/gpt-5.6-sol",
-  "gpt-5.6-terra": "openai/gpt-5.6-terra",
-  "gpt-5.6-luna": "openai/gpt-5.6-luna",
-  "gpt-6-astra": "openai/gpt-6-astra",
-  "gpt-5.3-codex": "openai/gpt-5.3-codex",
-};
+} satisfies Record<string, ValidModel>;
 
 /**
  * Extract model override from issue labels (e.g., "model:opus" → "anthropic/claude-opus-4-5").
  */
-export function extractModelFromLabels(labels: Array<{ name: string }>): string | null {
+export function extractModelFromLabels(labels: Array<{ name: string }>): ValidModel | null {
   for (const label of labels) {
     const match = label.name.match(/^model:(.+)$/i);
     if (match) {
       const key = match[1].toLowerCase();
-      if (MODEL_LABEL_MAP[key]) return MODEL_LABEL_MAP[key];
+      const alias = MODEL_LABEL_ALIASES[key as keyof typeof MODEL_LABEL_ALIASES];
+      if (alias) return alias;
+
+      const normalized = normalizeModelId(key.startsWith("gpt-") ? key : `claude-${key}`);
+      if (isValidModel(normalized)) return normalized;
     }
   }
   return null;

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -37,7 +37,7 @@ const MODEL_LABEL_ALIASES = {
   haiku: "anthropic/claude-haiku-4-5",
   sonnet: "anthropic/claude-sonnet-4-5",
   opus: "anthropic/claude-opus-4-5",
-  fable: "anthropic/claude-fable-5",
+  fable: "anthropic/claude-fable-5-1",
 } satisfies Record<string, ValidModel>;
 
 /**

--- a/packages/sandbox-runtime/tests/fixtures/reasoning-models.json
+++ b/packages/sandbox-runtime/tests/fixtures/reasoning-models.json
@@ -319,6 +319,36 @@
           "cache_read": 1,
           "cache_write": 12.5
         }
+      },
+      "claude-fable-5-1": {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "family": "claude-fable",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "release_date": "2026-09-01",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 0.25,
+          "cache_write": 12.5
+        }
       }
     }
   },

--- a/packages/sandbox-runtime/tests/test_opencode_reasoning_contract.py
+++ b/packages/sandbox-runtime/tests/test_opencode_reasoning_contract.py
@@ -3,9 +3,9 @@
 Uses real OpenCode 1.18.29, an isolated catalog/config, and fake localhost providers.
 Only reasoning settings are retained from requests; no real provider keys are used.
 
-Fixture: public subset of https://models.opencode.ai/api.json, retrieved 2026-09-04.
-Source SHA-256: ef112420273b7e572ef9c87db13a2f30fe1a562c29ea30d365b911889f9ff46c
-Subset SHA-256: 18e7e0ca29f785f273d50776d9d96f6dd2be6e754d62d14d73b23325d7eac6da
+Fixture: public subset of https://models.opencode.ai/api.json, retrieved 2026-09-09.
+Source SHA-256: a55f5a544d356a15a6491bc3293f2dabb692a381e65cce69fee4741de9636733
+Subset SHA-256: 2c9ff58346fec2db5cc4e1fefc2a6fa752f96570fca06d81bd60a9e93260955f
 Reconcile this frozen fixture with shared model/effort definitions when changing
 models or the binary. Mocks verify serialization, not live provider acceptance.
 """

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -30,6 +30,7 @@ const ANTHROPIC_MODELS = [
   "anthropic/claude-opus-4-8",
   "anthropic/claude-opus-5",
   "anthropic/claude-fable-5",
+  "anthropic/claude-fable-5-1",
 ] as const;
 
 const OPENAI_MODELS = [
@@ -118,12 +119,14 @@ describe("model utilities", () => {
     expect(normalizeModelId("claude-opus-4-8")).toBe("anthropic/claude-opus-4-8");
     expect(normalizeModelId("claude-opus-5")).toBe("anthropic/claude-opus-5");
     expect(normalizeModelId("claude-fable-5")).toBe("anthropic/claude-fable-5");
+    expect(normalizeModelId("claude-fable-5-1")).toBe("anthropic/claude-fable-5-1");
     expect(normalizeModelId("gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
     expect(normalizeModelId("gpt-5.6-sol")).toBe("openai/gpt-5.6-sol");
     expect(isValidModel("claude-sonnet-4-6")).toBe(true);
     expect(isValidModel("claude-opus-4-8")).toBe(true);
     expect(isValidModel("claude-opus-5")).toBe(true);
     expect(isValidModel("claude-fable-5")).toBe(true);
+    expect(isValidModel("claude-fable-5-1")).toBe(true);
     expect(isValidModel("gpt-5.3-codex")).toBe(true);
     expect(isValidModel("gpt-5.6-sol")).toBe(true);
   });
@@ -281,6 +284,7 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("anthropic/claude-sonnet-5")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-opus-5")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-fable-5")).toBe("high");
+    expect(getDefaultReasoningEffort("anthropic/claude-fable-5-1")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
     expect(getDefaultReasoningEffort("openai/gpt-5.6-sol")).toBe("medium");
@@ -308,6 +312,10 @@ describe("model utilities", () => {
       default: "high",
     });
     expect(getReasoningConfig("anthropic/claude-opus-5")).toEqual({
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      default: "high",
+    });
+    expect(getReasoningConfig("anthropic/claude-fable-5-1")).toEqual({
       efforts: ["low", "medium", "high", "xhigh", "max"],
       default: "high",
     });
@@ -352,6 +360,8 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("anthropic/claude-opus-5", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-5", "none")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-fable-5", "max")).toBe(true);
+    expect(isValidReasoningEffort("anthropic/claude-fable-5-1", "max")).toBe(true);
+    expect(isValidReasoningEffort("anthropic/claude-fable-5-1", "none")).toBe(false);
     expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-6-astra", "max")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-6-astra", "ultra")).toBe(false);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -124,6 +124,15 @@ export const MODEL_CATALOG = [
           default: "high",
         },
       },
+      {
+        id: "anthropic/claude-fable-5-1",
+        name: "Claude Fable 5.1",
+        description: "Demanding reasoning and long-horizon agentic work",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- add `anthropic/claude-fable-5-1` to the shared model catalog with low through max reasoning and a high default
- expose Fable 5.1 through model selectors and Linear's `model:fable-5-1` override
- update model documentation, changelog, and the frozen OpenCode reasoning catalog metadata and checksums

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared -- --run` (867 tests)
- `npm test -w @open-inspect/linear-bot -- --run` (235 tests)
- `npm test -w @open-inspect/web -- --run src/hooks/use-enabled-models.test.tsx src/components/model-reasoning-selector.test.tsx src/components/settings/models-settings.test.tsx` (23 tests)
- `npm test -w @open-inspect/slack-bot -- --run src/app-home/models.test.ts` (2 tests)
- `npm run typecheck`
- `npm run lint`
- `uv run --extra dev ruff check tests/test_opencode_reasoning_contract.py`
- `uv run --extra dev ruff format --check tests/test_opencode_reasoning_contract.py`
- `uv run --extra dev pytest tests/test_opencode_reasoning_contract.py tests/test_reasoning_config.py -v` (1 passed, 3 opt-in wire tests skipped)

## Verification note

The opt-in wire suite was also attempted with OpenCode 1.18.29. The binary reported the expected version, but its isolated health endpoint timed out before test execution in this environment, so live wire serialization remains unverified here. The non-wire reasoning configuration test passes, and the fixture metadata matches the current public OpenCode catalog.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/b63f573451504f0f4620f3f34b3520eb)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Claude Fable 5.1 (`anthropic/claude-fable-5-1`) to the available model catalog and model picker.
  - Added adaptive reasoning controls with effort levels from low to max, defaulting to high.
  - Added support for selecting Claude Fable 5.1 using the `model:fable-5-1` override label.

- **Bug Fixes**
  - Improved model label handling so versioned and provider-qualified Claude model labels resolve correctly.

- **Documentation**
  - Updated model support tables and available-model documentation to include Claude Fable 5.1.
  - Updated integration guidance with the new model override label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->