### PR TITLE
runtime: move OpenCode behind the AgentHarness seam

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/agent_bridge_process.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/agent_bridge_process.py
@@ -21,6 +21,7 @@ class AgentBridgeProcess:
         self.control_plane_url = config.control_plane_url
         self.sandbox_token = config.sandbox_token
         self.session_id = config.session_id
+        self.harness = config.harness
         self._process: asyncio.subprocess.Process | None = None
 
     async def start(self) -> None:
@@ -46,6 +47,8 @@ class AgentBridgeProcess:
             self.sandbox_token,
             "--opencode-port",
             str(OPENCODE_PORT),
+            "--harness",
+            self.harness.value,
             env=os.environ,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -681,7 +681,7 @@ class AgentBridge:
                     message_cost_usd = event["messageCostUsd"]
                 await self._send_event(event)
 
-            outcome: TurnOutcome = await self.harness.run_prompt(
+            turn: TurnOutcome = await self.harness.run_prompt(
                 HarnessPrompt(
                     message_id=message_id,
                     text=content,
@@ -692,12 +692,12 @@ class AgentBridge:
                 ),
                 emit,
             )
-            if outcome.message_cost_usd is not None:
-                message_cost_usd = outcome.message_cost_usd
-            if not outcome.success:
+            if turn.message_cost_usd is not None:
+                message_cost_usd = turn.message_cost_usd
+            if not turn.success:
                 had_error = True
-                error_message = outcome.error or "Unknown error"
-            if outcome.cancelled:
+                error_message = turn.error or "Unknown error"
+            if turn.cancelled:
                 raise asyncio.CancelledError
 
             if not had_error and not emitted_output:

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -4,9 +4,12 @@ Agent bridge - bidirectional communication between sandbox and control plane.
 This module handles:
 - WebSocket connection to control plane Durable Object
 - Heartbeat loop for connection health
-- Event forwarding from OpenCode to control plane
+- Event forwarding from the agent harness to the control plane
 - Command handling from control plane (prompt, stop, snapshot)
 - Git identity configuration per prompt author
+
+The agent itself sits behind the ``AgentHarness`` seam (see ``harness/``);
+this module never speaks a vendor protocol.
 """
 
 import argparse
@@ -15,9 +18,9 @@ import contextlib
 import json
 import math
 import os
+import sys
 import tempfile
 import time
-from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
@@ -27,11 +30,11 @@ from websockets.exceptions import InvalidStatus
 
 from .attachment_processor import (
     AttachmentProcessor,
-    HydratedSessionAttachment,
     parse_session_image_attachments,
 )
 from .constants import (
     BOOT_WARNINGS_FILE_PATH,
+    BRIDGE_FATAL_ERROR_FILE_PATH,
     DEFAULT_SANDBOX_TIMEOUT_SECONDS,
     MAX_SNAPSHOT_RESERVE_SECONDS,
     REPO_MANIFEST_FILE_PATH,
@@ -41,9 +44,19 @@ from .constants import (
 from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
 from .event_forwarder import BufferedEventForwarder
 from .git_signing import GitSigningError, GitSigningRuntime
+from .harness import (
+    DEFAULT_HARNESS_ID,
+    DETERMINISTIC_FAILURE_EXIT_CODE,
+    AgentHarness,
+    HarnessId,
+    HarnessPrompt,
+    HarnessStartError,
+    PromptLimits,
+    TurnOutcome,
+    build_agent_harness,
+    parse_harness_id,
+)
 from .log_config import configure_logging, get_logger
-from .opencode_client import OpenCodeClient
-from .prompt_stream import OpenCodePromptStream
 from .push_operation import PushOperation
 from .repo_config import load_repo_manifest
 from .types import GitUser
@@ -88,12 +101,12 @@ class SessionTerminatedError(Exception):
 
 class AgentBridge:
     """
-    Bridge between sandbox OpenCode instance and control plane.
+    Bridge between the sandbox's agent harness and the control plane.
 
     Handles:
     - WebSocket connection management with reconnection
     - Heartbeat for connection health
-    - Event streaming from OpenCode to control plane
+    - Event streaming from the harness to the control plane
     - Command handling (prompt, stop, snapshot, shutdown)
     - Git identity management per prompt author
     """
@@ -113,14 +126,14 @@ class AgentBridge:
         control_plane_url: str,
         auth_token: str,
         opencode_port: int = 4096,
-        opencode_client: OpenCodeClient | None = None,
+        harness_id: HarnessId = DEFAULT_HARNESS_ID,
+        harness: AgentHarness | None = None,
     ):
         self.sandbox_id = sandbox_id
         self.session_id = session_id
         self.control_plane_url = control_plane_url
         self.auth_token = auth_token
         self.opencode_port = opencode_port
-        self.opencode_base_url = f"http://localhost:{opencode_port}"
 
         # Logger
         self.log = get_logger(
@@ -137,7 +150,7 @@ class AgentBridge:
             warn_user=self._send_media_warning,
         )
 
-        self.sse_inactivity_timeout = self._resolve_timeout_seconds(
+        inactivity_timeout_seconds = self._resolve_timeout_seconds(
             name="BRIDGE_SSE_INACTIVITY_TIMEOUT",
             default=self.SSE_INACTIVITY_TIMEOUT,
             min_value=self.SSE_INACTIVITY_TIMEOUT_MIN,
@@ -151,11 +164,14 @@ class AgentBridge:
             MAX_SNAPSHOT_RESERVE_SECONDS,
             sandbox_timeout_seconds * SNAPSHOT_RESERVE_FRACTION,
         )
-        self.prompt_cleanup_timeout_seconds = snapshot_reserve_seconds
-        self.prompt_max_duration_seconds = sandbox_timeout_seconds - snapshot_reserve_seconds
+        self.prompt_limits = PromptLimits(
+            inactivity_timeout_seconds=inactivity_timeout_seconds,
+            prompt_max_duration_seconds=sandbox_timeout_seconds - snapshot_reserve_seconds,
+            prompt_cleanup_timeout_seconds=snapshot_reserve_seconds,
+        )
         self.log.info(
             "bridge.prompt_timeout_config",
-            timeout_ms=int(self.prompt_max_duration_seconds * 1000),
+            timeout_ms=int(self.prompt_limits.prompt_max_duration_seconds * 1000),
             sandbox_timeout_ms=int(sandbox_timeout_seconds * 1000),
             snapshot_reserve_ms=int(snapshot_reserve_seconds * 1000),
         )
@@ -164,9 +180,11 @@ class AgentBridge:
         self.shutdown_event = asyncio.Event()
         self.git_sync_complete = asyncio.Event()
 
-        # Session state
-        self.opencode_session_id: str | None = None
-        self.session_id_file = Path(tempfile.gettempdir()) / "opencode-session-id"
+        # Vendor session id persistence. The legacy file name is still read so
+        # snapshots taken before the rename keep their conversation history.
+        temp_dir = Path(tempfile.gettempdir())
+        self.session_id_file = temp_dir / "agent-session-id"
+        self.legacy_session_id_file = temp_dir / "opencode-session-id"
         self.repo_path = Path("/workspace")
         # Supervisor-written canonical repo manifest; push targeting resolves
         # member checkout paths through it rather than joining spec-supplied
@@ -179,16 +197,15 @@ class AgentBridge:
             repo_manifest_path=self.repo_manifest_path,
         )
 
-        # OpenCode transport client; owns its connection pool unless one was
-        # injected (mirrors ControlPlaneDiffClient).
-        self.opencode_client = opencode_client or OpenCodeClient(
-            base_url=self.opencode_base_url,
+        # The agent behind the seam. Injected in tests; built from the
+        # registry in production.
+        self.harness: AgentHarness = harness or build_agent_harness(
+            harness_id,
+            attachment_processor=self.attachment_processor,
             log=self.log,
+            limits=self.prompt_limits,
+            opencode_port=opencode_port,
         )
-
-        # Prompt SSE translator; created on first prompt so that
-        # sse_inactivity_timeout stays overridable until streaming starts.
-        self._prompt_stream: OpenCodePromptStream | None = None
 
         # Track the current prompt task so _handle_stop can cancel it
         self._current_prompt_task: asyncio.Task[None] | None = None
@@ -212,6 +229,11 @@ class AgentBridge:
         self._total_connected_duration_seconds = 0.0
 
     @property
+    def agent_session_id(self) -> str | None:
+        """The vendor session id, once created or resumed."""
+        return self.harness.session_id
+
+    @property
     def ws_url(self) -> str:
         """WebSocket URL for control plane connection."""
         url = self.control_plane_url.replace("https://", "wss://").replace("http://", "ws://")
@@ -226,7 +248,11 @@ class AgentBridge:
         return {
             "type": "ready",
             "sandboxId": self.sandbox_id,
-            "opencodeSessionId": self.opencode_session_id,
+            "agentSessionId": self.agent_session_id,
+            # Pre-rename spelling, kept for one runtime generation.
+            "opencodeSessionId": self.agent_session_id,
+            "harness": self.harness.id.value,
+            "capabilities": self.harness.capabilities.to_wire(),
             **({"runtimeVersion": runtime_version} if runtime_version else {}),
             "repositories": [
                 {
@@ -246,8 +272,15 @@ class AgentBridge:
         Handles reconnection for transient errors (network issues, etc.) but
         exits gracefully for terminal errors like HTTP 410 (session terminated).
         """
-        self.log.info("bridge.run_start")
+        self.log.info("bridge.run_start", harness=self.harness.id.value)
 
+        try:
+            await self.harness.open()
+        except HarnessStartError as error:
+            self._record_fatal_error(str(error))
+            self.log.error("bridge.harness_open_failed", exc=error, harness=self.harness.id.value)
+            await self.harness.close()
+            raise
         await self._load_session_id()
         reconnect_attempts = 0
         run_outcome = "shutdown"
@@ -311,7 +344,7 @@ class AgentBridge:
             await self.diff_refresh.close(
                 timeout_seconds=self.DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS
             )
-            await self.opencode_client.aclose()
+            await self.harness.close()
             self.log.info(
                 "bridge.run_complete",
                 outcome=run_outcome,
@@ -596,7 +629,7 @@ class AgentBridge:
         self.diff_refresh.request(str(event.get("messageId") or "") or None)
 
     async def _handle_prompt(self, cmd: dict[str, Any]) -> None:
-        """Handle prompt command - send to OpenCode and stream response."""
+        """Handle prompt command - run the turn through the harness and terminalise it."""
         message_id = cmd.get("messageId") or cmd.get("message_id", "unknown")
         content = cmd.get("content", "")
         model = cmd.get("model")
@@ -620,8 +653,7 @@ class AgentBridge:
             prompt_author = parse_prompt_git_author(author_data)
             await self._configure_git_identity(prompt_author)
 
-            if not self.opencode_session_id:
-                await self._create_opencode_session()
+            await self._ensure_agent_session()
 
             session_attachments, rejected_attachments = parse_session_image_attachments(
                 raw_attachments
@@ -638,21 +670,39 @@ class AgentBridge:
             attachments = await self.attachment_processor.process(session_attachments)
 
             emitted_output = False
-            async for event in self._stream_opencode_response_sse(
-                message_id, content, model, reasoning_effort, attachments
-            ):
-                if event.get("type") == "error":
-                    had_error = True
-                    error_message = event.get("error")
-                elif event.get("type") in ("token", "tool_call", "step_finish"):
+
+            async def emit(event: dict[str, Any]) -> None:
+                nonlocal emitted_output, message_cost_usd
+                if event.get("type") == "execution_complete":
+                    raise RuntimeError("harness must not emit execution_complete")
+                if event.get("type") in ("token", "tool_call", "step_finish"):
                     emitted_output = True
                 if event.get("type") == "step_finish" and "messageCostUsd" in event:
                     message_cost_usd = event["messageCostUsd"]
                 await self._send_event(event)
 
+            outcome: TurnOutcome = await self.harness.run_prompt(
+                HarnessPrompt(
+                    message_id=message_id,
+                    text=content,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                    attachments=tuple(attachments or ()),
+                    author=author_data if isinstance(author_data, dict) else {},
+                ),
+                emit,
+            )
+            if outcome.message_cost_usd is not None:
+                message_cost_usd = outcome.message_cost_usd
+            if not outcome.success:
+                had_error = True
+                error_message = outcome.error or "Unknown error"
+            if outcome.cancelled:
+                raise asyncio.CancelledError
+
             if not had_error and not emitted_output:
                 had_error = True
-                error_message = "OpenCode completed without emitting assistant output."
+                error_message = "The agent completed without emitting assistant output."
                 self.log.error(
                     "prompt.no_output",
                     message_id=message_id,
@@ -696,61 +746,21 @@ class AgentBridge:
             }
         )
 
-    async def _create_opencode_session(self) -> None:
-        """Create a new OpenCode session."""
-        self.opencode_session_id = await self.opencode_client.create_session()
-        self.log.info(
-            "opencode.session.ensure",
-            opencode_session_id=self.opencode_session_id,
-            action="created",
-        )
-
+    async def _ensure_agent_session(self) -> None:
+        """Create the vendor session on first use and persist its id."""
+        if self.agent_session_id:
+            return
+        await self.harness.create_or_resume_session(None)
         await self._save_session_id()
 
-    def _ensure_prompt_stream(self) -> OpenCodePromptStream:
-        """The long-lived prompt SSE translator, created on first use."""
-        if self._prompt_stream is None:
-            self._prompt_stream = OpenCodePromptStream(
-                client=self.opencode_client,
-                attachment_processor=self.attachment_processor,
-                log=self.log,
-                sse_inactivity_timeout_seconds=self.sse_inactivity_timeout,
-                prompt_max_duration_seconds=self.prompt_max_duration_seconds,
-                prompt_cleanup_timeout_seconds=self.prompt_cleanup_timeout_seconds,
-            )
-        return self._prompt_stream
-
-    async def _stream_opencode_response_sse(
-        self,
-        message_id: str,
-        content: str,
-        model: str | None = None,
-        reasoning_effort: str | None = None,
-        attachments: list[HydratedSessionAttachment] | None = None,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Stream one prompt's response events (see prompt_stream.py)."""
-        if not self.opencode_session_id:
-            raise RuntimeError("OpenCode session not initialized")
-
-        stream = self._ensure_prompt_stream()
-        async for event in stream.stream_prompt(
-            opencode_session_id=self.opencode_session_id,
-            message_id=message_id,
-            content=content,
-            model=model,
-            reasoning_effort=reasoning_effort,
-            attachments=attachments,
-        ):
-            yield event
-
     async def _handle_stop(self) -> None:
-        """Handle stop command - cancel prompt task and request OpenCode stop."""
+        """Handle stop command - cancel prompt task and ask the harness to abort."""
         self.log.info("bridge.stop")
         task = self._current_prompt_task
         if task and not task.done():
             task.cancel()
-        # Best-effort: also tell OpenCode to stop (saves LLM compute cost)
-        await self._request_opencode_stop(reason="command")
+        # Best-effort: also tell the agent to stop (saves LLM compute cost)
+        await self.harness.abort()
 
     async def _handle_snapshot(self) -> None:
         """Handle snapshot command - prepare for snapshot."""
@@ -758,7 +768,8 @@ class AgentBridge:
         await self._send_event(
             {
                 "type": "snapshot_ready",
-                "opencodeSessionId": self.opencode_session_id,
+                "agentSessionId": self.agent_session_id,
+                "opencodeSessionId": self.agent_session_id,
             }
         )
 
@@ -791,42 +802,46 @@ class AgentBridge:
         """Refresh signing state and configure prompt-scoped author identity."""
         await self.git_signing.refresh(user)
 
+    def _read_persisted_session_id(self) -> str | None:
+        for path in (self.session_id_file, self.legacy_session_id_file):
+            if not path.exists():
+                continue
+            persisted = path.read_text().strip()
+            if persisted:
+                return persisted
+        return None
+
     async def _load_session_id(self) -> None:
-        """Load OpenCode session ID from file if it exists."""
-        if self.session_id_file.exists():
-            try:
-                self.opencode_session_id = self.session_id_file.read_text().strip()
-                self.log.info(
-                    "opencode.session.ensure",
-                    opencode_session_id=self.opencode_session_id,
-                    action="loaded",
-                )
-
-                try:
-                    if not await self.opencode_client.session_exists(self.opencode_session_id):
-                        self.log.info(
-                            "opencode.session.invalid",
-                            opencode_session_id=self.opencode_session_id,
-                        )
-                        self.opencode_session_id = None
-                except Exception:
-                    self.opencode_session_id = None
-
-            except Exception as e:
-                self.log.error("opencode.session.load_error", exc=e)
+        """Resume the persisted vendor session, if any, through the harness."""
+        try:
+            persisted = self._read_persisted_session_id()
+        except Exception as e:
+            self.log.error("agent.session.load_error", exc=e)
+            return
+        if not persisted:
+            return
+        try:
+            await self.harness.create_or_resume_session(persisted)
+        except Exception as e:
+            # Creation happens lazily on the first prompt, as it always has.
+            self.log.error("agent.session.load_error", exc=e)
+            return
+        await self._save_session_id()
 
     async def _save_session_id(self) -> None:
-        """Save OpenCode session ID to file for persistence."""
-        if self.opencode_session_id:
+        """Persist the vendor session id so a snapshot restore can resume it."""
+        session_id = self.agent_session_id
+        if session_id:
             try:
-                self.session_id_file.write_text(self.opencode_session_id)
+                self.session_id_file.write_text(session_id)
             except Exception as e:
-                self.log.error("opencode.session.save_error", exc=e)
+                self.log.error("agent.session.save_error", exc=e)
 
-    async def _request_opencode_stop(self, reason: str) -> bool:
-        if not self.opencode_session_id:
-            return False
-        return await self.opencode_client.request_stop(self.opencode_session_id, reason=reason)
+    @staticmethod
+    def _record_fatal_error(message: str) -> None:
+        """Leave the deterministic-failure cause where the supervisor reports it from."""
+        with contextlib.suppress(Exception):
+            Path(BRIDGE_FATAL_ERROR_FILE_PATH).write_text(message)
 
     def _resolve_timeout_seconds(
         self,
@@ -907,6 +922,11 @@ async def main() -> None:
     parser.add_argument("--control-plane", required=True, help="Control plane URL")
     parser.add_argument("--token", required=True, help="Auth token")
     parser.add_argument("--opencode-port", type=int, default=4096, help="OpenCode port")
+    parser.add_argument(
+        "--harness",
+        default=DEFAULT_HARNESS_ID.value,
+        help="Agent harness id (opencode | claude)",
+    )
 
     args = parser.parse_args()
 
@@ -916,9 +936,15 @@ async def main() -> None:
         control_plane_url=args.control_plane,
         auth_token=args.token,
         opencode_port=args.opencode_port,
+        harness_id=parse_harness_id(args.harness),
     )
 
-    await bridge.run()
+    try:
+        await bridge.run()
+    except HarnessStartError:
+        # The cause is already recorded for the supervisor; this exit code
+        # tells it not to spend its restart budget.
+        sys.exit(DETERMINISTIC_FAILURE_EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -248,11 +248,7 @@ class AgentBridge:
         return {
             "type": "ready",
             "sandboxId": self.sandbox_id,
-            "agentSessionId": self.agent_session_id,
-            # Pre-rename spelling, kept for one runtime generation.
             "opencodeSessionId": self.agent_session_id,
-            "harness": self.harness.id.value,
-            "capabilities": self.harness.capabilities.to_wire(),
             **({"runtimeVersion": runtime_version} if runtime_version else {}),
             "repositories": [
                 {
@@ -273,20 +269,24 @@ class AgentBridge:
         exits gracefully for terminal errors like HTTP 410 (session terminated).
         """
         self.log.info("bridge.run_start", harness=self.harness.id.value)
-
-        try:
-            await self.harness.open()
-        except HarnessStartError as error:
-            self._record_fatal_error(str(error))
-            self.log.error("bridge.harness_open_failed", exc=error, harness=self.harness.id.value)
-            await self.harness.close()
-            raise
-        await self._load_session_id()
         reconnect_attempts = 0
-        run_outcome = "shutdown"
+        run_outcome = "harness_start_failed"
         signing_initialized = False
 
+        # One lifecycle: whatever the harness acquires in open() is released
+        # in the finally below, whether startup, session loading or the run
+        # loop is what ends the bridge.
         try:
+            try:
+                await self.harness.open()
+            except HarnessStartError as error:
+                self._record_fatal_error(str(error))
+                self.log.error(
+                    "bridge.harness_open_failed", exc=error, harness=self.harness.id.value
+                )
+                raise
+            await self._load_session_id()
+            run_outcome = "shutdown"
             while not self.shutdown_event.is_set():
                 run_outcome = "shutdown"
                 try:
@@ -344,7 +344,13 @@ class AgentBridge:
             await self.diff_refresh.close(
                 timeout_seconds=self.DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS
             )
-            await self.harness.close()
+            # A failing close() must not replace the exception that ended the
+            # run: a HarnessStartError still has to reach main() as itself so
+            # the supervisor sees the deterministic exit code.
+            try:
+                await self.harness.close()
+            except Exception as close_error:
+                self.log.error("bridge.harness_close_failed", exc=close_error)
             self.log.info(
                 "bridge.run_complete",
                 outcome=run_outcome,
@@ -677,6 +683,9 @@ class AgentBridge:
                     raise RuntimeError("harness must not emit execution_complete")
                 if event.get("type") in ("token", "tool_call", "step_finish"):
                     emitted_output = True
+                # A cancelled turn never returns an outcome, so the last cost
+                # report is the only figure execution_complete can carry then.
+                # When an outcome does arrive it is authoritative (below).
                 if event.get("type") == "step_finish" and "messageCostUsd" in event:
                     message_cost_usd = event["messageCostUsd"]
                 await self._send_event(event)
@@ -692,6 +701,8 @@ class AgentBridge:
                 ),
                 emit,
             )
+            # The outcome is authoritative for cost and success once it
+            # exists; the bridge adds only the no-output guard below.
             if turn.message_cost_usd is not None:
                 message_cost_usd = turn.message_cost_usd
             if not turn.success:
@@ -750,7 +761,7 @@ class AgentBridge:
         """Create the vendor session on first use and persist its id."""
         if self.agent_session_id:
             return
-        await self.harness.create_or_resume_session(None)
+        await self.harness.create_session()
         await self._save_session_id()
 
     async def _handle_stop(self) -> None:
@@ -768,7 +779,6 @@ class AgentBridge:
         await self._send_event(
             {
                 "type": "snapshot_ready",
-                "agentSessionId": self.agent_session_id,
                 "opencodeSessionId": self.agent_session_id,
             }
         )
@@ -812,7 +822,12 @@ class AgentBridge:
         return None
 
     async def _load_session_id(self) -> None:
-        """Resume the persisted vendor session, if any, through the harness."""
+        """Resume the persisted vendor session, if any, through the harness.
+
+        Startup only resumes. A missing or invalid id leaves the harness
+        without a session and the first prompt creates one, as it always has;
+        startup never replaces a conversation as a side effect of loading it.
+        """
         try:
             persisted = self._read_persisted_session_id()
         except Exception as e:
@@ -821,12 +836,12 @@ class AgentBridge:
         if not persisted:
             return
         try:
-            await self.harness.create_or_resume_session(persisted)
+            resumed = await self.harness.resume_session(persisted)
         except Exception as e:
-            # Creation happens lazily on the first prompt, as it always has.
             self.log.error("agent.session.load_error", exc=e)
             return
-        await self._save_session_id()
+        if resumed:
+            await self._save_session_id()
 
     async def _save_session_id(self) -> None:
         """Persist the vendor session id so a snapshot restore can resume it."""
@@ -925,7 +940,7 @@ async def main() -> None:
     parser.add_argument(
         "--harness",
         default=DEFAULT_HARNESS_ID.value,
-        help="Agent harness id (opencode | claude)",
+        help="Agent harness id",
     )
 
     args = parser.parse_args()

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -341,12 +341,16 @@ class AgentBridge:
                 self._current_prompt_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await self._current_prompt_task
-            await self.diff_refresh.close(
-                timeout_seconds=self.DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS
-            )
-            # A failing close() must not replace the exception that ended the
-            # run: a HarnessStartError still has to reach main() as itself so
-            # the supervisor sees the deterministic exit code.
+            # Cleanup failures are logged, never raised: an exception here
+            # would replace the one that ended the run, and a HarnessStartError
+            # has to reach main() as itself so the supervisor sees the
+            # deterministic exit code.
+            try:
+                await self.diff_refresh.close(
+                    timeout_seconds=self.DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS
+                )
+            except Exception as close_error:
+                self.log.error("bridge.diff_refresh_close_failed", exc=close_error)
             try:
                 await self.harness.close()
             except Exception as close_error:

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -57,6 +57,9 @@ IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR = "OI_IMAGE_BUILD_EXECUTION_TIMEOUT_SECOND
 # channel) and drained by the bridge as `warning` sandbox events after its
 # WebSocket handshake. JSONL: one {scope, message, repoOwner?, repoName?} per line.
 BOOT_WARNINGS_FILE_PATH = "/tmp/oi-boot-warnings.jsonl"
+# Written by the bridge before it exits with DETERMINISTIC_FAILURE_EXIT_CODE;
+# the supervisor reports its contents instead of restarting the bridge.
+BRIDGE_FATAL_ERROR_FILE_PATH = "/tmp/oi-bridge-fatal-error.txt"
 
 # Canonical repository manifest written by the supervisor before any child
 # process starts, rewritten on every boot. Consumed by the bridge (push

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -46,8 +46,6 @@ def build_harness_process(
                 log,
                 warnings.record,
             )
-        case HarnessId.CLAUDE:
-            raise ValueError("The claude harness is not available in this runtime yet")
     raise ValueError(f"Unsupported harness: {config.harness}")
 
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -7,12 +7,14 @@ import argparse
 import asyncio
 import os
 import signal
+from typing import Any
 
 from .agent_bridge_process import AgentBridgeProcess
 from .boot_warnings import BootWarningSink
 from .browser_desktop import BrowserDesktop
 from .code_server import CodeServer
 from .constants import VNC_DISPLAY, VNC_PASSWORD_ENV_VAR
+from .harness.base import HarnessId, HarnessProcessOwner
 from .image_environment import apply_image_environment
 from .log_config import configure_logging, get_logger
 from .managed_skills import ManagedSkillsClient, ManagedSkillsMaterializer
@@ -27,6 +29,26 @@ from .tunnel_environment import TunnelEnvironment
 from .web_terminal import WebTerminal
 
 configure_logging()
+
+
+def build_harness_process(
+    config: RuntimeConfig,
+    shutdown_event: asyncio.Event,
+    log: Any,
+    warnings: BootWarningSink,
+) -> HarnessProcessOwner:
+    """The supervisor-half registry: pick the process owner for the session's harness."""
+    match config.harness:
+        case HarnessId.OPENCODE:
+            return OpenCodeServer(
+                config.opencode_config(),
+                shutdown_event,
+                log,
+                warnings.record,
+            )
+        case HarnessId.CLAUDE:
+            raise ValueError("The claude harness is not available in this runtime yet")
+    raise ValueError(f"Unsupported harness: {config.harness}")
 
 
 def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
@@ -64,12 +86,7 @@ def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
             global_config_dir / "skills",
             log,
         )
-    opencode_server = OpenCodeServer(
-        config.opencode_config(),
-        shutdown_event,
-        log,
-        warnings.record,
-    )
+    harness_process = build_harness_process(config, shutdown_event, log, warnings)
     agent_bridge = AgentBridgeProcess(config.bridge_process_config(), log)
     code_server = CodeServer(log)
     web_terminal = WebTerminal(log)
@@ -77,7 +94,7 @@ def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
     return SandboxSupervisor(
         config,
         repository_boot,
-        opencode_server,
+        harness_process,
         agent_bridge,
         code_server,
         web_terminal,

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
@@ -1,0 +1,68 @@
+"""Agent harness seam: one registry, two halves (see ``base.py``)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import (
+    DEFAULT_HARNESS_ID,
+    DETERMINISTIC_FAILURE_EXIT_CODE,
+    AgentHarness,
+    BridgeEvent,
+    EventSink,
+    HarnessCapabilities,
+    HarnessId,
+    HarnessProcessOwner,
+    HarnessPrompt,
+    HarnessStartError,
+    PromptLimits,
+    TurnOutcome,
+    parse_harness_id,
+)
+
+if TYPE_CHECKING:
+    from ..attachment_processor import AttachmentProcessor
+    from ..log_config import StructuredLogger
+
+
+def build_agent_harness(
+    harness_id: HarnessId,
+    *,
+    attachment_processor: AttachmentProcessor,
+    log: StructuredLogger,
+    limits: PromptLimits,
+    opencode_port: int,
+) -> AgentHarness:
+    """The bridge-half registry: one ``match`` is the whole thing."""
+    match harness_id:
+        case HarnessId.OPENCODE:
+            from .opencode import OpencodeHarness
+            from .opencode_client import OpenCodeClient
+
+            return OpencodeHarness(
+                client=OpenCodeClient(base_url=f"http://localhost:{opencode_port}", log=log),
+                attachment_processor=attachment_processor,
+                log=log,
+                limits=limits,
+            )
+        case HarnessId.CLAUDE:
+            raise ValueError("The claude harness is not available in this runtime yet")
+    raise ValueError(f"Unsupported harness: {harness_id}")
+
+
+__all__ = [
+    "DEFAULT_HARNESS_ID",
+    "DETERMINISTIC_FAILURE_EXIT_CODE",
+    "AgentHarness",
+    "BridgeEvent",
+    "EventSink",
+    "HarnessCapabilities",
+    "HarnessId",
+    "HarnessProcessOwner",
+    "HarnessPrompt",
+    "HarnessStartError",
+    "PromptLimits",
+    "TurnOutcome",
+    "build_agent_harness",
+    "parse_harness_id",
+]

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
@@ -10,7 +10,6 @@ from .base import (
     AgentHarness,
     BridgeEvent,
     EventSink,
-    HarnessCapabilities,
     HarnessId,
     HarnessProcessOwner,
     HarnessPrompt,
@@ -19,6 +18,8 @@ from .base import (
     TurnOutcome,
     parse_harness_id,
 )
+from .opencode import OpencodeHarness
+from .opencode_client import OpenCodeClient
 
 if TYPE_CHECKING:
     from ..attachment_processor import AttachmentProcessor
@@ -36,17 +37,12 @@ def build_agent_harness(
     """The bridge-half registry: one ``match`` is the whole thing."""
     match harness_id:
         case HarnessId.OPENCODE:
-            from .opencode import OpencodeHarness
-            from .opencode_client import OpenCodeClient
-
             return OpencodeHarness(
                 client=OpenCodeClient(base_url=f"http://localhost:{opencode_port}", log=log),
                 attachment_processor=attachment_processor,
                 log=log,
                 limits=limits,
             )
-        case HarnessId.CLAUDE:
-            raise ValueError("The claude harness is not available in this runtime yet")
     raise ValueError(f"Unsupported harness: {harness_id}")
 
 
@@ -56,7 +52,6 @@ __all__ = [
     "AgentHarness",
     "BridgeEvent",
     "EventSink",
-    "HarnessCapabilities",
     "HarnessId",
     "HarnessProcessOwner",
     "HarnessPrompt",

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
@@ -1,0 +1,172 @@
+"""The harness seam: the contract between the sandbox runtime and an agent.
+
+The seam has two halves with one owner each:
+
+- ``HarnessProcessOwner`` is the supervisor half. It stages vendor config and
+  owns any long-lived vendor server process (``opencode serve``), including
+  its restart budget.
+- ``AgentHarness`` is the bridge half. It runs prompts against the vendor and
+  yields the runtime-neutral bridge events the control plane understands.
+
+The bridge owns terminalisation: a harness never emits ``execution_complete``.
+It yields events and returns a ``TurnOutcome``; the bridge emits exactly one
+terminal event per prompt from that outcome.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..attachment_processor import HydratedSessionAttachment
+    from ..repo_config import RepoEntry
+
+
+class HarnessId(StrEnum):
+    OPENCODE = "opencode"
+    CLAUDE = "claude"
+
+
+DEFAULT_HARNESS_ID = HarnessId.OPENCODE
+
+
+def parse_harness_id(value: object) -> HarnessId:
+    """Resolve a wire/env harness value; absent means the built-in harness."""
+    if value is None or value == "":
+        return DEFAULT_HARNESS_ID
+    try:
+        return HarnessId(str(value))
+    except ValueError as error:
+        raise ValueError(f"Unsupported harness: {value!r}") from error
+
+
+# Runtime-neutral bridge event dict (``token``, ``tool_call``, ``step_start``,
+# ``step_finish``, ``context_compacted``, ``session_title``, ``error``,
+# ``warning``). Never ``execution_complete``.
+BridgeEvent = dict[str, Any]
+EventSink = Callable[[BridgeEvent], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class HarnessCapabilities:
+    """Static capability record, mirrored by ``HARNESS_CATALOG`` in shared TS."""
+
+    # ``None`` means any model family the catalog offers.
+    model_families: tuple[str, ...] | None
+    # Provider id -> auth modes the harness can select.
+    provider_auth: Mapping[str, tuple[str, ...]]
+    reasoning_display: bool
+    resume: str = "session_id"
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "modelFamilies": "any" if self.model_families is None else list(self.model_families),
+            "providerAuth": {
+                provider: list(modes) for provider, modes in self.provider_auth.items()
+            },
+            "reasoningDisplay": self.reasoning_display,
+            "resume": self.resume,
+        }
+
+
+@dataclass(frozen=True)
+class PromptLimits:
+    """Per-prompt time budgets the bridge derives from the sandbox timeout."""
+
+    inactivity_timeout_seconds: float
+    prompt_max_duration_seconds: float
+    prompt_cleanup_timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class HarnessPrompt:
+    """One prompt turn, in the control plane's vocabulary."""
+
+    message_id: str
+    text: str
+    model: str | None = None
+    reasoning_effort: str | None = None
+    attachments: Sequence[HydratedSessionAttachment] = ()
+    author: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TurnOutcome:
+    """What one ``run_prompt`` call produced, for the bridge to terminalise."""
+
+    success: bool
+    error: str | None = None
+    cancelled: bool = False
+    message_cost_usd: float | None = None
+
+    @classmethod
+    def ok(cls, *, message_cost_usd: float | None = None) -> TurnOutcome:
+        return cls(success=True, message_cost_usd=message_cost_usd)
+
+    @classmethod
+    def failed(cls, error: str, *, message_cost_usd: float | None = None) -> TurnOutcome:
+        return cls(success=False, error=error, message_cost_usd=message_cost_usd)
+
+
+class HarnessStartError(RuntimeError):
+    """A harness could not open, and retrying without operator action is futile.
+
+    The bridge exits with ``DETERMINISTIC_FAILURE_EXIT_CODE`` so the supervisor
+    reports the cause instead of spending its restart budget.
+    """
+
+
+# Bridge exit code the supervisor treats as final (no restart).
+DETERMINISTIC_FAILURE_EXIT_CODE = 78  # EX_CONFIG
+
+
+@runtime_checkable
+class AgentHarness(Protocol):
+    """Bridge half of the seam: a per-session client for one agent vendor."""
+
+    @property
+    def id(self) -> HarnessId: ...
+
+    @property
+    def capabilities(self) -> HarnessCapabilities: ...
+
+    async def open(self) -> None:
+        """Connect to the vendor. Raises ``HarnessStartError`` on a final failure."""
+        ...
+
+    async def close(self) -> None:
+        """Tear down; must reap any child process the harness spawned."""
+        ...
+
+    async def create_or_resume_session(self, persisted_id: str | None) -> str:
+        """Return the vendor session id to use, resuming ``persisted_id`` when it still exists."""
+        ...
+
+    async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:
+        """Run one turn, delivering bridge events through ``emit``.
+
+        Never emits ``execution_complete``. ``asyncio.CancelledError`` propagates
+        so the bridge can settle the turn as cancelled.
+        """
+        ...
+
+    async def abort(self) -> bool:
+        """Best-effort stop of the in-flight turn; ``True`` when a stop was requested."""
+        ...
+
+
+class HarnessProcessOwner(Protocol):
+    """Supervisor half of the seam: staging plus any resident vendor process."""
+
+    async def start(self, repositories: Sequence[RepoEntry], workdir: Path) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    def exit_code(self) -> int | None:
+        """Exit code of the vendor process, or ``None`` while it runs or when there is none."""
+        ...

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
@@ -28,8 +28,9 @@ if TYPE_CHECKING:
 
 
 class HarnessId(StrEnum):
+    """Harnesses this runtime can run. Only deployable implementations are listed."""
+
     OPENCODE = "opencode"
-    CLAUDE = "claude"
 
 
 DEFAULT_HARNESS_ID = HarnessId.OPENCODE
@@ -50,28 +51,6 @@ def parse_harness_id(value: object) -> HarnessId:
 # ``warning``). Never ``execution_complete``.
 BridgeEvent = dict[str, Any]
 EventSink = Callable[[BridgeEvent], Awaitable[None]]
-
-
-@dataclass(frozen=True)
-class HarnessCapabilities:
-    """Static capability record, mirrored by ``HARNESS_CATALOG`` in shared TS."""
-
-    # ``None`` means any model family the catalog offers.
-    model_families: tuple[str, ...] | None
-    # Provider id -> auth modes the harness can select.
-    provider_auth: Mapping[str, tuple[str, ...]]
-    reasoning_display: bool
-    resume: str = "session_id"
-
-    def to_wire(self) -> dict[str, Any]:
-        return {
-            "modelFamilies": "any" if self.model_families is None else list(self.model_families),
-            "providerAuth": {
-                provider: list(modes) for provider, modes in self.provider_auth.items()
-            },
-            "reasoningDisplay": self.reasoning_display,
-            "resume": self.resume,
-        }
 
 
 @dataclass(frozen=True)
@@ -104,6 +83,12 @@ class TurnOutcome:
     cancelled: bool = False
     message_cost_usd: float | None = None
 
+    def __post_init__(self) -> None:
+        if self.cancelled and self.success:
+            raise ValueError("a cancelled turn cannot also be a success")
+        if not self.success and not self.error:
+            raise ValueError("a failed turn must carry an error message")
+
     @classmethod
     def ok(cls, *, message_cost_usd: float | None = None) -> TurnOutcome:
         return cls(success=True, message_cost_usd=message_cost_usd)
@@ -130,13 +115,12 @@ class AgentHarness(Protocol):
     """Bridge half of the seam: a per-session client for one agent vendor."""
 
     session_id: str | None
-    """The vendor session id, once created or resumed; None before that."""
+    """The vendor session id the harness owns: None until ``resume_session``
+    succeeds or ``create_session`` runs. The bridge reads it; only the harness
+    writes it."""
 
     @property
     def id(self) -> HarnessId: ...
-
-    @property
-    def capabilities(self) -> HarnessCapabilities: ...
 
     async def open(self) -> None:
         """Connect to the vendor. Raises ``HarnessStartError`` on a final failure."""
@@ -146,8 +130,12 @@ class AgentHarness(Protocol):
         """Tear down; must reap any child process the harness spawned."""
         ...
 
-    async def create_or_resume_session(self, persisted_id: str | None) -> str:
-        """Return the vendor session id to use, resuming ``persisted_id`` when it still exists."""
+    async def resume_session(self, persisted_id: str) -> bool:
+        """Adopt ``persisted_id`` when the vendor still has it; ``False`` leaves ``session_id`` unset."""
+        ...
+
+    async def create_session(self) -> None:
+        """Create a fresh vendor session and set ``session_id``. The bridge calls this lazily."""
         ...
 
     async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
@@ -129,6 +129,9 @@ DETERMINISTIC_FAILURE_EXIT_CODE = 78  # EX_CONFIG
 class AgentHarness(Protocol):
     """Bridge half of the seam: a per-session client for one agent vendor."""
 
+    session_id: str | None
+    """The vendor session id, once created or resumed; None before that."""
+
     @property
     def id(self) -> HarnessId: ...
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode.py
@@ -1,0 +1,142 @@
+"""``AgentHarness`` over the bundled local OpenCode server."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from .base import (
+    EventSink,
+    HarnessCapabilities,
+    HarnessId,
+    HarnessPrompt,
+    PromptLimits,
+    TurnOutcome,
+)
+from .opencode_stream import OpenCodePromptStream
+
+if TYPE_CHECKING:
+    from ..attachment_processor import AttachmentProcessor
+    from ..log_config import StructuredLogger
+    from .opencode_client import OpenCodeClient
+
+OPENCODE_CAPABILITIES = HarnessCapabilities(
+    model_families=None,
+    provider_auth={
+        "anthropic": ("api_key",),
+        "openai": ("api_key", "provider_account"),
+        "xai": ("api_key", "provider_account"),
+    },
+    # OpenCode does not stream thinking text to the timeline.
+    reasoning_display=False,
+)
+
+
+class OpencodeHarness:
+    """OpenCode behind the seam: HTTP/SSE transport plus the SSE translator.
+
+    The supervisor owns ``opencode serve`` (``OpenCodeServer``); this half only
+    speaks to it. ``open()`` is a no-op because the supervisor's health gate
+    runs before the bridge exists and a failed probe here would only turn a
+    prompt-time error into a bridge crash.
+    """
+
+    id = HarnessId.OPENCODE
+    capabilities = OPENCODE_CAPABILITIES
+
+    def __init__(
+        self,
+        *,
+        client: OpenCodeClient,
+        attachment_processor: AttachmentProcessor,
+        log: StructuredLogger,
+        limits: PromptLimits,
+    ) -> None:
+        self.client = client
+        self.attachment_processor = attachment_processor
+        self.log = log
+        # Read when the prompt stream is first built, so a caller can still
+        # adjust budgets between construction and the first prompt.
+        self.limits = limits
+        self.session_id: str | None = None
+        self._prompt_stream: OpenCodePromptStream | None = None
+
+    @property
+    def prompt_stream(self) -> OpenCodePromptStream:
+        """The long-lived SSE translator, created on first use."""
+        if self._prompt_stream is None:
+            self._prompt_stream = OpenCodePromptStream(
+                client=self.client,
+                attachment_processor=self.attachment_processor,
+                log=self.log,
+                sse_inactivity_timeout_seconds=self.limits.inactivity_timeout_seconds,
+                prompt_max_duration_seconds=self.limits.prompt_max_duration_seconds,
+                prompt_cleanup_timeout_seconds=self.limits.prompt_cleanup_timeout_seconds,
+            )
+        return self._prompt_stream
+
+    async def open(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+    async def create_or_resume_session(self, persisted_id: str | None) -> str:
+        if persisted_id:
+            try:
+                exists = await self.client.session_exists(persisted_id)
+            except Exception:
+                exists = False
+            if exists:
+                self.session_id = persisted_id
+                self.log.info(
+                    "opencode.session.ensure",
+                    opencode_session_id=persisted_id,
+                    action="loaded",
+                )
+                return persisted_id
+            self.log.info("opencode.session.invalid", opencode_session_id=persisted_id)
+
+        created = await self.client.create_session()
+        if not created:
+            raise RuntimeError("OpenCode did not return a session id")
+        self.session_id = created
+        self.log.info("opencode.session.ensure", opencode_session_id=created, action="created")
+        return created
+
+    def stream_events(self, prompt: HarnessPrompt) -> Any:
+        """The raw translated event stream for one prompt (test seam)."""
+        if not self.session_id:
+            raise RuntimeError("OpenCode session not initialized")
+        return self.prompt_stream.stream_prompt(
+            opencode_session_id=self.session_id,
+            message_id=prompt.message_id,
+            content=prompt.text,
+            model=prompt.model,
+            reasoning_effort=prompt.reasoning_effort,
+            attachments=list(prompt.attachments),
+        )
+
+    async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:
+        error_message: str | None = None
+        message_cost_usd: float | None = None
+        try:
+            async for event in self.stream_events(prompt):
+                if event.get("type") == "error":
+                    error_message = str(event.get("error") or "Unknown error")
+                if event.get("type") == "step_finish" and "messageCostUsd" in event:
+                    message_cost_usd = event["messageCostUsd"]
+                await emit(event)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            self.log.error("harness.prompt_error", exc=error, message_id=prompt.message_id)
+            return TurnOutcome.failed(str(error), message_cost_usd=message_cost_usd)
+        if error_message is not None:
+            return TurnOutcome.failed(error_message, message_cost_usd=message_cost_usd)
+        return TurnOutcome.ok(message_cost_usd=message_cost_usd)
+
+    async def abort(self) -> bool:
+        if not self.session_id:
+            return False
+        return await self.client.request_stop(self.session_id, reason="command")

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from .base import (
     EventSink,
-    HarnessCapabilities,
     HarnessId,
     HarnessPrompt,
     PromptLimits,
@@ -20,17 +19,6 @@ if TYPE_CHECKING:
     from ..log_config import StructuredLogger
     from .opencode_client import OpenCodeClient
 
-OPENCODE_CAPABILITIES = HarnessCapabilities(
-    model_families=None,
-    provider_auth={
-        "anthropic": ("api_key",),
-        "openai": ("api_key", "provider_account"),
-        "xai": ("api_key", "provider_account"),
-    },
-    # OpenCode does not stream thinking text to the timeline.
-    reasoning_display=False,
-)
-
 
 class OpencodeHarness:
     """OpenCode behind the seam: HTTP/SSE transport plus the SSE translator.
@@ -42,7 +30,6 @@ class OpencodeHarness:
     """
 
     id = HarnessId.OPENCODE
-    capabilities = OPENCODE_CAPABILITIES
 
     def __init__(
         self,
@@ -81,28 +68,30 @@ class OpencodeHarness:
     async def close(self) -> None:
         await self.client.aclose()
 
-    async def create_or_resume_session(self, persisted_id: str | None) -> str:
-        if persisted_id:
-            try:
-                exists = await self.client.session_exists(persisted_id)
-            except Exception:
-                exists = False
-            if exists:
-                self.session_id = persisted_id
-                self.log.info(
-                    "opencode.session.ensure",
-                    opencode_session_id=persisted_id,
-                    action="loaded",
-                )
-                return persisted_id
+    async def resume_session(self, persisted_id: str) -> bool:
+        # A probe failure counts as "not there", as it always has: the first
+        # prompt then starts a fresh conversation instead of the bridge dying.
+        try:
+            exists = await self.client.session_exists(persisted_id)
+        except Exception:
+            exists = False
+        if not exists:
             self.log.info("opencode.session.invalid", opencode_session_id=persisted_id)
+            return False
+        self.session_id = persisted_id
+        self.log.info(
+            "opencode.session.ensure",
+            opencode_session_id=persisted_id,
+            action="loaded",
+        )
+        return True
 
+    async def create_session(self) -> None:
         created = await self.client.create_session()
         if not created:
             raise RuntimeError("OpenCode did not return a session id")
         self.session_id = created
         self.log.info("opencode.session.ensure", opencode_session_id=created, action="created")
-        return created
 
     def stream_events(self, prompt: HarnessPrompt) -> Any:
         """The raw translated event stream for one prompt (test seam)."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode_client.py
@@ -12,7 +12,7 @@ import httpx
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from .log_config import StructuredLogger
+    from ..log_config import StructuredLogger
 
 HTTP_CONNECT_TIMEOUT_SECONDS: Final = 30.0
 OPENCODE_REQUEST_TIMEOUT_SECONDS: Final = 30.0

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/opencode_stream.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final
 
-from .child_activity import (
+from ..child_activity import (
     MAX_PENDING_CHILD_ACTIVITY,
     ChildActivityCorrelator,
     MessageDisposition,
@@ -19,19 +19,19 @@ from .child_activity import (
     PendingChildError,
     PendingChildMessage,
 )
-from .message_attribution import AssistantMessageDisposition, MessageAttribution
+from ..message_attribution import AssistantMessageDisposition, MessageAttribution
+from ..opencode_identifier import OpenCodeIdentifier
 from .opencode_client import (
     SSEConnectionError,
     SSEInactivityTimeoutError,
     SSEStreamDisconnectedError,
 )
-from .opencode_identifier import OpenCodeIdentifier
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from .attachment_processor import AttachmentProcessor, HydratedSessionAttachment
-    from .log_config import StructuredLogger
+    from ..attachment_processor import AttachmentProcessor, HydratedSessionAttachment
+    from ..log_config import StructuredLogger
     from .opencode_client import OpenCodeClient
 
 # Cap on parts buffered for assistant messages that have not been authorized

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
@@ -411,7 +411,7 @@ class OpenCodeServer:
                 config[name] = entry
         return config
 
-    async def start(self, repositories: tuple[RepoEntry, ...], workdir: Path) -> None:
+    async def start(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
         """Start OpenCode server with configuration."""
         self._setup_managed_oauth()
         self.log.info("opencode.start")

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_config.py
@@ -11,6 +11,8 @@ from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlsplit
 
+from .harness.base import HarnessId, parse_harness_id
+
 
 class BootMode(StrEnum):
     FRESH = "fresh"
@@ -88,6 +90,7 @@ class BridgeProcessConfig:
     control_plane_url: str
     sandbox_token: str
     session_id: str
+    harness: HarnessId
 
 
 @dataclass(frozen=True)
@@ -142,6 +145,11 @@ class RuntimeConfig:
     def session_id(self) -> str:
         return str(self.session_config.get("session_id") or "")
 
+    @property
+    def harness(self) -> HarnessId:
+        """Which agent runs this session; absent means the built-in OpenCode harness."""
+        return parse_harness_id(self.session_config.get("harness"))
+
     def repository_config(self) -> RepositoryConfig:
         raw_repositories = self.session_config.get("repositories")
         repositories = (
@@ -183,6 +191,7 @@ class RuntimeConfig:
             control_plane_url=self.control_plane_url,
             sandbox_token=self.sandbox_token,
             session_id=self.session_id,
+            harness=self.harness,
         )
 
     def managed_skills_config(self) -> ManagedSkillsConfig:

--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -194,7 +194,7 @@ class SandboxSupervisor:
             return restart_count
         if exit_code == DETERMINISTIC_FAILURE_EXIT_CODE:
             # The harness could not open and told us retrying is futile
-            # (denied credential, unsupported harness); report the cause
+            # (for example a denied credential); report the cause
             # rather than spending the restart budget on it.
             cause = self._read_bridge_fatal_error() or "agent harness failed to start"
             self.log.error("bridge.deterministic_failure", exit_code=exit_code, cause=cause)

--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -11,7 +11,12 @@ from urllib.parse import quote
 
 import httpx
 
-from .constants import BOOT_WARNINGS_FILE_PATH, IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR
+from .constants import (
+    BOOT_WARNINGS_FILE_PATH,
+    BRIDGE_FATAL_ERROR_FILE_PATH,
+    IMAGE_BUILD_EXECUTION_TIMEOUT_ENV_VAR,
+)
+from .harness.base import DETERMINISTIC_FAILURE_EXIT_CODE
 from .repo_image_callback import RepoImageBuildCallback
 from .runtime_config import BootMode, RuntimeConfig
 
@@ -22,8 +27,8 @@ if TYPE_CHECKING:
     from .agent_bridge_process import AgentBridgeProcess
     from .browser_desktop import BrowserDesktop
     from .code_server import CodeServer
+    from .harness.base import HarnessProcessOwner
     from .managed_skills import ManagedSkillsMaterializer
-    from .opencode_server import OpenCodeServer
     from .repository_boot import RepositoryBoot, RepositoryBootResult
     from .web_terminal import WebTerminal
 
@@ -50,7 +55,7 @@ class SandboxSupervisor:
         self,
         config: RuntimeConfig,
         repository_boot: RepositoryBoot,
-        opencode_server: OpenCodeServer,
+        harness_process: HarnessProcessOwner,
         agent_bridge: AgentBridgeProcess,
         code_server: CodeServer,
         web_terminal: WebTerminal,
@@ -61,7 +66,9 @@ class SandboxSupervisor:
     ) -> None:
         self.config = config
         self.repository_boot = repository_boot
-        self.opencode_server = opencode_server
+        # Supervisor half of the harness seam: staging plus any resident
+        # vendor process (``opencode serve`` today; nothing for claude).
+        self.harness_process = harness_process
         self.agent_bridge = agent_bridge
         self.code_server = code_server
         self.web_terminal = web_terminal
@@ -135,8 +142,8 @@ class SandboxSupervisor:
             return False
         return True
 
-    async def _handle_opencode_exit(self, restart_count: int) -> int:
-        exit_code = self.opencode_server.exit_code()
+    async def _handle_harness_process_exit(self, restart_count: int) -> int:
+        exit_code = self.harness_process.exit_code()
         if exit_code is None:
             return restart_count
 
@@ -162,11 +169,20 @@ class SandboxSupervisor:
             return restart_count
         if self._repository_boot_result is None:
             raise RuntimeError("OpenCode restart requested before repository boot")
-        await self.opencode_server.start(
+        await self.harness_process.start(
             self._repository_boot_result.repositories,
             self._repository_boot_result.workdir,
         )
         return restart_count
+
+    def _read_bridge_fatal_error(self) -> str:
+        path = Path(BRIDGE_FATAL_ERROR_FILE_PATH)
+        try:
+            message = path.read_text().strip()
+            path.unlink(missing_ok=True)
+        except OSError:
+            return ""
+        return message
 
     async def _handle_bridge_exit(self, restart_count: int) -> int:
         exit_code = self.agent_bridge.exit_code()
@@ -174,6 +190,15 @@ class SandboxSupervisor:
             return restart_count
         if exit_code == 0:
             self.log.info("bridge.graceful_exit", exit_code=exit_code)
+            self.shutdown_event.set()
+            return restart_count
+        if exit_code == DETERMINISTIC_FAILURE_EXIT_CODE:
+            # The harness could not open and told us retrying is futile
+            # (denied credential, unsupported harness); report the cause
+            # rather than spending the restart budget on it.
+            cause = self._read_bridge_fatal_error() or "agent harness failed to start"
+            self.log.error("bridge.deterministic_failure", exit_code=exit_code, cause=cause)
+            await self._report_fatal_error(cause)
             self.shutdown_event.set()
             return restart_count
 
@@ -280,14 +305,16 @@ class SandboxSupervisor:
 
     async def monitor_processes(self) -> None:
         """Monitor each concrete process owner with its explicit restart policy."""
-        opencode_restarts = 0
+        harness_process_restarts = 0
         bridge_restarts = 0
         code_server_restarts = 0
         terminal_restarts = 0
         desktop_restarts = 0
 
         while not self.shutdown_event.is_set():
-            opencode_restarts = await self._handle_opencode_exit(opencode_restarts)
+            harness_process_restarts = await self._handle_harness_process_exit(
+                harness_process_restarts
+            )
             if self.shutdown_event.is_set():
                 break
             bridge_restarts = await self._handle_bridge_exit(bridge_restarts)
@@ -380,7 +407,7 @@ class SandboxSupervisor:
         expected_tunnel_ports = self.repository_boot.prepare_tunnel_environment(self.boot_mode)
         Path(BOOT_WARNINGS_FILE_PATH).unlink(missing_ok=True)
 
-        opencode_ready = False
+        harness_ready = False
         try:
             if self.boot_mode is BootMode.BUILD:
                 boot_result = await self._run_image_build_execution(expected_tunnel_ports)
@@ -430,8 +457,8 @@ class SandboxSupervisor:
                 self.log.warn("web_terminal.start_failed", exc=error)
                 await self.web_terminal.stop()
 
-            await self.opencode_server.start(boot_result.repositories, boot_result.workdir)
-            opencode_ready = True
+            await self.harness_process.start(boot_result.repositories, boot_result.workdir)
+            harness_ready = True
             await self.agent_bridge.start()
             self.log.info(
                 "sandbox.startup",
@@ -443,7 +470,8 @@ class SandboxSupervisor:
                 git_sync_success=boot_result.git_sync_success,
                 setup_success=boot_result.setup_success,
                 start_success=boot_result.start_success,
-                opencode_ready=opencode_ready,
+                harness=self.config.harness.value,
+                opencode_ready=harness_ready,
                 duration_ms=int((time.time() - startup_start) * 1000),
                 outcome="success",
             )
@@ -485,5 +513,5 @@ class SandboxSupervisor:
         await self.web_terminal.stop()
         await self.code_server.stop()
         await self.browser_desktop.stop()
-        await self.opencode_server.stop()
+        await self.harness_process.stop()
         self.log.info("supervisor.shutdown_complete")

--- a/packages/sandbox-runtime/src/sandbox_runtime/types.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/types.py
@@ -67,10 +67,6 @@ class SessionConfig(BaseModel):
     repo_name: str | None = None
     branch: str | None = None
     base_sha: str | None = None
-    # The agent's own conversation id. `opencode_session_id` is the pre-rename
-    # spelling, accepted for one runtime generation so snapshots and older
-    # control planes keep resuming.
-    agent_session_id: str | None = None
     opencode_session_id: str | None = None
     # Which agent runs the session; absent means the built-in OpenCode harness.
     harness: str = "opencode"

--- a/packages/sandbox-runtime/src/sandbox_runtime/types.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/types.py
@@ -67,7 +67,13 @@ class SessionConfig(BaseModel):
     repo_name: str | None = None
     branch: str | None = None
     base_sha: str | None = None
+    # The agent's own conversation id. `opencode_session_id` is the pre-rename
+    # spelling, accepted for one runtime generation so snapshots and older
+    # control planes keep resuming.
+    agent_session_id: str | None = None
     opencode_session_id: str | None = None
+    # Which agent runs the session; absent means the built-in OpenCode harness.
+    harness: str = "opencode"
     provider: str = "anthropic"
     model: str = "claude-sonnet-4-6"
     mcp_servers: list[McpServerConfig] | None = None

--- a/packages/sandbox-runtime/tests/conftest.py
+++ b/packages/sandbox-runtime/tests/conftest.py
@@ -5,9 +5,13 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import pytest
 
-from sandbox_runtime.opencode_client import OpenCodeClient
+from sandbox_runtime.harness import EventSink, HarnessPrompt, PromptLimits, TurnOutcome
+from sandbox_runtime.harness.opencode import OpencodeHarness
+from sandbox_runtime.harness.opencode_client import OpenCodeClient
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
     from sandbox_runtime.bridge import AgentBridge
 
 
@@ -37,21 +41,130 @@ def isolate_runtime_file_paths(tmp_path, monkeypatch):
 
 
 def wire_opencode_transport(bridge: "AgentBridge", http_client: Any) -> Any:
-    """Point a bridge's OpenCode client at a fake HTTP transport (test seam).
+    """Point a bridge's OpenCode harness at a fake HTTP transport (test seam).
 
-    Rebuilds ``bridge.opencode_client`` around the fake, resets the lazily
-    built prompt stream so it rebinds to the new client, and stashes the fake
-    on ``bridge.http_client`` so tests can read it back to script responses.
-    Returns the fake for convenience.
+    Rebuilds ``bridge.harness`` around the fake (carrying the vendor session
+    id over), so the lazily built prompt stream rebinds to the new client,
+    and stashes the fake on ``bridge.http_client`` so tests can read it back
+    to script responses. Returns the fake for convenience.
     """
-    bridge.opencode_client = OpenCodeClient(
-        base_url=bridge.opencode_base_url,
+    previous = bridge.harness
+    assert isinstance(previous, OpencodeHarness)
+    harness = OpencodeHarness(
+        client=OpenCodeClient(
+            base_url=f"http://localhost:{bridge.opencode_port}",
+            log=bridge.log,
+            http_client=http_client,
+        ),
+        attachment_processor=bridge.attachment_processor,
         log=bridge.log,
-        http_client=http_client,
+        limits=previous.limits,
     )
-    bridge._prompt_stream = None
+    harness.session_id = previous.session_id
+    bridge.harness = harness
     bridge.http_client = http_client
     return http_client
+
+
+def set_prompt_limits(bridge: "AgentBridge", **overrides: float) -> None:
+    """Adjust per-prompt budgets before the harness builds its prompt stream."""
+    from dataclasses import replace
+
+    assert isinstance(bridge.harness, OpencodeHarness)
+    bridge.prompt_limits = replace(bridge.prompt_limits, **overrides)
+    bridge.harness.limits = bridge.prompt_limits
+
+
+def stream_opencode_events(
+    bridge: "AgentBridge",
+    message_id: str,
+    content: str,
+    *,
+    model: str | None = None,
+    reasoning_effort: str | None = None,
+    attachments: list[Any] | None = None,
+) -> "AsyncIterator[dict[str, Any]]":
+    """The raw translated event stream of one OpenCode prompt (what run_prompt drains)."""
+    assert isinstance(bridge.harness, OpencodeHarness)
+    return bridge.harness.stream_events(
+        HarnessPrompt(
+            message_id=message_id,
+            text=content,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            attachments=tuple(attachments or ()),
+        )
+    )
+
+
+class ScriptedHarness:
+    """An ``AgentHarness`` that replays a scripted event stream (bridge tests).
+
+    ``stream`` is an async-generator function; it is called once per prompt
+    and its events are emitted verbatim. The outcome is derived exactly as
+    the OpenCode harness derives it: an ``error`` event fails the turn, the
+    last ``step_finish.messageCostUsd`` is the turn cost.
+    """
+
+    from sandbox_runtime.harness import HarnessId
+    from sandbox_runtime.harness.opencode import OPENCODE_CAPABILITIES
+
+    id = HarnessId.OPENCODE
+    capabilities = OPENCODE_CAPABILITIES
+
+    def __init__(
+        self,
+        stream: "Callable[..., AsyncIterator[dict[str, Any]]] | None" = None,
+        *,
+        session_id: str | None = "oc-session-123",
+    ) -> None:
+        self.stream = stream
+        self.session_id = session_id
+        self.prompts: list[HarnessPrompt] = []
+        self.abort_calls = 0
+        self.opened = False
+        self.closed = False
+
+    async def open(self) -> None:
+        self.opened = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def create_or_resume_session(self, persisted_id: str | None) -> str:
+        self.session_id = persisted_id or self.session_id or "oc-session-new"
+        return self.session_id
+
+    async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:
+        self.prompts.append(prompt)
+        if self.stream is None:
+            return TurnOutcome.ok()
+        error: str | None = None
+        cost: float | None = None
+        async for event in self.stream(prompt.message_id, prompt.text):
+            if event.get("type") == "error":
+                error = str(event.get("error"))
+            if event.get("type") == "step_finish" and "messageCostUsd" in event:
+                cost = event["messageCostUsd"]
+            await emit(event)
+        if error is not None:
+            return TurnOutcome.failed(error, message_cost_usd=cost)
+        return TurnOutcome.ok(message_cost_usd=cost)
+
+    async def abort(self) -> bool:
+        self.abort_calls += 1
+        return True
+
+
+__all__ = [
+    "MockResponse",
+    "PromptLimits",
+    "ScriptedHarness",
+    "oc_message_id",
+    "set_prompt_limits",
+    "stream_opencode_events",
+    "wire_opencode_transport",
+]
 
 
 class MockResponse:

--- a/packages/sandbox-runtime/tests/conftest.py
+++ b/packages/sandbox-runtime/tests/conftest.py
@@ -107,10 +107,8 @@ class ScriptedHarness:
     """
 
     from sandbox_runtime.harness import HarnessId
-    from sandbox_runtime.harness.opencode import OPENCODE_CAPABILITIES
 
     id = HarnessId.OPENCODE
-    capabilities = OPENCODE_CAPABILITIES
 
     def __init__(
         self,
@@ -131,9 +129,12 @@ class ScriptedHarness:
     async def close(self) -> None:
         self.closed = True
 
-    async def create_or_resume_session(self, persisted_id: str | None) -> str:
-        self.session_id = persisted_id or self.session_id or "oc-session-new"
-        return self.session_id
+    async def resume_session(self, persisted_id: str) -> bool:
+        self.session_id = persisted_id
+        return True
+
+    async def create_session(self) -> None:
+        self.session_id = self.session_id or "oc-session-new"
 
     async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:
         self.prompts.append(prompt)

--- a/packages/sandbox-runtime/tests/test_bridge_ack.py
+++ b/packages/sandbox-runtime/tests/test_bridge_ack.py
@@ -25,7 +25,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    b.opencode_session_id = "oc-session-123"
+    b.harness.session_id = "oc-session-123"
     return b
 
 

--- a/packages/sandbox-runtime/tests/test_bridge_attachments.py
+++ b/packages/sandbox-runtime/tests/test_bridge_attachments.py
@@ -21,7 +21,7 @@ def bridge() -> AgentBridge:
 
 
 def test_prompt_request_body_appends_image_parts_after_text(bridge: AgentBridge) -> None:
-    body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+    body = bridge.harness.prompt_stream._build_prompt_request_body(
         "hello",
         model=None,
         attachments=[{"name": "a.png", "mimeType": "image/png", "content": "QQ=="}],
@@ -38,5 +38,5 @@ def test_prompt_request_body_appends_image_parts_after_text(bridge: AgentBridge)
 
 
 def test_prompt_request_body_text_only_when_no_attachments(bridge: AgentBridge) -> None:
-    body = bridge._ensure_prompt_stream()._build_prompt_request_body("hi", model=None)
+    body = bridge.harness.prompt_stream._build_prompt_request_body("hi", model=None)
     assert body["parts"] == [{"type": "text", "text": "hi"}]

--- a/packages/sandbox-runtime/tests/test_bridge_cost_report.py
+++ b/packages/sandbox-runtime/tests/test_bridge_cost_report.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
+from tests.conftest import ScriptedHarness
 
 
 @pytest.fixture
@@ -16,7 +17,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    b.opencode_session_id = "oc-session-123"
+    b.harness.session_id = "oc-session-123"
     b._configure_git_identity = AsyncMock()
     b._send_event = AsyncMock()
     return b
@@ -46,8 +47,7 @@ class TestExecutionCompleteCostReport:
             reported.set()
             await asyncio.Event().wait()
 
-        bridge._stream_opencode_response_sse = stream
-        bridge._request_opencode_stop = AsyncMock()
+        bridge.harness = ScriptedHarness(stream)
         bridge.diff_refresh = Mock()
         await bridge._handle_command({"type": "prompt", **_prompt_command()})
         await asyncio.wait_for(reported.wait(), timeout=1)
@@ -80,7 +80,7 @@ class TestExecutionCompleteCostReport:
                 "messageCostUsd": 0.75,
             }
 
-        bridge._stream_opencode_response_sse = stream
+        bridge.harness = ScriptedHarness(stream)
 
         await bridge._handle_prompt(_prompt_command())
 
@@ -94,7 +94,7 @@ class TestExecutionCompleteCostReport:
             yield {"type": "step_finish", "messageId": "msg-1", "cost": 0.5, "messageCostUsd": 0.5}
             yield {"type": "error", "messageId": "msg-1", "error": "boom"}
 
-        bridge._stream_opencode_response_sse = stream
+        bridge.harness = ScriptedHarness(stream)
 
         await bridge._handle_prompt(_prompt_command())
 
@@ -107,7 +107,7 @@ class TestExecutionCompleteCostReport:
         async def stream(*_args, **_kwargs):
             yield {"type": "token", "messageId": "msg-1", "content": "hi"}
 
-        bridge._stream_opencode_response_sse = stream
+        bridge.harness = ScriptedHarness(stream)
 
         await bridge._handle_prompt(_prompt_command())
 

--- a/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
+++ b/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
@@ -13,7 +13,6 @@ from sandbox_runtime.diff_capture import (
     ControlPlaneDiffClient,
     SessionDiffRefreshWorker,
 )
-from sandbox_runtime.harness.opencode import OPENCODE_CAPABILITIES
 from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.repo_config import RepoEntry, dump_repo_manifest
 
@@ -86,10 +85,7 @@ def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path:
     assert event == {
         "type": "ready",
         "sandboxId": "sandbox-1",
-        "agentSessionId": None,
         "opencodeSessionId": None,
-        "harness": "opencode",
-        "capabilities": OPENCODE_CAPABILITIES.to_wire(),
         "repositories": [
             {
                 "position": 0,

--- a/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
+++ b/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
@@ -13,6 +13,7 @@ from sandbox_runtime.diff_capture import (
     ControlPlaneDiffClient,
     SessionDiffRefreshWorker,
 )
+from sandbox_runtime.harness.opencode import OPENCODE_CAPABILITIES
 from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.repo_config import RepoEntry, dump_repo_manifest
 
@@ -85,7 +86,10 @@ def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path:
     assert event == {
         "type": "ready",
         "sandboxId": "sandbox-1",
+        "agentSessionId": None,
         "opencodeSessionId": None,
+        "harness": "opencode",
+        "capabilities": OPENCODE_CAPABILITIES.to_wire(),
         "repositories": [
             {
                 "position": 0,

--- a/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
+++ b/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
@@ -83,7 +83,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    bridge.opencode_session_id = "oc-session-123"
+    bridge.harness.session_id = "oc-session-123"
     wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 

--- a/packages/sandbox-runtime/tests/test_bridge_git_identity.py
+++ b/packages/sandbox-runtime/tests/test_bridge_git_identity.py
@@ -7,6 +7,7 @@ import pytest
 from sandbox_runtime.bridge import AgentBridge
 from sandbox_runtime.git_signing import GitSigningError
 from sandbox_runtime.types import GitUser
+from tests.conftest import ScriptedHarness
 
 
 async def empty_event_stream(*_args, **_kwargs):
@@ -23,7 +24,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    b.opencode_session_id = "oc-session-123"
+    b.harness.session_id = "oc-session-123"
     return b
 
 
@@ -34,7 +35,7 @@ class TestGitIdentityConfiguration:
     async def test_uses_author_identity_when_provided(self, bridge: AgentBridge):
         """Should use the attributed-user identity selected by the control plane."""
         bridge._configure_git_identity = AsyncMock()
-        bridge._stream_opencode_response_sse = empty_event_stream
+        bridge.harness = ScriptedHarness(empty_event_stream)
         bridge._send_event = AsyncMock()
 
         cmd = {
@@ -61,7 +62,7 @@ class TestGitIdentityConfiguration:
     @pytest.mark.asyncio
     async def test_uses_agent_only_mode_when_selected(self, bridge: AgentBridge):
         bridge._configure_git_identity = AsyncMock()
-        bridge._stream_opencode_response_sse = empty_event_stream
+        bridge.harness = ScriptedHarness(empty_event_stream)
         bridge._send_execution_complete = AsyncMock()
 
         cmd = {
@@ -81,7 +82,7 @@ class TestGitIdentityConfiguration:
     @pytest.mark.asyncio
     async def test_rejects_an_incomplete_attributed_identity(self, bridge: AgentBridge):
         bridge._configure_git_identity = AsyncMock()
-        bridge._stream_opencode_response_sse = empty_event_stream
+        bridge.harness = ScriptedHarness(empty_event_stream)
         bridge._send_event = AsyncMock()
 
         cmd = {
@@ -109,7 +110,7 @@ class TestGitIdentityConfiguration:
     @pytest.mark.asyncio
     async def test_rejects_an_unknown_identity_mode(self, bridge: AgentBridge):
         bridge._configure_git_identity = AsyncMock()
-        bridge._stream_opencode_response_sse = empty_event_stream
+        bridge.harness = ScriptedHarness(empty_event_stream)
         bridge._send_event = AsyncMock()
 
         cmd = {
@@ -137,7 +138,7 @@ class TestGitIdentityConfiguration:
     @pytest.mark.asyncio
     async def test_rejects_a_missing_git_identity_mode(self, bridge: AgentBridge):
         bridge._configure_git_identity = AsyncMock()
-        bridge._stream_opencode_response_sse = empty_event_stream
+        bridge.harness = ScriptedHarness(empty_event_stream)
         bridge._send_event = AsyncMock()
 
         cmd = {
@@ -187,7 +188,7 @@ class TestConfigureGitIdentity:
             side_effect=GitSigningError("Commit signing configuration unavailable")
         )
         stream = MagicMock()
-        bridge._stream_opencode_response_sse = stream
+        bridge.harness = ScriptedHarness(stream)
         bridge._send_event = AsyncMock()
 
         await bridge._handle_prompt(

--- a/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
@@ -1,0 +1,145 @@
+"""Bridge startup, cleanup and session-identity contract at the harness seam."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sandbox_runtime.bridge import AgentBridge
+from sandbox_runtime.harness import HarnessId, HarnessStartError, TurnOutcome, parse_harness_id
+from tests.conftest import ScriptedHarness
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _bridge(harness: ScriptedHarness) -> AgentBridge:
+    bridge = AgentBridge(
+        sandbox_id="sandbox-1",
+        session_id="session-1",
+        control_plane_url="https://control.example.com",
+        auth_token="sandbox-token",
+        harness=harness,
+    )
+    bridge.log = MagicMock()
+    bridge.git_signing.initialize = AsyncMock()
+    bridge.diff_refresh.close = AsyncMock()
+    return bridge
+
+
+class FailingOpenHarness(ScriptedHarness):
+    def __init__(self, error: Exception, *, close_error: Exception | None = None) -> None:
+        super().__init__(session_id=None)
+        self._error = error
+        self._close_error = close_error
+
+    async def open(self) -> None:
+        raise self._error
+
+    async def close(self) -> None:
+        self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class TestStartupLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_error_is_recorded_and_reaches_main_even_when_close_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fatal_path = tmp_path / "fatal.txt"
+        monkeypatch.setattr("sandbox_runtime.bridge.BRIDGE_FATAL_ERROR_FILE_PATH", str(fatal_path))
+        harness = FailingOpenHarness(
+            HarnessStartError("credential denied"), close_error=RuntimeError("close blew up")
+        )
+        bridge = _bridge(harness)
+
+        with pytest.raises(HarnessStartError, match="credential denied"):
+            await bridge.run()
+
+        assert harness.closed is True
+        assert fatal_path.read_text() == "credential denied"
+        bridge.log.error.assert_any_call("bridge.harness_close_failed", exc=harness._close_error)
+
+    @pytest.mark.asyncio
+    async def test_any_open_failure_still_closes_the_harness(self) -> None:
+        harness = FailingOpenHarness(RuntimeError("transient"))
+        bridge = _bridge(harness)
+
+        with pytest.raises(RuntimeError, match="transient"):
+            await bridge.run()
+
+        assert harness.closed is True
+        bridge.log.info.assert_any_call(
+            "bridge.run_complete",
+            outcome="harness_start_failed",
+            connection_count=0,
+            reconnect_count=0,
+            reconnect_attempt_count=0,
+            total_connected_duration_seconds=0.0,
+        )
+
+
+class TestSessionIdentity:
+    @pytest.mark.asyncio
+    async def test_invalid_persisted_id_does_not_create_a_session_at_startup(
+        self, tmp_path: Path
+    ) -> None:
+        harness = ScriptedHarness(session_id=None)
+        harness.resume_session = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        harness.create_session = AsyncMock()  # type: ignore[method-assign]
+        bridge = _bridge(harness)
+        bridge.session_id_file = tmp_path / "agent-session-id"
+        bridge.legacy_session_id_file = tmp_path / "opencode-session-id"
+        bridge.legacy_session_id_file.write_text("oc-gone")
+
+        await bridge._load_session_id()
+
+        harness.resume_session.assert_awaited_once_with("oc-gone")
+        harness.create_session.assert_not_awaited()
+        assert bridge.agent_session_id is None
+        assert not bridge.session_id_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_resumed_id_is_persisted_under_the_current_file_name(
+        self, tmp_path: Path
+    ) -> None:
+        harness = ScriptedHarness(session_id=None)
+        bridge = _bridge(harness)
+        bridge.session_id_file = tmp_path / "agent-session-id"
+        bridge.legacy_session_id_file = tmp_path / "opencode-session-id"
+        bridge.legacy_session_id_file.write_text("oc-live")
+
+        await bridge._load_session_id()
+
+        assert harness.session_id == "oc-live"
+        assert bridge.session_id_file.read_text() == "oc-live"
+
+    @pytest.mark.asyncio
+    async def test_first_prompt_creates_the_session_the_harness_owns(self, tmp_path: Path) -> None:
+        harness = ScriptedHarness(session_id=None)
+        bridge = _bridge(harness)
+        bridge.session_id_file = tmp_path / "agent-session-id"
+
+        await bridge._ensure_agent_session()
+        await bridge._ensure_agent_session()
+
+        assert bridge.agent_session_id == harness.session_id == "oc-session-new"
+        assert bridge.session_id_file.read_text() == "oc-session-new"
+
+
+class TestHarnessContracts:
+    def test_only_deployable_harness_ids_parse(self) -> None:
+        assert parse_harness_id(None) is HarnessId.OPENCODE
+        assert parse_harness_id("opencode") is HarnessId.OPENCODE
+        with pytest.raises(ValueError, match="Unsupported harness: 'claude'"):
+            parse_harness_id("claude")
+
+    def test_turn_outcome_rejects_contradictions(self) -> None:
+        with pytest.raises(ValueError, match="cancelled"):
+            TurnOutcome(success=True, cancelled=True)
+        with pytest.raises(ValueError, match="error message"):
+            TurnOutcome(success=False)
+        assert TurnOutcome.failed("boom", message_cost_usd=0.1).message_cost_usd == 0.1

--- a/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
@@ -55,12 +55,15 @@ class TestStartupLifecycle:
             HarnessStartError("credential denied"), close_error=RuntimeError("close blew up")
         )
         bridge = _bridge(harness)
+        diff_close_error = RuntimeError("diff flush blew up")
+        bridge.diff_refresh.close = AsyncMock(side_effect=diff_close_error)
 
         with pytest.raises(HarnessStartError, match="credential denied"):
             await bridge.run()
 
         assert harness.closed is True
         assert fatal_path.read_text() == "credential denied"
+        bridge.log.error.assert_any_call("bridge.diff_refresh_close_failed", exc=diff_close_error)
         bridge.log.error.assert_any_call("bridge.harness_close_failed", exc=harness._close_error)
 
     @pytest.mark.asyncio

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -15,8 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
+from sandbox_runtime.harness.opencode_stream import _PromptState
 from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
-from sandbox_runtime.prompt_stream import _PromptState
 from tests.conftest import wire_opencode_transport
 
 
@@ -59,7 +59,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    bridge.opencode_session_id = "oc-session-123"
+    bridge.harness.session_id = "oc-session-123"
     wire_opencode_transport(bridge, MagicMock())
     return bridge
 
@@ -86,7 +86,7 @@ class TestToolCallEvent:
             input_data={"command": "ls -la"},
         )
 
-        event = bridge._ensure_prompt_stream()._tool_call_event(part, "cp-message-456")
+        event = bridge.harness.prompt_stream._tool_call_event(part, "cp-message-456")
 
         assert event is not None
         assert event["type"] == "tool_call"
@@ -102,7 +102,7 @@ class TestToolCallEvent:
             input_data={},
         )
 
-        event = bridge._ensure_prompt_stream()._tool_call_event(part, "cp-message-123")
+        event = bridge.harness.prompt_stream._tool_call_event(part, "cp-message-123")
 
         assert event is None
 
@@ -116,7 +116,7 @@ class TestToolCallEvent:
             output="file1.txt\nfile2.txt",
         )
 
-        event = bridge._ensure_prompt_stream()._tool_call_event(part, "cp-message-123")
+        event = bridge.harness.prompt_stream._tool_call_event(part, "cp-message-123")
 
         assert event is not None
         assert event["type"] == "tool_call"
@@ -130,7 +130,7 @@ class TestHandlePartTranslation:
 
     def test_text_part_uses_provided_message_id(self, bridge: AgentBridge):
         """Text parts should use the provided message_id, not any internal ID."""
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         part = create_text_part("part-1", "Hello, world!")
 
         events = stream._handle_part(make_state("cp-message-123"), part, None)
@@ -141,7 +141,7 @@ class TestHandlePartTranslation:
 
     def test_empty_text_part_emits_nothing(self, bridge: AgentBridge):
         """Empty text parts should produce no events."""
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         part = create_text_part("part-1", "")
 
         events = stream._handle_part(make_state("cp-message-123"), part, None)
@@ -150,7 +150,7 @@ class TestHandlePartTranslation:
 
     def test_step_start_part(self, bridge: AgentBridge):
         """Step-start parts should be transformed correctly."""
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         part = {"type": "step-start", "id": "step-1"}
 
         events = stream._handle_part(make_state("cp-message-123"), part, None)
@@ -159,7 +159,7 @@ class TestHandlePartTranslation:
 
     def test_step_finish_part(self, bridge: AgentBridge):
         """Step-finish parts should include cost and token info."""
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         part = {
             "type": "step-finish",
             "id": "step-1",
@@ -182,7 +182,7 @@ class TestHandlePartTranslation:
         ]
 
     def test_step_finish_omits_unknown_cost(self, bridge: AgentBridge):
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         events = stream._handle_part(
             make_state("cp-message-123"),
             {"type": "step-finish", "id": "step-1", "cost": None, "tokens": 150},
@@ -194,7 +194,7 @@ class TestHandlePartTranslation:
 
     def test_step_finish_reports_cumulative_turn_cost(self, bridge: AgentBridge):
         """Each step carries the turn total; a re-emitted part replaces its own cost."""
-        stream = bridge._ensure_prompt_stream()
+        stream = bridge.harness.prompt_stream
         state = make_state("cp-message-123")
 
         first = stream._handle_part(state, {"type": "step-finish", "id": "s1", "cost": 0.5}, None)
@@ -215,7 +215,7 @@ class TestBuildPromptRequestBody:
 
     def test_basic_prompt(self, bridge: AgentBridge):
         """Should build request with text content."""
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body("Hello", None)
+        body = bridge.harness.prompt_stream._build_prompt_request_body("Hello", None)
 
         assert body["parts"] == [{"type": "text", "text": "Hello"}]
         assert "model" not in body
@@ -225,15 +225,13 @@ class TestBuildPromptRequestBody:
         """Should include messageID when provided (expects OpenCode format)."""
         # The function now expects an already-formatted OpenCode ID
         opencode_id = "msg_0123456789abcdefABCDEF"
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body("Hello", None, opencode_id)
+        body = bridge.harness.prompt_stream._build_prompt_request_body("Hello", None, opencode_id)
 
         assert body["messageID"] == opencode_id
 
     def test_with_model_short_form(self, bridge: AgentBridge):
         """Should expand short model name to provider/model."""
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
-            "Hello", "claude-haiku-4-5"
-        )
+        body = bridge.harness.prompt_stream._build_prompt_request_body("Hello", "claude-haiku-4-5")
 
         assert body["model"] == {
             "providerID": "anthropic",
@@ -242,7 +240,7 @@ class TestBuildPromptRequestBody:
 
     def test_with_model_full_form(self, bridge: AgentBridge):
         """Should parse provider/model format."""
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body("Hello", "openai/gpt-4")
+        body = bridge.harness.prompt_stream._build_prompt_request_body("Hello", "openai/gpt-4")
 
         assert body["model"] == {
             "providerID": "openai",
@@ -252,7 +250,7 @@ class TestBuildPromptRequestBody:
     def test_with_all_options(self, bridge: AgentBridge):
         """Should include all options when provided."""
         opencode_id = "msg_0123456789abcdefABCDEF"
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+        body = bridge.harness.prompt_stream._build_prompt_request_body(
             "Hello", "anthropic/claude-3-opus", opencode_id
         )
 
@@ -280,21 +278,21 @@ class TestBuildPromptRequestBody:
         ],
     )
     def test_reasoning_effort_uses_variant(self, bridge: AgentBridge, model: str, effort: str):
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+        body = bridge.harness.prompt_stream._build_prompt_request_body(
             "Hello", model, reasoning_effort=effort
         )
         assert body["variant"] == effort
         assert set(body["model"]) == {"providerID", "modelID"}
 
     def test_no_effort_preserves_opencode_default(self, bridge: AgentBridge):
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+        body = bridge.harness.prompt_stream._build_prompt_request_body(
             "Hello", "openai/gpt-5.6-sol"
         )
         assert "variant" not in body
         assert "options" not in body["model"]
 
     def test_with_xai_reasoning_effort(self, bridge: AgentBridge):
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+        body = bridge.harness.prompt_stream._build_prompt_request_body(
             "Hello",
             "xai/grok-4.5",
             reasoning_effort="high",
@@ -304,7 +302,7 @@ class TestBuildPromptRequestBody:
         assert "options" not in body["model"]
 
     def test_with_grok_4_6_reasoning_effort(self, bridge: AgentBridge):
-        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+        body = bridge.harness.prompt_stream._build_prompt_request_body(
             "Hello",
             "xai/grok-4.6",
             reasoning_effort="medium",

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -20,13 +20,19 @@ import httpx
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
-from sandbox_runtime.opencode_client import SSEConnectionError
-from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
-from sandbox_runtime.prompt_stream import (
+from sandbox_runtime.harness.opencode_client import SSEConnectionError
+from sandbox_runtime.harness.opencode_stream import (
     OpenCodePromptStream,
     _PromptState,
 )
-from tests.conftest import MockResponse, oc_message_id, wire_opencode_transport
+from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
+from tests.conftest import (
+    MockResponse,
+    oc_message_id,
+    set_prompt_limits,
+    stream_opencode_events,
+    wire_opencode_transport,
+)
 
 MOCK_HTTP_TIMEOUT_SECONDS = 30.0
 PROMPT_TIMEOUT_TEST_BUDGET_SECONDS = 0.8
@@ -139,7 +145,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    bridge.opencode_session_id = "oc-session-123"
+    bridge.harness.session_id = "oc-session-123"
     wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 
@@ -165,7 +171,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge.opencode_client._decoded_events(response):
+        async for event in bridge.harness.client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 1
@@ -193,7 +199,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge.opencode_client._decoded_events(response):
+        async for event in bridge.harness.client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 3
@@ -211,7 +217,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge.opencode_client._decoded_events(response):
+        async for event in bridge.harness.client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 2
@@ -273,7 +279,7 @@ class TestSSEStreaming:
 
         events = []
         with pytest.raises(SSEConnectionError, match="OpenCode event stream disconnected"):
-            async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+            async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
                 events.append(event)
 
         token_events = [event for event in events if event["type"] == "token"]
@@ -328,7 +334,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         # Should have 2 token events with cumulative text
@@ -373,7 +379,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -416,7 +422,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -470,7 +476,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -535,7 +541,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -591,7 +597,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -637,7 +643,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert len(events) == 1
@@ -676,7 +682,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert {"type": "session_title", "title": "Generated title"} in events
@@ -714,7 +720,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert [event for event in events if event["type"] == "session_title"] == []
@@ -752,7 +758,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert [event for event in events if event["type"] == "session_title"] == []
@@ -801,7 +807,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert [event["type"] for event in events] == ["token"]
@@ -825,7 +831,7 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         assert len(events) == 1
@@ -868,8 +874,8 @@ class TestSSEStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse(
-            "cp-message-from-control-plane", "Test prompt"
+        async for event in stream_opencode_events(
+            bridge, "cp-message-from-control-plane", "Test prompt"
         ):
             events.append(event)
 
@@ -902,7 +908,7 @@ class TestSSEStreaming:
         assert complete["type"] == "execution_complete"
         assert complete["messageId"] == "cp-msg-1"
         assert complete["success"] is False
-        assert complete["error"] == "OpenCode completed without emitting assistant output."
+        assert complete["error"] == "The agent completed without emitting assistant output."
 
 
 class TestFetchFinalMessageState:
@@ -926,7 +932,7 @@ class TestFetchFinalMessageState:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
+        bridge.harness.session_id = "oc-session-123"
         wire_opencode_transport(bridge, AsyncMock())
         return bridge
 
@@ -955,7 +961,7 @@ class TestFetchFinalMessageState:
         events = []
         # Pass both control plane ID and OpenCode ID
         state = make_prompt_state("cp-msg-2", "msg_0002bbbbbb", cumulative_text=cumulative_text)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should only have the second message's text (parentID matches msg_0002bbbbbb)
@@ -983,7 +989,7 @@ class TestFetchFinalMessageState:
         events = []
         # Pass both control plane ID and OpenCode ID (new ID doesn't match old parentID)
         state = make_prompt_state("cp-msg-new", "msg_0002newnew", cumulative_text=cumulative_text)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should have no events since parentID doesn't match
@@ -1008,7 +1014,7 @@ class TestFetchFinalMessageState:
 
         events = []
         state = make_prompt_state("cp-msg-1", "msg_0001aaaaaa", cumulative_text=cumulative_text)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should have no events since text is not longer
@@ -1033,7 +1039,7 @@ class TestFetchFinalMessageState:
 
         events = []
         state = make_prompt_state("cp-msg-1", "msg_0001aaaaaa", cumulative_text=cumulative_text)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should have one event with full text
@@ -1066,7 +1072,7 @@ class TestFetchFinalMessageState:
 
         events = []
         state = make_prompt_state("cp-msg-1", "msg_0001aaaaaa", cumulative_text=cumulative_text)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should only have assistant message
@@ -1143,7 +1149,7 @@ class TestFetchFinalMessageState:
             compaction_occurred=True,
             start_time=prompt_ts_ms / 1000,
         )
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         assert len(events) == 1
@@ -1260,9 +1266,7 @@ class TestSSEFollowUpMessageBug:
 
         # Process first prompt
         events1 = []
-        async for event in bridge._stream_opencode_response_sse(
-            "cp-msg-1", "what was last commit?"
-        ):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "what was last commit?"):
             events1.append(event)
 
         # Verify first prompt response
@@ -1340,7 +1344,7 @@ class TestSSEFollowUpMessageBug:
 
         # Process second prompt
         events2 = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-2", "who was it by?"):
+        async for event in stream_opencode_events(bridge, "cp-msg-2", "who was it by?"):
             events2.append(event)
 
         # Verify second prompt response
@@ -1474,8 +1478,8 @@ class TestInactivityTimeout:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.sse_inactivity_timeout = 0.2
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, inactivity_timeout_seconds=0.2)
 
         # SSE connects but then hangs after server.connected
         sse_response = HangingMockSSEResponse(
@@ -1484,7 +1488,7 @@ class TestInactivityTimeout:
         wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         with pytest.raises(RuntimeError, match="SSE stream inactive"):
-            async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
+            async for _event in stream_opencode_events(bridge, "msg-1", "test"):
                 pass
 
     @pytest.mark.asyncio
@@ -1496,8 +1500,8 @@ class TestInactivityTimeout:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.sse_inactivity_timeout = 0.5
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, inactivity_timeout_seconds=0.5)
 
         # Events arrive every 0.1s — well under the 0.5s inactivity limit
         # Total wall-clock time (~0.3s) would NOT matter; only gaps between chunks
@@ -1554,7 +1558,7 @@ class TestInactivityTimeout:
         wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("msg-1", "test"):
+        async for event in stream_opencode_events(bridge, "msg-1", "test"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -1570,8 +1574,8 @@ class TestInactivityTimeout:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.sse_inactivity_timeout = 0.3
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, inactivity_timeout_seconds=0.3)
 
         # Heartbeats arrive every 0.2s — under the 0.3s inactivity limit
         # Without heartbeats, the 0.2s gaps would eventually accumulate beyond
@@ -1616,7 +1620,7 @@ class TestInactivityTimeout:
         wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("msg-1", "test"):
+        async for event in stream_opencode_events(bridge, "msg-1", "test"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -1637,7 +1641,7 @@ class TestPromptMaxDuration:
             auth_token="test-token",
         )
 
-        assert bridge.prompt_max_duration_seconds == 6300
+        assert bridge.prompt_limits.prompt_max_duration_seconds == 6300
 
     def test_uses_configured_sandbox_timeout_with_snapshot_reserve(self, monkeypatch):
         monkeypatch.setenv("SANDBOX_TIMEOUT_SECONDS", "14400")
@@ -1649,7 +1653,7 @@ class TestPromptMaxDuration:
             auth_token="test-token",
         )
 
-        assert bridge.prompt_max_duration_seconds == 13500
+        assert bridge.prompt_limits.prompt_max_duration_seconds == 13500
 
     def test_uses_proportional_snapshot_reserve_for_short_sandboxes(self, monkeypatch):
         monkeypatch.setenv("SANDBOX_TIMEOUT_SECONDS", "600")
@@ -1661,7 +1665,7 @@ class TestPromptMaxDuration:
             auth_token="test-token",
         )
 
-        assert bridge.prompt_max_duration_seconds == 450
+        assert bridge.prompt_limits.prompt_max_duration_seconds == 450
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("hang_stage", ["sse_handshake", "prompt_post"])
@@ -1672,8 +1676,8 @@ class TestPromptMaxDuration:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.prompt_max_duration_seconds = 0.1
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, prompt_max_duration_seconds=0.1)
 
         if hang_stage == "sse_handshake":
             http_client = DelayedMockHttpClient(HangingHandshakeSSEResponse([]))
@@ -1684,7 +1688,7 @@ class TestPromptMaxDuration:
 
         started_at = time.monotonic()
         with pytest.raises(RuntimeError, match="Prompt exceeded max duration"):
-            async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
+            async for _event in stream_opencode_events(bridge, "msg-1", "test"):
                 pass
 
         assert time.monotonic() - started_at < PROMPT_TIMEOUT_TEST_BUDGET_SECONDS
@@ -1698,9 +1702,9 @@ class TestPromptMaxDuration:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.sse_inactivity_timeout = 2.0
-        bridge.prompt_max_duration_seconds = 0.1
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, inactivity_timeout_seconds=2.0)
+        set_prompt_limits(bridge, prompt_max_duration_seconds=0.1)
 
         sse_response = DelayedMockSSEResponse([(create_sse_event("server.heartbeat", {}), 1.0)])
         http_client = DelayedMockHttpClient(sse_response)
@@ -1709,7 +1713,7 @@ class TestPromptMaxDuration:
 
         started_at = time.monotonic()
         with pytest.raises(RuntimeError, match="Prompt exceeded max duration"):
-            async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
+            async for _event in stream_opencode_events(bridge, "msg-1", "test"):
                 pass
 
         assert time.monotonic() - started_at < PROMPT_TIMEOUT_TEST_BUDGET_SECONDS
@@ -1722,9 +1726,9 @@ class TestPromptMaxDuration:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.prompt_max_duration_seconds = 0.1
-        bridge.prompt_cleanup_timeout_seconds = 0.1
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, prompt_max_duration_seconds=0.1)
+        set_prompt_limits(bridge, prompt_cleanup_timeout_seconds=0.1)
 
         http_client = HangingAbortHttpClient(
             DelayedMockSSEResponse([(create_sse_event("server.heartbeat", {}), 1.0)])
@@ -1733,7 +1737,7 @@ class TestPromptMaxDuration:
 
         started_at = time.monotonic()
         with pytest.raises(RuntimeError, match="Prompt exceeded max duration"):
-            async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
+            async for _event in stream_opencode_events(bridge, "msg-1", "test"):
                 pass
 
         assert time.monotonic() - started_at < PROMPT_TIMEOUT_TEST_BUDGET_SECONDS
@@ -1749,8 +1753,8 @@ class TestPromptMaxDuration:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.prompt_max_duration_seconds = 0.1
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, prompt_max_duration_seconds=0.1)
 
         sse_response = DelayedMockSSEResponse(
             [
@@ -1788,7 +1792,7 @@ class TestPromptMaxDuration:
         http_client = DelayedMockHttpClient(sse_response)
         http_client.get_responses = [MockResponse(200, [])]
         wire_opencode_transport(bridge, http_client)
-        stream = bridge._stream_opencode_response_sse("msg-1", "test")
+        stream = stream_opencode_events(bridge, "msg-1", "test")
 
         assert (await anext(stream))["type"] == "token"
         await asyncio.sleep(0.2)
@@ -1806,9 +1810,9 @@ class TestPromptMaxDuration:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
-        bridge.sse_inactivity_timeout = 2.0
-        bridge.prompt_max_duration_seconds = 0.25
+        bridge.harness.session_id = "oc-session-123"
+        set_prompt_limits(bridge, inactivity_timeout_seconds=2.0)
+        set_prompt_limits(bridge, prompt_max_duration_seconds=0.25)
 
         sse_response = DelayedMockSSEResponse(
             [
@@ -1822,7 +1826,7 @@ class TestPromptMaxDuration:
         wire_opencode_transport(bridge, http_client)
 
         with pytest.raises(RuntimeError, match="Prompt exceeded max duration"):
-            async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
+            async for _event in stream_opencode_events(bridge, "msg-1", "test"):
                 pass
 
         assert any(url.endswith("/abort") for url in http_client.post_urls)
@@ -1937,7 +1941,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -2010,7 +2014,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -2065,7 +2069,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -2123,7 +2127,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -2184,7 +2188,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         error_events = [e for e in events if e["type"] == "error"]
@@ -2260,7 +2264,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -2342,7 +2346,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -2439,7 +2443,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -2523,7 +2527,7 @@ class TestSubtaskStreaming:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         tool_events = [e for e in events if e["type"] == "tool_call"]
@@ -2625,7 +2629,7 @@ class TestCompactionHandling:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -2917,7 +2921,7 @@ class TestCompactionHandling:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         # Summary text should not appear
@@ -2962,7 +2966,7 @@ class TestCompactionHandling:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -3024,7 +3028,7 @@ class TestCompactionHandling:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]
@@ -3040,7 +3044,7 @@ class TestCompactionHandling:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
+        bridge.harness.session_id = "oc-session-123"
         wire_opencode_transport(bridge, AsyncMock())
 
         prompt_ts_ms = 1_754_000_000_000
@@ -3081,7 +3085,7 @@ class TestCompactionHandling:
             compaction_occurred=True,
             start_time=prompt_ts_ms / 1000,
         )
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         # Should find the post-compaction response but NOT the summary
@@ -3098,7 +3102,7 @@ class TestCompactionHandling:
             control_plane_url="http://localhost:8787",
             auth_token="test-token",
         )
-        bridge.opencode_session_id = "oc-session-123"
+        bridge.harness.session_id = "oc-session-123"
         wire_opencode_transport(bridge, AsyncMock())
 
         messages = [
@@ -3118,7 +3122,7 @@ class TestCompactionHandling:
 
         events = []
         state = make_prompt_state("cp-msg-1", "msg_original_id", compaction_occurred=False)
-        async for event in bridge._ensure_prompt_stream()._fetch_final_message_state(state):
+        async for event in bridge.harness.prompt_stream._fetch_final_message_state(state):
             events.append(event)
 
         assert len(events) == 0
@@ -3186,7 +3190,7 @@ class TestCompactionHandling:
         ]
 
         events = []
-        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+        async for event in stream_opencode_events(bridge, "cp-msg-1", "Test prompt"):
             events.append(event)
 
         token_events = [e for e in events if e["type"] == "token"]

--- a/packages/sandbox-runtime/tests/test_bridge_stop.py
+++ b/packages/sandbox-runtime/tests/test_bridge_stop.py
@@ -79,7 +79,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    bridge.opencode_session_id = "oc-session-123"
+    bridge.harness.session_id = "oc-session-123"
     wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 

--- a/packages/sandbox-runtime/tests/test_browser_desktop.py
+++ b/packages/sandbox-runtime/tests/test_browser_desktop.py
@@ -291,7 +291,7 @@ class TestVncLifecycle:
     @pytest.mark.asyncio
     async def test_component_crash_restarts_stack_non_fatally(self):
         supervisor = _make_lifecycle_supervisor()
-        supervisor.opencode_server._opencode_process = _process()
+        supervisor.harness_process._opencode_process = _process()
         supervisor.agent_bridge._process = _process()
         supervisor.browser_desktop._x11vnc_process = _process(returncode=1)
         supervisor.browser_desktop.stop = AsyncMock()
@@ -320,7 +320,7 @@ class TestVncLifecycle:
     async def test_component_crash_stops_after_restart_budget(self):
         supervisor = _make_lifecycle_supervisor()
         supervisor.MAX_RESTARTS = 0
-        supervisor.opencode_server._opencode_process = _process()
+        supervisor.harness_process._opencode_process = _process()
         supervisor.agent_bridge._process = _process()
         supervisor.browser_desktop._x11vnc_process = _process(returncode=1)
 
@@ -348,7 +348,7 @@ class TestVncLifecycle:
     @pytest.mark.asyncio
     async def test_retries_after_a_restart_attempt_fails(self):
         supervisor = _make_lifecycle_supervisor()
-        supervisor.opencode_server._opencode_process = _process()
+        supervisor.harness_process._opencode_process = _process()
         supervisor.agent_bridge._process = _process()
         supervisor.browser_desktop._x11vnc_process = _process(returncode=1)
         supervisor.browser_desktop.stop = AsyncMock()

--- a/packages/sandbox-runtime/tests/test_code_server_supervisor.py
+++ b/packages/sandbox-runtime/tests/test_code_server_supervisor.py
@@ -26,7 +26,7 @@ def _fake_process(returncode: int | None) -> MagicMock:
 class TestCodeServerMonitorRestart:
     async def test_code_server_crash_does_not_set_shutdown(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.code_server._process = _fake_process(1)
 
@@ -45,7 +45,7 @@ class TestCodeServerMonitorRestart:
 
     async def test_code_server_restart_exception_is_caught(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.code_server._process = _fake_process(1)
         supervisor.code_server.start = AsyncMock(
@@ -59,7 +59,7 @@ class TestCodeServerMonitorRestart:
 
     async def test_code_server_max_restarts_gives_up(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.code_server._process = _fake_process(1)
         supervisor.code_server.start = AsyncMock()
@@ -79,7 +79,7 @@ class TestCodeServerMonitorRestart:
 class TestTerminalMonitorRestart:
     async def test_either_component_crash_restarts_whole_stack_nonfatally(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.web_terminal._proxy_process = _fake_process(1)
         supervisor.web_terminal._ttyd_process = _fake_process(None)
@@ -101,7 +101,7 @@ class TestTerminalMonitorRestart:
 
     async def test_restart_exception_stops_whole_stack(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.web_terminal._ttyd_process = _fake_process(1)
         supervisor.web_terminal.stop = AsyncMock(
@@ -116,7 +116,7 @@ class TestTerminalMonitorRestart:
 
     async def test_max_restarts_abandons_stack_nonfatally(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.web_terminal._ttyd_process = _fake_process(1)
         supervisor.web_terminal.start = AsyncMock()
@@ -137,7 +137,7 @@ class TestTerminalMonitorRestart:
 
     async def test_code_server_shutdown_during_backoff_does_not_restart(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.code_server._process = _fake_process(1)
         supervisor.code_server.start = AsyncMock()
@@ -149,7 +149,7 @@ class TestTerminalMonitorRestart:
 
     async def test_terminal_shutdown_during_backoff_does_not_restart(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(None)
+        supervisor.harness_process._opencode_process = _fake_process(None)
         supervisor.agent_bridge._process = _fake_process(None)
         supervisor.web_terminal._ttyd_process = _fake_process(1)
         supervisor.web_terminal.stop = AsyncMock()

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -119,7 +119,7 @@ class TestImageBuildMode:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -130,7 +130,7 @@ class TestImageBuildMode:
         supervisor.repository_boot.hooks.run_setup.assert_called_once()
         supervisor.repository_boot.hooks.run_start.assert_not_called()
         # OpenCode and bridge should NOT be started in build mode
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
         supervisor.agent_bridge.start.assert_not_called()
         supervisor.monitor_processes.assert_not_called()
 
@@ -273,7 +273,7 @@ class TestImageBuildMode:
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=False)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -283,7 +283,7 @@ class TestImageBuildMode:
             await supervisor.run()
 
         supervisor._report_fatal_error.assert_called_once()
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
         supervisor.agent_bridge.start.assert_not_called()
 
     @pytest.mark.asyncio
@@ -731,7 +731,7 @@ class TestFromRepoImage:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -755,7 +755,7 @@ class TestFromRepoImage:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -776,7 +776,7 @@ class TestFromRepoImage:
         )
 
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -784,7 +784,7 @@ class TestFromRepoImage:
         with patch.dict(os.environ, repo_image_env, clear=False):
             await supervisor.run()
 
-        supervisor.opencode_server.start.assert_called_once()
+        supervisor.harness_process.start.assert_called_once()
         supervisor.agent_bridge.start.assert_called_once()
 
     @pytest.mark.asyncio
@@ -797,7 +797,7 @@ class TestFromRepoImage:
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=False)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -807,7 +807,7 @@ class TestFromRepoImage:
             await supervisor.run()
 
         supervisor._report_fatal_error.assert_called_once()
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
         supervisor.agent_bridge.start.assert_not_called()
 
 
@@ -830,7 +830,7 @@ class TestNormalMode:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -856,7 +856,7 @@ class TestNormalMode:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -886,7 +886,7 @@ class TestNormalMode:
 
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -919,7 +919,7 @@ class TestSnapshotRestoreMode:
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -939,7 +939,7 @@ class TestSnapshotRestoreMode:
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=False)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -949,7 +949,7 @@ class TestSnapshotRestoreMode:
             await supervisor.run()
 
         supervisor._report_fatal_error.assert_called_once()
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resync_failure_is_reported_but_not_fatal(self, base_env, tmp_path):
@@ -967,7 +967,7 @@ class TestSnapshotRestoreMode:
         )
         supervisor.repository_boot.hooks.run_setup = AsyncMock(return_value=True)
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -994,7 +994,7 @@ class TestSnapshotRestoreMode:
             if c.args and c.args[0] == "sandbox.startup"
         )
         assert startup_call.kwargs["git_sync_success"] is False
-        supervisor.opencode_server.start.assert_called_once()
+        supervisor.harness_process.start.assert_called_once()
         # The warning is queued for the bridge to forward as a sandbox event.
         warning_lines = (tmp_path / "warnings.jsonl").read_text().splitlines()
         assert len(warning_lines) == 1
@@ -1031,7 +1031,7 @@ class TestNoRepository:
         supervisor.repository_boot.hooks.run_start = AsyncMock(return_value=True)
         supervisor.code_server.start = AsyncMock()
         supervisor.web_terminal.start = AsyncMock()
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process.start = AsyncMock()
         supervisor.agent_bridge.start = AsyncMock()
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
@@ -1046,7 +1046,7 @@ class TestNoRepository:
         supervisor.repository_boot.synchronizer.sync.assert_called_once()
         supervisor.repository_boot.hooks.run_setup.assert_not_called()
         supervisor.repository_boot.hooks.run_start.assert_not_called()
-        supervisor.opencode_server.start.assert_called_once()
+        supervisor.harness_process.start.assert_called_once()
         supervisor.agent_bridge.start.assert_called_once()
 
 

--- a/packages/sandbox-runtime/tests/test_opencode_client.py
+++ b/packages/sandbox-runtime/tests/test_opencode_client.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from sandbox_runtime.opencode_client import (
+from sandbox_runtime.harness.opencode_client import (
     OpenCodeClient,
     SSEConnectionError,
     SSEInactivityTimeoutError,

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -11,13 +11,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.constants import MAX_SNAPSHOT_RESERVE_SECONDS
-from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
-from sandbox_runtime.prompt_stream import (
+from sandbox_runtime.harness.opencode_stream import (
     OpenCodePromptStream,
     _Disposition,
     _message_created_epoch_ms,
     _PromptState,
 )
+from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
 from tests.conftest import oc_message_id
 
 PARENT_SESSION_ID = "oc-session-123"

--- a/packages/sandbox-runtime/tests/test_supervisor_monitor.py
+++ b/packages/sandbox-runtime/tests/test_supervisor_monitor.py
@@ -42,7 +42,7 @@ class TestBridgeGracefulShutdown:
     async def test_bridge_exit_0_sets_shutdown_event(self):
         supervisor = _make_supervisor()
         supervisor.agent_bridge._process = _fake_process(returncode=0)
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
 
         await supervisor.monitor_processes()
 
@@ -51,7 +51,7 @@ class TestBridgeGracefulShutdown:
     async def test_bridge_exit_0_does_not_restart(self):
         supervisor = _make_supervisor()
         supervisor.agent_bridge._process = _fake_process(returncode=0)
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         supervisor.agent_bridge.start = AsyncMock()
 
         await supervisor.monitor_processes()
@@ -135,7 +135,7 @@ class TestFatalErrorHttpReporting:
 class TestBridgeCrashRestart:
     async def test_bridge_crash_restarts_with_backoff(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         supervisor._report_fatal_error = AsyncMock()
         running_process = _fake_process(returncode=None)
 
@@ -154,7 +154,7 @@ class TestBridgeCrashRestart:
 
     async def test_bridge_crash_exceeds_max_restarts(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         supervisor.agent_bridge._process = _fake_process(returncode=1)
         supervisor.agent_bridge.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
@@ -169,7 +169,7 @@ class TestBridgeCrashRestart:
 
     async def test_bridge_killed_by_signal_restarts(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         running_process = _fake_process(returncode=None)
 
         def restart_side_effect():
@@ -188,7 +188,7 @@ class TestBridgeCrashRestart:
 class TestBridgeBackoffTiming:
     async def test_first_restart_uses_base_delay(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         running_process = _fake_process(returncode=None)
 
         def restart_side_effect():
@@ -207,7 +207,7 @@ class TestBridgeBackoffTiming:
 
     async def test_backoff_is_capped_at_max(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         supervisor.agent_bridge._process = _fake_process(returncode=1)
         supervisor.agent_bridge.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
@@ -226,33 +226,33 @@ class TestBridgeBackoffTiming:
 class TestOpenCodeCrashRestart:
     async def test_opencode_crash_exceeds_max_restarts(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=1)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process._opencode_process = _fake_process(returncode=1)
+        supervisor.harness_process.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
         with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=False)):
             await supervisor.monitor_processes()
 
-        assert supervisor.opencode_server.start.call_count == supervisor.MAX_RESTARTS
+        assert supervisor.harness_process.start.call_count == supervisor.MAX_RESTARTS
         supervisor._report_fatal_error.assert_called_once()
         assert "OpenCode crashed" in supervisor._report_fatal_error.call_args.args[0]
 
     async def test_opencode_shutdown_during_backoff_does_not_restart(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=1)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process._opencode_process = _fake_process(returncode=1)
+        supervisor.harness_process.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
         with patch.object(supervisor, "_wait_for_shutdown", AsyncMock(return_value=True)):
             await supervisor.monitor_processes()
 
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
         supervisor._report_fatal_error.assert_not_called()
 
     async def test_real_shutdown_event_interrupts_opencode_backoff(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=1)
-        supervisor.opencode_server.start = AsyncMock()
+        supervisor.harness_process._opencode_process = _fake_process(returncode=1)
+        supervisor.harness_process.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
 
         monitor_task = asyncio.create_task(supervisor.monitor_processes())
@@ -260,12 +260,12 @@ class TestOpenCodeCrashRestart:
         supervisor.shutdown_event.set()
         await asyncio.wait_for(monitor_task, timeout=0.5)
 
-        supervisor.opencode_server.start.assert_not_called()
+        supervisor.harness_process.start.assert_not_called()
         supervisor._report_fatal_error.assert_not_called()
 
     async def test_bridge_shutdown_during_backoff_does_not_restart(self):
         supervisor = _make_supervisor()
-        supervisor.opencode_server._opencode_process = _fake_process(returncode=None)
+        supervisor.harness_process._opencode_process = _fake_process(returncode=None)
         supervisor.agent_bridge._process = _fake_process(returncode=1)
         supervisor.agent_bridge.start = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()


### PR DESCRIPTION
## Summary

Moves OpenCode behind an `AgentHarness` seam in the sandbox runtime so a second agent can be added without touching the bridge's session, event and prompt-queue logic. No behaviour change for OpenCode sessions.

- `harness/base.py` defines the two halves of the seam: `AgentHarness` (bridge half: open, close, create-or-resume a session, run a prompt, abort) and `HarnessProcessOwner` (supervisor half: start and stop the vendor process).
- `harness/opencode.py` implements both for OpenCode. `opencode_client.py` and `prompt_stream.py` move under `harness/` as `opencode_client.py` and `opencode_stream.py`; `test_prompt_stream.py` keeps its name.
- `bridge.py` drops its OpenCode-specific code (about 260 lines) and drives the harness through the Protocol. `entrypoint.py` and `supervisor.py` pick the process owner from the session config's `harness` field, which only accepts `opencode` today.
- The second commit declares `session_id` on the Protocol, renames a local that shadowed the turn outcome, and widens `OpenCodeServer.start` to `Sequence`, which keeps `mypy src/` at the same five pre-existing errors `main` has.
- The third commit is the review round: harness startup sits inside the same try/finally as the run loop and a failing `close()` can no longer replace a `HarnessStartError`; the harness owns `session_id` through `resume_session` and `create_session` (startup only resumes, the first prompt creates, as before the seam); `TurnOutcome` rejects contradictory states; only deployable harness ids are listed, so `parse_harness_id("claude")` is rejected until that harness lands; the `ready` and `snapshot_ready` events emit exactly what the shared schema on `main` declares; registry imports are at module scope. `test_bridge_harness_lifecycle.py` covers the start-error, cleanup-failure, invalid-resume and contract cases.

No runtime manifest bump: the image ships the same Python package.

Part 1 of the Claude Agent harness stack. Next: the harness discriminator on sessions and automations.

## Testing

- `packages/sandbox-runtime`: `uv run python -m pytest` (950 passed, 3 skipped), `ruff check`, `ruff format --check`, `mypy src/` unchanged from `main`, `node --test tests/*.test.mjs` (21 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable agent selection for sessions, defaulting to OpenCode.
  * Added agent-aware session creation, resumption, prompting, stopping, and status reporting.
  * Added clearer reporting for unrecoverable startup failures.

* **Bug Fixes**
  * Improved restoration when saved sessions are unavailable.
  * Prevented cleanup errors from obscuring the original startup failure.
  * Improved handling of agent-process crashes and deterministic failures.
  * Ensured failed startup cleanup completes without masking the underlying error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->