### PR TITLE
runtime: Claude Agent SDK harness behind the seam

### DIFF
--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -17,7 +17,11 @@ import type {
   ImageBuildScopeKind,
   ImageBuildStatus,
 } from "@open-inspect/shared/types/image-builds";
-import { MIN_COMPATIBLE_RUNTIME_GENERATION } from "../sandbox/runtime-manifest";
+import type { HarnessId } from "@open-inspect/shared/harnesses";
+import {
+  HARNESS_MIN_RUNTIME_GENERATION,
+  MIN_COMPATIBLE_RUNTIME_GENERATION,
+} from "../sandbox/runtime-manifest";
 
 /**
  * Providers with image-build support: Modal images, Vercel snapshots,
@@ -85,6 +89,17 @@ export interface ImageBuildCallbackBuild {
  * generic token broker, so no image baked by an earlier runtime may be selected.
  */
 export const MIN_COMPATIBLE_RUNTIME_VERSION = MIN_COMPATIBLE_RUNTIME_GENERATION;
+
+/**
+ * The image floor for a session on `harness`. The global floor retires
+ * runtimes no session can boot any more; a harness whose runtime support
+ * arrived later names its own generation in the manifest, so its sessions
+ * skip older images without retiring any other session's images or
+ * snapshots.
+ */
+export function minCompatibleRuntimeVersionFor(harness: HarnessId): number {
+  return Math.max(MIN_COMPATIBLE_RUNTIME_VERSION, HARNESS_MIN_RUNTIME_GENERATION[harness] ?? 0);
+}
 
 /**
  * Parse the numeric prefix of a SANDBOX_VERSION ("v53-list-native-runtime"

--- a/packages/control-plane/src/sandbox/lifecycle/image-selection.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/image-selection.test.ts
@@ -6,7 +6,10 @@ import { describe, it, expect } from "vitest";
 import { evaluateImageBuildForSpawn, type ImageBuildSpawnRow } from "./image-selection";
 import { computeRepositoriesFingerprint } from "../../image-builds/fingerprint";
 import { COMPATIBLE_RUNTIME_VERSION } from "../../image-builds/test-helpers";
-import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../../image-builds/model";
+import {
+  MIN_COMPATIBLE_RUNTIME_VERSION,
+  minCompatibleRuntimeVersionFor,
+} from "../../image-builds/model";
 
 const SESSION_REPOSITORIES = [
   { repoOwner: "acme", repoName: "web", baseBranch: "main" },
@@ -110,6 +113,27 @@ describe("evaluateImageBuildForSpawn", () => {
         imageBuildId: "imgb-1",
       });
     }
+  });
+
+  it("applies the session harness's own floor without raising everyone else's", async () => {
+    // The Claude harness arrived after the global floor: its sessions skip
+    // images from before it, while OpenCode sessions keep using them.
+    const claudeFloor = minCompatibleRuntimeVersionFor("claude");
+    expect(claudeFloor).toBeGreaterThan(MIN_COMPATIBLE_RUNTIME_VERSION);
+    const image = await readyImage({ runtime_version: `v${claudeFloor - 1}-before-claude` });
+
+    expect(await evaluateImageBuildForSpawn(image, SESSION_REPOSITORIES, "claude")).toEqual({
+      outcome: "miss",
+      reason: "runtime_below_floor",
+      imageBuildId: "imgb-1",
+    });
+    expect(
+      (await evaluateImageBuildForSpawn(image, SESSION_REPOSITORIES, "opencode")).outcome
+    ).toBe("selected");
+    const current = await readyImage({ runtime_version: `v${claudeFloor}-claude` });
+    expect(
+      (await evaluateImageBuildForSpawn(current, SESSION_REPOSITORIES, "claude")).outcome
+    ).toBe("selected");
   });
 
   it("misses when the environment was edited after the session was created", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/image-selection.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/image-selection.ts
@@ -16,12 +16,13 @@
  * the lookup call, logging, and fallback plumbing.
  */
 
+import { DEFAULT_HARNESS, type HarnessId } from "@open-inspect/shared/harnesses";
 import {
   computeRepositoriesFingerprint,
   type FingerprintRepositoryInput,
 } from "../../image-builds/fingerprint";
 import {
-  MIN_COMPATIBLE_RUNTIME_VERSION,
+  minCompatibleRuntimeVersionFor,
   parseRuntimeVersionNumber,
   type ImageBuildScope,
 } from "../../image-builds/model";
@@ -80,12 +81,13 @@ export type ImageBuildSelectionResult =
 
 /**
  * Evaluate the latest ready image (or its absence) against the session's own
- * repository snapshot. Checks run cheapest-first; the floor fails closed on an
- * unparseable runtime version.
+ * repository snapshot. Checks run cheapest-first; the floor is the session
+ * harness's and fails closed on an unparseable runtime version.
  */
 export async function evaluateImageBuildForSpawn(
   image: ImageBuildSpawnRow | null,
-  sessionRepositories: FingerprintRepositoryInput[]
+  sessionRepositories: FingerprintRepositoryInput[],
+  harness: HarnessId = DEFAULT_HARNESS
 ): Promise<ImageBuildSelectionResult> {
   if (!image) {
     return { outcome: "miss", reason: "no_ready_image" };
@@ -97,7 +99,7 @@ export async function evaluateImageBuildForSpawn(
   }
 
   const runtimeVersion = parseRuntimeVersionNumber(image.runtime_version);
-  if (runtimeVersion === null || runtimeVersion < MIN_COMPATIBLE_RUNTIME_VERSION) {
+  if (runtimeVersion === null || runtimeVersion < minCompatibleRuntimeVersionFor(harness)) {
     return { outcome: "miss", reason: "runtime_below_floor", imageBuildId: image.id };
   }
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -10,7 +10,7 @@
  * spawn attempts within the same request.
  */
 
-import { getValidHarnessOrDefault } from "@open-inspect/shared/harnesses";
+import { getValidHarnessOrDefault, type HarnessId } from "@open-inspect/shared/harnesses";
 import type { McpServerConfig, SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { extractProviderAndModel } from "@open-inspect/shared/models";
 import type { ServerMessage } from "@open-inspect/shared/types/server-messages";
@@ -585,12 +585,14 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       if (session.environment_id) {
         selectedImage = await this.lookupImageBuildForSpawn(
           { kind: "environment", id: session.environment_id },
-          repositories
+          repositories,
+          getValidHarnessOrDefault(session.harness)
         );
       } else if (hasRepository && repositories.length === 1) {
         selectedImage = await this.lookupImageBuildForSpawn(
           repoImageBuildScope(repositories[0].repoOwner, repositories[0].repoName),
-          repositories
+          repositories,
+          getValidHarnessOrDefault(session.harness)
         );
       }
 
@@ -741,12 +743,13 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    */
   private async lookupImageBuildForSpawn(
     scope: ImageBuildScope,
-    repositories: SessionRepositoryInfo[]
+    repositories: SessionRepositoryInfo[],
+    harness: HarnessId
   ): Promise<SelectedImageBuild | null> {
     if (!this.imageBuildLookup || repositories.length === 0) return null;
     try {
       const image = await this.imageBuildLookup.getLatestReady(scope);
-      const result = await evaluateImageBuildForSpawn(image, repositories);
+      const result = await evaluateImageBuildForSpawn(image, repositories, harness);
       if (result.outcome === "selected") {
         this.log.info("Using prebuilt image", {
           event: "image_build.spawn_selected",

--- a/packages/control-plane/src/sandbox/runtime-manifest.test.ts
+++ b/packages/control-plane/src/sandbox/runtime-manifest.test.ts
@@ -4,6 +4,7 @@ import { MIN_REBUILD_RUNTIME_VERSION } from "../image-builds/rebuild-policy";
 import { OPENCOMPUTER_SANDBOX_VERSION } from "./opencomputer-rest-client";
 import { VERCEL_SANDBOX_VERSION } from "./providers/vercel/bootstrap";
 import {
+  HARNESS_MIN_RUNTIME_GENERATION,
   MIN_COMPATIBLE_RUNTIME_GENERATION,
   MIN_REBUILD_RUNTIME_GENERATION,
   SANDBOX_RUNTIME_GENERATION,
@@ -17,5 +18,12 @@ describe("sandbox runtime manifest", () => {
     expect(SANDBOX_RUNTIME_VERSION).toMatch(new RegExp(`^v${SANDBOX_RUNTIME_GENERATION}`));
     expect(MIN_COMPATIBLE_RUNTIME_VERSION).toBe(MIN_COMPATIBLE_RUNTIME_GENERATION);
     expect(MIN_REBUILD_RUNTIME_VERSION).toBe(MIN_REBUILD_RUNTIME_GENERATION);
+  });
+
+  it("keeps every per-harness floor between the global floor and the current generation", () => {
+    for (const [harness, floor] of Object.entries(HARNESS_MIN_RUNTIME_GENERATION)) {
+      expect(floor, harness).toBeGreaterThanOrEqual(MIN_COMPATIBLE_RUNTIME_GENERATION);
+      expect(floor, harness).toBeLessThanOrEqual(SANDBOX_RUNTIME_GENERATION);
+    }
   });
 });

--- a/packages/control-plane/src/sandbox/runtime-manifest.ts
+++ b/packages/control-plane/src/sandbox/runtime-manifest.ts
@@ -9,3 +9,6 @@ export const SANDBOX_RUNTIME_VERSION = runtimeManifest.runtimeVersion;
 export const SANDBOX_RUNTIME_GENERATION = runtimeManifest.generation;
 export const MIN_COMPATIBLE_RUNTIME_GENERATION = runtimeManifest.minimumCompatibleGeneration;
 export const MIN_REBUILD_RUNTIME_GENERATION = runtimeManifest.minimumRebuildGeneration;
+/** Per-harness image floors; see minCompatibleRuntimeVersionFor in image-builds/model.ts. */
+export const HARNESS_MIN_RUNTIME_GENERATION: Readonly<Partial<Record<string, number>>> =
+  runtimeManifest.harnessMinimumGeneration;

--- a/packages/control-plane/src/session/provider-account-resolution.test.ts
+++ b/packages/control-plane/src/session/provider-account-resolution.test.ts
@@ -168,4 +168,24 @@ describe("resolveProviderAccountSelections", () => {
       )
     ).rejects.toMatchObject({ status: 404 });
   });
+
+  it("takes the API-key fallback for providers the harness has no auth row for", async () => {
+    const deps = stores({
+      // The xai default points at an account that no longer exists. A Claude
+      // session never runs xai, so that stale default must not reject it.
+      defaults: [
+        providerDefault("openai", OPENAI_ACCOUNT_ID),
+        providerDefault("xai", "9".repeat(32)),
+      ],
+      accounts: [account(OPENAI_ACCOUNT_ID, "openai")],
+    });
+
+    await expect(
+      resolveProviderAccountSelections({ unattended: false, harness: "claude" }, deps)
+    ).resolves.toEqual([
+      { provider: "openai", authMode: "api_key", selectionSource: "harness_fallback" },
+      { provider: "xai", authMode: "api_key", selectionSource: "harness_fallback" },
+    ]);
+    expect(deps.accounts.getById).not.toHaveBeenCalled();
+  });
 });

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -48,6 +48,7 @@ from .harness import (
     DEFAULT_HARNESS_ID,
     DETERMINISTIC_FAILURE_EXIT_CODE,
     AgentHarness,
+    BridgeIdentity,
     HarnessId,
     HarnessPrompt,
     HarnessStartError,
@@ -201,6 +202,13 @@ class AgentBridge:
         # registry in production.
         self.harness: AgentHarness = harness or build_agent_harness(
             harness_id,
+            identity=BridgeIdentity(
+                sandbox_id=sandbox_id,
+                session_id=session_id,
+                control_plane_url=control_plane_url,
+                auth_token=auth_token,
+                repo_manifest_path=self.repo_manifest_path,
+            ),
             attachment_processor=self.attachment_processor,
             log=self.log,
             limits=self.prompt_limits,

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -714,6 +714,7 @@ class AgentBridge:
                 ),
                 emit,
             )
+            await self._persist_rotated_session_id()
             # The outcome is authoritative for cost and success once it
             # exists; the bridge adds only the no-output guard below.
             if turn.message_cost_usd is not None:
@@ -854,6 +855,16 @@ class AgentBridge:
             self.log.error("agent.session.load_error", exc=e)
             return
         if resumed:
+            await self._save_session_id()
+
+    async def _persist_rotated_session_id(self) -> None:
+        """A conversation reset rotates the vendor id mid-connection; keep the file current."""
+        try:
+            persisted = self._read_persisted_session_id()
+        except Exception as e:
+            self.log.error("agent.session.load_error", exc=e)
+            return
+        if self.agent_session_id and self.agent_session_id != persisted:
             await self._save_session_id()
 
     async def _save_session_id(self) -> None:

--- a/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
@@ -1,0 +1,146 @@
+"""Supervisor half of the Claude harness: staging only, no resident process.
+
+``ClaudeStager`` conforms to ``HarnessProcessOwner`` like ``OpenCodeServer``
+does, but the vendor process is spawned later by the SDK inside the bridge,
+so ``start()`` only prepares the filesystem the child will see:
+
+- a per-sandbox ``CLAUDE_CONFIG_DIR`` outside every repository, where the
+  harness never writes credentials (no ``claude auth login`` ever runs);
+- the bundled skills under that directory (managed skills land in the same
+  tree through ``ManagedSkillsMaterializer``);
+- the standalone bin scripts the agent calls from Bash;
+- a small JSON handoff (``CLAUDE_HARNESS_FILE_PATH``) telling the bridge which
+  workdir and config dir the supervisor chose.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .constants import CLAUDE_HARNESS_FILE_PATH
+from .sandbox_bin import install_bin_scripts
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from .repo_config import RepoEntry
+    from .runtime_config import ClaudeStagerConfig
+
+
+DEFAULT_CLAUDE_CONFIG_DIR_NAME = ".openinspect/claude"
+BUNDLED_SKILLS_PATH = Path("/app/sandbox_runtime/skills")
+
+
+def resolve_claude_config_dir() -> Path:
+    """Per-sandbox ``CLAUDE_CONFIG_DIR``: outside every repository, never snapshotted with a credential."""
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
+
+
+@dataclass(frozen=True)
+class ClaudeHarnessHandoff:
+    """What the supervisor decided and the bridge must use."""
+
+    workdir: Path
+    config_dir: Path
+    has_repository: bool
+    mcp_servers: tuple[Mapping[str, Any], ...]
+
+    def write(self, path: Path = Path(CLAUDE_HARNESS_FILE_PATH)) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "workdir": str(self.workdir),
+                    "configDir": str(self.config_dir),
+                    "hasRepository": self.has_repository,
+                    "mcpServers": [dict(server) for server in self.mcp_servers],
+                }
+            )
+        )
+
+    @classmethod
+    def read(cls, path: Path = Path(CLAUDE_HARNESS_FILE_PATH)) -> ClaudeHarnessHandoff:
+        data = json.loads(path.read_text())
+        servers = data.get("mcpServers")
+        return cls(
+            workdir=Path(str(data["workdir"])),
+            config_dir=Path(str(data["configDir"])),
+            has_repository=bool(data.get("hasRepository")),
+            mcp_servers=tuple(s for s in servers if isinstance(s, dict))
+            if isinstance(servers, list)
+            else (),
+        )
+
+
+class ClaudeStager:
+    """``HarnessProcessOwner`` for the Claude harness; ``exit_code()`` is always ``None``."""
+
+    def __init__(
+        self,
+        config: ClaudeStagerConfig,
+        log: Any,
+        *,
+        config_dir: Path | None = None,
+        bundled_skills_path: Path = BUNDLED_SKILLS_PATH,
+        handoff_path: Path = Path(CLAUDE_HARNESS_FILE_PATH),
+    ) -> None:
+        self.config = config
+        self.log = log
+        self.config_dir = config_dir or resolve_claude_config_dir()
+        self.bundled_skills_path = bundled_skills_path
+        self.handoff_path = handoff_path
+        self.started = False
+
+    @property
+    def skills_dir(self) -> Path:
+        return self.config_dir / "skills"
+
+    async def start(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
+        self.log.info("claude.stage", config_dir=str(self.config_dir), workdir=str(workdir))
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        # Nothing the harness writes here is a credential; the directory is
+        # only for Claude's own state (transcripts under projects/, settings).
+        self._install_bundled_skills()
+        install_bin_scripts(self.log)
+        ClaudeHarnessHandoff(
+            workdir=workdir,
+            config_dir=self.config_dir,
+            has_repository=self.config.has_repository,
+            mcp_servers=self.config.mcp_servers,
+        ).write(self.handoff_path)
+        self.started = True
+        self.log.info("claude.staged", repo_count=len(repositories))
+
+    def _install_bundled_skills(self) -> None:
+        if not self.bundled_skills_path.is_dir():
+            return
+        installed = 0
+        for skill_dir in self.bundled_skills_path.iterdir():
+            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                continue
+            shutil.copytree(
+                skill_dir,
+                self.skills_dir / skill_dir.name,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
+                symlinks=True,
+            )
+            installed += 1
+        if installed:
+            self.log.info(
+                "claude.skills_installed", skills_path=str(self.skills_dir), count=installed
+            )
+
+    async def stop(self) -> None:
+        return None
+
+    def exit_code(self) -> int | None:
+        # There is no resident vendor process; the SDK child belongs to the bridge.
+        return None

--- a/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
@@ -47,6 +47,31 @@ def resolve_claude_config_dir() -> Path:
     return Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
 
 
+def isolated_claude_config_dir(
+    candidate: Path, workspace: Path, repositories: Sequence[RepoEntry], log: Any
+) -> Path:
+    """``candidate``, unless it lies inside the workspace or a checkout.
+
+    A user-supplied ``CLAUDE_CONFIG_DIR`` pointing into a repository would put
+    transcripts, skills and the wrapper into the user's diff. Decided once, in
+    the composition root, so managed skills and the stager agree on the
+    directory before either writes to it.
+    """
+    resolved = _resolve_lenient(candidate)
+    for root in (workspace, *(repo.path for repo in repositories)):
+        root_resolved = _resolve_lenient(root)
+        if resolved == root_resolved or root_resolved in resolved.parents:
+            fallback = Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
+            log.warn(
+                "claude.config_dir_rejected",
+                config_dir=str(candidate),
+                inside=str(root),
+                fallback=str(fallback),
+            )
+            return fallback
+    return candidate
+
+
 @dataclass(frozen=True)
 class ClaudeHarnessHandoff:
     """What the supervisor decided and the bridge must use. Never a secret."""
@@ -106,7 +131,6 @@ class ClaudeStager:
         return self.config_dir / "skills"
 
     async def start(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
-        self.config_dir = self._isolated_config_dir(workdir, repositories)
         self.log.info("claude.stage", config_dir=str(self.config_dir), workdir=str(workdir))
         self.config_dir.mkdir(parents=True, exist_ok=True)
         # Nothing the harness writes here is a credential; the directory is
@@ -126,27 +150,6 @@ class ClaudeStager:
         ).write(self.handoff_path)
         self.started = True
         self.log.info("claude.staged", repo_count=len(repositories))
-
-    def _isolated_config_dir(self, workdir: Path, repositories: Sequence[RepoEntry]) -> Path:
-        """The configured directory, unless it lies inside the workspace or a checkout.
-
-        A user-supplied ``CLAUDE_CONFIG_DIR`` pointing into a repository would
-        put transcripts, skills and the wrapper into the user's diff.
-        """
-        candidate = self.config_dir
-        resolved = _resolve_lenient(candidate)
-        for root in (workdir, *(repo.path for repo in repositories)):
-            root_resolved = _resolve_lenient(root)
-            if resolved == root_resolved or root_resolved in resolved.parents:
-                fallback = Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
-                self.log.warn(
-                    "claude.config_dir_rejected",
-                    config_dir=str(candidate),
-                    inside=str(root),
-                    fallback=str(fallback),
-                )
-                return fallback
-        return candidate
 
     def _install_bundled_skills(self) -> None:
         if not self.bundled_skills_path.is_dir():

--- a/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
@@ -10,7 +10,9 @@ so ``start()`` only prepares the filesystem the child will see:
   tree through ``ManagedSkillsMaterializer``);
 - the standalone bin scripts the agent calls from Bash;
 - a small JSON handoff (``CLAUDE_HARNESS_FILE_PATH``) telling the bridge which
-  workdir and config dir the supervisor chose.
+  workdir and config dir the supervisor chose. It carries decisions only: MCP
+  configuration, which can hold credentials, reaches the bridge through its
+  own ``SESSION_CONFIG`` and is never written to disk here.
 """
 
 from __future__ import annotations
@@ -18,12 +20,12 @@ from __future__ import annotations
 import json
 import os
 import shutil
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .constants import CLAUDE_HARNESS_FILE_PATH
+from .mcp_packages import McpPackageInstaller
 from .sandbox_bin import install_bin_scripts
 
 if TYPE_CHECKING:
@@ -45,51 +47,36 @@ def resolve_claude_config_dir() -> Path:
     return Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
 
 
-def _plain_json(value: Any) -> Any:
-    """Undo ``runtime_config``'s freezing: mapping proxies and tuples → dicts and lists.
-
-    ``SESSION_CONFIG`` is frozen recursively, so an MCP server's nested ``env``
-    or ``headers`` is a ``MappingProxyType`` that ``json.dumps`` rejects.
-    """
-    if isinstance(value, Mapping):
-        return {str(key): _plain_json(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_plain_json(item) for item in value]
-    return value
-
-
 @dataclass(frozen=True)
 class ClaudeHarnessHandoff:
-    """What the supervisor decided and the bridge must use."""
+    """What the supervisor decided and the bridge must use. Never a secret."""
 
     workdir: Path
     config_dir: Path
     has_repository: bool
-    mcp_servers: tuple[Mapping[str, Any], ...]
 
     def write(self, path: Path = Path(CLAUDE_HARNESS_FILE_PATH)) -> None:
-        path.write_text(
-            json.dumps(
-                {
-                    "workdir": str(self.workdir),
-                    "configDir": str(self.config_dir),
-                    "hasRepository": self.has_repository,
-                    "mcpServers": [_plain_json(server) for server in self.mcp_servers],
-                }
-            )
+        payload = json.dumps(
+            {
+                "workdir": str(self.workdir),
+                "configDir": str(self.config_dir),
+                "hasRepository": self.has_repository,
+            }
         )
+        # Owner-only and atomic: a reader sees the whole file or none of it.
+        staging = path.with_name(path.name + ".tmp")
+        descriptor = os.open(staging, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w") as handle:
+            handle.write(payload)
+        staging.replace(path)
 
     @classmethod
     def read(cls, path: Path = Path(CLAUDE_HARNESS_FILE_PATH)) -> ClaudeHarnessHandoff:
         data = json.loads(path.read_text())
-        servers = data.get("mcpServers")
         return cls(
             workdir=Path(str(data["workdir"])),
             config_dir=Path(str(data["configDir"])),
             has_repository=bool(data.get("hasRepository")),
-            mcp_servers=tuple(s for s in servers if isinstance(s, dict))
-            if isinstance(servers, list)
-            else (),
         )
 
 
@@ -104,12 +91,14 @@ class ClaudeStager:
         config_dir: Path | None = None,
         bundled_skills_path: Path = BUNDLED_SKILLS_PATH,
         handoff_path: Path = Path(CLAUDE_HARNESS_FILE_PATH),
+        mcp_packages: McpPackageInstaller | None = None,
     ) -> None:
         self.config = config
         self.log = log
         self.config_dir = config_dir or resolve_claude_config_dir()
         self.bundled_skills_path = bundled_skills_path
         self.handoff_path = handoff_path
+        self._mcp_packages = mcp_packages or McpPackageInstaller(log)
         self.started = False
 
     @property
@@ -117,20 +106,47 @@ class ClaudeStager:
         return self.config_dir / "skills"
 
     async def start(self, repositories: Sequence[RepoEntry], workdir: Path) -> None:
+        self.config_dir = self._isolated_config_dir(workdir, repositories)
         self.log.info("claude.stage", config_dir=str(self.config_dir), workdir=str(workdir))
         self.config_dir.mkdir(parents=True, exist_ok=True)
         # Nothing the harness writes here is a credential; the directory is
         # only for Claude's own state (transcripts under projects/, settings).
         self._install_bundled_skills()
         install_bin_scripts(self.log)
+        # Best effort, as at OpenCode boot: a local npx server resolved now
+        # does not download during the first prompt.
+        try:
+            await self._mcp_packages.install(list(self.config.mcp_servers))
+        except Exception as error:
+            self.log.warn("claude.mcp_preinstall_failed", exc=error)
         ClaudeHarnessHandoff(
             workdir=workdir,
             config_dir=self.config_dir,
             has_repository=self.config.has_repository,
-            mcp_servers=self.config.mcp_servers,
         ).write(self.handoff_path)
         self.started = True
         self.log.info("claude.staged", repo_count=len(repositories))
+
+    def _isolated_config_dir(self, workdir: Path, repositories: Sequence[RepoEntry]) -> Path:
+        """The configured directory, unless it lies inside the workspace or a checkout.
+
+        A user-supplied ``CLAUDE_CONFIG_DIR`` pointing into a repository would
+        put transcripts, skills and the wrapper into the user's diff.
+        """
+        candidate = self.config_dir
+        resolved = _resolve_lenient(candidate)
+        for root in (workdir, *(repo.path for repo in repositories)):
+            root_resolved = _resolve_lenient(root)
+            if resolved == root_resolved or root_resolved in resolved.parents:
+                fallback = Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
+                self.log.warn(
+                    "claude.config_dir_rejected",
+                    config_dir=str(candidate),
+                    inside=str(root),
+                    fallback=str(fallback),
+                )
+                return fallback
+        return candidate
 
     def _install_bundled_skills(self) -> None:
         if not self.bundled_skills_path.is_dir():
@@ -158,3 +174,10 @@ class ClaudeStager:
     def exit_code(self) -> int | None:
         # There is no resident vendor process; the SDK child belongs to the bridge.
         return None
+
+
+def _resolve_lenient(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except OSError:
+        return path

--- a/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/claude_stager.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -26,7 +27,7 @@ from .constants import CLAUDE_HARNESS_FILE_PATH
 from .sandbox_bin import install_bin_scripts
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
     from .repo_config import RepoEntry
     from .runtime_config import ClaudeStagerConfig
@@ -42,6 +43,19 @@ def resolve_claude_config_dir() -> Path:
     if override:
         return Path(override)
     return Path.home() / DEFAULT_CLAUDE_CONFIG_DIR_NAME
+
+
+def _plain_json(value: Any) -> Any:
+    """Undo ``runtime_config``'s freezing: mapping proxies and tuples → dicts and lists.
+
+    ``SESSION_CONFIG`` is frozen recursively, so an MCP server's nested ``env``
+    or ``headers`` is a ``MappingProxyType`` that ``json.dumps`` rejects.
+    """
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain_json(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -60,7 +74,7 @@ class ClaudeHarnessHandoff:
                     "workdir": str(self.workdir),
                     "configDir": str(self.config_dir),
                     "hasRepository": self.has_repository,
-                    "mcpServers": [dict(server) for server in self.mcp_servers],
+                    "mcpServers": [_plain_json(server) for server in self.mcp_servers],
                 }
             )
         )

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -60,6 +60,8 @@ BOOT_WARNINGS_FILE_PATH = "/tmp/oi-boot-warnings.jsonl"
 # Written by the bridge before it exits with DETERMINISTIC_FAILURE_EXIT_CODE;
 # the supervisor reports its contents instead of restarting the bridge.
 BRIDGE_FATAL_ERROR_FILE_PATH = "/tmp/oi-bridge-fatal-error.txt"
+# Supervisor → bridge handoff for the Claude harness (workdir, config dir, MCP servers).
+CLAUDE_HARNESS_FILE_PATH = "/tmp/oi-claude-harness.json"
 
 # Canonical repository manifest written by the supervisor before any child
 # process starts, rewritten on every boot. Consumed by the bridge (push

--- a/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
@@ -106,7 +106,14 @@ class RuntimeCredentialClient:
         if response.status_code != 200:
             raise RuntimeCredentialDenied(self._denial_message(provider, response))
 
-        body: Any = response.json()
+        try:
+            body: Any = response.json()
+        except ValueError as error:
+            # An empty or truncated 200 body is a transport-class failure:
+            # the same request usually succeeds on retry.
+            raise RuntimeCredentialUnavailable(
+                f"credential response for {provider} was not valid JSON"
+            ) from error
         if not isinstance(body, dict):
             raise RuntimeCredentialDenied("credential response was not an object")
         kind = body.get("kind")

--- a/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
@@ -20,18 +20,25 @@ if TYPE_CHECKING:
 
 RUNTIME_CREDENTIAL_TIMEOUT_SECONDS: Final = 30.0
 BOOTSTRAP_SECRET_KIND: Final = "sandbox_bootstrap_secret"
+# Statuses that describe the moment, not the account.
+RETRYABLE_STATUSES: Final = frozenset({408, 425, 429})
 
 
 class RuntimeCredentialDenied(Exception):
     """The control plane refused to issue the credential; retrying is futile.
 
-    Raised for 401/403/404/409/410 (disabled, archived, expired or unbound
-    account; wrong provider; dead sandbox). The message is user-facing.
+    Raised for 401/403/404/410 and for a 409 the endpoint does not mark
+    retryable (disabled, archived, expired or unbound account; wrong
+    provider; dead sandbox). The message is user-facing.
     """
 
 
 class RuntimeCredentialUnavailable(Exception):
-    """A transient failure (network, 5xx); the caller may retry."""
+    """A transient failure; the caller may retry.
+
+    Network errors, 5xx, 408/425/429, and a 409 whose body says
+    ``retryable`` (the endpoint's issuance race).
+    """
 
 
 @dataclass(frozen=True)
@@ -83,6 +90,13 @@ class RuntimeCredentialClient:
         except httpx.HTTPError as error:
             raise RuntimeCredentialUnavailable(str(error)) from error
 
+        if response.status_code in RETRYABLE_STATUSES or (
+            response.status_code == 409 and _marked_retryable(response)
+        ):
+            raise RuntimeCredentialUnavailable(
+                f"control plane returned HTTP {response.status_code} for the {provider} "
+                "credential; retry"
+            )
         if response.status_code in (401, 403, 404, 409, 410):
             raise RuntimeCredentialDenied(self._denial_message(provider, response))
         if response.status_code >= 500:
@@ -117,16 +131,28 @@ class RuntimeCredentialClient:
 
     @staticmethod
     def _denial_message(provider: str, response: httpx.Response) -> str:
-        detail = ""
-        try:
-            body = response.json()
-            if isinstance(body, dict):
-                detail = str(body.get("error") or body.get("message") or "")
-        except ValueError:
-            detail = response.text[:200]
-        suffix = f": {detail}" if detail else ""
-        return (
-            f"The control plane refused the {provider} subscription credential "
-            f"(HTTP {response.status_code}){suffix}. Reconnect the account in Settings "
-            "and start a new session."
-        )
+        return _denial_message(provider, response)
+
+
+def _marked_retryable(response: httpx.Response) -> bool:
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return isinstance(body, dict) and body.get("retryable") is True
+
+
+def _denial_message(provider: str, response: httpx.Response) -> str:
+    detail = ""
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            detail = str(body.get("error") or body.get("message") or "")
+    except ValueError:
+        detail = response.text[:200]
+    suffix = f": {detail}" if detail else ""
+    return (
+        f"The control plane refused the {provider} subscription credential "
+        f"(HTTP {response.status_code}){suffix}. Reconnect the account in Settings "
+        "and start a new session."
+    )

--- a/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
@@ -1,7 +1,7 @@
 """Sandbox-side client for platform-managed provider credentials.
 
 The Claude harness fetches its subscription credential (a Claude setup token)
-from the control plane's sandbox-only bootstrap endpoint on every bridge
+from the control plane's sandbox-only runtime-credential endpoint on every bridge
 start, so a supervised restart and a snapshot restore both re-fetch and each
 fetch is an issuance record on the control plane. The token lives in process
 memory only.
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ..log_config import StructuredLogger
 
 RUNTIME_CREDENTIAL_TIMEOUT_SECONDS: Final = 30.0
-BOOTSTRAP_SECRET_KIND: Final = "sandbox_bootstrap_secret"
+STORED_PROVIDER_SECRET_KIND: Final = "stored_provider_secret"
 # Statuses that describe the moment, not the account.
 RETRYABLE_STATUSES: Final = frozenset({408, 425, 429})
 
@@ -118,9 +118,9 @@ class RuntimeCredentialClient:
             raise RuntimeCredentialDenied("credential response was not an object")
         kind = body.get("kind")
         secret = body.get("secret")
-        if kind != BOOTSTRAP_SECRET_KIND or not isinstance(secret, str) or not secret:
+        if kind != STORED_PROVIDER_SECRET_KIND or not isinstance(secret, str) or not secret:
             raise RuntimeCredentialDenied(
-                f"credential response for {provider} was not a {BOOTSTRAP_SECRET_KIND}"
+                f"credential response for {provider} was not a {STORED_PROVIDER_SECRET_KIND}"
             )
         version = body.get("credentialVersion")
         expires_at = body.get("expiresAt")

--- a/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/credentials/provider_credential_client.py
@@ -1,0 +1,132 @@
+"""Sandbox-side client for platform-managed provider credentials.
+
+The Claude harness fetches its subscription credential (a Claude setup token)
+from the control plane's sandbox-only bootstrap endpoint on every bridge
+start, so a supervised restart and a snapshot restore both re-fetch and each
+fetch is an issuance record on the control plane. The token lives in process
+memory only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+from urllib.parse import quote
+
+import httpx
+
+if TYPE_CHECKING:
+    from ..log_config import StructuredLogger
+
+RUNTIME_CREDENTIAL_TIMEOUT_SECONDS: Final = 30.0
+BOOTSTRAP_SECRET_KIND: Final = "sandbox_bootstrap_secret"
+
+
+class RuntimeCredentialDenied(Exception):
+    """The control plane refused to issue the credential; retrying is futile.
+
+    Raised for 401/403/404/409/410 (disabled, archived, expired or unbound
+    account; wrong provider; dead sandbox). The message is user-facing.
+    """
+
+
+class RuntimeCredentialUnavailable(Exception):
+    """A transient failure (network, 5xx); the caller may retry."""
+
+
+@dataclass(frozen=True)
+class RuntimeCredential:
+    kind: str
+    secret: str
+    credential_version: int | None
+    expires_at: int | None
+
+
+class RuntimeCredentialClient:
+    def __init__(
+        self,
+        *,
+        control_plane_url: str,
+        session_id: str,
+        sandbox_id: str,
+        auth_token: str,
+        log: StructuredLogger,
+        http_client: httpx.AsyncClient | None = None,
+        timeout_seconds: float = RUNTIME_CREDENTIAL_TIMEOUT_SECONDS,
+    ) -> None:
+        self._base_url = control_plane_url.rstrip("/")
+        self._session_id = session_id
+        self._sandbox_id = sandbox_id
+        self._auth_token = auth_token
+        self._log = log
+        self._http_client = http_client
+        self._timeout_seconds = timeout_seconds
+
+    def _url(self, provider: str) -> str:
+        session = quote(self._session_id, safe="")
+        return f"{self._base_url}/sessions/{session}/provider-auth/{provider}/runtime-credential"
+
+    async def fetch(self, provider: str) -> RuntimeCredential:
+        """Fetch the session-bound credential for ``provider`` (``anthropic`` today)."""
+        headers = {
+            "Authorization": f"Bearer {self._auth_token}",
+            "X-Sandbox-ID": self._sandbox_id,
+        }
+        try:
+            if self._http_client is not None:
+                response = await self._http_client.post(
+                    self._url(provider), headers=headers, json={}, timeout=self._timeout_seconds
+                )
+            else:
+                async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+                    response = await client.post(self._url(provider), headers=headers, json={})
+        except httpx.HTTPError as error:
+            raise RuntimeCredentialUnavailable(str(error)) from error
+
+        if response.status_code in (401, 403, 404, 409, 410):
+            raise RuntimeCredentialDenied(self._denial_message(provider, response))
+        if response.status_code >= 500:
+            raise RuntimeCredentialUnavailable(
+                f"control plane returned HTTP {response.status_code} for the {provider} credential"
+            )
+        if response.status_code != 200:
+            raise RuntimeCredentialDenied(self._denial_message(provider, response))
+
+        body: Any = response.json()
+        if not isinstance(body, dict):
+            raise RuntimeCredentialDenied("credential response was not an object")
+        kind = body.get("kind")
+        secret = body.get("secret")
+        if kind != BOOTSTRAP_SECRET_KIND or not isinstance(secret, str) or not secret:
+            raise RuntimeCredentialDenied(
+                f"credential response for {provider} was not a {BOOTSTRAP_SECRET_KIND}"
+            )
+        version = body.get("credentialVersion")
+        expires_at = body.get("expiresAt")
+        self._log.info(
+            "provider_credential.issued",
+            provider=provider,
+            credential_version=version if isinstance(version, int) else None,
+        )
+        return RuntimeCredential(
+            kind=kind,
+            secret=secret,
+            credential_version=version if isinstance(version, int) else None,
+            expires_at=expires_at if isinstance(expires_at, int) else None,
+        )
+
+    @staticmethod
+    def _denial_message(provider: str, response: httpx.Response) -> str:
+        detail = ""
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                detail = str(body.get("error") or body.get("message") or "")
+        except ValueError:
+            detail = response.text[:200]
+        suffix = f": {detail}" if detail else ""
+        return (
+            f"The control plane refused the {provider} subscription credential "
+            f"(HTTP {response.status_code}){suffix}. Reconnect the account in Settings "
+            "and start a new session."
+        )

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from .agent_bridge_process import AgentBridgeProcess
 from .boot_warnings import BootWarningSink
 from .browser_desktop import BrowserDesktop
-from .claude_stager import ClaudeStager, resolve_claude_config_dir
+from .claude_stager import ClaudeStager, isolated_claude_config_dir, resolve_claude_config_dir
 from .code_server import CodeServer
 from .constants import VNC_DISPLAY, VNC_PASSWORD_ENV_VAR
 from .harness.base import HarnessId, HarnessProcessOwner
@@ -30,7 +30,10 @@ from .tunnel_environment import TunnelEnvironment
 from .web_terminal import WebTerminal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
+
+    from .repo_config import RepoEntry
 
 configure_logging()
 
@@ -40,6 +43,7 @@ def build_harness_process(
     shutdown_event: asyncio.Event,
     log: Any,
     warnings: BootWarningSink,
+    claude_config_dir: Path | None,
 ) -> HarnessProcessOwner:
     """The supervisor-half registry: pick the process owner for the session's harness."""
     match config.harness:
@@ -51,17 +55,34 @@ def build_harness_process(
                 warnings.record,
             )
         case HarnessId.CLAUDE:
-            return ClaudeStager(config.claude_stager_config(), log)
+            return ClaudeStager(config.claude_stager_config(), log, config_dir=claude_config_dir)
     raise ValueError(f"Unsupported harness: {config.harness}")
 
 
-def managed_skills_destination(harness: HarnessId) -> Path:
+def claude_config_dir_for(
+    config: RuntimeConfig, repositories: Sequence[RepoEntry], log: Any
+) -> Path | None:
+    """Where Claude keeps its state, decided once before anything is written there.
+
+    Managed skills are materialized before the stager runs, so both take the
+    directory from here rather than deciding separately.
+    """
+    if config.harness is not HarnessId.CLAUDE:
+        return None
+    return isolated_claude_config_dir(
+        resolve_claude_config_dir(), config.workspace_path, repositories, log
+    )
+
+
+def managed_skills_destination(harness: HarnessId, claude_config_dir: Path | None) -> Path:
     """Where managed skills land: each harness discovers skills from its own tree."""
     match harness:
         case HarnessId.OPENCODE:
             return resolve_opencode_global_config_dir() / "skills"
         case HarnessId.CLAUDE:
-            return resolve_claude_config_dir() / "skills"
+            if claude_config_dir is None:
+                raise ValueError("Claude sessions need a config dir decided")
+            return claude_config_dir / "skills"
     raise ValueError(f"Unsupported harness: {harness}")
 
 
@@ -87,6 +108,7 @@ def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
         RepositoryHooks(log),
         RepositorySynchronizer(config.vcs_host, log),
     )
+    claude_config_dir = claude_config_dir_for(config, repository_boot.repositories, log)
     managed_skills_config = config.managed_skills_config()
     managed_skills = None
     if managed_skills_config.control_plane_url and managed_skills_config.session_id:
@@ -96,10 +118,12 @@ def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
                 managed_skills_config.session_id,
                 managed_skills_config.sandbox_token,
             ),
-            managed_skills_destination(config.harness),
+            managed_skills_destination(config.harness, claude_config_dir),
             log,
         )
-    harness_process = build_harness_process(config, shutdown_event, log, warnings)
+    harness_process = build_harness_process(
+        config, shutdown_event, log, warnings, claude_config_dir
+    )
     agent_bridge = AgentBridgeProcess(config.bridge_process_config(), log)
     code_server = CodeServer(log)
     web_terminal = WebTerminal(log)

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -7,11 +7,12 @@ import argparse
 import asyncio
 import os
 import signal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .agent_bridge_process import AgentBridgeProcess
 from .boot_warnings import BootWarningSink
 from .browser_desktop import BrowserDesktop
+from .claude_stager import ClaudeStager, resolve_claude_config_dir
 from .code_server import CodeServer
 from .constants import VNC_DISPLAY, VNC_PASSWORD_ENV_VAR
 from .harness.base import HarnessId, HarnessProcessOwner
@@ -27,6 +28,9 @@ from .runtime_config import RuntimeConfig
 from .supervisor import SandboxSupervisor
 from .tunnel_environment import TunnelEnvironment
 from .web_terminal import WebTerminal
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 configure_logging()
 
@@ -46,7 +50,19 @@ def build_harness_process(
                 log,
                 warnings.record,
             )
+        case HarnessId.CLAUDE:
+            return ClaudeStager(config.claude_stager_config(), log)
     raise ValueError(f"Unsupported harness: {config.harness}")
+
+
+def managed_skills_destination(harness: HarnessId) -> Path:
+    """Where managed skills land: each harness discovers skills from its own tree."""
+    match harness:
+        case HarnessId.OPENCODE:
+            return resolve_opencode_global_config_dir() / "skills"
+        case HarnessId.CLAUDE:
+            return resolve_claude_config_dir() / "skills"
+    raise ValueError(f"Unsupported harness: {harness}")
 
 
 def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
@@ -74,14 +90,13 @@ def build_supervisor(shutdown_event: asyncio.Event) -> SandboxSupervisor:
     managed_skills_config = config.managed_skills_config()
     managed_skills = None
     if managed_skills_config.control_plane_url and managed_skills_config.session_id:
-        global_config_dir = resolve_opencode_global_config_dir()
         managed_skills = ManagedSkillsMaterializer(
             ManagedSkillsClient(
                 managed_skills_config.control_plane_url,
                 managed_skills_config.session_id,
                 managed_skills_config.sandbox_token,
             ),
-            global_config_dir / "skills",
+            managed_skills_destination(config.harness),
             log,
         )
     harness_process = build_harness_process(config, shutdown_event, log, warnings)

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ..claude_stager import ClaudeHarnessHandoff
+from ..credentials.provider_credential_client import RuntimeCredentialClient
 from .base import (
     DEFAULT_HARNESS_ID,
     DETERMINISTIC_FAILURE_EXIT_CODE,
@@ -18,17 +22,34 @@ from .base import (
     TurnOutcome,
     parse_harness_id,
 )
+from .claude import ClaudeHarness, ClaudeHarnessConfig
+from .claude_env import OAUTH_MANAGED_ENV_VAR
+from .claude_tools import ToolServerConfig
 from .opencode import OpencodeHarness
 from .opencode_client import OpenCodeClient
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ..attachment_processor import AttachmentProcessor
     from ..log_config import StructuredLogger
+
+
+@dataclass(frozen=True)
+class BridgeIdentity:
+    """What a harness needs to call the control plane on the session's behalf."""
+
+    sandbox_id: str
+    session_id: str
+    control_plane_url: str
+    auth_token: str
+    repo_manifest_path: Path
 
 
 def build_agent_harness(
     harness_id: HarnessId,
     *,
+    identity: BridgeIdentity,
     attachment_processor: AttachmentProcessor,
     log: StructuredLogger,
     limits: PromptLimits,
@@ -43,7 +64,74 @@ def build_agent_harness(
                 log=log,
                 limits=limits,
             )
+        case HarnessId.CLAUDE:
+            handoff = ClaudeHarnessHandoff.read()
+            session_config = _session_config_from_env()
+            oauth_managed = bool(os.environ.get(OAUTH_MANAGED_ENV_VAR))
+            config = ClaudeHarnessConfig(
+                workdir=handoff.workdir,
+                config_dir=handoff.config_dir,
+                mcp_servers=handoff.mcp_servers,
+                default_model=str(session_config.get("model") or "claude-sonnet-4-6"),
+                oauth_managed=oauth_managed,
+                system_prompt_append=_repository_guidance(handoff.workdir),
+                tools=ToolServerConfig(
+                    control_plane_url=identity.control_plane_url,
+                    session_id=identity.session_id,
+                    auth_token=identity.auth_token,
+                    repo_manifest_path=identity.repo_manifest_path,
+                    has_repository=handoff.has_repository,
+                    slack_notify_enabled=os.environ.get("AGENT_SLACK_NOTIFY_ENABLED", "").lower()
+                    == "true",
+                ),
+            )
+            credential_client = (
+                RuntimeCredentialClient(
+                    control_plane_url=identity.control_plane_url,
+                    session_id=identity.session_id,
+                    sandbox_id=identity.sandbox_id,
+                    auth_token=identity.auth_token,
+                    log=log,
+                )
+                if oauth_managed and identity.control_plane_url
+                else None
+            )
+            return ClaudeHarness(
+                config=config,
+                log=log,
+                limits=limits,
+                credential_client=credential_client,
+            )
     raise ValueError(f"Unsupported harness: {harness_id}")
+
+
+def _session_config_from_env() -> dict[str, object]:
+    import json
+    import os
+
+    try:
+        parsed = json.loads(os.environ.get("SESSION_CONFIG", "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _repository_guidance(workdir: Path) -> str | None:
+    """Surface the supervisor's workspace AGENTS.md through the system prompt.
+
+    Claude reads CLAUDE.md natively; multi-repo workspaces only carry the
+    AGENTS.md the supervisor writes, and nothing is written into repositories.
+    """
+    notes = workdir / "AGENTS.md"
+    if not notes.is_file() or (workdir / "CLAUDE.md").is_file():
+        return None
+    try:
+        text = notes.read_text().strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    return "Workspace guidance (AGENTS.md):\n\n" + text
 
 
 __all__ = [
@@ -51,6 +139,7 @@ __all__ = [
     "DETERMINISTIC_FAILURE_EXIT_CODE",
     "AgentHarness",
     "BridgeEvent",
+    "BridgeIdentity",
     "EventSink",
     "HarnessId",
     "HarnessProcessOwner",

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/__init__.py
@@ -71,7 +71,9 @@ def build_agent_harness(
             config = ClaudeHarnessConfig(
                 workdir=handoff.workdir,
                 config_dir=handoff.config_dir,
-                mcp_servers=handoff.mcp_servers,
+                # From the bridge's own SESSION_CONFIG: MCP entries can carry
+                # credentials, and the handoff file never does.
+                mcp_servers=_mcp_servers_from(session_config),
                 default_model=str(session_config.get("model") or "claude-sonnet-4-6"),
                 oauth_managed=oauth_managed,
                 system_prompt_append=_repository_guidance(handoff.workdir),
@@ -114,6 +116,13 @@ def _session_config_from_env() -> dict[str, object]:
     except json.JSONDecodeError:
         return {}
     return parsed if isinstance(parsed, dict) else {}
+
+
+def _mcp_servers_from(session_config: dict[str, object]) -> tuple[dict[str, object], ...]:
+    servers = session_config.get("mcp_servers")
+    if not isinstance(servers, list):
+        return ()
+    return tuple(server for server in servers if isinstance(server, dict))
 
 
 def _repository_guidance(workdir: Path) -> str | None:

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/base.py
@@ -31,6 +31,7 @@ class HarnessId(StrEnum):
     """Harnesses this runtime can run. Only deployable implementations are listed."""
 
     OPENCODE = "opencode"
+    CLAUDE = "claude"
 
 
 DEFAULT_HARNESS_ID = HarnessId.OPENCODE
@@ -151,6 +152,7 @@ class AgentHarness(Protocol):
         ...
 
 
+@runtime_checkable
 class HarnessProcessOwner(Protocol):
     """Supervisor half of the seam: staging plus any resident vendor process."""
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
@@ -23,6 +23,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     ClaudeSDKClient,
     ConversationResetMessage,
+    MessageOrigin,
     RateLimitEvent,
     ResultMessage,
     StreamEvent,
@@ -138,6 +139,13 @@ class _MessageText:
     text: str = ""
 
 
+def _injected_origin(origin: MessageOrigin | None) -> MessageOrigin | None:
+    """The origin when it names a turn the session started on its own."""
+    if origin is None or origin.get("kind") == "human":
+        return None
+    return origin
+
+
 @dataclass
 class _TurnState:
     message_id: str
@@ -150,6 +158,9 @@ class _TurnState:
     tool_args: dict[str, dict[str, Any]] = field(default_factory=dict)
     emitted_error: bool = False
     step_started: bool = False
+    # Inside a turn the session injected (background task, channel, peer):
+    # skip everything until that turn's result.
+    injected: bool = False
 
     def turn_text(self) -> str:
         return "\n\n".join(entry.text for entry in self.texts if entry.text)
@@ -459,7 +470,7 @@ class ClaudeHarness:
         except TimeoutError:
             self.log.error("claude.connect_timeout", message_id=prompt.message_id)
             self._needs_reconnect = True
-            await self._cleanup_after_timeout()
+            await self._interrupt_within_budget()
             return TurnOutcome.failed(
                 f"Claude agent did not start within {self.limits.prompt_max_duration_seconds:.0f}s."
             )
@@ -482,7 +493,7 @@ class ClaudeHarness:
                         break
                     except TimeoutError as error:
                         raise _InactivityTimeout from error
-                    if self._answers_another_turn(message):
+                    if self._belongs_to_injected_turn(state, message):
                         continue
                     events, outcome = self._translate(state, message)
                     for event in events:
@@ -498,13 +509,13 @@ class ClaudeHarness:
             self._needs_reconnect = True
             raise
         except TimeoutError:
-            await self._cleanup_after_timeout()
+            await self._interrupt_within_budget()
             self._needs_reconnect = True
             return TurnOutcome.failed(
                 f"Prompt exceeded max duration of {self.limits.prompt_max_duration_seconds:.0f}s."
             )
         except _InactivityTimeout:
-            await self._cleanup_after_timeout()
+            await self._interrupt_within_budget()
             self._needs_reconnect = True
             return TurnOutcome.failed(
                 f"Claude agent produced no output for {self.limits.inactivity_timeout_seconds:.0f}s."
@@ -514,29 +525,42 @@ class ClaudeHarness:
             self._needs_reconnect = True
             return TurnOutcome.failed(f"Claude agent transport failed: {error}")
 
-    def _answers_another_turn(self, message: Any) -> bool:
-        """A result of a turn the session injected, not of this prompt.
+    def _belongs_to_injected_turn(self, state: _TurnState, message: Any) -> bool:
+        """Every message of a turn the session injected, not of this prompt.
 
         The streaming connection can interleave turns the CLI starts on its
-        own (task notifications, channel and peer messages). Our prompts are
-        stamped ``origin: human``, so a result carrying any other origin ends
-        someone else's turn and must not end this one.
+        own (task notifications, channel and peer messages). Only the user
+        message that opens such a turn and the result that closes it carry
+        ``origin``; the assistant messages, stream events and tool results
+        between them do not. So a non-human user message opens the skip, its
+        result closes it, and nothing in between reaches the timeline. Our
+        own prompts are stamped ``origin: human``. The injected turn's spend
+        stays in the running total and lands on the prompt in flight, so the
+        session's cost still adds up.
         """
-        if not isinstance(message, ResultMessage):
+        if isinstance(message, UserMessage):
+            if (origin := _injected_origin(message.origin)) is not None:
+                state.injected = True
+                self.log.info("claude.injected_turn_started", origin_kind=origin["kind"])
+            return state.injected
+        if isinstance(message, ResultMessage):
+            if (origin := _injected_origin(message.origin)) is not None:
+                state.injected = False
+                self.log.info("claude.injected_turn_ignored", origin_kind=origin["kind"])
+                return True
+            state.injected = False
             return False
-        origin = message.origin
-        if origin is None or origin.get("kind") == "human":
-            return False
-        self.log.info("claude.injected_turn_ignored", origin_kind=origin.get("kind"))
-        return True
+        return state.injected
 
-    async def _cleanup_after_timeout(self) -> None:
-        """Interrupt within the cleanup budget; drop the child if that hangs too."""
+    async def _interrupt_within_budget(self) -> bool:
+        """Interrupt within the cleanup budget; drop the child if that hangs too.
+
+        True when the child acknowledged the interrupt.
+        """
         budget = self.limits.prompt_cleanup_timeout_seconds
         try:
             async with asyncio.timeout(budget):
-                await self._interrupt_quietly()
-            return
+                return await self._interrupt_quietly()
         except TimeoutError:
             self.log.warn("claude.interrupt_timeout", timeout_s=budget)
         try:
@@ -545,14 +569,17 @@ class ClaudeHarness:
         except TimeoutError:
             self.log.warn("claude.disconnect_timeout", timeout_s=budget)
             self._client = None
+        return False
 
-    async def _interrupt_quietly(self) -> None:
+    async def _interrupt_quietly(self) -> bool:
         if self._client is None:
-            return
+            return False
         try:
             await self._client.interrupt()
         except Exception as error:
             self.log.warn("claude.interrupt_error", exc=error)
+            return False
+        return True
 
     async def abort(self) -> bool:
         if self._client is None:
@@ -561,12 +588,9 @@ class ClaudeHarness:
         # The bridge cancels the prompt task too; the next prompt reconnects so
         # the interrupted turn's trailing messages never leak into it.
         self._needs_reconnect = True
-        try:
-            await self._client.interrupt()
-        except Exception as error:
-            self.log.warn("claude.interrupt_error", exc=error)
-            return False
-        return True
+        # The bridge awaits this inline on its command loop, so a hung
+        # interrupt would stall every later command; bound it like cleanup.
+        return await self._interrupt_within_budget()
 
     async def _user_messages(self, prompt: HarnessPrompt) -> AsyncIterator[dict[str, Any]]:
         content: list[dict[str, Any]] = [{"type": "text", "text": prompt.text}]

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
@@ -18,6 +18,21 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    ConversationResetMessage,
+    RateLimitEvent,
+    ResultMessage,
+    StreamEvent,
+    SystemMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
 from ..credentials.provider_credential_client import (
     RuntimeCredentialClient,
     RuntimeCredentialDenied,
@@ -77,6 +92,10 @@ ALLOWED_TOOLS: Final = (
     "KillShell",
 )
 DISALLOWED_TOOLS: Final = ("AskUserQuestion",)
+# Claude's sub-agent tool. The timeline groups child activity under the
+# runtime-neutral task tool, so the vendor name never reaches the wire.
+SUBAGENT_TOOL_NAME: Final = "Agent"
+TASK_TOOL_NAME: Final = "task"
 MAX_RECONNECTS_PER_SESSION: Final = 3
 AUTHENTICATION_FAILED_MESSAGE: Final = (
     "Anthropic rejected this session's credential. Reconnect the Claude account in "
@@ -95,7 +114,7 @@ class SdkClient(Protocol):
 
     async def interrupt(self) -> None: ...
 
-    def receive_response(self) -> AsyncIterator[Any]: ...
+    def receive_messages(self) -> AsyncIterator[Any]: ...
 
 
 SdkClientFactory = Callable[[Any], SdkClient]
@@ -122,7 +141,9 @@ class _MessageText:
 @dataclass
 class _TurnState:
     message_id: str
-    cost_baseline: float
+    # None: the previous turn reported no running total, so the next total
+    # cannot be split between the two turns.
+    cost_baseline: float | None
     texts: list[_MessageText] = field(default_factory=list)
     last_token_content: str = ""
     tool_names: dict[str, str] = field(default_factory=dict)
@@ -254,7 +275,9 @@ class ClaudeHarness:
         self._resume_on_connect = False
         self._needs_reconnect = False
         self._reconnects = 0
-        self._cost_baseline = 0.0
+        self._cost_baseline: float | None = 0.0
+        # Set by a conversation reset: the next result carries the new id.
+        self._session_rotated = False
         self._interrupted = False
         self._tool_client: ControlPlaneToolClient | None = None
         self._tool_server: Any = None
@@ -374,20 +397,23 @@ class ClaudeHarness:
         )
         if same_shape and self._client is not None:
             return self._client
-        if self._client is not None:
-            if self._needs_reconnect:
-                self._reconnects += 1
-                if self._reconnects > MAX_RECONNECTS_PER_SESSION:
-                    raise RuntimeError(
-                        "The Claude agent process failed repeatedly for this session; "
-                        "start a new session."
-                    )
-            await self._disconnect()
+        if self._needs_reconnect:
+            # Spent whether or not the previous attempt produced a client: a
+            # connect that fails or hangs still counts against the budget.
+            self._reconnects += 1
+            if self._reconnects > MAX_RECONNECTS_PER_SESSION:
+                raise RuntimeError(
+                    "The Claude agent process failed repeatedly for this session; "
+                    "start a new session."
+                )
+        await self._disconnect()
         options = self.build_options(model, reasoning_effort)
         factory = self._client_factory or _default_client_factory
         client = factory(options)
-        await client.connect()
+        # Held before connect so a connect the deadline cuts short is still
+        # closed by the next reconnect rather than leaked.
         self._client = client
+        await client.connect()
         self._connected_model = model
         self._connected_effort = reasoning_effort
         self._needs_reconnect = False
@@ -419,10 +445,24 @@ class ClaudeHarness:
             model = bare_model_id(prompt.model, self.config.default_model)
         except ValueError as error:
             return TurnOutcome.failed(str(error))
+        # One budget covers the whole turn: connect, submit, every read and
+        # every emit. The inactivity budget applies to each read alone, and
+        # cleanup after either has its own budget, so a hung SDK call can
+        # never eat the snapshot reserve.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.limits.prompt_max_duration_seconds
         try:
-            client = await self._ensure_client(model, prompt.reasoning_effort)
+            async with asyncio.timeout_at(deadline):
+                client = await self._ensure_client(model, prompt.reasoning_effort)
         except HarnessStartError:
             raise
+        except TimeoutError:
+            self.log.error("claude.connect_timeout", message_id=prompt.message_id)
+            self._needs_reconnect = True
+            await self._cleanup_after_timeout()
+            return TurnOutcome.failed(
+                f"Claude agent did not start within {self.limits.prompt_max_duration_seconds:.0f}s."
+            )
         except Exception as error:
             self.log.error("claude.connect_error", exc=error, message_id=prompt.message_id)
             self._needs_reconnect = True
@@ -430,31 +470,25 @@ class ClaudeHarness:
 
         self._interrupted = False
         state = _TurnState(message_id=prompt.message_id, cost_baseline=self._cost_baseline)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + self.limits.prompt_max_duration_seconds
         try:
-            await client.query(self._user_messages(prompt))
-            stream = aiter(client.receive_response())
-            while True:
-                remaining = deadline - loop.time()
-                if remaining <= 0:
-                    raise _PromptMaxDurationTimeout
-                try:
-                    async with asyncio.timeout(
-                        min(remaining, self.limits.inactivity_timeout_seconds)
-                    ):
-                        message = await anext(stream)
-                except StopAsyncIteration:
-                    break
-                except TimeoutError as error:
-                    if deadline - loop.time() <= 0:
-                        raise _PromptMaxDurationTimeout from error
-                    raise _InactivityTimeout from error
-                events, outcome = self._translate(state, message)
-                for event in events:
-                    await emit(event)
-                if outcome is not None:
-                    return outcome
+            async with asyncio.timeout_at(deadline):
+                await client.query(self._user_messages(prompt))
+                stream = aiter(client.receive_messages())
+                while True:
+                    try:
+                        async with asyncio.timeout(self.limits.inactivity_timeout_seconds):
+                            message = await anext(stream)
+                    except StopAsyncIteration:
+                        break
+                    except TimeoutError as error:
+                        raise _InactivityTimeout from error
+                    if self._answers_another_turn(message):
+                        continue
+                    events, outcome = self._translate(state, message)
+                    for event in events:
+                        await emit(event)
+                    if outcome is not None:
+                        return outcome
             self._needs_reconnect = True
             return TurnOutcome.failed(
                 "The Claude agent stream ended before the turn completed.",
@@ -463,14 +497,14 @@ class ClaudeHarness:
         except asyncio.CancelledError:
             self._needs_reconnect = True
             raise
-        except _PromptMaxDurationTimeout:
-            await self._interrupt_quietly()
+        except TimeoutError:
+            await self._cleanup_after_timeout()
             self._needs_reconnect = True
             return TurnOutcome.failed(
                 f"Prompt exceeded max duration of {self.limits.prompt_max_duration_seconds:.0f}s."
             )
         except _InactivityTimeout:
-            await self._interrupt_quietly()
+            await self._cleanup_after_timeout()
             self._needs_reconnect = True
             return TurnOutcome.failed(
                 f"Claude agent produced no output for {self.limits.inactivity_timeout_seconds:.0f}s."
@@ -479,6 +513,38 @@ class ClaudeHarness:
             self.log.error("claude.turn_error", exc=error, message_id=prompt.message_id)
             self._needs_reconnect = True
             return TurnOutcome.failed(f"Claude agent transport failed: {error}")
+
+    def _answers_another_turn(self, message: Any) -> bool:
+        """A result of a turn the session injected, not of this prompt.
+
+        The streaming connection can interleave turns the CLI starts on its
+        own (task notifications, channel and peer messages). Our prompts are
+        stamped ``origin: human``, so a result carrying any other origin ends
+        someone else's turn and must not end this one.
+        """
+        if not isinstance(message, ResultMessage):
+            return False
+        origin = message.origin
+        if origin is None or origin.get("kind") == "human":
+            return False
+        self.log.info("claude.injected_turn_ignored", origin_kind=origin.get("kind"))
+        return True
+
+    async def _cleanup_after_timeout(self) -> None:
+        """Interrupt within the cleanup budget; drop the child if that hangs too."""
+        budget = self.limits.prompt_cleanup_timeout_seconds
+        try:
+            async with asyncio.timeout(budget):
+                await self._interrupt_quietly()
+            return
+        except TimeoutError:
+            self.log.warn("claude.interrupt_timeout", timeout_s=budget)
+        try:
+            async with asyncio.timeout(budget):
+                await self._disconnect()
+        except TimeoutError:
+            self.log.warn("claude.disconnect_timeout", timeout_s=budget)
+            self._client = None
 
     async def _interrupt_quietly(self) -> None:
         if self._client is None:
@@ -520,6 +586,8 @@ class ClaudeHarness:
             "message": {"role": "user", "content": content},
             "parent_tool_use_id": None,
             "session_id": self.session_id,
+            # Lets the result of this prompt be told apart from injected turns.
+            "origin": {"kind": "human"},
         }
 
     # --- translation (§5.2) -------------------------------------------------
@@ -527,19 +595,6 @@ class ClaudeHarness:
     def _translate(
         self, state: _TurnState, message: Any
     ) -> tuple[list[BridgeEvent], TurnOutcome | None]:
-        from claude_agent_sdk import (
-            AssistantMessage,
-            ConversationResetMessage,
-            RateLimitEvent,
-            ResultMessage,
-            StreamEvent,
-            SystemMessage,
-            TextBlock,
-            ToolResultBlock,
-            ToolUseBlock,
-            UserMessage,
-        )
-
         events: list[BridgeEvent] = []
         if isinstance(message, SystemMessage):
             if message.subtype == "init":
@@ -588,7 +643,9 @@ class ClaudeHarness:
                         events.extend(self._token_event(state))
             for block in message.content:
                 if isinstance(block, ToolUseBlock):
-                    state.tool_names[block.id] = block.name
+                    state.tool_names[block.id] = (
+                        TASK_TOOL_NAME if block.name == SUBAGENT_TOOL_NAME else block.name
+                    )
                     state.tool_args[block.id] = dict(block.input)
                     events.append(
                         self._tool_event(
@@ -631,19 +688,51 @@ class ClaudeHarness:
             return events, None
 
         if isinstance(message, ConversationResetMessage):
+            # The running total restarts, and the messages that follow carry
+            # the new session id the next resume and snapshot must use.
             self._cost_baseline = 0.0
             state.cost_baseline = 0.0
+            self._session_rotated = True
             return events, None
 
         if isinstance(message, ResultMessage):
+            if (
+                self._session_rotated
+                and message.session_id
+                and message.session_id != self.session_id
+            ):
+                self.log.info(
+                    "claude.session.rotated",
+                    agent_session_id=message.session_id,
+                    previous_session_id=self.session_id,
+                )
+                self.session_id = message.session_id
+                self._session_rotated = False
             total = message.total_cost_usd
             if total is None:
+                # No total means no baseline for the next turn either.
                 message_cost = 0.0
+                self._cost_baseline = None
                 events.append(
                     {
                         "type": "warning",
                         "scope": "provider",
                         "message": "The Claude agent reported no cost for this turn; it is recorded as 0.",
+                    }
+                )
+            elif state.cost_baseline is None:
+                # The previous turn's share of this total is unknowable, so
+                # neither turn is charged and the baseline re-anchors here.
+                message_cost = 0.0
+                self._cost_baseline = total
+                events.append(
+                    {
+                        "type": "warning",
+                        "scope": "provider",
+                        "message": (
+                            "The Claude agent reported no cost for the previous turn, so this "
+                            "turn's cost cannot be separated from it; it is recorded as 0."
+                        ),
                     }
                 )
             else:
@@ -730,10 +819,6 @@ class ClaudeHarness:
         ]
 
 
-class _PromptMaxDurationTimeout(Exception):
-    pass
-
-
 class _InactivityTimeout(Exception):
     pass
 
@@ -760,14 +845,10 @@ def _default_transcript_exists(session_id: str, workdir: Path, config_dir: Path)
 
 
 def _default_options_factory(**kwargs: Any) -> Any:
-    from claude_agent_sdk import ClaudeAgentOptions
-
     return ClaudeAgentOptions(**kwargs)
 
 
 def _default_client_factory(options: Any) -> SdkClient:
-    from claude_agent_sdk import ClaudeSDKClient
-
     return ClaudeSDKClient(options=options)
 
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
@@ -1,0 +1,765 @@
+"""``AgentHarness`` over the Claude Agent SDK.
+
+The SDK spawns the ``claude`` binary as a child of the bridge process. This
+module owns that child: it launches it through the clean-environment wrapper
+(``claude_env.py``), holds the one credential in memory, translates SDK
+messages into bridge events, applies the cost-baseline rule, and reconnects
+with ``resume=`` when the transport drops. It never emits
+``execution_complete``; the bridge terminalises every turn from the
+``TurnOutcome`` returned here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncIterator, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Final, Protocol
+
+from ..credentials.provider_credential_client import (
+    RuntimeCredentialClient,
+    RuntimeCredentialDenied,
+    RuntimeCredentialUnavailable,
+)
+from .base import (
+    BridgeEvent,
+    EventSink,
+    HarnessId,
+    HarnessPrompt,
+    HarnessStartError,
+    PromptLimits,
+    TurnOutcome,
+)
+from .claude_env import (
+    ClaudeCredential,
+    bundled_claude_binary,
+    harness_env,
+    resolve_api_key_credential,
+    write_clean_env_wrapper,
+)
+from .claude_tools import OI_TOOL_SERVER_NAME, ControlPlaneToolClient, ToolServerConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..log_config import StructuredLogger
+
+# Models whose catalog efforts are the two-value ladder; they take an explicit
+# thinking budget (the same budgets OpenCode configures) rather than `effort=`.
+THINKING_BUDGET_MODELS: Final = frozenset(
+    {"claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"}
+)
+THINKING_BUDGETS: Final = {"high": 16_000, "max": 31_999}
+EFFORT_LEVELS: Final = frozenset({"low", "medium", "high", "xhigh", "max"})
+
+# Everything the child may call; `dontAsk` approves what is listed and denies the rest.
+ALLOWED_TOOLS: Final = (
+    "Read",
+    "Edit",
+    "MultiEdit",
+    "Write",
+    "Bash",
+    "Glob",
+    "Grep",
+    "LS",
+    "Agent",
+    "Skill",
+    "WebFetch",
+    "WebSearch",
+    "TodoWrite",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskList",
+    "NotebookEdit",
+    "BashOutput",
+    "KillShell",
+)
+DISALLOWED_TOOLS: Final = ("AskUserQuestion",)
+MAX_RECONNECTS_PER_SESSION: Final = 3
+AUTHENTICATION_FAILED_MESSAGE: Final = (
+    "Anthropic rejected this session's credential. Reconnect the Claude account in "
+    "Settings (or check ANTHROPIC_API_KEY) and start a new session."
+)
+
+
+class SdkClient(Protocol):
+    """The slice of ``ClaudeSDKClient`` the harness uses (a fake stands in for tests)."""
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    async def query(self, prompt: Any, session_id: str = "default") -> None: ...
+
+    async def interrupt(self) -> None: ...
+
+    def receive_response(self) -> AsyncIterator[Any]: ...
+
+
+SdkClientFactory = Callable[[Any], SdkClient]
+
+
+@dataclass(frozen=True)
+class ClaudeHarnessConfig:
+    workdir: Path
+    config_dir: Path
+    mcp_servers: tuple[Mapping[str, Any], ...]
+    default_model: str
+    oauth_managed: bool
+    # Appended to the claude_code preset system prompt (repo guidance notes).
+    system_prompt_append: str | None = None
+    tools: ToolServerConfig | None = None
+
+
+@dataclass
+class _MessageText:
+    message_id: str | None
+    text: str = ""
+
+
+@dataclass
+class _TurnState:
+    message_id: str
+    cost_baseline: float
+    texts: list[_MessageText] = field(default_factory=list)
+    last_token_content: str = ""
+    tool_names: dict[str, str] = field(default_factory=dict)
+    tool_args: dict[str, dict[str, Any]] = field(default_factory=dict)
+    emitted_error: bool = False
+    step_started: bool = False
+
+    def turn_text(self) -> str:
+        return "\n\n".join(entry.text for entry in self.texts if entry.text)
+
+    def entry_for(self, message_id: str | None) -> _MessageText:
+        for entry in self.texts:
+            if entry.message_id == message_id and message_id is not None:
+                return entry
+        if self.texts and self.texts[-1].message_id is None:
+            self.texts[-1].message_id = message_id
+            return self.texts[-1]
+        entry = _MessageText(message_id)
+        self.texts.append(entry)
+        return entry
+
+
+def bare_model_id(model: str | None, default: str) -> str:
+    """``anthropic/claude-x`` → ``claude-x``; a bare id passes through."""
+    value = model or default
+    if "/" in value:
+        provider, _, bare = value.partition("/")
+        if provider != "anthropic":
+            raise ValueError(f"The Claude harness cannot run provider {provider!r}")
+        return bare
+    return value
+
+
+def reasoning_options(model: str, reasoning_effort: str | None) -> dict[str, Any]:
+    """Per-model reasoning controls, in ``ClaudeAgentOptions`` keywords."""
+    if not reasoning_effort or reasoning_effort == "none":
+        return {}
+    if model in THINKING_BUDGET_MODELS:
+        budget = THINKING_BUDGETS.get(reasoning_effort)
+        return {"thinking": {"type": "enabled", "budget_tokens": budget}} if budget else {}
+    return {"effort": reasoning_effort} if reasoning_effort in EFFORT_LEVELS else {}
+
+
+def mcp_server_options(servers: tuple[Mapping[str, Any], ...]) -> dict[str, Any]:
+    """Session MCP servers in the SDK's config shape."""
+    config: dict[str, Any] = {}
+    for server in servers:
+        name = server.get("name")
+        if not name or server.get("enabled") is False:
+            continue
+        if server.get("type") == "remote":
+            entry: dict[str, Any] = {"type": "http", "url": server.get("url", "")}
+            headers = server.get("headers") or server.get("env") or {}
+            if headers:
+                entry["headers"] = dict(headers)
+        else:
+            command = list(server.get("command") or [])
+            if not command:
+                continue
+            entry = {"type": "stdio", "command": command[0], "args": command[1:]}
+            if server.get("env"):
+                entry["env"] = dict(server["env"])
+        config[str(name)] = entry
+    return config
+
+
+def _tool_result_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(str(item.get("text", "")))
+    return "\n".join(parts)
+
+
+def _usage_tokens(usage: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not usage:
+        return None
+    cache = {
+        "read": usage.get("cache_read_input_tokens"),
+        "write": usage.get("cache_creation_input_tokens"),
+    }
+    tokens: dict[str, Any] = {
+        "input": usage.get("input_tokens"),
+        "output": usage.get("output_tokens"),
+        "cache": {k: v for k, v in cache.items() if isinstance(v, int)},
+    }
+    tokens = {k: v for k, v in tokens.items() if v not in (None, {})}
+    return tokens or None
+
+
+class ClaudeHarness:
+    id = HarnessId.CLAUDE
+
+    def __init__(
+        self,
+        *,
+        config: ClaudeHarnessConfig,
+        log: StructuredLogger,
+        limits: PromptLimits,
+        credential_client: RuntimeCredentialClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        client_factory: SdkClientFactory | None = None,
+        options_factory: Callable[..., Any] | None = None,
+        tool_server_factory: Callable[[ControlPlaneToolClient], Any] | None = None,
+        transcript_exists: Callable[[str, Path], bool] | None = None,
+        binary: Path | None = None,
+    ) -> None:
+        self.config = config
+        self.log = log
+        self.limits = limits
+        self.credential_client = credential_client
+        self.environ = environ if environ is not None else os.environ
+        self._client_factory = client_factory
+        self._options_factory = options_factory
+        self._tool_server_factory = tool_server_factory
+        self._transcript_exists = transcript_exists or _default_transcript_exists
+        self._binary = binary
+
+        self.session_id: str | None = None
+        self.credential: ClaudeCredential | None = None
+        self.wrapper_path: Path | None = None
+        self._client: SdkClient | None = None
+        self._connected_model: str | None = None
+        self._connected_effort: str | None = None
+        self._resume_on_connect = False
+        self._needs_reconnect = False
+        self._reconnects = 0
+        self._cost_baseline = 0.0
+        self._interrupted = False
+        self._tool_client: ControlPlaneToolClient | None = None
+        self._tool_server: Any = None
+        self.init_info: dict[str, Any] | None = None
+
+    # --- lifecycle -----------------------------------------------------------
+
+    async def open(self) -> None:
+        """Resolve the credential and generate the clean-env wrapper.
+
+        A credential denial is deterministic (``HarnessStartError``); a
+        transient control-plane failure is an ordinary error the supervisor's
+        bridge restart budget covers.
+        """
+        self.credential = await self._resolve_credential()
+        binary = self._binary or bundled_claude_binary()
+        self.wrapper_path = write_clean_env_wrapper(
+            self.config.config_dir / "bin", mode=self.credential.mode, binary=binary
+        )
+        if self.config.tools is not None and self._tool_client is None:
+            self._tool_client = ControlPlaneToolClient(self.config.tools, self.log)
+        self.log.info(
+            "claude.open",
+            auth_mode=self.credential.mode.value,
+            config_dir=str(self.config.config_dir),
+            workdir=str(self.config.workdir),
+        )
+
+    async def _resolve_credential(self) -> ClaudeCredential:
+        if self.config.oauth_managed:
+            if self.credential_client is None:
+                raise HarnessStartError(
+                    "This session uses a connected Claude account but the runtime has no "
+                    "credential endpoint configured."
+                )
+            try:
+                issued = await self.credential_client.fetch("anthropic")
+            except RuntimeCredentialDenied as error:
+                raise HarnessStartError(str(error)) from error
+            except RuntimeCredentialUnavailable as error:
+                raise RuntimeError(f"Claude credential unavailable: {error}") from error
+            return ClaudeCredential.oauth_token(issued.secret)
+        credential = resolve_api_key_credential(self.environ)
+        if credential is None:
+            raise HarnessStartError(
+                "No Anthropic credential is available to this session: set ANTHROPIC_API_KEY "
+                "or select a connected Claude account, then start a new session."
+            )
+        return credential
+
+    async def close(self) -> None:
+        await self._disconnect()
+        if self._tool_client is not None:
+            await self._tool_client.aclose()
+            self._tool_client = None
+
+    async def resume_session(self, persisted_id: str) -> bool:
+        if not self._transcript_exists(persisted_id, self.config.workdir):
+            self.log.info("claude.session.invalid", agent_session_id=persisted_id)
+            return False
+        self.session_id = persisted_id
+        self._resume_on_connect = True
+        self.log.info("claude.session.ensure", agent_session_id=persisted_id, action="loaded")
+        return True
+
+    async def create_session(self) -> None:
+        self.session_id = str(uuid.uuid4())
+        self._resume_on_connect = False
+        self.log.info("claude.session.ensure", agent_session_id=self.session_id, action="created")
+
+    # --- connection ------------------------------------------------------------
+
+    def build_options(self, model: str, reasoning_effort: str | None) -> Any:
+        """``ClaudeAgentOptions`` from the session's inputs (§5.1 of the design)."""
+        if self.credential is None or self.wrapper_path is None or self.session_id is None:
+            raise RuntimeError("Claude harness is not open")
+        mcp_servers: dict[str, Any] = mcp_server_options(self.config.mcp_servers)
+        allowed_tools = [*ALLOWED_TOOLS]
+        allowed_tools.extend(f"mcp__{name}__*" for name in mcp_servers)
+        if self._tool_client is not None:
+            if self._tool_server is None:
+                factory = self._tool_server_factory or _default_tool_server
+                self._tool_server = factory(self._tool_client)
+            mcp_servers[OI_TOOL_SERVER_NAME] = self._tool_server
+            allowed_tools.append(f"mcp__{OI_TOOL_SERVER_NAME}__*")
+        system_prompt: dict[str, Any] = {"type": "preset", "preset": "claude_code"}
+        if self.config.system_prompt_append:
+            system_prompt["append"] = self.config.system_prompt_append
+        kwargs: dict[str, Any] = {
+            "cwd": str(self.config.workdir),
+            "cli_path": str(self.wrapper_path),
+            "env": harness_env(self.config.config_dir, self.credential),
+            "model": model,
+            "mcp_servers": mcp_servers,
+            "allowed_tools": allowed_tools,
+            "disallowed_tools": [*DISALLOWED_TOOLS],
+            "permission_mode": "dontAsk",
+            "system_prompt": system_prompt,
+            "setting_sources": ["user", "project"],
+            "include_partial_messages": True,
+            "forward_subagent_text": False,
+            **reasoning_options(model, reasoning_effort),
+        }
+        if self._resume_on_connect:
+            kwargs["resume"] = self.session_id
+        else:
+            kwargs["session_id"] = self.session_id
+        build_options = self._options_factory or _default_options_factory
+        return build_options(**kwargs)
+
+    async def _ensure_client(self, model: str, reasoning_effort: str | None) -> SdkClient:
+        same_shape = (
+            self._client is not None
+            and self._connected_model == model
+            and self._connected_effort == reasoning_effort
+            and not self._needs_reconnect
+        )
+        if same_shape and self._client is not None:
+            return self._client
+        if self._client is not None:
+            if self._needs_reconnect:
+                self._reconnects += 1
+                if self._reconnects > MAX_RECONNECTS_PER_SESSION:
+                    raise RuntimeError(
+                        "The Claude agent process failed repeatedly for this session; "
+                        "start a new session."
+                    )
+            await self._disconnect()
+        options = self.build_options(model, reasoning_effort)
+        factory = self._client_factory or _default_client_factory
+        client = factory(options)
+        await client.connect()
+        self._client = client
+        self._connected_model = model
+        self._connected_effort = reasoning_effort
+        self._needs_reconnect = False
+        # A fresh child starts its running total at zero (§5.3 baseline rule).
+        self._cost_baseline = 0.0
+        self.log.info(
+            "claude.connected",
+            model=model,
+            reasoning_effort=reasoning_effort,
+            resume=self._resume_on_connect,
+        )
+        # Every later (re)connect resumes the transcript this child writes.
+        self._resume_on_connect = True
+        return client
+
+    async def _disconnect(self) -> None:
+        client, self._client = self._client, None
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except Exception as error:
+            self.log.warn("claude.disconnect_error", exc=error)
+
+    # --- prompt ------------------------------------------------------------
+
+    async def run_prompt(self, prompt: HarnessPrompt, emit: EventSink) -> TurnOutcome:
+        try:
+            model = bare_model_id(prompt.model, self.config.default_model)
+        except ValueError as error:
+            return TurnOutcome.failed(str(error))
+        try:
+            client = await self._ensure_client(model, prompt.reasoning_effort)
+        except HarnessStartError:
+            raise
+        except Exception as error:
+            self.log.error("claude.connect_error", exc=error, message_id=prompt.message_id)
+            self._needs_reconnect = True
+            return TurnOutcome.failed(f"Claude agent failed to start: {error}")
+
+        self._interrupted = False
+        state = _TurnState(message_id=prompt.message_id, cost_baseline=self._cost_baseline)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.limits.prompt_max_duration_seconds
+        try:
+            await client.query(self._user_messages(prompt))
+            stream = aiter(client.receive_response())
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise _PromptMaxDurationTimeout
+                try:
+                    async with asyncio.timeout(
+                        min(remaining, self.limits.inactivity_timeout_seconds)
+                    ):
+                        message = await anext(stream)
+                except StopAsyncIteration:
+                    break
+                except TimeoutError as error:
+                    if deadline - loop.time() <= 0:
+                        raise _PromptMaxDurationTimeout from error
+                    raise _InactivityTimeout from error
+                events, outcome = self._translate(state, message)
+                for event in events:
+                    await emit(event)
+                if outcome is not None:
+                    return outcome
+            self._needs_reconnect = True
+            return TurnOutcome.failed(
+                "The Claude agent stream ended before the turn completed.",
+                message_cost_usd=None,
+            )
+        except asyncio.CancelledError:
+            self._needs_reconnect = True
+            raise
+        except _PromptMaxDurationTimeout:
+            await self._interrupt_quietly()
+            self._needs_reconnect = True
+            return TurnOutcome.failed(
+                f"Prompt exceeded max duration of {self.limits.prompt_max_duration_seconds:.0f}s."
+            )
+        except _InactivityTimeout:
+            await self._interrupt_quietly()
+            self._needs_reconnect = True
+            return TurnOutcome.failed(
+                f"Claude agent produced no output for {self.limits.inactivity_timeout_seconds:.0f}s."
+            )
+        except Exception as error:
+            self.log.error("claude.turn_error", exc=error, message_id=prompt.message_id)
+            self._needs_reconnect = True
+            return TurnOutcome.failed(f"Claude agent transport failed: {error}")
+
+    async def _interrupt_quietly(self) -> None:
+        if self._client is None:
+            return
+        try:
+            await self._client.interrupt()
+        except Exception as error:
+            self.log.warn("claude.interrupt_error", exc=error)
+
+    async def abort(self) -> bool:
+        if self._client is None:
+            return False
+        self._interrupted = True
+        # The bridge cancels the prompt task too; the next prompt reconnects so
+        # the interrupted turn's trailing messages never leak into it.
+        self._needs_reconnect = True
+        try:
+            await self._client.interrupt()
+        except Exception as error:
+            self.log.warn("claude.interrupt_error", exc=error)
+            return False
+        return True
+
+    async def _user_messages(self, prompt: HarnessPrompt) -> AsyncIterator[dict[str, Any]]:
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt.text}]
+        for attachment in prompt.attachments:
+            content.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": attachment["mimeType"],
+                        "data": attachment["content"],
+                    },
+                }
+            )
+        yield {
+            "type": "user",
+            "message": {"role": "user", "content": content},
+            "parent_tool_use_id": None,
+            "session_id": self.session_id,
+        }
+
+    # --- translation (§5.2) -------------------------------------------------
+
+    def _translate(
+        self, state: _TurnState, message: Any
+    ) -> tuple[list[BridgeEvent], TurnOutcome | None]:
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ConversationResetMessage,
+            RateLimitEvent,
+            ResultMessage,
+            StreamEvent,
+            SystemMessage,
+            TextBlock,
+            ToolResultBlock,
+            ToolUseBlock,
+            UserMessage,
+        )
+
+        events: list[BridgeEvent] = []
+        if isinstance(message, SystemMessage):
+            if message.subtype == "init":
+                self.init_info = dict(message.data)
+                self.log.info(
+                    "claude.init",
+                    model=message.data.get("model"),
+                    tool_count=len(message.data.get("tools") or []),
+                )
+            elif message.subtype == "compact_boundary":
+                events.append({"type": "context_compacted", "messageId": state.message_id})
+            return events, None
+
+        if isinstance(message, StreamEvent):
+            if message.parent_tool_use_id:
+                return events, None
+            raw = message.event
+            kind = raw.get("type")
+            if kind == "message_start":
+                message_id = (raw.get("message") or {}).get("id")
+                state.texts.append(_MessageText(message_id))
+                if not state.step_started:
+                    state.step_started = True
+                    events.append({"type": "step_start", "messageId": state.message_id})
+            elif kind == "content_block_delta":
+                delta = raw.get("delta") or {}
+                if delta.get("type") == "text_delta" and delta.get("text"):
+                    entry = state.texts[-1] if state.texts else state.entry_for(None)
+                    entry.text += str(delta["text"])
+                    events.extend(self._token_event(state))
+            return events, None
+
+        if isinstance(message, AssistantMessage):
+            is_subtask = bool(message.parent_tool_use_id)
+            if not is_subtask:
+                if not state.step_started:
+                    state.step_started = True
+                    events.append({"type": "step_start", "messageId": state.message_id})
+                final_text = "".join(
+                    block.text for block in message.content if isinstance(block, TextBlock)
+                )
+                if final_text:
+                    entry = state.entry_for(message.message_id)
+                    if len(final_text) > len(entry.text):
+                        entry.text = final_text
+                        events.extend(self._token_event(state))
+            for block in message.content:
+                if isinstance(block, ToolUseBlock):
+                    state.tool_names[block.id] = block.name
+                    state.tool_args[block.id] = dict(block.input)
+                    events.append(
+                        self._tool_event(
+                            state,
+                            call_id=block.id,
+                            status="running",
+                            output="",
+                            parent_tool_use_id=message.parent_tool_use_id,
+                        )
+                    )
+            if message.error:
+                events.extend(self._error_events(state, message.error))
+            return events, None
+
+        if isinstance(message, UserMessage):
+            if isinstance(message.content, str):
+                return events, None
+            for block in message.content:
+                if isinstance(block, ToolResultBlock):
+                    events.append(
+                        self._tool_event(
+                            state,
+                            call_id=block.tool_use_id,
+                            status="error" if block.is_error else "completed",
+                            output=_tool_result_text(block.content),
+                            parent_tool_use_id=message.parent_tool_use_id,
+                        )
+                    )
+            return events, None
+
+        if isinstance(message, RateLimitEvent):
+            info = message.rate_limit_info
+            if info.status in ("allowed_warning", "rejected"):
+                detail = f"Anthropic rate limit {info.status}"
+                if info.rate_limit_type:
+                    detail += f" ({info.rate_limit_type})"
+                if info.resets_at:
+                    detail += f"; resets at {info.resets_at}"
+                events.append({"type": "warning", "scope": "provider", "message": detail})
+            return events, None
+
+        if isinstance(message, ConversationResetMessage):
+            self._cost_baseline = 0.0
+            state.cost_baseline = 0.0
+            return events, None
+
+        if isinstance(message, ResultMessage):
+            total = message.total_cost_usd
+            if total is None:
+                message_cost = 0.0
+                events.append(
+                    {
+                        "type": "warning",
+                        "scope": "provider",
+                        "message": "The Claude agent reported no cost for this turn; it is recorded as 0.",
+                    }
+                )
+            else:
+                message_cost = max(total - state.cost_baseline, 0.0)
+                self._cost_baseline = total
+            finish: BridgeEvent = {
+                "type": "step_finish",
+                "messageId": state.message_id,
+                "cost": message_cost,
+                "messageCostUsd": message_cost,
+                "reason": message.subtype,
+            }
+            tokens = _usage_tokens(message.usage)
+            if tokens:
+                finish["tokens"] = tokens
+            events.append(finish)
+            if self._interrupted:
+                return events, TurnOutcome(
+                    success=False,
+                    error="Task was cancelled",
+                    cancelled=True,
+                    message_cost_usd=message_cost,
+                )
+            if message.is_error or message.subtype != "success":
+                detail = message.result or "; ".join(message.errors or []) or message.subtype
+                if not state.emitted_error:
+                    events.append(
+                        {"type": "error", "error": str(detail), "messageId": state.message_id}
+                    )
+                return events, TurnOutcome.failed(str(detail), message_cost_usd=message_cost)
+            return events, TurnOutcome.ok(message_cost_usd=message_cost)
+
+        return events, None
+
+    def _token_event(self, state: _TurnState) -> list[BridgeEvent]:
+        content = state.turn_text()
+        if not content or content == state.last_token_content:
+            return []
+        state.last_token_content = content
+        return [{"type": "token", "content": content, "messageId": state.message_id}]
+
+    def _tool_event(
+        self,
+        state: _TurnState,
+        *,
+        call_id: str,
+        status: str,
+        output: str,
+        parent_tool_use_id: str | None,
+    ) -> BridgeEvent:
+        event: BridgeEvent = {
+            "type": "tool_call",
+            "tool": state.tool_names.get(call_id, "tool"),
+            "args": state.tool_args.get(call_id, {}),
+            "callId": call_id,
+            "status": status,
+            "output": output,
+            "messageId": state.message_id,
+        }
+        if parent_tool_use_id:
+            event["isSubtask"] = True
+            event["taskCallId"] = parent_tool_use_id
+        return event
+
+    def _error_events(self, state: _TurnState, error: str) -> list[BridgeEvent]:
+        if error == "authentication_failed":
+            if state.emitted_error:
+                return []
+            state.emitted_error = True
+            # No account-state mutation here: the sandbox is not authoritative.
+            return [
+                {
+                    "type": "error",
+                    "error": AUTHENTICATION_FAILED_MESSAGE,
+                    "messageId": state.message_id,
+                }
+            ]
+        return [
+            {
+                "type": "warning",
+                "scope": "provider",
+                "message": f"Anthropic reported {error.replace('_', ' ')} on this turn.",
+            }
+        ]
+
+
+class _PromptMaxDurationTimeout(Exception):
+    pass
+
+
+class _InactivityTimeout(Exception):
+    pass
+
+
+def _default_transcript_exists(session_id: str, workdir: Path) -> bool:
+    try:
+        from claude_agent_sdk import get_session_info
+
+        return get_session_info(session_id, directory=str(workdir)) is not None
+    except Exception:
+        return False
+
+
+def _default_options_factory(**kwargs: Any) -> Any:
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    return ClaudeAgentOptions(**kwargs)
+
+
+def _default_client_factory(options: Any) -> SdkClient:
+    from claude_agent_sdk import ClaudeSDKClient
+
+    return ClaudeSDKClient(options=options)
+
+
+def _default_tool_server(client: ControlPlaneToolClient) -> Any:
+    from .claude_tools import build_tool_server
+
+    return build_tool_server(client)

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
@@ -231,7 +231,7 @@ class ClaudeHarness:
         client_factory: SdkClientFactory | None = None,
         options_factory: Callable[..., Any] | None = None,
         tool_server_factory: Callable[[ControlPlaneToolClient], Any] | None = None,
-        transcript_exists: Callable[[str, Path], bool] | None = None,
+        transcript_exists: Callable[[str, Path, Path], bool] | None = None,
         binary: Path | None = None,
     ) -> None:
         self.config = config
@@ -312,7 +312,7 @@ class ClaudeHarness:
             self._tool_client = None
 
     async def resume_session(self, persisted_id: str) -> bool:
-        if not self._transcript_exists(persisted_id, self.config.workdir):
+        if not self._transcript_exists(persisted_id, self.config.workdir, self.config.config_dir):
             self.log.info("claude.session.invalid", agent_session_id=persisted_id)
             return False
         self.session_id = persisted_id
@@ -738,13 +738,25 @@ class _InactivityTimeout(Exception):
     pass
 
 
-def _default_transcript_exists(session_id: str, workdir: Path) -> bool:
-    try:
-        from claude_agent_sdk import get_session_info
+def _default_transcript_exists(session_id: str, workdir: Path, config_dir: Path) -> bool:
+    """Whether the child wrote a transcript for ``session_id`` under ``config_dir``.
 
-        return get_session_info(session_id, directory=str(workdir)) is not None
-    except Exception:
+    The SDK's ``get_session_info`` resolves the projects directory from the
+    *bridge's* ``CLAUDE_CONFIG_DIR``, which is never set: the config dir only
+    reaches the child through ``options.env``. Look under the directory the
+    child actually writes to. Session ids are UUIDs, so a glob across project
+    directories is unambiguous and immune to path-canonicalisation drift
+    between ``workdir`` and the child's realpath.
+    """
+    try:
+        uuid.UUID(session_id)
+    except ValueError:
         return False
+    projects = config_dir / "projects"
+    if not projects.is_dir():
+        return False
+    del workdir  # informational; the transcript is keyed by session id
+    return any(path.is_file() for path in projects.glob(f"*/{session_id}.jsonl"))
 
 
 def _default_options_factory(**kwargs: Any) -> Any:

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
@@ -146,6 +146,11 @@ def harness_env(config_dir: Path, credential: ClaudeCredential) -> dict[str, str
     return {
         CONFIG_DIR_ENV_VAR: str(config_dir),
         "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        # A background sub-agent returns a result before its work is done and
+        # delivers the findings on a later injected turn. Foreground sub-agents
+        # launched in one message still run concurrently, as OpenCode's task
+        # tool does.
+        "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": "1",
         "DISABLE_AUTOUPDATER": "1",
         "DISABLE_ERROR_REPORTING": "1",
         "DISABLE_TELEMETRY": "1",

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
@@ -1,13 +1,16 @@
-"""Clean-environment launch for the Claude Agent SDK child.
+"""Clean-credential launch for the Claude Agent SDK child.
 
 The SDK merges ``os.environ`` under ``ClaudeAgentOptions.env`` when it spawns
 the ``claude`` binary, and the bridge inherits the supervisor's full
-environment: the platform-delivered ``ANTHROPIC_API_KEY``, the sandbox auth
-token, ``SESSION_CONFIG`` and every user secret. So the harness never hands
-the SDK the real binary. It hands it a generated wrapper that re-executes the
-binary with exactly the allowlisted variables and nothing else, for every
-invocation including the SDK's version probe.
+environment, including the platform-delivered ``ANTHROPIC_API_KEY``. So the
+harness never hands the SDK the real binary. It hands it a generated wrapper
+that re-executes the binary with the sandbox environment minus the Anthropic
+credentials that do not belong to the active auth mode, for every invocation
+including the SDK's version probe.
 
+Everything else passes through, exactly as it does for OpenCode: the sandbox
+token, ``SESSION_CONFIG`` and user secrets are what ``oi-git-sign``,
+``oi-git-credentials``, ``upload-media`` and the agent's own commands need.
 The wrapper carries variable *names* only. Credential values travel through
 ``ClaudeAgentOptions.env`` in process memory and are never written to disk.
 """
@@ -25,55 +28,15 @@ from typing import TYPE_CHECKING, Final
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-# Variables the child always receives when the bridge has them.
-BASE_ALLOWLIST: Final[tuple[str, ...]] = (
-    "PATH",
-    "HOME",
-    "USER",
-    "LANG",
-    "LC_ALL",
-    "TERM",
-    "TMPDIR",
-    "SHELL",
-    "PWD",
-    "NODE_OPTIONS",
-    "NODE_EXTRA_CA_CERTS",
-    "SSL_CERT_FILE",
-    "SSL_CERT_DIR",
-    "https_proxy",
-    "HTTPS_PROXY",
-    "http_proxy",
-    "HTTP_PROXY",
-    "no_proxy",
-    "NO_PROXY",
-    "GIT_CONFIG_GLOBAL",
-    "GIT_CONFIG_SYSTEM",
-    "GIT_SSH_COMMAND",
-    "GH_TOKEN",
-    "GITHUB_TOKEN",
-    # Set by the SDK itself on every spawn.
-    "CLAUDE_CODE_ENTRYPOINT",
-    "CLAUDE_AGENT_SDK_VERSION",
-    "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
-    # Set by the harness through options.env.
-    "CLAUDE_CONFIG_DIR",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
-    "CLAUDE_CODE_SUBAGENT_MODEL",
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
-    "DISABLE_TELEMETRY",
-    "DISABLE_ERROR_REPORTING",
-    "DISABLE_AUTOUPDATER",
-    "MAX_THINKING_TOKENS",
-)
-
-# Credential variables per auth mode. Exactly one mode is ever active, so the
-# child sees either the key family or the OAuth token, never both.
-API_KEY_ALLOWLIST: Final[tuple[str, ...]] = (
+# Credential variables per auth mode. Exactly one mode is ever active: the
+# child sees either the key family or the OAuth token, never both, so the
+# family of the *other* mode is what the wrapper strips.
+API_KEY_CREDENTIAL_VARS: Final[tuple[str, ...]] = (
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_BASE_URL",
     "ANTHROPIC_AUTH_TOKEN",
 )
-OAUTH_ALLOWLIST: Final[tuple[str, ...]] = ("CLAUDE_CODE_OAUTH_TOKEN",)
+OAUTH_CREDENTIAL_VARS: Final[tuple[str, ...]] = ("CLAUDE_CODE_OAUTH_TOKEN",)
 
 OAUTH_TOKEN_ENV_VAR: Final = "CLAUDE_CODE_OAUTH_TOKEN"
 API_KEY_ENV_VAR: Final = "ANTHROPIC_API_KEY"
@@ -103,7 +66,7 @@ class ClaudeCredential:
             return None
         return cls(
             ClaudeAuthMode.API_KEY,
-            {name: environ[name] for name in API_KEY_ALLOWLIST if environ.get(name)},
+            {name: environ[name] for name in API_KEY_CREDENTIAL_VARS if environ.get(name)},
         )
 
     @classmethod
@@ -111,21 +74,22 @@ class ClaudeCredential:
         return cls(ClaudeAuthMode.OAUTH_TOKEN, {OAUTH_TOKEN_ENV_VAR: token})
 
 
-def allowlist_for(mode: ClaudeAuthMode) -> tuple[str, ...]:
-    credential = API_KEY_ALLOWLIST if mode is ClaudeAuthMode.API_KEY else OAUTH_ALLOWLIST
-    return BASE_ALLOWLIST + credential
+def denylist_for(mode: ClaudeAuthMode) -> tuple[str, ...]:
+    """The credential family the child must never see in ``mode``."""
+    return OAUTH_CREDENTIAL_VARS if mode is ClaudeAuthMode.API_KEY else API_KEY_CREDENTIAL_VARS
 
 
 def clean_child_env(
     parent: Mapping[str, str], mode: ClaudeAuthMode, extra: Mapping[str, str]
 ) -> dict[str, str]:
-    """What the child ends up with: the allowlisted subset of parent+extra.
+    """What the child ends up with: parent+extra minus the other mode's credentials.
 
     This is the reference the sentinel test compares the wrapper's real
     output against.
     """
     merged = {**parent, **extra}
-    return {name: merged[name] for name in allowlist_for(mode) if name in merged}
+    stripped = set(denylist_for(mode))
+    return {name: value for name, value in merged.items() if name not in stripped}
 
 
 def bundled_claude_binary() -> Path:
@@ -148,13 +112,13 @@ def write_clean_env_wrapper(
 ) -> Path:
     """Generate the wrapper set as ``ClaudeAgentOptions.cli_path``.
 
-    A Python script rather than a shell one so the allowlist is applied
+    A Python script rather than a shell one so the denylist is applied
     exactly (no word splitting, no accidental empty exports). It re-executes
-    ``binary`` with the allowlisted variables it finds in its own environment,
-    which is the SDK's merged ``os.environ`` + ``options.env``.
+    ``binary`` with its own environment, which is the SDK's merged
+    ``os.environ`` + ``options.env``, minus the other mode's credentials.
     """
     python = python_executable or sys.executable
-    names = allowlist_for(mode)
+    names = denylist_for(mode)
     script = "\n".join(
         [
             f"#!{python}",
@@ -163,9 +127,9 @@ def write_clean_env_wrapper(
             "import sys",
             "",
             f"BINARY = {str(binary)!r}",
-            f"ALLOWLIST = {names!r}",
+            f"DENYLIST = frozenset({names!r})",
             "",
-            "env = {name: os.environ[name] for name in ALLOWLIST if name in os.environ}",
+            "env = {name: value for name, value in os.environ.items() if name not in DENYLIST}",
             "os.execve(BINARY, [BINARY, *sys.argv[1:]], env)",
             "",
         ]

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
@@ -1,0 +1,193 @@
+"""Clean-environment launch for the Claude Agent SDK child.
+
+The SDK merges ``os.environ`` under ``ClaudeAgentOptions.env`` when it spawns
+the ``claude`` binary, and the bridge inherits the supervisor's full
+environment: the platform-delivered ``ANTHROPIC_API_KEY``, the sandbox auth
+token, ``SESSION_CONFIG`` and every user secret. So the harness never hands
+the SDK the real binary. It hands it a generated wrapper that re-executes the
+binary with exactly the allowlisted variables and nothing else, for every
+invocation including the SDK's version probe.
+
+The wrapper carries variable *names* only. Credential values travel through
+``ClaudeAgentOptions.env`` in process memory and are never written to disk.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# Variables the child always receives when the bridge has them.
+BASE_ALLOWLIST: Final[tuple[str, ...]] = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "TMPDIR",
+    "SHELL",
+    "PWD",
+    "NODE_OPTIONS",
+    "NODE_EXTRA_CA_CERTS",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "https_proxy",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "HTTP_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_SSH_COMMAND",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    # Set by the SDK itself on every spawn.
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_AGENT_SDK_VERSION",
+    "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
+    # Set by the harness through options.env.
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "DISABLE_TELEMETRY",
+    "DISABLE_ERROR_REPORTING",
+    "DISABLE_AUTOUPDATER",
+    "MAX_THINKING_TOKENS",
+)
+
+# Credential variables per auth mode. Exactly one mode is ever active, so the
+# child sees either the key family or the OAuth token, never both.
+API_KEY_ALLOWLIST: Final[tuple[str, ...]] = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+)
+OAUTH_ALLOWLIST: Final[tuple[str, ...]] = ("CLAUDE_CODE_OAUTH_TOKEN",)
+
+OAUTH_TOKEN_ENV_VAR: Final = "CLAUDE_CODE_OAUTH_TOKEN"
+API_KEY_ENV_VAR: Final = "ANTHROPIC_API_KEY"
+OAUTH_MANAGED_ENV_VAR: Final = "ANTHROPIC_OAUTH_MANAGED"
+CONFIG_DIR_ENV_VAR: Final = "CLAUDE_CONFIG_DIR"
+
+WRAPPER_NAME: Final = "claude-clean-env"
+
+
+class ClaudeAuthMode(StrEnum):
+    API_KEY = "api_key"
+    OAUTH_TOKEN = "oauth_token"
+
+
+@dataclass(frozen=True)
+class ClaudeCredential:
+    """The one credential the child receives, held in memory only."""
+
+    mode: ClaudeAuthMode
+    # Variables to pass through ``ClaudeAgentOptions.env``; never logged.
+    env: Mapping[str, str]
+
+    @classmethod
+    def api_key(cls, environ: Mapping[str, str]) -> ClaudeCredential | None:
+        """Adopt the bridge's Anthropic key family (a user-configured gateway keeps working)."""
+        if not environ.get(API_KEY_ENV_VAR):
+            return None
+        return cls(
+            ClaudeAuthMode.API_KEY,
+            {name: environ[name] for name in API_KEY_ALLOWLIST if environ.get(name)},
+        )
+
+    @classmethod
+    def oauth_token(cls, token: str) -> ClaudeCredential:
+        return cls(ClaudeAuthMode.OAUTH_TOKEN, {OAUTH_TOKEN_ENV_VAR: token})
+
+
+def allowlist_for(mode: ClaudeAuthMode) -> tuple[str, ...]:
+    credential = API_KEY_ALLOWLIST if mode is ClaudeAuthMode.API_KEY else OAUTH_ALLOWLIST
+    return BASE_ALLOWLIST + credential
+
+
+def clean_child_env(
+    parent: Mapping[str, str], mode: ClaudeAuthMode, extra: Mapping[str, str]
+) -> dict[str, str]:
+    """What the child ends up with: the allowlisted subset of parent+extra.
+
+    This is the reference the sentinel test compares the wrapper's real
+    output against.
+    """
+    merged = {**parent, **extra}
+    return {name: merged[name] for name in allowlist_for(mode) if name in merged}
+
+
+def bundled_claude_binary() -> Path:
+    """The ``claude`` binary the pinned SDK wheel ships (``claude_agent_sdk/_bundled``)."""
+    import claude_agent_sdk
+
+    package_dir = Path(claude_agent_sdk.__file__).parent
+    binary = package_dir / "_bundled" / "claude"
+    if not binary.is_file():
+        raise FileNotFoundError(f"The Claude Agent SDK wheel has no bundled binary at {binary}")
+    return binary
+
+
+def write_clean_env_wrapper(
+    directory: Path,
+    *,
+    mode: ClaudeAuthMode,
+    binary: Path,
+    python_executable: str | None = None,
+) -> Path:
+    """Generate the wrapper set as ``ClaudeAgentOptions.cli_path``.
+
+    A Python script rather than a shell one so the allowlist is applied
+    exactly (no word splitting, no accidental empty exports). It re-executes
+    ``binary`` with the allowlisted variables it finds in its own environment,
+    which is the SDK's merged ``os.environ`` + ``options.env``.
+    """
+    python = python_executable or sys.executable
+    names = allowlist_for(mode)
+    script = "\n".join(
+        [
+            f"#!{python}",
+            '"""Generated by the Open Inspect Claude harness. Do not edit."""',
+            "import os",
+            "import sys",
+            "",
+            f"BINARY = {str(binary)!r}",
+            f"ALLOWLIST = {names!r}",
+            "",
+            "env = {name: os.environ[name] for name in ALLOWLIST if name in os.environ}",
+            "os.execve(BINARY, [BINARY, *sys.argv[1:]], env)",
+            "",
+        ]
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    wrapper = directory / WRAPPER_NAME
+    wrapper.write_text(script)
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return wrapper
+
+
+def harness_env(config_dir: Path, credential: ClaudeCredential) -> dict[str, str]:
+    """``ClaudeAgentOptions.env``: config dir, policy, and the one credential."""
+    return {
+        CONFIG_DIR_ENV_VAR: str(config_dir),
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "DISABLE_AUTOUPDATER": "1",
+        "DISABLE_ERROR_REPORTING": "1",
+        "DISABLE_TELEMETRY": "1",
+        **credential.env,
+    }
+
+
+def resolve_api_key_credential(environ: Mapping[str, str] = os.environ) -> ClaudeCredential | None:
+    return ClaudeCredential.api_key(environ)

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_tools.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_tools.py
@@ -656,7 +656,11 @@ class OpenInspectTools:
                 data[key] = str(args[key])
             data["dimensions"] = _dimensions_field(args["dimensions"])
             data["truncated"] = "true" if args.get("truncated") else "false"
-            data["hasAudio"] = "true" if args.get("hasAudio") else "false"
+            # The endpoint rejects audio tracks; refuse here so the agent gets a
+            # clear message instead of a 400 after uploading the whole file.
+            if args.get("hasAudio") is True:
+                return _text_result("Video uploads do not support audio (hasAudio must be false).")
+            data["hasAudio"] = "false"
         try:
             response = await self.client.request(
                 "POST",
@@ -933,7 +937,11 @@ def build_tools(client: ControlPlaneToolClient) -> list[Any]:
                         "required": ["width", "height"],
                     },
                     "truncated": {"type": "boolean", "description": "Video only."},
-                    "hasAudio": {"type": "boolean", "description": "Video only."},
+                    "hasAudio": {
+                        "type": "boolean",
+                        "enum": [False],
+                        "description": "Video only. Audio tracks are not supported.",
+                    },
                 },
                 "required": ["filePath"],
             },

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_server.py
@@ -12,14 +12,11 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from .constants import (
-    BIN_INSTALL_DIR_ENV_VAR,
-    DEFAULT_BIN_INSTALL_DIR,
-    OPENCODE_PORT,
-)
+from .constants import OPENCODE_PORT
 from .git_excludes import install_runtime_git_excludes
 from .mcp_packages import McpPackageInstaller
 from .process_output import iter_process_lines
+from .sandbox_bin import install_bin_scripts
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -255,30 +252,8 @@ class OpenCodeServer:
         except Exception as e:
             self.log.warn("opencode.global_deps_seed_failed", exc=e)
         installed.update(self._install_skills(workdir))
-        self._install_bin_scripts()
+        install_bin_scripts(self.log)
         return installed
-
-    def _install_bin_scripts(self) -> None:
-        """Install standalone CLI scripts into the sandbox bin directory.
-
-        Scripts in bin/ are standalone CLIs (not OpenCode tool plugins) and must
-        NOT be placed in .opencode/tool/ — OpenCode would import() them during
-        tool discovery, executing module-level code with the parent process argv.
-        """
-        bin_dir = Path("/app/sandbox_runtime/bin")
-        if not bin_dir.is_dir():
-            return
-
-        install_dir = Path(os.environ.get(BIN_INSTALL_DIR_ENV_VAR, DEFAULT_BIN_INSTALL_DIR))
-        install_dir.mkdir(parents=True, exist_ok=True)
-        for script in bin_dir.iterdir():
-            if not script.is_file() or script.suffix not in {"", ".js"}:
-                continue
-            command_name = script.stem if script.suffix == ".js" else script.name
-            dest = install_dir / command_name
-            shutil.copy(script, dest)
-            dest.chmod(0o755)
-            self.log.info("bin.installed", script=command_name)
 
     def _install_skills(self, workdir: Path) -> set[str]:
         """Copy bundled Skills into the .opencode/skills directory."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_config.py
@@ -78,6 +78,12 @@ class OpenCodeConfig:
 
 
 @dataclass(frozen=True)
+class ClaudeStagerConfig:
+    has_repository: bool
+    mcp_servers: tuple[Mapping[str, Any], ...]
+
+
+@dataclass(frozen=True)
 class ManagedSkillsConfig:
     control_plane_url: str
     sandbox_token: str
@@ -184,6 +190,15 @@ class RuntimeConfig:
             has_repository=self.has_repository,
             workspace_path=self.workspace_path,
         )
+
+    def claude_stager_config(self) -> ClaudeStagerConfig:
+        raw_mcp_servers = self.session_config.get("mcp_servers")
+        mcp_servers = (
+            tuple(item for item in raw_mcp_servers if isinstance(item, Mapping))
+            if isinstance(raw_mcp_servers, tuple)
+            else ()
+        )
+        return ClaudeStagerConfig(has_repository=self.has_repository, mcp_servers=mcp_servers)
 
     def bridge_process_config(self) -> BridgeProcessConfig:
         return BridgeProcessConfig(

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "v63-mcp-package-cache",
-  "generation": 63,
-  "minimumCompatibleGeneration": 62,
-  "minimumRebuildGeneration": 63
+  "runtimeVersion": "v64-claude-harness",
+  "generation": 64,
+  "minimumCompatibleGeneration": 64,
+  "minimumRebuildGeneration": 64
 }

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,6 +1,9 @@
 {
   "runtimeVersion": "v64-claude-harness",
   "generation": 64,
-  "minimumCompatibleGeneration": 64,
-  "minimumRebuildGeneration": 64
+  "minimumCompatibleGeneration": 62,
+  "minimumRebuildGeneration": 64,
+  "harnessMinimumGeneration": {
+    "claude": 64
+  }
 }

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.py
@@ -11,6 +11,9 @@ class RuntimeManifest(TypedDict):
     generation: int
     minimumCompatibleGeneration: int
     minimumRebuildGeneration: int
+    # Per-harness floors for prebuilt-image selection: a harness whose runtime
+    # support arrived later than the global floor names its own generation.
+    harnessMinimumGeneration: dict[str, int]
 
 
 _MANIFEST_PATH = Path(__file__).with_name("runtime_manifest.json")

--- a/packages/sandbox-runtime/src/sandbox_runtime/sandbox_bin.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/sandbox_bin.py
@@ -1,0 +1,36 @@
+"""Standalone CLI scripts installed into the sandbox bin directory."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .constants import BIN_INSTALL_DIR_ENV_VAR, DEFAULT_BIN_INSTALL_DIR
+
+BUNDLED_BIN_DIR = Path("/app/sandbox_runtime/bin")
+
+
+def install_bin_scripts(log: Any, *, bin_dir: Path = BUNDLED_BIN_DIR) -> list[str]:
+    """Install the bundled CLIs (``upload-media``, ``oi-git-sign``) for the agent's shell.
+
+    These are standalone CLIs, not agent tool plugins, and both harnesses need
+    them on ``PATH``. They must never be placed where a harness discovers
+    tools (OpenCode would import them during tool discovery).
+    """
+    if not bin_dir.is_dir():
+        return []
+    install_dir = Path(os.environ.get(BIN_INSTALL_DIR_ENV_VAR, DEFAULT_BIN_INSTALL_DIR))
+    install_dir.mkdir(parents=True, exist_ok=True)
+    installed: list[str] = []
+    for script in sorted(bin_dir.iterdir()):
+        if not script.is_file() or script.suffix not in {"", ".js"}:
+            continue
+        command_name = script.stem if script.suffix == ".js" else script.name
+        dest = install_dir / command_name
+        shutil.copy(script, dest)
+        dest.chmod(0o755)
+        installed.append(command_name)
+        log.info("bin.installed", script=command_name)
+    return installed

--- a/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
@@ -132,6 +132,36 @@ class TestSessionIdentity:
         assert bridge.agent_session_id == harness.session_id == "oc-session-new"
         assert bridge.session_id_file.read_text() == "oc-session-new"
 
+    @pytest.mark.asyncio
+    async def test_an_id_rotated_during_a_turn_is_persisted(self, tmp_path: Path) -> None:
+        # A conversation reset gives the vendor session a new id mid-connection;
+        # the file a restore resumes from must follow it.
+        class RotatingHarness(ScriptedHarness):
+            async def run_prompt(self, prompt, emit):
+                self.session_id = "rotated-id"
+                return TurnOutcome.ok()
+
+        bridge = _bridge(RotatingHarness(session_id="original-id"))
+        bridge._configure_git_identity = AsyncMock()
+        bridge._send_event = AsyncMock()
+        bridge.session_id_file = tmp_path / "agent-session-id"
+        bridge.session_id_file.write_text("original-id")
+
+        await bridge._handle_command(
+            {
+                "type": "prompt",
+                "messageId": "m1",
+                "content": "hi",
+                "model": "claude-sonnet-4-6",
+                "author": {"userId": "user-1", "gitIdentity": {"mode": "agent-only"}},
+            }
+        )
+        task = bridge._current_prompt_task
+        assert task is not None
+        await task
+
+        assert bridge.session_id_file.read_text() == "rotated-id"
+
 
 class TestHarnessContracts:
     def test_only_deployable_harness_ids_parse(self) -> None:

--- a/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_bridge_harness_lifecycle.py
@@ -137,8 +137,9 @@ class TestHarnessContracts:
     def test_only_deployable_harness_ids_parse(self) -> None:
         assert parse_harness_id(None) is HarnessId.OPENCODE
         assert parse_harness_id("opencode") is HarnessId.OPENCODE
-        with pytest.raises(ValueError, match="Unsupported harness: 'claude'"):
-            parse_harness_id("claude")
+        assert parse_harness_id("claude") is HarnessId.CLAUDE
+        with pytest.raises(ValueError, match="Unsupported harness: 'codex'"):
+            parse_harness_id("codex")
 
     def test_turn_outcome_rejects_contradictions(self) -> None:
         with pytest.raises(ValueError, match="cancelled"):

--- a/packages/sandbox-runtime/tests/test_claude_env.py
+++ b/packages/sandbox-runtime/tests/test_claude_env.py
@@ -148,6 +148,12 @@ class TestDenylist:
         assert credential is not None
         assert dict(credential.env) == {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_AUTH_TOKEN": "t"}
 
+    def test_harness_env_keeps_sub_agents_in_the_foreground(self, tmp_path: Path) -> None:
+        # A background sub-agent would let the turn end before its work is done
+        # and deliver its result on a turn the harness never reads.
+        env = harness_env(tmp_path, ClaudeCredential.oauth_token("tok"))
+        assert env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+
     def test_harness_env_sets_config_dir_and_policy(self, tmp_path: Path) -> None:
         env = harness_env(tmp_path, ClaudeCredential.oauth_token("tok"))
         assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path)

--- a/packages/sandbox-runtime/tests/test_claude_env.py
+++ b/packages/sandbox-runtime/tests/test_claude_env.py
@@ -1,0 +1,143 @@
+"""The clean-environment launch: the child sees the allowlist and nothing else."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sandbox_runtime.harness.claude_env import (
+    API_KEY_ALLOWLIST,
+    BASE_ALLOWLIST,
+    OAUTH_ALLOWLIST,
+    ClaudeAuthMode,
+    ClaudeCredential,
+    allowlist_for,
+    clean_child_env,
+    harness_env,
+    write_clean_env_wrapper,
+)
+
+FAKE_BINARY = """#!{python}
+import json, os, sys
+print(json.dumps({{"env": dict(os.environ), "argv": sys.argv[1:]}}))
+"""
+
+
+def _fake_binary(tmp_path: Path) -> Path:
+    binary = tmp_path / "fake-claude"
+    binary.write_text(FAKE_BINARY.format(python=sys.executable))
+    binary.chmod(0o755)
+    return binary
+
+
+def _run_wrapper(wrapper: Path, parent_env: dict[str, str], *args: str) -> dict:
+    completed = subprocess.run(
+        [str(wrapper), *args],
+        env=parent_env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    result = json.loads(completed.stdout)
+    # The interpreter running the fake binary adds these itself (C-locale
+    # coercion, macOS CoreFoundation); they are not part of what the wrapper
+    # forwards, so they are dropped unless the caller supplied them.
+    for artifact in ("LC_CTYPE", "__CF_USER_TEXT_ENCODING"):
+        if artifact not in parent_env:
+            result["env"].pop(artifact, None)
+    return result
+
+
+def _polluted_parent_env(**overrides: str) -> dict[str, str]:
+    """The bridge's real inheritance: platform key, sandbox token, user secrets."""
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": "/root",
+        "ANTHROPIC_API_KEY": "sk-ant-platform-key",
+        "SANDBOX_AUTH_TOKEN": "sandbox-secret",
+        "CONTROL_PLANE_URL": "https://cp.example",
+        "SESSION_CONFIG": '{"session_id":"s1"}',
+        "DB_PASSWORD": "user-secret",
+        "OPENAI_API_KEY": "sk-openai",
+        "CLAUDECODE": "1",
+        **overrides,
+    }
+
+
+class TestSentinel:
+    """The design's sentinel: the child's environment equals the allowlist exactly."""
+
+    def test_oauth_mode_strips_the_platform_api_key(self, tmp_path: Path) -> None:
+        wrapper = write_clean_env_wrapper(
+            tmp_path / "bin", mode=ClaudeAuthMode.OAUTH_TOKEN, binary=_fake_binary(tmp_path)
+        )
+        # What the SDK builds: os.environ merged under options.env.
+        parent = _polluted_parent_env()
+        options_env = harness_env(tmp_path / "cfg", ClaudeCredential.oauth_token("sk-ant-oat01-x"))
+        child = _run_wrapper(wrapper, {**parent, **options_env}, "-v")["env"]
+
+        expected = clean_child_env(parent, ClaudeAuthMode.OAUTH_TOKEN, options_env)
+        assert child == expected
+        assert "ANTHROPIC_API_KEY" not in child
+        assert child["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-x"
+        for secret in ("SANDBOX_AUTH_TOKEN", "SESSION_CONFIG", "DB_PASSWORD", "OPENAI_API_KEY"):
+            assert secret not in child
+
+    def test_api_key_mode_forwards_the_key_family_only(self, tmp_path: Path) -> None:
+        wrapper = write_clean_env_wrapper(
+            tmp_path / "bin", mode=ClaudeAuthMode.API_KEY, binary=_fake_binary(tmp_path)
+        )
+        parent = _polluted_parent_env(ANTHROPIC_BASE_URL="https://gateway.example")
+        credential = ClaudeCredential.api_key(parent)
+        assert credential is not None
+        options_env = harness_env(tmp_path / "cfg", credential)
+        child = _run_wrapper(wrapper, {**parent, **options_env})["env"]
+
+        assert child == clean_child_env(parent, ClaudeAuthMode.API_KEY, options_env)
+        assert child["ANTHROPIC_API_KEY"] == "sk-ant-platform-key"
+        assert child["ANTHROPIC_BASE_URL"] == "https://gateway.example"
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in child
+        assert "SANDBOX_AUTH_TOKEN" not in child
+
+    def test_wrapper_forwards_arguments_including_the_version_probe(self, tmp_path: Path) -> None:
+        wrapper = write_clean_env_wrapper(
+            tmp_path / "bin", mode=ClaudeAuthMode.OAUTH_TOKEN, binary=_fake_binary(tmp_path)
+        )
+        result = _run_wrapper(wrapper, _polluted_parent_env(), "-v")
+        assert result["argv"] == ["-v"]
+
+    def test_wrapper_carries_names_not_values(self, tmp_path: Path) -> None:
+        wrapper = write_clean_env_wrapper(
+            tmp_path / "bin", mode=ClaudeAuthMode.OAUTH_TOKEN, binary=_fake_binary(tmp_path)
+        )
+        text = wrapper.read_text()
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in text
+        assert "sk-ant" not in text
+
+
+class TestAllowlist:
+    def test_modes_are_mutually_exclusive(self) -> None:
+        assert set(API_KEY_ALLOWLIST).isdisjoint(OAUTH_ALLOWLIST)
+        assert allowlist_for(ClaudeAuthMode.OAUTH_TOKEN) == BASE_ALLOWLIST + OAUTH_ALLOWLIST
+        assert allowlist_for(ClaudeAuthMode.API_KEY) == BASE_ALLOWLIST + API_KEY_ALLOWLIST
+
+    def test_base_allowlist_never_carries_a_credential(self) -> None:
+        assert "ANTHROPIC_API_KEY" not in BASE_ALLOWLIST
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in BASE_ALLOWLIST
+        assert "SANDBOX_AUTH_TOKEN" not in BASE_ALLOWLIST
+
+    def test_api_key_credential_requires_the_key(self) -> None:
+        assert ClaudeCredential.api_key({"ANTHROPIC_BASE_URL": "x"}) is None
+        credential = ClaudeCredential.api_key(
+            {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_AUTH_TOKEN": "t"}
+        )
+        assert credential is not None
+        assert dict(credential.env) == {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_AUTH_TOKEN": "t"}
+
+    def test_harness_env_sets_config_dir_and_policy(self, tmp_path: Path) -> None:
+        env = harness_env(tmp_path, ClaudeCredential.oauth_token("tok"))
+        assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path)
+        assert env["DISABLE_TELEMETRY"] == "1"
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "tok"

--- a/packages/sandbox-runtime/tests/test_claude_env.py
+++ b/packages/sandbox-runtime/tests/test_claude_env.py
@@ -1,4 +1,4 @@
-"""The clean-environment launch: the child sees the allowlist and nothing else."""
+"""The clean-credential launch: the child sees the sandbox environment minus the other mode's credentials."""
 
 import json
 import os
@@ -7,13 +7,12 @@ import sys
 from pathlib import Path
 
 from sandbox_runtime.harness.claude_env import (
-    API_KEY_ALLOWLIST,
-    BASE_ALLOWLIST,
-    OAUTH_ALLOWLIST,
+    API_KEY_CREDENTIAL_VARS,
+    OAUTH_CREDENTIAL_VARS,
     ClaudeAuthMode,
     ClaudeCredential,
-    allowlist_for,
     clean_child_env,
+    denylist_for,
     harness_env,
     write_clean_env_wrapper,
 )
@@ -67,29 +66,40 @@ def _polluted_parent_env(**overrides: str) -> dict[str, str]:
 
 
 class TestSentinel:
-    """The design's sentinel: the child's environment equals the allowlist exactly."""
+    """The design's sentinel: the child's environment is the parent's minus the other credential family."""
 
-    def test_oauth_mode_strips_the_platform_api_key(self, tmp_path: Path) -> None:
+    def test_oauth_mode_strips_the_platform_api_key_and_nothing_else(self, tmp_path: Path) -> None:
         wrapper = write_clean_env_wrapper(
             tmp_path / "bin", mode=ClaudeAuthMode.OAUTH_TOKEN, binary=_fake_binary(tmp_path)
         )
         # What the SDK builds: os.environ merged under options.env.
-        parent = _polluted_parent_env()
+        parent = _polluted_parent_env(ANTHROPIC_BASE_URL="https://gateway.example")
         options_env = harness_env(tmp_path / "cfg", ClaudeCredential.oauth_token("sk-ant-oat01-x"))
         child = _run_wrapper(wrapper, {**parent, **options_env}, "-v")["env"]
 
         expected = clean_child_env(parent, ClaudeAuthMode.OAUTH_TOKEN, options_env)
         assert child == expected
-        assert "ANTHROPIC_API_KEY" not in child
+        for stripped in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"):
+            assert stripped not in child
         assert child["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-x"
-        for secret in ("SANDBOX_AUTH_TOKEN", "SESSION_CONFIG", "DB_PASSWORD", "OPENAI_API_KEY"):
-            assert secret not in child
+        # Parity with OpenCode: the sandbox helpers (oi-git-sign, oi-git-credentials,
+        # upload-media) and the agent's commands need the session context and secrets.
+        assert child["SANDBOX_AUTH_TOKEN"] == parent["SANDBOX_AUTH_TOKEN"]
+        assert child["SESSION_CONFIG"] == parent["SESSION_CONFIG"]
+        assert child["CONTROL_PLANE_URL"] == parent["CONTROL_PLANE_URL"]
+        assert child["DB_PASSWORD"] == "user-secret"
+        assert child["OPENAI_API_KEY"] == "sk-openai"
 
-    def test_api_key_mode_forwards_the_key_family_only(self, tmp_path: Path) -> None:
+    def test_api_key_mode_forwards_the_key_family_and_strips_the_oauth_token(
+        self, tmp_path: Path
+    ) -> None:
         wrapper = write_clean_env_wrapper(
             tmp_path / "bin", mode=ClaudeAuthMode.API_KEY, binary=_fake_binary(tmp_path)
         )
-        parent = _polluted_parent_env(ANTHROPIC_BASE_URL="https://gateway.example")
+        parent = _polluted_parent_env(
+            ANTHROPIC_BASE_URL="https://gateway.example",
+            CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-stray",
+        )
         credential = ClaudeCredential.api_key(parent)
         assert credential is not None
         options_env = harness_env(tmp_path / "cfg", credential)
@@ -99,7 +109,7 @@ class TestSentinel:
         assert child["ANTHROPIC_API_KEY"] == "sk-ant-platform-key"
         assert child["ANTHROPIC_BASE_URL"] == "https://gateway.example"
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in child
-        assert "SANDBOX_AUTH_TOKEN" not in child
+        assert child["SANDBOX_AUTH_TOKEN"] == parent["SANDBOX_AUTH_TOKEN"]
 
     def test_wrapper_forwards_arguments_including_the_version_probe(self, tmp_path: Path) -> None:
         wrapper = write_clean_env_wrapper(
@@ -113,20 +123,22 @@ class TestSentinel:
             tmp_path / "bin", mode=ClaudeAuthMode.OAUTH_TOKEN, binary=_fake_binary(tmp_path)
         )
         text = wrapper.read_text()
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in text
+        # The script names what it strips, never what it forwards, and no value.
+        assert "ANTHROPIC_API_KEY" in text
         assert "sk-ant" not in text
 
 
-class TestAllowlist:
+class TestDenylist:
     def test_modes_are_mutually_exclusive(self) -> None:
-        assert set(API_KEY_ALLOWLIST).isdisjoint(OAUTH_ALLOWLIST)
-        assert allowlist_for(ClaudeAuthMode.OAUTH_TOKEN) == BASE_ALLOWLIST + OAUTH_ALLOWLIST
-        assert allowlist_for(ClaudeAuthMode.API_KEY) == BASE_ALLOWLIST + API_KEY_ALLOWLIST
+        assert set(API_KEY_CREDENTIAL_VARS).isdisjoint(OAUTH_CREDENTIAL_VARS)
+        assert denylist_for(ClaudeAuthMode.OAUTH_TOKEN) == API_KEY_CREDENTIAL_VARS
+        assert denylist_for(ClaudeAuthMode.API_KEY) == OAUTH_CREDENTIAL_VARS
 
-    def test_base_allowlist_never_carries_a_credential(self) -> None:
-        assert "ANTHROPIC_API_KEY" not in BASE_ALLOWLIST
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in BASE_ALLOWLIST
-        assert "SANDBOX_AUTH_TOKEN" not in BASE_ALLOWLIST
+    def test_only_anthropic_credentials_are_ever_stripped(self) -> None:
+        stripped = set(API_KEY_CREDENTIAL_VARS) | set(OAUTH_CREDENTIAL_VARS)
+        assert all(name.startswith(("ANTHROPIC_", "CLAUDE_CODE_OAUTH_")) for name in stripped)
+        for needed in ("SANDBOX_AUTH_TOKEN", "SESSION_CONFIG", "CONTROL_PLANE_URL", "PATH"):
+            assert needed not in stripped
 
     def test_api_key_credential_requires_the_key(self) -> None:
         assert ClaudeCredential.api_key({"ANTHROPIC_BASE_URL": "x"}) is None

--- a/packages/sandbox-runtime/tests/test_claude_harness.py
+++ b/packages/sandbox-runtime/tests/test_claude_harness.py
@@ -562,20 +562,40 @@ class TestTranslation:
     async def test_prompts_are_stamped_human_and_injected_results_are_skipped(
         self, tmp_path: Path
     ) -> None:
-        # A background task's result arrives on the same connection first; it
-        # ends that turn, not ours.
-        turn = [
+        # A background task's whole turn arrives on the same connection first:
+        # its user message and result carry the origin, the assistant output,
+        # stream events and tool results between them do not. None of it is
+        # ours, and its result ends that turn, not ours.
+        injected_turn = [
+            UserMessage(content="task finished", origin={"kind": "task-notification"}),
+            _text_delta("injected"),
+            AssistantMessage(
+                content=[
+                    TextBlock("injected answer"),
+                    ToolUseBlock(id="call_bg", name="Bash", input={"command": "ls"}),
+                ],
+                model="m",
+                message_id="msg_bg",
+            ),
+            UserMessage(
+                content=[ToolResultBlock(tool_use_id="call_bg", content="x", is_error=False)]
+            ),
             _result(0.1, origin={"kind": "task-notification"}),
+        ]
+        our_turn = [
             AssistantMessage(content=[TextBlock("real answer")], model="m", message_id="msg_1"),
             _result(0.3, origin={"kind": "human"}),
         ]
-        h = Harness(tmp_path, turns=[turn])
+        h = Harness(tmp_path, turns=[injected_turn + our_turn])
         await h.harness.open()
         await h.harness.create_session()
         events, outcome = await _run(h.harness)
         assert h.client.queries[0][0]["origin"] == {"kind": "human"}
+        # The injected turn's spend stays in the running total and lands here,
+        # so the session's cost still adds up.
         assert outcome.success is True and outcome.message_cost_usd == pytest.approx(0.3)
         assert [e["content"] for e in events if e["type"] == "token"] == ["real answer"]
+        assert [e for e in events if e["type"] == "tool"] == []
         assert len([e for e in events if e["type"] == "step_finish"]) == 1
 
 
@@ -712,6 +732,22 @@ class TestReconnectPolicy:
         assert h.client.interrupts == 1
         await _run(h.harness)
         assert len(h.clients) == 2
+
+    @pytest.mark.asyncio
+    async def test_abort_is_bounded_when_interrupt_hangs(self, tmp_path: Path) -> None:
+        # The bridge awaits abort() inline on its command loop.
+        limits = PromptLimits(
+            inactivity_timeout_seconds=5.0,
+            prompt_max_duration_seconds=5.0,
+            prompt_cleanup_timeout_seconds=0.05,
+        )
+        h = Harness(tmp_path, turns=[[]], limits=limits, client_kwargs={"hang_interrupt": True})
+        await h.harness.open()
+        await h.harness.create_session()
+        await h.harness._ensure_client("claude-sonnet-4-6", None)
+        assert await asyncio.wait_for(h.harness.abort(), timeout=2.0) is False
+        assert h.client.interrupts == 1
+        assert h.client.disconnected is True
 
     @pytest.mark.asyncio
     async def test_cancellation_propagates_to_the_bridge(self, tmp_path: Path) -> None:

--- a/packages/sandbox-runtime/tests/test_claude_harness.py
+++ b/packages/sandbox-runtime/tests/test_claude_harness.py
@@ -54,14 +54,21 @@ LIMITS = PromptLimits(
 )
 
 
-def _result(total_cost: float | None, *, subtype: str = "success", is_error: bool = False, **extra):
+def _result(
+    total_cost: float | None,
+    *,
+    subtype: str = "success",
+    is_error: bool = False,
+    session_id: str = "sess",
+    **extra,
+):
     return ResultMessage(
         subtype=subtype,
         duration_ms=10,
         duration_api_ms=5,
         is_error=is_error,
         num_turns=1,
-        session_id="sess",
+        session_id=session_id,
         total_cost_usd=total_cost,
         **extra,
     )
@@ -86,8 +93,15 @@ class FakeSdkClient:
     interrupts: int = 0
     queries: list[list[dict[str, Any]]] = field(default_factory=list)
     hang: bool = False
+    hang_connect: bool = False
+    hang_interrupt: bool = False
+    fail_connect: bool = False
 
     async def connect(self) -> None:
+        if self.fail_connect:
+            raise RuntimeError("spawn failed")
+        if self.hang_connect:
+            await asyncio.Event().wait()
         self.connected = True
 
     async def disconnect(self) -> None:
@@ -99,8 +113,10 @@ class FakeSdkClient:
 
     async def interrupt(self) -> None:
         self.interrupts += 1
+        if self.hang_interrupt:
+            await asyncio.Event().wait()
 
-    async def receive_response(self) -> AsyncIterator[Any]:
+    async def receive_messages(self) -> AsyncIterator[Any]:
         if self.hang:
             await asyncio.Event().wait()
         turn = self.turns.pop(0) if self.turns else []
@@ -131,6 +147,7 @@ class Harness:
     def __init__(self, tmp_path: Path, *, turns: list[list[Any]] | None = None, **overrides: Any):
         self.clients: list[FakeSdkClient] = []
         self.turns = turns or []
+        self.client_kwargs: dict[str, Any] = overrides.pop("client_kwargs", {})
         oauth_managed = overrides.pop("oauth_managed", False)
         credential_client = overrides.pop("credential_client", None)
         environ = overrides.pop("environ", {"ANTHROPIC_API_KEY": "sk-ant-key", "PATH": "/bin"})
@@ -148,7 +165,7 @@ class Harness:
         binary.write_text("#!/bin/sh\n")
 
         def client_factory(options: Any) -> FakeSdkClient:
-            client = FakeSdkClient(options=options, turns=self.turns)
+            client = FakeSdkClient(options=options, turns=self.turns, **self.client_kwargs)
             self.clients.append(client)
             return client
 
@@ -470,7 +487,8 @@ class TestTranslation:
         await h.harness.create_session()
         events, _ = await _run(h.harness)
         tool_events = [e for e in events if e["type"] == "tool_call"]
-        assert tool_events[0]["tool"] == "Agent" and "isSubtask" not in tool_events[0]
+        # The vendor name is normalised to the task tool the timeline groups under.
+        assert tool_events[0]["tool"] == "task" and "isSubtask" not in tool_events[0]
         assert tool_events[1]["tool"] == "Read"
         assert tool_events[1]["isSubtask"] is True and tool_events[1]["taskCallId"] == "agent_1"
         assert tool_events[2]["status"] == "error" and tool_events[2]["output"] == "ok"
@@ -540,6 +558,26 @@ class TestTranslation:
         assert outcome.message_cost_usd == 0.0
         assert any(e["type"] == "warning" and "no cost" in e["message"] for e in events)
 
+    @pytest.mark.asyncio
+    async def test_prompts_are_stamped_human_and_injected_results_are_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        # A background task's result arrives on the same connection first; it
+        # ends that turn, not ours.
+        turn = [
+            _result(0.1, origin={"kind": "task-notification"}),
+            AssistantMessage(content=[TextBlock("real answer")], model="m", message_id="msg_1"),
+            _result(0.3, origin={"kind": "human"}),
+        ]
+        h = Harness(tmp_path, turns=[turn])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+        assert h.client.queries[0][0]["origin"] == {"kind": "human"}
+        assert outcome.success is True and outcome.message_cost_usd == pytest.approx(0.3)
+        assert [e["content"] for e in events if e["type"] == "token"] == ["real answer"]
+        assert len([e for e in events if e["type"] == "step_finish"]) == 1
+
 
 class TestCostBaseline:
     """§5.3: messageCostUsd = running total at turn end - baseline."""
@@ -579,6 +617,48 @@ class TestCostBaseline:
         _, second = await _run(h.harness, HarnessPrompt(message_id="m2", text="b"))
         assert second.message_cost_usd == pytest.approx(0.2)
 
+    @pytest.mark.asyncio
+    async def test_conversation_reset_rotates_the_session_id(self, tmp_path: Path) -> None:
+        # After a reset the messages carry a new session id; the next resume
+        # and the persisted id must follow it, or the post-reset conversation
+        # is lost on the next reconnect.
+        turns = [
+            [_result(0.5)],
+            [
+                ConversationResetMessage(new_conversation_id="c2", uuid="u", session_id="s"),
+                _result(0.2, session_id="rotated-id"),
+            ],
+            [_result(0.1)],
+        ]
+        h = Harness(tmp_path, turns=turns)
+        await h.harness.open()
+        await h.harness.create_session()
+        original = h.harness.session_id
+        await _run(h.harness, HarnessPrompt(message_id="m1", text="a"))
+        assert h.harness.session_id == original
+        await _run(h.harness, HarnessPrompt(message_id="m2", text="b"))
+        assert h.harness.session_id == "rotated-id"
+        h.harness._needs_reconnect = True
+        await _run(h.harness, HarnessPrompt(message_id="m3", text="c"))
+        assert h.clients[1].options["resume"] == "rotated-id"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_total_never_charges_a_later_turn(self, tmp_path: Path) -> None:
+        # 0.10 -> None -> 0.40: the third turn's true cost is unknowable, so it
+        # is 0 with a warning, not 0.30.
+        h = Harness(tmp_path, turns=[[_result(0.10)], [_result(None)], [_result(0.40)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        _, first = await _run(h.harness, HarnessPrompt(message_id="m1", text="a"))
+        _, second = await _run(h.harness, HarnessPrompt(message_id="m2", text="b"))
+        events, third = await _run(h.harness, HarnessPrompt(message_id="m3", text="c"))
+        assert first.message_cost_usd == pytest.approx(0.10)
+        assert second.message_cost_usd == 0.0
+        assert third.message_cost_usd == 0.0
+        assert any("previous turn" in e.get("message", "") for e in events)
+        _, fourth = await _run(h.harness, HarnessPrompt(message_id="m4", text="d"))
+        assert fourth.success is False  # no scripted turn left; baseline is re-anchored at 0.40
+
 
 class TestReconnectPolicy:
     @pytest.mark.asyncio
@@ -610,6 +690,17 @@ class TestReconnectPolicy:
         _, outcome = await _run(h.harness)
         assert outcome.success is False
         assert "repeatedly" in (outcome.error or "")
+
+    @pytest.mark.asyncio
+    async def test_failed_connects_spend_the_reconnect_budget(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[], client_kwargs={"fail_connect": True})
+        await h.harness.open()
+        await h.harness.create_session()
+        outcomes = [(await _run(h.harness))[1] for _ in range(5)]
+        assert all(outcome.success is False for outcome in outcomes)
+        assert all("failed to start" in (o.error or "") for o in outcomes[:4])
+        assert "repeatedly" in (outcomes[4].error or "")
+        assert len(h.clients) == 4
 
     @pytest.mark.asyncio
     async def test_abort_interrupts_and_forces_a_fresh_stream_next_time(self, tmp_path: Path):
@@ -661,6 +752,39 @@ class TestReconnectPolicy:
         _, outcome = await _run(h.harness)
         assert outcome.success is False and "no output" in (outcome.error or "")
         assert h.client.interrupts == 1
+
+    @pytest.mark.asyncio
+    async def test_a_hung_connect_is_cut_by_the_prompt_budget(self, tmp_path: Path) -> None:
+        limits = PromptLimits(
+            inactivity_timeout_seconds=5.0,
+            prompt_max_duration_seconds=0.05,
+            prompt_cleanup_timeout_seconds=0.05,
+        )
+        h = Harness(tmp_path, turns=[], limits=limits, client_kwargs={"hang_connect": True})
+        await h.harness.open()
+        await h.harness.create_session()
+        _, outcome = await asyncio.wait_for(_run(h.harness), timeout=2.0)
+        assert outcome.success is False and "did not start" in (outcome.error or "")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_after_a_timeout_is_bounded_even_when_interrupt_hangs(
+        self, tmp_path: Path
+    ) -> None:
+        limits = PromptLimits(
+            inactivity_timeout_seconds=0.05,
+            prompt_max_duration_seconds=5.0,
+            prompt_cleanup_timeout_seconds=0.05,
+        )
+        h = Harness(tmp_path, turns=[[]], limits=limits, client_kwargs={"hang_interrupt": True})
+        await h.harness.open()
+        await h.harness.create_session()
+        await h.harness._ensure_client("claude-sonnet-4-6", None)
+        h.client.hang = True
+        _, outcome = await asyncio.wait_for(_run(h.harness), timeout=2.0)
+        assert outcome.success is False and "no output" in (outcome.error or "")
+        assert h.client.interrupts == 1
+        # Interrupt never settled, so the child was dropped instead.
+        assert h.client.disconnected is True
 
     @pytest.mark.asyncio
     async def test_close_disconnects_the_child(self, tmp_path: Path) -> None:

--- a/packages/sandbox-runtime/tests/test_claude_harness.py
+++ b/packages/sandbox-runtime/tests/test_claude_harness.py
@@ -1,0 +1,672 @@
+"""ClaudeHarness against a scripted fake of the SDK client.
+
+Covers the §5.2 translation table, the §5.3 cost-baseline rule, the
+credential-at-open contract, the reconnect policy, and terminalisation
+ownership (the harness returns a TurnOutcome and never emits
+execution_complete).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage,
+    ConversationResetMessage,
+    RateLimitEvent,
+    RateLimitInfo,
+    ResultMessage,
+    StreamEvent,
+    SystemMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from sandbox_runtime.credentials.provider_credential_client import (
+    RuntimeCredentialDenied,
+    RuntimeCredentialUnavailable,
+)
+from sandbox_runtime.harness import AgentHarness, HarnessPrompt, HarnessStartError, PromptLimits
+from sandbox_runtime.harness.claude import (
+    AUTHENTICATION_FAILED_MESSAGE,
+    ClaudeHarness,
+    ClaudeHarnessConfig,
+    bare_model_id,
+    mcp_server_options,
+    reasoning_options,
+)
+from sandbox_runtime.harness.claude_env import ClaudeAuthMode
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+LIMITS = PromptLimits(
+    inactivity_timeout_seconds=5.0,
+    prompt_max_duration_seconds=30.0,
+    prompt_cleanup_timeout_seconds=1.0,
+)
+
+
+def _result(total_cost: float | None, *, subtype: str = "success", is_error: bool = False, **extra):
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=is_error,
+        num_turns=1,
+        session_id="sess",
+        total_cost_usd=total_cost,
+        **extra,
+    )
+
+
+def _stream(kind: str, **event: Any) -> StreamEvent:
+    return StreamEvent(uuid="u", session_id="sess", event={"type": kind, **event})
+
+
+def _text_delta(text: str) -> StreamEvent:
+    return _stream("content_block_delta", delta={"type": "text_delta", "text": text})
+
+
+@dataclass
+class FakeSdkClient:
+    """Replays scripted turns; records what the harness asked of it."""
+
+    options: Any
+    turns: list[list[Any]]
+    connected: bool = False
+    disconnected: bool = False
+    interrupts: int = 0
+    queries: list[list[dict[str, Any]]] = field(default_factory=list)
+    hang: bool = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+    async def query(self, prompt: Any, session_id: str = "default") -> None:
+        messages = [message async for message in prompt]
+        self.queries.append(messages)
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+
+    async def receive_response(self) -> AsyncIterator[Any]:
+        if self.hang:
+            await asyncio.Event().wait()
+        turn = self.turns.pop(0) if self.turns else []
+        for message in turn:
+            yield message
+
+
+class FakeCredentialClient:
+    def __init__(self, outcome: Any) -> None:
+        self.outcome = outcome
+        self.calls = 0
+
+    async def fetch(self, provider: str) -> Any:
+        self.calls += 1
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+@dataclass
+class Issued:
+    secret: str = "sk-ant-oat01-secret"
+
+
+class Harness:
+    """A ClaudeHarness wired to fakes; exposes the clients it created."""
+
+    def __init__(self, tmp_path: Path, *, turns: list[list[Any]] | None = None, **overrides: Any):
+        self.clients: list[FakeSdkClient] = []
+        self.turns = turns or []
+        oauth_managed = overrides.pop("oauth_managed", False)
+        credential_client = overrides.pop("credential_client", None)
+        environ = overrides.pop("environ", {"ANTHROPIC_API_KEY": "sk-ant-key", "PATH": "/bin"})
+        transcript_exists = overrides.pop("transcript_exists", lambda _id, _dir: False)
+        self.config = ClaudeHarnessConfig(
+            workdir=tmp_path / "repo",
+            config_dir=tmp_path / "claude",
+            mcp_servers=overrides.pop("mcp_servers", ()),
+            default_model="claude-sonnet-4-6",
+            oauth_managed=oauth_managed,
+            system_prompt_append=overrides.pop("system_prompt_append", None),
+            tools=None,
+        )
+        binary = tmp_path / "claude-bin"
+        binary.write_text("#!/bin/sh\n")
+
+        def client_factory(options: Any) -> FakeSdkClient:
+            client = FakeSdkClient(options=options, turns=self.turns)
+            self.clients.append(client)
+            return client
+
+        self.harness = ClaudeHarness(
+            config=self.config,
+            log=MagicMock(),
+            limits=overrides.pop("limits", LIMITS),
+            credential_client=credential_client,
+            environ=environ,
+            client_factory=client_factory,
+            options_factory=lambda **kwargs: kwargs,
+            transcript_exists=transcript_exists,
+            binary=binary,
+        )
+
+    @property
+    def client(self) -> FakeSdkClient:
+        return self.clients[-1]
+
+
+async def _run(harness: ClaudeHarness, prompt: HarnessPrompt | None = None):
+    events: list[dict[str, Any]] = []
+
+    async def emit(event: dict[str, Any]) -> None:
+        events.append(event)
+
+    outcome = await harness.run_prompt(prompt or HarnessPrompt(message_id="m1", text="hi"), emit)
+    return events, outcome
+
+
+class TestOpen:
+    def test_conforms_to_the_protocol(self, tmp_path: Path) -> None:
+        assert isinstance(Harness(tmp_path).harness, AgentHarness)
+
+    @pytest.mark.asyncio
+    async def test_api_key_mode_adopts_the_bridge_key_and_writes_the_wrapper(self, tmp_path: Path):
+        h = Harness(tmp_path)
+        await h.harness.open()
+        assert h.harness.credential is not None
+        assert h.harness.credential.mode is ClaudeAuthMode.API_KEY
+        assert h.harness.wrapper_path is not None and h.harness.wrapper_path.exists()
+        assert "sk-ant-key" not in h.harness.wrapper_path.read_text()
+
+    @pytest.mark.asyncio
+    async def test_no_credential_is_a_deterministic_failure(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, environ={"PATH": "/bin"})
+        with pytest.raises(HarnessStartError, match="ANTHROPIC_API_KEY"):
+            await h.harness.open()
+
+    @pytest.mark.asyncio
+    async def test_oauth_mode_fetches_the_setup_token_on_open(self, tmp_path: Path) -> None:
+        credential_client = FakeCredentialClient(Issued())
+        h = Harness(
+            tmp_path,
+            oauth_managed=True,
+            credential_client=credential_client,
+            environ={
+                "ANTHROPIC_API_KEY": "sk-ant-platform-key-must-not-leak",
+            },
+        )
+        await h.harness.open()
+        assert credential_client.calls == 1
+        assert h.harness.credential is not None
+        assert h.harness.credential.mode is ClaudeAuthMode.OAUTH_TOKEN
+        assert dict(h.harness.credential.env) == {"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-secret"}
+
+    @pytest.mark.asyncio
+    async def test_oauth_denial_is_deterministic_and_unavailable_is_transient(self, tmp_path: Path):
+        denied = Harness(
+            tmp_path,
+            oauth_managed=True,
+            credential_client=FakeCredentialClient(RuntimeCredentialDenied("account disabled")),
+        )
+        with pytest.raises(HarnessStartError, match="account disabled"):
+            await denied.harness.open()
+
+        transient = Harness(
+            tmp_path,
+            oauth_managed=True,
+            credential_client=FakeCredentialClient(RuntimeCredentialUnavailable("503")),
+        )
+        with pytest.raises(RuntimeError, match="unavailable"):
+            await transient.harness.open()
+
+    @pytest.mark.asyncio
+    async def test_oauth_mode_without_a_client_is_deterministic(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, oauth_managed=True)
+        with pytest.raises(HarnessStartError):
+            await h.harness.open()
+
+
+class TestSession:
+    @pytest.mark.asyncio
+    async def test_fresh_session_gets_a_new_id_and_connects_with_session_id(self, tmp_path: Path):
+        h = Harness(tmp_path, turns=[[_result(0.1)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        session_id = h.harness.session_id
+        assert session_id
+        await _run(h.harness)
+        assert h.client.options["session_id"] == session_id
+        assert "resume" not in h.client.options
+
+    @pytest.mark.asyncio
+    async def test_persisted_session_resumes_when_the_transcript_exists(self, tmp_path: Path):
+        h = Harness(
+            tmp_path, turns=[[_result(0.1)]], transcript_exists=lambda sid, _d: sid == "old"
+        )
+        await h.harness.open()
+        assert await h.harness.resume_session("old") is True
+        assert h.harness.session_id == "old"
+        await _run(h.harness)
+        assert h.client.options["resume"] == "old"
+
+    @pytest.mark.asyncio
+    async def test_persisted_session_without_a_transcript_starts_fresh(self, tmp_path: Path):
+        h = Harness(tmp_path)
+        await h.harness.open()
+        assert await h.harness.resume_session("gone") is False
+        assert h.harness.session_id is None
+
+
+class TestOptions:
+    @pytest.mark.asyncio
+    async def test_options_follow_the_design_mapping(self, tmp_path: Path) -> None:
+        h = Harness(
+            tmp_path,
+            turns=[[_result(0.1)]],
+            mcp_servers=(
+                {
+                    "name": "linear",
+                    "type": "remote",
+                    "url": "https://mcp.linear",
+                    "headers": {"A": "b"},
+                },
+                {"name": "local", "type": "local", "command": ["npx", "server"], "env": {"K": "v"}},
+                {"name": "off", "type": "remote", "url": "u", "enabled": False},
+            ),
+            system_prompt_append="Workspace guidance",
+        )
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(
+            h.harness,
+            HarnessPrompt(
+                message_id="m1",
+                text="hi",
+                model="anthropic/claude-opus-4-6",
+                reasoning_effort="high",
+            ),
+        )
+        options = h.client.options
+        assert options["cwd"] == str(tmp_path / "repo")
+        assert options["cli_path"] == str(h.harness.wrapper_path)
+        assert options["model"] == "claude-opus-4-6"
+        assert options["effort"] == "high"
+        assert options["permission_mode"] == "dontAsk"
+        assert options["disallowed_tools"] == ["AskUserQuestion"]
+        assert options["setting_sources"] == ["user", "project"]
+        assert options["include_partial_messages"] is True
+        assert options["forward_subagent_text"] is False
+        assert options["system_prompt"] == {
+            "type": "preset",
+            "preset": "claude_code",
+            "append": "Workspace guidance",
+        }
+        assert options["env"]["CLAUDE_CONFIG_DIR"] == str(tmp_path / "claude")
+        assert options["env"]["ANTHROPIC_API_KEY"] == "sk-ant-key"
+        assert options["mcp_servers"] == {
+            "linear": {"type": "http", "url": "https://mcp.linear", "headers": {"A": "b"}},
+            "local": {"type": "stdio", "command": "npx", "args": ["server"], "env": {"K": "v"}},
+        }
+        assert "mcp__linear__*" in options["allowed_tools"]
+        assert "mcp__local__*" in options["allowed_tools"]
+        assert "Bash" in options["allowed_tools"]
+
+    def test_reasoning_controls_are_per_model(self) -> None:
+        assert reasoning_options("claude-sonnet-4-5", "max") == {
+            "thinking": {"type": "enabled", "budget_tokens": 31_999}
+        }
+        assert reasoning_options("claude-sonnet-4-5", "low") == {}
+        assert reasoning_options("claude-opus-4-6", "xhigh") == {"effort": "xhigh"}
+        assert reasoning_options("claude-opus-4-6", "none") == {}
+        assert reasoning_options("claude-opus-4-6", None) == {}
+
+    def test_bare_model_ids(self) -> None:
+        assert bare_model_id("anthropic/claude-x", "d") == "claude-x"
+        assert bare_model_id("claude-x", "d") == "claude-x"
+        assert bare_model_id(None, "d") == "d"
+        with pytest.raises(ValueError, match="openai"):
+            bare_model_id("openai/gpt-5", "d")
+
+    def test_mcp_options_skip_disabled_and_empty(self) -> None:
+        assert mcp_server_options(({"name": "x", "type": "local", "command": []},)) == {}
+
+
+class TestTranslation:
+    @pytest.mark.asyncio
+    async def test_a_turn_with_text_and_a_tool_call(self, tmp_path: Path) -> None:
+        turn = [
+            SystemMessage(subtype="init", data={"model": "claude-sonnet-4-6", "tools": ["Bash"]}),
+            _stream("message_start", message={"id": "msg_1"}),
+            _text_delta("Hel"),
+            _text_delta("lo"),
+            AssistantMessage(
+                content=[
+                    TextBlock("Hello"),
+                    ToolUseBlock(id="tu_1", name="Bash", input={"command": "ls"}),
+                ],
+                model="claude-sonnet-4-6",
+                message_id="msg_1",
+            ),
+            UserMessage(content=[ToolResultBlock(tool_use_id="tu_1", content="a.txt\nb.txt")]),
+            _stream("message_start", message={"id": "msg_2"}),
+            _text_delta("Done."),
+            AssistantMessage(
+                content=[TextBlock("Done.")], model="claude-sonnet-4-6", message_id="msg_2"
+            ),
+            _result(
+                0.25, usage={"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 2}
+            ),
+        ]
+        h = Harness(tmp_path, turns=[turn])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+
+        assert [e["type"] for e in events] == [
+            "step_start",
+            "token",
+            "token",
+            "tool_call",
+            "tool_call",
+            "token",
+            "step_finish",
+        ]
+        assert events[1]["content"] == "Hel" and events[2]["content"] == "Hello"
+        assert events[3] == {
+            "type": "tool_call",
+            "tool": "Bash",
+            "args": {"command": "ls"},
+            "callId": "tu_1",
+            "status": "running",
+            "output": "",
+            "messageId": "m1",
+        }
+        assert events[4]["status"] == "completed" and events[4]["output"] == "a.txt\nb.txt"
+        assert events[4]["tool"] == "Bash" and events[4]["args"] == {"command": "ls"}
+        assert events[5]["content"] == "Hello\n\nDone."
+        assert events[6]["messageCostUsd"] == 0.25
+        assert events[6]["tokens"] == {"input": 10, "output": 5, "cache": {"read": 2}}
+        assert all(e["messageId"] == "m1" for e in events)
+        assert "execution_complete" not in {e["type"] for e in events}
+        assert outcome.success is True and outcome.message_cost_usd == 0.25
+        assert h.harness.init_info == {"model": "claude-sonnet-4-6", "tools": ["Bash"]}
+        # The prompt went out as a streaming-input user message bound to the session.
+        sent = h.client.queries[0][0]
+        assert sent["type"] == "user"
+        assert sent["message"]["content"] == [{"type": "text", "text": "hi"}]
+        assert sent["session_id"] == h.harness.session_id
+
+    @pytest.mark.asyncio
+    async def test_attachments_become_image_blocks(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(0.0)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(
+            h.harness,
+            HarnessPrompt(
+                message_id="m1",
+                text="look",
+                attachments=({"name": "a.png", "mimeType": "image/png", "content": "QUJD"},),
+            ),
+        )
+        content = h.client.queries[0][0]["message"]["content"]
+        assert content[1] == {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "QUJD"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_subagent_activity_is_nested_and_its_text_dropped(self, tmp_path: Path) -> None:
+        turn = [
+            AssistantMessage(
+                content=[ToolUseBlock(id="agent_1", name="Agent", input={"prompt": "x"})],
+                model="m",
+                message_id="msg_1",
+            ),
+            StreamEvent(
+                uuid="u",
+                session_id="s",
+                parent_tool_use_id="agent_1",
+                event={
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "child"},
+                },
+            ),
+            AssistantMessage(
+                content=[
+                    TextBlock("child text"),
+                    ToolUseBlock(id="tu_c", name="Read", input={"file_path": "f"}),
+                ],
+                model="m",
+                message_id="msg_c",
+                parent_tool_use_id="agent_1",
+            ),
+            UserMessage(
+                content=[
+                    ToolResultBlock(
+                        tool_use_id="tu_c", content=[{"type": "text", "text": "ok"}], is_error=True
+                    )
+                ],
+                parent_tool_use_id="agent_1",
+            ),
+            _result(0.1),
+        ]
+        h = Harness(tmp_path, turns=[turn])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, _ = await _run(h.harness)
+        tool_events = [e for e in events if e["type"] == "tool_call"]
+        assert tool_events[0]["tool"] == "Agent" and "isSubtask" not in tool_events[0]
+        assert tool_events[1]["tool"] == "Read"
+        assert tool_events[1]["isSubtask"] is True and tool_events[1]["taskCallId"] == "agent_1"
+        assert tool_events[2]["status"] == "error" and tool_events[2]["output"] == "ok"
+        assert [e for e in events if e["type"] == "token"] == []
+
+    @pytest.mark.asyncio
+    async def test_compaction_and_provider_warnings(self, tmp_path: Path) -> None:
+        turn = [
+            SystemMessage(subtype="compact_boundary", data={}),
+            RateLimitEvent(
+                rate_limit_info=RateLimitInfo(
+                    status="allowed_warning", rate_limit_type="five_hour", resets_at=123
+                ),
+                uuid="u",
+                session_id="s",
+            ),
+            AssistantMessage(content=[], model="m", message_id="msg_1", error="rate_limit"),
+            _result(0.0),
+        ]
+        h = Harness(tmp_path, turns=[turn])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+        assert events[0] == {"type": "context_compacted", "messageId": "m1"}
+        warnings = [e for e in events if e["type"] == "warning"]
+        assert all(w["scope"] == "provider" for w in warnings)
+        assert "allowed_warning" in warnings[0]["message"] and "five_hour" in warnings[0]["message"]
+        assert "rate limit" in warnings[1]["message"]
+        assert outcome.success is True
+
+    @pytest.mark.asyncio
+    async def test_authentication_failure_is_an_error_with_reconnect_guidance(self, tmp_path: Path):
+        turn = [
+            AssistantMessage(
+                content=[], model="m", message_id="msg_1", error="authentication_failed"
+            ),
+            _result(0.0, subtype="error_during_execution", is_error=True, result="401"),
+        ]
+        h = Harness(tmp_path, turns=[turn])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+        errors = [e for e in events if e["type"] == "error"]
+        assert errors == [
+            {"type": "error", "error": AUTHENTICATION_FAILED_MESSAGE, "messageId": "m1"}
+        ]
+        assert outcome.success is False
+
+    @pytest.mark.asyncio
+    async def test_result_error_fails_the_turn(self, tmp_path: Path) -> None:
+        h = Harness(
+            tmp_path,
+            turns=[[_result(0.2, subtype="error_max_turns", is_error=True, errors=["too many"])]],
+        )
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+        assert outcome == outcome.__class__(success=False, error="too many", message_cost_usd=0.2)
+        assert next(e for e in events if e["type"] == "error")["error"] == "too many"
+
+    @pytest.mark.asyncio
+    async def test_missing_cost_is_zero_with_a_warning(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(None)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        events, outcome = await _run(h.harness)
+        assert outcome.message_cost_usd == 0.0
+        assert any(e["type"] == "warning" and "no cost" in e["message"] for e in events)
+
+
+class TestCostBaseline:
+    """§5.3: messageCostUsd = running total at turn end - baseline."""
+
+    @pytest.mark.asyncio
+    async def test_two_turns_then_restart_then_a_third(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(0.10)], [_result(0.35)], [_result(0.05)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        _, first = await _run(h.harness, HarnessPrompt(message_id="m1", text="a"))
+        _, second = await _run(h.harness, HarnessPrompt(message_id="m2", text="b"))
+        assert first.message_cost_usd == pytest.approx(0.10)
+        assert second.message_cost_usd == pytest.approx(0.25)
+        assert len(h.clients) == 1
+
+        # A transport drop forces a reconnect: the new child restarts its total.
+        h.harness._needs_reconnect = True
+        _, third = await _run(h.harness, HarnessPrompt(message_id="m3", text="c"))
+        assert third.message_cost_usd == pytest.approx(0.05)
+        assert len(h.clients) == 2
+        assert h.clients[0].disconnected is True
+        assert h.clients[1].options["resume"] == h.harness.session_id
+
+    @pytest.mark.asyncio
+    async def test_conversation_reset_zeroes_the_baseline(self, tmp_path: Path) -> None:
+        turns = [
+            [_result(0.5)],
+            [
+                ConversationResetMessage(new_conversation_id="c2", uuid="u", session_id="s"),
+                _result(0.2),
+            ],
+        ]
+        h = Harness(tmp_path, turns=turns)
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(h.harness, HarnessPrompt(message_id="m1", text="a"))
+        _, second = await _run(h.harness, HarnessPrompt(message_id="m2", text="b"))
+        assert second.message_cost_usd == pytest.approx(0.2)
+
+
+class TestReconnectPolicy:
+    @pytest.mark.asyncio
+    async def test_model_or_effort_change_reconnects_with_resume(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(0.1)], [_result(0.1)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(
+            h.harness, HarnessPrompt(message_id="m1", text="a", model="anthropic/claude-sonnet-4-6")
+        )
+        await _run(
+            h.harness, HarnessPrompt(message_id="m2", text="b", model="anthropic/claude-opus-4-6")
+        )
+        assert len(h.clients) == 2
+        assert h.clients[1].options["model"] == "claude-opus-4-6"
+        assert h.clients[1].options["resume"] == h.harness.session_id
+
+    @pytest.mark.asyncio
+    async def test_reconnect_budget_is_three_per_session(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(0.1)] for _ in range(6)])
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(h.harness)
+        for _ in range(3):
+            h.harness._needs_reconnect = True
+            _, outcome = await _run(h.harness)
+            assert outcome.success is True
+        h.harness._needs_reconnect = True
+        _, outcome = await _run(h.harness)
+        assert outcome.success is False
+        assert "repeatedly" in (outcome.error or "")
+
+    @pytest.mark.asyncio
+    async def test_abort_interrupts_and_forces_a_fresh_stream_next_time(self, tmp_path: Path):
+        h = Harness(tmp_path, turns=[[_result(0.1)], [_result(0.1)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(h.harness)
+        assert await h.harness.abort() is True
+        assert h.client.interrupts == 1
+        await _run(h.harness)
+        assert len(h.clients) == 2
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates_to_the_bridge(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[]])
+        await h.harness.open()
+        await h.harness.create_session()
+
+        async def emit(_event: dict[str, Any]) -> None:
+            pass
+
+        async def run() -> None:
+            h.clients[-1].hang = True if h.clients else None
+            await h.harness.run_prompt(HarnessPrompt(message_id="m1", text="x"), emit)
+
+        # Connect first so the hang flag lands on the live client.
+        await h.harness._ensure_client("claude-sonnet-4-6", None)
+        h.client.hang = True
+        task = asyncio.create_task(
+            h.harness.run_prompt(HarnessPrompt(message_id="m1", text="x"), emit)
+        )
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_inactivity_timeout_fails_the_turn_and_interrupts(self, tmp_path: Path) -> None:
+        limits = PromptLimits(
+            inactivity_timeout_seconds=0.05,
+            prompt_max_duration_seconds=5.0,
+            prompt_cleanup_timeout_seconds=1.0,
+        )
+        h = Harness(tmp_path, turns=[[]], limits=limits)
+        await h.harness.open()
+        await h.harness.create_session()
+        await h.harness._ensure_client("claude-sonnet-4-6", None)
+        h.client.hang = True
+        _, outcome = await _run(h.harness)
+        assert outcome.success is False and "no output" in (outcome.error or "")
+        assert h.client.interrupts == 1
+
+    @pytest.mark.asyncio
+    async def test_close_disconnects_the_child(self, tmp_path: Path) -> None:
+        h = Harness(tmp_path, turns=[[_result(0.1)]])
+        await h.harness.open()
+        await h.harness.create_session()
+        await _run(h.harness)
+        await h.harness.close()
+        assert h.client.disconnected is True

--- a/packages/sandbox-runtime/tests/test_claude_harness.py
+++ b/packages/sandbox-runtime/tests/test_claude_harness.py
@@ -134,7 +134,7 @@ class Harness:
         oauth_managed = overrides.pop("oauth_managed", False)
         credential_client = overrides.pop("credential_client", None)
         environ = overrides.pop("environ", {"ANTHROPIC_API_KEY": "sk-ant-key", "PATH": "/bin"})
-        transcript_exists = overrides.pop("transcript_exists", lambda _id, _dir: False)
+        transcript_exists = overrides.pop("transcript_exists", lambda _id, _dir, _cfg: False)
         self.config = ClaudeHarnessConfig(
             workdir=tmp_path / "repo",
             config_dir=tmp_path / "claude",
@@ -255,7 +255,7 @@ class TestSession:
     @pytest.mark.asyncio
     async def test_persisted_session_resumes_when_the_transcript_exists(self, tmp_path: Path):
         h = Harness(
-            tmp_path, turns=[[_result(0.1)]], transcript_exists=lambda sid, _d: sid == "old"
+            tmp_path, turns=[[_result(0.1)]], transcript_exists=lambda sid, _d, _c: sid == "old"
         )
         await h.harness.open()
         assert await h.harness.resume_session("old") is True
@@ -670,3 +670,24 @@ class TestReconnectPolicy:
         await _run(h.harness)
         await h.harness.close()
         assert h.client.disconnected is True
+
+
+class TestDefaultTranscriptLookup:
+    """The transcript lives under the child's config dir, not the bridge's."""
+
+    def test_finds_the_transcript_under_the_config_dir(self, tmp_path: Path) -> None:
+        from sandbox_runtime.harness.claude import _default_transcript_exists
+
+        config_dir = tmp_path / "claude-config"
+        session_id = "617347e9-9ff5-4205-9efe-c185b3459127"
+        project_dir = config_dir / "projects" / "-private-tmp-repo"
+        project_dir.mkdir(parents=True)
+        (project_dir / f"{session_id}.jsonl").write_text("{}\n")
+
+        # The workdir spelling need not match the child's canonical project key.
+        assert _default_transcript_exists(session_id, tmp_path / "repo", config_dir)
+        assert not _default_transcript_exists(
+            "00000000-0000-4000-8000-000000000000", tmp_path / "repo", config_dir
+        )
+        assert not _default_transcript_exists("not-a-uuid", tmp_path / "repo", config_dir)
+        assert not _default_transcript_exists(session_id, tmp_path / "repo", tmp_path / "missing")

--- a/packages/sandbox-runtime/tests/test_claude_stager.py
+++ b/packages/sandbox-runtime/tests/test_claude_stager.py
@@ -11,12 +11,22 @@ from sandbox_runtime.claude_stager import (
     ClaudeStager,
     resolve_claude_config_dir,
 )
+from sandbox_runtime.constants import BIN_INSTALL_DIR_ENV_VAR
 from sandbox_runtime.harness.base import HarnessProcessOwner
+from sandbox_runtime.repo_config import RepoEntry
 from sandbox_runtime.runtime_config import ClaudeStagerConfig, _freeze_json
 
 
+class FakeMcpPackages:
+    def __init__(self) -> None:
+        self.installed: list[list] = []
+
+    async def install(self, servers: list) -> None:
+        self.installed.append(servers)
+
+
 def _stager(tmp_path: Path, monkeypatch, **overrides) -> ClaudeStager:
-    monkeypatch.setenv("OI_BIN_INSTALL_DIR", str(tmp_path / "bin"))
+    monkeypatch.setenv(BIN_INSTALL_DIR_ENV_VAR, str(tmp_path / "bin"))
     skills = tmp_path / "bundled-skills"
     (skills / "review").mkdir(parents=True)
     (skills / "review" / "SKILL.md").write_text("# review")
@@ -30,9 +40,10 @@ def _stager(tmp_path: Path, monkeypatch, **overrides) -> ClaudeStager:
     return ClaudeStager(
         config,
         MagicMock(),
-        config_dir=tmp_path / "claude-config",
+        config_dir=overrides.pop("config_dir", tmp_path / "claude-config"),
         bundled_skills_path=skills,
         handoff_path=tmp_path / "handoff.json",
+        mcp_packages=overrides.pop("mcp_packages", FakeMcpPackages()),
     )
 
 
@@ -57,7 +68,6 @@ async def test_start_stages_config_dir_skills_and_handoff(tmp_path: Path, monkey
     assert handoff.workdir == workdir
     assert handoff.config_dir == tmp_path / "claude-config"
     assert handoff.has_repository is True
-    assert handoff.mcp_servers == ({"name": "linear", "type": "remote", "url": "u"},)
     # Still no process: the SDK child belongs to the bridge.
     assert stager.exit_code() is None
     await stager.stop()
@@ -78,40 +88,74 @@ async def test_start_never_writes_into_the_repository(tmp_path: Path, monkeypatc
     assert "credential" not in json.dumps(raw).lower()
 
 
+@pytest.mark.asyncio
+async def test_handoff_carries_decisions_only_and_is_owner_readable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """MCP configuration can hold credentials; it reaches the bridge through
+    SESSION_CONFIG and never through a file a snapshot would keep."""
+    stager = _stager(
+        tmp_path,
+        monkeypatch,
+        mcp_servers=tuple(
+            _freeze_json(
+                [
+                    {
+                        "name": "linear",
+                        "type": "remote",
+                        "url": "u",
+                        "headers": {"Authorization": "x"},
+                    }
+                ]
+            )
+        ),
+    )
+    workdir = tmp_path / "workspace" / "repo"
+    workdir.mkdir(parents=True)
+
+    await stager.start((), workdir)
+
+    handoff_path = tmp_path / "handoff.json"
+    raw = json.loads(handoff_path.read_text())
+    assert set(raw) == {"workdir", "configDir", "hasRepository"}
+    assert handoff_path.stat().st_mode & 0o777 == 0o600
+    assert not handoff_path.with_name("handoff.json.tmp").exists()
+
+
+@pytest.mark.asyncio
+async def test_start_preinstalls_local_mcp_packages(tmp_path: Path, monkeypatch) -> None:
+    packages = FakeMcpPackages()
+    servers = ({"name": "fs", "type": "local", "command": ["npx", "-y", "fs-mcp"]},)
+    stager = _stager(tmp_path, monkeypatch, mcp_servers=servers, mcp_packages=packages)
+    workdir = tmp_path / "workspace" / "repo"
+    workdir.mkdir(parents=True)
+
+    await stager.start((), workdir)
+
+    assert packages.installed == [list(servers)]
+
+
+@pytest.mark.asyncio
+async def test_config_dir_inside_a_checkout_falls_back_to_the_default(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    workdir = tmp_path / "workspace"
+    repo = workdir / "repo"
+    repo.mkdir(parents=True)
+    stager = _stager(tmp_path, monkeypatch, config_dir=repo / ".claude")
+    entry = RepoEntry(owner="acme", name="repo", branch="main", path=repo)
+
+    await stager.start((entry,), workdir)
+
+    assert stager.config_dir == tmp_path / "home" / ".openinspect" / "claude"
+    assert not (repo / ".claude").exists()
+    assert ClaudeHarnessHandoff.read(tmp_path / "handoff.json").config_dir == stager.config_dir
+
+
 def test_config_dir_defaults_outside_every_repository(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     assert resolve_claude_config_dir() == tmp_path / ".openinspect" / "claude"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/elsewhere")
     assert resolve_claude_config_dir() == Path("/elsewhere")
-
-
-def test_handoff_serializes_frozen_session_config(tmp_path: Path) -> None:
-    """SESSION_CONFIG is frozen recursively; nested proxies must still reach the file.
-
-    Regression: the first real Claude Agent session died in the supervisor with
-    "Object of type mappingproxy is not JSON serializable".
-    """
-    frozen = _freeze_json(
-        [
-            {
-                "name": "linear",
-                "type": "remote",
-                "url": "u",
-                "headers": {"Authorization": "Bearer x"},
-            },
-            {"name": "fs", "type": "local", "command": ["npx", "fs"], "env": {"A": "1"}},
-        ]
-    )
-    handoff = ClaudeHarnessHandoff(
-        workdir=tmp_path / "repo",
-        config_dir=tmp_path / "cfg",
-        has_repository=True,
-        mcp_servers=tuple(frozen),
-    )
-    path = tmp_path / "handoff.json"
-    handoff.write(path)
-    assert ClaudeHarnessHandoff.read(path).mcp_servers == (
-        {"name": "linear", "type": "remote", "url": "u", "headers": {"Authorization": "Bearer x"}},
-        {"name": "fs", "type": "local", "command": ["npx", "fs"], "env": {"A": "1"}},
-    )

--- a/packages/sandbox-runtime/tests/test_claude_stager.py
+++ b/packages/sandbox-runtime/tests/test_claude_stager.py
@@ -1,17 +1,20 @@
 """ClaudeStager: staging only, no process, a handoff the bridge can read."""
 
+import asyncio
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from sandbox_runtime.claude_stager import (
     ClaudeHarnessHandoff,
     ClaudeStager,
+    isolated_claude_config_dir,
     resolve_claude_config_dir,
 )
 from sandbox_runtime.constants import BIN_INSTALL_DIR_ENV_VAR
+from sandbox_runtime.entrypoint import build_supervisor
 from sandbox_runtime.harness.base import HarnessProcessOwner
 from sandbox_runtime.repo_config import RepoEntry
 from sandbox_runtime.runtime_config import ClaudeStagerConfig, _freeze_json
@@ -135,22 +138,45 @@ async def test_start_preinstalls_local_mcp_packages(tmp_path: Path, monkeypatch)
     assert packages.installed == [list(servers)]
 
 
-@pytest.mark.asyncio
-async def test_config_dir_inside_a_checkout_falls_back_to_the_default(
+def test_config_dir_inside_the_workspace_or_a_checkout_falls_back_to_the_default(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    workdir = tmp_path / "workspace"
-    repo = workdir / "repo"
-    repo.mkdir(parents=True)
-    stager = _stager(tmp_path, monkeypatch, config_dir=repo / ".claude")
+    workspace = tmp_path / "workspace"
+    repo = workspace / "repo"
+    elsewhere = tmp_path / "elsewhere"
     entry = RepoEntry(owner="acme", name="repo", branch="main", path=repo)
+    fallback = tmp_path / "home" / ".openinspect" / "claude"
 
-    await stager.start((entry,), workdir)
+    log = MagicMock()
+    assert isolated_claude_config_dir(repo / ".claude", workspace, (entry,), log) == fallback
+    assert isolated_claude_config_dir(workspace / ".claude", workspace, (entry,), log) == fallback
+    assert isolated_claude_config_dir(workspace, workspace, (entry,), log) == fallback
+    assert log.warn.call_count == 3
+    assert isolated_claude_config_dir(elsewhere, workspace, (entry,), log) == elsewhere
 
-    assert stager.config_dir == tmp_path / "home" / ".openinspect" / "claude"
-    assert not (repo / ".claude").exists()
-    assert ClaudeHarnessHandoff.read(tmp_path / "handoff.json").config_dir == stager.config_dir
+
+def test_managed_skills_and_the_stager_share_the_decided_config_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Managed skills land before the stager runs, so a rejected override must
+    # be replaced once, for both, not by the stager alone.
+    environment = {
+        "HOME": str(tmp_path / "home"),
+        "CONTROL_PLANE_URL": "https://control.example",
+        "REPO_OWNER": "acme",
+        "REPO_NAME": "repo",
+        "SESSION_CONFIG": json.dumps({"session_id": "session-1", "harness": "claude"}),
+        "CLAUDE_CONFIG_DIR": "/workspace/repo/.claude",
+    }
+    with patch.dict("os.environ", environment, clear=True):
+        supervisor = build_supervisor(asyncio.Event())
+
+    decided = tmp_path / "home" / ".openinspect" / "claude"
+    assert isinstance(supervisor.harness_process, ClaudeStager)
+    assert supervisor.harness_process.config_dir == decided
+    assert supervisor.managed_skills is not None
+    assert supervisor.managed_skills.destination == decided / "skills"
 
 
 def test_config_dir_defaults_outside_every_repository(monkeypatch, tmp_path: Path) -> None:

--- a/packages/sandbox-runtime/tests/test_claude_stager.py
+++ b/packages/sandbox-runtime/tests/test_claude_stager.py
@@ -1,0 +1,86 @@
+"""ClaudeStager: staging only, no process, a handoff the bridge can read."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from sandbox_runtime.claude_stager import (
+    ClaudeHarnessHandoff,
+    ClaudeStager,
+    resolve_claude_config_dir,
+)
+from sandbox_runtime.harness.base import HarnessProcessOwner
+from sandbox_runtime.runtime_config import ClaudeStagerConfig
+
+
+def _stager(tmp_path: Path, monkeypatch, **overrides) -> ClaudeStager:
+    monkeypatch.setenv("OI_BIN_INSTALL_DIR", str(tmp_path / "bin"))
+    skills = tmp_path / "bundled-skills"
+    (skills / "review").mkdir(parents=True)
+    (skills / "review" / "SKILL.md").write_text("# review")
+    (skills / "not-a-skill").mkdir()
+    config = ClaudeStagerConfig(
+        has_repository=overrides.pop("has_repository", True),
+        mcp_servers=overrides.pop(
+            "mcp_servers", ({"name": "linear", "type": "remote", "url": "u"},)
+        ),
+    )
+    return ClaudeStager(
+        config,
+        MagicMock(),
+        config_dir=tmp_path / "claude-config",
+        bundled_skills_path=skills,
+        handoff_path=tmp_path / "handoff.json",
+    )
+
+
+def test_conforms_to_the_process_owner_protocol(tmp_path: Path, monkeypatch) -> None:
+    stager = _stager(tmp_path, monkeypatch)
+    assert isinstance(stager, HarnessProcessOwner)
+    assert stager.exit_code() is None
+
+
+@pytest.mark.asyncio
+async def test_start_stages_config_dir_skills_and_handoff(tmp_path: Path, monkeypatch) -> None:
+    stager = _stager(tmp_path, monkeypatch)
+    workdir = tmp_path / "workspace" / "repo"
+    workdir.mkdir(parents=True)
+
+    await stager.start((), workdir)
+
+    assert (tmp_path / "claude-config").is_dir()
+    assert (tmp_path / "claude-config" / "skills" / "review" / "SKILL.md").read_text() == "# review"
+    assert not (tmp_path / "claude-config" / "skills" / "not-a-skill").exists()
+    handoff = ClaudeHarnessHandoff.read(tmp_path / "handoff.json")
+    assert handoff.workdir == workdir
+    assert handoff.config_dir == tmp_path / "claude-config"
+    assert handoff.has_repository is True
+    assert handoff.mcp_servers == ({"name": "linear", "type": "remote", "url": "u"},)
+    # Still no process: the SDK child belongs to the bridge.
+    assert stager.exit_code() is None
+    await stager.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_never_writes_into_the_repository(tmp_path: Path, monkeypatch) -> None:
+    stager = _stager(tmp_path, monkeypatch)
+    workdir = tmp_path / "workspace" / "repo"
+    workdir.mkdir(parents=True)
+    before = sorted(p.relative_to(workdir) for p in workdir.rglob("*"))
+
+    await stager.start((), workdir)
+
+    after = sorted(p.relative_to(workdir) for p in workdir.rglob("*"))
+    assert before == after
+    raw = json.loads((tmp_path / "handoff.json").read_text())
+    assert "credential" not in json.dumps(raw).lower()
+
+
+def test_config_dir_defaults_outside_every_repository(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert resolve_claude_config_dir() == tmp_path / ".openinspect" / "claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/elsewhere")
+    assert resolve_claude_config_dir() == Path("/elsewhere")

--- a/packages/sandbox-runtime/tests/test_claude_stager.py
+++ b/packages/sandbox-runtime/tests/test_claude_stager.py
@@ -12,7 +12,7 @@ from sandbox_runtime.claude_stager import (
     resolve_claude_config_dir,
 )
 from sandbox_runtime.harness.base import HarnessProcessOwner
-from sandbox_runtime.runtime_config import ClaudeStagerConfig
+from sandbox_runtime.runtime_config import ClaudeStagerConfig, _freeze_json
 
 
 def _stager(tmp_path: Path, monkeypatch, **overrides) -> ClaudeStager:
@@ -84,3 +84,34 @@ def test_config_dir_defaults_outside_every_repository(monkeypatch, tmp_path: Pat
     assert resolve_claude_config_dir() == tmp_path / ".openinspect" / "claude"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/elsewhere")
     assert resolve_claude_config_dir() == Path("/elsewhere")
+
+
+def test_handoff_serializes_frozen_session_config(tmp_path: Path) -> None:
+    """SESSION_CONFIG is frozen recursively; nested proxies must still reach the file.
+
+    Regression: the first real Claude Agent session died in the supervisor with
+    "Object of type mappingproxy is not JSON serializable".
+    """
+    frozen = _freeze_json(
+        [
+            {
+                "name": "linear",
+                "type": "remote",
+                "url": "u",
+                "headers": {"Authorization": "Bearer x"},
+            },
+            {"name": "fs", "type": "local", "command": ["npx", "fs"], "env": {"A": "1"}},
+        ]
+    )
+    handoff = ClaudeHarnessHandoff(
+        workdir=tmp_path / "repo",
+        config_dir=tmp_path / "cfg",
+        has_repository=True,
+        mcp_servers=tuple(frozen),
+    )
+    path = tmp_path / "handoff.json"
+    handoff.write(path)
+    assert ClaudeHarnessHandoff.read(path).mcp_servers == (
+        {"name": "linear", "type": "remote", "url": "u", "headers": {"Authorization": "Bearer x"}},
+        {"name": "fs", "type": "local", "command": ["npx", "fs"], "env": {"A": "1"}},
+    )

--- a/packages/sandbox-runtime/tests/test_claude_tools.py
+++ b/packages/sandbox-runtime/tests/test_claude_tools.py
@@ -328,6 +328,11 @@ async def test_upload_media_video_carries_every_required_field(tmp_path: Path) -
         assert f"require {missing}" in _text(await tools.upload_media(args))
         assert seen == []
 
+    seen.clear()
+    text = _text(await tools.upload_media({**video, "hasAudio": True}))
+    assert "do not support audio" in text
+    assert seen == []
+
 
 @pytest.mark.asyncio
 async def test_upload_media_rejects_unsupported_files(tmp_path: Path) -> None:

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -144,6 +144,7 @@ class TestCodexAuthPluginSetup:
                 "sandbox_runtime.opencode_server.asyncio.create_task",
                 side_effect=lambda coro: coro.close(),
             ),
+            patch("sandbox_runtime.opencode_server.install_bin_scripts"),
         ):
             mock_path.side_effect = lambda p: {
                 "/app/sandbox_runtime/plugins/codex-auth-plugin.js": plugin_source,
@@ -152,7 +153,6 @@ class TestCodexAuthPluginSetup:
             sup._setup_managed_oauth = MagicMock()
             sup._install_tools = MagicMock()
             sup._install_skills = MagicMock()
-            sup._install_bin_scripts = MagicMock()
             sup._wait_for_health = AsyncMock()
 
             await sup.start((), sup.workspace_path)

--- a/packages/sandbox-runtime/tests/test_provider_credential_client.py
+++ b/packages/sandbox-runtime/tests/test_provider_credential_client.py
@@ -1,4 +1,4 @@
-"""The sandbox-side runtime-credential client: denial is final, 5xx is transient."""
+"""The sandbox-side runtime-credential client: denial is final; the moment is not."""
 
 from unittest.mock import MagicMock
 
@@ -63,6 +63,29 @@ async def test_fetch_posts_with_sandbox_principal_headers_and_returns_the_secret
 async def test_denials_are_final(status: int) -> None:
     client, _ = _client(lambda _r: httpx.Response(status, json={"error": "account disabled"}))
     with pytest.raises(RuntimeCredentialDenied, match="account disabled"):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.parametrize("status", [408, 425, 429])
+@pytest.mark.asyncio
+async def test_timeouts_and_rate_limits_are_transient(status: int) -> None:
+    client, _ = _client(lambda _r: httpx.Response(status, json={"error": "slow down"}))
+    with pytest.raises(RuntimeCredentialUnavailable):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.asyncio
+async def test_the_issuance_race_is_transient_while_other_conflicts_are_final() -> None:
+    client, _ = _client(
+        lambda _r: httpx.Response(
+            409,
+            json={"error": "Provider account changed during issuance; retry", "retryable": True},
+        )
+    )
+    with pytest.raises(RuntimeCredentialUnavailable):
+        await client.fetch("anthropic")
+    client, _ = _client(lambda _r: httpx.Response(409, json={"error": "expired"}))
+    with pytest.raises(RuntimeCredentialDenied, match="expired"):
         await client.fetch("anthropic")
 
 

--- a/packages/sandbox-runtime/tests/test_provider_credential_client.py
+++ b/packages/sandbox-runtime/tests/test_provider_credential_client.py
@@ -107,6 +107,13 @@ async def test_transport_errors_are_transient() -> None:
 
 
 @pytest.mark.asyncio
+async def test_an_undecodable_success_body_is_transient() -> None:
+    client, _ = _client(lambda _r: httpx.Response(200, text=""))
+    with pytest.raises(RuntimeCredentialUnavailable, match="not valid JSON"):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.asyncio
 async def test_a_brokered_token_is_rejected_as_the_wrong_kind() -> None:
     client, _ = _client(
         lambda _r: httpx.Response(200, json={"kind": "brokered_access_token", "secret": "x"})

--- a/packages/sandbox-runtime/tests/test_provider_credential_client.py
+++ b/packages/sandbox-runtime/tests/test_provider_credential_client.py
@@ -37,7 +37,7 @@ async def test_fetch_posts_with_sandbox_principal_headers_and_returns_the_secret
         lambda _request: httpx.Response(
             200,
             json={
-                "kind": "sandbox_bootstrap_secret",
+                "kind": "stored_provider_secret",
                 "secret": "sk-ant-oat01-abc",
                 "credentialVersion": 3,
                 "expiresAt": 1_800_000_000_000,
@@ -118,5 +118,5 @@ async def test_a_brokered_token_is_rejected_as_the_wrong_kind() -> None:
     client, _ = _client(
         lambda _r: httpx.Response(200, json={"kind": "brokered_access_token", "secret": "x"})
     )
-    with pytest.raises(RuntimeCredentialDenied, match="sandbox_bootstrap_secret"):
+    with pytest.raises(RuntimeCredentialDenied, match="stored_provider_secret"):
         await client.fetch("anthropic")

--- a/packages/sandbox-runtime/tests/test_provider_credential_client.py
+++ b/packages/sandbox-runtime/tests/test_provider_credential_client.py
@@ -1,0 +1,92 @@
+"""The sandbox-side runtime-credential client: denial is final, 5xx is transient."""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from sandbox_runtime.credentials.provider_credential_client import (
+    RuntimeCredentialClient,
+    RuntimeCredentialDenied,
+    RuntimeCredentialUnavailable,
+)
+
+
+def _client(handler) -> tuple[RuntimeCredentialClient, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(transport_handler))
+    client = RuntimeCredentialClient(
+        control_plane_url="https://cp.example/",
+        session_id="session 1",
+        sandbox_id="sb-1",
+        auth_token="sandbox-token",
+        log=MagicMock(),
+        http_client=http,
+    )
+    return client, seen
+
+
+@pytest.mark.asyncio
+async def test_fetch_posts_with_sandbox_principal_headers_and_returns_the_secret() -> None:
+    client, seen = _client(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "kind": "sandbox_bootstrap_secret",
+                "secret": "sk-ant-oat01-abc",
+                "credentialVersion": 3,
+                "expiresAt": 1_800_000_000_000,
+            },
+        )
+    )
+    credential = await client.fetch("anthropic")
+
+    assert credential.secret == "sk-ant-oat01-abc"
+    assert credential.credential_version == 3
+    assert credential.expires_at == 1_800_000_000_000
+    request = seen[0]
+    assert request.method == "POST"
+    assert str(request.url) == (
+        "https://cp.example/sessions/session%201/provider-auth/anthropic/runtime-credential"
+    )
+    assert request.headers["Authorization"] == "Bearer sandbox-token"
+    assert request.headers["X-Sandbox-ID"] == "sb-1"
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 409, 410])
+@pytest.mark.asyncio
+async def test_denials_are_final(status: int) -> None:
+    client, _ = _client(lambda _r: httpx.Response(status, json={"error": "account disabled"}))
+    with pytest.raises(RuntimeCredentialDenied, match="account disabled"):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.asyncio
+async def test_server_errors_are_transient() -> None:
+    client, _ = _client(lambda _r: httpx.Response(503, text="try later"))
+    with pytest.raises(RuntimeCredentialUnavailable):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.asyncio
+async def test_transport_errors_are_transient() -> None:
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    client, _ = _client(boom)
+    with pytest.raises(RuntimeCredentialUnavailable):
+        await client.fetch("anthropic")
+
+
+@pytest.mark.asyncio
+async def test_a_brokered_token_is_rejected_as_the_wrong_kind() -> None:
+    client, _ = _client(
+        lambda _r: httpx.Response(200, json={"kind": "brokered_access_token", "secret": "x"})
+    )
+    with pytest.raises(RuntimeCredentialDenied, match="sandbox_bootstrap_secret"):
+        await client.fetch("anthropic")

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -5,7 +5,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.opencode_server import OpenCodeServer, resolve_opencode_global_config_dir
+from sandbox_runtime.sandbox_bin import install_bin_scripts
 from tests.runtime_helpers import make_opencode_server
 
 
@@ -333,25 +335,25 @@ class TestInstallTools:
 
 
 class TestInstallBinScripts:
-    """Cases for _install_bin_scripts() standalone CLI installation."""
+    """Cases for install_bin_scripts(): standalone CLIs both harnesses share."""
 
-    def test_scripts_installed_to_bin(self, tmp_path):
+    @staticmethod
+    def _install(monkeypatch, src: Path, dest: Path) -> list[str]:
+        monkeypatch.setattr("sandbox_runtime.sandbox_bin.DEFAULT_BIN_INSTALL_DIR", str(dest))
+        return install_bin_scripts(get_logger("test"), bin_dir=src)
+
+    def test_scripts_installed_to_bin(self, tmp_path, monkeypatch):
         """Checked-in bin scripts should be installed as executable commands."""
-        sup = _make_opencode_server()
-
         src = tmp_path / "app" / "sandbox_runtime" / "bin"
         src.mkdir(parents=True)
         (src / "upload-media.js").write_text("#!/usr/bin/env node\n// upload cli")
         (src / "oi-git-sign").write_text("#!/bin/sh\n# signer launcher")
-
         dest = tmp_path / "usr-local-bin"
         dest.mkdir()
 
-        with _patch_paths(
-            legacy=tmp_path / "no-legacy", tools=tmp_path / "no-tools", bin_src=src, bin_dest=dest
-        ):
-            sup._install_bin_scripts()
+        installed_names = self._install(monkeypatch, src, dest)
 
+        assert installed_names == ["oi-git-sign", "upload-media"]
         installed = dest / "upload-media"
         assert installed.exists()
         assert installed.read_text() == "#!/usr/bin/env node\n// upload cli"
@@ -363,66 +365,42 @@ class TestInstallBinScripts:
 
     def test_scripts_installed_to_configured_bin(self, tmp_path, monkeypatch):
         """OPENINSPECT_BIN_INSTALL_DIR can override the install directory."""
-        sup = _make_opencode_server()
-
         src = tmp_path / "app" / "sandbox_runtime" / "bin"
         src.mkdir(parents=True)
         (src / "upload-media.js").write_text("#!/usr/bin/env node\n// upload cli")
-
         default_dest = tmp_path / "usr-local-bin"
         default_dest.mkdir()
         user_dest = tmp_path / "configured-bin"
         monkeypatch.setenv("OPENINSPECT_BIN_INSTALL_DIR", str(user_dest))
 
-        with _patch_paths(
-            legacy=tmp_path / "no-legacy",
-            tools=tmp_path / "no-tools",
-            bin_src=src,
-            bin_dest=default_dest,
-        ):
-            sup._install_bin_scripts()
+        self._install(monkeypatch, src, default_dest)
 
         installed = user_dest / "upload-media"
         assert installed.exists()
         assert installed.read_text() == "#!/usr/bin/env node\n// upload cli"
         assert not (default_dest / "upload-media").exists()
 
-    def test_non_js_files_skipped(self, tmp_path):
-        """Non-.js files in bin/ should not be installed."""
-        sup = _make_opencode_server()
-
+    def test_non_js_files_skipped(self, tmp_path, monkeypatch):
+        """Files that are neither extensionless nor .js are not installed."""
         src = tmp_path / "app" / "sandbox_runtime" / "bin"
         src.mkdir(parents=True)
         (src / "upload-media.js").write_text("// cli")
         (src / "README.md").write_text("# docs")
-
         dest = tmp_path / "usr-local-bin"
         dest.mkdir()
 
-        with _patch_paths(
-            legacy=tmp_path / "no-legacy", tools=tmp_path / "no-tools", bin_src=src, bin_dest=dest
-        ):
-            sup._install_bin_scripts()
+        self._install(monkeypatch, src, dest)
 
         assert (dest / "upload-media").exists()
         assert not (dest / "README").exists()
+        assert not (dest / "README.md").exists()
 
-    def test_noop_when_bin_dir_missing(self, tmp_path):
-        """Should be a no-op when bin/ directory doesn't exist."""
-        sup = _make_opencode_server()
-
+    def test_noop_when_bin_dir_missing(self, tmp_path, monkeypatch):
+        """A missing bundled bin directory installs nothing and creates nothing."""
         dest = tmp_path / "usr-local-bin"
-        dest.mkdir()
 
-        with _patch_paths(
-            legacy=tmp_path / "no-legacy",
-            tools=tmp_path / "no-tools",
-            bin_src=tmp_path / "no-bin",
-            bin_dest=dest,
-        ):
-            sup._install_bin_scripts()
-
-        assert list(dest.iterdir()) == []
+        assert self._install(monkeypatch, tmp_path / "missing-bin", dest) == []
+        assert not dest.exists()
 
 
 class TestInstallSkills:

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+from sandbox_runtime.constants import BIN_INSTALL_DIR_ENV_VAR
 from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.opencode_server import OpenCodeServer, resolve_opencode_global_config_dir
 from sandbox_runtime.sandbox_bin import install_bin_scripts
@@ -339,7 +340,8 @@ class TestInstallBinScripts:
 
     @staticmethod
     def _install(monkeypatch, src: Path, dest: Path) -> list[str]:
-        monkeypatch.setattr("sandbox_runtime.sandbox_bin.DEFAULT_BIN_INSTALL_DIR", str(dest))
+        # The canonical override, so an ambient value on the host never wins.
+        monkeypatch.setenv(BIN_INSTALL_DIR_ENV_VAR, str(dest))
         return install_bin_scripts(get_logger("test"), bin_dir=src)
 
     def test_scripts_installed_to_bin(self, tmp_path, monkeypatch):
@@ -363,22 +365,22 @@ class TestInstallBinScripts:
         assert signer.read_text() == "#!/bin/sh\n# signer launcher"
         assert signer.stat().st_mode & 0o755
 
-    def test_scripts_installed_to_configured_bin(self, tmp_path, monkeypatch):
-        """OPENINSPECT_BIN_INSTALL_DIR can override the install directory."""
+    def test_scripts_fall_back_to_the_default_bin_without_the_override(self, tmp_path, monkeypatch):
+        """Without OPENINSPECT_BIN_INSTALL_DIR the default directory is used."""
         src = tmp_path / "app" / "sandbox_runtime" / "bin"
         src.mkdir(parents=True)
         (src / "upload-media.js").write_text("#!/usr/bin/env node\n// upload cli")
         default_dest = tmp_path / "usr-local-bin"
-        default_dest.mkdir()
-        user_dest = tmp_path / "configured-bin"
-        monkeypatch.setenv("OPENINSPECT_BIN_INSTALL_DIR", str(user_dest))
+        monkeypatch.delenv(BIN_INSTALL_DIR_ENV_VAR, raising=False)
+        monkeypatch.setattr(
+            "sandbox_runtime.sandbox_bin.DEFAULT_BIN_INSTALL_DIR", str(default_dest)
+        )
 
-        self._install(monkeypatch, src, default_dest)
+        install_bin_scripts(get_logger("test"), bin_dir=src)
 
-        installed = user_dest / "upload-media"
+        installed = default_dest / "upload-media"
         assert installed.exists()
         assert installed.read_text() == "#!/usr/bin/env node\n// upload cli"
-        assert not (default_dest / "upload-media").exists()
 
     def test_non_js_files_skipped(self, tmp_path, monkeypatch):
         """Files that are neither extensionless nor .js are not installed."""

--- a/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
+++ b/packages/sandbox-runtime/tests/test_xai_oauth_setup.py
@@ -146,6 +146,7 @@ async def test_start_deploys_xai_plugin_from_marker(tmp_path):
             "sandbox_runtime.opencode_server.asyncio.create_task",
             side_effect=lambda coro: coro.close(),
         ),
+        patch("sandbox_runtime.opencode_server.install_bin_scripts"),
     ):
         mock_path.side_effect = lambda value: {
             "/app/sandbox_runtime/plugins/xai-auth-plugin.js": plugin_source,
@@ -154,7 +155,6 @@ async def test_start_deploys_xai_plugin_from_marker(tmp_path):
         supervisor._setup_managed_oauth = MagicMock()
         supervisor._install_tools = MagicMock()
         supervisor._install_skills = MagicMock()
-        supervisor._install_bin_scripts = MagicMock()
         supervisor._wait_for_health = AsyncMock()
 
         await supervisor.start((), supervisor.workspace_path)

--- a/packages/shared/src/harnesses.test.ts
+++ b/packages/shared/src/harnesses.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HARNESS,
+  HARNESS_CATALOG,
   HARNESS_IDS,
   checkHarnessCompatibility,
   filterModelsForHarness,
@@ -14,16 +15,20 @@ import { VALID_MODELS } from "./models";
 
 describe("harness catalog", () => {
   it("lists only harnesses the runtime can boot, built-in first", () => {
-    expect(HARNESS_IDS).toEqual(["opencode"]);
+    expect(HARNESS_IDS).toEqual(["opencode", "claude"]);
     expect(DEFAULT_HARNESS).toBe("opencode");
+  });
+
+  it("never brands the Claude harness as Claude Code", () => {
+    expect(HARNESS_CATALOG.claude.label).toBe("Claude Agent");
   });
 
   it("resolves an absent or unknown harness to the default", () => {
     expect(getValidHarnessOrDefault(undefined)).toBe("opencode");
     expect(getValidHarnessOrDefault(null)).toBe("opencode");
     expect(getValidHarnessOrDefault("codex")).toBe("opencode");
-    expect(getValidHarnessOrDefault("opencode")).toBe("opencode");
-    expect(isValidHarness("opencode")).toBe(true);
+    expect(getValidHarnessOrDefault("claude")).toBe("claude");
+    expect(isValidHarness("claude")).toBe(true);
     expect(isValidHarness("codex")).toBe(false);
     expect(isValidHarness(42)).toBe(false);
   });
@@ -34,27 +39,46 @@ describe("harnessSupportsModel", () => {
     for (const model of VALID_MODELS) {
       expect(harnessSupportsModel("opencode", model)).toBe(true);
     }
+  });
+
+  it("restricts the Claude harness to Anthropic models", () => {
+    expect(harnessSupportsModel("claude", "anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(harnessSupportsModel("claude", "claude-sonnet-4-6")).toBe(true);
+    expect(harnessSupportsModel("claude", "openai/gpt-5.5")).toBe(false);
+    expect(harnessSupportsModel("claude", "xai/grok-4.6")).toBe(false);
+  });
+
+  it("filters a model list by harness", () => {
+    const filtered = filterModelsForHarness("claude", VALID_MODELS);
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.every((model) => model.startsWith("anthropic/"))).toBe(true);
     expect(filterModelsForHarness("opencode", VALID_MODELS)).toEqual([...VALID_MODELS]);
   });
 });
 
 describe("harnessSupportsProviderAuth", () => {
-  it("passes resolver-assigned legacy mode through", () => {
-    expect(harnessSupportsProviderAuth("opencode", "openai", "legacy_scoped_oauth")).toBe(true);
+  it("passes resolver-assigned legacy mode through on every harness", () => {
     expect(harnessSupportsProviderAuth("opencode", "anthropic", "legacy_scoped_oauth")).toBe(true);
+    expect(harnessSupportsProviderAuth("claude", "anthropic", "legacy_scoped_oauth")).toBe(true);
+    expect(harnessSupportsProviderAuth("claude", "openai", "legacy_scoped_oauth")).toBe(true);
   });
 
-  it("keeps OpenAI and xAI provider accounts and the Anthropic API key on OpenCode", () => {
+  it("only the Claude harness may select an Anthropic provider account", () => {
+    expect(harnessSupportsProviderAuth("opencode", "anthropic", "provider_account")).toBe(false);
+    expect(harnessSupportsProviderAuth("opencode", "anthropic", "api_key")).toBe(true);
+    expect(harnessSupportsProviderAuth("claude", "anthropic", "provider_account")).toBe(true);
+  });
+
+  it("keeps OpenAI and xAI provider accounts on OpenCode", () => {
     expect(harnessSupportsProviderAuth("opencode", "openai", "provider_account")).toBe(true);
     expect(harnessSupportsProviderAuth("opencode", "xai", "provider_account")).toBe(true);
-    expect(harnessSupportsProviderAuth("opencode", "anthropic", "api_key")).toBe(true);
-    expect(harnessSupportsProviderAuth("opencode", "anthropic", "provider_account")).toBe(false);
   });
 
   it("selects no auth mode for a provider the harness has no row for", () => {
+    expect(harnessSupportsProviderAuth("claude", "openai", "provider_account")).toBe(false);
+    expect(harnessSupportsProviderAuth("claude", "openai", "api_key")).toBe(false);
+    expect(harnessSupportsProviderAuth("claude", "xai", "provider_account")).toBe(false);
     expect(harnessSupportsProviderAuth("opencode", "google", "api_key")).toBe(false);
-    expect(harnessSupportsProviderAuth("opencode", "google", "provider_account")).toBe(false);
-    expect(harnessSupportsProviderAuth("opencode", "google", "legacy_scoped_oauth")).toBe(true);
   });
 });
 
@@ -74,8 +98,17 @@ describe("checkHarnessCompatibility", () => {
   it("accepts a compatible harness, model and auth", () => {
     expect(checkHarnessCompatibility("opencode", "anthropic/claude-sonnet-4-6")).toBeNull();
     expect(
-      checkHarnessCompatibility("opencode", "openai/gpt-5.5", { openai: "provider_account" })
+      checkHarnessCompatibility("claude", "anthropic/claude-sonnet-4-6", {
+        anthropic: "provider_account",
+        openai: "provider_account",
+      })
     ).toBeNull();
+  });
+
+  it("rejects a model the harness cannot run", () => {
+    const result = checkHarnessCompatibility("claude", "openai/gpt-5.5");
+    expect(result?.code).toBe("model");
+    expect(result?.message).toContain("Claude Agent");
   });
 
   it("rejects an auth mode the harness cannot select for the model's provider", () => {

--- a/packages/shared/src/harnesses.ts
+++ b/packages/shared/src/harnesses.ts
@@ -32,8 +32,6 @@ export interface HarnessCapabilities {
   readonly modelFamilies: "any" | readonly string[];
   /** Provider id → auth modes the harness can *select* for that provider. */
   readonly providerAuth: Readonly<Partial<Record<string, readonly ProviderAuthMode[]>>>;
-  /** Whether the harness surfaces thinking text to the timeline. */
-  readonly reasoningDisplay: boolean;
   /** How a sandbox restore resumes the conversation. */
   readonly resume: "session_id";
 }
@@ -47,7 +45,6 @@ export const HARNESS_CATALOG = {
       openai: ["api_key", "provider_account"],
       xai: ["api_key", "provider_account"],
     },
-    reasoningDisplay: false,
     resume: "session_id",
   },
   claude: {
@@ -56,7 +53,6 @@ export const HARNESS_CATALOG = {
     providerAuth: {
       anthropic: ["api_key", "provider_account"],
     },
-    reasoningDisplay: true,
     resume: "session_id",
   },
 } as const satisfies Record<HarnessId, HarnessCapabilities>;

--- a/packages/shared/src/harnesses.ts
+++ b/packages/shared/src/harnesses.ts
@@ -20,7 +20,7 @@ import type {
   SessionProviderAuthMode,
 } from "./types/provider-accounts";
 
-export const HARNESS_IDS = ["opencode"] as const;
+export const HARNESS_IDS = ["opencode", "claude"] as const;
 export type HarnessId = (typeof HARNESS_IDS)[number];
 export const DEFAULT_HARNESS: HarnessId = "opencode";
 export const harnessIdSchema = z.enum(HARNESS_IDS);
@@ -48,6 +48,15 @@ export const HARNESS_CATALOG = {
       xai: ["api_key", "provider_account"],
     },
     reasoningDisplay: false,
+    resume: "session_id",
+  },
+  claude: {
+    label: "Claude Agent",
+    modelFamilies: ["anthropic"],
+    providerAuth: {
+      anthropic: ["api_key", "provider_account"],
+    },
+    reasoningDisplay: true,
     resume: "session_id",
   },
 } as const satisfies Record<HarnessId, HarnessCapabilities>;


### PR DESCRIPTION
## Summary

The Claude Agent SDK harness behind the seam from #1850, on the tool server from #1852.

- `harness/claude.py`: the `AgentHarness` for the SDK client. Creates or resumes a session by UUID, streams SDK messages into bridge events (text, tool calls, results, cost), maps reasoning effort onto the SDK's thinking options, and aborts a running turn. The `oi` tool server from #1852 is registered as an MCP server and allow-listed as `mcp__oi__*`.
- `claude_stager.py`: the `HarnessProcessOwner` for Claude. There is no resident process (the SDK spawns the child inside the bridge), so `start()` only prepares what the child will see: a per-sandbox `CLAUDE_CONFIG_DIR` outside every repository where no credential is ever written, bundled and managed skills, the standalone bin scripts, and a small JSON handoff.
- `harness/claude_env.py` and `sandbox_bin.py`: the child runs with the sandbox environment OpenCode sees, minus the Anthropic credential family of the other auth mode, so it holds exactly one credential and never both. The sentinel test in `test_claude_env.py` is the one to read.
- `credentials/provider_credential_client.py`: fetches a connected subscription's stored provider secret (the `stored_provider_secret` credential kind, as opposed to a brokered access token) from the control plane's sandbox-only runtime-credential endpoint on every bridge start (the route lands in #1854), so restarts and snapshot restores each produce an issuance record; the token lives in process memory only. Without a connected account the harness uses `ANTHROPIC_API_KEY`.
- `@open-inspect/shared/harnesses`: `claude` enters the catalog here, with the runtime that boots it: Anthropic models only, API key or a connected Anthropic account (that account mode gets its control-plane route in #1854). Providers the harness has no auth row for resolve to the API-key fallback.
- Runtime manifest: generation 64, `v64-claude-harness`, rebuild generation 64, global compatibility floor unchanged at 62, and a per-harness floor `harnessMinimumGeneration: { claude: 64 }`. Image selection applies the session harness's floor, so a Claude session never boots a prebuilt image from before its runtime existed, and no OpenCode image or snapshot is retired by this change.

**Turn contract.** Prompts are stamped `origin: human` and the harness consumes the SDK message stream turn-aware: a turn the session injected is skipped from its opening user message through its result (only those two carry an origin), so none of its output reaches the timeline and its result never ends this prompt; the child also runs with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`, so an `Agent` call returns when its sub-agent finishes (several launched in one message still run concurrently, as OpenCode's `task` tool does), and Claude's `Agent` tool is reported as the runtime-neutral `task` tool the timeline groups under. One prompt budget covers connect, submit, reads and emits, each read keeps the inactivity budget, and both cleanup after a timeout and `abort()` are bounded by the cleanup budget, dropping the child when the interrupt hangs. A conversation reset rotates the vendor session id, which the harness adopts and the bridge persists after the turn. A turn without a running total leaves the cost baseline unknown so the next total charges nothing rather than the missing turn's cost; failed connects spend the reconnect budget.

**Handoff and staging.** The supervisor's handoff to the bridge carries decisions only (workdir, config dir, repository presence), written owner-only and atomically; MCP configuration reaches the bridge through its own `SESSION_CONFIG`. A `CLAUDE_CONFIG_DIR` inside the workspace or a checkout falls back to the default, decided once in the composition root so managed skills (materialized before the stager runs) and the stager use the same directory; local MCP packages are preinstalled at staging as at OpenCode boot. The credential client treats 408/425/429, a retryable 409 and an undecodable success body as transient.

One follow-up from the #1852 review rides at the bottom of this PR since that one merged first: the upload tool refuses `hasAudio: true` locally and its schema says so, instead of sending the file and relaying the endpoint's 400.

Three bugs found running real sessions are kept as separate commits so they read apart from the harness itself: resume looked for transcripts under the bridge's config dir instead of the child's; the handoff writer choked on the frozen session config; the child's allow-listed environment stripped the session context the sandbox helpers need.

## Testing

- sandbox-runtime: pytest 1033 passed, 3 skipped; ruff; mypy unchanged from `main`; node tests 21 passed.
- control-plane unit 4124 passed; shared 882 passed; typecheck and lint across every package.
- modal-infra: pytest 238 passed. sandbox-images: lock check, pytest 56 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Agent as a supported harness for Anthropic models.
  * Added isolated Claude configuration, managed skills, MCP setup, and secure credential handling.
  * Added automatic session recovery and persistence when conversations reconnect or rotate session IDs.
  * Added harness-specific runtime compatibility checks for prebuilt sandbox images.
* **Bug Fixes**
  * Improved provider account fallback when harness-specific authentication is unavailable.
  * Video uploads now reject files containing audio tracks.
* **Tests**
  * Expanded coverage for Claude execution, authentication, reconnects, tools, staging, and runtime compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->