### PR TITLE
web: Claude provider account settings and authorization-code dialog

### DIFF
--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/complete/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/complete/route.ts
@@ -1,0 +1,16 @@
+import {
+  providerAccountSettingsProxy,
+  validProviderDeviceAuthorizationId,
+  validSubscriptionProvider,
+} from "@/lib/provider-account-proxy";
+
+type Params = { provider: string; transactionId: string };
+const { POST } = providerAccountSettingsProxy<Params>(
+  ({ provider, transactionId }) =>
+    `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes/${encodeURIComponent(transactionId)}/complete`,
+  "provider authorization code completion",
+  ({ provider, transactionId }) =>
+    validSubscriptionProvider(provider) && validProviderDeviceAuthorizationId(transactionId)
+);
+
+export { POST };

--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/complete/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/complete/route.ts
@@ -1,7 +1,7 @@
 import {
   providerAccountSettingsProxy,
   validProviderDeviceAuthorizationId,
-  validSubscriptionProvider,
+  validProviderForConnectionMethod,
 } from "@/lib/provider-account-proxy";
 
 type Params = { provider: string; transactionId: string };
@@ -10,7 +10,8 @@ const { POST } = providerAccountSettingsProxy<Params>(
     `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes/${encodeURIComponent(transactionId)}/complete`,
   "provider authorization code completion",
   ({ provider, transactionId }) =>
-    validSubscriptionProvider(provider) && validProviderDeviceAuthorizationId(transactionId)
+    validProviderForConnectionMethod(provider, "authorization_code") &&
+    validProviderDeviceAuthorizationId(transactionId)
 );
 
 export { POST };

--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/route.ts
@@ -1,7 +1,7 @@
 import {
   providerAccountSettingsProxy,
   validProviderDeviceAuthorizationId,
-  validSubscriptionProvider,
+  validProviderForConnectionMethod,
 } from "@/lib/provider-account-proxy";
 
 type Params = { provider: string; transactionId: string };
@@ -10,7 +10,8 @@ const { GET, DELETE } = providerAccountSettingsProxy<Params>(
     `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes/${encodeURIComponent(transactionId)}`,
   "provider authorization code",
   ({ provider, transactionId }) =>
-    validSubscriptionProvider(provider) && validProviderDeviceAuthorizationId(transactionId)
+    validProviderForConnectionMethod(provider, "authorization_code") &&
+    validProviderDeviceAuthorizationId(transactionId)
 );
 
 export { GET, DELETE };

--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/[transactionId]/route.ts
@@ -1,0 +1,16 @@
+import {
+  providerAccountSettingsProxy,
+  validProviderDeviceAuthorizationId,
+  validSubscriptionProvider,
+} from "@/lib/provider-account-proxy";
+
+type Params = { provider: string; transactionId: string };
+const { GET, DELETE } = providerAccountSettingsProxy<Params>(
+  ({ provider, transactionId }) =>
+    `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes/${encodeURIComponent(transactionId)}`,
+  "provider authorization code",
+  ({ provider, transactionId }) =>
+    validSubscriptionProvider(provider) && validProviderDeviceAuthorizationId(transactionId)
+);
+
+export { GET, DELETE };

--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/route.ts
@@ -1,0 +1,13 @@
+import {
+  providerAccountSettingsProxy,
+  validSubscriptionProvider,
+} from "@/lib/provider-account-proxy";
+
+type Params = { provider: string };
+const { POST } = providerAccountSettingsProxy<Params>(
+  ({ provider }) => `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes`,
+  "provider authorization code",
+  ({ provider }) => validSubscriptionProvider(provider)
+);
+
+export { POST };

--- a/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/route.ts
+++ b/packages/web/src/app/api/model-provider-accounts/authorization-codes/[provider]/route.ts
@@ -1,13 +1,13 @@
 import {
   providerAccountSettingsProxy,
-  validSubscriptionProvider,
+  validProviderForConnectionMethod,
 } from "@/lib/provider-account-proxy";
 
 type Params = { provider: string };
 const { POST } = providerAccountSettingsProxy<Params>(
   ({ provider }) => `/model-provider-accounts/${encodeURIComponent(provider)}/authorization-codes`,
   "provider authorization code",
-  ({ provider }) => validSubscriptionProvider(provider)
+  ({ provider }) => validProviderForConnectionMethod(provider, "authorization_code")
 );
 
 export { POST };

--- a/packages/web/src/app/api/model-provider-accounts/provider-account-routes.test.ts
+++ b/packages/web/src/app/api/model-provider-accounts/provider-account-routes.test.ts
@@ -189,6 +189,21 @@ describe("provider account BFF routes", () => {
     );
   });
 
+  it("refuses authorization codes for a provider that connects by device authorization", async () => {
+    const cookie = { Cookie: "openinspect.session_token=value" };
+    const response = await startAuthorizationCode(
+      new NextRequest("http://localhost/api/model-provider-accounts/authorization-codes/openai", {
+        method: "POST",
+        headers: cookie,
+        body: JSON.stringify({ operation: "create", displayName: "ChatGPT" }),
+      }),
+      { params: Promise.resolve({ provider: "openai" }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid authorization code provider and transaction parameters", async () => {
     const cookie = { Cookie: "openinspect.session_token=value" };
     const invalidProvider = await startAuthorizationCode(

--- a/packages/web/src/app/api/model-provider-accounts/provider-account-routes.test.ts
+++ b/packages/web/src/app/api/model-provider-accounts/provider-account-routes.test.ts
@@ -10,6 +10,12 @@ import { PUT as setDefault } from "../model-provider-account-defaults/[provider]
 import { POST as startDeviceAuthorization } from "./device-authorizations/[provider]/route";
 import { DELETE as cancelDeviceAuthorization } from "./device-authorizations/[provider]/[transactionId]/route";
 import { POST as pollDeviceAuthorization } from "./device-authorizations/[provider]/[transactionId]/poll/route";
+import { POST as startAuthorizationCode } from "./authorization-codes/[provider]/route";
+import {
+  DELETE as cancelAuthorizationCode,
+  GET as readAuthorizationCode,
+} from "./authorization-codes/[provider]/[transactionId]/route";
+import { POST as completeAuthorizationCode } from "./authorization-codes/[provider]/[transactionId]/complete/route";
 
 describe("provider account BFF routes", () => {
   beforeEach(() => {
@@ -130,6 +136,88 @@ describe("provider account BFF routes", () => {
     expect(invalidTransaction.status).toBe(400);
     expect(invalidProvider.headers.get("Cache-Control")).toBe("private, no-store");
     expect(invalidTransaction.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies authorization code start, status, complete, and cancel methods", async () => {
+    const transactionId = "f".repeat(64);
+    const cookie = { Cookie: "openinspect.session_token=value" };
+    const base = "http://localhost/api/model-provider-accounts/authorization-codes/anthropic";
+    await startAuthorizationCode(
+      new NextRequest(base, {
+        method: "POST",
+        headers: cookie,
+        body: JSON.stringify({ operation: "create", displayName: "Claude account" }),
+      }),
+      { params: Promise.resolve({ provider: "anthropic" }) }
+    );
+    await readAuthorizationCode(new NextRequest(`${base}/${transactionId}`, { headers: cookie }), {
+      params: Promise.resolve({ provider: "anthropic", transactionId }),
+    });
+    await completeAuthorizationCode(
+      new NextRequest(`${base}/${transactionId}/complete`, {
+        method: "POST",
+        headers: cookie,
+        body: JSON.stringify({ code: "code#state" }),
+      }),
+      { params: Promise.resolve({ provider: "anthropic", transactionId }) }
+    );
+    await cancelAuthorizationCode(
+      new NextRequest(`${base}/${transactionId}`, { method: "DELETE", headers: cookie }),
+      { params: Promise.resolve({ provider: "anthropic", transactionId }) }
+    );
+
+    expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
+      1,
+      "/model-provider-accounts/anthropic/authorization-codes",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
+      2,
+      `/model-provider-accounts/anthropic/authorization-codes/${transactionId}`,
+      undefined
+    );
+    expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
+      3,
+      `/model-provider-accounts/anthropic/authorization-codes/${transactionId}/complete`,
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
+      4,
+      `/model-provider-accounts/anthropic/authorization-codes/${transactionId}`,
+      { method: "DELETE" }
+    );
+  });
+
+  it("rejects invalid authorization code provider and transaction parameters", async () => {
+    const cookie = { Cookie: "openinspect.session_token=value" };
+    const invalidProvider = await startAuthorizationCode(
+      new NextRequest("http://localhost/api/model-provider-accounts/authorization-codes/unknown", {
+        method: "POST",
+        headers: cookie,
+        body: "{}",
+      }),
+      { params: Promise.resolve({ provider: "../anthropic" }) }
+    );
+    const invalidStatus = await readAuthorizationCode(
+      new NextRequest(
+        "http://localhost/api/model-provider-accounts/authorization-codes/anthropic/unsafe",
+        { headers: cookie }
+      ),
+      { params: Promise.resolve({ provider: "anthropic", transactionId: "../unsafe" }) }
+    );
+    const invalidCompletion = await completeAuthorizationCode(
+      new NextRequest(
+        "http://localhost/api/model-provider-accounts/authorization-codes/anthropic/unsafe/complete",
+        { method: "POST", headers: cookie, body: JSON.stringify({ code: "x" }) }
+      ),
+      { params: Promise.resolve({ provider: "anthropic", transactionId: "b".repeat(63) }) }
+    );
+
+    for (const response of [invalidProvider, invalidStatus, invalidCompletion]) {
+      expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    }
     expect(controlPlaneUserFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -412,6 +412,34 @@ describe("ProviderAccountsSettings", () => {
     );
   });
 
+  it("closes the setup token form once the connect succeeds even if the refresh fails", async () => {
+    refresh.mockRejectedValueOnce(new Error("Failed to load provider accounts"));
+    render(<ProviderAccountsSettings />);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Add account" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Claude" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Paste a setup token instead" }));
+    fireEvent.change(screen.getByLabelText("Setup token"), {
+      target: { value: "sk-ant-oat01-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: "Connect your Claude account" })
+      ).not.toBeInTheDocument()
+    );
+    expect(connectAccount).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith("Claude account connected");
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Saved, but the account list could not be refreshed. Reload the page to see it."
+      )
+    );
+  });
+
   it("reconnects a Claude account with a setup token against the explicit account", async () => {
     accountsResult = [claudeAccount];
     startAuthorizationCode.mockResolvedValue({ ...authorizationCodeStart, operation: "reconnect" });

--- a/packages/web/src/components/settings/provider-accounts-settings.test.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@open-inspect/shared/types/provider-accounts";
 import { ProviderAccountsSettings } from "./provider-accounts-settings";
 import { CHATGPT_DEVICE_AUTHORIZATION_SETTINGS_URL } from "./provider-device-authorization-dialog";
+import { ANTHROPIC_CREDENTIAL_ROTATION_WARNING } from "./provider-authorization-code-dialog";
 
 expect.extend(matchers);
 afterEach(cleanup);
@@ -22,10 +23,15 @@ const startAuthorization = vi.fn();
 const pollAuthorization = vi.fn();
 const cancelAuthorization = vi.fn();
 const reconnectAccount = vi.fn();
+const connectAccount = vi.fn();
+const startAuthorizationCode = vi.fn();
+const completeAuthorizationCode = vi.fn();
+const cancelAuthorizationCode = vi.fn();
 let legacyCredentialsResult: Record<string, unknown>;
 const providers = [
   { provider: "openai" as const, displayName: "OpenAI", subscriptionName: "ChatGPT" },
   { provider: "xai" as const, displayName: "xAI", subscriptionName: "SuperGrok" },
+  { provider: "anthropic" as const, displayName: "Anthropic", subscriptionName: "Claude" },
 ];
 const account = {
   id: "a".repeat(32),
@@ -40,6 +46,21 @@ const account = {
   createdAt: 1,
   updatedAt: 1,
   archivedAt: null,
+};
+const claudeAccount = {
+  ...account,
+  id: "f".repeat(32),
+  provider: "anthropic" as const,
+  displayName: "Team Claude",
+  externalAccountId: null,
+};
+const authorizationCodeStart = {
+  transactionId: "9".repeat(64),
+  provider: "anthropic" as const,
+  operation: "create" as const,
+  authorizationUrl: "https://claude.ai/oauth/authorize?state=abc",
+  expiresAt: Date.now() + 60_000,
+  expiresInMs: 60_000,
 };
 let accountsResult: ModelProviderAccount[];
 let defaultsResult: ModelProviderAccountDefault[];
@@ -64,13 +85,16 @@ vi.mock("@/hooks/use-provider-accounts", () => ({
   useLegacyProviderCredentials: () => legacyCredentialsResult,
   runProviderAccountAction: (...args: unknown[]) => runAction(...args),
   archiveProviderAccount: vi.fn(),
-  connectProviderAccount: vi.fn(),
+  connectProviderAccount: (...args: unknown[]) => connectAccount(...args),
   reconnectProviderAccount: (...args: unknown[]) => reconnectAccount(...args),
   renameProviderAccount: vi.fn(),
   setProviderAccountDefault: (...args: unknown[]) => setDefault(...args),
   startProviderDeviceAuthorization: (...args: unknown[]) => startAuthorization(...args),
   pollProviderDeviceAuthorization: (...args: unknown[]) => pollAuthorization(...args),
   cancelProviderDeviceAuthorization: (...args: unknown[]) => cancelAuthorization(...args),
+  startProviderAuthorizationCode: (...args: unknown[]) => startAuthorizationCode(...args),
+  completeProviderAuthorizationCode: (...args: unknown[]) => completeAuthorizationCode(...args),
+  cancelProviderAuthorizationCode: (...args: unknown[]) => cancelAuthorizationCode(...args),
 }));
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -94,6 +118,10 @@ describe("ProviderAccountsSettings", () => {
     pollAuthorization.mockImplementation(() => new Promise(() => undefined));
     cancelAuthorization.mockResolvedValue(undefined);
     reconnectAccount.mockResolvedValue(undefined);
+    connectAccount.mockResolvedValue(undefined);
+    startAuthorizationCode.mockResolvedValue(authorizationCodeStart);
+    completeAuthorizationCode.mockImplementation(() => new Promise(() => undefined));
+    cancelAuthorizationCode.mockResolvedValue(undefined);
     accountsResult = [account];
     defaultsResult = [];
     allowedPermissions = null;
@@ -330,6 +358,115 @@ describe("ProviderAccountsSettings", () => {
     expect(startAuthorization).not.toHaveBeenCalled();
   });
 
+  it("starts Claude through the authorization-code dialog from the provider picker", async () => {
+    render(<ProviderAccountsSettings />);
+
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Add account" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Claude" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Connect your Claude account" })
+    ).toBeInTheDocument();
+    expect(startAuthorizationCode).toHaveBeenCalledWith("anthropic", {
+      operation: "create",
+      displayName: "Claude account",
+    });
+    expect(startAuthorization).not.toHaveBeenCalled();
+    const link = await screen.findByRole("link", { name: "Open Anthropic" });
+    expect(link).toHaveAttribute("href", authorizationCodeStart.authorizationUrl);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.getByLabelText("Authorization code")).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/Claude Code/);
+  });
+
+  it("connects a Claude setup token through the direct path", async () => {
+    render(<ProviderAccountsSettings />);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Add account" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Claude" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Paste a setup token instead" }));
+    fireEvent.change(screen.getByLabelText("Setup token"), {
+      target: { value: "sk-ant-oat01-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(connectAccount).toHaveBeenCalledWith({
+        provider: "anthropic",
+        displayName: "Claude account",
+        setupToken: "sk-ant-oat01-token",
+      })
+    );
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith("Claude account connected");
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: "Connect your Claude account" })
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  it("reconnects a Claude account with a setup token against the explicit account", async () => {
+    accountsResult = [claudeAccount];
+    startAuthorizationCode.mockResolvedValue({ ...authorizationCodeStart, operation: "reconnect" });
+    render(<ProviderAccountsSettings />);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team Claude" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Reconnect" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Reconnect Team Claude" })
+    ).toBeInTheDocument();
+    expect(screen.getByText(ANTHROPIC_CREDENTIAL_ROTATION_WARNING)).toBeInTheDocument();
+    expect(startAuthorizationCode).toHaveBeenCalledWith("anthropic", {
+      operation: "reconnect",
+      providerAccountId: claudeAccount.id,
+    });
+    expect(await screen.findByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Paste a setup token instead" }));
+    expect(screen.queryByLabelText("Account name")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Setup token"), {
+      target: { value: "sk-ant-oat01-rotated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(reconnectAccount).toHaveBeenCalledWith(claudeAccount.id, {
+        provider: "anthropic",
+        setupToken: "sk-ant-oat01-rotated",
+      })
+    );
+  });
+
+  it("hides Verify for Claude accounts and warns before disabling", async () => {
+    accountsResult = [claudeAccount];
+    render(<ProviderAccountsSettings />);
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions for Team Claude" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(await screen.findByRole("menuitem", { name: "Reconnect" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Verify" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Copy account ID" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent(
+      ANTHROPIC_CREDENTIAL_ROTATION_WARNING
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+    await waitFor(() => expect(runAction).toHaveBeenCalledWith(claudeAccount.id, "disable"));
+  });
+
   it("keeps the changing countdown outside the live region", async () => {
     render(<ProviderAccountsSettings />);
     fireEvent.pointerDown(screen.getByRole("button", { name: "Add account" }), {
@@ -356,10 +493,11 @@ describe("ProviderAccountsSettings", () => {
       )
     ).toBeInTheDocument();
     expect(screen.queryByLabelText("Automated authentication")).not.toBeInTheDocument();
-    expect(screen.getAllByText("No default account selected")).toHaveLength(2);
-    expect(screen.getAllByText("Choose Make default from an account above.")).toHaveLength(2);
+    expect(screen.getAllByText("No default account selected")).toHaveLength(3);
+    expect(screen.getAllByText("Choose Make default from an account above.")).toHaveLength(3);
     expect(screen.getAllByTitle("OpenAI")).not.toHaveLength(0);
     expect(screen.getAllByTitle("Grok")).not.toHaveLength(0);
+    expect(screen.getAllByTitle("Anthropic")).not.toHaveLength(0);
   });
 
   it("names the effective account used by automated sessions", () => {

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -4,12 +4,14 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   modelProviderAccountReconnectMethod,
+  STATIC_CREDENTIAL_PROVIDER_IDS,
   SUBSCRIPTION_PROVIDER_DISPLAY_METADATA,
   type ModelProviderAccount,
   type SubscriptionProviderId,
 } from "@open-inspect/shared/types/provider-accounts";
 import {
   archiveProviderAccount,
+  connectProviderAccount,
   reconnectProviderAccount,
   renameProviderAccount,
   runProviderAccountAction,
@@ -22,6 +24,11 @@ import {
   ProviderDeviceAuthorizationDialog,
   type ProviderDeviceAuthorizationTarget,
 } from "@/components/settings/provider-device-authorization-dialog";
+import {
+  ANTHROPIC_CREDENTIAL_ROTATION_WARNING,
+  ProviderAuthorizationCodeDialog,
+  type ProviderAuthorizationCodeTarget,
+} from "@/components/settings/provider-authorization-code-dialog";
 import { formatRelativeTime } from "@/lib/time";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,6 +66,7 @@ import { useCurrentUserAuthorization } from "@/hooks/use-current-user-authorizat
 type Confirm = { account: ModelProviderAccount; action: "disable" | "archive" } | null;
 type Connection =
   | { kind: "device"; target: ProviderDeviceAuthorizationTarget }
+  | { kind: "authorization-code"; target: ProviderAuthorizationCodeTarget }
   | { kind: "legacy-xai"; account: ModelProviderAccount };
 
 type ConnectionStrategy = {
@@ -66,7 +74,7 @@ type ConnectionStrategy = {
   reconnect: (account: ModelProviderAccount) => Connection;
 };
 
-const CONNECTION_STRATEGIES: Partial<Record<SubscriptionProviderId, ConnectionStrategy>> = {
+const CONNECTION_STRATEGIES: Record<SubscriptionProviderId, ConnectionStrategy> = {
   openai: {
     add: () => ({ kind: "device", target: { provider: "openai", operation: "create" } }),
     reconnect: (account) => ({
@@ -94,11 +102,34 @@ const CONNECTION_STRATEGIES: Partial<Record<SubscriptionProviderId, ConnectionSt
           }
         : { kind: "legacy-xai", account },
   },
+  anthropic: {
+    add: () => ({
+      kind: "authorization-code",
+      target: { provider: "anthropic", operation: "create" },
+    }),
+    reconnect: (account) => ({
+      kind: "authorization-code",
+      target: {
+        provider: "anthropic",
+        operation: "reconnect",
+        providerAccountId: account.id,
+        displayName: account.displayName,
+      },
+    }),
+  },
 };
 
-/** Providers this page can connect; the rest are listed but wait for their flow. */
-function connectionStrategy(provider: SubscriptionProviderId): ConnectionStrategy | undefined {
-  return CONNECTION_STRATEGIES[provider];
+function connectionKey(
+  target: ProviderDeviceAuthorizationTarget | ProviderAuthorizationCodeTarget
+) {
+  return target.operation === "create"
+    ? `${target.provider}:create`
+    : `${target.provider}:reconnect:${target.providerAccountId}`;
+}
+
+/** Static credentials (a Claude setup token) cannot be verified against the provider. */
+function supportsVerify(provider: SubscriptionProviderId) {
+  return !STATIC_CREDENTIAL_PROVIDER_IDS.includes(provider);
 }
 
 function dateLabel(timestamp: number | null) {
@@ -128,7 +159,7 @@ function legacyKeyLocationLabel(location: LegacyProviderKeyLocation): string {
 function connectionToastMessage(
   provider: SubscriptionProviderId,
   reconnectedExisting: boolean,
-  operation: ProviderDeviceAuthorizationTarget["operation"]
+  operation: "create" | "reconnect"
 ): string {
   if (!reconnectedExisting) {
     return `${SUBSCRIPTION_PROVIDER_DISPLAY_METADATA[provider].subscriptionName} account connected`;
@@ -280,11 +311,10 @@ export function ProviderAccountsSettings() {
                     {providers.map((provider) => (
                       <DropdownMenuItem
                         key={provider.provider}
-                        disabled={saving || !connectionStrategy(provider.provider)}
-                        onSelect={() => {
-                          const strategy = connectionStrategy(provider.provider);
-                          if (strategy) beginConnection(strategy.add());
-                        }}
+                        disabled={saving}
+                        onSelect={() =>
+                          beginConnection(CONNECTION_STRATEGIES[provider.provider].add())
+                        }
                       >
                         <SubscriptionProviderIcon
                           provider={provider.provider}
@@ -375,11 +405,12 @@ export function ProviderAccountsSettings() {
                             {account.status === "reconnect_required" && (
                               <Button
                                 size="xs"
-                                disabled={saving || !connectionStrategy(account.provider)}
-                                onClick={() => {
-                                  const strategy = connectionStrategy(account.provider);
-                                  if (strategy) beginConnection(strategy.reconnect(account));
-                                }}
+                                disabled={saving}
+                                onClick={() =>
+                                  beginConnection(
+                                    CONNECTION_STRATEGIES[account.provider].reconnect(account)
+                                  )
+                                }
                               >
                                 Reconnect
                               </Button>
@@ -413,26 +444,29 @@ export function ProviderAccountsSettings() {
                               <DropdownMenuContent align="end">
                                 {account.status !== "reconnect_required" && (
                                   <DropdownMenuItem
-                                    disabled={saving || !connectionStrategy(account.provider)}
-                                    onSelect={() => {
-                                      const strategy = connectionStrategy(account.provider);
-                                      if (strategy) beginConnection(strategy.reconnect(account));
-                                    }}
+                                    disabled={saving}
+                                    onSelect={() =>
+                                      beginConnection(
+                                        CONNECTION_STRATEGIES[account.provider].reconnect(account)
+                                      )
+                                    }
                                   >
                                     Reconnect
                                   </DropdownMenuItem>
                                 )}
-                                <DropdownMenuItem
-                                  disabled={saving || account.status !== "active"}
-                                  onSelect={() =>
-                                    void run(
-                                      () => runProviderAccountAction(account.id, "verify"),
-                                      "Account verified"
-                                    )
-                                  }
-                                >
-                                  Verify
-                                </DropdownMenuItem>
+                                {supportsVerify(account.provider) && (
+                                  <DropdownMenuItem
+                                    disabled={saving || account.status !== "active"}
+                                    onSelect={() =>
+                                      void run(
+                                        () => runProviderAccountAction(account.id, "verify"),
+                                        "Account verified"
+                                      )
+                                    }
+                                  >
+                                    Verify
+                                  </DropdownMenuItem>
+                                )}
                                 {account.status === "active" && !isDefault && (
                                   <DropdownMenuItem
                                     disabled={saving}
@@ -604,11 +638,7 @@ export function ProviderAccountsSettings() {
 
       {canManage && connection?.kind === "device" && (
         <ProviderDeviceAuthorizationDialog
-          key={
-            connection.target.operation === "create"
-              ? `${connection.target.provider}:create`
-              : `${connection.target.provider}:reconnect:${connection.target.providerAccountId}`
-          }
+          key={connectionKey(connection.target)}
           target={connection.target}
           onClose={() => setConnection(null)}
           onConnected={(result) => {
@@ -619,6 +649,41 @@ export function ProviderAccountsSettings() {
               connectionToastMessage(target.provider, result.reconnectedExisting, target.operation)
             );
           }}
+        />
+      )}
+
+      {canManage && connection?.kind === "authorization-code" && (
+        <ProviderAuthorizationCodeDialog
+          key={connectionKey(connection.target)}
+          target={connection.target}
+          saving={saving}
+          onClose={() => setConnection(null)}
+          onConnected={(result) => {
+            const target = connection.target;
+            setConnection(null);
+            void refresh();
+            toast.success(
+              connectionToastMessage(target.provider, result.reconnectedExisting, target.operation)
+            );
+          }}
+          onSubmitSetupToken={(submission) =>
+            void run(
+              () =>
+                submission.operation === "create"
+                  ? connectProviderAccount({
+                      provider: "anthropic",
+                      displayName: submission.displayName,
+                      setupToken: submission.setupToken,
+                    })
+                  : reconnectProviderAccount(submission.providerAccountId, {
+                      provider: "anthropic",
+                      setupToken: submission.setupToken,
+                    }),
+              submission.operation === "create"
+                ? connectionToastMessage("anthropic", false, "create")
+                : "Account reconnected"
+            )
+          }
         />
       )}
 
@@ -648,8 +713,10 @@ export function ProviderAccountsSettings() {
               {confirm?.action === "archive" ? "Archive" : "Disable"} this account?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Running sessions may retain issued access until it expires. Defaults and pinned
-              automations can cause a conflict and must be updated first.
+              {confirm?.account.provider === "anthropic"
+                ? ANTHROPIC_CREDENTIAL_ROTATION_WARNING
+                : "Running sessions may retain issued access until it expires."}{" "}
+              Defaults and pinned automations can cause a conflict and must be updated first.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -231,15 +231,24 @@ export function ProviderAccountsSettings() {
     setSaving(true);
     try {
       await operation();
-      await refresh();
-      setConnection(null);
-      setConfirm(null);
-      toast.success(success);
     } catch (caught) {
       toast.error(caught instanceof Error ? caught.message : "Provider account request failed");
+      return;
     } finally {
       operationInFlightRef.current = false;
       setSaving(false);
+    }
+    // The write is durable once the request succeeds, so the form closes
+    // before the list refreshes: a refresh failure must not leave a form that
+    // would repeat the write (an identity-less setup-token account has no
+    // uniqueness backstop).
+    setConnection(null);
+    setConfirm(null);
+    toast.success(success);
+    try {
+      await refresh();
+    } catch {
+      toast.error("Saved, but the account list could not be refreshed. Reload the page to see it.");
     }
   }
 

--- a/packages/web/src/components/settings/provider-accounts-settings.tsx
+++ b/packages/web/src/components/settings/provider-accounts-settings.tsx
@@ -114,6 +114,7 @@ const CONNECTION_STRATEGIES: Record<SubscriptionProviderId, ConnectionStrategy> 
         operation: "reconnect",
         providerAccountId: account.id,
         displayName: account.displayName,
+        externalAccountId: account.externalAccountId,
       },
     }),
   },

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
@@ -72,8 +72,12 @@ function renderDialog(
     onClose: vi.fn(),
     ...overrides,
   };
-  render(<ProviderAuthorizationCodeDialog {...props} />);
-  return props;
+  const view = render(<ProviderAuthorizationCodeDialog {...props} />);
+  return {
+    ...props,
+    rerender: (next: Partial<typeof props>) =>
+      view.rerender(<ProviderAuthorizationCodeDialog {...props} {...next} />),
+  };
 }
 
 describe("ProviderAuthorizationCodeDialog", () => {
@@ -109,7 +113,12 @@ describe("ProviderAuthorizationCodeDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Complete" }));
 
     await waitFor(() =>
-      expect(completeAuthorization).toHaveBeenCalledWith("anthropic", transactionId, "code#state")
+      expect(completeAuthorization).toHaveBeenCalledWith(
+        "anthropic",
+        transactionId,
+        "code#state",
+        expect.any(AbortSignal)
+      )
     );
     await waitFor(() => expect(onConnected).toHaveBeenCalledWith(connected));
     expect(cancelAuthorization).not.toHaveBeenCalled();
@@ -126,7 +135,7 @@ describe("ProviderAuthorizationCodeDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Complete" }));
 
     expect(await screen.findByText("Invalid authorization code")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start over" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Complete" })).toBeEnabled();
     expect(document.querySelector('[aria-live="polite"]')).toHaveTextContent(
       "Authorization failed: Invalid authorization code"
@@ -141,7 +150,7 @@ describe("ProviderAuthorizationCodeDialog", () => {
     renderDialog();
 
     expect(await screen.findByText("Anthropic is temporarily unavailable")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start over" }));
 
     expect(await screen.findByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
     expect(startAuthorization).toHaveBeenCalledTimes(2);
@@ -179,9 +188,49 @@ describe("ProviderAuthorizationCodeDialog", () => {
       setupToken: "sk-ant-oat01-token",
     });
     expect(completeAuthorization).not.toHaveBeenCalled();
+    // Switching methods ended the browser transaction; Back starts a fresh one.
+    expect(cancelAuthorization).toHaveBeenCalledWith("anthropic", transactionId);
 
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
-    expect(screen.getByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+    expect(startAuthorization).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers a fresh transaction after the provider rejects the code", async () => {
+    completeAuthorization.mockResolvedValueOnce({
+      status: "denied",
+      error: "Anthropic rejected the code",
+      retryable: false,
+    });
+    startAuthorization.mockResolvedValue(started);
+    renderDialog();
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.change(screen.getByLabelText("Authorization code"), { target: { value: "used" } });
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    expect(await screen.findByText("Anthropic rejected the code")).toBeInTheDocument();
+    expect(screen.getByLabelText("Authorization code")).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Start over" }));
+
+    await waitFor(() => expect(startAuthorization).toHaveBeenCalledTimes(2));
+    expect(await screen.findByLabelText("Authorization code")).toHaveValue("");
+  });
+
+  it("cancelling with a pasted code closes without completing it", async () => {
+    const { onClose } = renderDialog();
+    await screen.findByRole("link", { name: "Open Anthropic" });
+    fireEvent.change(screen.getByLabelText("Authorization code"), {
+      target: { value: "code#state" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(cancelAuthorization).toHaveBeenCalledWith("anthropic", transactionId)
+    );
+    expect(completeAuthorization).not.toHaveBeenCalled();
   });
 
   it("offers no setup token for a slot the browser flow named", async () => {
@@ -213,14 +262,26 @@ describe("ProviderAuthorizationCodeDialog", () => {
     });
   });
 
-  it("disables the setup token form while a save is in flight", async () => {
-    renderDialog({ saving: true });
+  it("locks the setup token form, navigation and dismissal while a save is in flight", async () => {
+    const { onClose, rerender } = renderDialog();
     await screen.findByRole("link", { name: "Open Anthropic" });
-
     fireEvent.click(screen.getByRole("button", { name: "Paste a setup token instead" }));
     fireEvent.change(screen.getByLabelText("Setup token"), { target: { value: "token" } });
 
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    rerender({ saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByLabelText("Setup token")).toBeDisabled();
+    expect(screen.getByLabelText("Account name")).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.keyDown(screen.getByLabelText("Setup token"), { key: "Escape" });
+    expect(screen.queryByRole("link", { name: "Open Anthropic" })).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    // The browser transaction ended when the method switched, so nothing can
+    // complete alongside the save.
+    expect(startAuthorization).toHaveBeenCalledOnce();
   });
 
   it("cancels the unfinished transaction when closed", async () => {

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import {
+  ANTHROPIC_CREDENTIAL_ROTATION_WARNING,
+  ProviderAuthorizationCodeDialog,
+} from "./provider-authorization-code-dialog";
+
+expect.extend(matchers);
+afterEach(cleanup);
+
+const startAuthorization = vi.fn();
+const completeAuthorization = vi.fn();
+const cancelAuthorization = vi.fn();
+
+vi.mock("@/hooks/use-provider-accounts", () => ({
+  startProviderAuthorizationCode: (...args: unknown[]) => startAuthorization(...args),
+  completeProviderAuthorizationCode: (...args: unknown[]) => completeAuthorization(...args),
+  cancelProviderAuthorizationCode: (...args: unknown[]) => cancelAuthorization(...args),
+}));
+
+const transactionId = "f".repeat(64);
+const authorizationUrl = "https://claude.ai/oauth/authorize?state=abc";
+const started = {
+  transactionId,
+  provider: "anthropic" as const,
+  operation: "create" as const,
+  authorizationUrl,
+  expiresAt: Date.now() + 60_000,
+  expiresInMs: 60_000,
+};
+const connected = {
+  status: "connected" as const,
+  account: {
+    id: "a".repeat(32),
+    provider: "anthropic" as const,
+    displayName: "Claude account",
+    externalAccountId: null,
+    status: "active" as const,
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+  },
+  reconnectedExisting: false,
+  completedAt: Date.now(),
+};
+const reconnectStarted = { ...started, operation: "reconnect" as const };
+const createTarget = { provider: "anthropic" as const, operation: "create" as const };
+const reconnectTarget = {
+  provider: "anthropic" as const,
+  operation: "reconnect" as const,
+  providerAccountId: "e".repeat(32),
+  displayName: "Team Claude",
+};
+
+function renderDialog(
+  overrides: Partial<Parameters<typeof ProviderAuthorizationCodeDialog>[0]> = {}
+) {
+  const props = {
+    target: createTarget,
+    saving: false,
+    onConnected: vi.fn(),
+    onSubmitSetupToken: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(<ProviderAuthorizationCodeDialog {...props} />);
+  return props;
+}
+
+describe("ProviderAuthorizationCodeDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startAuthorization.mockResolvedValue(started);
+    completeAuthorization.mockImplementation(() => new Promise(() => undefined));
+    cancelAuthorization.mockResolvedValue(undefined);
+  });
+
+  it("opens Anthropic in a new tab and completes with the pasted code", async () => {
+    completeAuthorization.mockResolvedValue(connected);
+    const { onConnected } = renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: "Connect your Claude account" })
+    ).toBeInTheDocument();
+    expect(startAuthorization).toHaveBeenCalledWith("anthropic", {
+      operation: "create",
+      displayName: "Claude account",
+    });
+    const link = await screen.findByRole("link", { name: "Open Anthropic" });
+    expect(link).toHaveAttribute("href", authorizationUrl);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByText(/expires in/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Complete" })).toBeDisabled();
+    expect(document.body.textContent).not.toMatch(/Claude Code/);
+
+    fireEvent.change(screen.getByLabelText("Authorization code"), {
+      target: { value: " code#state " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    await waitFor(() =>
+      expect(completeAuthorization).toHaveBeenCalledWith("anthropic", transactionId, "code#state")
+    );
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith(connected));
+    expect(cancelAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("shows a rejected code inline and lets the user paste again", async () => {
+    completeAuthorization.mockRejectedValueOnce(
+      Object.assign(new Error("Invalid authorization code"), { status: 400 })
+    );
+    renderDialog();
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.change(screen.getByLabelText("Authorization code"), { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    expect(await screen.findByText("Invalid authorization code")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Complete" })).toBeEnabled();
+    expect(document.querySelector('[aria-live="polite"]')).toHaveTextContent(
+      "Authorization failed: Invalid authorization code"
+    );
+    expect(startAuthorization).toHaveBeenCalledOnce();
+  });
+
+  it("retry starts a fresh transaction after a retryable start failure", async () => {
+    startAuthorization
+      .mockRejectedValueOnce(new Error("Anthropic is temporarily unavailable"))
+      .mockResolvedValueOnce({ ...started, transactionId: "e".repeat(64) });
+    renderDialog();
+
+    expect(await screen.findByText("Anthropic is temporarily unavailable")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+    expect(startAuthorization).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns that reconnecting rotates the stored token", async () => {
+    startAuthorization.mockResolvedValue(reconnectStarted);
+    renderDialog({ target: reconnectTarget });
+
+    expect(screen.getByRole("heading", { name: "Reconnect Team Claude" })).toBeInTheDocument();
+    expect(screen.getByText(ANTHROPIC_CREDENTIAL_ROTATION_WARNING)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(startAuthorization).toHaveBeenCalledWith("anthropic", {
+        operation: "reconnect",
+        providerAccountId: reconnectTarget.providerAccountId,
+      })
+    );
+  });
+
+  it("submits a new account from a pasted setup token", async () => {
+    const { onSubmitSetupToken } = renderDialog();
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Paste a setup token instead" }));
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Account name"), { target: { value: " Team Claude " } });
+    fireEvent.change(screen.getByLabelText("Setup token"), {
+      target: { value: "sk-ant-oat01-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmitSetupToken).toHaveBeenCalledWith({
+      operation: "create",
+      displayName: "Team Claude",
+      setupToken: "sk-ant-oat01-token",
+    });
+    expect(completeAuthorization).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+  });
+
+  it("submits a reconnect setup token against the explicit account", async () => {
+    startAuthorization.mockResolvedValue(reconnectStarted);
+    const { onSubmitSetupToken } = renderDialog({ target: reconnectTarget });
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Paste a setup token instead" }));
+    expect(screen.queryByLabelText("Account name")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Setup token"), {
+      target: { value: "sk-ant-oat01-rotated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmitSetupToken).toHaveBeenCalledWith({
+      operation: "reconnect",
+      providerAccountId: reconnectTarget.providerAccountId,
+      setupToken: "sk-ant-oat01-rotated",
+    });
+  });
+
+  it("disables the setup token form while a save is in flight", async () => {
+    renderDialog({ saving: true });
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Paste a setup token instead" }));
+    fireEvent.change(screen.getByLabelText("Setup token"), { target: { value: "token" } });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("cancels the unfinished transaction when closed", async () => {
+    const { onClose } = renderDialog();
+    await screen.findByRole("link", { name: "Open Anthropic" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(cancelAuthorization).toHaveBeenCalledWith("anthropic", transactionId)
+    );
+  });
+});

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.test.tsx
@@ -58,6 +58,7 @@ const reconnectTarget = {
   operation: "reconnect" as const,
   providerAccountId: "e".repeat(32),
   displayName: "Team Claude",
+  externalAccountId: null,
 };
 
 function renderDialog(
@@ -181,6 +182,16 @@ describe("ProviderAuthorizationCodeDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.getByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+  });
+
+  it("offers no setup token for a slot the browser flow named", async () => {
+    startAuthorization.mockResolvedValue(reconnectStarted);
+    renderDialog({ target: { ...reconnectTarget, externalAccountId: "claude-account-uuid" } });
+
+    expect(await screen.findByRole("link", { name: "Open Anthropic" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Paste a setup token instead" })
+    ).not.toBeInTheDocument();
   });
 
   it("submits a reconnect setup token against the explicit account", async () => {

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
@@ -17,6 +17,8 @@ export type ProviderAuthorizationCodeTarget =
       operation: "reconnect";
       providerAccountId: string;
       displayName: string;
+      /** The Claude account the browser flow named; a pasted token cannot reconnect such a slot. */
+      externalAccountId: string | null;
     };
 
 /** A setup token minted elsewhere, submitted through the ordinary connect/reconnect request. */
@@ -75,6 +77,10 @@ export function ProviderAuthorizationCodeDialog({
   };
   const canComplete = status === "awaiting_code" && code.trim().length > 0;
   const needsFreshTransaction = status === "failed" || status === "expired";
+  // A slot the browser flow bound to a Claude account is reconnected the same
+  // way, so the granting account can be verified; the control plane refuses a
+  // pasted token there.
+  const setupTokenAllowed = target.operation === "create" || target.externalAccountId === null;
 
   return (
     <Dialog open onOpenChange={(open) => !open && close()}>
@@ -210,13 +216,15 @@ export function ProviderAuthorizationCodeDialog({
               </div>
             </div>
 
-            <button
-              type="button"
-              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-              onClick={() => setSetupTokenMode(true)}
-            >
-              Paste a setup token instead
-            </button>
+            {setupTokenAllowed && (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                onClick={() => setSetupTokenMode(true)}
+              >
+                Paste a setup token instead
+              </button>
+            )}
           </form>
         )}
       </DialogContent>

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
@@ -270,7 +270,9 @@ function SetupTokenForm({
     >
       <p className="text-sm text-muted-foreground">
         Run <code className="font-mono text-xs">claude setup-token</code> on a workstation signed in
-        to your Claude account, then paste the token it prints. The token is stored write-only.
+        to your Claude account, then paste the token it prints. Generate it right before pasting: a
+        setup token lasts a year from when it was minted, and that is what the stored expiry
+        assumes. The token is stored write-only.
       </p>
       {target.operation === "create" && (
         <div>

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import type { ProviderAuthorizationCodeStatusResponse } from "@open-inspect/shared/types/provider-accounts";
+import { useProviderAuthorizationCode } from "@/hooks/use-provider-authorization-code";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { SubscriptionProviderIcon } from "@/components/subscription-provider-icon";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+
+export type ProviderAuthorizationCodeTarget =
+  | { provider: "anthropic"; operation: "create" }
+  | {
+      provider: "anthropic";
+      operation: "reconnect";
+      providerAccountId: string;
+      displayName: string;
+    };
+
+/** A setup token minted elsewhere, submitted through the ordinary connect/reconnect request. */
+export type ProviderSetupTokenSubmission =
+  | { operation: "create"; displayName: string; setupToken: string }
+  | { operation: "reconnect"; providerAccountId: string; setupToken: string };
+
+export const ANTHROPIC_CREDENTIAL_ROTATION_WARNING =
+  "Running sessions that received this credential will be stopped. Reconnecting rotates what Open Inspect stores; it does not revoke the token at Anthropic.";
+
+const PROVIDER_CONTENT = {
+  anthropic: {
+    accountName: "Claude",
+    defaultDisplayName: "Claude account",
+    description:
+      "Use your Claude subscription for Claude Agent. Anthropic shows a code after you grant access; paste it here to finish.",
+  },
+} as const;
+
+function countdownLabel(remainingMs: number): string {
+  const seconds = Math.max(0, Math.ceil(remainingMs / 1_000));
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function ProviderAuthorizationCodeDialog({
+  target,
+  saving,
+  onConnected,
+  onSubmitSetupToken,
+  onClose,
+}: {
+  target: ProviderAuthorizationCodeTarget;
+  saving: boolean;
+  onConnected: (
+    result: Extract<ProviderAuthorizationCodeStatusResponse, { status: "connected" }>
+  ) => void;
+  onSubmitSetupToken: (submission: ProviderSetupTokenSubmission) => void;
+  onClose: () => void;
+}) {
+  const [code, setCode] = useState("");
+  const [setupTokenMode, setSetupTokenMode] = useState(false);
+  const content = PROVIDER_CONTENT[target.provider];
+  const { authorization, failure, status, remainingMs, complete, retry, cancel } =
+    useProviderAuthorizationCode(
+      target.provider,
+      target.operation === "create"
+        ? { operation: "create", displayName: content.defaultDisplayName }
+        : { operation: "reconnect", providerAccountId: target.providerAccountId },
+      onConnected
+    );
+
+  const close = () => {
+    cancel();
+    onClose();
+  };
+  const canComplete = status === "awaiting_code" && code.trim().length > 0;
+  const needsFreshTransaction = status === "failed" || status === "expired";
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && close()}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] w-[calc(100%-1.5rem)] max-w-2xl overflow-y-auto p-0 sm:w-full">
+        <div className="border-b border-border-muted bg-muted/30 px-5 py-5 sm:px-7">
+          <div className="flex items-start gap-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full border border-border bg-background">
+              <SubscriptionProviderIcon
+                provider={target.provider}
+                className="size-5 text-foreground"
+              />
+            </div>
+            <div>
+              <DialogTitle>
+                {target.operation === "create"
+                  ? `Connect your ${content.accountName} account`
+                  : `Reconnect ${target.displayName}`}
+              </DialogTitle>
+              <DialogDescription className="mt-1">{content.description}</DialogDescription>
+              {target.operation === "reconnect" && (
+                <p className="mt-2 rounded-md bg-warning-muted px-3 py-2 text-xs text-warning">
+                  {ANTHROPIC_CREDENTIAL_ROTATION_WARNING}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {setupTokenMode ? (
+          <SetupTokenForm
+            target={target}
+            defaultDisplayName={content.defaultDisplayName}
+            saving={saving}
+            onSubmit={onSubmitSetupToken}
+            onBack={() => setSetupTokenMode(false)}
+            onCancel={close}
+          />
+        ) : (
+          <form
+            className="space-y-3 px-5 py-5 sm:px-7"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (canComplete) void complete(code);
+            }}
+          >
+            <AuthorizationStep number={1} title="Open Anthropic and grant access to Claude Agent.">
+              {authorization ? (
+                <Button asChild size="sm" variant="outline">
+                  <a
+                    href={authorization.authorizationUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open Anthropic
+                  </a>
+                </Button>
+              ) : (
+                <Button size="sm" variant="outline" disabled>
+                  Open Anthropic
+                </Button>
+              )}
+            </AuthorizationStep>
+
+            <AuthorizationStep number={2} title="Paste the code Anthropic shows you.">
+              <Label htmlFor="provider-authorization-code" className="sr-only">
+                Authorization code
+              </Label>
+              <Textarea
+                id="provider-authorization-code"
+                rows={2}
+                autoComplete="off"
+                spellCheck={false}
+                className="font-mono text-sm"
+                placeholder="Paste the code here"
+                value={code}
+                disabled={status !== "awaiting_code"}
+                onChange={(event) => setCode(event.target.value)}
+              />
+              <Button type="submit" size="sm" disabled={!canComplete}>
+                {status === "completing" ? "Completing..." : "Complete"}
+              </Button>
+            </AuthorizationStep>
+
+            <div className="flex flex-col gap-3 border-t border-border-muted pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0 text-sm">
+                {failure ? (
+                  <p className="text-destructive">{failure.message}</p>
+                ) : (
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    {(status === "starting" || status === "completing") && (
+                      <span className="size-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    )}
+                    <span>
+                      {status === "starting"
+                        ? "Starting authorization..."
+                        : status === "completing"
+                          ? "Completing authorization..."
+                          : status === "connected"
+                            ? "Connected."
+                            : remainingMs !== null && (
+                                <>Waiting for the code · expires in {countdownLabel(remainingMs)}</>
+                              )}
+                    </span>
+                  </div>
+                )}
+              </div>
+              <p aria-live="polite" aria-atomic="true" className="sr-only">
+                {failure
+                  ? `Authorization failed: ${failure.message}`
+                  : status === "awaiting_code"
+                    ? "Authorization started. Waiting for the code from Anthropic."
+                    : status === "completing"
+                      ? "Completing authorization."
+                      : status === "connected"
+                        ? "Claude account connected."
+                        : "Starting authorization."}
+              </p>
+              <div className="flex shrink-0 gap-2">
+                {failure?.retryable && needsFreshTransaction && (
+                  <Button
+                    size="sm"
+                    onClick={() => {
+                      setCode("");
+                      retry();
+                    }}
+                  >
+                    Retry
+                  </Button>
+                )}
+                <Button size="sm" variant="subtle" onClick={close}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              onClick={() => setSetupTokenMode(true)}
+            >
+              Paste a setup token instead
+            </button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SetupTokenForm({
+  target,
+  defaultDisplayName,
+  saving,
+  onSubmit,
+  onBack,
+  onCancel,
+}: {
+  target: ProviderAuthorizationCodeTarget;
+  defaultDisplayName: string;
+  saving: boolean;
+  onSubmit: (submission: ProviderSetupTokenSubmission) => void;
+  onBack: () => void;
+  onCancel: () => void;
+}) {
+  const [displayName, setDisplayName] = useState(defaultDisplayName);
+  const [setupToken, setSetupToken] = useState("");
+  const trimmedDisplayName = displayName.trim();
+  const canSubmit =
+    !saving &&
+    setupToken.trim().length > 0 &&
+    (target.operation === "reconnect" || !!trimmedDisplayName);
+
+  return (
+    <form
+      className="space-y-3 px-5 py-5 sm:px-7"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!canSubmit) return;
+        onSubmit(
+          target.operation === "create"
+            ? {
+                operation: "create",
+                displayName: trimmedDisplayName,
+                setupToken: setupToken.trim(),
+              }
+            : {
+                operation: "reconnect",
+                providerAccountId: target.providerAccountId,
+                setupToken: setupToken.trim(),
+              }
+        );
+      }}
+    >
+      <p className="text-sm text-muted-foreground">
+        Run <code className="font-mono text-xs">claude setup-token</code> on a workstation signed in
+        to your Claude account, then paste the token it prints. The token is stored write-only.
+      </p>
+      {target.operation === "create" && (
+        <div>
+          <Label htmlFor="provider-setup-token-display-name">Account name</Label>
+          <Input
+            id="provider-setup-token-display-name"
+            autoComplete="off"
+            maxLength={100}
+            value={displayName}
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+        </div>
+      )}
+      <div>
+        <Label htmlFor="provider-setup-token">Setup token</Label>
+        <Input
+          id="provider-setup-token"
+          type="password"
+          autoComplete="off"
+          value={setupToken}
+          onChange={(event) => setSetupToken(event.target.value)}
+        />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" size="sm" disabled={!canSubmit}>
+          Save
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button type="button" size="sm" variant="subtle" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function AuthorizationStep({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 rounded-md border border-border-muted p-4">
+      <div className="flex size-8 items-center justify-center rounded-full bg-foreground text-sm font-semibold text-background">
+        {number}
+      </div>
+      <div className="min-w-0 space-y-3">
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
@@ -26,6 +26,11 @@ export type ProviderSetupTokenSubmission =
   | { operation: "create"; displayName: string; setupToken: string }
   | { operation: "reconnect"; providerAccountId: string; setupToken: string };
 
+type ConnectedAuthorization = Extract<
+  ProviderAuthorizationCodeStatusResponse,
+  { status: "connected" }
+>;
+
 export const ANTHROPIC_CREDENTIAL_ROTATION_WARNING =
   "Sessions that already received this credential keep it until their sandbox exits. Reconnecting rotates what Open Inspect stores; it does not revoke the token at Anthropic.";
 
@@ -44,6 +49,13 @@ function countdownLabel(remainingMs: number): string {
   return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
+/**
+ * One connection method is mounted at a time. The browser flow lives in
+ * `AuthorizationCodeForm`, which owns its transaction: switching to the
+ * setup-token form unmounts it and cancels the transaction, and switching
+ * back starts a fresh one. While a setup token is being saved the dialog
+ * cannot be dismissed or switched, so two credential writes never overlap.
+ */
 export function ProviderAuthorizationCodeDialog({
   target,
   saving,
@@ -53,37 +65,19 @@ export function ProviderAuthorizationCodeDialog({
 }: {
   target: ProviderAuthorizationCodeTarget;
   saving: boolean;
-  onConnected: (
-    result: Extract<ProviderAuthorizationCodeStatusResponse, { status: "connected" }>
-  ) => void;
+  onConnected: (result: ConnectedAuthorization) => void;
   onSubmitSetupToken: (submission: ProviderSetupTokenSubmission) => void;
   onClose: () => void;
 }) {
-  const [code, setCode] = useState("");
-  const [setupTokenMode, setSetupTokenMode] = useState(false);
+  const [method, setMethod] = useState<"browser" | "setup_token">("browser");
   const content = PROVIDER_CONTENT[target.provider];
-  const { authorization, failure, status, remainingMs, complete, retry, cancel } =
-    useProviderAuthorizationCode(
-      target.provider,
-      target.operation === "create"
-        ? { operation: "create", displayName: content.defaultDisplayName }
-        : { operation: "reconnect", providerAccountId: target.providerAccountId },
-      onConnected
-    );
-
-  const close = () => {
-    cancel();
-    onClose();
-  };
-  const canComplete = status === "awaiting_code" && code.trim().length > 0;
-  const needsFreshTransaction = status === "failed" || status === "expired";
   // A slot the browser flow bound to a Claude account is reconnected the same
   // way, so the granting account can be verified; the control plane refuses a
   // pasted token there.
   const setupTokenAllowed = target.operation === "create" || target.externalAccountId === null;
 
   return (
-    <Dialog open onOpenChange={(open) => !open && close()}>
+    <Dialog open onOpenChange={(open) => !open && !saving && onClose()}>
       <DialogContent className="max-h-[calc(100vh-2rem)] w-[calc(100%-1.5rem)] max-w-2xl overflow-y-auto p-0 sm:w-full">
         <div className="border-b border-border-muted bg-muted/30 px-5 py-5 sm:px-7">
           <div className="flex items-start gap-3">
@@ -109,126 +103,169 @@ export function ProviderAuthorizationCodeDialog({
           </div>
         </div>
 
-        {setupTokenMode ? (
+        {method === "setup_token" ? (
           <SetupTokenForm
             target={target}
             defaultDisplayName={content.defaultDisplayName}
             saving={saving}
             onSubmit={onSubmitSetupToken}
-            onBack={() => setSetupTokenMode(false)}
-            onCancel={close}
+            onBack={() => setMethod("browser")}
+            onCancel={onClose}
           />
         ) : (
-          <form
-            className="space-y-3 px-5 py-5 sm:px-7"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (canComplete) void complete(code);
-            }}
-          >
-            <AuthorizationStep number={1} title="Open Anthropic and grant access to Claude Agent.">
-              {authorization ? (
-                <Button asChild size="sm" variant="outline">
-                  <a
-                    href={authorization.authorizationUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Open Anthropic
-                  </a>
-                </Button>
-              ) : (
-                <Button size="sm" variant="outline" disabled>
-                  Open Anthropic
-                </Button>
-              )}
-            </AuthorizationStep>
-
-            <AuthorizationStep number={2} title="Paste the code Anthropic shows you.">
-              <Label htmlFor="provider-authorization-code" className="sr-only">
-                Authorization code
-              </Label>
-              <Textarea
-                id="provider-authorization-code"
-                rows={2}
-                autoComplete="off"
-                spellCheck={false}
-                className="font-mono text-sm"
-                placeholder="Paste the code here"
-                value={code}
-                disabled={status !== "awaiting_code"}
-                onChange={(event) => setCode(event.target.value)}
-              />
-              <Button type="submit" size="sm" disabled={!canComplete}>
-                {status === "completing" ? "Completing..." : "Complete"}
-              </Button>
-            </AuthorizationStep>
-
-            <div className="flex flex-col gap-3 border-t border-border-muted pt-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="min-w-0 text-sm">
-                {failure ? (
-                  <p className="text-destructive">{failure.message}</p>
-                ) : (
-                  <div className="flex items-center gap-2 text-muted-foreground">
-                    {(status === "starting" || status === "completing") && (
-                      <span className="size-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    )}
-                    <span>
-                      {status === "starting"
-                        ? "Starting authorization..."
-                        : status === "completing"
-                          ? "Completing authorization..."
-                          : status === "connected"
-                            ? "Connected."
-                            : remainingMs !== null && (
-                                <>Waiting for the code · expires in {countdownLabel(remainingMs)}</>
-                              )}
-                    </span>
-                  </div>
-                )}
-              </div>
-              <p aria-live="polite" aria-atomic="true" className="sr-only">
-                {failure
-                  ? `Authorization failed: ${failure.message}`
-                  : status === "awaiting_code"
-                    ? "Authorization started. Waiting for the code from Anthropic."
-                    : status === "completing"
-                      ? "Completing authorization."
-                      : status === "connected"
-                        ? "Claude account connected."
-                        : "Starting authorization."}
-              </p>
-              <div className="flex shrink-0 gap-2">
-                {failure?.retryable && needsFreshTransaction && (
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      setCode("");
-                      retry();
-                    }}
-                  >
-                    Retry
-                  </Button>
-                )}
-                <Button size="sm" variant="subtle" onClick={close}>
-                  Cancel
-                </Button>
-              </div>
-            </div>
-
-            {setupTokenAllowed && (
-              <button
-                type="button"
-                className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-                onClick={() => setSetupTokenMode(true)}
-              >
-                Paste a setup token instead
-              </button>
-            )}
-          </form>
+          <AuthorizationCodeForm
+            target={target}
+            defaultDisplayName={content.defaultDisplayName}
+            onConnected={onConnected}
+            onClose={onClose}
+            onUseSetupToken={setupTokenAllowed ? () => setMethod("setup_token") : undefined}
+          />
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function AuthorizationCodeForm({
+  target,
+  defaultDisplayName,
+  onConnected,
+  onClose,
+  onUseSetupToken,
+}: {
+  target: ProviderAuthorizationCodeTarget;
+  defaultDisplayName: string;
+  onConnected: (result: ConnectedAuthorization) => void;
+  onClose: () => void;
+  onUseSetupToken?: () => void;
+}) {
+  const [code, setCode] = useState("");
+  const { authorization, failure, status, remainingMs, complete, retry, cancel } =
+    useProviderAuthorizationCode(
+      target.provider,
+      target.operation === "create"
+        ? { operation: "create", displayName: defaultDisplayName }
+        : { operation: "reconnect", providerAccountId: target.providerAccountId },
+      onConnected
+    );
+
+  const close = () => {
+    cancel();
+    onClose();
+  };
+  const canComplete = status === "awaiting_code" && code.trim().length > 0;
+  const settled = status !== "starting" && status !== "awaiting_code" && status !== "completing";
+  // A settled transaction is over; a fresh one is the way forward whenever the
+  // failure is transient or the provider rejected the code (`denied`). Only a
+  // start refused outright (a permission or archived-account error) offers
+  // nothing to start over with.
+  const canStartOver = settled && failure !== null && (failure.retryable || status === "denied");
+
+  return (
+    <form
+      className="space-y-3 px-5 py-5 sm:px-7"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canComplete) void complete(code);
+      }}
+    >
+      <AuthorizationStep number={1} title="Open Anthropic and grant access to Claude Agent.">
+        {authorization ? (
+          <Button asChild size="sm" variant="outline">
+            <a href={authorization.authorizationUrl} target="_blank" rel="noopener noreferrer">
+              Open Anthropic
+            </a>
+          </Button>
+        ) : (
+          <Button size="sm" variant="outline" disabled>
+            Open Anthropic
+          </Button>
+        )}
+      </AuthorizationStep>
+
+      <AuthorizationStep number={2} title="Paste the code Anthropic shows you.">
+        <Label htmlFor="provider-authorization-code" className="sr-only">
+          Authorization code
+        </Label>
+        <Textarea
+          id="provider-authorization-code"
+          rows={2}
+          autoComplete="off"
+          spellCheck={false}
+          className="font-mono text-sm"
+          placeholder="Paste the code here"
+          value={code}
+          disabled={status !== "awaiting_code"}
+          onChange={(event) => setCode(event.target.value)}
+        />
+        <Button type="submit" size="sm" disabled={!canComplete}>
+          {status === "completing" ? "Completing..." : "Complete"}
+        </Button>
+      </AuthorizationStep>
+
+      <div className="flex flex-col gap-3 border-t border-border-muted pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 text-sm">
+          {failure ? (
+            <p className="text-destructive">{failure.message}</p>
+          ) : (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              {(status === "starting" || status === "completing") && (
+                <span className="size-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              )}
+              <span>
+                {status === "starting"
+                  ? "Starting authorization..."
+                  : status === "completing"
+                    ? "Completing authorization..."
+                    : status === "connected"
+                      ? "Connected."
+                      : remainingMs !== null && (
+                          <>Waiting for the code · expires in {countdownLabel(remainingMs)}</>
+                        )}
+              </span>
+            </div>
+          )}
+        </div>
+        <p aria-live="polite" aria-atomic="true" className="sr-only">
+          {failure
+            ? `Authorization failed: ${failure.message}`
+            : status === "awaiting_code"
+              ? "Authorization started. Waiting for the code from Anthropic."
+              : status === "completing"
+                ? "Completing authorization."
+                : status === "connected"
+                  ? "Claude account connected."
+                  : "Starting authorization."}
+        </p>
+        <div className="flex shrink-0 gap-2">
+          {canStartOver && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setCode("");
+                retry();
+              }}
+            >
+              Start over
+            </Button>
+          )}
+          <Button type="button" size="sm" variant="subtle" onClick={close}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+
+      {onUseSetupToken && (
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          onClick={onUseSetupToken}
+        >
+          Paste a setup token instead
+        </button>
+      )}
+    </form>
   );
 }
 
@@ -290,6 +327,7 @@ function SetupTokenForm({
             autoComplete="off"
             maxLength={100}
             value={displayName}
+            disabled={saving}
             onChange={(event) => setDisplayName(event.target.value)}
           />
         </div>
@@ -301,17 +339,18 @@ function SetupTokenForm({
           type="password"
           autoComplete="off"
           value={setupToken}
+          disabled={saving}
           onChange={(event) => setSetupToken(event.target.value)}
         />
       </div>
       <div className="flex flex-wrap gap-2">
         <Button type="submit" size="sm" disabled={!canSubmit}>
-          Save
+          {saving ? "Saving..." : "Save"}
         </Button>
-        <Button type="button" size="sm" variant="outline" onClick={onBack}>
+        <Button type="button" size="sm" variant="outline" disabled={saving} onClick={onBack}>
           Back
         </Button>
-        <Button type="button" size="sm" variant="subtle" onClick={onCancel}>
+        <Button type="button" size="sm" variant="subtle" disabled={saving} onClick={onCancel}>
           Cancel
         </Button>
       </div>

--- a/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
+++ b/packages/web/src/components/settings/provider-authorization-code-dialog.tsx
@@ -25,7 +25,7 @@ export type ProviderSetupTokenSubmission =
   | { operation: "reconnect"; providerAccountId: string; setupToken: string };
 
 export const ANTHROPIC_CREDENTIAL_ROTATION_WARNING =
-  "Running sessions that received this credential will be stopped. Reconnecting rotates what Open Inspect stores; it does not revoke the token at Anthropic.";
+  "Sessions that already received this credential keep it until their sandbox exits. Reconnecting rotates what Open Inspect stores; it does not revoke the token at Anthropic.";
 
 const PROVIDER_CONTENT = {
   anthropic: {

--- a/packages/web/src/hooks/use-provider-accounts.test.tsx
+++ b/packages/web/src/hooks/use-provider-accounts.test.tsx
@@ -6,12 +6,16 @@ import { SWRConfig } from "swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
+  cancelProviderAuthorizationCode,
   cancelProviderDeviceAuthorization,
   archiveProviderAccount,
+  completeProviderAuthorizationCode,
   connectProviderAccount,
   pollProviderDeviceAuthorization,
+  readProviderAuthorizationCodeStatus,
   renameProviderAccount,
   setProviderAccountDefault,
+  startProviderAuthorizationCode,
   startProviderDeviceAuthorization,
   type ProviderResourceError,
   useLegacyProviderCredentials,
@@ -329,6 +333,101 @@ describe("provider device authorization requests", () => {
       startProviderDeviceAuthorization("unknown" as "openai", {
         operation: "create",
         displayName: "ChatGPT account",
+      })
+    ).rejects.toThrow();
+    expect(browserApiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("provider authorization code requests", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("validates start, status, and complete responses with shared schemas", async () => {
+    const transactionId = "f".repeat(64);
+    const authorizationUrl = "https://claude.ai/oauth/authorize?state=abc";
+    vi.mocked(browserApiFetch)
+      .mockResolvedValueOnce(
+        Response.json({
+          transactionId,
+          provider: "anthropic",
+          operation: "create",
+          authorizationUrl,
+          expiresAt: Date.now() + 60_000,
+          expiresInMs: 60_000,
+        })
+      )
+      .mockResolvedValueOnce(Response.json({ status: "pending", expiresAt: Date.now() + 60_000 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          status: "connected",
+          account: { ...account, provider: "anthropic", externalAccountId: null },
+          reconnectedExisting: false,
+          completedAt: Date.now(),
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(
+      startProviderAuthorizationCode("anthropic", {
+        operation: "create",
+        displayName: "Claude account",
+      })
+    ).resolves.toMatchObject({ transactionId, authorizationUrl, expiresInMs: 60_000 });
+    await expect(
+      readProviderAuthorizationCodeStatus("anthropic", transactionId)
+    ).resolves.toMatchObject({ status: "pending" });
+    await expect(
+      completeProviderAuthorizationCode("anthropic", transactionId, "  code#state  ")
+    ).resolves.toMatchObject({ status: "connected" });
+    await expect(
+      cancelProviderAuthorizationCode("anthropic", transactionId)
+    ).resolves.toBeUndefined();
+
+    expect(browserApiFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/model-provider-accounts/authorization-codes/anthropic",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ operation: "create", displayName: "Claude account" }),
+      })
+    );
+    expect(browserApiFetch).toHaveBeenNthCalledWith(
+      2,
+      `/api/model-provider-accounts/authorization-codes/anthropic/${transactionId}`,
+      expect.objectContaining({ method: undefined, body: undefined })
+    );
+    expect(browserApiFetch).toHaveBeenNthCalledWith(
+      3,
+      `/api/model-provider-accounts/authorization-codes/anthropic/${transactionId}/complete`,
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ code: "code#state" }) })
+    );
+    expect(browserApiFetch).toHaveBeenNthCalledWith(
+      4,
+      `/api/model-provider-accounts/authorization-codes/anthropic/${transactionId}`,
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("rejects malformed authorization code responses", async () => {
+    vi.mocked(browserApiFetch).mockResolvedValue(Response.json({ transactionId: "unsafe" }));
+
+    await expect(
+      startProviderAuthorizationCode("anthropic", {
+        operation: "create",
+        displayName: "Claude account",
+      })
+    ).rejects.toThrow("Invalid provider account response");
+  });
+
+  it("rejects an empty code and unsafe path parameters before fetching", async () => {
+    await expect(
+      completeProviderAuthorizationCode("anthropic", "f".repeat(64), "   ")
+    ).rejects.toThrow();
+    await expect(readProviderAuthorizationCodeStatus("anthropic", "../unsafe")).rejects.toThrow();
+    await expect(
+      startProviderAuthorizationCode("unknown" as "anthropic", {
+        operation: "create",
+        displayName: "Claude account",
       })
     ).rejects.toThrow();
     expect(browserApiFetch).not.toHaveBeenCalled();

--- a/packages/web/src/hooks/use-provider-accounts.ts
+++ b/packages/web/src/hooks/use-provider-accounts.ts
@@ -7,6 +7,7 @@ import {
   modelProviderAccountDefaultResponseSchema,
   modelProviderAccountResponseSchema,
   modelProviderAccountsResponseSchema,
+  providerAuthorizationCodeStatusResponseSchema,
   providerDeviceAuthorizationIdSchema,
   providerDeviceAuthorizationStatusResponseSchema,
   createModelProviderAccountResponseSchema,
@@ -14,12 +15,18 @@ import {
   SUBSCRIPTION_PROVIDER_DISPLAY_METADATA,
   SUBSCRIPTION_PROVIDER_IDS,
   subscriptionProviderIdSchema,
+  completeProviderAuthorizationCodeRequestSchema,
+  startProviderAuthorizationCodeRequestSchema,
+  startProviderAuthorizationCodeResponseSchema,
   startProviderDeviceAuthorizationRequestSchema,
   startProviderDeviceAuthorizationResponseSchema,
   type ConnectModelProviderAccountRequest,
   type ModelProviderAccount,
   type ModelProviderAccountDefault,
+  type ProviderAuthorizationCodeStatusResponse,
   type ReconnectModelProviderAccountRequest,
+  type StartProviderAuthorizationCodeRequest,
+  type StartProviderAuthorizationCodeResponse,
   type StartProviderDeviceAuthorizationRequest,
   type StartProviderDeviceAuthorizationResponse,
   type LegacyProviderCredentialsResponse,
@@ -173,6 +180,61 @@ export async function cancelProviderDeviceAuthorization(
   const id = providerDeviceAuthorizationIdSchema.parse(transactionId);
   await requestProviderResourceWithoutContent(
     `${ACCOUNTS_KEY}/device-authorizations/${parsedProvider}/${id}`,
+    { method: "DELETE" }
+  );
+}
+
+export async function startProviderAuthorizationCode(
+  provider: SubscriptionProviderId,
+  input: StartProviderAuthorizationCodeRequest
+): Promise<StartProviderAuthorizationCodeResponse> {
+  const parsedProvider = subscriptionProviderIdSchema.parse(provider);
+  const request = startProviderAuthorizationCodeRequestSchema.parse(input);
+  return requestProviderResource(
+    `${ACCOUNTS_KEY}/authorization-codes/${parsedProvider}`,
+    startProviderAuthorizationCodeResponseSchema,
+    { method: "POST", body: request }
+  );
+}
+
+export async function readProviderAuthorizationCodeStatus(
+  provider: SubscriptionProviderId,
+  transactionId: string,
+  signal?: AbortSignal
+): Promise<ProviderAuthorizationCodeStatusResponse> {
+  const parsedProvider = subscriptionProviderIdSchema.parse(provider);
+  const id = providerDeviceAuthorizationIdSchema.parse(transactionId);
+  return requestProviderResource(
+    `${ACCOUNTS_KEY}/authorization-codes/${parsedProvider}/${id}`,
+    providerAuthorizationCodeStatusResponseSchema,
+    { signal }
+  );
+}
+
+export async function completeProviderAuthorizationCode(
+  provider: SubscriptionProviderId,
+  transactionId: string,
+  code: string,
+  signal?: AbortSignal
+): Promise<ProviderAuthorizationCodeStatusResponse> {
+  const parsedProvider = subscriptionProviderIdSchema.parse(provider);
+  const id = providerDeviceAuthorizationIdSchema.parse(transactionId);
+  const request = completeProviderAuthorizationCodeRequestSchema.parse({ code });
+  return requestProviderResource(
+    `${ACCOUNTS_KEY}/authorization-codes/${parsedProvider}/${id}/complete`,
+    providerAuthorizationCodeStatusResponseSchema,
+    { method: "POST", body: request, signal }
+  );
+}
+
+export async function cancelProviderAuthorizationCode(
+  provider: SubscriptionProviderId,
+  transactionId: string
+) {
+  const parsedProvider = subscriptionProviderIdSchema.parse(provider);
+  const id = providerDeviceAuthorizationIdSchema.parse(transactionId);
+  await requestProviderResourceWithoutContent(
+    `${ACCOUNTS_KEY}/authorization-codes/${parsedProvider}/${id}`,
     { method: "DELETE" }
   );
 }

--- a/packages/web/src/hooks/use-provider-authorization-code.test.tsx
+++ b/packages/web/src/hooks/use-provider-authorization-code.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderAuthorizationCodeStatusResponse } from "@open-inspect/shared/types/provider-accounts";
+import {
+  cancelProviderAuthorizationCode,
+  completeProviderAuthorizationCode,
+  startProviderAuthorizationCode,
+} from "./use-provider-accounts";
+import { useProviderAuthorizationCode } from "./use-provider-authorization-code";
+
+vi.mock("./use-provider-accounts", () => ({
+  cancelProviderAuthorizationCode: vi.fn(),
+  completeProviderAuthorizationCode: vi.fn(),
+  startProviderAuthorizationCode: vi.fn(),
+}));
+
+const transactionId = "f".repeat(64);
+const authorizationUrl = "https://claude.ai/oauth/authorize?state=abc";
+const createTarget = { operation: "create" as const, displayName: "Claude account" };
+const started = {
+  transactionId,
+  provider: "anthropic" as const,
+  operation: "create" as const,
+  authorizationUrl,
+  expiresAt: 61_000,
+  expiresInMs: 60_000,
+};
+const connected = {
+  status: "connected" as const,
+  account: {
+    id: "a".repeat(32),
+    provider: "anthropic" as const,
+    displayName: "Claude account",
+    externalAccountId: null,
+    status: "active" as const,
+    createdBy: null,
+    updatedBy: null,
+    lastVerifiedAt: null,
+    lastUsedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    archivedAt: null,
+  },
+  reconnectedExisting: false,
+  completedAt: 5_000,
+};
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("useProviderAuthorizationCode", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    vi.mocked(cancelProviderAuthorizationCode).mockResolvedValue(undefined);
+    vi.mocked(startProviderAuthorizationCode).mockResolvedValue(started);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("starts a transaction and waits for the pasted code with a local countdown", async () => {
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    expect(result.current.status).toBe("starting");
+
+    await flushEffects();
+
+    expect(startProviderAuthorizationCode).toHaveBeenCalledWith("anthropic", createTarget);
+    expect(result.current.status).toBe("awaiting_code");
+    expect(result.current.authorization?.authorizationUrl).toBe(authorizationUrl);
+    expect(result.current.remainingMs).toBe(60_000);
+    await act(() => vi.advanceTimersByTimeAsync(1_000));
+    expect(result.current.remainingMs).toBe(59_000);
+    expect(completeProviderAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it("completes with the trimmed code and reports the connected account", async () => {
+    const onConnected = vi.fn();
+    vi.mocked(completeProviderAuthorizationCode).mockResolvedValue(connected);
+    const { result, unmount } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, onConnected)
+    );
+    await flushEffects();
+
+    await act(() => result.current.complete("  code#state  "));
+
+    expect(completeProviderAuthorizationCode).toHaveBeenCalledWith(
+      "anthropic",
+      transactionId,
+      "code#state"
+    );
+    expect(result.current.status).toBe("connected");
+    expect(onConnected).toHaveBeenCalledWith(connected);
+    unmount();
+    expect(cancelProviderAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it("returns to awaiting_code when the pasted code is rejected", async () => {
+    vi.mocked(completeProviderAuthorizationCode)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Invalid authorization code"), { status: 400 })
+      )
+      .mockResolvedValueOnce(connected);
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(() => result.current.complete("wrong"));
+    expect(result.current.status).toBe("awaiting_code");
+    expect(result.current.failure).toEqual({
+      message: "Invalid authorization code",
+      status: 400,
+      retryable: false,
+    });
+    expect(startProviderAuthorizationCode).toHaveBeenCalledOnce();
+
+    await act(() => result.current.complete("right"));
+    expect(result.current.status).toBe("connected");
+    expect(result.current.failure).toBeNull();
+  });
+
+  it("refuses an empty code without calling the control plane", async () => {
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(() => result.current.complete("   "));
+
+    expect(completeProviderAuthorizationCode).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("awaiting_code");
+    expect(result.current.failure?.message).toBe("Enter the authorization code first.");
+  });
+
+  it("fails and offers a fresh transaction when the current one is gone", async () => {
+    vi.mocked(completeProviderAuthorizationCode).mockRejectedValue(
+      Object.assign(new Error("Authorization transaction not found"), { status: 404 })
+    );
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(() => result.current.complete("code"));
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toEqual({
+      message: "Authorization transaction not found",
+      status: 404,
+      retryable: true,
+    });
+
+    act(() => result.current.retry());
+    await flushEffects();
+    expect(startProviderAuthorizationCode).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("awaiting_code");
+    expect(result.current.failure).toBeNull();
+  });
+
+  it("surfaces terminal provider outcomes from completion", async () => {
+    const denied: ProviderAuthorizationCodeStatusResponse = {
+      status: "denied",
+      error: "Access was denied",
+      retryable: false,
+    };
+    vi.mocked(completeProviderAuthorizationCode).mockResolvedValue(denied);
+    const { result, unmount } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(() => result.current.complete("code"));
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toEqual({ message: "Access was denied", retryable: false });
+    unmount();
+    expect(cancelProviderAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it("expires when no code arrives before the deadline", async () => {
+    vi.mocked(startProviderAuthorizationCode).mockResolvedValue({
+      ...started,
+      expiresAt: 3_000,
+      expiresInMs: 2_000,
+    });
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+
+    expect(result.current.status).toBe("expired");
+    expect(result.current.remainingMs).toBe(0);
+    expect(result.current.failure).toEqual({
+      message: "Provider authorization expired.",
+      retryable: true,
+    });
+    await act(() => result.current.complete("late"));
+    expect(completeProviderAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it("lets an in-flight completion settle before applying the deadline", async () => {
+    vi.mocked(startProviderAuthorizationCode).mockResolvedValue({
+      ...started,
+      expiresAt: 3_000,
+      expiresInMs: 2_000,
+    });
+    let resolveCompletion!: (value: ProviderAuthorizationCodeStatusResponse) => void;
+    vi.mocked(completeProviderAuthorizationCode).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCompletion = resolve;
+        })
+    );
+    const onConnected = vi.fn();
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, onConnected)
+    );
+    await flushEffects();
+
+    let completion!: Promise<void>;
+    await act(async () => {
+      completion = result.current.complete("code");
+    });
+    expect(result.current.status).toBe("completing");
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+    expect(result.current.status).toBe("completing");
+
+    await act(async () => {
+      resolveCompletion(connected);
+      await completion;
+    });
+
+    expect(result.current.status).toBe("connected");
+    expect(onConnected).toHaveBeenCalledOnce();
+  });
+
+  it("keeps its initial target immutable across rerenders", async () => {
+    const { rerender } = renderHook(
+      ({ target }) => useProviderAuthorizationCode("anthropic", target, vi.fn()),
+      { initialProps: { target: createTarget } }
+    );
+    await flushEffects();
+
+    rerender({ target: { operation: "create" as const, displayName: "Changed account" } });
+
+    expect(startProviderAuthorizationCode).toHaveBeenCalledOnce();
+    expect(startProviderAuthorizationCode).toHaveBeenCalledWith("anthropic", createTarget);
+  });
+
+  it("best-effort cancels an unfinished transaction on cleanup", async () => {
+    const { unmount } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    unmount();
+
+    expect(cancelProviderAuthorizationCode).toHaveBeenCalledWith("anthropic", transactionId);
+  });
+
+  it("preserves permanent start failure metadata", async () => {
+    vi.mocked(startProviderAuthorizationCode).mockRejectedValue(
+      Object.assign(new Error("Provider account is archived"), {
+        status: 409,
+        retryable: false,
+      })
+    );
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toEqual({
+      message: "Provider account is archived",
+      status: 409,
+      retryable: false,
+    });
+  });
+});

--- a/packages/web/src/hooks/use-provider-authorization-code.test.tsx
+++ b/packages/web/src/hooks/use-provider-authorization-code.test.tsx
@@ -6,6 +6,7 @@ import type { ProviderAuthorizationCodeStatusResponse } from "@open-inspect/shar
 import {
   cancelProviderAuthorizationCode,
   completeProviderAuthorizationCode,
+  readProviderAuthorizationCodeStatus,
   startProviderAuthorizationCode,
 } from "./use-provider-accounts";
 import { useProviderAuthorizationCode } from "./use-provider-authorization-code";
@@ -13,8 +14,20 @@ import { useProviderAuthorizationCode } from "./use-provider-authorization-code"
 vi.mock("./use-provider-accounts", () => ({
   cancelProviderAuthorizationCode: vi.fn(),
   completeProviderAuthorizationCode: vi.fn(),
+  readProviderAuthorizationCodeStatus: vi.fn(),
   startProviderAuthorizationCode: vi.fn(),
 }));
+
+/** A request that settles only when its signal is aborted, the way a hung fetch does. */
+function neverSettles<T>(): (...args: unknown[]) => Promise<T> {
+  return (...args) =>
+    new Promise((_, reject) => {
+      const signal = args[args.length - 1] as AbortSignal;
+      signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+        once: true,
+      });
+    });
+}
 
 const transactionId = "f".repeat(64);
 const authorizationUrl = "https://claude.ai/oauth/authorize?state=abc";
@@ -97,7 +110,8 @@ describe("useProviderAuthorizationCode", () => {
     expect(completeProviderAuthorizationCode).toHaveBeenCalledWith(
       "anthropic",
       transactionId,
-      "code#state"
+      "code#state",
+      expect.any(AbortSignal)
     );
     expect(result.current.status).toBe("connected");
     expect(onConnected).toHaveBeenCalledWith(connected);
@@ -181,10 +195,117 @@ describe("useProviderAuthorizationCode", () => {
 
     await act(() => result.current.complete("code"));
 
-    expect(result.current.status).toBe("failed");
+    expect(result.current.status).toBe("denied");
     expect(result.current.failure).toEqual({ message: "Access was denied", retryable: false });
     unmount();
     expect(cancelProviderAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a completion another request owns instead of declaring it gone", async () => {
+    vi.mocked(completeProviderAuthorizationCode).mockRejectedValue(
+      Object.assign(new Error("This authorization is already being completed"), {
+        status: 409,
+        retryable: true,
+      })
+    );
+    vi.mocked(readProviderAuthorizationCodeStatus)
+      .mockResolvedValueOnce({ status: "pending", expiresAt: 61_000 })
+      .mockResolvedValueOnce(connected);
+    const onConnected = vi.fn();
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, onConnected)
+    );
+    await flushEffects();
+
+    let completion!: Promise<void>;
+    await act(async () => {
+      completion = result.current.complete("code");
+    });
+    expect(result.current.status).toBe("completing");
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+    await act(() => completion);
+
+    expect(readProviderAuthorizationCodeStatus).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("connected");
+    expect(onConnected).toHaveBeenCalledWith(connected);
+    expect(startProviderAuthorizationCode).toHaveBeenCalledOnce();
+  });
+
+  it("returns to code entry when a reconciled completion is still pending after the window", async () => {
+    vi.mocked(completeProviderAuthorizationCode).mockRejectedValue(
+      new TypeError("Failed to fetch")
+    );
+    vi.mocked(readProviderAuthorizationCodeStatus).mockResolvedValue({
+      status: "pending",
+      expiresAt: 61_000,
+    });
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    let completion!: Promise<void>;
+    await act(async () => {
+      completion = result.current.complete("code");
+    });
+    await act(() => vi.advanceTimersByTimeAsync(46_000));
+    await act(() => completion);
+
+    expect(result.current.status).toBe("awaiting_code");
+    expect(result.current.failure).toEqual({
+      message: "The provider has not confirmed the code yet. Paste it again.",
+      retryable: false,
+    });
+  });
+
+  it("aborts a completion that never settles at the deadline and reconciles the outcome", async () => {
+    vi.mocked(startProviderAuthorizationCode).mockResolvedValue({
+      ...started,
+      expiresAt: 3_000,
+      expiresInMs: 2_000,
+    });
+    vi.mocked(completeProviderAuthorizationCode).mockImplementation(neverSettles());
+    vi.mocked(readProviderAuthorizationCodeStatus).mockResolvedValue({
+      status: "pending",
+      expiresAt: 3_000,
+    });
+    const { result } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    let completion!: Promise<void>;
+    await act(async () => {
+      completion = result.current.complete("code");
+    });
+    const signal = vi.mocked(completeProviderAuthorizationCode).mock.calls[0][3] as AbortSignal;
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+    expect(signal.aborted).toBe(true);
+    expect(result.current.status).toBe("completing");
+
+    await act(() => vi.advanceTimersByTimeAsync(46_000));
+    await act(() => completion);
+
+    expect(readProviderAuthorizationCodeStatus).toHaveBeenCalled();
+    expect(result.current.status).toBe("expired");
+    expect(result.current.remainingMs).toBe(0);
+  });
+
+  it("aborts an in-flight completion on unmount", async () => {
+    vi.mocked(completeProviderAuthorizationCode).mockImplementation(neverSettles());
+    const { result, unmount } = renderHook(() =>
+      useProviderAuthorizationCode("anthropic", createTarget, vi.fn())
+    );
+    await flushEffects();
+
+    await act(async () => {
+      void result.current.complete("code");
+    });
+    const signal = vi.mocked(completeProviderAuthorizationCode).mock.calls[0][3] as AbortSignal;
+    unmount();
+
+    expect(signal.aborted).toBe(true);
+    expect(cancelProviderAuthorizationCode).toHaveBeenCalledWith("anthropic", transactionId);
   });
 
   it("expires when no code arrives before the deadline", async () => {

--- a/packages/web/src/hooks/use-provider-authorization-code.ts
+++ b/packages/web/src/hooks/use-provider-authorization-code.ts
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  ProviderAuthorizationCodeStatusResponse,
+  StartProviderAuthorizationCodeRequest,
+  StartProviderAuthorizationCodeResponse,
+  SubscriptionProviderId,
+} from "@open-inspect/shared/types/provider-accounts";
+import {
+  cancelProviderAuthorizationCode,
+  completeProviderAuthorizationCode,
+  startProviderAuthorizationCode,
+} from "@/hooks/use-provider-accounts";
+
+type ConnectedAuthorization = Extract<
+  ProviderAuthorizationCodeStatusResponse,
+  { status: "connected" }
+>;
+
+/**
+ * starting → awaiting_code → completing → connected | failed | expired.
+ * A rejected code returns to awaiting_code so the user can paste again;
+ * failed/expired need a fresh transaction (`retry`).
+ */
+export type ProviderAuthorizationCodeStatus =
+  | "starting"
+  | "awaiting_code"
+  | "completing"
+  | "connected"
+  | "expired"
+  | "failed";
+
+export type ProviderAuthorizationCodeFailure = {
+  message: string;
+  retryable: boolean;
+  status?: number;
+};
+
+const COUNTDOWN_TICK_INTERVAL_MS = 1_000;
+/** The transaction itself is unusable (consumed, superseded, or gone), not the pasted code. */
+const TRANSACTION_GONE_STATUSES = new Set([404, 409, 410]);
+
+type Flow = {
+  active: boolean;
+  finished: boolean;
+  completing: boolean;
+  expiredWhileCompleting: boolean;
+  cancellationRequested: boolean;
+  transactionId: string | null;
+  deadlineTimer?: ReturnType<typeof setTimeout>;
+  cancel: () => void;
+  expire: () => void;
+};
+
+function authorizationFailure(error: unknown): ProviderAuthorizationCodeFailure {
+  if (error instanceof Error && "status" in error && typeof error.status === "number") {
+    const retryable =
+      "retryable" in error && typeof error.retryable === "boolean"
+        ? error.retryable
+        : error.status >= 500;
+    return { message: error.message, status: error.status, retryable };
+  }
+  return {
+    message: error instanceof Error ? error.message : "Authorization request failed",
+    retryable: true,
+  };
+}
+
+export function useProviderAuthorizationCode(
+  provider: SubscriptionProviderId,
+  target: StartProviderAuthorizationCodeRequest,
+  onConnected: (result: ConnectedAuthorization) => void
+) {
+  // Provider and target are frozen for one flow; remount with a new key to change either.
+  const [{ initialProvider, initialTarget }] = useState(() => ({
+    initialProvider: provider,
+    initialTarget: target,
+  }));
+  const [authorization, setAuthorization] = useState<StartProviderAuthorizationCodeResponse | null>(
+    null
+  );
+  const [failure, setFailure] = useState<ProviderAuthorizationCodeFailure | null>(null);
+  const [status, setStatus] = useState<ProviderAuthorizationCodeStatus>("starting");
+  const [attempt, setAttempt] = useState(0);
+  const [localDeadline, setLocalDeadline] = useState<number | null>(null);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+  const flowRef = useRef<Flow | null>(null);
+  const onConnectedRef = useRef(onConnected);
+
+  useEffect(() => {
+    onConnectedRef.current = onConnected;
+  }, [onConnected]);
+
+  useEffect(() => {
+    const flow: Flow = {
+      active: true,
+      finished: false,
+      completing: false,
+      expiredWhileCompleting: false,
+      cancellationRequested: false,
+      transactionId: null,
+      cancel: () => undefined,
+      expire: () => undefined,
+    };
+    flowRef.current = flow;
+
+    setAuthorization(null);
+    setFailure(null);
+    setStatus("starting");
+    setLocalDeadline(null);
+    setRemainingMs(null);
+
+    flow.cancel = () => {
+      if (!flow.transactionId || flow.finished || flow.cancellationRequested) return;
+      flow.cancellationRequested = true;
+      void cancelProviderAuthorizationCode(initialProvider, flow.transactionId).catch(
+        () => undefined
+      );
+    };
+
+    flow.expire = () => {
+      if (!flow.active || flow.finished) return;
+      if (flow.completing) {
+        flow.expiredWhileCompleting = true;
+        return;
+      }
+      flow.finished = true;
+      setRemainingMs(0);
+      setStatus("expired");
+      setFailure({ message: "Provider authorization expired.", retryable: true });
+    };
+
+    const start = async () => {
+      try {
+        const result = await startProviderAuthorizationCode(initialProvider, initialTarget);
+        flow.transactionId = result.transactionId;
+        if (!flow.active) {
+          flow.cancel();
+          return;
+        }
+        if (result.provider !== initialProvider || result.operation !== initialTarget.operation) {
+          setStatus("failed");
+          setFailure({ message: "Authorization target changed unexpectedly", retryable: true });
+          flow.cancel();
+          return;
+        }
+        setAuthorization(result);
+        setStatus("awaiting_code");
+        flow.deadlineTimer = setTimeout(flow.expire, result.expiresInMs);
+        setLocalDeadline(performance.now() + result.expiresInMs);
+        setRemainingMs(result.expiresInMs);
+      } catch (error) {
+        if (!flow.active) return;
+        setStatus("failed");
+        setFailure(authorizationFailure(error));
+      }
+    };
+
+    void start();
+    return () => {
+      flow.active = false;
+      clearTimeout(flow.deadlineTimer);
+      flow.cancel();
+      if (flowRef.current === flow) flowRef.current = null;
+    };
+  }, [attempt, initialProvider, initialTarget]);
+
+  useEffect(() => {
+    if (localDeadline === null || (status !== "awaiting_code" && status !== "completing")) return;
+    const updateRemaining = () => setRemainingMs(Math.max(0, localDeadline - performance.now()));
+    updateRemaining();
+    const timer = setInterval(updateRemaining, COUNTDOWN_TICK_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [localDeadline, status]);
+
+  const complete = useCallback(
+    async (code: string) => {
+      const flow = flowRef.current;
+      if (!flow || !flow.active || flow.finished || flow.completing || !flow.transactionId) return;
+      const trimmed = code.trim();
+      if (!trimmed) {
+        setFailure({ message: "Enter the authorization code first.", retryable: false });
+        return;
+      }
+
+      flow.completing = true;
+      setFailure(null);
+      setStatus("completing");
+      try {
+        const result = await completeProviderAuthorizationCode(
+          initialProvider,
+          flow.transactionId,
+          trimmed
+        );
+        if (!flow.active) return;
+        flow.completing = false;
+        if (result.status === "pending") {
+          if (flow.expiredWhileCompleting) {
+            flow.expire();
+            return;
+          }
+          setStatus("awaiting_code");
+          setFailure({
+            message: "The code was not accepted yet. Paste it again.",
+            retryable: false,
+          });
+          return;
+        }
+
+        flow.finished = true;
+        clearTimeout(flow.deadlineTimer);
+        if (result.status === "connected") {
+          setStatus("connected");
+          onConnectedRef.current(result);
+          return;
+        }
+        setStatus(result.status === "expired" ? "expired" : "failed");
+        setFailure({ message: result.error, retryable: result.retryable });
+      } catch (error) {
+        if (!flow.active) return;
+        flow.completing = false;
+        if (flow.expiredWhileCompleting) {
+          flow.expire();
+          return;
+        }
+        const nextFailure = authorizationFailure(error);
+        if (nextFailure.status !== undefined && TRANSACTION_GONE_STATUSES.has(nextFailure.status)) {
+          flow.finished = true;
+          clearTimeout(flow.deadlineTimer);
+          setStatus("failed");
+          setFailure({ ...nextFailure, retryable: true });
+          return;
+        }
+        // The transaction is still live: the user can paste the code again.
+        setStatus("awaiting_code");
+        setFailure(nextFailure);
+      }
+    },
+    [initialProvider]
+  );
+
+  return {
+    authorization,
+    failure,
+    status,
+    remainingMs,
+    complete,
+    retry: () => setAttempt((value) => value + 1),
+    cancel: () => flowRef.current?.cancel(),
+  };
+}

--- a/packages/web/src/hooks/use-provider-authorization-code.ts
+++ b/packages/web/src/hooks/use-provider-authorization-code.ts
@@ -10,6 +10,7 @@ import type {
 import {
   cancelProviderAuthorizationCode,
   completeProviderAuthorizationCode,
+  readProviderAuthorizationCodeStatus,
   startProviderAuthorizationCode,
 } from "@/hooks/use-provider-accounts";
 
@@ -17,19 +18,21 @@ type ConnectedAuthorization = Extract<
   ProviderAuthorizationCodeStatusResponse,
   { status: "connected" }
 >;
+type SettledStatus = Exclude<ProviderAuthorizationCodeStatusResponse["status"], "pending">;
 
 /**
- * starting → awaiting_code → completing → connected | failed | expired.
- * A rejected code returns to awaiting_code so the user can paste again;
- * failed/expired need a fresh transaction (`retry`).
+ * starting → awaiting_code → completing → connected | denied | failed |
+ * expired | cancelled | superseded. A code the transaction did not accept
+ * returns to awaiting_code so the user can paste again; every settled state
+ * needs a fresh transaction (`retry`). Settled states are the control
+ * plane's own vocabulary, so the dialog can tell a provider rejection
+ * (`denied`) from a lost transaction (`failed`).
  */
 export type ProviderAuthorizationCodeStatus =
   | "starting"
   | "awaiting_code"
   | "completing"
-  | "connected"
-  | "expired"
-  | "failed";
+  | SettledStatus;
 
 export type ProviderAuthorizationCodeFailure = {
   message: string;
@@ -38,19 +41,41 @@ export type ProviderAuthorizationCodeFailure = {
 };
 
 const COUNTDOWN_TICK_INTERVAL_MS = 1_000;
-/** The transaction itself is unusable (consumed, superseded, or gone), not the pasted code. */
-const TRANSACTION_GONE_STATUSES = new Set([404, 409, 410]);
+/** The transaction itself is gone for this user: never existed, or settled and cleaned up. */
+const TRANSACTION_GONE_STATUSES = new Set([404, 410]);
+/**
+ * A completion whose outcome the browser did not learn (another request owns
+ * the claim, the response was lost, or the deadline aborted it) is settled by
+ * reading the durable status. The window must outlast the control plane's
+ * provider exchange and finalization, so a healthy exchange reports its
+ * result before the hook stops waiting for it.
+ */
+const COMPLETION_RECONCILE_WINDOW_MS = 45_000;
+const COMPLETION_RECONCILE_INTERVAL_MS = 2_000;
+const RECONCILE_PENDING_MESSAGE = "The provider has not confirmed the code yet. Paste it again.";
+
+/**
+ * One transaction's lifecycle. `phase` is the only mutable model: every
+ * async branch reads it before acting, so a settled or torn-down flow
+ * ignores late results, and only one completion or reconciliation can own
+ * the transaction at a time.
+ */
+type Phase =
+  | { kind: "starting" }
+  | { kind: "awaiting_code" }
+  | { kind: "completing"; controller: AbortController }
+  | { kind: "reconciling"; controller: AbortController }
+  | { kind: "settled" };
 
 type Flow = {
   active: boolean;
-  finished: boolean;
-  completing: boolean;
-  expiredWhileCompleting: boolean;
-  cancellationRequested: boolean;
+  phase: Phase;
   transactionId: string | null;
+  deadlineAt: number | null;
   deadlineTimer?: ReturnType<typeof setTimeout>;
+  cancellationRequested: boolean;
+  complete: (code: string) => Promise<void>;
   cancel: () => void;
-  expire: () => void;
 };
 
 function authorizationFailure(error: unknown): ProviderAuthorizationCodeFailure {
@@ -65,6 +90,28 @@ function authorizationFailure(error: unknown): ProviderAuthorizationCodeFailure 
     message: error instanceof Error ? error.message : "Authorization request failed",
     retryable: true,
   };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export function useProviderAuthorizationCode(
@@ -95,13 +142,12 @@ export function useProviderAuthorizationCode(
   useEffect(() => {
     const flow: Flow = {
       active: true,
-      finished: false,
-      completing: false,
-      expiredWhileCompleting: false,
-      cancellationRequested: false,
+      phase: { kind: "starting" },
       transactionId: null,
+      deadlineAt: null,
+      cancellationRequested: false,
+      complete: async () => undefined,
       cancel: () => undefined,
-      expire: () => undefined,
     };
     flowRef.current = flow;
 
@@ -111,24 +157,162 @@ export function useProviderAuthorizationCode(
     setLocalDeadline(null);
     setRemainingMs(null);
 
+    const deadlinePassed = () => flow.deadlineAt !== null && performance.now() >= flow.deadlineAt;
+
+    const abortInFlight = () => {
+      if (flow.phase.kind === "completing" || flow.phase.kind === "reconciling") {
+        flow.phase.controller.abort();
+      }
+    };
+
+    const settle = (
+      nextStatus: SettledStatus,
+      nextFailure: ProviderAuthorizationCodeFailure | null
+    ) => {
+      abortInFlight();
+      flow.phase = { kind: "settled" };
+      clearTimeout(flow.deadlineTimer);
+      setStatus(nextStatus);
+      setFailure(nextFailure);
+    };
+
+    const settleFromResponse = (result: ProviderAuthorizationCodeStatusResponse) => {
+      if (result.status === "pending") return false;
+      if (result.status === "connected") {
+        settle("connected", null);
+        onConnectedRef.current(result);
+        return true;
+      }
+      settle(result.status, { message: result.error, retryable: result.retryable });
+      return true;
+    };
+
+    const expireNow = () => {
+      settle("expired", { message: "Provider authorization expired.", retryable: true });
+      setRemainingMs(0);
+    };
+
+    const awaitCode = (nextFailure: ProviderAuthorizationCodeFailure | null) => {
+      if (deadlinePassed()) {
+        expireNow();
+        return;
+      }
+      flow.phase = { kind: "awaiting_code" };
+      setStatus("awaiting_code");
+      setFailure(nextFailure);
+    };
+
     flow.cancel = () => {
-      if (!flow.transactionId || flow.finished || flow.cancellationRequested) return;
+      if (!flow.transactionId || flow.phase.kind === "settled" || flow.cancellationRequested) {
+        return;
+      }
       flow.cancellationRequested = true;
       void cancelProviderAuthorizationCode(initialProvider, flow.transactionId).catch(
         () => undefined
       );
     };
 
-    flow.expire = () => {
-      if (!flow.active || flow.finished) return;
-      if (flow.completing) {
-        flow.expiredWhileCompleting = true;
+    // At the deadline an idle transaction expires locally. A completion still
+    // in flight is aborted instead; its own handling then reconciles the
+    // durable status, so a result the control plane already reached is kept.
+    const expire = () => {
+      if (!flow.active || flow.phase.kind === "settled") return;
+      if (flow.phase.kind === "completing") {
+        flow.phase.controller.abort();
         return;
       }
-      flow.finished = true;
-      setRemainingMs(0);
-      setStatus("expired");
-      setFailure({ message: "Provider authorization expired.", retryable: true });
+      if (flow.phase.kind === "reconciling") return;
+      expireNow();
+    };
+
+    const reconcile = async () => {
+      if (!flow.active || flow.phase.kind === "settled" || !flow.transactionId) return;
+      const controller = new AbortController();
+      flow.phase = { kind: "reconciling", controller };
+      setStatus("completing");
+      const startedAt = performance.now();
+      while (
+        flow.active &&
+        flow.phase.kind === "reconciling" &&
+        flow.phase.controller === controller
+      ) {
+        try {
+          const result = await readProviderAuthorizationCodeStatus(
+            initialProvider,
+            flow.transactionId,
+            controller.signal
+          );
+          if (!flow.active || flow.phase.kind !== "reconciling") return;
+          if (settleFromResponse(result)) return;
+        } catch (error) {
+          if (!flow.active || flow.phase.kind !== "reconciling" || isAbortError(error)) return;
+          const nextFailure = authorizationFailure(error);
+          if (
+            nextFailure.status !== undefined &&
+            TRANSACTION_GONE_STATUSES.has(nextFailure.status)
+          ) {
+            settle("failed", { ...nextFailure, retryable: true });
+            return;
+          }
+        }
+        if (performance.now() - startedAt >= COMPLETION_RECONCILE_WINDOW_MS) break;
+        await abortableDelay(COMPLETION_RECONCILE_INTERVAL_MS, controller.signal);
+      }
+      if (
+        !flow.active ||
+        flow.phase.kind !== "reconciling" ||
+        flow.phase.controller !== controller
+      ) {
+        return;
+      }
+      // Still pending after the window: nothing consumed the code, so the
+      // user may paste it again while the transaction is alive.
+      awaitCode({ message: RECONCILE_PENDING_MESSAGE, retryable: false });
+    };
+
+    flow.complete = async (code: string) => {
+      if (!flow.active || flow.phase.kind !== "awaiting_code" || !flow.transactionId) return;
+      const trimmed = code.trim();
+      if (!trimmed) {
+        setFailure({ message: "Enter the authorization code first.", retryable: false });
+        return;
+      }
+
+      const controller = new AbortController();
+      flow.phase = { kind: "completing", controller };
+      setFailure(null);
+      setStatus("completing");
+      try {
+        const result = await completeProviderAuthorizationCode(
+          initialProvider,
+          flow.transactionId,
+          trimmed,
+          controller.signal
+        );
+        if (!flow.active || flow.phase.kind !== "completing") return;
+        if (!settleFromResponse(result)) {
+          awaitCode({
+            message: "The code was not accepted yet. Paste it again.",
+            retryable: false,
+          });
+        }
+      } catch (error) {
+        if (!flow.active || flow.phase.kind !== "completing") return;
+        const nextFailure = authorizationFailure(error);
+        // The outcome is unknown: the deadline aborted the request, another
+        // request owns the completion claim (409), or the transport failed.
+        // The durable status says what actually happened.
+        if (isAbortError(error) || nextFailure.status === 409 || nextFailure.status === undefined) {
+          await reconcile();
+          return;
+        }
+        if (TRANSACTION_GONE_STATUSES.has(nextFailure.status)) {
+          settle("failed", { ...nextFailure, retryable: true });
+          return;
+        }
+        // The transaction is still live and the code was not consumed.
+        awaitCode(nextFailure);
+      }
     };
 
     const start = async () => {
@@ -140,20 +324,23 @@ export function useProviderAuthorizationCode(
           return;
         }
         if (result.provider !== initialProvider || result.operation !== initialTarget.operation) {
-          setStatus("failed");
-          setFailure({ message: "Authorization target changed unexpectedly", retryable: true });
+          settle("failed", {
+            message: "Authorization target changed unexpectedly",
+            retryable: true,
+          });
           flow.cancel();
           return;
         }
         setAuthorization(result);
+        flow.phase = { kind: "awaiting_code" };
         setStatus("awaiting_code");
-        flow.deadlineTimer = setTimeout(flow.expire, result.expiresInMs);
-        setLocalDeadline(performance.now() + result.expiresInMs);
+        flow.deadlineAt = performance.now() + result.expiresInMs;
+        flow.deadlineTimer = setTimeout(expire, result.expiresInMs);
+        setLocalDeadline(flow.deadlineAt);
         setRemainingMs(result.expiresInMs);
       } catch (error) {
         if (!flow.active) return;
-        setStatus("failed");
-        setFailure(authorizationFailure(error));
+        settle("failed", authorizationFailure(error));
       }
     };
 
@@ -161,6 +348,7 @@ export function useProviderAuthorizationCode(
     return () => {
       flow.active = false;
       clearTimeout(flow.deadlineTimer);
+      abortInFlight();
       flow.cancel();
       if (flowRef.current === flow) flowRef.current = null;
     };
@@ -175,69 +363,8 @@ export function useProviderAuthorizationCode(
   }, [localDeadline, status]);
 
   const complete = useCallback(
-    async (code: string) => {
-      const flow = flowRef.current;
-      if (!flow || !flow.active || flow.finished || flow.completing || !flow.transactionId) return;
-      const trimmed = code.trim();
-      if (!trimmed) {
-        setFailure({ message: "Enter the authorization code first.", retryable: false });
-        return;
-      }
-
-      flow.completing = true;
-      setFailure(null);
-      setStatus("completing");
-      try {
-        const result = await completeProviderAuthorizationCode(
-          initialProvider,
-          flow.transactionId,
-          trimmed
-        );
-        if (!flow.active) return;
-        flow.completing = false;
-        if (result.status === "pending") {
-          if (flow.expiredWhileCompleting) {
-            flow.expire();
-            return;
-          }
-          setStatus("awaiting_code");
-          setFailure({
-            message: "The code was not accepted yet. Paste it again.",
-            retryable: false,
-          });
-          return;
-        }
-
-        flow.finished = true;
-        clearTimeout(flow.deadlineTimer);
-        if (result.status === "connected") {
-          setStatus("connected");
-          onConnectedRef.current(result);
-          return;
-        }
-        setStatus(result.status === "expired" ? "expired" : "failed");
-        setFailure({ message: result.error, retryable: result.retryable });
-      } catch (error) {
-        if (!flow.active) return;
-        flow.completing = false;
-        if (flow.expiredWhileCompleting) {
-          flow.expire();
-          return;
-        }
-        const nextFailure = authorizationFailure(error);
-        if (nextFailure.status !== undefined && TRANSACTION_GONE_STATUSES.has(nextFailure.status)) {
-          flow.finished = true;
-          clearTimeout(flow.deadlineTimer);
-          setStatus("failed");
-          setFailure({ ...nextFailure, retryable: true });
-          return;
-        }
-        // The transaction is still live: the user can paste the code again.
-        setStatus("awaiting_code");
-        setFailure(nextFailure);
-      }
-    },
-    [initialProvider]
+    (code: string) => flowRef.current?.complete(code) ?? Promise.resolve(),
+    []
   );
 
   return {

--- a/packages/web/src/lib/provider-account-proxy.ts
+++ b/packages/web/src/lib/provider-account-proxy.ts
@@ -2,6 +2,8 @@ import {
   MODEL_PROVIDER_ACCOUNT_ID_PATTERN,
   PROVIDER_DEVICE_AUTHORIZATION_ID_PATTERN,
   SUBSCRIPTION_PROVIDER_IDS,
+  modelProviderAccountConnectionMethod,
+  type ModelProviderAccountConnectionMethod,
   type SubscriptionProviderId,
 } from "@open-inspect/shared/types/provider-accounts";
 import { NextResponse } from "next/server";
@@ -19,6 +21,16 @@ export function validProviderDeviceAuthorizationId(id: string): boolean {
 
 export function validSubscriptionProvider(provider: string): provider is SubscriptionProviderId {
   return SUBSCRIPTION_PROVIDER_IDS.some((candidate) => candidate === provider);
+}
+
+/** A provider whose accounts connect through the given method; the other method's routes refuse it. */
+export function validProviderForConnectionMethod(
+  provider: string,
+  method: ModelProviderAccountConnectionMethod
+): provider is SubscriptionProviderId {
+  return (
+    validSubscriptionProvider(provider) && modelProviderAccountConnectionMethod(provider) === method
+  );
 }
 
 function invalidProviderParameter(): NextResponse {


### PR DESCRIPTION
## Summary

Settings > Provider Accounts learns to connect a Claude account. Stacked on #1856; it depends on #1855 for the routes.

- `provider-authorization-code-dialog.tsx`: two entry points, one mounted at a time. Browser: open the authorization URL, paste the `code#state` value the consent page shows (the `#state` half is required), and the dialog completes the transaction. Setup token: paste the output of `claude setup-token`. Switching to the setup token unmounts the browser flow and cancels its transaction; a save in flight locks the inputs, Back, Cancel and dismissal, so two credential writes never overlap.
- `use-provider-authorization-code.ts`: the transaction lifecycle (start, complete, reconcile, cancel) as one phase machine, validated with the shared schemas. A completion is abortable; when its outcome is unknown (another request owns the claim, a lost response, or the deadline aborted it) the hook polls the durable status for a bounded window before it decides. Only 404/410 mean the transaction is gone. Settled states use the control plane's vocabulary, so a provider rejection (`denied`) offers a fresh transaction.
- The settings page's connection strategies are a complete record again: Anthropic maps to the authorization-code dialog and Verify is hidden for static-credential providers. The reconnect dialog explains that sessions which already received the credential keep it until their sandbox exits. A form closes as soon as its write succeeds and the list refreshes best-effort, so a refresh failure cannot resubmit an identity-less setup-token account.
- The authorization-code BFF routes accept only providers that connect by that method.

## Testing

- `npm run typecheck`, `npm run lint`.
- web 1648 passed. The hook tests cover start, completion, 409 reconciliation, a never-settling completion aborted at the deadline, unmount abort, expiry and reconnect; the dialog tests cover both entry points, cancel with a pasted code, Start over after denial, and the save lock; the settings tests cover a connect whose refresh fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Anthropic account connection and reconnection through an authorization-code flow.
  - Added support for connecting with a Claude setup token where applicable.
  - Added progress, countdown, cancellation, retry, and failure states during authorization.
  - Added clearer handling for denied or expired authorization attempts.
- **Bug Fixes**
  - Improved account refresh and error feedback after connection actions.
  - Added credential-rotation warnings and restricted unsupported account actions for Anthropic connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->