### PR TITLE
docs: Claude Agent guide, runbook and release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ beside OpenCode. Choose the harness in the composer; the model list follows what
 run, child sessions inherit it, and automations carry it. Claude Agent sessions can use a
 **connected Claude subscription** from Settings > Provider Accounts (browser authorization or a
 pasted `claude setup-token`), delivered to the sandbox at boot and never written to disk. Disabling
-or reconnecting an account stops the sandboxes that received it. See
-[Using the Claude Agent Harness](docs/CLAUDE_AGENT.md).
+or reconnecting an account stops new hand-outs; a sandbox that already holds the token keeps it
+until it exits. See [Using the Claude Agent Harness](docs/CLAUDE_AGENT.md).
 
-**Deploy note.** This release ships D1 migrations `0075` and `0076`. Session create/resume and the
-Provider Accounts page are unavailable for a few minutes between the migration apply and the worker
-deploy; the runtime manifest bump retires existing snapshots and prebuilt images once.
+**Deploy note.** This release ships D1 migrations `0075` and `0076`. Session create/resume is
+unavailable for a few minutes between the migration apply and the worker deploy; the runtime
+manifest bump retires existing snapshots and prebuilt images once.
 
 ## September 1, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 **Claude Fable 5.1.** Adds `claude-fable-5-1` to the model picker and integrations, with adaptive
 thinking controls from low through max.
 
+**Claude Agent harness.** Sessions can now run on the Claude Agent SDK as a second agent harness
+beside OpenCode. Choose the harness in the composer; the model list follows what the harness can
+run, child sessions inherit it, and automations carry it. Claude Agent sessions can use a
+**connected Claude subscription** from Settings > Provider Accounts (browser authorization or a
+pasted `claude setup-token`), delivered to the sandbox at boot and never written to disk. Disabling
+or reconnecting an account stops the sandboxes that received it. See
+[Using the Claude Agent Harness](docs/CLAUDE_AGENT.md).
+
+**Deploy note.** This release ships D1 migrations `0075` and `0076`. Session create/resume and the
+Provider Accounts page are unavailable for a few minutes between the migration apply and the worker
+deploy; the runtime manifest bump retires existing snapshots and prebuilt images once.
+
 ## September 1, 2026
 
 **Workspace audit log.** Owners, Administrators, and authorized custom roles can review paginated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,10 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 **Claude Fable 5.1.** Adds `claude-fable-5-1` to the model picker and integrations, with adaptive
 thinking controls from low through max.
 
-**Claude Agent harness.** Sessions can now run on the Claude Agent SDK as a second agent harness
-beside OpenCode. Choose the harness in the composer; the model list follows what the harness can
-run, child sessions inherit it, and automations carry it. Claude Agent sessions can use a
-**connected Claude subscription** from Settings > Provider Accounts (browser authorization or a
-pasted `claude setup-token`), delivered to the sandbox at boot and never written to disk. Disabling
-or reconnecting an account stops new hand-outs; a sandbox that already holds the token keeps it
-until it exits. See [Using the Claude Agent Harness](docs/CLAUDE_AGENT.md).
-
-**Deploy note.** This release ships D1 migrations `0075` and `0076`. Session create/resume is
-unavailable for a few minutes between the migration apply and the worker deploy; the runtime
-manifest bump retires existing snapshots and prebuilt images once.
+**Claude Agent harness.** Sessions can run on the Claude Agent SDK as a second harness beside
+OpenCode, chosen in the composer and inherited by child sessions and automations. Claude Agent
+sessions can use a **connected Claude subscription** from Settings > Provider Accounts instead of an
+API key. See [Using the Claude Agent Harness](docs/CLAUDE_AGENT.md).
 
 ## September 1, 2026
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Open-Inspect provides a hosted background coding agent that can:
 - Run scheduled automations for cron jobs, or event-driven automations for GitHub events, Sentry
   alerts, and webhooks
 - Spawn parallel sub-tasks that work in separate sandboxes simultaneously
-- Use your choice of AI model — Anthropic Claude, OpenAI Codex (via ChatGPT subscription), xAI Grok
-  (via SuperGrok subscription), or OpenCode Zen
+- Use your choice of AI model — Anthropic Claude (via API key or a connected Claude subscription on
+  the Claude Agent harness), OpenAI Codex (via ChatGPT subscription), xAI Grok (via SuperGrok
+  subscription), or OpenCode Zen
 
 ## Security Model (Single-Tenant Only)
 
@@ -107,7 +108,9 @@ ownership, bots, and member suspension.
 │  ┌──────────────────────────────────────────────────────────────┐  │
 │  │                     Session Sandbox                          │  │
 │  │  ┌───────────┐  ┌───────────┐  ┌───────────┐                 │  │
-│  │  │ Supervisor│──│  OpenCode │──│   Bridge  │─────────────────┼──┼──▶ Control Plane
+│  │  │ Supervisor│──│  Harness  │──│   Bridge  │─────────────────┼──┼──▶ Control Plane
+│  │  └───────────┘  │ (OpenCode │  └───────────┘                 │  │
+│  │                 │ or Claude)│                                │  │
 │  │  └───────────┘  └───────────┘  └───────────┘                 │  │
 │  │                      │                                       │  │
 │  │              Full Dev Environment                            │  │
@@ -213,7 +216,9 @@ Choose the AI model that fits your task, with per-session reasoning effort contr
 | Z.AI Coding Plan | GLM 5.2/5.3 (opt-in)                                                    |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
-Grok models work with an eligible SuperGrok subscription through control-plane-managed OAuth. See
+Anthropic models can run on the **Claude Agent** harness with a connected Claude subscription; see
+[Using the Claude Agent Harness](docs/CLAUDE_AGENT.md). Grok models work with an eligible SuperGrok
+subscription through control-plane-managed OAuth. See
 **[docs/AVAILABLE_MODELS.md](docs/AVAILABLE_MODELS.md)** for the full model list and
 **[docs/OPENAI_MODELS.md](docs/OPENAI_MODELS.md)** or **[docs/GROK_MODELS.md](docs/GROK_MODELS.md)**
 for subscription setup instructions.
@@ -317,5 +322,7 @@ built with:
 - [OpenComputer](https://www.opencomputer.dev) - Cloud sandbox infrastructure
 - [E2B](https://e2b.dev) - Cloud sandbox infrastructure
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing
-- [OpenCode](https://opencode.ai) - Coding agent runtime
+- [OpenCode](https://opencode.ai) - Coding agent runtime (built-in harness)
+- [Claude Agent SDK](https://docs.anthropic.com/en/docs/agent-sdk) - Coding agent runtime (Claude
+  Agent harness)
 - [Next.js](https://nextjs.org) - Web framework

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ownership, bots, and member suspension.
 │  │  │ Supervisor│──│  Harness  │──│   Bridge  │─────────────────┼──┼──▶ Control Plane
 │  │  └───────────┘  │ (OpenCode │  └───────────┘                 │  │
 │  │                 │ or Claude)│                                │  │
-│  │  └───────────┘  └───────────┘  └───────────┘                 │  │
+│  │                 └───────────┘                                │  │
 │  │                      │                                       │  │
 │  │              Full Dev Environment                            │  │
 │  │      (Node.js, Python, git, agent-browser)                   │  │

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -9,7 +9,8 @@ subscriptions are configured in **Settings > Provider Accounts**; Z.AI Coding Pl
 OpenAI, xAI and Anthropic session selectors offer provider policy, any active connected account, and
 API-key mode. Automation editors can resolve defaults on each run or pin an account/API-key choice.
 Unattended Slack, GitHub, Linear, and unpinned automation launches follow the provider's configured
-unattended mode.
+unattended mode. For Anthropic that policy reaches only Claude Agent automations: Slack, GitHub and
+Linear launches run on OpenCode, which uses the API key.
 
 ## Harnesses
 

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -6,12 +6,27 @@ and DeepSeek models are available but must be enabled in **Settings > Models**. 
 subscriptions are configured in **Settings > Provider Accounts**; Z.AI Coding Plan requires
 `ZHIPU_API_KEY`; DeepSeek requires `DEEPSEEK_API_KEY`.
 
-OpenAI and xAI session selectors offer provider policy, any active connected account, and API-key
-mode. Automation editors can resolve defaults on each run or pin an account/API-key choice.
+OpenAI, xAI and Anthropic session selectors offer provider policy, any active connected account, and
+API-key mode. Automation editors can resolve defaults on each run or pin an account/API-key choice.
 Unattended Slack, GitHub, Linear, and unpinned automation launches follow the provider's configured
 unattended mode.
 
+## Harnesses
+
+A session runs on one agent harness, fixed at create. Which models and which Anthropic
+authentication a session can use depends on it:
+
+| Harness      | Models            | Anthropic authentication                   |
+| ------------ | ----------------- | ------------------------------------------ |
+| OpenCode     | every model below | `ANTHROPIC_API_KEY`                        |
+| Claude Agent | Anthropic models  | `ANTHROPIC_API_KEY` or a connected account |
+
+See [Using the Claude Agent Harness](CLAUDE_AGENT.md).
+
 ## Anthropic
+
+Anthropic models run on both harnesses. A connected Claude subscription (Settings > Provider
+Accounts) applies only on the Claude Agent harness; OpenCode sessions use `ANTHROPIC_API_KEY`.
 
 | Model ID                      | Display name      | Description                                       | Reasoning efforts             | Default effort |
 | ----------------------------- | ----------------- | ------------------------------------------------- | ----------------------------- | -------------- |

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -83,8 +83,7 @@ at create.
 3. On every bridge start (fresh spawn, supervised restart, snapshot restore), the Claude harness
    calls the sandbox-authenticated endpoint
    `POST /sessions/:id/provider-auth/anthropic/runtime-credential`. The control plane checks the
-   binding and the account, decrypts the token, records an **issuance** (session, sandbox,
-   credential version) and returns the token with `Cache-Control: no-store`.
+   binding and the account, decrypts the token and returns it with `Cache-Control: no-store`.
 4. The harness keeps the token in process memory and launches the `claude` binary through a
    **clean-credential wrapper**: the child sees the sandbox environment exactly as OpenCode does
    (the sandbox token, `SESSION_CONFIG`, user secrets, proxies) minus the Anthropic credentials of
@@ -103,11 +102,13 @@ exfiltration by code the agent chooses to run. The sandbox helpers (`oi-git-sign
 
 ## Lifecycle: disable, archive, reconnect
 
-Disabling, archiving or reconnecting a Claude account denies future issuance immediately and
-enqueues a durable cleanup task in the same database write. A coordinator (run every minute by the
-scheduler) stops every sandbox that holds a live issuance at or below the revoked credential
-version, using a sandbox-id-conditional stop so a session whose sandbox was respawned since is
-untouched. The next prompt on an affected session fails the pre-spawn check with reconnect guidance.
+Disabling, archiving or reconnecting a Claude account stops new hand-outs immediately: the next
+bridge start on any session bound to the account is refused, and the next prompt on such a session
+fails the pre-spawn check with reconnect guidance. A sandbox that already holds the token keeps it
+in memory until it exits (inactivity timeout, hard timeout, or a stop), so a turn already running
+finishes on the old token. Open-Inspect does not chase running sandboxes: the token stays valid at
+Anthropic whatever Open-Inspect does, so stopping its own sandboxes would only shorten a window it
+cannot close. Revocation happens at Anthropic (runbook below).
 
 The sandbox is never authoritative for account lifecycle. A runtime authentication failure fails the
 prompt with reconnect guidance and emits a warning; only local expiry (the recorded expiry
@@ -118,20 +119,22 @@ account active and appear on the session timeline.
 
 ## Runbook: revoking a Claude setup token
 
-Reconnecting or disabling in Open-Inspect rotates what Open-Inspect stores and stops the sandboxes
-that received the old token. It does **not** revoke the token at Anthropic. A token that has left
-the deployment stays valid until Anthropic expires it. To revoke:
+Reconnecting or disabling in Open-Inspect rotates or fences what Open-Inspect stores. It does
+**not** revoke the token at Anthropic, and it does not stop sandboxes that already hold the token;
+they keep it until they exit. A token that has left the deployment stays valid until Anthropic
+expires it or you revoke it. To revoke:
 
-1. In Open-Inspect, **Disable** (or **Archive**) the account. Wait one scheduler tick (one minute)
-   and confirm in the control-plane logs that `provider_credential.issuance_terminated` fired for
-   every session listed under `provider_credential.issued` for that account.
+1. In Open-Inspect, **Disable** (or **Archive**) the account so no new sandbox receives the token.
+   Sessions with a running sandbox keep it until that sandbox exits; stop those sessions from the
+   session page if you want that sooner. The control-plane log lists every hand-out under
+   `provider_credential.issued`.
 2. At Anthropic, sign in to the subscription that minted the token and revoke it. A slot connected
    in the browser stores Anthropic's `token_uuid` for the credential; quote it in a support request.
    `claude auth logout` on a workstation does **not** revoke an environment-supplied token, so use
    the account's connected-applications / API session management in the Claude console, or contact
    Anthropic support if no self-service revocation is offered for setup tokens.
 3. Mint a new token (browser authorization or `claude setup-token`) and **Reconnect** the slot.
-4. Start a new session; sessions that were stopped resume from their snapshot on the next prompt.
+4. Start a new session, or prompt an existing one; the next bridge start fetches the new token.
 
 ---
 

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -55,10 +55,12 @@ A slot connected by **browser authorization** records the Claude account that gr
 returns the account and organization with the token), so a second slot for the same account is
 rejected as a duplicate and a reconnect from a different Claude account is refused. A slot connected
 by **pasting a setup token** has no identity: Open-Inspect cannot tell two pasted tokens apart and
-does not de-duplicate them. A slot's identity is fixed when it is created: reconnecting a pasted
-slot in the browser keeps it identity-less. Neither kind can be verified against Anthropic on
-demand. Reconnecting replaces what Open-Inspect stores for that slot; it does not revoke the
-previous token at Anthropic (see the runbook below).
+does not de-duplicate them. A pasted slot adopts an identity the first time it is reconnected in the
+browser, unless that Claude account already has a slot. Once a slot has an identity it is
+reconnected in the browser only; the setup-token option is not offered for it, so the granting
+account is always verified. Neither kind can be verified against Anthropic on demand. Reconnecting
+replaces what Open-Inspect stores for that slot; it does not revoke the previous token at Anthropic
+(see the runbook below).
 
 ### Step 2: Configure defaults
 

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -1,0 +1,169 @@
+# Using the Claude Agent Harness with a Claude Subscription
+
+Open-Inspect can run a session on one of two agent harnesses. **OpenCode** is the built-in harness
+and runs every model in the catalog. **Claude Agent** runs Anthropic models through the Claude Agent
+SDK inside the sandbox, and it is the harness that can use a connected Claude subscription instead
+of an API key.
+
+This deployment uses a connected Claude account as first-party use of the deployment owner's own
+subscription by the owner's own authorised users. The platform holds the credential; users never
+sign in inside a sandbox.
+
+> **Note**: Model availability under a Claude subscription is controlled by Anthropic. Confirm the
+> account you connect can use the selected model before rolling it out broadly.
+
+---
+
+## Choosing a harness
+
+Every session runs on exactly one harness, chosen when the session is created and fixed for its
+lifetime (like the base branch). Child sessions inherit their parent's harness. Automations carry a
+harness for the sessions they create. Bots and integrations create OpenCode sessions.
+
+| Harness          | Models                | Anthropic authentication                   | Notes                                 |
+| ---------------- | --------------------- | ------------------------------------------ | ------------------------------------- |
+| **OpenCode**     | Every catalog model   | `ANTHROPIC_API_KEY` only                   | Built-in; the default                 |
+| **Claude Agent** | Anthropic models only | `ANTHROPIC_API_KEY` or a connected account | Reads repository `CLAUDE.md` natively |
+
+The composer shows a harness menu beside the model picker; the model list is filtered to what the
+chosen harness can run. A per-message model override that the session's harness cannot run is
+rejected with an error rather than silently replaced.
+
+An **installation default** Anthropic account only takes effect on Claude Agent sessions. OpenCode,
+bot and automation sessions on OpenCode keep using the API key, so setting a default never breaks
+sessions that cannot use it.
+
+---
+
+## Setup
+
+### Step 1: Connect a Claude account
+
+1. Open **Settings > Provider Accounts**.
+2. Choose **Add account > Claude** and name the slot.
+3. Either:
+   - **Authorize in the browser**: open the Anthropic consent page, grant access with the scope
+     `user:inference`, copy the code Anthropic displays, and paste it back into the dialog; or
+   - **Paste a setup token**: run `claude setup-token` on a workstation signed in to the
+     subscription and paste the printed `sk-ant-oat…` value.
+
+The credential is a Claude **setup token**: inference-only, valid for about a year, and static. It
+does not rotate and carries no refresh token. Open-Inspect encrypts it at rest and never shows it in
+the browser.
+
+A slot connected by **browser authorization** records the Claude account that granted it (Anthropic
+returns the account and organization with the token), so a second slot for the same account is
+rejected as a duplicate and a reconnect from a different Claude account is refused. A slot connected
+by **pasting a setup token** has no identity: Open-Inspect cannot tell two pasted tokens apart and
+does not de-duplicate them. A slot's identity is fixed when it is created: reconnecting a pasted
+slot in the browser keeps it identity-less. Neither kind can be verified against Anthropic on
+demand. Reconnecting replaces what Open-Inspect stores for that slot; it does not revoke the
+previous token at Anthropic (see the runbook below).
+
+### Step 2: Configure defaults
+
+Choose an Anthropic **Default account** in **Settings > Provider Accounts** if unattended Claude
+Agent sessions should use the subscription. Set **Unattended mode** to **Use API key** to keep
+automations on the platform key while interactive sessions pick the account.
+
+### Step 3: Create a Claude Agent session
+
+Pick **Claude Agent** in the composer, choose an Anthropic model, and select the connected account
+in the provider controls (or leave the policy default). The session's authentication choice is fixed
+at create.
+
+---
+
+## How the credential reaches the sandbox
+
+1. At session create, the Anthropic selection is persisted with the session before any sandbox is
+   spawned. Every later prompt runs a pre-spawn check: a disabled, archived or fenced account fails
+   the prompt in the queue with reconnect guidance instead of spawning a sandbox into a denial.
+2. The sandbox boots with `ANTHROPIC_OAUTH_MANAGED=1` and no Anthropic key in its user secrets.
+3. On every bridge start (fresh spawn, supervised restart, snapshot restore), the Claude harness
+   calls the sandbox-authenticated endpoint
+   `POST /sessions/:id/provider-auth/anthropic/runtime-credential`. The control plane checks the
+   binding and the account, decrypts the token, records an **issuance** (session, sandbox,
+   credential version) and returns the token with `Cache-Control: no-store`.
+4. The harness keeps the token in process memory and launches the `claude` binary through a
+   **clean-credential wrapper**: the child sees the sandbox environment exactly as OpenCode does
+   (the sandbox token, `SESSION_CONFIG`, user secrets, proxies) minus the Anthropic credentials of
+   the other mode, so it holds exactly one Anthropic credential (`CLAUDE_CODE_OAUTH_TOKEN` in
+   account mode, `ANTHROPIC_API_KEY` in key mode), never both. Nothing is written to disk, so
+   snapshots carry no credential and a restore re-fetches.
+
+Code the agent runs from Bash inherits the `claude` process environment, so repository code can read
+the token, the same way it can read the sandbox token and user secrets under either harness. This
+same-sandbox exposure is accepted; the wrapper limits accidental propagation (OpenCode, code-server,
+the terminal, user shells and repository hooks never see the Claude token), not deliberate
+exfiltration by code the agent chooses to run. The sandbox helpers (`oi-git-sign`,
+`oi-git-credentials`, `upload-media`) need the session context, which is why it passes through.
+
+---
+
+## Lifecycle: disable, archive, reconnect
+
+Disabling, archiving or reconnecting a Claude account denies future bootstrap immediately and
+enqueues a durable cleanup task in the same database write. A coordinator (run every minute by the
+scheduler) stops every sandbox that holds a live issuance at or below the revoked credential
+version, using a sandbox-id-conditional stop so a session whose sandbox was respawned since is
+untouched. The next prompt on an affected session fails the pre-spawn check with reconnect guidance.
+
+The sandbox is never authoritative for account lifecycle. A runtime authentication failure fails the
+prompt with reconnect guidance and emits a warning; only local expiry (the recorded expiry
+approaching) fences an account to **reconnect required**. Quota and rate-limit warnings keep the
+account active and appear on the session timeline.
+
+---
+
+## Runbook: revoking a Claude setup token
+
+Reconnecting or disabling in Open-Inspect rotates what Open-Inspect stores and stops the sandboxes
+that received the old token. It does **not** revoke the token at Anthropic. A token that has left
+the deployment stays valid until Anthropic expires it. To revoke:
+
+1. In Open-Inspect, **Disable** (or **Archive**) the account. Wait one scheduler tick (one minute)
+   and confirm in the control-plane logs that `provider_credential.issuance_terminated` fired for
+   every session listed under `provider_credential.issued` for that account.
+2. At Anthropic, sign in to the subscription that minted the token and revoke it. A slot connected
+   in the browser stores Anthropic's `token_uuid` for the credential; quote it in a support request.
+   `claude auth logout` on a workstation does **not** revoke an environment-supplied token, so use
+   the account's connected-applications / API session management in the Claude console, or contact
+   Anthropic support if no self-service revocation is offered for setup tokens.
+3. Mint a new token (browser authorization or `claude setup-token`) and **Reconnect** the slot.
+4. Start a new session; sessions that were stopped resume from their snapshot on the next prompt.
+
+---
+
+## Deploying this feature: the migration window
+
+Migrations `0075` (session harness) and `0076` (Anthropic provider accounts) are applied by
+`terraform apply` before the worker is deployed. Once `0076` is applied, the previous worker rejects
+session create/resume and the Provider Accounts settings page until the new worker is live, because
+it requires exactly two provider rows per session and rejects a third provider in payloads. On
+Cloudflare this is one window of a few minutes; on Vercel there is a second window until the web
+deploy lands. Announce it and prefer a low-traffic slot.
+
+**Rollback is fix-forward.** There is no reverse script: one that deleted Anthropic rows would
+delete provider accounts and strand every Claude Agent session created after the migration. Deploy a
+fix instead.
+
+---
+
+## Operational notes
+
+- **Cost.** The Claude harness reports the SDK's client-side cost estimate per turn (running total
+  at turn end minus the total at turn start, reset when the agent process restarts). Under a
+  subscription it is informational, but the session spend limit still applies to it as configured; a
+  limit of `0` remains unlimited.
+- **Skills.** Managed skills and the bundled skills are staged under the per-sandbox
+  `CLAUDE_CONFIG_DIR` (`~/.openinspect/claude/skills`); repository `.claude/` settings, hooks and
+  agents load through `setting_sources=["user","project"]`, the same trust boundary as the
+  repository's `.openinspect/setup.sh` and `.opencode/` directory under OpenCode.
+- **Tools.** Open-Inspect's own tools (`create-pull-request`, child sessions, `slack-notify`,
+  `upload-media`) are served to the Claude harness in-process as the `oi` MCP server; session MCP
+  servers are passed through unchanged.
+- **Follow-ups queue.** Both harnesses hold follow-up prompts until the running turn completes.
+- **Image.** The sandbox image pins `claude-agent-sdk`, whose wheel bundles the `claude` binary;
+  bumping it retires snapshots and prebuilt images through the runtime manifest, like any runtime
+  bump.

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -163,7 +163,14 @@ fix instead.
 - **Tools.** Open-Inspect's own tools (`create-pull-request`, child sessions, `slack-notify`,
   `upload-media`) are served to the Claude harness in-process as the `oi` MCP server; session MCP
   servers are passed through unchanged.
+- **Sub-agents.** The child runs with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`, so an `Agent` tool
+  call returns only when its sub-agent has finished, and several sub-agents launched in one message
+  still run concurrently. This is the same contract as OpenCode's `task` tool, and the timeline
+  groups the sub-agent's activity under it the same way. Background sub-agents would let the turn
+  end before their work is done and deliver their findings on a later turn nobody reads; as a second
+  guard, the harness ignores the result of any turn it did not submit.
 - **Follow-ups queue.** Both harnesses hold follow-up prompts until the running turn completes.
-- **Image.** The sandbox image pins `claude-agent-sdk`, whose wheel bundles the `claude` binary;
-  bumping it retires snapshots and prebuilt images through the runtime manifest, like any runtime
-  bump.
+- **Image.** The sandbox image pins `claude-agent-sdk`, whose wheel bundles the `claude` binary. The
+  runtime manifest names the first generation that carries it under `harnessMinimumGeneration`, so a
+  Claude session never boots a prebuilt image from before that generation; OpenCode sessions keep
+  their images and snapshots, since the global compatibility floor did not move.

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -103,7 +103,7 @@ exfiltration by code the agent chooses to run. The sandbox helpers (`oi-git-sign
 
 ## Lifecycle: disable, archive, reconnect
 
-Disabling, archiving or reconnecting a Claude account denies future bootstrap immediately and
+Disabling, archiving or reconnecting a Claude account denies future issuance immediately and
 enqueues a durable cleanup task in the same database write. A coordinator (run every minute by the
 scheduler) stops every sandbox that holds a live issuance at or below the revoked credential
 version, using a sandbox-id-conditional stop so a session whose sandbox was respawned since is

--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -40,22 +40,25 @@ sessions that cannot use it.
 ### Step 1: Connect a Claude account
 
 1. Open **Settings > Provider Accounts**.
-2. Choose **Add account > Claude** and name the slot.
+2. Choose **Add account > Claude**.
 3. Either:
-   - **Authorize in the browser**: open the Anthropic consent page, grant access with the scope
-     `user:inference`, copy the code Anthropic displays, and paste it back into the dialog; or
-   - **Paste a setup token**: run `claude setup-token` on a workstation signed in to the
-     subscription and paste the printed `sk-ant-oat…` value.
+   - **Authorize in the browser** (the default): open the Anthropic consent page, grant access with
+     the scope `user:inference`, copy the code Anthropic displays, and paste it back into the
+     dialog. The slot is created as **Claude account**; use **Rename** on it afterwards.
+   - **Paste a setup token instead**: run `claude setup-token` on a workstation signed in to the
+     subscription, name the slot, and paste the printed `sk-ant-oat…` value.
 
 The credential is a Claude **setup token**: inference-only, valid for about a year, and static. It
 does not rotate and carries no refresh token. Open-Inspect encrypts it at rest and never shows it in
 the browser.
 
-A slot connected by **browser authorization** records the Claude account that granted it (Anthropic
-returns the account and organization with the token), so a second slot for the same account is
-rejected as a duplicate and a reconnect from a different Claude account is refused. A slot connected
-by **pasting a setup token** has no identity: Open-Inspect cannot tell two pasted tokens apart and
-does not de-duplicate them. A pasted slot adopts an identity the first time it is reconnected in the
+A slot connected by **browser authorization** records the Claude account that granted it, when
+Anthropic returns an account id with the token. One Claude account has at most one slot: authorizing
+the same account again from **Add account** does not create a duplicate, it reconnects the existing
+slot and replaces its stored credential (a disabled slot is refused instead; enable or reconnect it
+explicitly), and a reconnect from a different Claude account is refused. A slot connected by
+**pasting a setup token** has no identity: Open-Inspect cannot tell two pasted tokens apart and does
+not de-duplicate them. A pasted slot adopts an identity the first time it is reconnected in the
 browser, unless that Claude account already has a slot. Once a slot has an identity it is
 reconnected in the browser only; the setup-token option is not offered for it, so the granting
 account is always verified. Neither kind can be verified against Anthropic on demand. Reconnecting
@@ -64,9 +67,10 @@ replaces what Open-Inspect stores for that slot; it does not revoke the previous
 
 ### Step 2: Configure defaults
 
-Choose an Anthropic **Default account** in **Settings > Provider Accounts** if unattended Claude
-Agent sessions should use the subscription. Set **Unattended mode** to **Use API key** to keep
-automations on the platform key while interactive sessions pick the account.
+Choose **Make default** on the Anthropic account in **Settings > Provider Accounts** if unattended
+Claude Agent sessions should use the subscription. Under **Automated sessions**, set **Automated
+authentication** to **No account (API key)** to keep automations on the platform key while
+interactive sessions pick the account.
 
 ### Step 3: Create a Claude Agent session
 
@@ -79,8 +83,9 @@ at create.
 ## How the credential reaches the sandbox
 
 1. At session create, the Anthropic selection is persisted with the session before any sandbox is
-   spawned. Every later prompt runs a pre-spawn check: a disabled, archived or fenced account fails
-   the prompt in the queue with reconnect guidance instead of spawning a sandbox into a denial.
+   spawned. Every later prompt runs a pre-spawn check: a disabled or fenced account fails the prompt
+   in the queue with reconnect guidance, and an archived account fails it with "start a new
+   session", instead of spawning a sandbox into a denial.
 2. The sandbox boots with `ANTHROPIC_OAUTH_MANAGED=1` and no Anthropic key in its user secrets.
 3. On every bridge start (fresh spawn, supervised restart, snapshot restore), the Claude harness
    calls the sandbox-authenticated endpoint
@@ -90,30 +95,35 @@ at create.
    **clean-credential wrapper**: the child sees the sandbox environment exactly as OpenCode does
    (the sandbox token, `SESSION_CONFIG`, user secrets, proxies) minus the Anthropic credentials of
    the other mode, so it holds exactly one Anthropic credential (`CLAUDE_CODE_OAUTH_TOKEN` in
-   account mode, `ANTHROPIC_API_KEY` in key mode), never both. Nothing is written to disk, so
-   snapshots carry no credential and a restore re-fetches.
+   account mode, `ANTHROPIC_API_KEY` in key mode), never both. Open-Inspect writes the token nowhere
+   on disk, so a snapshot carries no credential of its own and a restore re-fetches.
 
-Code the agent runs from Bash inherits the `claude` process environment, so repository code can read
-the token, the same way it can read the sandbox token and user secrets under either harness. This
-same-sandbox exposure is accepted; the wrapper limits accidental propagation (OpenCode, code-server,
-the terminal, user shells and repository hooks never see the Claude token), not deliberate
-exfiltration by code the agent chooses to run. The sandbox helpers (`oi-git-sign`,
-`oi-git-credentials`, `upload-media`) need the session context, which is why it passes through.
+Code the agent runs from Bash, and any hooks the repository's `.claude/` settings register, run as
+children of the `claude` process and inherit its environment, so repository code can read the token,
+the same way it can read the sandbox token and user secrets under either harness. This same-sandbox
+exposure is accepted; the wrapper limits accidental propagation (OpenCode, code-server, the terminal
+and user shells never see the Claude token), not deliberate exfiltration by code the agent chooses
+to run or a hook the repository configures, and what such code persists to disk is that same
+accepted exposure. The sandbox helpers (`oi-git-sign`, `oi-git-credentials`, `upload-media`) need
+the session context, which is why it passes through.
 
 ---
 
 ## Lifecycle: disable, archive, reconnect
 
-Disabling, archiving or reconnecting a Claude account stops new hand-outs immediately: the next
-bridge start on any session bound to the account is refused, and the next prompt on such a session
-fails the pre-spawn check with reconnect guidance. A sandbox that already holds the token keeps it
-in memory until it exits (inactivity timeout, hard timeout, or a stop), so a turn already running
-finishes on the old token. Open-Inspect does not chase running sandboxes: the token stays valid at
-Anthropic whatever Open-Inspect does, so stopping its own sandboxes would only shorten a window it
-cannot close. Revocation happens at Anthropic (runbook below).
+Disabling or archiving a Claude account stops new hand-outs immediately: the next bridge start on
+any session bound to the account is refused, and the next prompt on such a session fails the
+pre-spawn check (reconnect guidance for a disabled or fenced account; "start a new session with
+another account or an API key" for an archived one, since an archived slot cannot be reconnected).
+Reconnecting is different: the slot stays active with the new credential, so sessions bound to it
+carry on and their next bridge start fetches the new token. In every case a sandbox that already
+holds a token keeps it in memory until it exits (inactivity timeout, hard timeout, or a stop), so a
+turn already running finishes on the old token. Open-Inspect does not chase running sandboxes: the
+token stays valid at Anthropic whatever Open-Inspect does, so stopping its own sandboxes would only
+shorten a window it cannot close. Revocation happens at Anthropic (runbook below).
 
 The sandbox is never authoritative for account lifecycle. A runtime authentication failure fails the
-prompt with reconnect guidance and emits a warning; only local expiry (the recorded expiry
+prompt with reconnect guidance and emits an error event; only local expiry (the recorded expiry
 approaching) fences an account to **reconnect required**. Quota and rate-limit warnings keep the
 account active and appear on the session timeline.
 
@@ -126,16 +136,20 @@ Reconnecting or disabling in Open-Inspect rotates or fences what Open-Inspect st
 they keep it until they exit. A token that has left the deployment stays valid until Anthropic
 expires it or you revoke it. To revoke:
 
-1. In Open-Inspect, **Disable** (or **Archive**) the account so no new sandbox receives the token.
-   Sessions with a running sandbox keep it until that sandbox exits; stop those sessions from the
-   session page if you want that sooner. The control-plane log lists every hand-out under
-   `provider_credential.issued`.
-2. At Anthropic, sign in to the subscription that minted the token and revoke it. A slot connected
-   in the browser stores Anthropic's `token_uuid` for the credential; quote it in a support request.
+1. In Open-Inspect, stop new hand-outs of the old token. If the slot stays in service, mint a new
+   token (browser authorization or `claude setup-token`) and **Reconnect** the slot: from then on
+   only the new token is handed out, and bound sessions carry on. If the slot is being retired,
+   **Disable** it (or **Archive** it and create a new slot later; an archived slot cannot be
+   reconnected). The provider's default account, which is what a single connected account becomes,
+   cannot be disabled or archived: reconnect it in place, or choose **Make default** on another
+   account first. Either way, sessions with a running sandbox keep the old token until that sandbox
+   exits; stop those sessions from the session page if you want that sooner. The control-plane log
+   lists every hand-out under `provider_credential.issued`.
+2. At Anthropic, sign in to the subscription that minted the token and revoke it.
    `claude auth logout` on a workstation does **not** revoke an environment-supplied token, so use
    the account's connected-applications / API session management in the Claude console, or contact
    Anthropic support if no self-service revocation is offered for setup tokens.
-3. Mint a new token (browser authorization or `claude setup-token`) and **Reconnect** the slot.
+3. If you disabled the slot, mint a new token and **Reconnect** it; reconnecting reactivates it.
 4. Start a new session, or prompt an existing one; the next bridge start fetches the new token.
 
 ---
@@ -144,10 +158,11 @@ expires it or you revoke it. To revoke:
 
 Migrations `0075` (session harness) and `0076` (Anthropic provider accounts) are applied by
 `terraform apply` before the worker is deployed. Once `0076` is applied, the previous worker rejects
-session create/resume and the Provider Accounts settings page until the new worker is live, because
-it requires exactly two provider rows per session and rejects a third provider in payloads. On
-Cloudflare this is one window of a few minutes; on Vercel there is a second window until the web
-deploy lands. Announce it and prefer a low-traffic slot.
+session create/resume until the new worker is live: it requires exactly one provider row per
+provider it knows (two), and the migration backfills an Anthropic row onto every session. The
+Provider Accounts page keeps working through the window; its Anthropic controls appear once the new
+worker and web build are deployed. On Cloudflare this is one window of a few minutes; on Vercel
+there is a second window until the web deploy lands. Announce it and prefer a low-traffic slot.
 
 **Rollback is fix-forward.** There is no reverse script: one that deleted Anthropic rows would
 delete provider accounts and strand every Claude Agent session created after the migration. Deploy a
@@ -159,15 +174,16 @@ fix instead.
 
 - **Cost.** The Claude harness reports the SDK's client-side cost estimate per turn (running total
   at turn end minus the total at turn start, reset when the agent process restarts). Under a
-  subscription it is informational, but the session spend limit still applies to it as configured; a
-  limit of `0` remains unlimited.
+  subscription it is informational, but the session spend limit still applies to it as configured.
+  Unlimited is a blank limit in Settings (`null` in the API); `0` is rejected as a value.
 - **Skills.** Managed skills and the bundled skills are staged under the per-sandbox
   `CLAUDE_CONFIG_DIR` (`~/.openinspect/claude/skills`); repository `.claude/` settings, hooks and
   agents load through `setting_sources=["user","project"]`, the same trust boundary as the
   repository's `.openinspect/setup.sh` and `.opencode/` directory under OpenCode.
-- **Tools.** Open-Inspect's own tools (`create-pull-request`, child sessions, `slack-notify`,
-  `upload-media`) are served to the Claude harness in-process as the `oi` MCP server; session MCP
-  servers are passed through unchanged.
+- **Tools.** Open-Inspect's own tools are served to the Claude harness in-process as the `oi` MCP
+  server: child sessions and `upload-media` always, `create-pull-request` when the session has a
+  repository, and `slack-notify` when agent notifications are enabled for the repository. Session
+  MCP servers are passed through unchanged.
 - **Sub-agents.** The child runs with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`, so an `Agent` tool
   call returns only when its sub-agent has finished, and several sub-agents launched in one message
   still run concurrently. This is the same contract as OpenCode's `task` tool, and the timeline

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -202,7 +202,7 @@ development environment.
 - Node.js 22, Python 3.12, git, curl
 - Package managers: npm, pnpm, pip, uv
 - agent-browser CLI + headless Chrome (for browser automation)
-- OpenCode (the coding agent)
+- OpenCode and the Claude Agent SDK (the coding agent harnesses)
 
 Open-Inspect supports these sandbox backends:
 
@@ -458,8 +458,20 @@ will not see `send-child-prompt` until it starts in a fresh sandbox built from t
 
 ## The Agent
 
-Open-Inspect uses [OpenCode](https://opencode.ai) as its coding agent. OpenCode is an open-source
-agent designed to run as a server, making it ideal for background execution.
+The sandbox runtime speaks to its coding agent through one seam, the **agent harness**. A session
+runs on exactly one harness, chosen at create:
+
+- **OpenCode** (built-in): [OpenCode](https://opencode.ai) runs as a server inside the sandbox; the
+  supervisor owns the `opencode serve` process and the bridge talks to it over HTTP/SSE.
+- **Claude Agent**: the [Claude Agent SDK](https://docs.anthropic.com/en/docs/agent-sdk) runs inside
+  the bridge and spawns the `claude` binary as its own child, launched with a clean environment that
+  carries exactly one Anthropic credential. This is the harness that can use a connected Claude
+  subscription. See [Using the Claude Agent Harness](CLAUDE_AGENT.md).
+
+Both harnesses emit the same session events (tokens, tool calls, steps, warnings), so everything
+above the sandbox is harness-neutral. The bridge owns turn completion: a harness reports the outcome
+of a turn and the bridge emits the single `execution_complete` event. Follow-up prompts queue until
+the running turn ends on both harnesses.
 
 ### What the Agent Can Do
 


### PR DESCRIPTION
## Summary

Documentation for the Claude Agent harness. Stacked on #1857.

- `docs/CLAUDE_AGENT.md`: choosing a harness, connecting a Claude account (browser and setup token), how the credential reaches the sandbox, the lifecycle of disable, archive and reconnect, a runbook for revoking a setup token, and the migration window to plan for when deploying.
- CHANGELOG release note, including the deploy-window note for migrations 0075 and 0076 and the runtime manifest bump.
- README, HOW_IT_WORKS and AVAILABLE_MODELS mention the second harness.

## Testing

- `prettier --check` on the five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting Anthropic/Claude accounts through browser authorization or setup tokens.
  - Added connection and reconnection flows with expiration tracking, retry handling, cancellation, and credential-rotation warnings.
  - Added Claude Agent harness support alongside OpenCode, including selectable harness and authentication options.

- **Documentation**
  - Expanded setup, authentication, harness, model, sandbox, migration, and operational guidance for Claude Agent.
  - Updated architecture documentation and credits to include the Claude Agent SDK.

- **Bug Fixes**
  - Improved connection handling so successful saves close forms reliably while refresh issues are reported separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->