### PR TITLE
control plane: present the Claude Agent CLI identity on the token exchange

### DIFF
--- a/packages/control-plane/src/auth/anthropic.test.ts
+++ b/packages/control-plane/src/auth/anthropic.test.ts
@@ -117,7 +117,7 @@ describe("exchangeAnthropicAuthorizationCode", () => {
     });
     expect(init?.signal).toBeInstanceOf(AbortSignal);
     // Cloudflare in front of the token endpoint bans anonymous client signatures.
-    expect(new Headers(init?.headers).get("User-Agent")).toBe("open-inspect-control-plane/1.0");
+    expect(new Headers(init?.headers).get("User-Agent")).toBe("claude-cli/2.1.259 (external, cli)");
   });
 
   it("keeps the granting account, organization and token id the real response carries", async () => {

--- a/packages/control-plane/src/auth/anthropic.ts
+++ b/packages/control-plane/src/auth/anthropic.ts
@@ -26,11 +26,17 @@ export const ANTHROPIC_SETUP_TOKEN_SCOPE = "user:inference";
 export const ANTHROPIC_SETUP_TOKEN_LIFETIME_MS = 365 * 24 * 60 * 60 * 1000;
 export const ANTHROPIC_EXCHANGE_TIMEOUT_MS = 30_000;
 /**
- * Cloudflare in front of the token endpoint bans generic client
- * signatures (error 1010), and a Worker's outbound fetch carries no
- * User-Agent at all. Identify the deployment explicitly.
+ * The version of the Claude Agent CLI the sandbox runtime ships, bundled with
+ * the pinned `claude-agent-sdk`; bump it alongside that pin.
  */
-export const ANTHROPIC_EXCHANGE_USER_AGENT = "open-inspect-control-plane/1.0";
+export const CLAUDE_AGENT_CLI_VERSION = "2.1.259";
+/**
+ * Cloudflare in front of the token endpoint bans generic client signatures
+ * (error 1010), and a Worker's outbound fetch carries no User-Agent at all.
+ * The exchange presents the same identity the CLI uses on its Anthropic API
+ * traffic, so the token is minted and used under one client string.
+ */
+export const ANTHROPIC_EXCHANGE_USER_AGENT = `claude-cli/${CLAUDE_AGENT_CLI_VERSION} (external, cli)`;
 
 export interface AnthropicAuthorizationRequest {
   authorizationUrl: string;


### PR DESCRIPTION
## Summary

The Anthropic token exchange now sends `User-Agent: claude-cli/<version> (external, cli)`, the identity the Claude Agent CLI presents on its Anthropic API traffic, instead of `open-inspect-control-plane/1.0`. The version is the CLI bundled with the pinned `claude-agent-sdk` (2.1.259 with 0.2.152), held in one constant next to the header with a note to bump it with the pin. The token is then minted and used under the same client string, since the sandbox runs that CLI.

The header exists because Cloudflare in front of the token endpoint rejects requests with no User-Agent (error 1010) and a Worker's outbound fetch sends none; any value works, this one is chosen for consistency with the runtime.

For the record: the CLI's own `setup-token` exchange goes through a bare axios instance, so what it sends on this exact request is `axios/1.15.2`. The CLI's `claude-cli/…` string is what its API and OAuth profile calls carry.

## Testing

- `anthropic.test.ts` asserts the header; control-plane lint and typecheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic authentication requests now identify themselves with the Claude CLI user agent and version, improving compatibility with the token exchange endpoint.

- **Tests**
  - Updated authentication coverage to verify the new user-agent value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->