### PR TITLE
fix: preserve session recovery after stopping snapshots

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -301,6 +301,12 @@ export function evaluateSpawnDecision(
     return { action: "skip", reason: "spawn already in progress (in-memory flag)" };
   }
 
+  // The source may already be stopped while its snapshot is still being saved.
+  // Wait for the image to be recorded before deciding how to resume the session.
+  if (state.status === "snapshotting") {
+    return { action: "wait", reason: "snapshot in progress" };
+  }
+
   if (
     supportsPersistentResume &&
     state.providerObjectId &&

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1802,6 +1802,94 @@ describe("SandboxLifecycleManager", () => {
   });
 
   describe("triggerSnapshot", () => {
+    it.each([5000, 2025_000])(
+      "restores after a stopping snapshot at sandbox age %i ms",
+      async (ageMs) => {
+        const sandbox = createMockSandbox({ status: "ready", created_at: Date.now() - ageMs });
+        const storage = createMockStorage(createMockSession(), sandbox);
+        const broadcaster = createMockBroadcaster();
+        const wsManager = createMockWebSocketManager();
+        let finishSnapshot!: (result: SnapshotResult) => void;
+        const provider = createMockProvider({
+          capabilities: { snapshotStopsSandbox: true },
+          takeSnapshot: vi.fn(
+            () =>
+              new Promise<SnapshotResult>((resolve) => {
+                finishSnapshot = resolve;
+              })
+          ),
+        });
+        const manager = new SandboxLifecycleManager(
+          provider,
+          storage,
+          storage,
+          broadcaster,
+          wsManager,
+          createMockAlarmScheduler(),
+          createMockIdGenerator(),
+          createTestConfig()
+        );
+
+        const snapshot = manager.triggerSnapshot("execution_complete");
+        expect(manager.isSnapshotting()).toBe(true);
+        // Vercel closes the source socket before the snapshot response returns.
+        await manager.spawnSandbox();
+        expect(provider.createSandbox).not.toHaveBeenCalled();
+        expect(provider.restoreFromSnapshot).not.toHaveBeenCalled();
+
+        finishSnapshot({ success: true, imageId: "saved-conversation-and-worktree" });
+        await snapshot;
+
+        expect(sandbox.status).toBe("stopped");
+        expect(manager.isSnapshotting()).toBe(false);
+        expect(wsManager.detachSandboxWebSocket).toHaveBeenCalledOnce();
+        expect(storage.calls).toContain("clearSandboxAccess:codeServer");
+        expect(broadcaster.messages).toContainEqual({ type: "sandbox_status", status: "stopped" });
+
+        await manager.spawnSandbox();
+
+        expect(provider.createSandbox).not.toHaveBeenCalled();
+        expect(provider.restoreFromSnapshot).toHaveBeenCalledWith(
+          expect.objectContaining({
+            snapshotImageId: "saved-conversation-and-worktree",
+          })
+        );
+      }
+    );
+
+    it("does not retire a replacement when a stopping snapshot finishes late", async () => {
+      const sandbox = createMockSandbox({ status: "ready" });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager();
+      const provider = createMockProvider({
+        capabilities: { snapshotStopsSandbox: true },
+        takeSnapshot: vi.fn(async () => {
+          sandbox.modal_sandbox_id = "replacement";
+          sandbox.created_at += 1;
+          sandbox.status = "ready";
+          return { success: true, imageId: "old-snapshot" };
+        }),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        storage,
+        broadcaster,
+        wsManager,
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.triggerSnapshot("execution_complete");
+
+      expect(sandbox.status).toBe("ready");
+      expect(sandbox.snapshot_image_id).toBeNull();
+      expect(wsManager.detachSandboxWebSocket).not.toHaveBeenCalled();
+      expect(storage.calls).not.toContain("clearSandboxAccess:codeServer");
+    });
+
     it("takes snapshot when provider supports it", async () => {
       const sandbox = createMockSandbox({ status: "ready" });
       const storage = createMockStorage(createMockSession(), sandbox);

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1831,7 +1831,7 @@ describe("SandboxLifecycleManager", () => {
         );
 
         const snapshot = manager.triggerSnapshot("execution_complete");
-        expect(manager.isSnapshotting()).toBe(true);
+        expect(manager.isSnapshotStoppingSandbox()).toBe(true);
         // Vercel closes the source socket before the snapshot response returns.
         await manager.spawnSandbox();
         expect(provider.createSandbox).not.toHaveBeenCalled();
@@ -1841,7 +1841,7 @@ describe("SandboxLifecycleManager", () => {
         await snapshot;
 
         expect(sandbox.status).toBe("stopped");
-        expect(manager.isSnapshotting()).toBe(false);
+        expect(manager.isSnapshotStoppingSandbox()).toBe(false);
         expect(wsManager.detachSandboxWebSocket).toHaveBeenCalledOnce();
         expect(storage.calls).toContain("clearSandboxAccess:codeServer");
         expect(broadcaster.messages).toContainEqual({ type: "sandbox_status", status: "stopped" });
@@ -1888,6 +1888,68 @@ describe("SandboxLifecycleManager", () => {
       expect(sandbox.snapshot_image_id).toBeNull();
       expect(wsManager.detachSandboxWebSocket).not.toHaveBeenCalled();
       expect(storage.calls).not.toContain("clearSandboxAccess:codeServer");
+    });
+
+    it("marks a stopping provider's sandbox stopped even when the snapshot fails", async () => {
+      const sandbox = createMockSandbox({ status: "ready" });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager();
+      const provider = createMockProvider({
+        capabilities: { snapshotStopsSandbox: true },
+        takeSnapshot: vi.fn(async () => ({ success: false, error: "Snapshot status was failed" })),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        storage,
+        broadcaster,
+        wsManager,
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.triggerSnapshot("execution_complete");
+
+      // The provider stopped the source regardless; a `ready` row here would
+      // send follow-ups to a dead sandbox until heartbeat reconciliation.
+      expect(sandbox.status).toBe("stopped");
+      expect(sandbox.snapshot_image_id).toBeNull();
+      expect(wsManager.detachSandboxWebSocket).toHaveBeenCalledOnce();
+      expect(broadcaster.messages).toContainEqual({ type: "sandbox_status", status: "stopped" });
+    });
+
+    it("does not hold dispatch while a non-stopping provider snapshots", async () => {
+      const sandbox = createMockSandbox({ status: "ready" });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      let finishSnapshot!: (result: SnapshotResult) => void;
+      const provider = createMockProvider({
+        takeSnapshot: vi.fn(
+          () =>
+            new Promise<SnapshotResult>((resolve) => {
+              finishSnapshot = resolve;
+            })
+        ),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const snapshot = manager.triggerSnapshot("execution_complete");
+      expect(sandbox.status).toBe("snapshotting");
+      expect(manager.isSnapshotStoppingSandbox()).toBe(false);
+
+      finishSnapshot({ success: true, imageId: "img" });
+      await snapshot;
+      expect(sandbox.status).toBe("ready");
     });
 
     it("takes snapshot when provider supports it", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -329,6 +329,7 @@ export interface SlackAgentNotifyLookup {
  */
 export interface SandboxLifecycle {
   spawnSandbox(): Promise<void>;
+  isSnapshotting(): boolean;
   updateLastActivity(timestamp: number): void;
   terminateUnresponsiveSandbox(trigger: UnresponsiveSandboxTrigger): Promise<void>;
   terminateFailedSandbox(reason: string): Promise<boolean>;
@@ -1173,6 +1174,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       createdAt: sandbox.created_at,
     };
     const runtimeVersion = sandbox.runtime_version;
+    let snapshotStoppedSandbox = false;
 
     if (!isTerminalState) {
       this.storage.updateSandboxStatus("snapshotting");
@@ -1193,6 +1195,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
 
       if (result.success && result.imageId) {
+        snapshotStoppedSandbox = this.provider.capabilities.snapshotStopsSandbox === true;
         // Stamp the snapshot with the runtime that produced it: the image
         // carries that runtime's binaries, so this is what a later restore is
         // gated on, not whatever the session runs next. Recorded for the
@@ -1231,7 +1234,9 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
     }
 
-    // Restore the previous status only while the row is still this sandbox's
+    // Preserve provider snapshot semantics: Vercel stops the source, while
+    // providers such as Modal leave it running. Change status only while the
+    // row is still this sandbox's
     // and still says `snapshotting`: a cancel, a stale heartbeat, or an
     // unresponsive-sandbox termination during the provider call has already
     // retired the sandbox (status written, access cleared, socket detached),
@@ -1239,9 +1244,14 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     // a reconnect that cannot come; a replacement that is itself snapshotting
     // keeps its own status.
     if (!isTerminalState && reason !== "heartbeat_timeout") {
-      if (this.storage.transitionSandboxStatus(generation, "snapshotting", previousStatus)) {
-        this.broadcaster.broadcast({ type: "sandbox_status", status: previousStatus });
-        if (previousStatus === "ready") {
+      const nextStatus = snapshotStoppedSandbox ? "stopped" : previousStatus;
+      if (this.storage.transitionSandboxStatus(generation, "snapshotting", nextStatus)) {
+        if (snapshotStoppedSandbox) {
+          this.clearSandboxAccessState();
+          this.wsManager.detachSandboxWebSocket(1000, "Sandbox stopped after snapshot");
+        }
+        this.broadcaster.broadcast({ type: "sandbox_status", status: nextStatus });
+        if (nextStatus === "ready") {
           this.broadcaster.broadcast({ type: "sandbox_access_changed" });
         }
       } else {
@@ -1798,6 +1808,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
    */
   isSpawning(): boolean {
     return this.isSpawningSandbox || this.isTerminatingSandbox;
+  }
+
+  isSnapshotting(): boolean {
+    return this.storage.getSandbox()?.status === "snapshotting";
   }
 
   isProviderStartupPending(): boolean {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -329,7 +329,8 @@ export interface SlackAgentNotifyLookup {
  */
 export interface SandboxLifecycle {
   spawnSandbox(): Promise<void>;
-  isSnapshotting(): boolean;
+  /** Whether a snapshot in progress has stopped, or will stop, the source sandbox. */
+  isSnapshotStoppingSandbox(): boolean;
   updateLastActivity(timestamp: number): void;
   terminateUnresponsiveSandbox(trigger: UnresponsiveSandboxTrigger): Promise<void>;
   terminateFailedSandbox(reason: string): Promise<boolean>;
@@ -1174,7 +1175,10 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       createdAt: sandbox.created_at,
     };
     const runtimeVersion = sandbox.runtime_version;
-    let snapshotStoppedSandbox = false;
+    // Vercel stops the source as part of the snapshot request, whether or not
+    // the snapshot itself succeeds, so this is decided by the provider, not
+    // by the result.
+    const snapshotStopsSandbox = this.provider.capabilities.snapshotStopsSandbox === true;
 
     if (!isTerminalState) {
       this.storage.updateSandboxStatus("snapshotting");
@@ -1195,7 +1199,6 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       });
 
       if (result.success && result.imageId) {
-        snapshotStoppedSandbox = this.provider.capabilities.snapshotStopsSandbox === true;
         // Stamp the snapshot with the runtime that produced it: the image
         // carries that runtime's binaries, so this is what a later restore is
         // gated on, not whatever the session runs next. Recorded for the
@@ -1236,17 +1239,17 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
 
     // Preserve provider snapshot semantics: Vercel stops the source, while
     // providers such as Modal leave it running. Change status only while the
-    // row is still this sandbox's
-    // and still says `snapshotting`: a cancel, a stale heartbeat, or an
+    // row is still this sandbox's and still says `snapshotting`: a cancel, a
+    // stale heartbeat, or an
     // unresponsive-sandbox termination during the provider call has already
     // retired the sandbox (status written, access cleared, socket detached),
     // and restoring `ready` over that would make the spawn decision wait for
     // a reconnect that cannot come; a replacement that is itself snapshotting
     // keeps its own status.
     if (!isTerminalState && reason !== "heartbeat_timeout") {
-      const nextStatus = snapshotStoppedSandbox ? "stopped" : previousStatus;
+      const nextStatus = snapshotStopsSandbox ? "stopped" : previousStatus;
       if (this.storage.transitionSandboxStatus(generation, "snapshotting", nextStatus)) {
-        if (snapshotStoppedSandbox) {
+        if (snapshotStopsSandbox) {
           this.clearSandboxAccessState();
           this.wsManager.detachSandboxWebSocket(1000, "Sandbox stopped after snapshot");
         }
@@ -1810,8 +1813,11 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     return this.isSpawningSandbox || this.isTerminatingSandbox;
   }
 
-  isSnapshotting(): boolean {
-    return this.storage.getSandbox()?.status === "snapshotting";
+  isSnapshotStoppingSandbox(): boolean {
+    return (
+      this.provider.capabilities.snapshotStopsSandbox === true &&
+      this.storage.getSandbox()?.status === "snapshotting"
+    );
   }
 
   isProviderStartupPending(): boolean {

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -56,6 +56,8 @@ export interface SandboxProviderCapabilities {
   supportsSandboxTimeout: boolean;
   /** Whether the provider supports filesystem snapshots */
   supportsSnapshots: boolean;
+  /** Whether taking a snapshot stops the source sandbox instead of leaving it running. */
+  snapshotStopsSandbox?: boolean;
   /** Whether the provider supports restoring from snapshots */
   supportsRestore: boolean;
   /** Whether the provider can resume a previously stopped sandbox in place */

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -165,6 +165,7 @@ describe("VercelSandboxProvider", () => {
     expect(provider.capabilities).toEqual({
       supportsSandboxTimeout: true,
       supportsSnapshots: true,
+      snapshotStopsSandbox: true,
       supportsRestore: true,
       supportsPersistentResume: false,
       supportsExplicitStop: true,

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -84,6 +84,7 @@ export class VercelSandboxProvider implements SandboxProvider {
   readonly capabilities: SandboxProviderCapabilities = {
     supportsSandboxTimeout: true,
     supportsSnapshots: true,
+    snapshotStopsSandbox: true,
     supportsRestore: true,
     supportsPersistentResume: false,
     supportsExplicitStop: true,

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -220,7 +220,7 @@ function buildQueue() {
   };
   const sandboxLifecycle = {
     spawnSandbox: vi.fn(async () => {}),
-    isSnapshotting: vi.fn(() => false),
+    isSnapshotStoppingSandbox: vi.fn(() => false),
     updateLastActivity: vi.fn((_timestamp: number) => {}),
     terminateUnresponsiveSandbox: vi.fn(async () => {}),
     terminateFailedSandbox: vi.fn(async () => true),
@@ -591,7 +591,7 @@ describe("SessionMessageQueue", () => {
       // Start snapshotting during the asynchronous auth lookup to exercise the
       // dispatch-time recheck as well as the already-snapshotting case.
       h.getProviderAuthenticationError.mockImplementation(async () => {
-        h.sandboxLifecycle.isSnapshotting.mockReturnValue(true);
+        h.sandboxLifecycle.isSnapshotStoppingSandbox.mockReturnValue(true);
         return null;
       });
 
@@ -602,7 +602,7 @@ describe("SessionMessageQueue", () => {
       expect(h.sandboxLifecycle.spawnSandbox).not.toHaveBeenCalled();
 
       h.getProviderAuthenticationError.mockResolvedValue(null);
-      h.sandboxLifecycle.isSnapshotting.mockReturnValue(false);
+      h.sandboxLifecycle.isSnapshotStoppingSandbox.mockReturnValue(false);
       h.wsManager.getSandboxSocket.mockReturnValue(null);
       await h.queue.processMessageQueue();
       expect(h.sandboxLifecycle.spawnSandbox).toHaveBeenCalledOnce();

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -220,6 +220,7 @@ function buildQueue() {
   };
   const sandboxLifecycle = {
     spawnSandbox: vi.fn(async () => {}),
+    isSnapshotting: vi.fn(() => false),
     updateLastActivity: vi.fn((_timestamp: number) => {}),
     terminateUnresponsiveSandbox: vi.fn(async () => {}),
     terminateFailedSandbox: vi.fn(async () => true),
@@ -579,6 +580,34 @@ describe("SessionMessageQueue", () => {
 
     expect(h.sessionStatus.reconcileAfterQueueRemoval).toHaveBeenCalledOnce();
   });
+
+  it.each([true, false])(
+    "keeps follow-ups pending during a snapshot (socket connected=%s)",
+    async (connected) => {
+      const h = buildQueue();
+      h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+      const socket = { readyState: WebSocket.OPEN } as WebSocket;
+      h.wsManager.getSandboxSocket.mockReturnValue(connected ? socket : null);
+      // Start snapshotting during the asynchronous auth lookup to exercise the
+      // dispatch-time recheck as well as the already-snapshotting case.
+      h.getProviderAuthenticationError.mockImplementation(async () => {
+        h.sandboxLifecycle.isSnapshotting.mockReturnValue(true);
+        return null;
+      });
+
+      await h.queue.processMessageQueue();
+
+      expect(h.repository.startMessageProcessing).not.toHaveBeenCalled();
+      expect(h.wsManager.send).not.toHaveBeenCalled();
+      expect(h.sandboxLifecycle.spawnSandbox).not.toHaveBeenCalled();
+
+      h.getProviderAuthenticationError.mockResolvedValue(null);
+      h.sandboxLifecycle.isSnapshotting.mockReturnValue(false);
+      h.wsManager.getSandboxSocket.mockReturnValue(null);
+      await h.queue.processMessageQueue();
+      expect(h.sandboxLifecycle.spawnSandbox).toHaveBeenCalledOnce();
+    }
+  );
 
   it("spawns sandbox when queue has work but no sandbox socket", async () => {
     const h = buildQueue();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -413,9 +413,11 @@ export class SessionMessageQueue {
       }
       return;
     }
-    // Snapshot completion pumps the queue again. A provider may stop its source
-    // during snapshotting, so neither dispatch nor replace it in this window.
-    if (this.sandboxLifecycle.isSnapshotting()) {
+    // A provider that stops its source while snapshotting must neither be
+    // dispatched to nor replaced until the image is recorded; snapshot
+    // completion pumps the queue again. Providers that keep the source running
+    // dispatch through the snapshot as before.
+    if (this.sandboxLifecycle.isSnapshotStoppingSandbox()) {
       return;
     }
     const sandboxWs = this.wsManager.getSandboxSocket();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -413,6 +413,11 @@ export class SessionMessageQueue {
       }
       return;
     }
+    // Snapshot completion pumps the queue again. A provider may stop its source
+    // during snapshotting, so neither dispatch nor replace it in this window.
+    if (this.sandboxLifecycle.isSnapshotting()) {
+      return;
+    }
     const sandboxWs = this.wsManager.getSandboxSocket();
     if (!sandboxWs) {
       // The provider-auth lookup above is a non-storage await. The socket

--- a/packages/control-plane/src/session/sandbox-events/execution.handler.ts
+++ b/packages/control-plane/src/session/sandbox-events/execution.handler.ts
@@ -121,12 +121,25 @@ export class SandboxExecutionEventHandler {
       });
     }
 
-    this.backgroundTasks.submit(() => this.triggerSnapshot("execution_complete"), {
-      name: "snapshot.trigger",
-      context: { reason: "execution_complete", message_id: event.messageId },
-    });
+    this.backgroundTasks.submit(
+      async () => {
+        try {
+          // A prompt may have claimed the queue during terminal projection, or
+          // this may be a late completion from its predecessor. Never stop that
+          // newer turn with a provider's destructive snapshot operation.
+          if (!this.messageRepository.getProcessingMessage()) {
+            await this.triggerSnapshot("execution_complete");
+          }
+        } finally {
+          await this.processMessageQueue();
+        }
+      },
+      {
+        name: "snapshot.trigger",
+        context: { reason: "execution_complete", message_id: event.messageId },
+      }
+    );
     this.updateLastActivity(context.now);
     await this.scheduleInactivityCheck();
-    await this.processMessageQueue();
   }
 }

--- a/packages/control-plane/src/session/sandbox-events/execution.handler.ts
+++ b/packages/control-plane/src/session/sandbox-events/execution.handler.ts
@@ -141,5 +141,9 @@ export class SandboxExecutionEventHandler {
     );
     this.updateLastActivity(context.now);
     await this.scheduleInactivityCheck();
+    // The task above has already marked the sandbox `snapshotting` by now. The
+    // queue dispatches through the snapshot for providers that keep the source
+    // running and holds until the task's final pump for providers that stop it.
+    await this.processMessageQueue();
   }
 }

--- a/packages/control-plane/src/session/sandbox-events/processor.test.ts
+++ b/packages/control-plane/src/session/sandbox-events/processor.test.ts
@@ -181,7 +181,7 @@ function createProcessor() {
 
 describe("SessionSandboxEventProcessor", () => {
   it.each([true, false])(
-    "waits for the snapshot before dispatching after success=%s",
+    "pumps the queue before the snapshot and again after it settles (success=%s)",
     async (success) => {
       const h = createProcessor();
       h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
@@ -202,10 +202,12 @@ describe("SessionSandboxEventProcessor", () => {
       });
 
       expect(h.triggerSnapshot).toHaveBeenCalledOnce();
-      expect(h.processMessageQueue).not.toHaveBeenCalled();
+      // The queue itself decides whether to hold: providers that keep the
+      // source running dispatch now, stopping providers wait for the re-pump.
+      expect(h.processMessageQueue).toHaveBeenCalledOnce();
       finishSnapshot();
       await h.backgroundTasks.settle();
-      expect(h.processMessageQueue).toHaveBeenCalledOnce();
+      expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
     }
   );
 
@@ -226,7 +228,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.backgroundTasks.settle();
 
     expect(h.triggerSnapshot).not.toHaveBeenCalled();
-    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
   });
 
   it("releases the next prompt without waiting for diff work", async () => {
@@ -241,7 +243,7 @@ describe("SessionSandboxEventProcessor", () => {
       timestamp: 2000,
     });
 
-    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
     expect(h.repository.recordMessageCompletion).toHaveBeenCalledOnce();
   });
 
@@ -261,7 +263,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.backgroundTasks.settle();
     // The failed snapshot is absorbed by the boundary, not thrown at the caller.
     expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
-    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
   });
 
   it("updates heartbeat without broadcasting", async () => {
@@ -593,7 +595,7 @@ describe("SessionSandboxEventProcessor", () => {
     );
     expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
     expect(h.scheduleInactivityCheck).toHaveBeenCalledTimes(1);
-    expect(h.processMessageQueue).toHaveBeenCalledTimes(1);
+    expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
     expect(h.backgroundTasks.submissions).not.toHaveLength(0);
   });
 
@@ -677,7 +679,7 @@ describe("SessionSandboxEventProcessor", () => {
     await processing;
 
     expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
-    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
     expect(h.wsManager.send).toHaveBeenCalledWith(sandboxWs, { type: "ack", ackId: "ack-1" });
   });
 
@@ -962,7 +964,7 @@ describe("SessionSandboxEventProcessor", () => {
       expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
       expect(h.updateLastActivity).toHaveBeenCalledOnce();
       expect(h.scheduleInactivityCheck).toHaveBeenCalledOnce();
-      expect(h.processMessageQueue).toHaveBeenCalledOnce();
+      expect(h.processMessageQueue).toHaveBeenCalledTimes(2);
     });
 
     it("does not send ACK for non-critical events even with ackId", async () => {

--- a/packages/control-plane/src/session/sandbox-events/processor.test.ts
+++ b/packages/control-plane/src/session/sandbox-events/processor.test.ts
@@ -180,6 +180,55 @@ function createProcessor() {
 }
 
 describe("SessionSandboxEventProcessor", () => {
+  it.each([true, false])(
+    "waits for the snapshot before dispatching after success=%s",
+    async (success) => {
+      const h = createProcessor();
+      h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
+      let finishSnapshot!: () => void;
+      h.triggerSnapshot.mockReturnValue(
+        new Promise<void>((resolve) => {
+          finishSnapshot = resolve;
+        })
+      );
+
+      await h.processor.processSandboxEvent({
+        type: "execution_complete",
+        messageId: "msg-1",
+        success,
+        ...(!success ? { error: "Prompt exceeded max duration of 2025s." } : {}),
+        sandboxId: "sb-1",
+        timestamp: 2000,
+      });
+
+      expect(h.triggerSnapshot).toHaveBeenCalledOnce();
+      expect(h.processMessageQueue).not.toHaveBeenCalled();
+      finishSnapshot();
+      await h.backgroundTasks.settle();
+      expect(h.processMessageQueue).toHaveBeenCalledOnce();
+    }
+  );
+
+  it("does not snapshot a newer turn that started during terminal projection", async () => {
+    const h = createProcessor();
+    h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
+    h.projectTerminalMessage.mockImplementation(async () => {
+      h.repository.getProcessingMessage.mockReturnValue({ id: "msg-2" });
+    });
+
+    await h.processor.processSandboxEvent({
+      type: "execution_complete",
+      messageId: "msg-1",
+      success: false,
+      sandboxId: "sb-1",
+      timestamp: 2000,
+    });
+    await h.backgroundTasks.settle();
+
+    expect(h.triggerSnapshot).not.toHaveBeenCalled();
+    expect(h.processMessageQueue).toHaveBeenCalledOnce();
+  });
+
   it("releases the next prompt without waiting for diff work", async () => {
     const h = createProcessor();
     h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
@@ -212,6 +261,7 @@ describe("SessionSandboxEventProcessor", () => {
     await h.backgroundTasks.settle();
     // The failed snapshot is absorbed by the boundary, not thrown at the caller.
     expect(h.backgroundTasks.failures).toEqual([expect.any(Error)]);
+    expect(h.processMessageQueue).toHaveBeenCalledOnce();
   });
 
   it("updates heartbeat without broadcasting", async () => {


### PR DESCRIPTION
Vercel stops the source sandbox when taking a filesystem snapshot, but the lifecycle manager restored its previous `ready` status. After a completed or timed-out prompt, a follow-up arriving before heartbeat reconciliation could therefore create a fresh sandbox even though the previous conversation and uncommitted work had been saved. A follow-up arriving during snapshot creation could also replace the source before the image was recorded.

This change declares Vercel's stopping-snapshot behavior and transitions the source to `stopped`, clearing its access URLs and dispatch socket after the image is saved. Follow-ups stay pending during snapshotting and the queue resumes after the snapshot attempt settles, allowing the existing restore path to load the saved workspace and agent session. Late completion handling skips snapshotting when a newer turn is already running. Providers whose snapshots leave the source running retain their previous status.

Timeout values and plan limits are unchanged. This addresses recovery from an available, compatible snapshot; it does not reconstruct state from a missing or failed snapshot.

Validation:
- All 4,226 control-plane unit tests pass, including regressions for successful and failed prompt completion, follow-ups during snapshotting, immediate restoration at different sandbox ages, and late snapshot results after replacement.
- Control-plane type checks and Worker/Node builds pass.
- Repository ESLint and formatting checks for changed files pass.
- Provider behavior is mocked in tests; no live Vercel deployment was exercised.

Provider contract: https://vercel.com/docs/vercel-sandbox/concepts/snapshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sandbox sessions from being resumed or recreated while a snapshot is in progress.
  * Deferred follow-up message processing only when snapshots stop the source sandbox.
  * Ensured message processing continues when snapshot creation fails or the provider remains active.
  * Improved cleanup for stopped sandboxes and prevented outdated snapshot results from affecting replacement sessions.
  * Ensured follow-up messages are processed after snapshot completion or failure.

* **Supported Providers**
  * Added support for providers whose snapshot operation stops the source sandbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->