### PR TITLE
fix(runtime): stop failing turns a reasoning model is still working on

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -115,7 +115,19 @@ class AgentBridge:
     HEARTBEAT_INTERVAL = 30.0
     RECONNECT_BACKOFF_BASE = 2.0
     RECONNECT_MAX_DELAY = 60.0
-    SSE_INACTIVITY_TIMEOUT = 120.0
+    # How long a turn may go without the harness producing anything before the
+    # bridge gives up on it. This is a liveness check for a harness that has
+    # stopped talking, not a budget for how long the model may think: a reasoning
+    # model on a high effort setting can be silent for minutes before its first
+    # streamed message, and the old two-minute value failed those turns while
+    # they were still working.
+    #
+    # Kept below the control plane's own inactivity watchdog
+    # (SANDBOX_INACTIVITY_TIMEOUT_MS, 10 minutes) so the bridge still owns the
+    # outcome. That watchdog snapshots and stops the sandbox for sessions with
+    # no client attached, which loses the turn's partial output and reports a
+    # stuck-processing error instead of this one.
+    SSE_INACTIVITY_TIMEOUT = 300.0
     SSE_INACTIVITY_TIMEOUT_MIN = 5.0
     SSE_INACTIVITY_TIMEOUT_MAX = 3600.0
     DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS = 5.0

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -115,18 +115,9 @@ class AgentBridge:
     HEARTBEAT_INTERVAL = 30.0
     RECONNECT_BACKOFF_BASE = 2.0
     RECONNECT_MAX_DELAY = 60.0
-    # How long a turn may go without the harness producing anything before the
-    # bridge gives up on it. This is a liveness check for a harness that has
-    # stopped talking, not a budget for how long the model may think: a reasoning
-    # model on a high effort setting can be silent for minutes before its first
-    # streamed message, and the old two-minute value failed those turns while
-    # they were still working.
-    #
-    # Kept below the control plane's own inactivity watchdog
-    # (SANDBOX_INACTIVITY_TIMEOUT_MS, 10 minutes) so the bridge still owns the
-    # outcome. That watchdog snapshots and stops the sandbox for sessions with
-    # no client attached, which loses the turn's partial output and reports a
-    # stuck-processing error instead of this one.
+    # Liveness check for a harness that stopped talking, not a budget for how
+    # long the model may think. Stays under the control plane's own inactivity
+    # watchdog (SANDBOX_INACTIVITY_TIMEOUT_MS) so the bridge owns the outcome.
     SSE_INACTIVITY_TIMEOUT = 300.0
     SSE_INACTIVITY_TIMEOUT_MIN = 5.0
     SSE_INACTIVITY_TIMEOUT_MAX = 3600.0

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,8 +1,8 @@
 {
-  "runtimeVersion": "v64-claude-harness",
-  "generation": 64,
+  "runtimeVersion": "v65-turn-inactivity-timeout",
+  "generation": 65,
   "minimumCompatibleGeneration": 62,
-  "minimumRebuildGeneration": 64,
+  "minimumRebuildGeneration": 65,
   "harnessMinimumGeneration": {
     "claude": 64
   }


### PR DESCRIPTION
## Summary

The bridge fails a turn when the harness produces nothing for a while. That budget was **two minutes**, applied to the gap before *every* message including the first, so it has to cover harness startup, MCP server init, settings and skills loading, and the model's time to its first streamed message.

Two minutes is a reasonable liveness check for OpenCode's token stream, which emits continuously. It is too short for a reasoning model on a high effort setting, where the first streamed message can be minutes away. Those turns were failed while they were still working.

The symptom on the Claude harness is `Execution failed: Claude agent produced no output for 120s.` The equivalent on OpenCode is `SSE stream inactive for 120s (no data received)`. The default has never been tuned and `BRIDGE_SSE_INACTIVITY_TIMEOUT` is not set in any environment, so 120s has always been the live value.

## Why five minutes and not ten

The control plane runs its own inactivity watchdog, `SANDBOX_INACTIVITY_TIMEOUT_MS`, defaulting to **10 minutes**. For sessions with no client attached (every bot and automation session) it snapshots and stops the sandbox and reports a stuck-processing error.

Setting the bridge budget to ten minutes would collide with that watchdog. Five keeps the bridge as the component that owns the outcome, so the failure stays the clearer one and OpenCode's path still preserves the turn's partial output.

## What this does not fix

This raises a number; it does not reconsider the mechanism. A silence budget cannot distinguish a harness that has died from a model that is thinking, and related reports suggest that distinction is what actually matters:

- #1263 — sandbox inactivity timeout stops active long-running processes
- #1601 — closed attempt at not stopping a sandbox mid-execution
- #681 — reasoning-heavy sessions failing with a timeout while the model appears to be thinking

A liveness signal that does not depend on the model producing output would address the class. Worth a follow-up.

## Testing

- `uv run python -m pytest` in `packages/sandbox-runtime`: 1034 passed, 3 skipped
- `npm test -w @open-inspect/control-plane`: 4218 passed
- ruff check and format clean

No test pinned the old default; the suites inject their own timeout values.

The runtime manifest moves to generation 65 with `minimumRebuildGeneration` 65, so prebuilt images rebuild and actually pick the new value up. The compatibility floor is unchanged since nothing about this is breaking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the streamed-response inactivity timeout from 120 to 300 seconds, reducing premature timeouts while waiting for activity.

* **Chores**
  * Updated the runtime version and generation metadata.
  * Preserved compatibility with supported earlier runtime generations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->