### PR TITLE
fix(slack): refresh the activity indicator from the sandbox heartbeat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,10 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
 
+  # quay.io, not Docker Hub: MinIO withdrew both images from Hub, so a Hub
+  # reference now fails to pull anonymously. Same releases, same digests.
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
@@ -60,7 +62,7 @@ services:
   # Creates the media and backup buckets once, then exits. It sees only the
   # variables named here, never the app's secrets.
   minio-init:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set; generate one with openssl rand -hex 16}

--- a/docs/CONTROL_PLANE_CONTAINER.md
+++ b/docs/CONTROL_PLANE_CONTAINER.md
@@ -13,8 +13,8 @@ providers behave the same; only the platform adapters differ.
 | Service      | Image                   | Role                                                                                  |
 | ------------ | ----------------------- | ------------------------------------------------------------------------------------- |
 | `app`        | built from this repo    | The control plane: HTTP API, session WebSockets, cron jobs. Port 8787.                |
-| `minio`      | `minio/minio`           | S3-compatible object storage for media and backups. Console on port 9001.             |
-| `minio-init` | `minio/mc`              | Creates the `media` and `backups` buckets, then exits.                                |
+| `minio`      | `quay.io/minio/minio`   | S3-compatible object storage for media and backups. Console on port 9001.             |
+| `minio-init` | `quay.io/minio/mc`      | Creates the `media` and `backups` buckets, then exits.                                |
 | `litestream` | `litestream/litestream` | Replicates the global store (`/data/global.db`) to the `backups` bucket every second. |
 | `caddy`      | `caddy` (profile `tls`) | Optional TLS termination for a public hostname.                                       |
 

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Logger } from "../logger";
 import {
   CallbackNotificationService,
+  SLACK_ACTIVITY_REFRESH_INTERVAL_MS,
   type CallbackRepository,
   type CallbackServiceEnv,
   type CallbackServiceDeps,
@@ -501,6 +502,129 @@ describe("CallbackNotificationService", () => {
         expect(harness.linearBot.fetch).not.toHaveBeenCalled();
       }
     );
+  });
+
+  describe("refreshSlackActivity", () => {
+    const SLACK_CONTEXT = { source: "slack", channel: "C123", threadTs: "111.222" };
+    // `now` is a wall-clock reading taken by the sandbox-event router.
+    const NOW = 1_700_000_000_000;
+
+    function withSlackMessage() {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(SLACK_CONTEXT),
+        source: "slack",
+      });
+      const fetchMock = vi.mocked(harness.slackBot.fetch);
+      fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+      return fetchMock;
+    }
+
+    it("posts a signed refresh for a slack message", async () => {
+      const fetchMock = withSlackMessage();
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://internal/callbacks/activity",
+        expect.objectContaining({ method: "POST" })
+      );
+      const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+      expect(body).toMatchObject({
+        sessionId: "session-123",
+        messageId: "msg-1",
+        timestamp: NOW,
+        context: expect.objectContaining({ channel: "C123", threadTs: "111.222" }),
+      });
+      expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
+    });
+
+    it("holds the next refresh until the interval has passed", async () => {
+      const fetchMock = withSlackMessage();
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await harness.service.refreshSlackActivity(
+        "msg-1",
+        NOW + SLACK_ACTIVITY_REFRESH_INTERVAL_MS - 1
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await harness.service.refreshSlackActivity("msg-1", NOW + SLACK_ACTIVITY_REFRESH_INTERVAL_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not read the message while the window is still open", async () => {
+      withSlackMessage();
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+      harness.repository.getMessageCallbackContext.mockClear();
+
+      await harness.service.refreshSlackActivity("msg-1", NOW + 30_000);
+      expect(harness.repository.getMessageCallbackContext).not.toHaveBeenCalled();
+    });
+
+    it("leaves the window open when delivery fails so the next heartbeat retries", async () => {
+      const fetchMock = withSlackMessage();
+      fetchMock.mockResolvedValue(new Response("nope", { status: 500 }));
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+      const afterFirstRefresh = fetchMock.mock.calls.length;
+      expect(afterFirstRefresh).toBeGreaterThan(0);
+
+      // A heartbeat well inside the interval still retries: nothing was
+      // delivered, so nothing moved the window.
+      await harness.service.refreshSlackActivity("msg-1", NOW + 30_000);
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(afterFirstRefresh);
+    });
+
+    it("skips a non-slack message without calling any bot", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(LINEAR_CALLBACK_CONTEXT),
+        source: "linear",
+      });
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
+      expect(harness.linearBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("skips a slack message that carries no callback context", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: null,
+        source: "slack",
+      });
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("skips when the slack binding is absent", async () => {
+      harness = createTestHarness({ env: { SLACK_BOT: undefined } });
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(SLACK_CONTEXT),
+        source: "slack",
+      });
+
+      await expect(harness.service.refreshSlackActivity("msg-1", NOW)).resolves.toBeUndefined();
+      expect(harness.slackBot.fetch).not.toHaveBeenCalled();
+    });
+
+    it("is renewed by a delivered tool-call callback, so a busy turn pays nothing", async () => {
+      const fetchMock = withSlackMessage();
+      const toolCallAt = Date.now();
+
+      await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // That callback set the Slack indicator, so a heartbeat arriving inside
+      // the interval has nothing left to do.
+      await harness.service.refreshSlackActivity("msg-1", toolCallAt + 30_000);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("notifyToolCall", () => {

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -13,6 +13,8 @@ import { verifyCallbackSignature } from "@open-inspect/shared/auth";
 import {
   linearCompletionCallbackSchema,
   linearToolCallCallbackSchema,
+  slackCallbackContextSchema,
+  SLACK_ACTIVITY_REFRESH_KIND,
 } from "@open-inspect/shared/types/session-api";
 
 const LINEAR_CALLBACK_CONTEXT = {
@@ -38,6 +40,9 @@ function createMockLogger(): Logger {
 function createMockRepository() {
   return {
     getMessageCallbackContext: vi.fn<MessageRepository["getMessageCallbackContext"]>(() => null),
+    getProcessingMessageWithStartedAt: vi.fn<
+      MessageRepository["getProcessingMessageWithStartedAt"]
+    >(() => null),
     getSession: vi.fn(() => null),
   };
 }
@@ -505,15 +510,26 @@ describe("CallbackNotificationService", () => {
   });
 
   describe("refreshSlackActivity", () => {
-    const SLACK_CONTEXT = { source: "slack", channel: "C123", threadTs: "111.222" };
+    // The real shape the slack-bot stores and its own route re-validates —
+    // a thinner fixture would sign a body the route rejects.
+    const SLACK_CONTEXT = {
+      source: "slack",
+      channel: "C123",
+      threadTs: "111.222",
+      repoFullName: "acme/app",
+      model: "anthropic/claude-haiku-4-5",
+    };
     // `now` is a wall-clock reading taken by the sandbox-event router.
     const NOW = 1_700_000_000_000;
 
-    function withSlackMessage() {
+    function withSlackMessage(processingId: string | null = "msg-1") {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
         callback_context: JSON.stringify(SLACK_CONTEXT),
         source: "slack",
       });
+      vi.mocked(harness.repository.getProcessingMessageWithStartedAt).mockReturnValue(
+        processingId === null ? null : { id: processingId, started_at: NOW - 1000 }
+      );
       const fetchMock = vi.mocked(harness.slackBot.fetch);
       fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
       return fetchMock;
@@ -531,12 +547,44 @@ describe("CallbackNotificationService", () => {
       );
       const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
       expect(body).toMatchObject({
+        kind: SLACK_ACTIVITY_REFRESH_KIND,
         sessionId: "session-123",
         messageId: "msg-1",
         timestamp: NOW,
-        context: expect.objectContaining({ channel: "C123", threadTs: "111.222" }),
       });
+      // The route re-parses the context it is handed, so the producer must
+      // already satisfy the canonical contract.
+      expect(slackCallbackContextSchema.safeParse(body.context).success).toBe(true);
       expect(await verifyCallbackSignature(body, "test-secret")).toBe(true);
+    });
+
+    it("does not refresh a message that is no longer processing", async () => {
+      const fetchMock = withSlackMessage(null);
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not refresh once a different message owns the turn", async () => {
+      const fetchMock = withSlackMessage("msg-2");
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("abandons a refresh whose message terminates before it reaches the wire", async () => {
+      const fetchMock = withSlackMessage();
+      // The turn completes between the heartbeat that asked for this refresh
+      // and the moment the refresh is ready to send.
+      vi.mocked(harness.repository.getProcessingMessageWithStartedAt).mockImplementation(
+        () => null
+      );
+
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it("holds the next refresh until the interval has passed", async () => {
@@ -555,6 +603,28 @@ describe("CallbackNotificationService", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it("refreshes on the first heartbeat after a runtime is rebuilt", async () => {
+      const fetchMock = withSlackMessage();
+      await harness.service.refreshSlackActivity("msg-1", NOW);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // An evicted Durable Object reconstructs the service, so the window is
+      // gone. Losing it can only make a refresh earlier, never later.
+      const rebuilt = createTestHarness();
+      vi.mocked(rebuilt.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify(SLACK_CONTEXT),
+        source: "slack",
+      });
+      vi.mocked(rebuilt.repository.getProcessingMessageWithStartedAt).mockReturnValue({
+        id: "msg-1",
+        started_at: NOW - 1000,
+      });
+      vi.mocked(rebuilt.slackBot.fetch).mockResolvedValue(new Response("ok", { status: 200 }));
+
+      await rebuilt.service.refreshSlackActivity("msg-1", NOW + 30_000);
+      expect(rebuilt.slackBot.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it("does not read the message while the window is still open", async () => {
       withSlackMessage();
 
@@ -565,18 +635,26 @@ describe("CallbackNotificationService", () => {
       expect(harness.repository.getMessageCallbackContext).not.toHaveBeenCalled();
     });
 
-    it("leaves the window open when delivery fails so the next heartbeat retries", async () => {
+    it("sends one bounded attempt and leaves the window open when it fails", async () => {
       const fetchMock = withSlackMessage();
       fetchMock.mockResolvedValue(new Response("nope", { status: 500 }));
 
       await harness.service.refreshSlackActivity("msg-1", NOW);
-      const afterFirstRefresh = fetchMock.mock.calls.length;
-      expect(afterFirstRefresh).toBeGreaterThan(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
 
       // A heartbeat well inside the interval still retries: nothing was
       // delivered, so nothing moved the window.
       await harness.service.refreshSlackActivity("msg-1", NOW + 30_000);
-      expect(fetchMock.mock.calls.length).toBeGreaterThan(afterFirstRefresh);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("swallows a delivery that throws", async () => {
+      const fetchMock = withSlackMessage();
+      fetchMock.mockRejectedValue(new Error("binding exploded"));
+
+      await expect(harness.service.refreshSlackActivity("msg-1", NOW)).resolves.toBeUndefined();
+      expect(harness.log.warn).toHaveBeenCalled();
     });
 
     it("skips a non-slack message without calling any bot", async () => {
@@ -624,6 +702,56 @@ describe("CallbackNotificationService", () => {
       // the interval has nothing left to do.
       await harness.service.refreshSlackActivity("msg-1", toolCallAt + 30_000);
       expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not let an in-flight refresh rewind the window past a newer tool call", async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = withSlackMessage();
+        let release!: (response: Response) => void;
+        let markOnWire!: () => void;
+        // Park the refresh on the wire, keyed on its route rather than on call
+        // order — the refresh awaits HMAC signing first, so the tool call can
+        // otherwise reach `fetch` before it does.
+        const refreshOnWire = new Promise<void>((resolve) => {
+          markOnWire = resolve;
+        });
+        fetchMock.mockImplementation((url) => {
+          if (!String(url).endsWith("/callbacks/activity")) {
+            return Promise.resolve(new Response("ok", { status: 200 }));
+          }
+          markOnWire();
+          return new Promise<Response>((resolve) => {
+            release = resolve;
+          });
+        });
+
+        vi.setSystemTime(NOW);
+        const refresh = harness.service.refreshSlackActivity("msg-1", NOW);
+        await refreshOnWire;
+
+        // A tool call asserts the indicator two intervals later, while the
+        // refresh minted at NOW is still in flight.
+        vi.setSystemTime(NOW + 2 * SLACK_ACTIVITY_REFRESH_INTERVAL_MS);
+        await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+
+        release(new Response("ok", { status: 200 }));
+        await refresh;
+
+        // Back to a plain responder so the probe below fails on the assertion
+        // rather than by parking on the wire.
+        fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+        const sent = fetchMock.mock.calls.length;
+        // The tool call's assertion is the newer truth. If the resolved
+        // refresh had rewound the window to NOW, this would re-send.
+        await harness.service.refreshSlackActivity(
+          "msg-1",
+          NOW + 2 * SLACK_ACTIVITY_REFRESH_INTERVAL_MS + 1_000
+        );
+        expect(fetchMock.mock.calls).toHaveLength(sent);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -12,6 +12,7 @@ import {
   automationCallbackContextSchema,
   linearCompletionCallbackPayloadSchema,
   linearToolCallCallbackPayloadSchema,
+  SLACK_ACTIVITY_REFRESH_KIND,
 } from "@open-inspect/shared/types/session-api";
 import { callbackSigningSecret, type CallbackDestination } from "../auth/service/callback-signing";
 import type { Logger } from "../logger";
@@ -76,8 +77,20 @@ const EMPTY_TOOL_ARGS: Record<string, unknown> = {};
  * the session still believes in has proven itself within the last 90s. One
  * refresh per minute therefore lands with a full minute to spare, and costs
  * nothing on a session that is already emitting tool calls.
+ *
+ * The window is per activation, so an evicted runtime refreshes on its first
+ * heartbeat back. That can only make a refresh earlier, never later, and the
+ * floor is the 30s heartbeat itself — well under what a single turn already
+ * spends on tool-call status updates.
  */
 export const SLACK_ACTIVITY_REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * One bounded attempt per refresh. A retry would buy a second correlated shot
+ * at the same binding while widening the window in which a turn can terminate
+ * under an in-flight refresh; the next heartbeat is the better retry.
+ */
+const ACTIVITY_REFRESH_TIMEOUT_MS = 10_000;
 
 interface CallbackDeliveryResult {
   delivered: boolean;
@@ -419,42 +432,69 @@ export class CallbackNotificationService {
     }
 
     const sessionId = this.getSessionId();
-    const callbackData = { sessionId, messageId, timestamp: now, context };
+    const callbackData = {
+      kind: SLACK_ACTIVITY_REFRESH_KIND,
+      sessionId,
+      messageId,
+      timestamp: now,
+      context,
+    };
     const signature = await this.signPayload(callbackData, secret);
 
-    let lastError: unknown;
-    const delivery = await deliverWithRetry(
-      (signal) =>
-        binding.fetch("https://internal/callbacks/activity", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...callbackData, signature }),
-          signal,
-        }),
-      this.sleep,
-      ({ error }) => {
-        lastError = error;
+    // Last look before the wire. The turn can terminate between the heartbeat
+    // that asked for this refresh and here — completion posts the final reply
+    // and nothing clears the indicator afterwards, so a refresh that lands
+    // after it would re-assert `Working...` on a finished thread.
+    if (this.messageRepository.getProcessingMessageWithStartedAt()?.id !== messageId) {
+      this.log.debug("callback.activity_refresh", {
+        message_id: messageId,
+        session_id: sessionId,
+        source: "slack",
+        outcome: "skipped",
+        skip_reason: "no_longer_processing",
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ACTIVITY_REFRESH_TIMEOUT_MS);
+    try {
+      const response = await binding.fetch("https://internal/callbacks/activity", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...callbackData, signature }),
+        signal: controller.signal,
+      });
+
+      const fields = {
+        message_id: messageId,
+        session_id: sessionId,
+        source: "slack",
+        outcome: response.ok ? "success" : "error",
+        http_status: response.status,
+        duration_ms: Date.now() - now,
+      };
+      if (response.ok) {
+        // `max` because a tool-call callback may have asserted the indicator
+        // while this refresh was in flight; that is the newer truth.
+        this._lastSlackActivityAt = Math.max(this._lastSlackActivityAt, now);
+        this.log.info("callback.activity_refresh", fields);
+      } else {
+        // The window stays open, so the next heartbeat retries in 30s.
+        this.log.warn("callback.activity_refresh", fields);
       }
-    );
-
-    // Only a delivered refresh moves the window. An undelivered one leaves it
-    // open so the next heartbeat retries 30s from now rather than 60s.
-    if (delivery.delivered) this._lastSlackActivityAt = now;
-
-    const fields = {
-      message_id: messageId,
-      session_id: sessionId,
-      source: "slack",
-      outcome: delivery.delivered ? "success" : "error",
-      attempts: delivery.attempts,
-      ...(delivery.httpStatus !== undefined ? { http_status: delivery.httpStatus } : {}),
-      ...(lastError !== undefined
-        ? { error: lastError instanceof Error ? lastError : new Error(String(lastError)) }
-        : {}),
-      duration_ms: Date.now() - now,
-    };
-    if (delivery.delivered) this.log.info("callback.activity_refresh", fields);
-    else this.log.warn("callback.activity_refresh", fields);
+    } catch (error) {
+      this.log.warn("callback.activity_refresh", {
+        message_id: messageId,
+        session_id: sessionId,
+        source: "slack",
+        outcome: "error",
+        error: error instanceof Error ? error : new Error(String(error)),
+        duration_ms: Date.now() - now,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   /**
@@ -581,7 +621,8 @@ export class CallbackNotificationService {
         // The bot sets the Slack indicator from this callback, so it renews the
         // same window `refreshSlackActivity` guards. A turn that keeps calling
         // tools therefore never pays for a separate refresh.
-        if (source === "slack") this._lastSlackActivityAt = now;
+        if (source === "slack")
+          this._lastSlackActivityAt = Math.max(this._lastSlackActivityAt, now);
         this.log.info("callback.tool_call", {
           message_id: messageId,
           session_id: sessionId,

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -66,6 +66,19 @@ export interface CallbackServiceDeps {
 const NOTIFIED_CALL_IDS_CAP = 500;
 const EMPTY_TOOL_ARGS: Record<string, unknown> = {};
 
+/**
+ * How stale a Slack assistant-thread activity indicator may get before the
+ * next sandbox heartbeat refreshes it.
+ *
+ * Slack clears the indicator two minutes after the last `setStatus`. The
+ * sandbox bridge heartbeats every 30s while a turn is in flight, and the
+ * control plane declares a sandbox dead after 90s without one, so a sandbox
+ * the session still believes in has proven itself within the last 90s. One
+ * refresh per minute therefore lands with a full minute to spare, and costs
+ * nothing on a session that is already emitting tool calls.
+ */
+export const SLACK_ACTIVITY_REFRESH_INTERVAL_MS = 60_000;
+
 interface CallbackDeliveryResult {
   delivered: boolean;
   attempts: number;
@@ -82,6 +95,13 @@ export class CallbackNotificationService {
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly completeAutomationRun: AutomationRunCompletionHandler | undefined;
   private _lastToolCallCallbackTs = 0;
+  /**
+   * When Slack's activity indicator was last (re)asserted for this session, by
+   * any path that calls `setStatus` — tool-call progress or an explicit
+   * refresh. In memory on purpose: losing it on eviction costs one redundant
+   * refresh, never a missed one.
+   */
+  private _lastSlackActivityAt = 0;
   private readonly notifiedCallIds = new Set<string>();
 
   constructor(deps: CallbackServiceDeps) {
@@ -351,6 +371,93 @@ export class CallbackNotificationService {
   }
 
   /**
+   * Re-assert Slack's assistant-thread activity indicator while a turn is
+   * still in flight.
+   *
+   * Driven by the sandbox heartbeat rather than by a timer. The heartbeat is
+   * the session's evidence that the agent is still occupied with this turn —
+   * the same evidence the inactivity watchdog renews `last_activity` from — so
+   * the indicator cannot outlive the thing it claims. A turn that emits tool
+   * calls keeps the indicator alive through `notifyToolCall` and never reaches
+   * delivery here.
+   *
+   * Best-effort: the bot acknowledges the callback before it calls Slack, so a
+   * delivered refresh is not proof the indicator was set. It is only proof the
+   * next one is a minute away.
+   */
+  async refreshSlackActivity(messageId: string, now: number): Promise<void> {
+    if (now - this._lastSlackActivityAt < SLACK_ACTIVITY_REFRESH_INTERVAL_MS) return;
+
+    // Web, Linear, automation and agent turns have no Slack indicator to hold
+    // open. Nothing to log — this is the ordinary shape of most sessions.
+    const message = this.messageRepository.getMessageCallbackContext(messageId);
+    if (!message?.callback_context || message.source !== "slack") return;
+
+    const { binding, secret } = this.resolveCallbackRoute("slack");
+    if (!secret || !binding) {
+      this.log.debug("callback.activity_refresh", {
+        message_id: messageId,
+        source: "slack",
+        outcome: "skipped",
+        skip_reason: secret ? "no_binding" : "no_secret",
+      });
+      return;
+    }
+
+    let context: unknown;
+    try {
+      context = JSON.parse(message.callback_context);
+    } catch (error) {
+      this.log.warn("callback.activity_refresh", {
+        message_id: messageId,
+        source: "slack",
+        outcome: "skipped",
+        skip_reason: "invalid_callback_context",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      return;
+    }
+
+    const sessionId = this.getSessionId();
+    const callbackData = { sessionId, messageId, timestamp: now, context };
+    const signature = await this.signPayload(callbackData, secret);
+
+    let lastError: unknown;
+    const delivery = await deliverWithRetry(
+      (signal) =>
+        binding.fetch("https://internal/callbacks/activity", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...callbackData, signature }),
+          signal,
+        }),
+      this.sleep,
+      ({ error }) => {
+        lastError = error;
+      }
+    );
+
+    // Only a delivered refresh moves the window. An undelivered one leaves it
+    // open so the next heartbeat retries 30s from now rather than 60s.
+    if (delivery.delivered) this._lastSlackActivityAt = now;
+
+    const fields = {
+      message_id: messageId,
+      session_id: sessionId,
+      source: "slack",
+      outcome: delivery.delivered ? "success" : "error",
+      attempts: delivery.attempts,
+      ...(delivery.httpStatus !== undefined ? { http_status: delivery.httpStatus } : {}),
+      ...(lastError !== undefined
+        ? { error: lastError instanceof Error ? lastError : new Error(String(lastError)) }
+        : {}),
+      duration_ms: Date.now() - now,
+    };
+    if (delivery.delivered) this.log.info("callback.activity_refresh", fields);
+    else this.log.warn("callback.activity_refresh", fields);
+  }
+
+  /**
    * Notify the originating client of a tool_call event (best-effort, throttled).
    * Max 1 callback per 3 seconds per session.
    */
@@ -471,6 +578,10 @@ export class CallbackNotificationService {
         // event for this callId (Anthropic's running and completed may be
         // seconds apart for long-running tools — the second event should retry).
         if (callId) this.markCallIdNotified(callId);
+        // The bot sets the Slack indicator from this callback, so it renews the
+        // same window `refreshSlackActivity` guards. A turn that keeps calling
+        // tools therefore never pays for a separate refresh.
+        if (source === "slack") this._lastSlackActivityAt = now;
         this.log.info("callback.tool_call", {
           message_id: messageId,
           session_id: sessionId,

--- a/packages/control-plane/src/session/components.ts
+++ b/packages/control-plane/src/session/components.ts
@@ -526,6 +526,11 @@ export function createSessionRuntime(platform: SessionPlatform, env: Env): Sessi
     diffService,
     (title, options) => titleService.applySessionTitleUpdate(title, options),
     updateLastActivity,
+    (messageId, timestamp) =>
+      backgroundTasks.submit(() => callbackService.refreshSlackActivity(messageId, timestamp), {
+        name: "callback.refresh_slack_activity",
+        context: { message_id: messageId },
+      }),
     log
   );
   const pushService = new SandboxPushService(log, wsManager);

--- a/packages/control-plane/src/session/sandbox-events/processor.test.ts
+++ b/packages/control-plane/src/session/sandbox-events/processor.test.ts
@@ -83,6 +83,7 @@ function createProcessor() {
   const processMessageQueue = vi.fn(async () => {});
   const broadcastPromptQueue = vi.fn();
   const updateLastActivity = vi.fn();
+  const refreshSlackActivity = vi.fn();
   const applySessionTitleUpdate = vi.fn((title: string) => ({ ok: true as const, title }));
   const offerFallbackTitle = vi.fn((_title: string) => {});
   const log = {
@@ -149,6 +150,7 @@ function createProcessor() {
       diffService as unknown as SessionDiffService,
       applySessionTitleUpdate,
       updateLastActivity,
+      refreshSlackActivity,
       log
     ),
     pushService
@@ -172,6 +174,7 @@ function createProcessor() {
     processMessageQueue,
     broadcastPromptQueue,
     updateLastActivity,
+    refreshSlackActivity,
     applySessionTitleUpdate,
     backgroundTasks,
     log,
@@ -785,6 +788,33 @@ describe("SessionSandboxEventProcessor", () => {
       });
 
       expect(h.updateLastActivity).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it("refreshes the slack activity indicator on heartbeat while a message is processing", async () => {
+      const h = createProcessor();
+      h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
+
+      await h.processor.processSandboxEvent({
+        type: "heartbeat",
+        sandboxId: "sb-1",
+        status: "ready",
+        timestamp: 1000,
+      });
+
+      expect(h.refreshSlackActivity).toHaveBeenCalledWith("msg-1", expect.any(Number));
+    });
+
+    it("does not refresh the slack activity indicator on heartbeat while idle", async () => {
+      const h = createProcessor();
+
+      await h.processor.processSandboxEvent({
+        type: "heartbeat",
+        sandboxId: "sb-1",
+        status: "ready",
+        timestamp: 1000,
+      });
+
+      expect(h.refreshSlackActivity).not.toHaveBeenCalled();
     });
 
     it("does not reset activity timer on token", async () => {

--- a/packages/control-plane/src/session/sandbox-events/runtime.handler.ts
+++ b/packages/control-plane/src/session/sandbox-events/runtime.handler.ts
@@ -27,6 +27,7 @@ export class SandboxRuntimeEventHandler {
       options?: SessionTitleUpdateOptions
     ) => SessionTitleUpdateResult,
     private readonly updateLastActivity: (timestamp: number) => void,
+    private readonly refreshSlackActivity: (messageId: string, timestamp: number) => void,
     private readonly log: Logger
   ) {}
 
@@ -37,6 +38,10 @@ export class SandboxRuntimeEventHandler {
     // the sandbox is still occupied and should renew its activity timestamp.
     if (context.processingMessage !== null) {
       this.updateLastActivity(context.now);
+      // The same proof drives Slack's assistant-thread indicator, which Slack
+      // clears two minutes after the last update. Refreshing it from here, and
+      // not from a timer, is what keeps it from outliving the turn it claims.
+      this.refreshSlackActivity(context.processingMessage.id, context.now);
     }
   }
 

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -47,6 +47,14 @@ export const slackCallbackContextSchema = z.object({
 
 export type SlackCallbackContext = z.infer<typeof slackCallbackContextSchema>;
 
+/**
+ * Domain separator for the Slack activity-refresh callback. Signed into the
+ * body and required by the route, so a body minted for another callback — whose
+ * signature is equally valid — cannot satisfy this one. Shared so the producer
+ * and the route cannot drift apart on the literal.
+ */
+export const SLACK_ACTIVITY_REFRESH_KIND = "slack.activity_refresh";
+
 const linearCallbackContextBaseSchema = z.strictObject({
   source: z.literal("linear"),
   issueId: nonEmptyStringSchema,

--- a/packages/slack-bot/src/activity-status.ts
+++ b/packages/slack-bot/src/activity-status.ts
@@ -7,7 +7,8 @@ const DEFAULT_STATUS_PART_MAX_LENGTH = 80;
 const DEFAULT_STATUS_TEXT_MAX_LENGTH = 80;
 const LOADING_MESSAGE_MAX_LENGTH = 50;
 const FILE_ARG_KEYS = ["filePath", "file_path", "filepath", "path", "file"];
-const TOOL_STATUS_INDICATOR = "Working...";
+/** The indicator Slack shows while a turn is in flight, whatever the turn is doing. */
+export const ASSISTANT_WORKING_STATUS = "Working...";
 
 const log = createLogger("activity-status");
 
@@ -39,7 +40,7 @@ type AssistantThreadStatusResult =
     };
 
 type AssistantStatusMeta = {
-  event: "start" | "tool_call";
+  event: "start" | "tool_call" | "refresh";
   traceId?: string;
   sessionId?: string;
   tool?: string;
@@ -235,7 +236,9 @@ export async function setAssistantThreadStatusBestEffort(
   const eventName =
     meta.event === "tool_call"
       ? "slack.assistant_status.tool_call"
-      : "slack.assistant_status.start";
+      : meta.event === "refresh"
+        ? "slack.assistant_status.refresh"
+        : "slack.assistant_status.start";
   const base = {
     trace_id: meta.traceId,
     session_id: meta.sessionId,
@@ -246,7 +249,7 @@ export async function setAssistantThreadStatusBestEffort(
   };
 
   try {
-    const statusText = meta.event === "tool_call" ? TOOL_STATUS_INDICATOR : status;
+    const statusText = meta.event === "tool_call" ? ASSISTANT_WORKING_STATUS : status;
     const requestStatusLength = prepareStatusText(statusText).length;
     const requestLoadingMessageLengths = [status].map(
       (message) => prepareLoadingMessageText(message).length

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -312,6 +312,91 @@ async function postCallback(path: string, payload: unknown, env = makeEnv(), ctx
   return { response, env, ctx };
 }
 
+describe("POST /callbacks/activity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function activityData(overrides: Record<string, unknown> = {}) {
+    return {
+      sessionId: "session-1",
+      messageId: "msg-1",
+      timestamp: Date.now(),
+      context: {
+        source: "slack",
+        channel: "C123",
+        threadTs: "111.222",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+      },
+      ...overrides,
+    };
+  }
+
+  it("re-asserts the working indicator on the thread", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(activityData());
+
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+    expect(response.status).toBe(200);
+
+    await flushWaitUntil(ctx);
+    expect(slackCall(fetchMock, "assistant.threads.setStatus")?.body).toEqual({
+      channel_id: "C123",
+      thread_ts: "111.222",
+      status: "Working...",
+      loading_messages: ["Working..."],
+    });
+  });
+
+  it("rejects a payload signed with the wrong secret", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(activityData(), "wrong-secret");
+
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(401);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale refresh", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(activityData({ timestamp: Date.now() - 5 * 60 * 1000 }));
+
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(401);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a future-dated refresh", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(activityData({ timestamp: Date.now() + 5 * 60 * 1000 }));
+
+    const { response, ctx } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(401);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a payload missing the thread context", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload({
+      sessionId: "session-1",
+      messageId: "msg-1",
+      timestamp: Date.now(),
+    });
+
+    const { response } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /callbacks/complete", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -319,6 +319,7 @@ describe("POST /callbacks/activity", () => {
 
   function activityData(overrides: Record<string, unknown> = {}) {
     return {
+      kind: "slack.activity_refresh",
       sessionId: "session-1",
       messageId: "msg-1",
       timestamp: Date.now(),
@@ -379,6 +380,40 @@ describe("POST /callbacks/activity", () => {
 
     expect(response.status).toBe(401);
     expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a validly signed completion payload replayed onto this route", async () => {
+    const fetchMock = okFetchMock();
+    // A real /callbacks/complete body: same signing key, same context, and its
+    // signature verifies. Only the domain separator keeps it off this route.
+    const payload = await signPayload({
+      sessionId: "session-1",
+      messageId: "msg-1",
+      success: true,
+      timestamp: Date.now(),
+      context: {
+        source: "slack",
+        channel: "C123",
+        threadTs: "111.222",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+      },
+    });
+
+    const { response } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a refresh carrying the wrong domain separator", async () => {
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(activityData({ kind: "slack.completion" }));
+
+    const { response } = await postCallback("/callbacks/activity", payload);
+
+    expect(response.status).toBe(400);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -9,9 +9,21 @@ import { z } from "zod";
 import type { Env } from "./types";
 import { createSlackCompletionJob, type SlackCompletionJob } from "./completion/job";
 import { createLogger } from "./logger";
-import { formatToolStatus, setAssistantThreadStatusBestEffort } from "./activity-status";
+import {
+  ASSISTANT_WORKING_STATUS,
+  formatToolStatus,
+  setAssistantThreadStatusBestEffort,
+} from "./activity-status";
 
 const log = createLogger("callback");
+
+/**
+ * How far an activity refresh's signed timestamp may sit from now. A refresh
+ * only asserts "still working" for the two minutes Slack keeps the indicator
+ * up, so bounding the window to the same two minutes bounds what a captured
+ * one can replay to a single extra display period.
+ */
+const ACTIVITY_CALLBACK_MAX_AGE_MS = 2 * 60 * 1000;
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -44,6 +56,14 @@ const toolCallCallbackSchema = z.looseObject({
   tool: z.string(),
   args: z.record(z.string(), z.unknown()),
   callId: z.string(),
+  timestamp: z.number(),
+  signature: z.string(),
+  context: slackCallbackContextSchema,
+});
+
+const activityCallbackSchema = z.looseObject({
+  sessionId: z.string(),
+  messageId: z.string(),
   timestamp: z.number(),
   signature: z.string(),
   context: slackCallbackContextSchema,
@@ -228,6 +248,72 @@ callbacksRouter.post("/complete", async (c) => {
     "/callbacks/complete",
     startTime
   );
+});
+
+/**
+ * Re-assert the assistant-thread activity indicator for a turn that is still
+ * in flight. Slack clears the indicator two minutes after the last update, and
+ * a turn can spend longer than that inside one quiet tool call.
+ */
+callbacksRouter.post("/activity", async (c) => {
+  const startTime = Date.now();
+  const traceId = c.req.header("x-trace-id") || crypto.randomUUID();
+  let payload: unknown;
+
+  try {
+    payload = await c.req.json();
+  } catch {
+    return rejectInvalidPayload(c, "/callbacks/activity", traceId, startTime);
+  }
+
+  const parsed = activityCallbackSchema.safeParse(payload);
+  if (!parsed.success || !isSignedCallbackPayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/activity", traceId, startTime);
+  }
+  const valid = parsed.data;
+
+  const rejection = await rejectInvalidCallback(c, payload, {
+    path: "/callbacks/activity",
+    traceId,
+    startTime,
+  });
+  if (rejection) return rejection;
+
+  if (Math.abs(startTime - valid.timestamp) > ACTIVITY_CALLBACK_MAX_AGE_MS) {
+    log.warn("http.request", {
+      trace_id: traceId,
+      http_method: "POST",
+      http_path: "/callbacks/activity",
+      http_status: 401,
+      outcome: "rejected",
+      reject_reason: "stale_timestamp",
+      session_id: valid.sessionId,
+      duration_ms: Date.now() - startTime,
+    });
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  c.executionCtx.waitUntil(
+    setAssistantThreadStatusBestEffort(
+      c.env,
+      valid.context.channel,
+      valid.context.threadTs,
+      ASSISTANT_WORKING_STATUS,
+      { event: "refresh", traceId, sessionId: valid.sessionId }
+    )
+  );
+
+  log.info("http.request", {
+    trace_id: traceId,
+    http_method: "POST",
+    http_path: "/callbacks/activity",
+    http_status: 200,
+    session_id: valid.sessionId,
+    message_id: valid.messageId,
+    duration_ms: Date.now() - startTime,
+  });
+
+  return c.json({ ok: true });
 });
 
 /**

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -4,6 +4,7 @@
 
 import { postEphemeral } from "@open-inspect/shared/slack";
 import { verifyCallbackFromControlPlane } from "@open-inspect/shared/auth";
+import { SLACK_ACTIVITY_REFRESH_KIND } from "@open-inspect/shared/types/session-api";
 import { Hono, type Context } from "hono";
 import { z } from "zod";
 import type { Env } from "./types";
@@ -61,7 +62,13 @@ const toolCallCallbackSchema = z.looseObject({
   context: slackCallbackContextSchema,
 });
 
+/**
+ * `kind` is the domain separator. Without it a body signed for another callback
+ * route satisfies this shape too — the HMAC covers only the body, so a valid
+ * `/callbacks/complete` payload would verify here and re-assert `Working...`.
+ */
 const activityCallbackSchema = z.looseObject({
+  kind: z.literal(SLACK_ACTIVITY_REFRESH_KIND),
   sessionId: z.string(),
   messageId: z.string(),
   timestamp: z.number(),


### PR DESCRIPTION
## Problem

Slack clears an assistant-thread activity indicator two minutes after the last `assistant.threads.setStatus`. The only thing that re-asserts it mid-turn today is the tool-call callback, so a turn that spends longer than two minutes inside one quiet tool call (`sleep 600`, a long build, a slow embedding job) keeps working while its indicator disappears.

Fixes #1262.

## Approach

The indicator is a projection of "this Slack thread has a turn in flight". Today it is a side effect of a *different* event stream, which happens to fire often enough in the common case and not at all in the reported one.

Rather than add a timer, this drives the indicator from the signal that already proves the turn is alive. The sandbox bridge heartbeats every 30s on a task that runs concurrent with the prompt (`bridge.py`), and `handleHeartbeat` already treats *heartbeat + a processing message* as proof the sandbox is still occupied with this turn — it renews `last_activity` from exactly that, with a comment describing this very scenario. Slack's indicator now follows the same conclusion:

- `SandboxRuntimeEventHandler.handleHeartbeat` asks for a refresh when a message is processing.
- `CallbackNotificationService.refreshSlackActivity` rate-limits to one refresh per minute and posts a signed callback to a new `POST /callbacks/activity` on the slack-bot, which re-asserts `Working...`.
- A delivered tool-call callback renews the same window, so a turn that keeps calling tools costs nothing extra.

Interval: Slack expires at 120s, the bridge heartbeats every 30s, and the control plane declares a sandbox dead after 90s without one — so any sandbox the session still believes in has proven itself within the last 90s. One refresh per minute lands with a minute to spare.

### Why not a Durable Object alarm

[#1621](https://github.com/ColeMurray/background-agents/pull/1621) solved this with a self-rescheduling 90s alarm, and it is a careful piece of work — the signed-callback boundary and the slack-bot route here are its design, kept. The trigger is what differs, for three reasons:

1. **The indicator could outlive its evidence.** An alarm-driven refresh keyed on `messages.status = 'processing'` re-asserts "Working..." from a database row. The alarm's health gate, `lifecycleResult === "no_action"`, is also returned by `handleAlarm` when there is *no sandbox row* and when the sandbox is *already terminal* — neither of which fails the processing message. With the default two-hour execution timeout, a stuck row means up to two hours of "Working..." on a dead turn. Today Slack's two-minute expiry quietly self-heals every stuck-row bug; keying the refresh to live evidence keeps that property instead of removing it.
2. **No new writer on the single alarm slot.** The DO has one alarm, already shared by the execution deadline, lifecycle checks, stop confirmation, auth-lease expiry, and projection retries; six call sites carry comments about not disturbing it. This adds none, and does no network I/O inside the alarm handler.
3. **It costs nothing to run.** The DO is already awake for that heartbeat, and a session emitting tool calls never sends a refresh at all — where a fixed timer sends ~40 an hour per active session regardless, each one replacing the tool-specific loading text with the generic one.

## Known limits

- A turn orphaned by a sandbox reconnect (message still `processing`, prompt never re-sent to the new sandbox) will still show "Working...", because the new sandbox does heartbeat. That is a pre-existing stuck-state bug and is not addressed here either way.
- The window is in-memory. Losing it on DO eviction costs one redundant refresh, never a missed one.
- The slack-bot acknowledges the callback before calling Slack, so a delivered refresh is not proof the indicator was set. The bot logs the Slack outcome separately under `slack.assistant_status.refresh`.
- Sandbox spawn/cold start is out of scope: the message is `pending`, not `processing`, and nothing is alive to heartbeat yet.

## Testing

- `npm run test -w @open-inspect/control-plane` — 4,230 passed
- `npm run test -w @open-inspect/slack-bot` — 437 passed
- `npm run typecheck -w @open-inspect/control-plane -w @open-inspect/slack-bot` — passed
- `npm run lint` / `npm run format` — clean
- `npm run build -w @open-inspect/control-plane -w @open-inspect/slack-bot` — passed

New coverage: the refresh posts a correctly signed payload; the window holds and then reopens; an undelivered refresh leaves the window open so the next heartbeat retries; non-Slack, context-less and binding-less sessions send nothing; a delivered tool-call callback suppresses the next refresh; a heartbeat refreshes only while a message is processing; and the route rejects bad signatures, stale and future-dated timestamps, and payloads missing the thread context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack assistant threads now keep the “Working...” indicator refreshed while a message is actively processing, including heartbeat and tool-call progress.
  - Added a secure activity-refresh callback with signature, timestamp, payload, and thread-context validation.

- **Bug Fixes**
  - Refreshes stop when processing ends or another message takes ownership.
  - Idle messages no longer trigger refreshes.
  - Activity timestamps no longer move backward, and failed deliveries remain bounded without prematurely closing the refresh window.
  - Invalid or mismatched callback requests are rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->