### PR TITLE
fix(scripts): bootstrap owner with an atomic result-bearing batch

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -762,7 +762,9 @@ The command uses Wrangler credentials (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_AC
 `wrangler login`) and targets remote D1. It refuses a suspended/missing user, a missing or ambiguous
 assignment, or another unsuspended Owner. There is no force option. Execution is one atomic Wrangler
 SQL file: it writes one redacted `workspace.owner_bootstrapped` service audit event and replaces the
-target's assignment. A no-op writes nothing.
+target's assignment. After the import, a separate read verifies the current assignment and the exact
+audit event from this invocation before reporting completion; import statistics alone are not proof
+of ownership. A no-op writes nothing.
 
 6. Verify the control-plane health response contains `"rbac":{"ownerAssignment":"present"}`:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -761,10 +761,10 @@ npm run rbac:bootstrap-owner -- \
 The command uses Wrangler credentials (`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, or
 `wrangler login`) and targets remote D1. It refuses a suspended/missing user, a missing or ambiguous
 assignment, or another unsuspended Owner. There is no force option. Execution is one atomic Wrangler
-SQL file: it writes one redacted `workspace.owner_bootstrapped` service audit event and replaces the
-target's assignment. After the import, a separate read verifies the current assignment and the exact
-audit event from this invocation before reporting completion; import statistics alone are not proof
-of ownership. A no-op writes nothing.
+`--command` batch: it writes one redacted `workspace.owner_bootstrapped` service audit event,
+replaces the target's assignment, and returns the exact audit-bound postcondition from that same
+transaction. A no-op writes nothing. A lost batch response can leave the outcome uncertain; the
+command does not automatically retry writes or claim success without the postcondition.
 
 6. Verify the control-plane health response contains `"rbac":{"ownerAssignment":"present"}`:
 

--- a/scripts/bootstrap-workspace-owner.test.ts
+++ b/scripts/bootstrap-workspace-owner.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { DatabaseSync } from "node:sqlite";
 import { buildBootstrapSql, parseArgs, run } from "./bootstrap-workspace-owner.ts";
@@ -49,16 +49,51 @@ function createDatabase(): DatabaseSync {
   return database;
 }
 
-function sql(execute: boolean, auditId = "audit-id", now = 100): string {
-  return buildBootstrapSql({ userId: USER_ID, execute, auditId, now });
+function sql(auditId = "audit-id", now = 100) {
+  return buildBootstrapSql({ userId: USER_ID, auditId, now });
 }
 
 function preflight(database: DatabaseSync): Record<string, unknown> {
-  return { ...database.prepare(sql(false, "unused", 0)).get() };
+  return { ...database.prepare(sql().preflight).get() };
 }
 
 function execute(database: DatabaseSync, auditId: string, now: number): void {
-  database.exec(sql(true, auditId, now));
+  database.exec(sql(auditId, now).mutation);
+}
+
+// Remote --file uses D1's atomic import, whose response contains statistics,
+// not SELECT rows. --command returns query results. Execute the real SQL here
+// so the orchestration tests cannot invent successful postconditions.
+function databaseRunner(database: DatabaseSync) {
+  return (_database: string, operation: readonly string[]): string => {
+    if (operation[0] === "--command") {
+      return JSON.stringify([{ success: true, results: database.prepare(operation[1]).all() }]);
+    }
+    assert.equal(operation[0], "--file");
+    database.exec("BEGIN");
+    try {
+      database.exec(readFileSync(operation[1], "utf8"));
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
+    return JSON.stringify([
+      {
+        success: true,
+        results: [
+          {
+            "Total queries executed": 2,
+            "Rows read": 10,
+            "Rows written": 2,
+            "Database size (MB)": "0.01",
+          },
+        ],
+        finalBookmark: "test-bookmark",
+        meta: {},
+      },
+    ]);
+  };
 }
 
 function insertPriorAudit(
@@ -221,7 +256,7 @@ describe("Owner bootstrap SQL", () => {
 
   it("cannot replay generated SQL after ownership conditions change", () => {
     const database = createDatabase();
-    const generated = sql(true, "audit-replay", 100);
+    const generated = sql("audit-replay", 100).mutation;
     database.exec(generated);
     database.exec(`
       UPDATE user_role_assignments
@@ -308,7 +343,7 @@ describe("Owner bootstrap SQL", () => {
   });
 
   it("uses only current RBAC schema and the generated audit ID as execution provenance", () => {
-    const generated = sql(true, "audit-exact", 100);
+    const generated = sql("audit-exact", 100).mutation;
 
     assert.doesNotMatch(
       generated,
@@ -316,11 +351,33 @@ describe("Owner bootstrap SQL", () => {
     );
     assert.match(generated, /operation_result/);
     assert.match(generated, /metadata_json/);
-    assert.match(generated, /SELECT 1 FROM authorization_audit_events WHERE id = 'audit-exact'/);
+    assert.match(generated, /WHERE id = 'audit-exact'/);
   });
 });
 
 describe("Owner bootstrap orchestration", () => {
+  it("verifies an atomic remote import with a separate query bound to its audit", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    const operations: string[] = [];
+    await run(
+      { database: "workspace", userId: USER_ID, execute: true },
+      {
+        randomUUID: () => "audit-exact",
+        now: () => 123,
+        runWrangler: (name, operation) => {
+          operations.push(operation[0]);
+          return runner(name, operation);
+        },
+      }
+    );
+    assert.deepEqual(operations, ["--command", "--file", "--command"]);
+    assert.equal(
+      database.prepare("SELECT id FROM authorization_audit_events").get()!.id,
+      "audit-exact"
+    );
+  });
+
   it("rejects malformed Wrangler JSON result shapes", async () => {
     await assert.rejects(
       run(
@@ -343,66 +400,241 @@ describe("Owner bootstrap orchestration", () => {
     );
   });
 
-  it("accepts only the execution response bound to this invocation's audit", async () => {
-    let calls = 0;
+  it("ignores import progress and verifies the database instead", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    let sqlPath = "";
     await run(
       { database: "workspace", userId: USER_ID, execute: true },
       {
         randomUUID: () => "audit-exact",
         now: () => 123,
-        runWrangler: (_database, operation) => {
-          calls += 1;
-          if (operation[0] === "--command") {
-            return JSON.stringify([
-              { success: true, results: [{ report: "preflight", status: "ready" }] },
-            ]);
-          }
-          assert.equal(operation[0], "--file");
-          const sqlPath = operation[1];
-          assert.ok(sqlPath);
-          const generated = readFileSync(sqlPath, "utf8");
-          assert.match(generated, /audit-exact/);
-          assert.match(generated, /123/);
-          return JSON.stringify([
-            {
-              success: true,
-              results: [
-                {
-                  report: "postcondition",
-                  status: "executed",
-                  audit_written: 1,
-                },
-              ],
-            },
-          ]);
+        runWrangler: (name, operation) => {
+          const output = runner(name, operation);
+          if (operation[0] !== "--file") return output;
+          sqlPath = operation[1];
+          return `├ Checking if file needs uploading\n${output}`;
         },
       }
     );
 
-    assert.equal(calls, 2);
+    assert.ok(sqlPath);
+    assert.equal(existsSync(sqlPath), false);
   });
 
   it("reports a concurrent winner instead of claiming this invocation completed", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
     await assert.rejects(
       run(
         { database: "workspace", userId: USER_ID, execute: true },
         {
           randomUUID: () => "audit-loser",
           now: () => 123,
-          runWrangler: (_database, operation) =>
-            JSON.stringify([
-              {
-                success: true,
-                results: [
-                  operation[0] === "--command"
-                    ? { report: "preflight", status: "ready" }
-                    : { report: "postcondition", status: "no-op", audit_written: 0 },
-                ],
-              },
-            ]),
+          runWrangler: (name, operation) => {
+            if (operation[0] === "--file") execute(database, "audit-winner", 122);
+            return runner(name, operation);
+          },
         }
       ),
-      /ownership changed concurrently/
+      /ownership may have changed concurrently/
+    );
+    assert.equal(
+      database.prepare("SELECT id FROM authorization_audit_events").get()!.id,
+      "audit-winner"
     );
   });
+
+  it("does not accept an import's claimed postcondition without database evidence", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: (name, operation) =>
+            operation[0] === "--file"
+              ? JSON.stringify([
+                  {
+                    success: true,
+                    results: [{ report: "postcondition", status: "executed", audit_written: 1 }],
+                  },
+                ])
+              : runner(name, operation),
+        }
+      ),
+      /did not prove its exact audit and assignment/
+    );
+  });
+
+  for (const [label, change] of [
+    ["missing audit", "DELETE FROM authorization_audit_events"],
+    ["wrong audit ID", "UPDATE authorization_audit_events SET id = 'other-audit'"],
+    ["wrong audit time", "UPDATE authorization_audit_events SET occurred_at = 999"],
+    ["wrong request", "UPDATE authorization_audit_events SET request_id = 'other-request'"],
+    [
+      "wrong target",
+      `UPDATE authorization_audit_events SET target_user_id_snapshot = '${OTHER_USER_ID}'`,
+    ],
+    ["wrong action", "UPDATE authorization_audit_events SET action = 'other-action'"],
+    ["wrong result", "UPDATE authorization_audit_events SET operation_result = 'refused'"],
+    ["wrong role metadata", "UPDATE authorization_audit_events SET metadata_json = '{}'"],
+    ["demoted Owner", "UPDATE user_role_assignments SET role_id = 'role_builtin_member'"],
+    ["suspended Owner", "UPDATE users SET suspended_at = 1"],
+    ["missing assignment", "DELETE FROM user_role_assignments"],
+    [
+      "another Owner",
+      `INSERT INTO users VALUES ('${OTHER_USER_ID}', NULL);
+      INSERT INTO user_role_assignments VALUES ('${OTHER_USER_ID}', 'role_builtin_owner')`,
+    ],
+  ]) {
+    it(`rejects verification with ${label}`, async () => {
+      const database = createDatabase();
+      const runner = databaseRunner(database);
+      await assert.rejects(
+        run(
+          { database: "workspace", userId: USER_ID, execute: true },
+          {
+            randomUUID: () => "audit-exact",
+            now: () => 123,
+            runWrangler: (name, operation) => {
+              const output = runner(name, operation);
+              if (operation[0] === "--file") database.exec(change);
+              return output;
+            },
+          }
+        ),
+        /ownership may have changed concurrently|did not prove its exact audit and assignment/
+      );
+    });
+  }
+
+  it("rolls back the audit if assignment fails and cleans up the SQL file", async () => {
+    const database = createDatabase();
+    database.exec(`CREATE TRIGGER refuse_owner BEFORE UPDATE ON user_role_assignments
+      BEGIN SELECT RAISE(ABORT, 'assignment failed'); END`);
+    const runner = databaseRunner(database);
+    const operations: string[] = [];
+    let sqlPath = "";
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: (name, operation) => {
+            operations.push(operation[0]);
+            if (operation[0] === "--file") sqlPath = operation[1];
+            return runner(name, operation);
+          },
+        }
+      ),
+      /assignment failed/
+    );
+    assert.deepEqual(operations, ["--command", "--file"]);
+    assert.equal(existsSync(sqlPath), false);
+    assert.equal(
+      database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+      0
+    );
+    assert.equal(
+      database.prepare("SELECT role_id FROM user_role_assignments").get()!.role_id,
+      "role_builtin_member"
+    );
+  });
+
+  it("does not report success or retry the mutation when the verification query fails", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    let imported = false;
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: (name, operation) => {
+            if (imported) throw new Error("verification unavailable");
+            const output = runner(name, operation);
+            imported = operation[0] === "--file";
+            return output;
+          },
+        }
+      ),
+      /verification unavailable/
+    );
+    assert.equal(
+      database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+      1
+    );
+  });
+
+  it("rejects a failed verification response even if it contains successful-looking rows", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    let imported = false;
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: (name, operation) => {
+            if (imported) {
+              return JSON.stringify([
+                {
+                  success: false,
+                  results: [{ report: "postcondition", status: "executed", audit_written: 1 }],
+                },
+              ]);
+            }
+            const output = runner(name, operation);
+            imported = operation[0] === "--file";
+            return output;
+          },
+        }
+      ),
+      /malformed JSON result/
+    );
+  });
+
+  it("never imports after an unknown preflight status", async () => {
+    let calls = 0;
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: () => {
+            calls += 1;
+            return JSON.stringify([
+              { success: true, results: [{ report: "preflight", status: "unknown" }] },
+            ]);
+          },
+        }
+      ),
+      /no valid Owner bootstrap preflight/
+    );
+    assert.equal(calls, 1);
+  });
+
+  for (const execute of [false, true]) {
+    it(
+      execute ? "does not import for a current Owner" : "does not import during a dry run",
+      async () => {
+        const database = createDatabase();
+        if (execute)
+          database.exec("UPDATE user_role_assignments SET role_id = 'role_builtin_owner'");
+        const runner = databaseRunner(database);
+        const operations: string[] = [];
+        await run(
+          { database: "workspace", userId: USER_ID, execute },
+          {
+            runWrangler: (name, operation) => {
+              operations.push(operation[0]);
+              return runner(name, operation);
+            },
+          }
+        );
+        assert.deepEqual(operations, ["--command"]);
+        assert.equal(
+          database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+          0
+        );
+      }
+    );
+  }
 });

--- a/scripts/bootstrap-workspace-owner.test.ts
+++ b/scripts/bootstrap-workspace-owner.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { DatabaseSync } from "node:sqlite";
 import { buildBootstrapSql, parseArgs, run } from "./bootstrap-workspace-owner.ts";
@@ -58,41 +57,29 @@ function preflight(database: DatabaseSync): Record<string, unknown> {
 }
 
 function execute(database: DatabaseSync, auditId: string, now: number): void {
-  database.exec(sql(auditId, now).mutation);
+  database.exec(sql(auditId, now).execution.join("\n"));
 }
 
-// Remote --file uses D1's atomic import, whose response contains statistics,
-// not SELECT rows. --command returns query results. Execute the real SQL here
-// so the orchestration tests cannot invent successful postconditions.
+// Model the result-bearing D1 query transaction with real SQLite statements.
+// SQLite identifies statement boundaries; do not split SQL on literal semicolons.
 function databaseRunner(database: DatabaseSync) {
   return (_database: string, operation: readonly string[]): string => {
-    if (operation[0] === "--command") {
-      return JSON.stringify([{ success: true, results: database.prepare(operation[1]).all() }]);
-    }
-    assert.equal(operation[0], "--file");
+    assert.equal(operation[0], "--command");
     database.exec("BEGIN");
     try {
-      database.exec(readFileSync(operation[1], "utf8"));
+      let remaining = operation[1];
+      const results = [];
+      while (remaining.trim()) {
+        const statement = database.prepare(remaining);
+        results.push({ success: true, results: statement.all() });
+        remaining = remaining.slice(statement.sourceSQL.length);
+      }
       database.exec("COMMIT");
+      return JSON.stringify(results);
     } catch (error) {
       database.exec("ROLLBACK");
       throw error;
     }
-    return JSON.stringify([
-      {
-        success: true,
-        results: [
-          {
-            "Total queries executed": 2,
-            "Rows read": 10,
-            "Rows written": 2,
-            "Database size (MB)": "0.01",
-          },
-        ],
-        finalBookmark: "test-bookmark",
-        meta: {},
-      },
-    ]);
   };
 }
 
@@ -256,7 +243,7 @@ describe("Owner bootstrap SQL", () => {
 
   it("cannot replay generated SQL after ownership conditions change", () => {
     const database = createDatabase();
-    const generated = sql("audit-replay", 100).mutation;
+    const generated = sql("audit-replay", 100).execution.join("\n");
     database.exec(generated);
     database.exec(`
       UPDATE user_role_assignments
@@ -343,7 +330,7 @@ describe("Owner bootstrap SQL", () => {
   });
 
   it("uses only current RBAC schema and the generated audit ID as execution provenance", () => {
-    const generated = sql("audit-exact", 100).mutation;
+    const generated = sql("audit-exact", 100).execution.join("\n");
 
     assert.doesNotMatch(
       generated,
@@ -356,75 +343,50 @@ describe("Owner bootstrap SQL", () => {
 });
 
 describe("Owner bootstrap orchestration", () => {
-  it("verifies an atomic remote import with a separate query bound to its audit", async () => {
+  it("returns the exact audit proof in one mutation batch after preflight", async () => {
     const database = createDatabase();
     const runner = databaseRunner(database);
-    const operations: string[] = [];
+    const results: unknown[] = [];
     await run(
       { database: "workspace", userId: USER_ID, execute: true },
       {
-        randomUUID: () => "audit-exact",
-        now: () => 123,
-        runWrangler: (name, operation) => {
-          operations.push(operation[0]);
-          return runner(name, operation);
-        },
-      }
-    );
-    assert.deepEqual(operations, ["--command", "--file", "--command"]);
-    assert.equal(
-      database.prepare("SELECT id FROM authorization_audit_events").get()!.id,
-      "audit-exact"
-    );
-  });
-
-  it("rejects malformed Wrangler JSON result shapes", async () => {
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: false },
-        {
-          runWrangler: () => JSON.stringify({ success: true, results: [] }),
-        }
-      ),
-      /malformed JSON result/
-    );
-
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: false },
-        {
-          runWrangler: () => JSON.stringify([{ success: true, results: [null] }]),
-        }
-      ),
-      /malformed JSON result/
-    );
-  });
-
-  it("ignores import progress and verifies the database instead", async () => {
-    const database = createDatabase();
-    const runner = databaseRunner(database);
-    let sqlPath = "";
-    await run(
-      { database: "workspace", userId: USER_ID, execute: true },
-      {
-        randomUUID: () => "audit-exact",
+        randomUUID: () => "audit-';exact",
         now: () => 123,
         runWrangler: (name, operation) => {
           const output = runner(name, operation);
-          if (operation[0] !== "--file") return output;
-          sqlPath = operation[1];
-          return `├ Checking if file needs uploading\n${output}`;
+          results.push(JSON.parse(output));
+          return output;
         },
       }
     );
-
-    assert.ok(sqlPath);
-    assert.equal(existsSync(sqlPath), false);
+    assert.equal(results.length, 2);
+    assert.deepEqual(results[1], [
+      { success: true, results: [] },
+      { success: true, results: [] },
+      {
+        success: true,
+        results: [
+          {
+            report: "postcondition",
+            status: "executed",
+            user_id: USER_ID,
+            suspended_at: null,
+            role_id: "role_builtin_owner",
+            audit_written: 1,
+          },
+        ],
+      },
+    ]);
+    assert.equal(
+      database.prepare("SELECT id FROM authorization_audit_events").get()!.id,
+      "audit-';exact"
+    );
   });
 
-  it("reports a concurrent winner instead of claiming this invocation completed", async () => {
+  it("rejects a concurrent winner between preflight and the mutation batch", async () => {
     const database = createDatabase();
     const runner = databaseRunner(database);
+    let calls = 0;
     await assert.rejects(
       run(
         { database: "workspace", userId: USER_ID, execute: true },
@@ -432,7 +394,7 @@ describe("Owner bootstrap orchestration", () => {
           randomUUID: () => "audit-loser",
           now: () => 123,
           runWrangler: (name, operation) => {
-            if (operation[0] === "--file") execute(database, "audit-winner", 122);
+            if (++calls === 2) execute(database, "audit-winner", 122);
             return runner(name, operation);
           },
         }
@@ -443,30 +405,175 @@ describe("Owner bootstrap orchestration", () => {
       database.prepare("SELECT id FROM authorization_audit_events").get()!.id,
       "audit-winner"
     );
+    assert.equal(calls, 2);
   });
 
-  it("does not accept an import's claimed postcondition without database evidence", async () => {
+  for (const failure of ["assignment", "postcondition"]) {
+    it(`rolls back the entire batch when ${failure} SQL fails`, async () => {
+      const database = createDatabase();
+      if (failure === "assignment") {
+        database.exec(`CREATE TRIGGER refuse_owner BEFORE UPDATE ON user_role_assignments
+          BEGIN SELECT RAISE(ABORT, 'assignment failed'); END`);
+      }
+      const runner = databaseRunner(database);
+      let calls = 0;
+      await assert.rejects(
+        run(
+          { database: "workspace", userId: USER_ID, execute: true },
+          {
+            runWrangler: (name, operation) => {
+              calls += 1;
+              // Fail the actual final SELECT after both writes have executed.
+              const command =
+                calls === 2 && failure === "postcondition"
+                  ? operation[1].replace(
+                      "SELECT 'postcondition' AS report",
+                      "SELECT missing_function() AS report"
+                    )
+                  : operation[1];
+              return runner(name, [operation[0], command]);
+            },
+          }
+        ),
+        /assignment failed|no such function/
+      );
+      assert.equal(calls, 2);
+      assert.equal(
+        database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+        0
+      );
+      assert.equal(
+        database.prepare("SELECT role_id FROM user_role_assignments").get()!.role_id,
+        "role_builtin_member"
+      );
+    });
+  }
+
+  it("does not add a read that can fail after the batch has returned its proof", async () => {
     const database = createDatabase();
     const runner = databaseRunner(database);
+    let calls = 0;
+    await run(
+      { database: "workspace", userId: USER_ID, execute: true },
+      {
+        runWrangler: (name, operation) => {
+          if (++calls > 2) throw new Error("unexpected post-commit read");
+          const output = runner(name, operation);
+          if (calls === 2) database.exec("UPDATE users SET suspended_at = 1");
+          return output;
+        },
+      }
+    );
+    assert.equal(calls, 2);
+  });
+
+  it("does not automatically retry an uncertain batch response", async () => {
+    const database = createDatabase();
+    const runner = databaseRunner(database);
+    let calls = 0;
     await assert.rejects(
       run(
         { database: "workspace", userId: USER_ID, execute: true },
         {
-          runWrangler: (name, operation) =>
-            operation[0] === "--file"
-              ? JSON.stringify([
-                  {
-                    success: true,
-                    results: [{ report: "postcondition", status: "executed", audit_written: 1 }],
-                  },
-                ])
-              : runner(name, operation),
+          runWrangler: (name, operation) => {
+            const output = runner(name, operation);
+            if (++calls === 2) throw new Error("batch response lost");
+            return output;
+          },
         }
       ),
-      /did not prove its exact audit and assignment/
+      /batch response lost/
+    );
+    assert.equal(calls, 2);
+    assert.equal(
+      database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+      1
     );
   });
 
+  const empty = { success: true, results: [] };
+  const proof = { report: "postcondition", status: "executed", audit_written: 1 };
+  for (const [label, response] of [
+    ["non-array", {}],
+    ["import aggregate", [{ success: true, results: [{ "Total queries executed": 3 }] }]],
+    ["missing statement result", [empty, empty]],
+    ["extra statement result", [empty, empty, empty, empty]],
+    [
+      "failed statement",
+      [{ success: false, results: [] }, empty, { success: true, results: [proof] }],
+    ],
+    ["malformed rows", [empty, empty, { success: true, results: [null] }]],
+    ["missing proof", [empty, empty, empty]],
+    ["misplaced proof", [{ success: true, results: [proof] }, empty, empty]],
+    ["ambiguous proof", [empty, empty, { success: true, results: [proof, proof] }]],
+    ["missing audit", [empty, empty, { success: true, results: [{ ...proof, audit_written: 0 }] }]],
+  ]) {
+    it(`rejects a batch response with ${label}`, async () => {
+      const database = createDatabase();
+      const runner = databaseRunner(database);
+      let calls = 0;
+      await assert.rejects(
+        run(
+          { database: "workspace", userId: USER_ID, execute: true },
+          {
+            runWrangler: (name, operation) =>
+              ++calls === 1 ? runner(name, operation) : JSON.stringify(response),
+          }
+        ),
+        /malformed|results for|no valid|did not prove/
+      );
+      assert.equal(calls, 2);
+    });
+  }
+
+  it("never executes after an unknown preflight status", async () => {
+    let calls = 0;
+    await assert.rejects(
+      run(
+        { database: "workspace", userId: USER_ID, execute: true },
+        {
+          runWrangler: () => {
+            calls += 1;
+            return JSON.stringify([
+              { success: true, results: [{ report: "preflight", status: "unknown" }] },
+            ]);
+          },
+        }
+      ),
+      /no valid Owner bootstrap preflight/
+    );
+    assert.equal(calls, 1);
+  });
+
+  for (const execute of [false, true]) {
+    it(
+      execute ? "does not mutate for a current Owner" : "does not mutate during a dry run",
+      async () => {
+        const database = createDatabase();
+        if (execute)
+          database.exec("UPDATE user_role_assignments SET role_id = 'role_builtin_owner'");
+        const runner = databaseRunner(database);
+        let calls = 0;
+        await run(
+          { database: "workspace", userId: USER_ID, execute },
+          {
+            runWrangler: (name, operation) => {
+              calls += 1;
+              return runner(name, operation);
+            },
+          }
+        );
+        assert.equal(calls, 1);
+        assert.equal(
+          database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
+          0
+        );
+      }
+    );
+  }
+});
+
+describe("Owner bootstrap verification evidence", () => {
   for (const [label, change] of [
     ["missing audit", "DELETE FROM authorization_audit_events"],
     ["wrong audit ID", "UPDATE authorization_audit_events SET id = 'other-audit'"],
@@ -488,153 +595,12 @@ describe("Owner bootstrap orchestration", () => {
       INSERT INTO user_role_assignments VALUES ('${OTHER_USER_ID}', 'role_builtin_owner')`,
     ],
   ]) {
-    it(`rejects verification with ${label}`, async () => {
+    it(`rejects verification with ${label}`, () => {
       const database = createDatabase();
-      const runner = databaseRunner(database);
-      await assert.rejects(
-        run(
-          { database: "workspace", userId: USER_ID, execute: true },
-          {
-            randomUUID: () => "audit-exact",
-            now: () => 123,
-            runWrangler: (name, operation) => {
-              const output = runner(name, operation);
-              if (operation[0] === "--file") database.exec(change);
-              return output;
-            },
-          }
-        ),
-        /ownership may have changed concurrently|did not prove its exact audit and assignment/
-      );
+      execute(database, "audit-exact", 123);
+      database.exec(change);
+      const report = database.prepare(sql("audit-exact", 123).execution[2]).get();
+      assert.notEqual(report?.status, "executed");
     });
-  }
-
-  it("rolls back the audit if assignment fails and cleans up the SQL file", async () => {
-    const database = createDatabase();
-    database.exec(`CREATE TRIGGER refuse_owner BEFORE UPDATE ON user_role_assignments
-      BEGIN SELECT RAISE(ABORT, 'assignment failed'); END`);
-    const runner = databaseRunner(database);
-    const operations: string[] = [];
-    let sqlPath = "";
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: true },
-        {
-          runWrangler: (name, operation) => {
-            operations.push(operation[0]);
-            if (operation[0] === "--file") sqlPath = operation[1];
-            return runner(name, operation);
-          },
-        }
-      ),
-      /assignment failed/
-    );
-    assert.deepEqual(operations, ["--command", "--file"]);
-    assert.equal(existsSync(sqlPath), false);
-    assert.equal(
-      database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
-      0
-    );
-    assert.equal(
-      database.prepare("SELECT role_id FROM user_role_assignments").get()!.role_id,
-      "role_builtin_member"
-    );
-  });
-
-  it("does not report success or retry the mutation when the verification query fails", async () => {
-    const database = createDatabase();
-    const runner = databaseRunner(database);
-    let imported = false;
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: true },
-        {
-          runWrangler: (name, operation) => {
-            if (imported) throw new Error("verification unavailable");
-            const output = runner(name, operation);
-            imported = operation[0] === "--file";
-            return output;
-          },
-        }
-      ),
-      /verification unavailable/
-    );
-    assert.equal(
-      database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
-      1
-    );
-  });
-
-  it("rejects a failed verification response even if it contains successful-looking rows", async () => {
-    const database = createDatabase();
-    const runner = databaseRunner(database);
-    let imported = false;
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: true },
-        {
-          runWrangler: (name, operation) => {
-            if (imported) {
-              return JSON.stringify([
-                {
-                  success: false,
-                  results: [{ report: "postcondition", status: "executed", audit_written: 1 }],
-                },
-              ]);
-            }
-            const output = runner(name, operation);
-            imported = operation[0] === "--file";
-            return output;
-          },
-        }
-      ),
-      /malformed JSON result/
-    );
-  });
-
-  it("never imports after an unknown preflight status", async () => {
-    let calls = 0;
-    await assert.rejects(
-      run(
-        { database: "workspace", userId: USER_ID, execute: true },
-        {
-          runWrangler: () => {
-            calls += 1;
-            return JSON.stringify([
-              { success: true, results: [{ report: "preflight", status: "unknown" }] },
-            ]);
-          },
-        }
-      ),
-      /no valid Owner bootstrap preflight/
-    );
-    assert.equal(calls, 1);
-  });
-
-  for (const execute of [false, true]) {
-    it(
-      execute ? "does not import for a current Owner" : "does not import during a dry run",
-      async () => {
-        const database = createDatabase();
-        if (execute)
-          database.exec("UPDATE user_role_assignments SET role_id = 'role_builtin_owner'");
-        const runner = databaseRunner(database);
-        const operations: string[] = [];
-        await run(
-          { database: "workspace", userId: USER_ID, execute },
-          {
-            runWrangler: (name, operation) => {
-              operations.push(operation[0]);
-              return runner(name, operation);
-            },
-          }
-        );
-        assert.deepEqual(operations, ["--command"]);
-        assert.equal(
-          database.prepare("SELECT COUNT(*) AS count FROM authorization_audit_events").get()!.count,
-          0
-        );
-      }
-    );
   }
 });

--- a/scripts/bootstrap-workspace-owner.ts
+++ b/scripts/bootstrap-workspace-owner.ts
@@ -12,9 +12,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const CANONICAL_USER_ID = /^[0-9a-f]{32}$/;
@@ -38,8 +36,7 @@ export interface BootstrapSqlOptions {
 
 interface BootstrapSql {
   preflight: string;
-  mutation: string;
-  verification: string;
+  execution: readonly [string, string, string];
 }
 
 /** Parse and validate Owner bootstrap command-line arguments. */
@@ -88,7 +85,7 @@ function sqlLiteral(value: string | number): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-/** Build read-only checks and an atomic mutation from the same audit identity. */
+/** Build preflight and a result-bearing atomic batch from one audit identity. */
 export function buildBootstrapSql(options: BootstrapSqlOptions): BootstrapSql {
   const userId = sqlLiteral(options.userId);
   const auditId = sqlLiteral(options.auditId);
@@ -179,7 +176,7 @@ export function buildBootstrapSql(options: BootstrapSqlOptions): BootstrapSql {
   (SELECT suspended_at FROM users WHERE id = ${userId}) AS suspended_at,
   (SELECT role_id FROM user_role_assignments WHERE user_id = ${userId}) AS role_id;`;
 
-  const mutation = `INSERT INTO authorization_audit_events
+  const insertAudit = `INSERT INTO authorization_audit_events
   (id, occurred_at, request_id, principal_kind,
    actor_service_snapshot, action, resource_type,
     target_user_id_snapshot, reason_code, operation_result, metadata_json)
@@ -194,8 +191,9 @@ SELECT ${auditId}, ${now}, ${requestId}, 'service',
          'after', json_object('roleId', ${ownerRoleId})
        )
 WHERE ${ready};
+`;
 
-UPDATE user_role_assignments
+  const assignOwner = `UPDATE user_role_assignments
 SET role_id = ${ownerRoleId}
 WHERE user_id = ${userId} AND (${ready}) AND ${exactAudit};
 `;
@@ -216,18 +214,25 @@ JOIN user_role_assignments assignment ON assignment.user_id = u.id
 WHERE u.id = ${userId};
 `;
 
-  return { preflight, mutation, verification };
+  return { preflight, execution: [insertAudit, assignOwner, verification] };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function reportRows(stdout: string): Array<Record<string, unknown>> {
+function readReport(
+  stdout: string,
+  statementCount: number,
+  report: "preflight" | "postcondition"
+): Record<string, unknown> {
   const parsed: unknown = JSON.parse(stdout);
   if (!Array.isArray(parsed)) throw new Error("Wrangler returned a malformed JSON result");
+  if (parsed.length !== statementCount) {
+    throw new Error(`Wrangler returned ${parsed.length} results for ${statementCount} statements`);
+  }
 
-  const rows = parsed.flatMap((result) => {
+  const results = parsed.map((result) => {
     if (
       !isRecord(result) ||
       result.success !== true ||
@@ -236,10 +241,14 @@ function reportRows(stdout: string): Array<Record<string, unknown>> {
     ) {
       throw new Error("Wrangler returned a malformed JSON result");
     }
-    return result.results.filter((row) => row.report);
+    return result.results;
   });
-  for (const row of rows) console.log(JSON.stringify(row));
-  return rows;
+  const rows = results.at(-1);
+  if (rows?.length !== 1 || rows[0].report !== report) {
+    throw new Error(`Wrangler returned no valid Owner bootstrap ${report}`);
+  }
+  console.log(JSON.stringify(rows[0]));
+  return rows[0];
 }
 
 type WranglerRunner = (database: string, operation: readonly string[]) => string;
@@ -275,8 +284,11 @@ export async function run(
     auditId: dependencies.randomUUID?.() ?? crypto.randomUUID(),
     now: dependencies.now?.() ?? Date.now(),
   });
-  const preflightRows = reportRows(runner(options.database, ["--command", sql.preflight]));
-  const status = preflightRows.find((row) => row.report === "preflight")?.status;
+  const { status } = readReport(
+    runner(options.database, ["--command", sql.preflight]),
+    1,
+    "preflight"
+  );
   if (status !== "ready" && status !== "no-op" && status !== "refused") {
     throw new Error("Wrangler returned no valid Owner bootstrap preflight");
   }
@@ -287,25 +299,19 @@ export async function run(
     return;
   }
 
-  const directory = await mkdtemp(join(tmpdir(), "open-inspect-owner-bootstrap-"));
-  const sqlPath = join(directory, "bootstrap.sql");
-  try {
-    await writeFile(sqlPath, sql.mutation, { encoding: "utf8", mode: 0o600 });
-    // Remote --file returns import statistics (and possibly progress text), not
-    // SELECT results. Only the subsequent audit-bound read can prove completion.
-    runner(options.database, ["--file", sqlPath]);
-  } finally {
-    await rm(directory, { recursive: true, force: true });
-  }
-
-  const verificationRows = reportRows(runner(options.database, ["--command", sql.verification]));
-  const postcondition = verificationRows.find((row) => row.report === "postcondition");
-  if (postcondition?.status === "no-op") {
+  // Like WranglerD1Database.batch, use D1's result-bearing /query transaction:
+  // the mutation and its proof commit together, with one result per statement.
+  const postcondition = readReport(
+    runner(options.database, ["--command", sql.execution.join("\n")]),
+    sql.execution.length,
+    "postcondition"
+  );
+  if (postcondition.status === "no-op") {
     throw new Error(
       "Owner bootstrap did not prove this invocation completed; ownership may have changed concurrently"
     );
   }
-  if (postcondition?.status !== "executed" || postcondition.audit_written !== 1) {
+  if (postcondition.status !== "executed" || postcondition.audit_written !== 1) {
     throw new Error("Owner bootstrap execution did not prove its exact audit and assignment");
   }
   console.error(

--- a/scripts/bootstrap-workspace-owner.ts
+++ b/scripts/bootstrap-workspace-owner.ts
@@ -29,12 +29,17 @@ export interface BootstrapCliOptions {
   execute: boolean;
 }
 
-/** Inputs used to build an Owner bootstrap preflight or execution script. */
+/** Inputs shared by the Owner bootstrap mutation and its verification query. */
 export interface BootstrapSqlOptions {
   userId: string;
-  execute: boolean;
   auditId: string;
   now: number;
+}
+
+interface BootstrapSql {
+  preflight: string;
+  mutation: string;
+  verification: string;
 }
 
 /** Parse and validate Owner bootstrap command-line arguments. */
@@ -83,8 +88,8 @@ function sqlLiteral(value: string | number): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-/** Build guarded SQL for an Owner bootstrap preflight or execution. */
-export function buildBootstrapSql(options: BootstrapSqlOptions): string {
+/** Build read-only checks and an atomic mutation from the same audit identity. */
+export function buildBootstrapSql(options: BootstrapSqlOptions): BootstrapSql {
   const userId = sqlLiteral(options.userId);
   const auditId = sqlLiteral(options.auditId);
   const requestId = sqlLiteral(`operator-cli:${options.auditId}`);
@@ -174,11 +179,7 @@ export function buildBootstrapSql(options: BootstrapSqlOptions): string {
   (SELECT suspended_at FROM users WHERE id = ${userId}) AS suspended_at,
   (SELECT role_id FROM user_role_assignments WHERE user_id = ${userId}) AS role_id;`;
 
-  if (!options.execute) return `${preflight}\n`;
-
-  return `${preflight}
-
-INSERT INTO authorization_audit_events
+  const mutation = `INSERT INTO authorization_audit_events
   (id, occurred_at, request_id, principal_kind,
    actor_service_snapshot, action, resource_type,
     target_user_id_snapshot, reason_code, operation_result, metadata_json)
@@ -197,9 +198,11 @@ WHERE ${ready};
 UPDATE user_role_assignments
 SET role_id = ${ownerRoleId}
 WHERE user_id = ${userId} AND (${ready}) AND ${exactAudit};
+`;
 
-SELECT 'postcondition' AS report,
+  const verification = `SELECT 'postcondition' AS report,
   CASE
+    WHEN NOT (${commonPreconditions}) OR (${anotherUnsuspendedOwner}) THEN 'refused'
     WHEN (${targetIsOwner}) AND (${exactAudit}) THEN 'executed'
     WHEN ${targetIsOwner} THEN 'no-op'
     ELSE 'refused'
@@ -207,33 +210,36 @@ SELECT 'postcondition' AS report,
   u.id AS user_id,
   u.suspended_at,
   assignment.role_id,
-  EXISTS(SELECT 1 FROM authorization_audit_events WHERE id = ${auditId}) AS audit_written
+  ${exactAudit} AS audit_written
 FROM users u
 JOIN user_role_assignments assignment ON assignment.user_id = u.id
 WHERE u.id = ${userId};
 `;
-}
 
-interface WranglerResult {
-  results?: Array<Record<string, unknown>>;
+  return { preflight, mutation, verification };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseWranglerResults(stdout: string): WranglerResult[] {
+function reportRows(stdout: string): Array<Record<string, unknown>> {
   const parsed: unknown = JSON.parse(stdout);
   if (!Array.isArray(parsed)) throw new Error("Wrangler returned a malformed JSON result");
 
-  return parsed.map((result) => {
-    if (!isRecord(result)) throw new Error("Wrangler returned a malformed JSON result");
-    const rows = result.results;
-    if (rows !== undefined && (!Array.isArray(rows) || !rows.every(isRecord))) {
+  const rows = parsed.flatMap((result) => {
+    if (
+      !isRecord(result) ||
+      result.success !== true ||
+      !Array.isArray(result.results) ||
+      !result.results.every(isRecord)
+    ) {
       throw new Error("Wrangler returned a malformed JSON result");
     }
-    return { results: rows };
+    return result.results.filter((row) => row.report);
   });
+  for (const row of rows) console.log(JSON.stringify(row));
+  return rows;
 }
 
 type WranglerRunner = (database: string, operation: readonly string[]) => string;
@@ -243,13 +249,6 @@ export interface BootstrapRunDependencies {
   runWrangler?: WranglerRunner;
   randomUUID?: () => string;
   now?: () => number;
-}
-
-function reportRows(stdout: string): Array<Record<string, unknown>> {
-  const parsed = parseWranglerResults(stdout);
-  const rows = parsed.flatMap((result) => result.results ?? []).filter((row) => row.report);
-  for (const row of rows) console.log(JSON.stringify(row));
-  return rows;
 }
 
 function runWrangler(database: string, operation: readonly string[]): string {
@@ -264,14 +263,6 @@ function runWrangler(database: string, operation: readonly string[]): string {
   return child.stdout;
 }
 
-function preflight(database: string, userId: string, runner: WranglerRunner): string {
-  const sql = buildBootstrapSql({ userId, execute: false, auditId: "unused", now: 0 });
-  const rows = reportRows(runner(database, ["--command", sql]));
-  const status = rows.find((row) => row.report === "preflight")?.status;
-  if (typeof status !== "string") throw new Error("Wrangler returned no Owner bootstrap preflight");
-  return status;
-}
-
 /** Run the remote Owner bootstrap workflow and verify its postcondition. */
 export async function run(
   options: BootstrapCliOptions,
@@ -279,7 +270,16 @@ export async function run(
 ): Promise<void> {
   const runner = dependencies.runWrangler ?? runWrangler;
   console.error(`${options.execute ? "Executing" : "Dry-running"} Owner bootstrap on remote D1...`);
-  const status = preflight(options.database, options.userId, runner);
+  const sql = buildBootstrapSql({
+    userId: options.userId,
+    auditId: dependencies.randomUUID?.() ?? crypto.randomUUID(),
+    now: dependencies.now?.() ?? Date.now(),
+  });
+  const preflightRows = reportRows(runner(options.database, ["--command", sql.preflight]));
+  const status = preflightRows.find((row) => row.report === "preflight")?.status;
+  if (status !== "ready" && status !== "no-op" && status !== "refused") {
+    throw new Error("Wrangler returned no valid Owner bootstrap preflight");
+  }
   if (status === "refused") throw new Error("Owner bootstrap preflight was refused");
   if (status === "no-op") return;
   if (!options.execute) {
@@ -289,30 +289,23 @@ export async function run(
 
   const directory = await mkdtemp(join(tmpdir(), "open-inspect-owner-bootstrap-"));
   const sqlPath = join(directory, "bootstrap.sql");
-  let executionRows: Array<Record<string, unknown>>;
   try {
-    const auditId = dependencies.randomUUID?.() ?? crypto.randomUUID();
-    const now = dependencies.now?.() ?? Date.now();
-    await writeFile(
-      sqlPath,
-      buildBootstrapSql({
-        userId: options.userId,
-        execute: true,
-        auditId,
-        now,
-      }),
-      { encoding: "utf8", mode: 0o600 }
-    );
-    executionRows = reportRows(runner(options.database, ["--file", sqlPath]));
+    await writeFile(sqlPath, sql.mutation, { encoding: "utf8", mode: 0o600 });
+    // Remote --file returns import statistics (and possibly progress text), not
+    // SELECT results. Only the subsequent audit-bound read can prove completion.
+    runner(options.database, ["--file", sqlPath]);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 
-  const postcondition = executionRows.find((row) => row.report === "postcondition");
+  const verificationRows = reportRows(runner(options.database, ["--command", sql.verification]));
+  const postcondition = verificationRows.find((row) => row.report === "postcondition");
   if (postcondition?.status === "no-op") {
-    throw new Error("Owner bootstrap did not execute because ownership changed concurrently");
+    throw new Error(
+      "Owner bootstrap did not prove this invocation completed; ownership may have changed concurrently"
+    );
   }
-  if (postcondition?.status !== "executed" || Number(postcondition.audit_written) !== 1) {
+  if (postcondition?.status !== "executed" || postcondition.audit_written !== 1) {
     throw new Error("Owner bootstrap execution did not prove its exact audit and assignment");
   }
   console.error(


### PR DESCRIPTION
## Summary

Supersedes #1819 with a focused fix for the real Owner bootstrap failure. Thanks to @rhlsthrm for surfacing the deployment-script reliability concern.

- Keep the operator-facing preflight read separate.
- Submit the guarded audit INSERT, role UPDATE, and exact postcondition SELECT in one result-bearing remote `--command` batch, using one invocation's audit identity.
- Require successful positional results for all three statements and the exact postcondition in the final result before reporting completion.
- Remove the bulk-import path and temporary SQL file lifecycle. No separate post-commit verification call remains.
- Preserve fail-closed handling of concurrent winners, malformed responses, and uncertain batch outcomes without automatically retrying writes.

## Design and scope

Wrangler 4.103.0's remote `--file` path returns import statistics, not SQL SELECT result rows. Its `--command` path sends SQL to D1's result-bearing `/query` API ([pinned implementation](https://github.com/cloudflare/workers-sdk/blob/wrangler%404.103.0/packages/wrangler/src/d1/execute.ts#L408-L492)). The repository already uses this transactional batch pattern in `WranglerD1Database.batch` in `scripts/merge-split-users.ts`.

The initial version used an import followed by a verification read. Review identified the simpler result-bearing batch: the transaction now returns its own proof, removing the extra read failure/race window. A lost batch response can still leave an uncertain outcome; the CLI does not claim that all transport uncertainty is eliminated.

Neither the permissive JSON extraction nor the migration-ledger equality policy from #1819 is adopted. The migration runner already submits each migration and ledger insert atomically, and the review did not establish a current partial-commit failure. Requiring every recorded migration to exist in this checkout would introduce a separate compatibility policy for downstream migrations and older checkouts. `scripts/d1-migrate.sh` remains unchanged.

## Verification

- Reproduced the original missing-postcondition failure before implementing the fix.
- Owner bootstrap suite: **42 passing tests**. Tests execute generated SQL in SQLite transactions and cover positional batch results, exact-audit evidence, concurrent winners, rollback when the UPDATE or postcondition SELECT fails, malformed/partial responses, dry runs/no-ops, and lost batch responses without write retries.
- The tests run in CI through the existing `Test Owner bootstrap CLI` step in `.github/workflows/ci.yml`; no Vitest migration is needed.
- Focused strict TypeScript check for both script files: passed.
- ESLint, Prettier, and `git diff --check`: passed.

No live remote D1 operation or deployment was performed. The tests model the provider transaction locally; they are not a remote-provider smoke test. No migrations, dependencies, or application packages changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace owner bootstrapping now performs assignment, audit recording, and verification atomically.
  - Concurrent ownership changes and failed operations are detected safely, with incomplete changes rolled back.
  - Completion is based on the exact transaction postcondition rather than import statistics or a separate follow-up read.
  - Lost command responses remain unresolved without automatic retries or unverified success claims.
  - No-op scenarios continue to make no database writes.

- **Documentation**
  - Updated the getting-started guide to describe atomic execution, verification, no-op behavior, and uncertain outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->