### PR TITLE
Disable Claude attribution and telemetry

### DIFF
--- a/docs/CLAUDE_AGENT.md
+++ b/docs/CLAUDE_AGENT.md
@@ -180,6 +180,10 @@ fix instead.
   `CLAUDE_CONFIG_DIR` (`~/.openinspect/claude/skills`); repository `.claude/` settings, hooks and
   agents load through `setting_sources=["user","project"]`, the same trust boundary as the
   repository's `.openinspect/setup.sh` and `.opencode/` directory under OpenCode.
+- **Privacy.** The harness disables Claude Code's commit, pull request, and session-link
+  attribution. It also disables nonessential Anthropic traffic, error reporting, feedback and
+  surveys, and both Anthropic and OpenTelemetry usage telemetry. Model requests and Open-Inspect's
+  own per-turn cost accounting are unaffected.
 - **Tools.** Open-Inspect's own tools are served to the Claude harness in-process as the `oi` MCP
   server: child sessions and `upload-media` always, `create-pull-request` when the session has a
   repository, and `slack-notify` when agent notifications are enabled for the repository. Session

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude.py
@@ -49,6 +49,7 @@ from .base import (
     TurnOutcome,
 )
 from .claude_env import (
+    CLAUDE_POLICY_SETTINGS,
     ClaudeCredential,
     bundled_claude_binary,
     harness_env,
@@ -400,6 +401,7 @@ class ClaudeHarness:
             "disallowed_tools": [*DISALLOWED_TOOLS],
             "permission_mode": "dontAsk",
             "system_prompt": system_prompt,
+            "settings": CLAUDE_POLICY_SETTINGS,
             "setting_sources": ["user", "project"],
             "include_partial_messages": True,
             "forward_subagent_text": False,

--- a/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/harness/claude_env.py
@@ -17,6 +17,7 @@ The wrapper carries variable *names* only. Credential values travel through
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 import sys
@@ -44,6 +45,15 @@ OAUTH_MANAGED_ENV_VAR: Final = "ANTHROPIC_OAUTH_MANAGED"
 CONFIG_DIR_ENV_VAR: Final = "CLAUDE_CONFIG_DIR"
 
 WRAPPER_NAME: Final = "claude-clean-env"
+
+CLAUDE_POLICY_SETTINGS: Final = json.dumps(
+    {
+        "attribution": {"commit": "", "pr": "", "sessionUrl": False},
+        "feedbackDrafts": "off",
+        "feedbackSurveyRate": 0,
+    },
+    separators=(",", ":"),
+)
 
 
 class ClaudeAuthMode(StrEnum):
@@ -154,6 +164,11 @@ def harness_env(config_dir: Path, credential: ClaudeCredential) -> dict[str, str
         "DISABLE_AUTOUPDATER": "1",
         "DISABLE_ERROR_REPORTING": "1",
         "DISABLE_TELEMETRY": "1",
+        # Anthropic telemetry and opt-in customer OpenTelemetry are separate.
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+        "OTEL_METRICS_EXPORTER": "none",
+        "OTEL_LOGS_EXPORTER": "none",
+        "OTEL_TRACES_EXPORTER": "none",
         **credential.env,
     }
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,8 +1,8 @@
 {
-  "runtimeVersion": "v65-turn-inactivity-timeout",
-  "generation": 65,
+  "runtimeVersion": "v66-claude-privacy-policy",
+  "generation": 66,
   "minimumCompatibleGeneration": 62,
-  "minimumRebuildGeneration": 65,
+  "minimumRebuildGeneration": 66,
   "harnessMinimumGeneration": {
     "claude": 64
   }

--- a/packages/sandbox-runtime/tests/test_claude_env.py
+++ b/packages/sandbox-runtime/tests/test_claude_env.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from sandbox_runtime.harness.claude_env import (
     API_KEY_CREDENTIAL_VARS,
+    CLAUDE_POLICY_SETTINGS,
     OAUTH_CREDENTIAL_VARS,
     ClaudeAuthMode,
     ClaudeCredential,
@@ -157,5 +158,18 @@ class TestDenylist:
     def test_harness_env_sets_config_dir_and_policy(self, tmp_path: Path) -> None:
         env = harness_env(tmp_path, ClaudeCredential.oauth_token("tok"))
         assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path)
+        assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+        assert env["DISABLE_ERROR_REPORTING"] == "1"
         assert env["DISABLE_TELEMETRY"] == "1"
+        assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "0"
+        assert env["OTEL_METRICS_EXPORTER"] == "none"
+        assert env["OTEL_LOGS_EXPORTER"] == "none"
+        assert env["OTEL_TRACES_EXPORTER"] == "none"
         assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "tok"
+
+    def test_policy_settings_disable_attribution_and_feedback(self) -> None:
+        assert json.loads(CLAUDE_POLICY_SETTINGS) == {
+            "attribution": {"commit": "", "pr": "", "sessionUrl": False},
+            "feedbackDrafts": "off",
+            "feedbackSurveyRate": 0,
+        }

--- a/packages/sandbox-runtime/tests/test_claude_harness.py
+++ b/packages/sandbox-runtime/tests/test_claude_harness.py
@@ -9,6 +9,7 @@ execution_complete).
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
@@ -324,6 +325,11 @@ class TestOptions:
         assert options["effort"] == "high"
         assert options["permission_mode"] == "dontAsk"
         assert options["disallowed_tools"] == ["AskUserQuestion"]
+        assert json.loads(options["settings"]) == {
+            "attribution": {"commit": "", "pr": "", "sessionUrl": False},
+            "feedbackDrafts": "off",
+            "feedbackSurveyRate": 0,
+        }
         assert options["setting_sources"] == ["user", "project"]
         assert options["include_partial_messages"] is True
         assert options["forward_subagent_text"] is False


### PR DESCRIPTION
## Summary
- disable Claude Code commit, pull request, and session-link attribution through session-level settings
- disable feedback drafts and surveys, and explicitly neutralize optional OpenTelemetry exporters alongside existing Anthropic telemetry controls
- bump the sandbox runtime generation so prebuilt images pick up the policy
- document the Claude harness privacy behavior

## Verification
- `env -u PYTHONPATH uv run pytest tests/test_claude_env.py tests/test_claude_harness.py -q`
- `env -u PYTHONPATH uv run ruff check src/sandbox_runtime/harness/claude_env.py src/sandbox_runtime/harness/claude.py tests/test_claude_env.py tests/test_claude_harness.py`
- `env -u PYTHONPATH uv run ruff format --check src/sandbox_runtime/harness/claude_env.py src/sandbox_runtime/harness/claude.py tests/test_claude_env.py tests/test_claude_harness.py`
- `env -u PYTHONPATH uv run mypy src/sandbox_runtime/harness/claude_env.py src/sandbox_runtime/harness/claude.py --cache-dir /tmp/openinspect-mypy-claude`
- `npm test -w @open-inspect/control-plane -- --run src/sandbox/runtime-manifest.test.ts src/image-builds/rebuild-policy.test.ts`
- `uv run pytest tests/test_bundle.py -q` in `packages/sandbox-images`
- `npx prettier --check docs/CLAUDE_AGENT.md packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6bf978980ef14ef2b1af7512108e1788)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Disabled Claude Code attribution for commits, pull requests, and session links.
  * Disabled nonessential Anthropic traffic, error reporting, feedback requests, surveys, and usage telemetry.
  * Model requests and per-turn cost tracking remain available.

* **Runtime**
  * Updated the sandbox runtime to the latest compatible generation while preserving compatibility with earlier supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->