### PR TITLE
fix: remove setup and start hook timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ docker compose up -d postgres redis
 - `setup.sh` failures are non-fatal for fresh sessions, but fatal in image build mode
 - `start.sh` runs for every non-build session startup (fresh, prebuilt-image, snapshot-restore)
 - `start.sh` failures are strict: if present and it fails, session startup fails
-- Default timeouts:
-  - `SETUP_TIMEOUT_SECONDS` (default `300`)
-  - `START_TIMEOUT_SECONDS` (default `120`)
+- Open-Inspect does not impose hook-specific timeouts. Scripts remain subject to enclosing sandbox
+  shutdown and image-build limits; scripts can apply their own command-specific deadlines when
+  needed.
 - Both hooks receive `OPENINSPECT_BOOT_MODE` (`build`, `fresh`, `repo_image`, `snapshot_restore`)
 - Git operations in hooks can authenticate to other private repos on the configured SCM host when
   the shared installation has access

--- a/packages/control-plane/src/node/session-store.test.ts
+++ b/packages/control-plane/src/node/session-store.test.ts
@@ -89,7 +89,7 @@ describe("openSessionStore", () => {
       import { mkdirSync } from "node:fs";
       mkdirSync(process.argv[2] + "/sessions", { recursive: true });
       const db = new DatabaseSync(process.argv[2] + "/sessions/session-1.db");
-      db.exec("BEGIN IMMEDIATE; CREATE TABLE held (v TEXT);");
+      db.exec("PRAGMA journal_mode = WAL; BEGIN IMMEDIATE; CREATE TABLE held (v TEXT);");
       process.stdout.write("locked\\n");
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
       db.exec("COMMIT");

--- a/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
@@ -9,7 +9,7 @@ import signal
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable
 
 TRUNCATED_LINE_NOTICE = "[log line too large to forward; truncated]"
 PROCESS_OUTPUT_TAIL_BYTES = 64 * 1024
@@ -99,6 +99,46 @@ async def terminate_owned_subprocess(
         # The leader may have exited while descendants still hold its output pipes.
         send_signal(signal.SIGKILL)
         await asyncio.shield(process.wait())
+
+
+async def finish_cancellation_cleanup[ResultT](task: asyncio.Task[ResultT]) -> ResultT:
+    """Finish an independent cleanup task despite repeated caller cancellation."""
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    return task.result()
+
+
+async def spawn_owned_subprocess(
+    process_factory: Callable[[], Awaitable[asyncio.subprocess.Process]],
+    *,
+    kill_process_group: Callable[[int, int], None] = os.killpg,
+) -> asyncio.subprocess.Process:
+    """Create a subprocess or clean it up before propagating cancellation."""
+
+    async def spawn() -> asyncio.subprocess.Process:
+        return await process_factory()
+
+    spawn_task = asyncio.create_task(spawn())
+    try:
+        return await asyncio.shield(spawn_task)
+    except asyncio.CancelledError:
+
+        async def cleanup_spawned_process() -> None:
+            try:
+                process = await spawn_task
+            except (asyncio.CancelledError, Exception):
+                return
+            await terminate_owned_subprocess(
+                process,
+                kill_process_group=kill_process_group,
+            )
+
+        cleanup_task = asyncio.create_task(cleanup_spawned_process())
+        await finish_cancellation_cleanup(cleanup_task)
+        raise
 
 
 async def communicate_owned_subprocess(

--- a/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
@@ -112,16 +112,13 @@ async def finish_cancellation_cleanup[ResultT](task: asyncio.Task[ResultT]) -> R
 
 
 async def spawn_owned_subprocess(
-    process_factory: Callable[[], Awaitable[asyncio.subprocess.Process]],
+    process_awaitable: Awaitable[asyncio.subprocess.Process],
     *,
     kill_process_group: Callable[[int, int], None] = os.killpg,
 ) -> asyncio.subprocess.Process:
     """Create a subprocess or clean it up before propagating cancellation."""
 
-    async def spawn() -> asyncio.subprocess.Process:
-        return await process_factory()
-
-    spawn_task = asyncio.create_task(spawn())
+    spawn_task = asyncio.ensure_future(process_awaitable)
     try:
         return await asyncio.shield(spawn_task)
     except asyncio.CancelledError:

--- a/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
@@ -12,6 +12,63 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
 
 TRUNCATED_LINE_NOTICE = "[log line too large to forward; truncated]"
+PROCESS_OUTPUT_TAIL_BYTES = 64 * 1024
+
+
+class BoundedOutputCollector:
+    """Continuously drain a stream while retaining only a bounded byte tail."""
+
+    def __init__(
+        self,
+        stream: asyncio.StreamReader,
+        *,
+        max_tail_bytes: int = PROCESS_OUTPUT_TAIL_BYTES,
+    ) -> None:
+        if max_tail_bytes <= 0:
+            raise ValueError("max_tail_bytes must be positive")
+        self._stream = stream
+        self._max_tail_bytes = max_tail_bytes
+        self._tail = bytearray()
+        self._retaining = True
+        self.task = asyncio.create_task(self._drain())
+
+    async def _drain(self) -> None:
+        while chunk := await self._stream.read(16 * 1024):
+            if not self._retaining:
+                continue
+            self._tail.extend(chunk)
+            overflow = len(self._tail) - self._max_tail_bytes
+            if overflow > 0:
+                del self._tail[:overflow]
+
+    async def wait(self) -> None:
+        """Wait until every writer has closed the stream."""
+        await self.task
+
+    def discard_tail(self) -> None:
+        """Continue draining without retaining output."""
+        self._retaining = False
+        self._tail.clear()
+
+    def tail_lines(self, max_lines: int = 50) -> str:
+        """Decode and return at most the requested final lines."""
+        return "\n".join(bytes(self._tail).decode(errors="replace").splitlines()[-max_lines:])
+
+
+async def wait_for_process_exit(process: asyncio.subprocess.Process) -> int:
+    """Wait for the process leader without waiting for inherited output pipes to close."""
+    wait_task = asyncio.create_task(process.wait())
+    try:
+        await asyncio.sleep(0)
+        while process.returncode is None:
+            if wait_task.done():
+                return wait_task.result()
+            await asyncio.sleep(0.01)
+        return process.returncode
+    finally:
+        if not wait_task.done():
+            wait_task.cancel()
+        await asyncio.gather(wait_task, return_exceptions=True)
 
 
 async def terminate_owned_subprocess(

--- a/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/process_output.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 TRUNCATED_LINE_NOTICE = "[log line too large to forward; truncated]"
 PROCESS_OUTPUT_TAIL_BYTES = 64 * 1024
+PROCESS_OUTPUT_SHUTDOWN_SECONDS = 1.0
 
 
 class BoundedOutputCollector:
@@ -44,6 +45,20 @@ class BoundedOutputCollector:
     async def wait(self) -> None:
         """Wait until every writer has closed the stream."""
         await self.task
+
+    async def shutdown(self) -> None:
+        """Close the stream and bound how long collector cleanup can take."""
+        transport = getattr(self._stream, "_transport", None)
+        if transport is not None:
+            transport.close()
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self.task),
+                timeout=PROCESS_OUTPUT_SHUTDOWN_SECONDS,
+            )
+        except TimeoutError:
+            self.task.cancel()
+            await asyncio.gather(self.task, return_exceptions=True)
 
     def discard_tail(self) -> None:
         """Continue draining without retaining output."""
@@ -98,7 +113,7 @@ async def terminate_owned_subprocess(
     finally:
         # The leader may have exited while descendants still hold its output pipes.
         send_signal(signal.SIGKILL)
-        await asyncio.shield(process.wait())
+        await asyncio.shield(wait_for_process_exit(process))
 
 
 async def finish_cancellation_cleanup[ResultT](task: asyncio.Task[ResultT]) -> ResultT:

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
@@ -68,7 +68,7 @@ class RepositoryHooks:
             env = os.environ.copy()
             env["OPENINSPECT_BOOT_MODE"] = boot_mode.value
             process = await spawn_owned_subprocess(
-                lambda: asyncio.create_subprocess_exec(
+                asyncio.create_subprocess_exec(
                     "bash",
                     str(script_path),
                     cwd=repo.path,

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 import time
 from typing import TYPE_CHECKING, Any
 
-from .process_output import communicate_owned_subprocess, terminate_owned_subprocess
+from .process_output import terminate_owned_subprocess
 from .runtime_config import BootMode
 
 if TYPE_CHECKING:
@@ -15,17 +16,12 @@ if TYPE_CHECKING:
 class RepositoryHooks:
     SETUP_SCRIPT_PATH = ".openinspect/setup.sh"
     START_SCRIPT_PATH = ".openinspect/start.sh"
-    DEFAULT_SETUP_TIMEOUT_SECONDS = 300
-    DEFAULT_START_TIMEOUT_SECONDS = 120
 
     def __init__(self, log: Any) -> None:
         self.log = log
 
     async def _terminate(self, process: asyncio.subprocess.Process) -> None:
         await terminate_owned_subprocess(process, kill_process_group=os.killpg)
-
-    async def _communicate(self, process: asyncio.subprocess.Process) -> tuple[bytes, bytes]:
-        return await communicate_owned_subprocess(process, kill_process_group=os.killpg)
 
     async def _run(
         self,
@@ -34,8 +30,6 @@ class RepositoryHooks:
         *,
         hook_name: str,
         relative_script_path: str,
-        timeout_env_var: str,
-        default_timeout_seconds: int,
     ) -> bool:
         script_path = repo.path / relative_script_path
         start_time = time.time()
@@ -47,51 +41,43 @@ class RepositoryHooks:
                 boot_mode=boot_mode.value,
             )
             return True
-        try:
-            timeout_seconds = int(os.environ.get(timeout_env_var, str(default_timeout_seconds)))
-        except ValueError:
-            timeout_seconds = default_timeout_seconds
         self.log.info(
             f"{hook_name}.start",
             script=str(script_path),
             repo_owner=repo.owner,
             repo_name=repo.name,
-            timeout_seconds=timeout_seconds,
             boot_mode=boot_mode.value,
         )
+        process: asyncio.subprocess.Process | None = None
         try:
             env = os.environ.copy()
             env["OPENINSPECT_BOOT_MODE"] = boot_mode.value
-            process = await asyncio.create_subprocess_exec(
-                "bash",
-                str(script_path),
-                cwd=repo.path,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=env,
-                start_new_session=True,
-            )
-            try:
-                stdout, _ = await asyncio.wait_for(
-                    self._communicate(process), timeout=timeout_seconds
-                )
-            except TimeoutError:
-                if process.returncode is None:
-                    await self._terminate(process)
-                stdout = await process.stdout.read() if process.stdout else b""
-                fields: dict[str, object] = {
-                    "timeout_seconds": timeout_seconds,
-                    "script": str(script_path),
-                    "duration_ms": int((time.time() - start_time) * 1000),
-                    "boot_mode": boot_mode.value,
-                }
-                if boot_mode is not BootMode.BUILD:
-                    fields["output_tail"] = "\n".join(
-                        stdout.decode(errors="replace").splitlines()[-50:]
+            with tempfile.TemporaryFile() as output_file:
+                spawn_task = asyncio.create_task(
+                    asyncio.create_subprocess_exec(
+                        "bash",
+                        str(script_path),
+                        cwd=repo.path,
+                        stdout=output_file,
+                        stderr=asyncio.subprocess.STDOUT,
+                        env=env,
+                        start_new_session=True,
                     )
-                self.log.error(f"{hook_name}.timeout", **fields)
-                return False
-            output_tail = "\n".join(stdout.decode(errors="replace").splitlines()[-50:])
+                )
+                try:
+                    process = await asyncio.shield(spawn_task)
+                except asyncio.CancelledError:
+                    # Process creation can complete after its caller is cancelled.
+                    # Retain ownership so shutdown cannot leave a hook behind.
+                    process = await spawn_task
+                    raise
+                await process.wait()
+                output_tail = ""
+                if process.returncode != 0 and boot_mode is not BootMode.BUILD:
+                    output_file.seek(0)
+                    output_tail = "\n".join(
+                        output_file.read().decode(errors="replace").splitlines()[-50:]
+                    )
             fields = {
                 "exit_code": process.returncode,
                 "script": str(script_path),
@@ -101,11 +87,29 @@ class RepositoryHooks:
             if process.returncode == 0:
                 self.log.info(f"{hook_name}.complete", **fields)
                 return True
+            await self._terminate(process)
             if boot_mode is not BootMode.BUILD:
                 fields["output_tail"] = output_tail
             self.log.error(f"{hook_name}.failed", **fields)
             return False
+        except asyncio.CancelledError:
+            if process is not None:
+                cleanup = asyncio.create_task(self._terminate(process))
+                try:
+                    await asyncio.shield(cleanup)
+                except asyncio.CancelledError:
+                    await cleanup
+                self.log.info(
+                    f"{hook_name}.cancelled",
+                    reason="outer_operation_cancelled",
+                    script=str(script_path),
+                    boot_mode=boot_mode.value,
+                    duration_ms=int((time.time() - start_time) * 1000),
+                )
+            raise
         except Exception as error:
+            if process is not None:
+                await self._terminate(process)
             self.log.error(
                 f"{hook_name}.error",
                 exc=error,
@@ -121,8 +125,6 @@ class RepositoryHooks:
             boot_mode,
             hook_name="setup",
             relative_script_path=self.SETUP_SCRIPT_PATH,
-            timeout_env_var="SETUP_TIMEOUT_SECONDS",
-            default_timeout_seconds=self.DEFAULT_SETUP_TIMEOUT_SECONDS,
         )
 
     async def run_start(self, repo: RepoEntry, boot_mode: BootMode) -> bool:
@@ -131,6 +133,4 @@ class RepositoryHooks:
             boot_mode,
             hook_name="start",
             relative_script_path=self.START_SCRIPT_PATH,
-            timeout_env_var="START_TIMEOUT_SECONDS",
-            default_timeout_seconds=self.DEFAULT_START_TIMEOUT_SECONDS,
         )

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import os
-import tempfile
 import time
 from typing import TYPE_CHECKING, Any
 
-from .process_output import terminate_owned_subprocess
+from .process_output import (
+    BoundedOutputCollector,
+    terminate_owned_subprocess,
+    wait_for_process_exit,
+)
 from .runtime_config import BootMode
 
 if TYPE_CHECKING:
@@ -19,6 +22,15 @@ class RepositoryHooks:
 
     def __init__(self, log: Any) -> None:
         self.log = log
+        self._output_collectors: set[BoundedOutputCollector] = set()
+
+    def _collect_output(self, process: asyncio.subprocess.Process) -> BoundedOutputCollector:
+        if process.stdout is None:
+            raise RuntimeError("hook process output pipe was not created")
+        collector = BoundedOutputCollector(process.stdout)
+        self._output_collectors.add(collector)
+        collector.task.add_done_callback(lambda _task: self._output_collectors.discard(collector))
+        return collector
 
     async def _terminate(self, process: asyncio.subprocess.Process) -> None:
         await terminate_owned_subprocess(process, kill_process_group=os.killpg)
@@ -49,35 +61,30 @@ class RepositoryHooks:
             boot_mode=boot_mode.value,
         )
         process: asyncio.subprocess.Process | None = None
+        output: BoundedOutputCollector | None = None
         try:
             env = os.environ.copy()
             env["OPENINSPECT_BOOT_MODE"] = boot_mode.value
-            with tempfile.TemporaryFile() as output_file:
-                spawn_task = asyncio.create_task(
-                    asyncio.create_subprocess_exec(
-                        "bash",
-                        str(script_path),
-                        cwd=repo.path,
-                        stdout=output_file,
-                        stderr=asyncio.subprocess.STDOUT,
-                        env=env,
-                        start_new_session=True,
-                    )
+            spawn_task = asyncio.create_task(
+                asyncio.create_subprocess_exec(
+                    "bash",
+                    str(script_path),
+                    cwd=repo.path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    env=env,
+                    start_new_session=True,
                 )
-                try:
-                    process = await asyncio.shield(spawn_task)
-                except asyncio.CancelledError:
-                    # Process creation can complete after its caller is cancelled.
-                    # Retain ownership so shutdown cannot leave a hook behind.
-                    process = await spawn_task
-                    raise
-                await process.wait()
-                output_tail = ""
-                if process.returncode != 0 and boot_mode is not BootMode.BUILD:
-                    output_file.seek(0)
-                    output_tail = "\n".join(
-                        output_file.read().decode(errors="replace").splitlines()[-50:]
-                    )
+            )
+            try:
+                process = await asyncio.shield(spawn_task)
+            except asyncio.CancelledError:
+                # Process creation can complete after its caller is cancelled.
+                # Retain ownership so shutdown cannot leave a hook behind.
+                process = await spawn_task
+                raise
+            output = self._collect_output(process)
+            await wait_for_process_exit(process)
             fields = {
                 "exit_code": process.returncode,
                 "script": str(script_path),
@@ -85,11 +92,13 @@ class RepositoryHooks:
                 "boot_mode": boot_mode.value,
             }
             if process.returncode == 0:
+                output.discard_tail()
                 self.log.info(f"{hook_name}.complete", **fields)
                 return True
             await self._terminate(process)
+            await output.wait()
             if boot_mode is not BootMode.BUILD:
-                fields["output_tail"] = output_tail
+                fields["output_tail"] = output.tail_lines()
             self.log.error(f"{hook_name}.failed", **fields)
             return False
         except asyncio.CancelledError:
@@ -99,6 +108,8 @@ class RepositoryHooks:
                     await asyncio.shield(cleanup)
                 except asyncio.CancelledError:
                     await cleanup
+                if output is not None:
+                    await output.wait()
                 self.log.info(
                     f"{hook_name}.cancelled",
                     reason="outer_operation_cancelled",
@@ -110,6 +121,8 @@ class RepositoryHooks:
         except Exception as error:
             if process is not None:
                 await self._terminate(process)
+            if output is not None:
+                await output.wait()
             self.log.error(
                 f"{hook_name}.error",
                 exc=error,

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
@@ -92,15 +92,21 @@ class RepositoryHooks:
                 self.log.info(f"{hook_name}.complete", **fields)
                 return True
             await self._terminate(process)
-            await output.wait()
+            await output.shutdown()
             if boot_mode is not BootMode.BUILD:
                 fields["output_tail"] = output.tail_lines()
             self.log.error(f"{hook_name}.failed", **fields)
             return False
         except asyncio.CancelledError:
-            if process is not None:
-                cleanup = asyncio.create_task(self._terminate(process))
-                await finish_cancellation_cleanup(cleanup)
+
+            async def cleanup_cancelled_hook() -> None:
+                if process is not None:
+                    await self._terminate(process)
+                if output is not None:
+                    await output.shutdown()
+
+            cleanup = asyncio.create_task(cleanup_cancelled_hook())
+            await finish_cancellation_cleanup(cleanup)
             if output is not None:
                 output.discard_tail()
             self.log.info(
@@ -115,7 +121,7 @@ class RepositoryHooks:
             if process is not None:
                 await self._terminate(process)
             if output is not None:
-                await output.wait()
+                await output.shutdown()
             self.log.error(
                 f"{hook_name}.error",
                 exc=error,

--- a/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repository_hooks.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from .process_output import (
     BoundedOutputCollector,
+    finish_cancellation_cleanup,
+    spawn_owned_subprocess,
     terminate_owned_subprocess,
     wait_for_process_exit,
 )
@@ -65,8 +67,8 @@ class RepositoryHooks:
         try:
             env = os.environ.copy()
             env["OPENINSPECT_BOOT_MODE"] = boot_mode.value
-            spawn_task = asyncio.create_task(
-                asyncio.create_subprocess_exec(
+            process = await spawn_owned_subprocess(
+                lambda: asyncio.create_subprocess_exec(
                     "bash",
                     str(script_path),
                     cwd=repo.path,
@@ -74,15 +76,9 @@ class RepositoryHooks:
                     stderr=asyncio.subprocess.STDOUT,
                     env=env,
                     start_new_session=True,
-                )
+                ),
+                kill_process_group=os.killpg,
             )
-            try:
-                process = await asyncio.shield(spawn_task)
-            except asyncio.CancelledError:
-                # Process creation can complete after its caller is cancelled.
-                # Retain ownership so shutdown cannot leave a hook behind.
-                process = await spawn_task
-                raise
             output = self._collect_output(process)
             await wait_for_process_exit(process)
             fields = {
@@ -104,19 +100,16 @@ class RepositoryHooks:
         except asyncio.CancelledError:
             if process is not None:
                 cleanup = asyncio.create_task(self._terminate(process))
-                try:
-                    await asyncio.shield(cleanup)
-                except asyncio.CancelledError:
-                    await cleanup
-                if output is not None:
-                    await output.wait()
-                self.log.info(
-                    f"{hook_name}.cancelled",
-                    reason="outer_operation_cancelled",
-                    script=str(script_path),
-                    boot_mode=boot_mode.value,
-                    duration_ms=int((time.time() - start_time) * 1000),
-                )
+                await finish_cancellation_cleanup(cleanup)
+            if output is not None:
+                output.discard_tail()
+            self.log.info(
+                f"{hook_name}.cancelled",
+                reason="outer_operation_cancelled",
+                script=str(script_path),
+                boot_mode=boot_mode.value,
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
             raise
         except Exception as error:
             if process is not None:

--- a/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
+++ b/packages/sandbox-runtime/src/sandbox_runtime/runtime_manifest.json
@@ -1,8 +1,8 @@
 {
-  "runtimeVersion": "v66-claude-privacy-policy",
-  "generation": 66,
+  "runtimeVersion": "v67-unbounded-repository-hooks",
+  "generation": 67,
   "minimumCompatibleGeneration": 62,
-  "minimumRebuildGeneration": 66,
+  "minimumRebuildGeneration": 67,
   "harnessMinimumGeneration": {
     "claude": 64
   }

--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -40,8 +40,8 @@ FATAL_ERROR_REPORT_TIMEOUT_SECONDS = 5.0
 FATAL_ERROR_REPORT_MAX_CHARS = 1000
 
 
-class ImageBuildExecutionCancelled(Exception):
-    """A handled process signal interrupted image-build work."""
+class BootExecutionCancelled(Exception):
+    """A handled process signal interrupted boot work."""
 
 
 class SandboxSupervisor:
@@ -350,7 +350,7 @@ class SandboxSupervisor:
         self, operation_factory: Callable[[], Awaitable[_ResultT]]
     ) -> _ResultT:
         if self.shutdown_event.is_set():
-            raise ImageBuildExecutionCancelled
+            raise BootExecutionCancelled
         operation_task = asyncio.ensure_future(operation_factory())
         shutdown_task = asyncio.create_task(self.shutdown_event.wait())
         tasks = {operation_task, shutdown_task}
@@ -358,7 +358,7 @@ class SandboxSupervisor:
             done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             if operation_task in done:
                 return operation_task.result()
-            raise ImageBuildExecutionCancelled
+            raise BootExecutionCancelled
         finally:
             for task in tasks:
                 if not task.done():
@@ -412,7 +412,7 @@ class SandboxSupervisor:
             if self.boot_mode is BootMode.BUILD:
                 boot_result = await self._run_image_build_execution(expected_tunnel_ports)
                 if self.shutdown_event.is_set():
-                    raise ImageBuildExecutionCancelled
+                    raise BootExecutionCancelled
                 runtime_version = os.environ.get("SANDBOX_VERSION", "")
                 self.log.info(
                     "image_build.complete",
@@ -438,7 +438,9 @@ class SandboxSupervisor:
                 self.log.warn("vnc.start_failed", exc=error)
                 await self.browser_desktop.stop()
 
-            boot_result = await self.repository_boot.boot(self.boot_mode, expected_tunnel_ports)
+            boot_result = await self._run_until_shutdown(
+                lambda: self.repository_boot.boot(self.boot_mode, expected_tunnel_ports)
+            )
             self._repository_boot_result = boot_result
 
             # Materialization is sandbox-boot work; OpenCode process restarts
@@ -476,8 +478,13 @@ class SandboxSupervisor:
                 outcome="success",
             )
             await self.monitor_processes()
-        except ImageBuildExecutionCancelled:
-            self.log.info("image_build.cancelled", reason="shutdown_requested")
+        except BootExecutionCancelled:
+            event = (
+                "image_build.cancelled"
+                if self.boot_mode is BootMode.BUILD
+                else "supervisor.boot_cancelled"
+            )
+            self.log.info(event, reason="shutdown_requested")
             return True
         except Exception as error:
             self.log.error("supervisor.error", exc=error)
@@ -490,7 +497,7 @@ class SandboxSupervisor:
                     await self._run_until_shutdown(
                         lambda: repo_image_callback.report_failure(error_message)
                     )
-                except ImageBuildExecutionCancelled:
+                except BootExecutionCancelled:
                     self.log.info("image_build.cancelled", reason="shutdown_requested")
                     return True
             await self._report_fatal_error(str(error))

--- a/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/supervisor.py
@@ -356,6 +356,8 @@ class SandboxSupervisor:
         tasks = {operation_task, shutdown_task}
         try:
             done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            if shutdown_task in done or self.shutdown_event.is_set():
+                raise BootExecutionCancelled
             if operation_task in done:
                 return operation_task.result()
             raise BootExecutionCancelled
@@ -411,8 +413,6 @@ class SandboxSupervisor:
         try:
             if self.boot_mode is BootMode.BUILD:
                 boot_result = await self._run_image_build_execution(expected_tunnel_ports)
-                if self.shutdown_event.is_set():
-                    raise BootExecutionCancelled
                 runtime_version = os.environ.get("SANDBOX_VERSION", "")
                 self.log.info(
                     "image_build.complete",

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -15,7 +15,7 @@ from sandbox_runtime.repository_sync import (
     RepositorySyncStatus,
 )
 from sandbox_runtime.runtime_config import BootMode
-from sandbox_runtime.supervisor import ImageBuildExecutionCancelled
+from sandbox_runtime.supervisor import BootExecutionCancelled
 
 
 @pytest.fixture(autouse=True)
@@ -140,7 +140,7 @@ class TestImageBuildMode:
         supervisor.shutdown_event.set()
         operation_factory = MagicMock()
 
-        with pytest.raises(ImageBuildExecutionCancelled):
+        with pytest.raises(BootExecutionCancelled):
             await supervisor._run_until_shutdown(operation_factory)
 
         operation_factory.assert_not_called()

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -146,6 +146,28 @@ class TestImageBuildMode:
         operation_factory.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_shutdown_wins_when_operation_succeeds_in_same_turn(self, build_env):
+        supervisor = _make_supervisor(build_env)
+
+        async def operation():
+            supervisor.shutdown_event.set()
+            return "complete"
+
+        with pytest.raises(BootExecutionCancelled):
+            await supervisor._run_until_shutdown(operation)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_wins_when_operation_fails_in_same_turn(self, build_env):
+        supervisor = _make_supervisor(build_env)
+
+        async def operation():
+            supervisor.shutdown_event.set()
+            raise RuntimeError("racing failure")
+
+        with pytest.raises(BootExecutionCancelled):
+            await supervisor._run_until_shutdown(operation)
+
+    @pytest.mark.asyncio
     async def test_resolves_diff_baseline_after_sync_before_setup(self, build_env):
         supervisor = _make_supervisor(build_env)
         supervisor.repository_boot.synchronizer.sync = AsyncMock(

--- a/packages/sandbox-runtime/tests/test_process_output.py
+++ b/packages/sandbox-runtime/tests/test_process_output.py
@@ -7,7 +7,40 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from sandbox_runtime.process_output import communicate_owned_subprocess, terminate_owned_subprocess
+from sandbox_runtime.process_output import (
+    PROCESS_OUTPUT_TAIL_BYTES,
+    BoundedOutputCollector,
+    communicate_owned_subprocess,
+    terminate_owned_subprocess,
+    wait_for_process_exit,
+)
+
+
+async def test_bounded_output_collector_retains_only_tail_window():
+    stream = asyncio.StreamReader()
+    collector = BoundedOutputCollector(stream)
+    stream.feed_data(b"discarded\n" * 10_000 + b"final line\n")
+    stream.feed_eof()
+
+    await collector.wait()
+
+    tail = collector.tail_lines(max_lines=10_000)
+    assert len(tail.encode()) <= PROCESS_OUTPUT_TAIL_BYTES
+    assert tail.endswith("final line")
+
+
+async def test_wait_for_process_exit_does_not_wait_for_inherited_pipe_eof():
+    process = MagicMock(returncode=None)
+    wait_forever = asyncio.Event()
+    process.wait = AsyncMock(side_effect=wait_forever.wait)
+
+    async def mark_process_exited():
+        await asyncio.sleep(0)
+        process.returncode = 0
+
+    await asyncio.gather(wait_for_process_exit(process), mark_process_exited())
+
+    process.wait.assert_awaited_once()
 
 
 @pytest.mark.parametrize("returncode", [None, 0])

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from sandbox_runtime.process_output import PROCESS_OUTPUT_TAIL_BYTES
 from sandbox_runtime.repository_boot import RepositoryBoot
 from sandbox_runtime.runtime_config import BootMode
 from tests.runtime_helpers import make_repository_boot
@@ -42,6 +43,19 @@ def _create_setup_script(repo_path, content="#!/bin/bash\necho hello\n"):
     script = setup_dir / "setup.sh"
     script.write_text(content)
     return script
+
+
+def _background_writer_script(*, exit_code: int) -> str:
+    return (
+        "#!/bin/bash\n"
+        f'"{sys.executable}" -c \'import os,time\n'
+        "while True:\n"
+        '    os.write(1, b"x" * 4095 + b"\\n")\n'
+        "    time.sleep(0.01)' &\n"
+        "echo $! > child.pid\n"
+        "echo diagnostic\n"
+        f"exit {exit_code}\n"
+    )
 
 
 def _fake_process(returncode=0):
@@ -184,6 +198,25 @@ class TestSetupScriptFailure:
         assert failure.args == ("setup.failed",)
         assert failure.kwargs["output_tail"] == "diagnostic"
 
+    async def test_failed_hook_stops_background_writer_before_reading_bounded_tail(self, tmp_path):
+        sup = _make_repository_boot(tmp_path)
+        sup.hooks.log = MagicMock()
+        _create_setup_script(sup.repo_path, content=_background_writer_script(exit_code=1))
+        child_pid = None
+
+        try:
+            async with asyncio.timeout(2):
+                result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
+            child_pid = int((sup.repo_path / "child.pid").read_text())
+            output_tail = sup.hooks.log.error.call_args.kwargs["output_tail"]
+            assert result is False
+            assert "diagnostic" in output_tail
+            assert len(output_tail.encode()) <= PROCESS_OUTPUT_TAIL_BYTES
+        finally:
+            if child_pid is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(child_pid, signal.SIGKILL)
+
 
 # ---------------------------------------------------------------------------
 # TestSetupScriptWaitPolicy
@@ -212,14 +245,7 @@ class TestSetupScriptWaitPolicy:
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(
             sup.repo_path,
-            content=(
-                "#!/bin/bash\n"
-                f'"{sys.executable}" -c \'import os,time\n'
-                "while True:\n"
-                '    os.write(1, b"x" * 4096)\n'
-                "    time.sleep(0.001)' &\n"
-                "echo $! > child.pid\n"
-            ),
+            content=_background_writer_script(exit_code=0),
         )
         child_pid = None
 

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -45,10 +45,12 @@ def _create_setup_script(repo_path, content="#!/bin/bash\necho hello\n"):
     return script
 
 
-def _background_writer_script(*, exit_code: int) -> str:
+def _background_writer_script(*, exit_code: int, escape_process_group: bool = False) -> str:
+    escape_group = "os.setsid()\n" if escape_process_group else ""
     return (
         "#!/bin/bash\n"
         f'"{sys.executable}" -c \'import os,time\n'
+        f"{escape_group}"
         "while True:\n"
         '    os.write(1, b"x" * 4095 + b"\\n")\n'
         "    time.sleep(0.01)' &\n"
@@ -212,6 +214,26 @@ class TestSetupScriptFailure:
             assert result is False
             assert "diagnostic" in output_tail
             assert len(output_tail.encode()) <= PROCESS_OUTPUT_TAIL_BYTES
+        finally:
+            if child_pid is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(child_pid, signal.SIGKILL)
+
+    async def test_failed_hook_closes_output_from_detached_background_writer(self, tmp_path):
+        sup = _make_repository_boot(tmp_path)
+        sup.hooks.log = MagicMock()
+        _create_setup_script(
+            sup.repo_path,
+            content=_background_writer_script(exit_code=1, escape_process_group=True),
+        )
+        child_pid = None
+
+        try:
+            async with asyncio.timeout(2):
+                result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
+            child_pid = int((sup.repo_path / "child.pid").read_text())
+            assert result is False
+            assert "diagnostic" in sup.hooks.log.error.call_args.kwargs["output_tail"]
         finally:
             if child_pid is not None:
                 with contextlib.suppress(ProcessLookupError):

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -1,8 +1,12 @@
 """Tests for RepositoryHooks.run_setup() and its integration in RepositoryBoot.boot()."""
 
 import asyncio
+import contextlib
+import os
 import signal
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from sandbox_runtime.repository_boot import RepositoryBoot
 from sandbox_runtime.runtime_config import BootMode
@@ -39,13 +43,13 @@ def _create_setup_script(repo_path, content="#!/bin/bash\necho hello\n"):
     return script
 
 
-def _fake_process(returncode=0, stdout=b""):
+def _fake_process(returncode=0):
     """Return a mock async process."""
     proc = MagicMock()
     proc.returncode = returncode
-    proc.communicate = AsyncMock(return_value=(stdout, None))
+    proc.communicate = AsyncMock(side_effect=AssertionError("hooks must wait for shell exit"))
     proc.kill = MagicMock()
-    proc.wait = AsyncMock()
+    proc.wait = AsyncMock(return_value=returncode)
     return proc
 
 
@@ -80,7 +84,7 @@ class TestSetupScriptSuccess:
     async def test_bash_called_with_correct_args(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         script = _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
+        fake_proc = _fake_process(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -92,11 +96,18 @@ class TestSetupScriptSuccess:
         assert call_args[0][0] == "bash"
         assert call_args[0][1] == str(script)
         assert call_args[1]["cwd"] == sup.repo_path
+        assert call_args[1]["stdout"] not in (
+            asyncio.subprocess.PIPE,
+            asyncio.subprocess.DEVNULL,
+        )
+        assert call_args[1]["stderr"] == asyncio.subprocess.STDOUT
+        fake_proc.wait.assert_awaited_once()
+        fake_proc.communicate.assert_not_awaited()
 
     async def test_inherits_environment(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"")
+        fake_proc = _fake_process(returncode=0)
 
         with (
             patch.dict("os.environ", {"MY_VAR": "hello"}, clear=False),
@@ -122,7 +133,7 @@ class TestSetupScriptFailure:
     async def test_nonzero_exit_returns_false(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(sup.repo_path, content="#!/bin/bash\nexit 1\n")
-        fake_proc = _fake_process(returncode=1, stdout=b"error: something broke\n")
+        fake_proc = _fake_process(returncode=1)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -148,7 +159,7 @@ class TestSetupScriptFailure:
         sup = _make_repository_boot(tmp_path)
         sup.hooks.log = MagicMock()
         _create_setup_script(sup.repo_path, content="#!/bin/bash\nexit 1\n")
-        fake_proc = _fake_process(returncode=1, stdout=b"secret from repository hook\n")
+        fake_proc = _fake_process(returncode=1)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -161,121 +172,89 @@ class TestSetupScriptFailure:
         assert failure.kwargs["exit_code"] == 1
         assert "output_tail" not in failure.kwargs
 
-
-# ---------------------------------------------------------------------------
-# TestSetupScriptTimeout
-# ---------------------------------------------------------------------------
-
-
-class TestSetupScriptTimeout:
-    """Timeout handling for the setup script."""
-
-    async def test_timeout_kills_process_group(self, tmp_path):
-        sup = _make_repository_boot(tmp_path)
-        _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=None)
-        fake_proc.pid = 123
-        fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
-        fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
-        fake_proc.stdout = MagicMock()
-        fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
-
-        with (
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
-        ):
-            result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
-
-        assert result is False
-        kill_process_group.assert_called_once_with(fake_proc.pid, signal.SIGKILL)
-        fake_proc.kill.assert_not_called()
-        fake_proc.wait.assert_awaited_once()
-
-    async def test_build_timeout_log_omits_hook_output(self, tmp_path):
+    async def test_fresh_failure_log_preserves_hook_output_tail(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         sup.hooks.log = MagicMock()
-        _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=None)
-        fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
-        fake_proc.stdout = MagicMock()
-        fake_proc.stdout.read = AsyncMock(return_value=b"secret partial output\n")
+        _create_setup_script(sup.repo_path, content="#!/bin/bash\necho diagnostic\nexit 1\n")
 
-        with patch(
-            "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
-        ):
-            result = await sup.hooks.run_setup(sup.repositories[0], BootMode.BUILD)
+        result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
 
         assert result is False
-        timeout = sup.hooks.log.error.call_args
-        assert timeout.args == ("setup.timeout",)
-        assert "output_tail" not in timeout.kwargs
+        failure = sup.hooks.log.error.call_args
+        assert failure.args == ("setup.failed",)
+        assert failure.kwargs["output_tail"] == "diagnostic"
 
-    async def test_default_timeout_300(self, tmp_path):
+
+# ---------------------------------------------------------------------------
+# TestSetupScriptWaitPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestSetupScriptWaitPolicy:
+    """Setup waits for the script instead of imposing a hook-specific deadline."""
+
+    async def test_legacy_timeout_environment_does_not_bound_script(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
-        captured_timeout = {}
-
-        original_wait_for = asyncio.wait_for
-
-        async def capturing_wait_for(coro, *, timeout=None):
-            captured_timeout["value"] = timeout
-            return await original_wait_for(coro, timeout=timeout)
+        fake_proc = _fake_process(returncode=0)
 
         with (
-            patch.dict("os.environ", {}, clear=False),
+            patch.dict("os.environ", {"SETUP_TIMEOUT_SECONDS": "0"}, clear=False),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("asyncio.wait_for", side_effect=capturing_wait_for),
-        ):
-            import os
-
-            os.environ.pop("SETUP_TIMEOUT_SECONDS", None)
-            await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
-
-        assert captured_timeout["value"] == 300
-
-    async def test_custom_timeout_from_env(self, tmp_path):
-        sup = _make_repository_boot(tmp_path)
-        _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
-        captured_timeout = {}
-
-        original_wait_for = asyncio.wait_for
-
-        async def capturing_wait_for(coro, *, timeout=None):
-            captured_timeout["value"] = timeout
-            return await original_wait_for(coro, timeout=timeout)
-
-        with (
-            patch.dict("os.environ", {"SETUP_TIMEOUT_SECONDS": "60"}, clear=False),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("asyncio.wait_for", side_effect=capturing_wait_for),
-        ):
-            await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
-
-        assert captured_timeout["value"] == 60
-
-    async def test_invalid_timeout_env_uses_default(self, tmp_path):
-        sup = _make_repository_boot(tmp_path)
-        _create_setup_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
-        captured_timeout = {}
-
-        original_wait_for = asyncio.wait_for
-
-        async def capturing_wait_for(coro, *, timeout=None):
-            captured_timeout["value"] = timeout
-            return await original_wait_for(coro, timeout=timeout)
-
-        with (
-            patch.dict("os.environ", {"SETUP_TIMEOUT_SECONDS": "not_a_number"}, clear=False),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("asyncio.wait_for", side_effect=capturing_wait_for),
         ):
             result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
 
         assert result is True
-        assert captured_timeout["value"] == 300
+        fake_proc.wait.assert_awaited_once()
+        fake_proc.communicate.assert_not_awaited()
+
+    async def test_background_child_does_not_delay_shell_completion(self, tmp_path):
+        sup = _make_repository_boot(tmp_path)
+        _create_setup_script(
+            sup.repo_path, content="#!/bin/bash\nsleep 60 &\necho $! > child.pid\n"
+        )
+        child_pid = None
+
+        try:
+            async with asyncio.timeout(2):
+                result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
+            child_pid = int((sup.repo_path / "child.pid").read_text())
+            assert result is True
+        finally:
+            if child_pid is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(child_pid, signal.SIGKILL)
+
+    async def test_cancellation_stops_the_hook_process_group(self, tmp_path):
+        sup = _make_repository_boot(tmp_path)
+        _create_setup_script(sup.repo_path)
+        fake_proc = _fake_process(returncode=None)
+        fake_proc.pid = 12345
+        wait_started = asyncio.Event()
+        wait_calls = 0
+
+        async def wait():
+            nonlocal wait_calls
+            wait_calls += 1
+            if wait_calls == 1:
+                wait_started.set()
+                await asyncio.Event().wait()
+            fake_proc.returncode = -signal.SIGKILL
+            return fake_proc.returncode
+
+        fake_proc.wait.side_effect = wait
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
+            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
+        ):
+            task = asyncio.create_task(sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH))
+            await asyncio.wait_for(wait_started.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        kill_process_group.assert_called_once_with(12345, signal.SIGKILL)
+        assert wait_calls == 2
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import os
 import signal
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,6 +51,8 @@ def _fake_process(returncode=0):
     proc.communicate = AsyncMock(side_effect=AssertionError("hooks must wait for shell exit"))
     proc.kill = MagicMock()
     proc.wait = AsyncMock(return_value=returncode)
+    proc.stdout = asyncio.StreamReader()
+    proc.stdout.feed_eof()
     return proc
 
 
@@ -96,10 +99,7 @@ class TestSetupScriptSuccess:
         assert call_args[0][0] == "bash"
         assert call_args[0][1] == str(script)
         assert call_args[1]["cwd"] == sup.repo_path
-        assert call_args[1]["stdout"] not in (
-            asyncio.subprocess.PIPE,
-            asyncio.subprocess.DEVNULL,
-        )
+        assert call_args[1]["stdout"] == asyncio.subprocess.PIPE
         assert call_args[1]["stderr"] == asyncio.subprocess.STDOUT
         fake_proc.wait.assert_awaited_once()
         fake_proc.communicate.assert_not_awaited()
@@ -211,7 +211,15 @@ class TestSetupScriptWaitPolicy:
     async def test_background_child_does_not_delay_shell_completion(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_setup_script(
-            sup.repo_path, content="#!/bin/bash\nsleep 60 &\necho $! > child.pid\n"
+            sup.repo_path,
+            content=(
+                "#!/bin/bash\n"
+                f'"{sys.executable}" -c \'import os,time\n'
+                "while True:\n"
+                '    os.write(1, b"x" * 4096)\n'
+                "    time.sleep(0.001)' &\n"
+                "echo $! > child.pid\n"
+            ),
         )
         child_pid = None
 
@@ -220,6 +228,9 @@ class TestSetupScriptWaitPolicy:
                 result = await sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH)
             child_pid = int((sup.repo_path / "child.pid").read_text())
             assert result is True
+            await asyncio.sleep(0.1)
+            os.kill(child_pid, 0)
+            assert sup.hooks._output_collectors
         finally:
             if child_pid is not None:
                 with contextlib.suppress(ProcessLookupError):

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -293,6 +293,36 @@ class TestSetupScriptWaitPolicy:
         kill_process_group.assert_called_once_with(12345, signal.SIGKILL)
         assert wait_calls == 2
 
+    async def test_repeated_cancellation_during_spawn_still_stops_process_group(self, tmp_path):
+        sup = _make_repository_boot(tmp_path)
+        _create_setup_script(sup.repo_path)
+        fake_proc = _fake_process(returncode=None)
+        fake_proc.pid = 12345
+        spawn_started = asyncio.Event()
+        release_spawn = asyncio.Event()
+
+        async def spawn(*_args, **_kwargs):
+            spawn_started.set()
+            await release_spawn.wait()
+            return fake_proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, side_effect=spawn),
+            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
+        ):
+            task = asyncio.create_task(sup.hooks.run_setup(sup.repositories[0], BootMode.FRESH))
+            await asyncio.wait_for(spawn_started.wait(), timeout=1)
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()
+            release_spawn.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=1)
+
+        kill_process_group.assert_called_once_with(12345, signal.SIGKILL)
+        fake_proc.wait.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # TestSetupInRun (integration)

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -52,6 +52,8 @@ def _fake_process(returncode=0):
     proc.communicate = AsyncMock(side_effect=AssertionError("hooks must wait for shell exit"))
     proc.kill = MagicMock()
     proc.wait = AsyncMock(return_value=returncode)
+    proc.stdout = asyncio.StreamReader()
+    proc.stdout.feed_eof()
     return proc
 
 
@@ -108,10 +110,7 @@ class TestStartScriptSuccess:
         assert call_args[0][0] == "bash"
         assert call_args[0][1] == str(script)
         assert call_args[1]["cwd"] == sup.repo_path
-        assert call_args[1]["stdout"] not in (
-            asyncio.subprocess.PIPE,
-            asyncio.subprocess.DEVNULL,
-        )
+        assert call_args[1]["stdout"] == asyncio.subprocess.PIPE
         assert call_args[1]["stderr"] == asyncio.subprocess.STDOUT
         fake_proc.wait.assert_awaited_once()
         fake_proc.communicate.assert_not_awaited()

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -1,7 +1,6 @@
 """Tests for RepositoryHooks.run_start() and strict repository boot integration."""
 
 import asyncio
-import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,13 +45,13 @@ def _create_start_script(repo_path, content="#!/bin/bash\necho start\n"):
     return script
 
 
-def _fake_process(returncode=0, stdout=b""):
+def _fake_process(returncode=0):
     """Return a mock async process."""
     proc = MagicMock()
     proc.returncode = returncode
-    proc.communicate = AsyncMock(return_value=(stdout, None))
+    proc.communicate = AsyncMock(side_effect=AssertionError("hooks must wait for shell exit"))
     proc.kill = MagicMock()
-    proc.wait = AsyncMock()
+    proc.wait = AsyncMock(return_value=returncode)
     return proc
 
 
@@ -85,7 +84,7 @@ class TestStartScriptSuccess:
     async def test_successful_run(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"started\n")
+        fake_proc = _fake_process(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -97,7 +96,7 @@ class TestStartScriptSuccess:
     async def test_bash_called_with_correct_args(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         script = _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
+        fake_proc = _fake_process(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -109,11 +108,18 @@ class TestStartScriptSuccess:
         assert call_args[0][0] == "bash"
         assert call_args[0][1] == str(script)
         assert call_args[1]["cwd"] == sup.repo_path
+        assert call_args[1]["stdout"] not in (
+            asyncio.subprocess.PIPE,
+            asyncio.subprocess.DEVNULL,
+        )
+        assert call_args[1]["stderr"] == asyncio.subprocess.STDOUT
+        fake_proc.wait.assert_awaited_once()
+        fake_proc.communicate.assert_not_awaited()
 
     async def test_sets_boot_mode_env_for_script(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
+        fake_proc = _fake_process(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -130,7 +136,7 @@ class TestStartScriptFailure:
     async def test_nonzero_exit_returns_false(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_start_script(sup.repo_path, content="#!/bin/bash\nexit 1\n")
-        fake_proc = _fake_process(returncode=1, stdout=b"start failed\n")
+        fake_proc = _fake_process(returncode=1)
 
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
@@ -153,74 +159,23 @@ class TestStartScriptFailure:
         assert result is False
 
 
-class TestStartScriptTimeout:
-    """Timeout handling for the start script."""
+class TestStartScriptWaitPolicy:
+    """Start waits for the script instead of imposing a hook-specific deadline."""
 
-    async def test_timeout_kills_process_group(self, tmp_path):
+    async def test_legacy_timeout_environment_does_not_bound_script(self, tmp_path):
         sup = _make_repository_boot(tmp_path)
         _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=None)
-        fake_proc.pid = 123
-        fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
-        fake_proc.wait.side_effect = lambda: setattr(fake_proc, "returncode", -9)
-        fake_proc.stdout = MagicMock()
-        fake_proc.stdout.read = AsyncMock(return_value=b"partial output\n")
+        fake_proc = _fake_process(returncode=0)
 
         with (
+            patch.dict("os.environ", {"START_TIMEOUT_SECONDS": "0"}, clear=False),
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("sandbox_runtime.repository_hooks.os.killpg") as kill_process_group,
         ):
             result = await sup.hooks.run_start(sup.repositories[0], BootMode.FRESH)
 
-        assert result is False
-        kill_process_group.assert_called_once_with(fake_proc.pid, signal.SIGKILL)
-        fake_proc.kill.assert_not_called()
+        assert result is True
         fake_proc.wait.assert_awaited_once()
-
-    async def test_default_timeout_120(self, tmp_path):
-        sup = _make_repository_boot(tmp_path)
-        _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
-        captured_timeout = {}
-
-        original_wait_for = asyncio.wait_for
-
-        async def capturing_wait_for(coro, *, timeout=None):
-            captured_timeout["value"] = timeout
-            return await original_wait_for(coro, timeout=timeout)
-
-        with (
-            patch.dict("os.environ", {}, clear=False),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("asyncio.wait_for", side_effect=capturing_wait_for),
-        ):
-            import os
-
-            os.environ.pop("START_TIMEOUT_SECONDS", None)
-            await sup.hooks.run_start(sup.repositories[0], BootMode.FRESH)
-
-        assert captured_timeout["value"] == 120
-
-    async def test_custom_timeout_from_env(self, tmp_path):
-        sup = _make_repository_boot(tmp_path)
-        _create_start_script(sup.repo_path)
-        fake_proc = _fake_process(returncode=0, stdout=b"ok\n")
-        captured_timeout = {}
-
-        original_wait_for = asyncio.wait_for
-
-        async def capturing_wait_for(coro, *, timeout=None):
-            captured_timeout["value"] = timeout
-            return await original_wait_for(coro, timeout=timeout)
-
-        with (
-            patch.dict("os.environ", {"START_TIMEOUT_SECONDS": "45"}, clear=False),
-            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
-            patch("asyncio.wait_for", side_effect=capturing_wait_for),
-        ):
-            await sup.hooks.run_start(sup.repositories[0], BootMode.FRESH)
-
-        assert captured_timeout["value"] == 45
+        fake_proc.communicate.assert_not_awaited()
 
 
 class TestStartInRepositoryBootStrict:

--- a/packages/sandbox-runtime/tests/test_supervisor_lifecycle.py
+++ b/packages/sandbox-runtime/tests/test_supervisor_lifecycle.py
@@ -100,6 +100,40 @@ async def test_regular_boot_passes_repository_workspace_to_services(tmp_path, mo
     terminal.start.assert_awaited_once_with(workdir)
 
 
+async def test_shutdown_cancels_repository_boot_before_starting_services(tmp_path, monkeypatch):
+    supervisor, repository, opencode_server, agent_bridge, code_server, terminal, _desktop = (
+        _supervisor(tmp_path, [])
+    )
+    boot_started = asyncio.Event()
+    boot_cancelled = asyncio.Event()
+
+    async def blocked_boot(_mode, _ports):
+        boot_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            boot_cancelled.set()
+
+    repository.boot.side_effect = blocked_boot
+    monkeypatch.delenv("IMAGE_BUILD_MODE", raising=False)
+    monkeypatch.delenv("RESTORED_FROM_SNAPSHOT", raising=False)
+    monkeypatch.delenv("FROM_REPO_IMAGE", raising=False)
+
+    run_task = asyncio.create_task(supervisor.run())
+    await asyncio.wait_for(boot_started.wait(), timeout=1)
+    supervisor.shutdown_event.set()
+
+    assert await asyncio.wait_for(run_task, timeout=1) is True
+    assert boot_cancelled.is_set()
+    opencode_server.start.assert_not_awaited()
+    agent_bridge.start.assert_not_awaited()
+    code_server.start.assert_not_awaited()
+    terminal.start.assert_not_awaited()
+    assert any(
+        call.args == ("supervisor.boot_cancelled",) for call in supervisor.log.info.mock_calls
+    )
+
+
 async def test_build_boot_excludes_runtime_services(tmp_path, monkeypatch):
     supervisor, repository, opencode_server, agent_bridge, _code_server, _terminal, desktop = (
         _supervisor(tmp_path, [])


### PR DESCRIPTION
## Summary

- remove the runtime-owned 300-second `setup.sh` and 120-second `start.sh` deadlines
- wait for each hook's shell process to exit, while using a temporary output file so background children cannot keep an inherited pipe open and block completion
- preserve non-build failure-tail diagnostics and process-group cleanup on failure or cancellation
- make normal repository boot respond to supervisor shutdown, and advance the sandbox runtime/rebuild generation to 67

## Lifecycle boundary

Projects now own any command-specific deadlines inside their hook scripts. This does not remove enclosing lifecycle controls: sandbox shutdown still cancels repository boot and cleans up the active hook process group, and `IMAGE_BUILD_EXECUTION_TIMEOUT_SECONDS` still bounds image-build execution when configured. Existing control-plane/provider watchdogs are unchanged.

A successful hook is complete when its shell exits. Background processes launched by that shell may continue without delaying startup merely because they inherited stdout or stderr.

## Testing

- `uv run --python 3.12 --extra dev python -m pytest -q` (`1038 passed, 3 skipped`)
- focused hook, supervisor, and image-build tests (`77 passed`)
- Ruff check and format check across sandbox-runtime
- mypy on `repository_hooks.py` and `supervisor.py`
- control-plane runtime manifest and rebuild-policy tests (`7 passed`)
- Modal runtime manifest test (`1 passed`)
- sandbox-images bundle tests (`27 passed`)
- Prettier check for README and runtime manifest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Repository setup and start scripts now run until completion, subject to enclosing sandbox limits.
  - Hook cancellation and shutdown handling now terminate active processes cleanly.
  - Failed hooks retain a bounded tail of recent output for troubleshooting.
  - Repository startup can be interrupted before services launch when shutdown begins.
- **Compatibility**
  - Existing hook timeout environment variables no longer impose time limits.
  - The runtime generation has been updated to support these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->